### PR TITLE
Fix API for loginInProgress to be public

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -2146,7 +2146,7 @@ export class UserAgentApplication {
   /**
    * tracks if login is in progress
    */
-  protected getLoginInProgress(): boolean {
+  public getLoginInProgress(): boolean {
     const pendingCallback = this.cacheStorage.getItem(Constants.urlHash);
     if (pendingCallback) {
         return true;


### PR DESCRIPTION
This PR is to fix an issue raised here: #670 

This makes the getLoginInProgress function public for the UserAgentApplication object.