### PR TITLE
Add Endpoint Resolution Error Handling for Redirect Cases

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -367,6 +367,10 @@ export class UserAgentApplication {
 
       // Redirect user to login URL
       this.promptUser(urlNavigate);
+    }).catch((err) => {
+      // All catch - when is this executed? Possibly when error is thrown, but not if previous function rejects instead of throwing
+      this.logger.warning("could not resolve endpoints");
+      this.errorReceivedCallback(ClientAuthError.createEndpointResolutionError(err.toString), this.getAccountState(this.silentAuthenticationState));
     });
   }
 
@@ -442,6 +446,10 @@ export class UserAgentApplication {
         this.cacheStorage.setItem(Constants.stateAcquireToken, serverAuthenticationRequest.state, this.inCookie);
         window.location.replace(urlNavigate);
       }
+    }).catch((err) => {
+      // All catch - when is this executed? Possibly when error is thrown, but not if previous function rejects instead of throwing
+      this.logger.warning("could not resolve endpoints");
+      this.errorReceivedCallback(ClientAuthError.createEndpointResolutionError(err.toString), this.getAccountState(this.silentAuthenticationState));
     });
   }
 

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -370,7 +370,7 @@ export class UserAgentApplication {
     }).catch((err) => {
       // All catch - when is this executed? Possibly when error is thrown, but not if previous function rejects instead of throwing
       this.logger.warning("could not resolve endpoints");
-      this.errorReceivedCallback(ClientAuthError.createEndpointResolutionError(err.toString), this.getAccountState(this.silentAuthenticationState));
+      this.errorReceivedCallback(ClientAuthError.createEndpointResolutionError(err.toString), this.getAccountState(this.config.auth.state));
     });
   }
 
@@ -449,7 +449,7 @@ export class UserAgentApplication {
     }).catch((err) => {
       // All catch - when is this executed? Possibly when error is thrown, but not if previous function rejects instead of throwing
       this.logger.warning("could not resolve endpoints");
-      this.errorReceivedCallback(ClientAuthError.createEndpointResolutionError(err.toString), this.getAccountState(this.silentAuthenticationState));
+      this.errorReceivedCallback(ClientAuthError.createEndpointResolutionError(err.toString), this.getAccountState(this.config.auth.state));
     });
   }
 


### PR DESCRIPTION
Adds the catch calls for the discover endpoints call to make sure we are catching errors in these cases.