### PR TITLE
Remove guid from state in response cases

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1802,7 +1802,7 @@ export class UserAgentApplication {
         if (hashParams.hasOwnProperty(Constants.sessionState)) {
             this.cacheStorage.setItem(Constants.msalSessionState, hashParams[Constants.sessionState]);
         }
-        response.accountState = stateInfo.state;
+        response.accountState = this.getAccountState(stateInfo.state);
 
         let clientInfo: string = "";
 


### PR DESCRIPTION
This PR is for a fix to remove the guid from the state parameter in the response in successful cases. This allows users to retrieve the state they passed in. This state is tied to the request state passed into the msal APIs.

This PR will also fix the issue raised in #548.