### PR TITLE
fix: clean acquireToken caching so it doesn't accrue through states

### DIFF
--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -107,7 +107,7 @@ export class Storage {// Singleton
         return results;
     }
 
-    removeAcquireTokenEntries(clearCookies?: boolean): void {
+    removeAcquireTokenEntries(): void {
         const storage = window[this._cacheLocation];
         if (storage) {
             let key: string;
@@ -119,10 +119,7 @@ export class Storage {// Singleton
                         const renewStatus = storage[Constants.renewStatus + state];
                         if (!renewStatus || renewStatus !== Constants.tokenRenewStatusInProgress) {
                             this.removeItem(key);
-
-                            if (clearCookies) {
-                                this.setItemCookie(key, "", -1);
-                            }
+                            this.setItemCookie(key, "", -1);
                         }
                     }
                     if (key.indexOf(Constants.renewStatus) !== -1) {
@@ -135,9 +132,7 @@ export class Storage {// Singleton
             }
         }
 
-        if (clearCookies) {
-            this.clearCookie();
-        }
+        this.clearCookie();
     }
 
     resetCacheItems(): void {

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1443,7 +1443,7 @@ protected getCachedTokenInternal(scopes : Array<string> , user: User): CacheResu
 
     this._cacheStorage.setItem(acquireTokenUserKey, JSON.stringify(user));
     this._cacheStorage.setItem(authorityKey, authenticationRequest.authority, this.storeAuthStateInCookie);
-    this._cacheStorage.setItem(Constants.nonceIdToken, authenticationRequest.nonce);
+    this._cacheStorage.setItem(Constants.nonceIdToken, authenticationRequest.nonce, this.storeAuthStateInCookie);
   }
 
   /*

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1729,7 +1729,7 @@ protected getCachedTokenInternal(scopes : Array<string> , user: User): CacheResu
       }
       }
       this._cacheStorage.setItem(Constants.renewStatus + tokenResponse.stateResponse, Constants.tokenRenewStatusCompleted);
-      this._cacheStorage.removeAcquireTokenEntries(this.storeAuthStateInCookie);
+      this._cacheStorage.removeAcquireTokenEntries();
   }
   /* tslint:enable:no-string-literal */
 

--- a/lib/msal-core/tests/MSAL.spec.ts
+++ b/lib/msal-core/tests/MSAL.spec.ts
@@ -666,8 +666,7 @@ describe('Msal', function (): any {
         var msalInstance = msal;
         var mockIdToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJjbGllbnRpZDEyMyIsIm5hbWUiOiJKb2huIERvZSIsInVwbiI6ImpvaG5AZW1haWwuY29tIiwibm9uY2UiOiIxMjM0In0.bpIBG3n1w7Cv3i_JHRGji6Zuc9F5H8jbDV5q3oj0gcw';
         // cookie-clearing is expected to be handled in Storage
-        spyOn(storageFake, 'removeAcquireTokenEntries').and.callFake(function (clearCookies) {
-            expect(clearCookies).toBe(true);
+        spyOn(storageFake, 'removeAcquireTokenEntries').and.callFake(function () {
             const state = this.getItemCookie(Constants.stateLogin);
             const authorityKey = Constants.authority + Constants.resourceDelimeter + state;
             this.setItemCookie(authorityKey, '', -1);


### PR DESCRIPTION
Fix for #527 

The cache entries for the Acquire Token process aren't properly removed, resulting in a build-up of entries (with different state values) over time.

Update to `Storage.removeAcquireTokenEntries` so it removes all entries that are not In Progress, rather than only specified entries.

Update to `Storage.resetCacheItems` so it removes all the cache entries for the Acquire Token process.

Create private function in `UserAgentApplication.updateAcquireTokenCache` to set the Acquire Token cache values from the user and the authenticationRequest objects.  Update to Acquire Token processes to use that function, eliminating duplicate code.

Minor cleanup to `UserAgentApplication.saveTokenFromHash`.

Update tests to reflect cache-clearing responsibility getting moved to `Storage`.