### PR TITLE
Fix for silent token renewal - Angular

### DIFF
--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -81,8 +81,8 @@
     "zone.js": "^0.8.10"
   },
   "peerDependencies": {
-    "@angular/common": "^4.3.0",
-    "@angular/core": "^4.3.0",
+    "@angular/common": ">=4.3.0 <6.0.0",
+    "@angular/core": ">=4.3.0 <6.0.0",
     "rxjs": "^5.0.1"
   },
   "directories": {

--- a/lib/msal-angular/src/msal-config.ts
+++ b/lib/msal-angular/src/msal-config.ts
@@ -15,6 +15,7 @@ export class MsalConfig {
     popUp?: boolean;
     consentScopes?: string[];
     isAngular?:true;
+    fallbackToInteractive?: false;
     unprotectedResources? :  string[];
     protectedResourceMap?: [string, string[]][];
     extraQueryParameters?: string;

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -365,6 +365,10 @@ export class MsalService extends UserAgentApplication {
         super.acquireTokenRedirect(scopes, authority, user, extraQueryParameters);
     }
 
+    public acquireTokenInProgress(): boolean {
+        return super.getAcquireTokenInProgress();
+    }
+
     public loginInProgress(): boolean {
         return super.loginInProgress();
     }

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -316,7 +316,14 @@ export class MsalService extends UserAgentApplication {
 
     public acquireTokenSilent(scopes: Array<string>, authority?: string, user?: User, extraQueryParameters?: string): Promise<any> {
         return new Promise((resolve, reject) => {
-            super.acquireTokenSilent(scopes, authority, user, extraQueryParameters).then((token: any) => {
+            super.acquireTokenSilent(scopes, authority, user, extraQueryParameters)
+            .catch((error: any) => {
+                if (this.config.popUp) {
+                    return super.acquireTokenPopup(scopes, authority, user, extraQueryParameters)
+                }
+                return Promise.reject(error);
+            })
+            .then((token: any) => {
                 this._renewActive = false;
                 var authenticationResult = new AuthenticationResult(token);
                 this.broadcastService.broadcast('msal:acquireTokenSuccess', authenticationResult);


### PR DESCRIPTION
This is a simple fix to the following error that I keep having when trying to acquire token:
>Error when acquiring token for scopes: https://management.azure.com/user_impersonation Token renewal operation failed due to timeout|Token Renewal Failed

I believe this is related to #288 (but even setting longer timeout does not solve it).

If we have set popup in msal configuration, user will be presented with popup window if error happen during silent token renewal.

Let me know if this should be changed in the msal-core instead.