### PR TITLE
Handle 'undefined' case for SSO Params generation

### DIFF
--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -623,6 +623,10 @@ export class Utils {
       ssoParam = {};
     }
 
+    if (!ssoData) {
+        return ssoParam;
+    }
+
     switch (ssoType) {
       case SSOTypes.SID: {
         ssoParam[SSOTypes.SID] = ssoData;


### PR DESCRIPTION
In error cases where homeAccountIdentifier is undefined from the server response, need to add a 'undefined' case for SSO Params generation.