### PR TITLE
update acquireTokenAccountKey generation when client_info is empty

### DIFF
--- a/lib/msal-core/src/Account.ts
+++ b/lib/msal-core/src/Account.ts
@@ -78,7 +78,10 @@ export class Account {
         const uid: string = clientInfo ? clientInfo.uid : "";
         const utid: string = clientInfo ? clientInfo.utid : "";
 
-        const homeAccountIdentifier = Utils.base64EncodeStringUrlSafe(uid) + "." + Utils.base64EncodeStringUrlSafe(utid);
+        let homeAccountIdentifier: string;
+        if (!Utils.isEmpty(uid) && !Utils.isEmpty(utid)) {
+            homeAccountIdentifier = Utils.base64EncodeStringUrlSafe(uid) + "." + Utils.base64EncodeStringUrlSafe(utid);
+        }
         return new Account(accountIdentifier, homeAccountIdentifier, idToken.preferredName, idToken.name, idToken.decodedIdToken, idToken.sid, idToken.issuer);
     }
 }

--- a/lib/msal-core/src/Constants.ts
+++ b/lib/msal-core/src/Constants.ts
@@ -86,7 +86,7 @@ export class Constants {
  */
 export const CacheKeys = {
     AUTHORITY: "msal_authority",
-    ACQUIRE_TOKEN_USER: "msal.acquireTokenUser"
+    ACQUIRE_TOKEN_ACCOUNT: "msal.acquireTokenAccount"
 };
 
 /**

--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -165,7 +165,7 @@ export class Storage {// Singleton
      * @param state
      */
     static generateAcquireTokenAccountKey(accountId: any, state: string): string {
-        return CacheKeys.ACQUIRE_TOKEN_USER + Constants.resourceDelimiter +
+        return CacheKeys.ACQUIRE_TOKEN_ACCOUNT + Constants.resourceDelimiter +
             `${accountId}` + Constants.resourceDelimiter  + `${state}`;
     }
 

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1806,7 +1806,7 @@ export class UserAgentApplication {
           let accountKey: string;
           if (response.account && !Utils.isEmpty(response.account.homeAccountIdentifier)) {
             accountKey = response.account.homeAccountIdentifier;
-            }
+          }
           else {
             accountKey = Constants.no_account;
           }
@@ -1877,6 +1877,7 @@ export class UserAgentApplication {
             } else {
               authorityKey = stateInfo.state;
               acquireTokenAccountKey = stateInfo.state;
+
               this.logger.error("Invalid id_token received in the response");
               error = ClientAuthError.createInvalidIdTokenError(response.idToken);
               this.cacheStorage.setItem(Constants.msalError, error.errorCode);
@@ -1891,7 +1892,6 @@ export class UserAgentApplication {
 
         const expectedState = this.cacheStorage.getItem(Constants.stateLogin, this.inCookie);
         this.logger.error("State Mismatch.Expected State: " + expectedState + "," + "Actual State: " + stateInfo.state);
-
         error = ClientAuthError.createInvalidStateError(stateInfo.state, expectedState);
         this.cacheStorage.setItem(Constants.msalError, error.errorCode);
         this.cacheStorage.setItem(Constants.msalErrorDescription, error.errorMessage);
@@ -2320,6 +2320,9 @@ export class UserAgentApplication {
     if (account) {
         accountId = this.getAccountId(account);
     }
+    else {
+        accountId = Constants.no_account;
+    }
 
     const acquireTokenAccountKey = Storage.generateAcquireTokenAccountKey(accountId, state);
     this.cacheStorage.setItem(acquireTokenAccountKey, JSON.stringify(account));
@@ -2343,7 +2346,7 @@ export class UserAgentApplication {
   private getAccountId(account: Account): any {
     //return `${account.accountIdentifier}` + Constants.resourceDelimiter + `${account.homeAccountIdentifier}`;
     let accountId: string;
-    if (account.homeAccountIdentifier) {
+    if (!Utils.isEmpty(account.homeAccountIdentifier)) {
          accountId = account.homeAccountIdentifier;
     }
     else {

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1816,7 +1816,6 @@ export class UserAgentApplication {
           const acquireTokenAccountKey_noaccount = Storage.generateAcquireTokenAccountKey(Constants.no_account, stateInfo.state);
 
           let cachedAccount: string = this.cacheStorage.getItem(acquireTokenAccountKey);
-          console.log("cache acquireTokenAccountKey", cachedAccount);
           let acquireTokenAccount: Account;
 
           // Check with the account in the Cache
@@ -2317,13 +2316,7 @@ export class UserAgentApplication {
   private setAccountCache(account: Account, state: string) {
 
     // Cache acquireTokenAccountKey
-    let accountId: string;
-    if (account) {
-        accountId = this.getAccountId(account);
-    }
-    else {
-        accountId = Constants.no_account;
-    }
+    let accountId = account ? this.getAccountId(account) : Constants.no_account;
 
     const acquireTokenAccountKey = Storage.generateAcquireTokenAccountKey(accountId, state);
     this.cacheStorage.setItem(acquireTokenAccountKey, JSON.stringify(account));

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1799,6 +1799,7 @@ export class UserAgentApplication {
             clientInfo = hashParams[Constants.clientInfo];
           } else {
             this.logger.warning("ClientInfo not received in the response from AAD");
+            throw ClientAuthError.createClientInfoNotPopulatedError("ClientInfo not received in the response from the server");
           }
 
           response.account = Account.createAccount(response.idToken, new ClientInfo(clientInfo));

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -623,7 +623,7 @@ export class Utils {
       ssoParam = {};
     }
 
-    if(!ssoData) {
+    if (!ssoData) {
         return ssoParam;
     }
 

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -623,6 +623,10 @@ export class Utils {
       ssoParam = {};
     }
 
+    if(!ssoData) {
+        return ssoParam;
+    }
+
     switch (ssoType) {
       case SSOTypes.SID: {
         ssoParam[SSOTypes.SID] = ssoData;

--- a/lib/msal-core/src/error/ClientAuthError.ts
+++ b/lib/msal-core/src/error/ClientAuthError.ts
@@ -67,6 +67,10 @@ export const ClientAuthErrorMessage = {
         code: "client_info_decoding_error",
         desc: "The client info could not be parsed/decoded correctly. Please review the trace to determine the root cause."
     },
+    clientInfoNotPopulatedError: {
+        code: "client_info_not_populated_error",
+        desc: "The service did not populate client_info in the response, Please verify with the service team"
+    },
     nullOrEmptyIdToken: {
         code: "null_or_empty_id_token",
         desc: "The idToken is null or empty. Please review the trace to determine the root cause."
@@ -174,6 +178,11 @@ export class ClientAuthError extends AuthError {
     static createClientInfoDecodingError(caughtError: string) : ClientAuthError {
         return new ClientAuthError(ClientAuthErrorMessage.clientInfoDecodingError.code,
             `${ClientAuthErrorMessage.clientInfoDecodingError.desc} Failed with error: ${caughtError}`);
+    }
+
+    static createClientInfoNotPopulatedError(caughtError: string) : ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.clientInfoNotPopulatedError.code,
+            `${ClientAuthErrorMessage.clientInfoNotPopulatedError.desc} Failed with error: ${caughtError}`);
     }
 
     static createIdTokenNullOrEmptyError(invalidRawTokenString: string) : ClientAuthError {

--- a/lib/msal-core/test/Storage.localStorage.spec.ts
+++ b/lib/msal-core/test/Storage.localStorage.spec.ts
@@ -46,9 +46,9 @@ describe("Local Storage", function () {
     };
 
     describe("class constructor", function () {
-        
+
         beforeEach(function () {
-            
+
         });
 
         afterEach(function () {
@@ -134,7 +134,7 @@ describe("Local Storage", function () {
             let actualNextDayUTC = cacheStorage.getCookieExpirationTime(1);
             let dayAfterUTC = new Date(nextDayUTC.getTime() + 86400000);
             let actualDayAfterUTC = cacheStorage.getCookieExpirationTime(2);
-            
+
             expect(actualNextDayUTC).to.be.eq(nextDayUTC.toUTCString());
             expect(actualDayAfterUTC).to.be.eq(dayAfterUTC.toUTCString());
         });
@@ -208,7 +208,7 @@ describe("Local Storage", function () {
             expect(cacheStorage.getItem(authorityKey)).to.be.eq(validAuthority);
 
             cacheStorage.removeAcquireTokenEntries(authorityKey, acquireTokenAccountKey);
-            
+
             expect(cacheStorage.getItem(acquireTokenAccountKey)).to.be.null;
             expect(cacheStorage.getItem(authorityKey)).to.be.null;
         });
@@ -229,7 +229,7 @@ describe("Local Storage", function () {
             expect(cacheStorage.getItem(Constants.renewStatus)).to.be.eq("Completed");
 
             cacheStorage.resetCacheItems();
-            
+
             expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.stateLogin)).to.be.eq("");
@@ -246,7 +246,7 @@ describe("Local Storage", function () {
             let acquireTokenAccountKey = Storage.generateAcquireTokenAccountKey(TEST_ACCOUNT_ID, TEST_STATE);
             expect(acquireTokenAccountKey).to.include(TEST_ACCOUNT_ID);
             expect(acquireTokenAccountKey).to.include(TEST_STATE);
-            expect(acquireTokenAccountKey).to.include(CacheKeys.ACQUIRE_TOKEN_USER);
+            expect(acquireTokenAccountKey).to.include(CacheKeys.ACQUIRE_TOKEN_ACCOUNT);
         });
 
         it("generates authority key", function () {

--- a/lib/msal-core/test/Storage.sessionStorage.spec.ts
+++ b/lib/msal-core/test/Storage.sessionStorage.spec.ts
@@ -46,9 +46,9 @@ describe("Session Storage", function () {
     };
 
     describe("class constructor", function () {
-        
+
         beforeEach(function () {
-            
+
         });
 
         afterEach(function () {
@@ -57,7 +57,7 @@ describe("Session Storage", function () {
         });
 
         it("parses the cache location correctly", function (done) {
-            cacheStorage = new Storage("sessionStorage");    
+            cacheStorage = new Storage("sessionStorage");
             sinon.stub(cacheStorage, <any>"cacheLocation").value("sessionStorage");
             sinon.stub(window.sessionStorage, "setItem").callsFake(function (key, value) {
                 expect(key).to.be.eq(TEST_KEY);
@@ -135,7 +135,7 @@ describe("Session Storage", function () {
             let actualNextDayUTC = cacheStorage.getCookieExpirationTime(1);
             let dayAfterUTC = new Date(nextDayUTC.getTime() + 86400000);
             let actualDayAfterUTC = cacheStorage.getCookieExpirationTime(2);
-            
+
             expect(actualNextDayUTC).to.be.eq(nextDayUTC.toUTCString());
             expect(actualDayAfterUTC).to.be.eq(dayAfterUTC.toUTCString());
         });
@@ -209,7 +209,7 @@ describe("Session Storage", function () {
             expect(cacheStorage.getItem(authorityKey)).to.be.eq(validAuthority);
 
             cacheStorage.removeAcquireTokenEntries(authorityKey, acquireTokenAccountKey);
-            
+
             expect(cacheStorage.getItem(acquireTokenAccountKey)).to.be.null;
             expect(cacheStorage.getItem(authorityKey)).to.be.null;
         });
@@ -230,7 +230,7 @@ describe("Session Storage", function () {
             expect(cacheStorage.getItem(Constants.renewStatus)).to.be.eq("Completed");
 
             cacheStorage.resetCacheItems();
-            
+
             expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.stateLogin)).to.be.eq("");
@@ -247,7 +247,7 @@ describe("Session Storage", function () {
             let acquireTokenAccountKey = Storage.generateAcquireTokenAccountKey(TEST_ACCOUNT_ID, TEST_STATE);
             expect(acquireTokenAccountKey).to.include(TEST_ACCOUNT_ID);
             expect(acquireTokenAccountKey).to.include(TEST_STATE);
-            expect(acquireTokenAccountKey).to.include(CacheKeys.ACQUIRE_TOKEN_USER);
+            expect(acquireTokenAccountKey).to.include(CacheKeys.ACQUIRE_TOKEN_ACCOUNT);
         });
 
         it("generates authority key", function () {

--- a/lib/msal-core/test/error/ClientAuthError.spec.ts
+++ b/lib/msal-core/test/error/ClientAuthError.spec.ts
@@ -321,6 +321,26 @@ describe("ClientAuthError", () => {
     expect(err.stack).to.include("ClientAuthError.spec.js");
   });
 
+  it("createClientInfoNotPopulatedError creates a ClientAuthError object", () => {
+
+    const caughtErrorString = "There was an error.";
+    const clientInfoNotPopulatedError = ClientAuthError.createClientInfoNotPopulatedError(caughtErrorString);
+    let err: ClientAuthError;
+
+    try {
+      throw clientInfoNotPopulatedError;
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err.errorCode).to.equal(ClientAuthErrorMessage.clientInfoNotPopulatedError.code);
+    expect(err.errorMessage).to.include(ClientAuthErrorMessage.clientInfoNotPopulatedError.desc);
+    expect(err.errorMessage).to.include(caughtErrorString);
+    expect(err.message).to.include(ClientAuthErrorMessage.clientInfoNotPopulatedError.desc);
+    expect(err.name).to.equal("ClientAuthError");
+    expect(err.stack).to.include("ClientAuthError.spec.js");
+  });
+
   it("createIdTokenNullOrEmptyError creates a ClientAuthError object", () => {
 
     const invalidRawIdToken = "invalidRawIdToken";


### PR DESCRIPTION
- Fix the case where the account has no "homeAccountIdentifier" while generating an acquireTokenAccountKey in the code. 
- Minor name change to adhere to "account" instead of "user"
- Test cases modified for Storage class
 