### PR TITLE
Remove prompt=select_account from all login functions

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -410,7 +410,7 @@ export class UserAgentApplication {
               this._cacheStorage.setItem(Constants.msalErrorDescription, "");
               const authorityKey = Constants.authority + Constants.resourceDelimeter + authenticationRequest.state;
               this._cacheStorage.setItem(authorityKey, this.authority, this.storeAuthStateInCookie);
-              const urlNavigate = authenticationRequest.createNavigateUrl(scopes) + Constants.prompt_select_account + Constants.response_mode_fragment;
+              const urlNavigate = authenticationRequest.createNavigateUrl(scopes)  + Constants.response_mode_fragment;
               this.promptUser(urlNavigate);
           });
   }
@@ -495,7 +495,7 @@ export class UserAgentApplication {
           this._cacheStorage.setItem(Constants.msalErrorDescription, "");
           const authorityKey = Constants.authority + Constants.resourceDelimeter + authenticationRequest.state;
           this._cacheStorage.setItem(authorityKey, this.authority, this.storeAuthStateInCookie);
-          const urlNavigate = authenticationRequest.createNavigateUrl(scopes) + Constants.prompt_select_account + Constants.response_mode_fragment;
+          const urlNavigate = authenticationRequest.createNavigateUrl(scopes)  + Constants.response_mode_fragment;
           window.renewStates.push(authenticationRequest.state);
           window.requestType = Constants.login;
           this.registerCallback(authenticationRequest.state, scope, resolve, reject);


### PR DESCRIPTION
Remove prompt=select_account from all login functions, This is to ensure that the MSAL JS library is not hard coding prompt=select_account in its code, completes the fix for https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/489
