### PR TITLE
remove dist from npm ignore

### DIFF
--- a/lib/msal-core/.npmignore
+++ b/lib/msal-core/.npmignore
@@ -258,5 +258,4 @@ test/
 typings/
 .git
 coverage/
-dist/
 endToEndTests/


### PR DESCRIPTION
it is a fair build artifact to ship to npm 