### PR TITLE
Fix: navigateToLoginRequestUrl set to false does not call callbacks

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1383,7 +1383,8 @@ export class UserAgentApplication {
         window.location.hash = "";
       }
       if (!this.redirectCallbacksSet) {
-        // We reached this point too early, return and come back later
+        // We reached this point too early - cache hash, return and process in handleRedirectCallbacks
+        self.cacheStorage.setItem(Constants.urlHash, hash);
         return;
       }
     }


### PR DESCRIPTION
This PR is a fix for issue #689. This was a bug introduced with changes to the API.

We now cache the hash briefly before processing the callback in handleRedirectCallback. 