### PR TITLE
Fix: Adding response_mode config value to use in OAuth calls

### DIFF
--- a/lib/msal-angular/README.md
+++ b/lib/msal-angular/README.md
@@ -145,6 +145,7 @@ Besides the required clientID, you can optionally pass the following config opti
                   correlationId: '1234',
                   level: LogLevel.Verbose,
                   piiLoggingEnabled: true,
+                  response_mode: 'fragment',
                 })]
            })
 
@@ -188,6 +189,8 @@ loggerCallback(logLevel, message, piiEnabled) { }
 
 * **piiLoggingEnabled** : PII stands for Personal Identifiable Information. By default, MSAL does not capture or log any PII. By turning on PII, the app takes responsibility for safely handling highly-sensitive data and complying with any regulatory requirements.
  This flag is to enable/disable logging of PII data. PII logs are never written to default outputs like Console, Logcat or NSLog. Default is set to false.
+
+* **response_mode** : The method that you use to send the resulting authorization code back to your app. It can be query, form_post, or fragment.
 
 * **correlationId** : Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
 

--- a/lib/msal-angular/dist/msal-config.d.ts
+++ b/lib/msal-angular/dist/msal-config.d.ts
@@ -20,4 +20,5 @@ export declare class MsalConfig {
     correlationId?: string;
     level?: LogLevel;
     piiLoggingEnabled?: boolean;
+    response_mode: 'fragment'
 }

--- a/lib/msal-angular/docs/index.html
+++ b/lib/msal-angular/docs/index.html
@@ -181,7 +181,8 @@
                   <span class="hljs-attr">logger</span> :loggerCallback,
                   <span class="hljs-attr">correlationId</span>: <span class="hljs-string">'1234'</span>,
                   <span class="hljs-attr">level</span>: LogLevel.Verbose,
-                  <span class="hljs-attr">piiLoggingEnabled</span>: <span class="hljs-literal">true</span>,
+				  <span class="hljs-attr">piiLoggingEnabled</span>: <span class="hljs-literal">true</span>,
+				  <span class="hljs-attr">response_mode</span>: <span class="hljs-literal">'fragment'</span>,
                 })]
            })
 
@@ -237,6 +238,8 @@
 					</li>
 					<li><p><strong>piiLoggingEnabled</strong> : PII stands for Personal Identifiable Information. By default, MSAL does not capture or log any PII. By turning on PII, the app takes responsibility for safely handling highly-sensitive data and complying with any regulatory requirements.
 						This flag is to enable/disable logging of PII data. PII logs are never written to default outputs like Console, Logcat or NSLog. Default is set to false.</p>
+					</li>
+					<li><p><strong>response_mode</strong> : The method that you use to send the resulting authorization code back to your app. It can be query, form_post, or fragment.</p>
 					</li>
 					<li><p><strong>correlationId</strong> : Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).</p>
 					</li>

--- a/lib/msal-angular/samples/MSALAngularDemoApp/src/app/app.module.ts
+++ b/lib/msal-angular/samples/MSALAngularDemoApp/src/app/app.module.ts
@@ -50,7 +50,8 @@ export const protectedResourceMap:[string, string[]][]=[ ['https://buildtodoserv
         logger: loggerCallback,
         correlationId: '1234',
         level: LogLevel.Info,
-        piiLoggingEnabled: true
+        piiLoggingEnabled: true,
+        response_mode: 'fragment',
       }
     ),
   ],

--- a/lib/msal-angular/src/msal-config.ts
+++ b/lib/msal-angular/src/msal-config.ts
@@ -21,7 +21,7 @@ export class MsalConfig {
     correlationId?: string;
     level?: LogLevel;
     piiLoggingEnabled?: boolean;
-
+    response_mode?: string;
 }
 
 

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -37,6 +37,7 @@ export class MsalService extends UserAgentApplication {
                 isAngular: true,
                 unprotectedResources: config.unprotectedResources,
                 protectedResourceMap: new Map(config.protectedResourceMap),
+                response_mode: config.response_mode,
             });
 
         this.loginScopes = [this.clientId];

--- a/lib/msal-angular/tests/MSALSpec.ts
+++ b/lib/msal-angular/tests/MSALSpec.ts
@@ -38,7 +38,8 @@ describe('Msal Angular Pubic API tests', function () {
                     consentScopes: ["user.read", "mail.send"],
                     unprotectedResources: ["https:google.com"],
                     correlationId: '1234',
-                    piiLoggingEnabled: true
+                    piiLoggingEnabled: true,
+                    response_mode: 'fragment'
                 }
             }, BroadcastService, {provide: Storage, useClass: {mockLocalStorage: "localStorage"}}
             ]

--- a/lib/msal-angular/tests/sample/src/app/app.module.ts
+++ b/lib/msal-angular/tests/sample/src/app/app.module.ts
@@ -52,7 +52,8 @@ export const protectedResourceMap:[string, string[]][]=[ ['https://buildtodoserv
         logger: loggerCallback,
         correlationId: '1234',
         level: LogLevel.Info,
-        piiLoggingEnabled: true
+        piiLoggingEnabled: true,
+        response_mode: 'fragment',
       }
     ),
   ],

--- a/lib/msal-angularjs/samples/MsalAngularjsDemoApp/app.js
+++ b/lib/msal-angularjs/samples/MsalAngularjsDemoApp/app.js
@@ -40,7 +40,8 @@ if (window !== window.parent && !window.opener) {
                 routeProtectionConfig: {
                     consentScopes: applicationConfig.consentScopes,
                     popUp: true
-                }
+                },
+                response_mode: 'fragment',
             }, $httpProvider);
 
             $locationProvider.html5Mode(false).hashPrefix('');

--- a/lib/msal-core/src/Constants.ts
+++ b/lib/msal-core/src/Constants.ts
@@ -66,6 +66,7 @@ export class Constants {
   static get prompt_none(): string { return "&prompt=none"; }
   static get prompt(): string { return "prompt"; }
   static get response_mode_fragment(): string { return "&response_mode=fragment"; }
+  static get response_mode(): string { return "&response_mode="; }
   static get resourceDelimeter(): string { return "|"; }
   static get tokenRenewStatusCancelled(): string { return "Canceled"; }
   static get tokenRenewStatusCompleted(): string { return "Completed"; }

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -192,6 +192,12 @@ export class UserAgentApplication {
    */
   private _postLogoutredirectUri: string;
 
+  /*
+   * Used to set the response_mode
+   * Defaults to `fragment`.
+   */
+  private _response_mode: string;
+
   loadFrameTimeout: number;
 
   protected _navigateToLoginRequestUrl: boolean;
@@ -228,6 +234,7 @@ export class UserAgentApplication {
         cacheLocation?: string,
         redirectUri?: string,
         postLogoutRedirectUri?: string,
+        response_mode?: string,
         logger?: Logger,
         loadFrameTimeout?: number,
         navigateToLoginRequestUrl?: boolean,
@@ -242,6 +249,7 @@ export class UserAgentApplication {
           cacheLocation = "sessionStorage",
           redirectUri = window.location.href.split("?")[0].split("#")[0],
           postLogoutRedirectUri = window.location.href.split("?")[0].split("#")[0],
+          response_mode = 'fragment',
           logger = new Logger(null),
           loadFrameTimeout = 6000,
           navigateToLoginRequestUrl = true,
@@ -258,6 +266,7 @@ export class UserAgentApplication {
     this.authority = authority || "https://login.microsoftonline.com/common";
     this._tokenReceivedCallback = tokenReceivedCallback;
     this._redirectUri = redirectUri;
+    this._response_mode = response_mode;
     this._postLogoutredirectUri = postLogoutRedirectUri;
     this._loginInProgress = false;
     this._acquireTokenInProgress = false;
@@ -410,7 +419,7 @@ export class UserAgentApplication {
               this._cacheStorage.setItem(Constants.msalErrorDescription, "");
               const authorityKey = Constants.authority + Constants.resourceDelimeter + authenticationRequest.state;
               this._cacheStorage.setItem(authorityKey, this.authority, this.storeAuthStateInCookie);
-              const urlNavigate = authenticationRequest.createNavigateUrl(scopes) + Constants.prompt_select_account + Constants.response_mode_fragment;
+              const urlNavigate = authenticationRequest.createNavigateUrl(scopes) + Constants.prompt_select_account + Constants.response_mode + this._response_mode;
               this.promptUser(urlNavigate);
           });
   }
@@ -495,7 +504,7 @@ export class UserAgentApplication {
           this._cacheStorage.setItem(Constants.msalErrorDescription, "");
           const authorityKey = Constants.authority + Constants.resourceDelimeter + authenticationRequest.state;
           this._cacheStorage.setItem(authorityKey, this.authority, this.storeAuthStateInCookie);
-          const urlNavigate = authenticationRequest.createNavigateUrl(scopes) + Constants.prompt_select_account + Constants.response_mode_fragment;
+          const urlNavigate = authenticationRequest.createNavigateUrl(scopes) + Constants.prompt_select_account + Constants.response_mode + this._response_mode;
           window.renewStates.push(authenticationRequest.state);
           window.requestType = Constants.login;
           this.registerCallback(authenticationRequest.state, scope, resolve, reject);
@@ -1066,7 +1075,7 @@ protected getCachedTokenInternal(scopes : Array<string> , user: User): CacheResu
         authenticationRequest.extraQueryParameters = extraQueryParameters;
       }
 
-      let urlNavigate = authenticationRequest.createNavigateUrl(scopes) +  Constants.prompt_select_account  + Constants.response_mode_fragment;
+      let urlNavigate = authenticationRequest.createNavigateUrl(scopes) +  Constants.prompt_select_account  + Constants.response_mode + this._response_mode;
       urlNavigate = this.addHintParameters(urlNavigate, userObject);
       if (urlNavigate) {
         this._cacheStorage.setItem(Constants.stateAcquireToken, authenticationRequest.state, this.storeAuthStateInCookie);
@@ -1154,7 +1163,7 @@ protected getCachedTokenInternal(scopes : Array<string> , user: User): CacheResu
           authenticationRequest.extraQueryParameters = extraQueryParameters;
         }
 
-        let urlNavigate = authenticationRequest.createNavigateUrl(scopes) + Constants.prompt_select_account  + Constants.response_mode_fragment;
+        let urlNavigate = authenticationRequest.createNavigateUrl(scopes) + Constants.prompt_select_account  + Constants.response_mode + this._response_mode;
         urlNavigate = this.addHintParameters(urlNavigate, userObject);
         window.renewStates.push(authenticationRequest.state);
         window.requestType = Constants.renewToken;


### PR DESCRIPTION
The current MSAL library always uses Fragment as the response_mode for the OAuth calls (see https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oauth-code).

Fragment causes issues when using HashLocationStrategy with Angular so that the state and error details cannot be read. This will allow developers to choose the response format.

This addresses issues #480 