### PR TITLE
Update UserAgentApplication.ts

### DIFF
--- a/src/UserAgentApplication.ts
+++ b/src/UserAgentApplication.ts
@@ -1396,7 +1396,7 @@ protected getCachedTokenInternal(scopes : Array<string> , user: User): CacheResu
     if (window.parent !== window && window.parent.msal) {
         tokenReceivedCallback = window.parent.callBackMappedToRenewStates[requestInfo.stateResponse];
     }
-    else if (window.opener && window.opener.msal) {
+    else if (isWindowOpenerMsal) {
         tokenReceivedCallback = window.opener.callBackMappedToRenewStates[requestInfo.stateResponse];
     }
     else {


### PR DESCRIPTION
This is in reference to the issue in #300

Resolving an issue where if the msal library is initiated from a browser window that linked via a target=_blank it will throw an error. Instead of touching the window.opener.msal yet again, this will just utilize the already evaluated isWindowOpenerMsal variable set above.

To repro the issue prior to this change, you just need a page which is utilizing the msal library to handle a signup or sign-in. Then, create a secondary html page which links to the page that then has a target=_blank which will then open another tab. The end result is that the library will throw an exception and rendering is halted (assuming no error handling is being leveraged).