### PR TITLE
fix iFrame redirect not calling handleAuthenticationResponse

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -14,7 +14,7 @@ import { Logger } from "./Logger";
 import { TokenResponse } from "./RequestInfo";
 import { Storage } from "./Storage";
 import { User } from "./User";
-import { Utils } from "./Utils";
+import { getUrlHashFromFrame, Utils } from "./Utils";
 
 /**
  * Interface to handle iFrame generation, Popup Window creation and redirect handling
@@ -1152,10 +1152,7 @@ export class UserAgentApplication {
     numberOfExecutionLeft: number
   ): void {
     const timeout = setTimeout(() => {
-      const urlHash =
-        frameHandle.contentWindow &&
-        frameHandle.contentWindow.location &&
-        frameHandle.contentWindow.location.hash;
+      const urlHash = getUrlHashFromFrame(frameHandle);
       const isCallback = this.isCallback(urlHash);
 
       // If redirect is successfully and we have the hash

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -222,6 +222,11 @@ export class UserAgentApplication {
   private _silentLogin: boolean;
 
   /**
+   * Number of retry for the iFrame onload handler
+   */
+  private IFRAME_HANDLE_RETRY_COUNT = 5;
+
+  /**
    * Initialize a UserAgentApplication with a given clientId and authority.
    * @constructor
    * @param {string} clientId - The clientID of your application, you should get this from the application registration portal.
@@ -1124,7 +1129,7 @@ export class UserAgentApplication {
     // Check hash on iframe
     // 100ms delay each check for 5 times. 500ms total delay before function times out.
     frameHandle.onload = () => {
-      this.recursiveDelayCheckFrameHash(frameHandle, 5);
+      this.recursiveDelayCheckFrameHash(frameHandle, this.IFRAME_HANDLE_RETRY_COUNT);
     };
 
     // TODO: VSTS AI, work on either removing the 500ms timeout or making it optional for IE??
@@ -1144,7 +1149,7 @@ export class UserAgentApplication {
    */
   private recursiveDelayCheckFrameHash(
     frameHandle: HTMLIFrameElement,
-    executionsNumber: number
+    numberOfExecutionLeft: number
   ): void {
     const timeout = setTimeout(() => {
       const urlHash =
@@ -1167,8 +1172,8 @@ export class UserAgentApplication {
 
         this.handleAuthenticationResponse(urlHash);
       } else {
-        if (executionsNumber) {
-          this.recursiveDelayCheckFrameHash(frameHandle, executionsNumber - 1);
+        if (numberOfExecutionLeft) {
+          this.recursiveDelayCheckFrameHash(frameHandle, numberOfExecutionLeft - 1);
         }
       }
     }, 100);

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1133,7 +1133,7 @@ export class UserAgentApplication {
         frameHandle.contentDocument || frameHandle.contentWindow.document;
         frameDoc.documentElement.innerHTML = "";
         this._logger.info("Remove frame");
-        
+
         // Check hash on iframe
         // 100ms delay each check for 5 times. 500ms total delay before function times out.
         this.recursiveDelayCheckFrameHash(frameHandle, 5);
@@ -1160,7 +1160,7 @@ export class UserAgentApplication {
   ): void {
     const urlHash = getUrlHashFromFrame(frameHandle);
     const isCallback = this.isCallback(urlHash);
-  
+
     // If redirect is successfully and we have the hash
     if (isCallback) {
       this.handleAuthenticationResponse(urlHash);

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { Constants } from "./Constants";
 import { IUri } from "./IUri";
 import { User } from "./User";
-import {Constants} from "./Constants";
 
 /**
  * @hidden
@@ -588,3 +588,5 @@ export class Utils {
   //#endregion
 
 }
+
+export const getUrlHashFromFrame = (frame: HTMLIFrameElement): string =>  frame.contentWindow && frame.contentWindow.location && frame.contentWindow.location.hash;


### PR DESCRIPTION
The invisible iFrame created by `acquireTokenSilent` will try to load the token url then gets redirect. However, in some case, the redirect will not trigger msal. Resulting in the hash never gets properly parsed. I have changed the behavior to rely on the iFrame calling the `onload` instead of relying on reinitializing msal.

This PR should only effect the `acquireTokenSilent` flow. The `onload` handler on iFrame will trigger 5 times with 100ms delay on each to make sure the iFrame is redirected from login.microsoft.com. After the redirect, it will run the `recursiveDelayCheckFrameHash`. I've also added additional security and clean up on the iFrame. This should prevent the iFrame from loading / initialing the bundle again