### PR TITLE
API Changes: Error - First set of changes to UAA

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -91,11 +91,7 @@ export interface CacheResult {
 // TODO: Rework the callback as per new design - handleRedirectCallbacks() implementation etc.
 export type tokenReceivedCallback = (errorDesc: string, token: string, error: string, tokenType: string, userState: string ) => void;
 
-/**
- * A type alias of for a errorReceivedCallback function.
- * @param errorReceivedCallback.err error object created by library that contains the message returned from the STS if API call fails.
- */
-export type errorReceivedCallback = (err: AuthError) => void;
+// TODO: Add second callback for error cases
 
 /**
  * A wrapper to handle the token response/error within the iFrame always
@@ -174,11 +170,6 @@ export class UserAgentApplication {
    * @hidden
    */
   private _tokenReceivedCallback: tokenReceivedCallback = null;
-
-  /**
-   * @hidden
-   */
-  private _errorReceivedCallback: errorReceivedCallback = null;
 
   /**
    * @hidden
@@ -269,7 +260,6 @@ export class UserAgentApplication {
     clientId: string,
     authority: string | null,
     tokenReceivedCallback: tokenReceivedCallback,
-    errorReceivedCallback: errorReceivedCallback,
     options:
       {
         validateAuthority?: boolean,
@@ -316,8 +306,8 @@ export class UserAgentApplication {
     this._logger = logger;
     this.storeAuthStateInCookie = storeAuthStateInCookie;
 
+    // TODO: This should be replaced with two different callbacks for success and error cases
     this._tokenReceivedCallback = tokenReceivedCallback;
-    this._errorReceivedCallback = errorReceivedCallback;
 
     // Track login and acquireToken in progress
     this._loginInProgress = false;

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -366,7 +366,7 @@ export class UserAgentApplication {
     // Validate and filter scopes (the validate function will throw if validation fails)
     this.validateInputScope(scopes, false);
     scopes = this.filterScopes(scopes);
-    
+
     // extract ADAL id_token if exists
     var idTokenObject;
     idTokenObject = this.extractADALIdToken();
@@ -960,7 +960,7 @@ export class UserAgentApplication {
         console.log("ADAL's idToken exists. Extracting login information from ADAL's idToken ");
         extraQueryParameters = Utils.constructUnifiedCacheExtraQueryParameter(idTokenObject, extraQueryParameters);
       }
-      
+
       let authenticationRequest: AuthenticationRequestParameters;
       if (Utils.compareObjects(userObject, this.getUser())) {
         if (scopes.indexOf(this.clientId) > -1) {

--- a/lib/msal-core/src/error/AuthError.ts
+++ b/lib/msal-core/src/error/AuthError.ts
@@ -22,11 +22,6 @@
   */
 
 export const AuthErrorMessage = {
-    // TODO: Should this be an interaction required error?
-    userLoginError: {
-        code: "user_login_error",
-        desc: "User login is required."
-    },
     unexpectedError: {
         code: "unexpected_error",
         desc: "Unexpected error in authentication."

--- a/lib/msal-core/src/error/ClientAuthError.ts
+++ b/lib/msal-core/src/error/ClientAuthError.ts
@@ -152,7 +152,7 @@ export class ClientAuthError extends AuthError {
         return new ClientAuthError(ClientAuthErrorMessage.callbackError.code,
             `${ClientAuthErrorMessage.callbackError.desc} ${errorDesc}.`);
     }
-  
+
     static createUserLoginRequiredError() : ClientAuthError {
         return new ClientAuthError(ClientAuthErrorMessage.userLoginRequiredError.code, ClientAuthErrorMessage.userLoginRequiredError.desc);
     }

--- a/lib/msal-core/src/error/ClientAuthError.ts
+++ b/lib/msal-core/src/error/ClientAuthError.ts
@@ -70,6 +70,10 @@ export const ClientAuthErrorMessage = {
         code: "callback_error",
         desc: "Error occurred in token received callback function."
     },
+    userLoginRequiredError: {
+        code: "user_login_error",
+        desc: "User login is required."
+    },
 };
 
 /**
@@ -140,5 +144,9 @@ export class ClientAuthError extends AuthError {
     static createErrorInCallbackFunction(errorDesc: string): ClientAuthError {
         return new ClientAuthError(ClientAuthErrorMessage.callbackError.code,
             `${ClientAuthErrorMessage.callbackError.desc} ${errorDesc}.`);
+    }
+
+    static createUserLoginRequiredError() : ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.userLoginRequiredError.code, ClientAuthErrorMessage.userLoginRequiredError.desc);
     }
 }

--- a/lib/msal-core/src/error/ClientAuthError.ts
+++ b/lib/msal-core/src/error/ClientAuthError.ts
@@ -111,7 +111,7 @@ export class ClientAuthError extends AuthError {
     }
 
     static createPopupWindowError(errDetail?: string): ClientAuthError {
-        var errorMessage = ClientAuthErrorMessage.endpointResolutionError.desc;
+        var errorMessage = ClientAuthErrorMessage.popUpWindowError.desc;
         if (errDetail && !Utils.isEmpty(errDetail)) {
             errorMessage += ` Details: ${errDetail}`;
         }

--- a/lib/msal-core/src/error/ClientAuthError.ts
+++ b/lib/msal-core/src/error/ClientAuthError.ts
@@ -74,6 +74,10 @@ export const ClientAuthErrorMessage = {
         code: "user_login_error",
         desc: "User login is required."
     },
+    userDoesNotExistError: {
+        code: "user_non_existent",
+        desc: "User object does not exist. Please call a login API."
+    }
 };
 
 /**
@@ -88,10 +92,10 @@ export class ClientAuthError extends AuthError {
         Object.setPrototypeOf(this, ClientAuthError.prototype);
     }
 
-    static createEndpointResolutionError(errDesc: string): ClientAuthError {
+    static createEndpointResolutionError(errDetail?: string): ClientAuthError {
         var errorMessage = ClientAuthErrorMessage.endpointResolutionError.desc;
-        if (!Utils.isEmpty(errDesc)) {
-            errorMessage += ` Details: ${errDesc}`;
+        if (errDetail && !Utils.isEmpty(errDetail)) {
+            errorMessage += ` Details: ${errDetail}`;
         }
         return new ClientAuthError(ClientAuthErrorMessage.endpointResolutionError.code, errorMessage);
     }
@@ -106,9 +110,12 @@ export class ClientAuthError extends AuthError {
             `Cache error for scope ${scope}: ${ClientAuthErrorMessage.multipleMatchingAuthorities.desc}.`);
     }
 
-    static createPopupWindowError(): ClientAuthError {
-        return new ClientAuthError(ClientAuthErrorMessage.popUpWindowError.code,
-            ClientAuthErrorMessage.popUpWindowError.desc);
+    static createPopupWindowError(errDetail?: string): ClientAuthError {
+        var errorMessage = ClientAuthErrorMessage.endpointResolutionError.desc;
+        if (errDetail && !Utils.isEmpty(errDetail)) {
+            errorMessage += ` Details: ${errDetail}`;
+        }
+        return new ClientAuthError(ClientAuthErrorMessage.popUpWindowError.code, errorMessage);
     }
 
     static createTokenRenewalTimeoutError(): ClientAuthError {
@@ -148,5 +155,9 @@ export class ClientAuthError extends AuthError {
 
     static createUserLoginRequiredError() : ClientAuthError {
         return new ClientAuthError(ClientAuthErrorMessage.userLoginRequiredError.code, ClientAuthErrorMessage.userLoginRequiredError.desc);
+    }
+
+    static createUserDoesNotExistError() : ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.userDoesNotExistError.code, ClientAuthErrorMessage.userDoesNotExistError.desc);
     }
 }

--- a/lib/msal-core/src/error/ClientAuthError.ts
+++ b/lib/msal-core/src/error/ClientAuthError.ts
@@ -93,7 +93,7 @@ export class ClientAuthError extends AuthError {
     }
 
     static createEndpointResolutionError(errDetail?: string): ClientAuthError {
-        var errorMessage = ClientAuthErrorMessage.endpointResolutionError.desc;
+        let errorMessage = ClientAuthErrorMessage.endpointResolutionError.desc;
         if (errDetail && !Utils.isEmpty(errDetail)) {
             errorMessage += ` Details: ${errDetail}`;
         }

--- a/lib/msal-core/src/error/ClientConfigurationError.ts
+++ b/lib/msal-core/src/error/ClientConfigurationError.ts
@@ -23,6 +23,7 @@
 
 import { Constants } from "../Constants";
 import { ClientAuthError } from "./ClientAuthError";
+import { AuthError } from "./AuthError";
 
 export const ClientConfigurationErrorMessage = {
     invalidCacheLocation: {
@@ -30,10 +31,14 @@ export const ClientConfigurationErrorMessage = {
         desc: "The cache contains multiple tokens satisfying the requirements. " +
             "Call AcquireToken again providing more requirements like authority."
     },
-    noCallback: {
-        code: "no_callback",
-        desc: "Error in configuration: no callback(s) registered for login/acquireTokenRedirect flows. " +
-            "Please call handleRedirectCallbacks() with the appropriate callback signatures. " +
+    noSuccessCallback: {
+        code: "no_success_callback",
+        desc: "Error in configuration: no success callback(s) registered for login/acquireTokenRedirect flows. " +
+            "More information is available here: https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/-basics."
+    },
+    noErrorCallback: {
+        code: "no_error_callback",
+        desc: "Error in configuration: no error callback(s) registered for login/acquireTokenRedirect flows. " +
             "More information is available here: https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/-basics."
     },
     scopesRequired: {
@@ -90,9 +95,14 @@ export class ClientConfigurationError extends ClientAuthError {
             `${ClientConfigurationErrorMessage.invalidCacheLocation.desc} Provided value: ${givenCacheLocation}. Possible values are: ${Constants.cacheLocationLocal}, ${Constants.cacheLocationSession}.`);
     }
 
-    static createNoCallbackError(): ClientConfigurationError {
-        return new ClientConfigurationError(ClientConfigurationErrorMessage.noCallback.code,
-            ClientConfigurationErrorMessage.noCallback.desc);
+    static createNoSuccessCallbackError(): ClientConfigurationError {
+        return new ClientConfigurationError(ClientConfigurationErrorMessage.noSuccessCallback.code,
+            ClientConfigurationErrorMessage.noSuccessCallback.desc);
+    }
+
+    static createNoErrorCallbackError(thrownError: AuthError): ClientConfigurationError {
+        return new ClientConfigurationError(ClientConfigurationErrorMessage.noErrorCallback.code,
+            `${ClientConfigurationErrorMessage.noErrorCallback.desc} Thrown Error: ${thrownError}`);
     }
 
     static createEmptyScopesArrayError(scopesValue: string): ClientConfigurationError {

--- a/lib/msal-core/tests/MSAL.spec.ts
+++ b/lib/msal-core/tests/MSAL.spec.ts
@@ -241,10 +241,8 @@ describe('Msal', function (): any {
     });
 
     it('navigates user to redirectURI passed as extraQueryParameter', (done) => {
-        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (token) {
-                }, function (err) {
-                },
-                { redirectUri: TEST_REDIR_URI });
+        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (errorDes, token, error) {
+                }, { redirectUri: TEST_REDIR_URI });
         msal._user = null;
         msal._renewStates = [];
         msal._activeRenewals = {};
@@ -466,7 +464,6 @@ describe('Msal', function (): any {
         } catch (e) {
             authErr = e;
         }
-        
         expect(authErr).toEqual(jasmine.any(ClientAuthError));
         msal._loginInProgress = false;
     });
@@ -479,10 +476,6 @@ describe('Msal', function (): any {
             authErr = e;
         }
         expect(authErr).toEqual(jasmine.any(ClientConfigurationError));
-        // expect(errDesc).toBe(ErrorDescription.inputScopesError);
-        // expect(err).toBe(ErrorCodes.inputScopesError);
-        // expect(token).toBe(null);
-        // expect(tokenType).toBe(Constants.idToken);
     });
 
     it('tests if loginRedirect fails with error if clientID is not passed as a single scope in the scopes array', function () {
@@ -676,7 +669,7 @@ describe('Msal', function (): any {
         expect(decodeURIComponent(result[4])).toContain("https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2");
     });
 
-    // TODO: These tests need to be updated to use the success callback path and check that state is passed back there.
+    // We no longer return state as a part of the error, so these tests need to be updated
     // it('tests if you get the state back in tokenReceived callback, if state is a number', function () {
     //     spyOn(msal, 'getUserState').and.returnValue("1234");
     //     msal._loginInProgress = true;
@@ -730,8 +723,6 @@ describe('Msal', function (): any {
             expect(error).toBeUndefined();
             expect(token).toBe(mockIdToken);
             expect(tokenType).toBe(Constants.idToken);
-        }, function(err) {
-            return err;
         }, { storeAuthStateInCookie: true });
         msal._cacheStorage = storageFake;
         var _promptUser = msal.promptUser;
@@ -761,8 +752,6 @@ describe('Msal', function (): any {
              expect(error).toBeUndefined();
              expect(token).toBe(mockIdToken);
              expect(tokenType).toBe(Constants.idToken);
-         }, function (err) {
-             return err;
          }, { cacheLocation: 'localStorage' });
 
          expect(msal._cacheLocation).toBe('localStorage');
@@ -772,16 +761,12 @@ describe('Msal', function (): any {
         var msalInstance = msal;
         var mockIdToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJjbGllbnRpZDEyMyIsIm5hbWUiOiJKb2huIERvZSIsInVwbiI6ImpvaG5AZW1haWwuY29tIiwibm9uY2UiOiIxMjM0In0.bpIBG3n1w7Cv3i_JHRGji6Zuc9F5H8jbDV5q3oj0gcw';
 
-         msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null,
-         function (errorDesc, token, error, tokenType) {
+         msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (errorDesc, token, error, tokenType) {
              expect(document.cookie).toBe('');
              expect(errorDesc).toBeUndefined();
              expect(error).toBeUndefined();
              expect(token).toBe(mockIdToken);
              expect(tokenType).toBe(Constants.idToken);
-         }, 
-         function (err) {
-             return err;
          });
 
          expect(msal._cacheLocation).toBe('sessionStorage');
@@ -790,7 +775,6 @@ describe('Msal', function (): any {
     it('tests cacheLocation functionality malformed strings throw error', function () {
          var msalInstance = msal;
          var mockIdToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJjbGllbnRpZDEyMyIsIm5hbWUiOiJKb2huIERvZSIsInVwbiI6ImpvaG5AZW1haWwuY29tIiwibm9uY2UiOiIxMjM0In0.bpIBG3n1w7Cv3i_JHRGji6Zuc9F5H8jbDV5q3oj0gcw';
-
          msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (errorDesc, token, error, tokenType) {
              expect(document.cookie).toBe('');
              expect(errorDesc).toBe("Cache Location is not valid.");
@@ -856,5 +840,3 @@ describe('acquireTokenSilent functionality', function () {
     });
 
 });
-
-

--- a/lib/msal-core/tests/MSAL.spec.ts
+++ b/lib/msal-core/tests/MSAL.spec.ts
@@ -1,4 +1,4 @@
-import {UserAgentApplication, AuthError, ClientConfigurationError} from '../src/index';
+import {UserAgentApplication, AuthError, ClientConfigurationError, ClientAuthError} from '../src/index';
 import { Constants, ErrorCodes, ErrorDescription} from '../src/Constants';
 import {Authority} from "../src/Authority";
 import {AuthenticationRequestParameters} from "../src/AuthenticationRequestParameters";
@@ -241,8 +241,10 @@ describe('Msal', function (): any {
     });
 
     it('navigates user to redirectURI passed as extraQueryParameter', (done) => {
-        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (errorDes, token, error) {
-                }, { redirectUri: TEST_REDIR_URI });
+        msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (token) {
+                }, function (err) {
+                },
+                { redirectUri: TEST_REDIR_URI });
         msal._user = null;
         msal._renewStates = [];
         msal._activeRenewals = {};
@@ -458,19 +460,14 @@ describe('Msal', function (): any {
 
     it('tests if login function exits with error if loginInProgress is true and callback is called with loginProgress error', function () {
         msal._loginInProgress = true;
-        var errDesc = '', token = '', err = '', tokenType = '';
-        var callback = function (valErrDesc:string, valToken:string, valErr:string, valTokenType:string) {
-            errDesc = valErrDesc;
-            token = valToken;
-            err = valErr;
-            tokenType = valTokenType;
-        };
-        msal._tokenReceivedCallback = callback;
-        msal.loginRedirect();
-        expect(errDesc).toBe(ErrorDescription.loginProgressError);
-        expect(err).toBe(ErrorCodes.loginProgressError);
-        expect(token).toBe(null);
-        expect(tokenType).toBe(Constants.idToken);
+        var authErr: AuthError;
+        try {
+            msal.loginRedirect();
+        } catch (e) {
+            authErr = e;
+        }
+        
+        expect(authErr).toEqual(jasmine.any(ClientAuthError));
         msal._loginInProgress = false;
     });
 
@@ -679,49 +676,50 @@ describe('Msal', function (): any {
         expect(decodeURIComponent(result[4])).toContain("https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2");
     });
 
-    it('tests if you get the state back in tokenReceived callback, if state is a number', function () {
-        spyOn(msal, 'getUserState').and.returnValue("1234");
-        msal._loginInProgress = true;
-        var errDesc = '', token = '', err = '', tokenType = '', state= '' ;
-        var callback = function (valErrDesc:string, valToken:string, valErr:string, valTokenType:string, valState: string) {
-            errDesc = valErrDesc;
-            token = valToken;
-            err = valErr;
-            tokenType = valTokenType;
-            state= valState;
-        };
+    // TODO: These tests need to be updated to use the success callback path and check that state is passed back there.
+    // it('tests if you get the state back in tokenReceived callback, if state is a number', function () {
+    //     spyOn(msal, 'getUserState').and.returnValue("1234");
+    //     msal._loginInProgress = true;
+    //     var errDesc = '', token = '', err = '', tokenType = '', state= '' ;
+    //     var callback = function (valErrDesc:string, valToken:string, valErr:string, valTokenType:string, valState: string) {
+    //         errDesc = valErrDesc;
+    //         token = valToken;
+    //         err = valErr;
+    //         tokenType = valTokenType;
+    //         state= valState;
+    //     };
 
-        msal._tokenReceivedCallback = callback;
-        msal.loginRedirect();
-        expect(errDesc).toBe(ErrorDescription.loginProgressError);
-        expect(err).toBe(ErrorCodes.loginProgressError);
-        expect(token).toBe(null);
-        expect(tokenType).toBe(Constants.idToken);
-        expect(state).toBe('1234');
-        msal._loginInProgress = false;
-    });
+    //     msal._tokenReceivedCallback = callback;
+    //     msal.loginRedirect();
+    //     expect(errDesc).toBe(ErrorDescription.loginProgressError);
+    //     expect(err).toBe(ErrorCodes.loginProgressError);
+    //     expect(token).toBe(null);
+    //     expect(tokenType).toBe(Constants.idToken);
+    //     expect(state).toBe('1234');
+    //     msal._loginInProgress = false;
+    // });
 
-    it('tests if you get the state back in tokenReceived callback, if state is a url', function () {
-        spyOn(msal, 'getUserState').and.returnValue("https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2");
-        msal._loginInProgress = true;
-        var errDesc = '', token = '', err = '', tokenType = '', state= '' ;
-        var callback = function (valErrDesc:string, valToken:string, valErr:string, valTokenType:string, valState: string) {
-            errDesc = valErrDesc;
-            token = valToken;
-            err = valErr;
-            tokenType = valTokenType;
-            state= valState;
-        };
+    // it('tests if you get the state back in tokenReceived callback, if state is a url', function () {
+    //     spyOn(msal, 'getUserState').and.returnValue("https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2");
+    //     msal._loginInProgress = true;
+    //     var errDesc = '', token = '', err = '', tokenType = '', state= '' ;
+    //     var callback = function (valErrDesc:string, valToken:string, valErr:string, valTokenType:string, valState: string) {
+    //         errDesc = valErrDesc;
+    //         token = valToken;
+    //         err = valErr;
+    //         tokenType = valTokenType;
+    //         state= valState;
+    //     };
 
-        msal._tokenReceivedCallback = callback;
-        msal.loginRedirect();
-        expect(errDesc).toBe(ErrorDescription.loginProgressError);
-        expect(err).toBe(ErrorCodes.loginProgressError);
-        expect(token).toBe(null);
-        expect(tokenType).toBe(Constants.idToken);
-        expect(state).toBe('https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2');
-        msal._loginInProgress = false;
-    });
+    //     msal._tokenReceivedCallback = callback;
+    //     msal.loginRedirect();
+    //     expect(errDesc).toBe(ErrorDescription.loginProgressError);
+    //     expect(err).toBe(ErrorCodes.loginProgressError);
+    //     expect(token).toBe(null);
+    //     expect(tokenType).toBe(Constants.idToken);
+    //     expect(state).toBe('https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2');
+    //     msal._loginInProgress = false;
+    // });
 
     it('tests that loginStartPage, nonce and state are saved in cookies if enableCookieStorage flag is enables through the msal optional params', function (done) {
         var msalInstance = msal;
@@ -732,6 +730,8 @@ describe('Msal', function (): any {
             expect(error).toBeUndefined();
             expect(token).toBe(mockIdToken);
             expect(tokenType).toBe(Constants.idToken);
+        }, function(err) {
+            return err;
         }, { storeAuthStateInCookie: true });
         msal._cacheStorage = storageFake;
         var _promptUser = msal.promptUser;
@@ -761,6 +761,8 @@ describe('Msal', function (): any {
              expect(error).toBeUndefined();
              expect(token).toBe(mockIdToken);
              expect(tokenType).toBe(Constants.idToken);
+         }, function (err) {
+             return err;
          }, { cacheLocation: 'localStorage' });
 
          expect(msal._cacheLocation).toBe('localStorage');
@@ -770,12 +772,16 @@ describe('Msal', function (): any {
         var msalInstance = msal;
         var mockIdToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJjbGllbnRpZDEyMyIsIm5hbWUiOiJKb2huIERvZSIsInVwbiI6ImpvaG5AZW1haWwuY29tIiwibm9uY2UiOiIxMjM0In0.bpIBG3n1w7Cv3i_JHRGji6Zuc9F5H8jbDV5q3oj0gcw';
 
-         msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null, function (errorDesc, token, error, tokenType) {
+         msal = new UserAgentApplication("0813e1d1-ad72-46a9-8665-399bba48c201", null,
+         function (errorDesc, token, error, tokenType) {
              expect(document.cookie).toBe('');
              expect(errorDesc).toBeUndefined();
              expect(error).toBeUndefined();
              expect(token).toBe(mockIdToken);
              expect(tokenType).toBe(Constants.idToken);
+         }, 
+         function (err) {
+             return err;
          });
 
          expect(msal._cacheLocation).toBe('sessionStorage');


### PR DESCRIPTION
Please review PR #582 before reviewing this.

This is the first set of changes in the UserAgentApplication class that utilizes the newly added Error objects for MSAL. These changes include:
- login and acquireToken APIs now throw errors directly for configuration errors, and will return errors in callbacks for all errors returned by the server.
- The openWindow and openPopup functions now use the error objects to communicate popupWindow errors