### PR TITLE
Expose handleAuthenticationResponse()

### DIFF
--- a/src/UserAgentApplication.ts
+++ b/src/UserAgentApplication.ts
@@ -1367,9 +1367,8 @@ protected getCachedTokenInternal(scopes : Array<string> , user: User): CacheResu
    * This method must be called for processing the response received from the STS. It extracts the hash, processes the token or error information and saves it in the cache. It then
    * calls the registered callbacks in case of redirect or resolves the promises with the result.
    * @param {string} [hash=window.location.hash] - Hash fragment of Url.
-   * @hidden
    */
-  private handleAuthenticationResponse(hash: string): void {
+  handleAuthenticationResponse(hash: string): void {
     if (hash == null) {
       hash = window.location.hash;
     }


### PR DESCRIPTION
I'd like to expose the `handleAuthenticationResponse` function. We are unable to rely on MSAL to consistently use the redirect id_token to complete the login flow in our Angular 5 app.

Exposing this functions lets us bootstrap the MSAL library in our custom auth service when the app starts. We've been doing this in production for over a month now and have seen it consistently work. 

I'd appreciate if this change made it in. Thanks!

Edit: Note that I did not run the dist build for this, only TS changes.