### PR TITLE
Correct formatting of url in replaceFirstPath method

### DIFF
--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -470,7 +470,7 @@ export class Utils {
       var pathArray = urlObject.PathSegments;
       if (pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === Constants.organizations)) {
           pathArray[0] = tenantId;
-          url = urlObject.Protocol + "//" + urlObject.HostNameAndPort + "/" + pathArray.join("/");
+          url = urlObject.Protocol + "//" + urlObject.HostNameAndPort + "/" + pathArray.join("/") + "/";
       }
       return url;
   }


### PR DESCRIPTION
## Current behavior

I've stumbled upon a bug, where we get page reload 1-4 times, occasionally an infinite loop and the error message `Could not retrieve token silently. Multiple authorities found in the cache. Pass authority in the API overload.|multiple_matching_tokens_detected`. I traced down the issue to ending up with two differently formatted sessionStorage keys:

`{"authority":"https://login.microsoftonline.com/<tenant_id>"...}`

and 

`{"authority":"https://login.microsoftonline.com/<tenant_id>/"...}`

With the only difference being the slash (/) at the end.

## Expected behavior

The formatting of the authority key should be consistent, so either no slash or slash at the end.

The issue seems to be the function `replaceFirstPath`, which strips the last `/`.

```
  /**
   * Given a url like https://a:b/common/d?e=f#g, and a tenantId, returns https://a:b/tenantId/d
   * @param href The url
   * @param tenantId The tenant id to replace
   */
  static replaceFirstPath(url: string, tenantId: string): string {
      if (!tenantId) {
          return url;
      }
      var urlObject = this.GetUrlComponents(url);
      var pathArray = urlObject.PathSegments;
      if (pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === Constants.organizations)) {
          pathArray[0] = tenantId;
          url = urlObject.Protocol + "//" + urlObject.HostNameAndPort + "/" + pathArray.join("/");
      }
      return url;
  }
```

So perhaps the solution is only as simple as adding a slash to the end of the url (I tried it and it works) but I'm not sure if that's the intended functionality of the method? I'll gladly adjust my code to suit the specifications.
