### PR TITLE
Fix a bug caused by the default border width of iframe

### DIFF
--- a/lib/UserAgentApplication.ts
+++ b/lib/UserAgentApplication.ts
@@ -1073,6 +1073,7 @@ namespace Msal {
                     ifr.style.visibility = "hidden";
                     ifr.style.position = "absolute";
                     ifr.style.width = ifr.style.height = "0";
+                    ifr.style.border = "0";
                     adalFrame = (document.getElementsByTagName("body")[0].appendChild(ifr) as HTMLIFrameElement);
                 } else if (document.body && document.body.insertAdjacentHTML) {
                     document.body.insertAdjacentHTML('beforeend', '<iframe name="' + iframeId + '" id="' + iframeId + '" style="display:none"></iframe>');


### PR DESCRIPTION
For most browsers, the default style for iframe has a border width of 2px, which makes the "invisible" renewal iframe actually "visible" and might break the layout of many applications using adal.