### PR TITLE
First stab to make the wait time configurable

### DIFF
--- a/lib/msal-core/src/Configuration.ts
+++ b/lib/msal-core/src/Configuration.ts
@@ -12,7 +12,7 @@ export type CacheLocation = "localStorage" | "sessionStorage";
  */
 const FRAME_TIMEOUT = 6000;
 const OFFSET = 300;
-const LOAD_FRAME_WAIT_TIME = 500;
+const NAVIGATE_FRAME_WAIT = 500;
 
 
 /**
@@ -65,7 +65,7 @@ export type SystemOptions = {
   logger?: Logger;
   loadFrameTimeout?: number;
   tokenRenewalOffsetSeconds?: number;
-  waitTimeToLoadFrame?: number;
+  navigateFrameWait?: number;
 };
 
 /**
@@ -115,7 +115,7 @@ const DEFAULT_SYSTEM_OPTIONS: SystemOptions = {
   logger: new Logger(null),
   loadFrameTimeout: FRAME_TIMEOUT,
   tokenRenewalOffsetSeconds: OFFSET,
-  waitTimeToLoadFrame: LOAD_FRAME_WAIT_TIME
+  navigateFrameWait: NAVIGATE_FRAME_WAIT
 };
 
 const DEFAULT_FRAMEWORK_OPTIONS: FrameworkOptions = {

--- a/lib/msal-core/src/Configuration.ts
+++ b/lib/msal-core/src/Configuration.ts
@@ -12,6 +12,8 @@ export type CacheLocation = "localStorage" | "sessionStorage";
  */
 const FRAME_TIMEOUT = 6000;
 const OFFSET = 300;
+const LOAD_FRAME_WAIT_TIME = 500;
+
 
 /**
  *  Authentication Options
@@ -63,6 +65,7 @@ export type SystemOptions = {
   logger?: Logger;
   loadFrameTimeout?: number;
   tokenRenewalOffsetSeconds?: number;
+  waitTimeToLoadFrame?: number;
 };
 
 /**
@@ -111,7 +114,8 @@ const DEFAULT_CACHE_OPTIONS: CacheOptions = {
 const DEFAULT_SYSTEM_OPTIONS: SystemOptions = {
   logger: new Logger(null),
   loadFrameTimeout: FRAME_TIMEOUT,
-  tokenRenewalOffsetSeconds: OFFSET
+  tokenRenewalOffsetSeconds: OFFSET,
+  waitTimeToLoadFrame: LOAD_FRAME_WAIT_TIME
 };
 
 const DEFAULT_FRAMEWORK_OPTIONS: FrameworkOptions = {

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1017,7 +1017,7 @@ export class UserAgentApplication {
         this.logger.infoPii("Frame Name : " + frameName + " Navigated to: " + urlNavigate);
       }
     },
-    this.config.system.waitTimeToLoadFrame);
+    this.config.system.navigateFrameWait);
   }
 
   /**

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1017,7 +1017,7 @@ export class UserAgentApplication {
         this.logger.infoPii("Frame Name : " + frameName + " Navigated to: " + urlNavigate);
       }
     },
-    500);
+    this.config.system.waitTimeToLoadFrame);
   }
 
   /**


### PR DESCRIPTION
Today we are hardcoding the wait time of 500ms when we load an iFrame. Added this to make it configurable.

Future rollout:
To make this more accurate by dynamically checking if the iFrame is loaded and further improvements if possible.