### PR TITLE
feature: loginSilent

### DIFF
--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -51,6 +51,7 @@
     "grunt-file-append": "0.0.7",
     "grunt-jasmine-node": "~0.3.1",
     "grunt-tslint": "^5.0.1",
+    "highlight.js": "~9.14.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine": "^2.99.0",
     "jasmine-ajax": "^3.3.1",

--- a/lib/msal-core/karma.conf.js
+++ b/lib/msal-core/karma.conf.js
@@ -24,6 +24,9 @@ module.exports = function (config) {
         logLevel: config.LOG_INFO,
         autoWatch: true,
         browsers: ['PhantomJS'],
+        client: {
+            useIframe: false
+        },
         singleRun: true,
         concurrency: Infinity,
         coverageIstanbulReporter: {

--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -44,6 +44,7 @@
     "grunt-jasmine-node": "~0.3.1",
     "grunt-tslint": "^5.0.1",
     "grunt-typedoc": "^0.2.4",
+    "highlight.js": "~9.14.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine": "^2.8.0",
     "jasmine-ajax": "^3.3.1",

--- a/lib/msal-core/src/Constants.ts
+++ b/lib/msal-core/src/Constants.ts
@@ -100,6 +100,7 @@ export class ErrorCodes {
   static get popUpWindowError(): string { return "popup_window_error"; }
   static get userLoginError(): string { return "user_login_error"; }
   static get userCancelledError(): string { return "user_cancelled"; }
+  static get iframeError(): string { return "iframe_error"; }
 }
 
 /**
@@ -113,5 +114,5 @@ export class ErrorDescription {
   static get popUpWindowError(): string { return "Error opening popup window. This can happen if you are using IE or if popups are blocked in the browser."; }
   static get userLoginError(): string { return "User login is required"; }
   static get userCancelledError(): string { return "User closed the popup window and cancelled the flow"; }
-
+  static get iframeError(): string { return "Cannot open an iframe from inside an iframe"; }
 }

--- a/lib/msal-core/tests/MSAL.spec.ts
+++ b/lib/msal-core/tests/MSAL.spec.ts
@@ -1,8 +1,9 @@
-import {UserAgentApplication} from '../src/index';
-import { Constants, ErrorCodes, ErrorDescription} from '../src/Constants';
+import {UserAgentApplication, User} from '../src/index';
+import {Constants, ErrorCodes, ErrorDescription} from '../src/Constants';
 import {Authority} from "../src/Authority";
 import {AuthenticationRequestParameters} from "../src/AuthenticationRequestParameters";
 import {AuthorityFactory} from "../src/AuthorityFactory";
+import { idText } from 'typescript';
 
 describe('Msal', function (): any {
     let window: any;
@@ -140,6 +141,17 @@ describe('Msal', function (): any {
     }();
 
     beforeEach(function () {
+        // clear all cookies
+        var cookies = document.cookie.split(';');
+        for (var i in cookies) {
+            const cookie = cookies[i];
+            if (!cookie) {
+                continue;
+            }
+            const key = cookie.substring(0, cookie.indexOf('='));
+            document.cookie = key + "=;expires=" + new Date(0).toUTCString();
+        }
+
         // one item in cache
         storageFake.clear();
         var secondsNow = mathMock.round(0);
@@ -170,7 +182,6 @@ describe('Msal', function (): any {
         });
         msal._user = null;
         msal._renewStates = [];
-        msal._activeRenewals = {};
         msal._cacheStorage = storageFake;
 
         jasmine.Ajax.install();
@@ -243,7 +254,6 @@ describe('Msal', function (): any {
                 }, { redirectUri: TEST_REDIR_URI });
         msal._user = null;
         msal._renewStates = [];
-        msal._activeRenewals = {};
         msal._cacheStorage = storageFake;
         expect(msal._redirectUri).toBe(TEST_REDIR_URI);
         msal.promptUser = function (args: string) {
@@ -258,13 +268,26 @@ describe('Msal', function (): any {
         msal.loginRedirect();
     });
 
-    it('uses current location.href as returnUri by default, even if location changed after UserAgentApplication was instantiated', (done) => {
-        history.pushState(null, null, '/new_pushstate_uri');
-        msal.promptUser = function (args: string) {
-            expect(args).toContain('&redirect_uri=' + encodeURIComponent('http://localhost:8080/new_pushstate_uri'));
-            done();
-        };
-        msal.loginRedirect();
+    describe('in case of location change', function () {
+        var currentHref: string;
+
+        beforeEach(function () {
+            currentHref = global.window.location.href;
+        });
+
+        afterEach(function () {
+            // Reset location
+            history.pushState(null, null, currentHref);
+        });
+
+        it('uses current location.href as returnUri by default, even if location changed after UserAgentApplication was instantiated', (done) => {
+            history.pushState(null, null, '/new_pushstate_uri');
+            msal.promptUser = function (args: string) {
+                expect(args).toContain('&redirect_uri=' + encodeURIComponent('http://localhost:8080/new_pushstate_uri'));
+                done();
+            };
+            msal.loginRedirect();
+        });
     });
 
     it('tests getCachedToken when authority is not passed and single accessToken is present in the cache for a set of scopes', function () {
@@ -736,58 +759,339 @@ describe('Msal', function (): any {
 });
 
 describe('loginPopup functionality', function () {
-    var loginPopupPromise:Promise<string>;
     var msal;
     beforeEach(function () {
-        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (errorDes, token, error) {
+        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, null);
+
+        spyOn(msal, 'openWindow').and.callFake(function (urlNavigate: string, title: string, interval: number, instance: UserAgentApplication, resolve?: Function, reject?: Function) {
+            resolve();
         });
-        spyOn(msal, 'loginPopup').and.callThrough();
-        loginPopupPromise = msal.loginPopup([msal.clientId]);
     });
 
     it('returns a promise', function () {
+        const loginPopupPromise = msal.loginPopup([msal.clientId]);
         expect(loginPopupPromise).toEqual(jasmine.any(Promise));
+
+        // Make sure the promise completes before continuing
+        return new Promise(function (resolve, reject) {
+            loginPopupPromise
+                .then(function () {
+                    resolve();
+                })
+                .catch(function (err) {
+                    resolve();
+                });
+        });
     });
 });
 
 describe('acquireTokenPopup functionality', function () {
-    var acquireTokenPopupPromise: Promise<string>;
     var msal;
     beforeEach(function () {
-        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (errorDes, token, error) {
-        });
-        spyOn(msal, 'acquireTokenPopup').and.callThrough();
-        acquireTokenPopupPromise = msal.acquireTokenPopup([msal.clientId]);
-        acquireTokenPopupPromise.then(function(accessToken) {
-        }, function(error) {
+        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, null);
+
+        spyOn(msal, 'openWindow').and.callFake(function (urlNavigate: string, title: string, interval: number, instance: UserAgentApplication, resolve?: Function, reject?: Function) {
+            resolve();
         });
     });
 
     it('returns a promise', function () {
+        const acquireTokenPopupPromise = msal.acquireTokenPopup([msal.clientId]);
         expect(acquireTokenPopupPromise).toEqual(jasmine.any(Promise));
+
+        // Make sure the promise completes before continuing
+        return new Promise(function (resolve, reject) {
+            acquireTokenPopupPromise
+                .then(function () {
+                    resolve();
+                })
+                .catch(function (err) {
+                    resolve();
+                });
+        });
     });
 
+});
+
+describe('loginSilent functionality', function () {
+    var msal;
+
+    const CLIENT_ID = "0813e1d1-ad72-46a9-8665-399bba48c201"
+    const ID_TOKEN = "fake_id_token";
+
+    beforeEach(function () {
+        // clear all cookies
+        var cookies = document.cookie.split(';');
+        for (var i in cookies) {
+            const cookie = cookies[i];
+            if (!cookie) {
+                continue;
+            }
+            const key = cookie.substring(0, cookie.indexOf('='));
+            document.cookie = key + "=;expires=" + new Date(0).toUTCString();
+        }
+
+        msal = new UserAgentApplication(CLIENT_ID, null, null);
+    });
+
+    describe('when there is an active session on the authority', function () {
+        beforeEach(function () {
+            // Fake the iframe redirects that actually try to get the token from the authority
+            spyOn(msal, 'renewIdToken').and.callFake(function (scopes: Array<string>, resolve: Function, reject: Function, user: User, authenticationRequest: AuthenticationRequestParameters, extraQueryParameters?: string) {
+                resolve(ID_TOKEN);
+            });
+        });
+
+        it('returns a promise', function () {
+            const loginSilentPromise = msal.loginSilent();
+            expect(loginSilentPromise).toEqual(jasmine.any(Promise));
+
+            // Make sure the promise completes before continuing
+            return new Promise(function (resolve, reject) {
+                loginSilentPromise
+                    .then(function () {
+                        resolve();
+                    })
+                    .catch(function () {
+                        resolve();
+                    });
+            });
+        });
+
+        it('uses the cached token or userObject if available through acquireTokenSilent', function () {
+            spyOn(msal, 'acquireTokenSilent').and.returnValue(Promise.resolve(ID_TOKEN));
+
+            return new Promise((resolve, reject) => {
+                msal.loginSilent()
+                    .then((token) => {
+                        expect(token).toEqual(ID_TOKEN);
+                        expect(msal.acquireTokenSilent).toHaveBeenCalled();
+                        resolve();
+                    })
+                    .catch((error) => {
+                        reject(error);
+                    })
+            });
+        });
+
+        it('gets a token from renewIdToken if a cached token or userObject is not available', function () {
+            spyOn(msal, 'acquireTokenSilent').and.returnValue(Promise.reject());
+
+            return new Promise((resolve, reject) => {
+                msal.loginSilent()
+                    .then((token) => {
+                        expect(token).toEqual(ID_TOKEN);
+                        expect(msal.renewIdToken).toHaveBeenCalled();
+                        resolve();
+                    })
+                    .catch((error) => {
+                        reject(error);
+                    })
+            });
+        });
+    });
+
+    describe('when there is *not* an active session on the authority', function () {
+        beforeEach(function () {
+            // Fake the iframe redirects that actually try to get the token from the authority
+            spyOn(msal, 'renewIdToken').and.callFake(function (scopes: Array<string>, resolve: Function, reject: Function, user: User, authenticationRequest: AuthenticationRequestParameters, extraQueryParameters?: string) {
+                reject('No session');
+            });
+        });
+
+        it('returns a promise', function () {
+            const loginSilentPromise = msal.loginSilent();
+            expect(loginSilentPromise).toEqual(jasmine.any(Promise));
+
+            // Make sure the promise completes before continuing
+            return new Promise(function (resolve, reject) {
+                loginSilentPromise
+                    .then(function () {
+                        resolve();
+                    })
+                    .catch(function () {
+                        resolve();
+                    });
+            });
+        });
+
+        it('rejects the promise', function () {
+            spyOn(msal, 'acquireTokenSilent').and.returnValue(Promise.reject());
+
+            return new Promise((resolve, reject) => {
+                msal.loginSilent()
+                    .then((token) => {
+                        reject('somehow got token ' + token);
+                    })
+                    .catch(() => {
+                        expect(msal.renewIdToken).toHaveBeenCalled();
+                        resolve();
+                    })
+            });
+        });
+    });
 });
 
 describe('acquireTokenSilent functionality', function () {
-    var acquireTokenSilentPromise: Promise<string>;
     var msal;
+
+    const CLIENT_ID = "0813e1d1-ad72-46a9-8665-399bba48c201"
+    const ID_TOKEN = "fake_id_token";
+    const ACCESS_TOKEN = "fake_access_token"
+
+    const userFake = new User("fake_user_display_id", "Fake User", "fake_identity_provider", "fake_user_id", ID_TOKEN, "fake_sid");
+
     beforeEach(function () {
-        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (errorDes, token, error) {
+        msal = new UserAgentApplication(CLIENT_ID, null, null);
+
+        // Fake the iframe redirects that actually try to get the token from the authority
+        spyOn(msal, 'renewIdToken').and.callFake(function (scopes: Array<string>, resolve: Function, reject: Function, user: User, authenticationRequest: AuthenticationRequestParameters, extraQueryParameters?: string) {
+            resolve(ID_TOKEN);
         });
-        spyOn(msal, 'acquireTokenSilent').and.callThrough();
-        spyOn(msal, 'loadIframeTimeout').and.callThrough();
-        acquireTokenSilentPromise = msal.acquireTokenSilent([msal.clientId]);
-        acquireTokenSilentPromise.then(function(accessToken) {
-        }, function(error) {
+
+        spyOn(msal, 'renewToken').and.callFake(function (scopes: Array<string>, resolve: Function, reject: Function, user: User, authenticationRequest: AuthenticationRequestParameters, extraQueryParameters?: string) {
+            resolve(ACCESS_TOKEN);
         });
     });
-
 
     it('returns a promise', function () {
+        const acquireTokenSilentPromise = msal.acquireTokenSilent([msal.clientId]);
         expect(acquireTokenSilentPromise).toEqual(jasmine.any(Promise));
+
+        // Make sure the promise completes before continuing
+        return new Promise(function (resolve, reject) {
+            acquireTokenSilentPromise
+                .then(function () {
+                    resolve();
+                })
+                .catch(function () {
+                    resolve();
+                });
+        });
     });
 
+    describe('when the user is not logged in to the local application', function () {
+        it('rejects if no hint is provided and no adal token is cached', function () {
+            return new Promise(function (resolve, reject) {
+                const acquireTokenSilentPromise = msal.acquireTokenSilent([msal.clientId]);
+
+                acquireTokenSilentPromise
+                    .then(function (token) {
+                        reject();
+                    })
+                    .catch(function (err) {
+                        expect(msal.renewIdToken).not.toHaveBeenCalled();
+                        expect(msal.renewToken).not.toHaveBeenCalled();
+
+                        resolve();
+                    });
+            });
+        });
+
+        it('gets token if a login_hint query parameter is provided', function () {
+            return new Promise(function (resolve, reject) {
+                const acquireTokenSilentPromise = msal.acquireTokenSilent([msal.clientId], null, null, Constants.login_hint + "=test");
+
+                acquireTokenSilentPromise
+                    .then(function (token) {
+                        resolve();
+                    })
+                    .catch(function (err) {
+                        reject();
+                    });
+            });
+        });
+
+        it('gets token if an sid query parameter is provided', function () {
+            return new Promise(function (resolve, reject) {
+                const acquireTokenSilentPromise = msal.acquireTokenSilent([msal.clientId], null, null, Constants.sid + "=test");
+
+                acquireTokenSilentPromise
+                    .then(function (token) {
+                        resolve();
+                    })
+                    .catch(function (err) {
+                        reject();
+                    });
+            });
+        });
+
+        it('gets token if an ADAL id token is cached', function () {
+            const realGetItem = msal._cacheStorage.getItem;
+            spyOn(msal._cacheStorage, 'getItem').and.callFake(function (key: string, enableCookieStorage?: boolean) {
+                if (key === Constants.adalIdToken) {
+                    return "fake_adal_id_token";
+                }
+
+                // For all other keys, defer to the real method
+                return realGetItem.call(msal._cacheStorage, key, enableCookieStorage);
+            });
+
+            return new Promise(function (resolve, reject) {
+                const acquireTokenSilentPromise = msal.acquireTokenSilent([msal.clientId]);
+
+                acquireTokenSilentPromise
+                    .then(function (token) {
+                        resolve();
+                    })
+                    .catch(function (err) {
+                        reject(err);
+                    });
+            });
+        });
+    });
+
+    describe('when the user is logged in to the local application', function () {
+        beforeEach(function () {
+            spyOn(msal, 'getUser').and.returnValue(userFake);
+        })
+
+        it('gets token if no hint is provided and no ADAL token is cached', function () {
+            return new Promise(function (resolve, reject) {
+                const acquireTokenSilentPromise = msal.acquireTokenSilent([msal.clientId]);
+
+                acquireTokenSilentPromise
+                    .then(function (token) {
+                        resolve();
+                    })
+                    .catch(function (err) {
+                        reject();
+                    });
+            });
+        });
+
+        it('gets an id token if the scope is the clientId', function () {
+            return new Promise(function (resolve, reject) {
+                const acquireTokenSilentPromise = msal.acquireTokenSilent([msal.clientId]);
+
+                acquireTokenSilentPromise
+                    .then(function (token) {
+                        expect(msal.renewIdToken).toHaveBeenCalled();
+                        expect(msal.renewToken).not.toHaveBeenCalled();
+                        expect(token).toEqual(ID_TOKEN);
+                        resolve();
+                    })
+                    .catch(function (err) {
+                        reject(err);
+                    });
+            });
+        });
+
+        it('gets an access token if the scope is not the clientId', function () {
+            return new Promise(function (resolve, reject) {
+                const acquireTokenSilentPromise = msal.acquireTokenSilent(["otherscope"]);
+
+                acquireTokenSilentPromise
+                    .then(function (token) {
+                        expect(msal.renewIdToken).not.toHaveBeenCalled();
+                        expect(msal.renewToken).toHaveBeenCalled();
+                        expect(token).toEqual(ACCESS_TOKEN);
+                        resolve();
+                    })
+                    .catch(function (err) {
+                        reject(err);
+                    });
+            });
+        });
+    });
 });
-
-


### PR DESCRIPTION
This resolves #275 and #563.

This is an alternative to PR #541.  Rather than adding a new config value that changes the `acquireToken` behavior, this adds a new function.

This adds `loginSilent`, following the same patterns as the existing `loginRedirect` and `loginPopup`.  Like the other `login` processes, `loginSilent` is for attempting to get an id token from the authority without any locally available user data or tokens.  It first uses `acquireTokenSilent` to try to get an id token from cache or with cached data.  Failing that, it makes a new silent request to the authority for an id token.  If the authority has an active session, then an id token is provided.  If the authority does not have an active session, then the promise is rejected.