### PR TITLE
Fix postLogoutUri adding extra slash

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1214,7 +1214,7 @@ export class UserAgentApplication {
     if (this.getPostLogoutRedirectUri()) {
       logout = "post_logout_redirect_uri=" + encodeURIComponent(this.getPostLogoutRedirectUri());
     }
-    const urlNavigate = this.authority + "/oauth2/v2.0/logout?" + logout;
+    const urlNavigate = this.authority + "oauth2/v2.0/logout?" + logout;
     this.promptUser(urlNavigate);
   }
 

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -800,13 +800,12 @@ describe("UserAgentApplication.ts Class", function () {
         });
 
         it("adds postLogoutRedirectUri to logout URI", function (done) {
-            // TODO: This test fails because we are appending a '/' character too many times. Will push a fix for this soon.
-            // sinon.stub(window.location, "replace").callsFake(function (url) {
-            //     expect(url).to.include(DEFAULT_INSTANCE + TENANT + '/oauth2/v2.0/logout?');
-            //     expect(url).to.include(TEST_LOGOUT_URI);
+            sinon.stub(window.location, "replace").callsFake(function (url) {
+                expect(url).to.include(DEFAULT_INSTANCE + TENANT + '/oauth2/v2.0/logout?');
+                expect(url).to.include(encodeURIComponent(TEST_LOGOUT_URI));
                 done();
-            // });
-            // msal.logout();
+            });
+            msal.logout();
         });
     });
 


### PR DESCRIPTION
Previously some tests were failing due to an extra slash being added to the postLogoutRedirectUri. This PR fixes this functionality.