### PR TITLE
Move state parameter from Configuration to Request

### DIFF
--- a/lib/msal-core/src/AuthenticationParameters.ts
+++ b/lib/msal-core/src/AuthenticationParameters.ts
@@ -16,6 +16,7 @@ export type AuthenticationParameters = {
     extraQueryParameters?: QPDict;
     claimsRequest?: null;
     authority?: string;
+    state?: string;
     correlationId?: string;
     account?: Account;
     sid?: string;

--- a/lib/msal-core/src/Configuration.ts
+++ b/lib/msal-core/src/Configuration.ts
@@ -35,7 +35,6 @@ export type AuthOptions = {
   validateAuthority?: boolean;
   redirectUri?: string | (() => string);
   postLogoutRedirectUri?: string | (() => string);
-  state?: string;
   navigateToLoginRequestUrl?: boolean;
 };
 
@@ -99,7 +98,6 @@ const DEFAULT_AUTH_OPTIONS: AuthOptions = {
   validateAuthority: true,
   redirectUri: () => Utils.getDefaultRedirectUri(),
   postLogoutRedirectUri: () => Utils.getDefaultRedirectUri(),
-  state: "",
   navigateToLoginRequestUrl: true
 };
 

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1253,7 +1253,6 @@ export class UserAgentApplication {
       // Clear the cookie in the hash
       this.cacheStorage.clearCookie();
       const accountState: string = this.getAccountState(stateInfo.state);
-
       if (response) {
         if ((stateInfo.requestType === Constants.renewToken) || response.accessToken) {
           if (window.parent !== window) {
@@ -1943,7 +1942,7 @@ export class UserAgentApplication {
         return state.substring(splitIndex + 1);
       }
     }
-    return "";
+    return state;
   }
 
   /**

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -237,11 +237,10 @@ export class UserAgentApplication {
     this.redirectCallbacksSet = true;
 
     // On the server 302 - Redirect, handle this
-    // TODO: rename pendingCallback to cachedHash
     if (!this.config.framework.isAngular) {
-      const pendingCallback = this.cacheStorage.getItem(Constants.urlHash);
-      if (pendingCallback) {
-        this.processCallBack(pendingCallback, null);
+      const cachedHash = this.cacheStorage.getItem(Constants.urlHash);
+      if (cachedHash) {
+        this.processCallBack(cachedHash, null);
       }
     }
   }
@@ -264,7 +263,11 @@ export class UserAgentApplication {
 
     // Creates navigate url; saves value in cache; redirect user to AAD
     if (this.loginInProgress) {
-      this.errorReceivedCallback(ClientAuthError.createLoginInProgressError(), this.getAccountState(this.silentAuthenticationState));
+      let reqState;
+      if (request) {
+        reqState = request.state;
+      }
+      this.errorReceivedCallback(ClientAuthError.createLoginInProgressError(), reqState);
       return;
     }
 
@@ -277,9 +280,9 @@ export class UserAgentApplication {
     const account: Account = this.getAccount();
 
     // defer queryParameters generation to Helper if developer passes account/sid/login_hint
-     if (Utils.isSSOParam(request)) {
-       // if account is not provided, we pass null
-       this.loginRedirectHelper(account, request, scopes);
+    if (Utils.isSSOParam(request)) {
+      // if account is not provided, we pass null
+      this.loginRedirectHelper(account, request, scopes);
     }
     // else handle the library data
     else {
@@ -335,7 +338,7 @@ export class UserAgentApplication {
         this.clientId, scopes,
         ResponseTypes.id_token,
         this.getRedirectUri(),
-        this.config.auth.state
+        request.state
       );
 
       // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
@@ -395,12 +398,15 @@ export class UserAgentApplication {
 
     // If already in progress, do not proceed
     if (this.acquireTokenInProgress) {
-      this.errorReceivedCallback(ClientAuthError.createAcquireTokenInProgressError(), this.getAccountState(this.silentAuthenticationState));
+      let reqState;
+      if (request) {
+        reqState = request.state;
+      }
+      this.errorReceivedCallback(ClientAuthError.createAcquireTokenInProgressError(), reqState);
       return;
     }
 
     // If no session exists, prompt the user to login.
-    const scope = request.scopes.join(" ").toLowerCase();
     if (!account && !(request.sid  || request.loginHint)) {
       this.logger.info("User login is required");
       throw ClientAuthError.createUserLoginRequiredError();
@@ -421,7 +427,7 @@ export class UserAgentApplication {
         request.scopes,
         responseType,
         this.getRedirectUri(),
-        this.config.auth.state
+        request.state
       );
 
       // Cache nonce
@@ -554,7 +560,7 @@ export class UserAgentApplication {
 
     // Resolve endpoint
     this.authorityInstance.resolveEndpointsAsync().then(() => {
-      let serverAuthenticationRequest = new ServerRequestParameters(this.authorityInstance, this.clientId, scopes, ResponseTypes.id_token, this.getRedirectUri(), this.config.auth.state);
+      let serverAuthenticationRequest = new ServerRequestParameters(this.authorityInstance, this.clientId, scopes, ResponseTypes.id_token, this.getRedirectUri(), request.state);
 
       // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer;
       serverAuthenticationRequest = this.populateQueryParams(account, request, serverAuthenticationRequest);
@@ -662,7 +668,7 @@ export class UserAgentApplication {
           request.scopes,
           responseType,
           this.getRedirectUri(),
-          this.config.auth.state
+          request.state
         );
 
         // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
@@ -875,7 +881,7 @@ export class UserAgentApplication {
         request.scopes,
         responseType,
         this.getRedirectUri(),
-        this.config.auth.state
+        request.state
       );
 
       // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
@@ -1246,7 +1252,7 @@ export class UserAgentApplication {
     try {
       // Clear the cookie in the hash
       this.cacheStorage.clearCookie();
-      const accountState: string = this.getAccountState(this.cacheStorage.getItem(Constants.stateLogin, this.inCookie));
+      const accountState: string = this.getAccountState(stateInfo.state);
 
       if (response) {
         if ((stateInfo.requestType === Constants.renewToken) || response.accessToken) {
@@ -1504,7 +1510,7 @@ export class UserAgentApplication {
             throw AuthError.createUnexpectedError("Account should not be null here.");
           }
         }
-        const aState = this.getAccountState(this.cacheStorage.getItem(Constants.stateLogin, this.inCookie));
+        const aState = this.getAccountState(serverAuthenticationRequest.state);
         let response : AuthResponse = {
           uniqueId: "",
           tenantId: "",
@@ -2078,7 +2084,7 @@ export class UserAgentApplication {
    * @param scopes
    * @param account
    */
-  protected getCachedTokenInternal(scopes : Array<string> , account: Account): AuthResponse {
+  protected getCachedTokenInternal(scopes : Array<string> , account: Account, state: string): AuthResponse {
     // Get the current session's account object
     const accountObject: Account = account || this.getAccount();
     if (!accountObject) {
@@ -2094,7 +2100,7 @@ export class UserAgentApplication {
       scopes,
       responseType,
       this.getRedirectUri(),
-      this.config.auth.state
+      state
     );
 
     // get cached token

--- a/lib/msal-core/test/Configuration.spec.ts
+++ b/lib/msal-core/test/Configuration.spec.ts
@@ -22,7 +22,6 @@ describe("Configuration.ts", () => {
         };
         const configWithDefaults: Configuration = buildConfiguration(config);
         const { auth } = configWithDefaults;
-        expect(auth.state).to.eq("");
         expect(auth.validateAuthority).to.be.true;
     });
     it("buildConfiguration respects auth passed in", () => {
@@ -31,13 +30,11 @@ describe("Configuration.ts", () => {
         const config: Configuration = {
             auth: {
                 clientId: "iamnotreal",
-                state: fake_state,
                 validateAuthority: fake_validateAuthority
             }
         };
         const configWithDefaults: Configuration = buildConfiguration(config);
         const { auth } = configWithDefaults;
-        expect(auth.state).to.eq(fake_state);
         expect(auth.validateAuthority).to.eq(fake_validateAuthority);
     });
     it("buildConfiguration cache defaults", () => {

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -254,7 +254,7 @@ describe("UserAgentApplication", function () {
 
         it('exits login function with error if loginInProgress is true', function (done) {
             sinon.stub(msal, <any>"loginInProgress").value(true);
-            let checkErrorFromLibrary = function (authErr: AuthError) {
+            let checkErrorFromLibrary = function (authErr: AuthError, state: string) {
                 expect(authErr instanceof ClientAuthError).to.be.true;
                 expect(authErr.errorCode).to.equal(ClientAuthErrorMessage.loginProgressError.code);
                 expect(authErr.errorMessage).to.equal(ClientAuthErrorMessage.loginProgressError.desc);
@@ -584,8 +584,7 @@ describe("UserAgentApplication", function () {
             const config: Configuration = {
                 auth: {
                     clientId: MSAL_CLIENT_ID,
-                    redirectUri: TEST_REDIR_URI,
-                    state: TEST_USER_STATE_NUM
+                    redirectUri: TEST_REDIR_URI
                 }
             };
             msal = new UserAgentApplication(config);
@@ -698,8 +697,7 @@ describe("UserAgentApplication", function () {
             const config: Configuration = {
                 auth: {
                     clientId: MSAL_CLIENT_ID,
-                    redirectUri: TEST_REDIR_URI,
-                    state: TEST_USER_STATE_NUM
+                    redirectUri: TEST_REDIR_URI
                 }
             };
             msal = new UserAgentApplication(config);

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -33,11 +33,11 @@ describe("UserAgentApplication", function () {
     const ALTERNATE_INSTANCE = "https://login.windows.net/"
     const TEST_REDIR_URI = "https://localhost:8081/redirect.html";
     const TEST_LOGOUT_URI = "https://localhost:8081/logout.html";
-    const TEST_ERROR_HASH = "#error=error_code&error_description=msal+error+description&state=12345";
+    const TEST_ERROR_HASH = "#error=error_code&error_description=msal+error+description";
     const TEST_ERROR_CODE = "error_code";
     const TEST_ERROR_DESC = "msal error description"
     const TEST_USER_STATE_NUM = "1234";
-    const TEST_USER_STATE_URL = "https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2";
+    const TEST_USER_STATE_URL = "https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow/scope1";
     const TEST_STATE = "6789|" + TEST_USER_STATE_NUM;
     const TEST_CLIENT_INFO_B64ENCODED = "eyJ1aWQiOiIxMjM0NSIsInV0aWQiOiI2Nzg5MCJ9";
     const TENANT = 'common';
@@ -598,9 +598,10 @@ describe("UserAgentApplication", function () {
         });
 
         it("tests saveTokenForHash in case of error", function(done) {
-            cacheStorage.setItem(Constants.urlHash, TEST_ERROR_HASH);
-            cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
+            let errHash = TEST_ERROR_HASH + "&state=RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM;
+            cacheStorage.setItem(Constants.urlHash, errHash);
             let checkErrorFromServer = function(error: AuthError, accountState: string) {
+                expect(accountState).to.be.eq(TEST_USER_STATE_NUM);
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
                 expect(error instanceof ServerError).to.be.true;
                 expect(error.name).to.include("ServerError");
@@ -614,8 +615,8 @@ describe("UserAgentApplication", function () {
         });
 
         it("tests if you get the state back in errorReceived callback, if state is a number", function (done) {
-            cacheStorage.setItem(Constants.urlHash, TEST_ERROR_HASH);
-            cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
+            let errHash = TEST_ERROR_HASH + "&state=RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM;
+            cacheStorage.setItem(Constants.urlHash, errHash);
             let checkErrorHasState = function(error: AuthError, accountState: string) {
                 expect(accountState).to.include(TEST_USER_STATE_NUM);
                 done();
@@ -624,8 +625,8 @@ describe("UserAgentApplication", function () {
         });
 
         it("tests if you get the state back in errorReceived callback, if state is a url", function (done) {
-            cacheStorage.setItem(Constants.urlHash, TEST_ERROR_HASH);
-            cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_URL);
+            let errHash = TEST_ERROR_HASH + "&state=RANDOM-GUID-HERE|" + TEST_USER_STATE_URL;
+            cacheStorage.setItem(Constants.urlHash, errHash);
             let checkErrorHasState = function(error: AuthError, accountState: string) {
                 expect(accountState).to.include(TEST_USER_STATE_URL);
                 done();
@@ -717,7 +718,7 @@ describe("UserAgentApplication", function () {
 
         it('test getAccountState when there is no user state', function () {
             var result = msal.getAccountState("123465464565");
-            expect(result).to.be.eq("");
+            expect(result).to.be.eq("123465464565");
         });
 
         it('test getAccountState when there is no state', function () {


### PR DESCRIPTION
This PR moves the state parameter from the Configuration object to the request object. This more closely follows the Open ID Connect protocol [here](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest). 

Also includes name change for cachedHash.