### PR TITLE
feature: add config option to allow silent check for sso token

### DIFF
--- a/lib/msal-core/karma.conf.js
+++ b/lib/msal-core/karma.conf.js
@@ -24,6 +24,9 @@ module.exports = function (config) {
         logLevel: config.LOG_INFO,
         autoWatch: true,
         browsers: ['PhantomJS'],
+        client: {
+            useIframe: false
+        },
         singleRun: true,
         concurrency: Infinity,
         coverageIstanbulReporter: {

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -411,7 +411,7 @@ export class Utils {
     * Checks to see if query parameters include login_hint or sid
   */
   static hasSsoHint(extraQueryParameters: string) {
-    return extraQueryParameters && (extraQueryParameters.indexOf(Constants.login_hint) !== -1 || extraQueryParameters.indexOf(Constants.sid) !== -1 );
+    return extraQueryParameters && (extraQueryParameters.includes(Constants.login_hint) || extraQueryParameters.includes(Constants.sid));
   }
 
      static constructUnifiedCacheExtraQueryParameter(idTokenObject: any, extraQueryParameters?: string) {

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -407,9 +407,12 @@ export class Utils {
     return url.indexOf(suffix, url.length - suffix.length) !== -1;
   }
 
-     static checkSSO(extraQueryParameters: string) {
-        return  !(extraQueryParameters &&  ((extraQueryParameters.indexOf(Constants.login_hint) !== -1 ||  extraQueryParameters.indexOf(Constants.sid) !== -1 )));
-    }
+  /*
+    * Checks to see if query parameters include login_hint or sid
+  */
+  static hasSsoHint(extraQueryParameters: string) {
+    return extraQueryParameters && (extraQueryParameters.indexOf(Constants.login_hint) !== -1 || extraQueryParameters.indexOf(Constants.sid) !== -1 );
+  }
 
      static constructUnifiedCacheExtraQueryParameter(idTokenObject: any, extraQueryParameters?: string) {
          if (idTokenObject) {


### PR DESCRIPTION
Applications using Azure AD B2C should have single-sign-on behavior
based on the tenant's configuration.  The session is saved as a cookie
on the tenant's domain.

This adds `requiresSsoHint` to the `UserAgentApplication` constructor.
It has a default value of `true` in keeping with the existing behavior.
If this option is set to `false`, then the `acquireTokenSilent` does not
reject if there is no login_hint or sid provided for the authentication
request.  Instead, it continues with the AuthenticationRequest to check
if the tenant has an active session.

Related to issue #275 