### PR TITLE
Fix MSAL cache cleaning method

### DIFF
--- a/lib/msal-core/src/Constants.ts
+++ b/lib/msal-core/src/Constants.ts
@@ -85,7 +85,7 @@ export class Constants {
  * @hidden
  */
 export const CacheKeys = {
-    AUTHORITY: "msal_authority",
+    AUTHORITY: "msal.authority",
     ACQUIRE_TOKEN_USER: "msal.acquireTokenUser"
 };
 

--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -101,6 +101,8 @@ export class Storage {// Singleton
                         if (state && !this.tokenRenewalInProgress(state)) {
                             this.removeItem(key);
                             this.removeItem(Constants.renewStatus + state);
+                            this.removeItem(Constants.stateLogin);
+                            this.removeItem(Constants.stateAcquireToken);
                             this.setItemCookie(key, "", -1);
                         }
                     }

--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -98,7 +98,7 @@ export class Storage {// Singleton
                 if (storage.hasOwnProperty(key)) {
                     if (key.indexOf(CacheKeys.AUTHORITY) !== -1 || key.indexOf(CacheKeys.ACQUIRE_TOKEN_USER) !== 1) {
                         const state = key.split(Constants.resourceDelimiter)[1];
-                        if (!this.tokenRenewalInProgress(state)) {
+                        if (state && !this.tokenRenewalInProgress(state)) {
                             this.removeItem(key);
                             this.removeItem(Constants.renewStatus + state);
                             this.setItemCookie(key, "", -1);

--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -90,18 +90,31 @@ export class Storage {// Singleton
         return results;
     }
 
-    removeAcquireTokenEntries(authorityKey: string, acquireTokenAccountKey: string): void {
+    removeAcquireTokenEntries(): void {
         const storage = window[this.cacheLocation];
         if (storage) {
             let key: string;
             for (key in storage) {
                 if (storage.hasOwnProperty(key)) {
-                    if ((authorityKey !== "" && key.indexOf(authorityKey) > -1) || (acquireTokenAccountKey !== "" && key.indexOf(acquireTokenAccountKey) > -1)) {
-                        this.removeItem(key);
+                    if (key.indexOf(CacheKeys.AUTHORITY) !== -1 || key.indexOf(CacheKeys.ACQUIRE_TOKEN_USER) !== 1) {
+                        const state = key.split(Constants.resourceDelimiter)[1];
+                        if (!this.tokenRenewalInProgress(state)) {
+                            this.removeItem(key);
+                            this.removeItem(Constants.renewStatus + state);
+                            this.setItemCookie(key, "", -1);
+                        }
                     }
                 }
             }
         }
+
+        this.clearCookie();
+    }
+
+    private tokenRenewalInProgress(stateValue: string): boolean {
+        const storage = window[this.cacheLocation];
+        const renewStatus = storage[Constants.renewStatus + stateValue];
+        return !(!renewStatus || renewStatus !== Constants.tokenRenewStatusInProgress);
     }
 
     resetCacheItems(): void {
@@ -113,11 +126,9 @@ export class Storage {// Singleton
                     if (key.indexOf(Constants.msal) !== -1) {
                         this.setItem(key, "");
                     }
-                    if (key.indexOf(Constants.renewStatus) !== -1) {
-                        this.removeItem(key);
-                    }
                 }
             }
+            this.removeAcquireTokenEntries();
         }
     }
 

--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -97,7 +97,11 @@ export class Storage {// Singleton
             for (key in storage) {
                 if (storage.hasOwnProperty(key)) {
                     if (key.indexOf(CacheKeys.AUTHORITY) !== -1 || key.indexOf(CacheKeys.ACQUIRE_TOKEN_USER) !== 1) {
-                        const state = key.split(Constants.resourceDelimiter)[1];
+                        const splitKey = key.split(Constants.resourceDelimiter);
+                        let state;
+                        if (splitKey.length > 1) {
+                            state = splitKey[1];
+                        }
                         if (state && !this.tokenRenewalInProgress(state)) {
                             this.removeItem(key);
                             this.removeItem(Constants.renewStatus + state);

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -352,18 +352,7 @@ export class UserAgentApplication {
         this.cacheStorage.setItem(Constants.angularLoginRequest, "");
       }
 
-      // Cache the state, nonce, and login request data
-      this.cacheStorage.setItem(Constants.loginRequest, loginStartPage, this.inCookie);
-      this.cacheStorage.setItem(Constants.loginError, "");
-
-      this.cacheStorage.setItem(Constants.stateLogin, serverAuthenticationRequest.state, this.inCookie);
-      this.cacheStorage.setItem(Constants.nonceIdToken, serverAuthenticationRequest.nonce, this.inCookie);
-
-      this.cacheStorage.setItem(Constants.msalError, "");
-      this.cacheStorage.setItem(Constants.msalErrorDescription, "");
-
-      // Cache authorityKey
-      this.setAuthorityCache(serverAuthenticationRequest.state, this.authority);
+      this.updateCacheEntries(serverAuthenticationRequest, account, loginStartPage);
 
       // build URL to navigate to proceed with the login
       let urlNavigate = serverAuthenticationRequest.createNavigateUrl(scopes) + Constants.response_mode_fragment;
@@ -430,7 +419,7 @@ export class UserAgentApplication {
         request.state
       );
 
-      this.updateAcquireTokenCacheEntries(serverAuthenticationRequest, account);
+      this.updateCacheEntries(serverAuthenticationRequest, account);
 
       // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
       serverAuthenticationRequest = this.populateQueryParams(account, request, serverAuthenticationRequest);
@@ -558,6 +547,8 @@ export class UserAgentApplication {
       // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer;
       serverAuthenticationRequest = this.populateQueryParams(account, request, serverAuthenticationRequest);
 
+      this.updateCacheEntries(serverAuthenticationRequest, account, window.location.href);
+
       // Cache the state, nonce, and login request data
       this.cacheStorage.setItem(Constants.loginRequest, window.location.href, this.inCookie);
       this.cacheStorage.setItem(Constants.loginError, "");
@@ -667,7 +658,7 @@ export class UserAgentApplication {
         // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
         serverAuthenticationRequest = this.populateQueryParams(account, request, serverAuthenticationRequest);
 
-        this.updateAcquireTokenCacheEntries(serverAuthenticationRequest, account);
+        this.updateCacheEntries(serverAuthenticationRequest, account);
 
         // Construct the urlNavigate
         let urlNavigate = serverAuthenticationRequest.createNavigateUrl(request.scopes) + Constants.response_mode_fragment;
@@ -1560,7 +1551,7 @@ export class UserAgentApplication {
     this.logger.verbose("renewToken is called for scope:" + scope);
     const frameHandle = this.addHiddenIFrame("msalRenewFrame" + scope);
 
-    this.updateAcquireTokenCacheEntries(serverAuthenticationRequest, account);
+    this.updateCacheEntries(serverAuthenticationRequest, account);
     this.logger.verbose("Renew token Expected state: " + serverAuthenticationRequest.state);
 
     // Build urlNavigate with "prompt=none" and navigate to URL in hidden iFrame
@@ -1584,7 +1575,7 @@ export class UserAgentApplication {
     this.logger.info("renewidToken is called");
     const frameHandle = this.addHiddenIFrame("msalIdTokenFrame");
 
-    this.updateAcquireTokenCacheEntries(serverAuthenticationRequest, account);
+    this.updateCacheEntries(serverAuthenticationRequest, account);
 
     this.logger.verbose("Renew Idtoken Expected state: " + serverAuthenticationRequest.state);
 
@@ -2300,9 +2291,22 @@ export class UserAgentApplication {
    * @param serverAuthenticationRequest
    * @param account
    */
-  private updateAcquireTokenCacheEntries(serverAuthenticationRequest: ServerRequestParameters, account: Account) {
+  private updateCacheEntries(serverAuthenticationRequest: ServerRequestParameters, account: Account, loginStartPage?: any) {
     // Cache account and authority
-    this.setAccountCache(account, serverAuthenticationRequest.state);
+    if (loginStartPage) {
+      // Cache the state, nonce, and login request data
+      this.cacheStorage.setItem(Constants.loginRequest, loginStartPage, this.inCookie);
+      this.cacheStorage.setItem(Constants.loginError, "");
+
+      this.cacheStorage.setItem(Constants.stateLogin, serverAuthenticationRequest.state, this.inCookie);
+      this.cacheStorage.setItem(Constants.nonceIdToken, serverAuthenticationRequest.nonce, this.inCookie);
+
+      this.cacheStorage.setItem(Constants.msalError, "");
+      this.cacheStorage.setItem(Constants.msalErrorDescription, "");
+    } else {
+      this.setAccountCache(account, serverAuthenticationRequest.state);
+    }
+    // Cache authorityKey
     this.setAuthorityCache(serverAuthenticationRequest.state, serverAuthenticationRequest.authority);
 
     // Cache nonce

--- a/lib/msal-core/test/Storage.localStorage.spec.ts
+++ b/lib/msal-core/test/Storage.localStorage.spec.ts
@@ -207,7 +207,7 @@ describe("Local Storage", function () {
             expect(cacheStorage.getItem(acquireTokenAccountKey)).to.be.eq(JSON.stringify(ACCOUNT));
             expect(cacheStorage.getItem(authorityKey)).to.be.eq(validAuthority);
 
-            cacheStorage.removeAcquireTokenEntries(authorityKey, acquireTokenAccountKey);
+            cacheStorage.removeAcquireTokenEntries();
             
             expect(cacheStorage.getItem(acquireTokenAccountKey)).to.be.null;
             expect(cacheStorage.getItem(authorityKey)).to.be.null;
@@ -219,17 +219,17 @@ describe("Local Storage", function () {
             window.localStorage.setItem(Constants.stateLogin, "stateLogin");
             window.localStorage.setItem(Constants.idTokenKey, "idToken1");
             window.localStorage.setItem(Constants.nonceIdToken, "idTokenNonce");
-            window.localStorage.setItem(Constants.renewStatus, "Completed");
+            window.localStorage.setItem(Constants.renewStatus + "|RANDOM_GUID", "Completed");
 
             expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("clientInfo");
             expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("tokenKeys");
             expect(cacheStorage.getItem(Constants.stateLogin)).to.be.eq("stateLogin");
             expect(cacheStorage.getItem(Constants.idTokenKey)).to.be.eq("idToken1");
             expect(cacheStorage.getItem(Constants.nonceIdToken)).to.be.eq("idTokenNonce");
-            expect(cacheStorage.getItem(Constants.renewStatus)).to.be.eq("Completed");
+            expect(cacheStorage.getItem(Constants.renewStatus + "|RANDOM_GUID")).to.be.eq("Completed");
 
             cacheStorage.resetCacheItems();
-            
+
             expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.stateLogin)).to.be.eq("");

--- a/lib/msal-core/test/Storage.localStorage.spec.ts
+++ b/lib/msal-core/test/Storage.localStorage.spec.ts
@@ -232,10 +232,10 @@ describe("Local Storage", function () {
 
             expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("");
-            expect(cacheStorage.getItem(Constants.stateLogin)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.idTokenKey)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.nonceIdToken)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.renewStatus)).to.be.null;
+            expect(cacheStorage.getItem(Constants.stateLogin)).to.be.null;
         });
 
     });

--- a/lib/msal-core/test/Storage.sessionStorage.spec.ts
+++ b/lib/msal-core/test/Storage.sessionStorage.spec.ts
@@ -233,10 +233,10 @@ describe("Session Storage", function () {
             
             expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("");
-            expect(cacheStorage.getItem(Constants.stateLogin)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.idTokenKey)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.nonceIdToken)).to.be.eq("");
             expect(cacheStorage.getItem(Constants.renewStatus)).to.be.null;
+            expect(cacheStorage.getItem(Constants.stateLogin)).to.be.null;
         });
 
     });

--- a/lib/msal-core/test/Storage.sessionStorage.spec.ts
+++ b/lib/msal-core/test/Storage.sessionStorage.spec.ts
@@ -208,7 +208,7 @@ describe("Session Storage", function () {
             expect(cacheStorage.getItem(acquireTokenAccountKey)).to.be.eq(JSON.stringify(ACCOUNT));
             expect(cacheStorage.getItem(authorityKey)).to.be.eq(validAuthority);
 
-            cacheStorage.removeAcquireTokenEntries(authorityKey, acquireTokenAccountKey);
+            cacheStorage.removeAcquireTokenEntries();
             
             expect(cacheStorage.getItem(acquireTokenAccountKey)).to.be.null;
             expect(cacheStorage.getItem(authorityKey)).to.be.null;
@@ -220,14 +220,14 @@ describe("Session Storage", function () {
             window.sessionStorage.setItem(Constants.stateLogin, "stateLogin");
             window.sessionStorage.setItem(Constants.idTokenKey, "idToken1");
             window.sessionStorage.setItem(Constants.nonceIdToken, "idTokenNonce");
-            window.sessionStorage.setItem(Constants.renewStatus, "Completed");
+            window.sessionStorage.setItem(Constants.renewStatus + "|RANDOM_GUID", "Completed");
 
             expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("clientInfo");
             expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("tokenKeys");
             expect(cacheStorage.getItem(Constants.stateLogin)).to.be.eq("stateLogin");
             expect(cacheStorage.getItem(Constants.idTokenKey)).to.be.eq("idToken1");
             expect(cacheStorage.getItem(Constants.nonceIdToken)).to.be.eq("idTokenNonce");
-            expect(cacheStorage.getItem(Constants.renewStatus)).to.be.eq("Completed");
+            expect(cacheStorage.getItem(Constants.renewStatus + "|RANDOM_GUID")).to.be.eq("Completed");
 
             cacheStorage.resetCacheItems();
             

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -614,7 +614,7 @@ describe("UserAgentApplication", function () {
             msal.handleRedirectCallbacks(successCallback, checkErrorFromServer);
         });
 
-        it("tests if you get the state back in errorReceived callback, if state is a number", function (done) {
+        it.only("tests if you get the state back in errorReceived callback, if state is a number", function (done) {
             cacheStorage.setItem(Constants.urlHash, TEST_ERROR_HASH);
             cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
             let checkErrorHasState = function(error: AuthError, accountState: string) {


### PR DESCRIPTION
This PR is a fix for issue #527 where cache keys are not being cleared out. 

A previous PR (#544) was submitted for this, but was failing some use cases. This fix works for manually tested use cases and passes all unit tests.