### PR TITLE
Issue #89 - insertAdjacentHTML('beforeEnd', ...)

### DIFF
--- a/lib/UserAgentApplication.ts
+++ b/lib/UserAgentApplication.ts
@@ -1056,7 +1056,7 @@ namespace Msal {
                     ifr.style.width = ifr.style.height = "0";
                     adalFrame = (document.getElementsByTagName("body")[0].appendChild(ifr) as HTMLIFrameElement);
                 } else if (document.body && document.body.insertAdjacentHTML) {
-                    document.body.insertAdjacentHTML('beforeEnd', '<iframe name="' + iframeId + '" id="' + iframeId + '" style="display:none"></iframe>');
+                    document.body.insertAdjacentHTML('beforeend', '<iframe name="' + iframeId + '" id="' + iframeId + '" style="display:none"></iframe>');
                 }
 
                 if (window.frames && window.frames[iframeId]) {

--- a/out/msal.js
+++ b/out/msal.js
@@ -1724,7 +1724,7 @@ var Msal;
                     adalFrame = document.getElementsByTagName("body")[0].appendChild(ifr);
                 }
                 else if (document.body && document.body.insertAdjacentHTML) {
-                    document.body.insertAdjacentHTML('beforeEnd', '<iframe name="' + iframeId + '" id="' + iframeId + '" style="display:none"></iframe>');
+                    document.body.insertAdjacentHTML('beforeend', '<iframe name="' + iframeId + '" id="' + iframeId + '" style="display:none"></iframe>');
                 }
                 if (window.frames && window.frames[iframeId]) {
                     adalFrame = window.frames[iframeId];


### PR DESCRIPTION
Bug in call to insertAdjacentHTML('beforeEnd', ...) in UserAgentApplication.ts.

The specifications states that it should be "beforeend", not "beforeEnd":
https://www.w3.org/TR/2011/WD-html5-20110525/apis-in-html-documents.html

This broke the TypeScript pre-processing for me since InsertPosition in lib.es6.d.ts in the typescript node-package is defined as:
type InsertPosition = "beforebegin" | "afterbegin" | "beforeend" | "afterend";

Pull request coming.
Feel free to add a CONTRIBUTING.MD if I'm out of line.