### PR TITLE
Canonicalize all URIs when storing and retrieving from cache

### DIFF
--- a/lib/msal-core/src/AccessTokenKey.ts
+++ b/lib/msal-core/src/AccessTokenKey.ts
@@ -15,7 +15,7 @@ export class AccessTokenKey {
 
   constructor(authority: string, clientId: string, scopes: string, uid: string, utid: string) {
     // TODO: Canonicalize authority URI
-    this.authority = authority;
+    this.authority = Utils.CanonicalizeUri(authority);
     this.clientId = clientId;
     this.scopes = scopes;
     this.homeAccountIdentifier = Utils.base64EncodeStringUrlSafe(uid) + "." + Utils.base64EncodeStringUrlSafe(utid);

--- a/lib/msal-core/src/AccessTokenKey.ts
+++ b/lib/msal-core/src/AccessTokenKey.ts
@@ -14,7 +14,6 @@ export class AccessTokenKey {
   homeAccountIdentifier: string;
 
   constructor(authority: string, clientId: string, scopes: string, uid: string, utid: string) {
-    // TODO: Canonicalize authority URI
     this.authority = Utils.CanonicalizeUri(authority);
     this.clientId = clientId;
     this.scopes = scopes;

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1474,7 +1474,7 @@ export class UserAgentApplication {
       for (let i = 0; i < tokenCacheItems.length; i++) {
         const cacheItem = tokenCacheItems[i];
         const cachedScopes = cacheItem.key.scopes.split(" ");
-        if (Utils.containsScope(cachedScopes, scopes) && cacheItem.key.authority === serverAuthenticationRequest.authority) {
+        if (Utils.containsScope(cachedScopes, scopes) && Utils.CanonicalizeUri(cacheItem.key.authority) === serverAuthenticationRequest.authority) {
           filteredItems.push(cacheItem);
         }
       }
@@ -2310,7 +2310,7 @@ export class UserAgentApplication {
   private setAuthorityCache(state: string, authority: string) {
     // Cache authorityKey
     const authorityKey = Storage.generateAuthorityKey(state);
-    this.cacheStorage.setItem(authorityKey, authority, this.inCookie);
+    this.cacheStorage.setItem(authorityKey, Utils.CanonicalizeUri(authority), this.inCookie);
   }
 
   /**

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -452,16 +452,21 @@ export class Utils {
    * @param tenantId The tenant id to replace
    */
   static replaceTenantPath(url: string, tenantId: string): string {
-      if (!tenantId) {
-          return url;
-      }
+      url = url.toLowerCase();
       var urlObject = this.GetUrlComponents(url);
       var pathArray = urlObject.PathSegments;
-      if (pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === SSOTypes.ORGANIZATIONS)) {
-          pathArray[0] = tenantId;
-          url = urlObject.Protocol + "//" + urlObject.HostNameAndPort + "/" + pathArray.join("/");
+      if (!tenantId) {
+        return this.constructAuthorityUriFromObject(urlObject, pathArray);
       }
-      return this.CanonicalizeUri(url);
+      if (pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === SSOTypes.ORGANIZATIONS)) {
+        pathArray[0] = tenantId;
+        return this.constructAuthorityUriFromObject(urlObject, pathArray);
+      }
+      return url;
+  }
+
+  static constructAuthorityUriFromObject(urlObject: IUri, pathArray: string[]) {
+    return this.CanonicalizeUri(urlObject.Protocol + "//" + urlObject.HostNameAndPort + "/" + pathArray.join("/"));
   }
 
   /**

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -455,14 +455,11 @@ export class Utils {
       url = url.toLowerCase();
       var urlObject = this.GetUrlComponents(url);
       var pathArray = urlObject.PathSegments;
-      if (!tenantId) {
-        return this.constructAuthorityUriFromObject(urlObject, pathArray);
-      }
-      if (pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === SSOTypes.ORGANIZATIONS)) {
+      if (tenantId && pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === SSOTypes.ORGANIZATIONS)) {
         pathArray[0] = tenantId;
         return this.constructAuthorityUriFromObject(urlObject, pathArray);
       }
-      return url;
+      return this.constructAuthorityUriFromObject(urlObject, pathArray);
   }
 
   static constructAuthorityUriFromObject(urlObject: IUri, pathArray: string[]) {

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -461,7 +461,7 @@ export class Utils {
           pathArray[0] = tenantId;
           url = urlObject.Protocol + "//" + urlObject.HostNameAndPort + "/" + pathArray.join("/");
       }
-      return Utils.CanonicalizeUri(url);
+      return this.CanonicalizeUri(url);
   }
 
   /**

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -461,7 +461,7 @@ export class Utils {
           pathArray[0] = tenantId;
           url = urlObject.Protocol + "//" + urlObject.HostNameAndPort + "/" + pathArray.join("/");
       }
-      return url;
+      return Utils.CanonicalizeUri(url);
   }
 
   /**

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -457,7 +457,6 @@ export class Utils {
       var pathArray = urlObject.PathSegments;
       if (tenantId && pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === SSOTypes.ORGANIZATIONS)) {
         pathArray[0] = tenantId;
-        return this.constructAuthorityUriFromObject(urlObject, pathArray);
       }
       return this.constructAuthorityUriFromObject(urlObject, pathArray);
   }

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -455,7 +455,7 @@ export class Utils {
       url = url.toLowerCase();
       var urlObject = this.GetUrlComponents(url);
       var pathArray = urlObject.PathSegments;
-      if (tenantId && pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === SSOTypes.ORGANIZATIONS)) {
+      if (tenantId && (pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === SSOTypes.ORGANIZATIONS))) {
         pathArray[0] = tenantId;
       }
       return this.constructAuthorityUriFromObject(urlObject, pathArray);

--- a/lib/msal-core/test/Utils.spec.ts
+++ b/lib/msal-core/test/Utils.spec.ts
@@ -8,4 +8,10 @@ describe("Utils.ts", () => {
         expect(version).to.be.string;
         expect(version.split(".").length).to.be.greaterThan(2);
     });
+
+    it("replaceTenantPath", () => {
+        console.log(Utils.replaceTenantPath("http://a.com/common/d?e=f", "1234-5678"));
+        console.log(Utils.replaceTenantPath("http://a.com/common/", "1234-56778"));
+        console.log(Utils.replaceTenantPath("http://a.com/common", "1234-5678"));
+    });
 });


### PR DESCRIPTION
This PR canonicalizes all URIs when using the authority URIs for cache keys. 

I believe this solution will also capture the issue called out by PR #591.