### PR TITLE
Delete MSAL related cache entries on logout instead of clearing values

### DIFF
--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -130,7 +130,7 @@ export class Storage {// Singleton
             for (key in storage) {
                 if (storage.hasOwnProperty(key)) {
                     if (key.indexOf(Constants.msal) !== -1) {
-                        this.setItem(key, "");
+                        this.removeItem(key);
                     }
                 }
             }

--- a/lib/msal-core/test/Storage.localStorage.spec.ts
+++ b/lib/msal-core/test/Storage.localStorage.spec.ts
@@ -213,7 +213,7 @@ describe("CacheStorage.ts Class - Local Storage", function () {
             expect(cacheStorage.getItem(authorityKey)).to.be.null;
         });
 
-        it("resetCacheItems resets all msal related cache items", function () {
+        it("resetCacheItems deletes all msal related cache items", function () {
             window.localStorage.setItem(Constants.msalClientInfo, "clientInfo");
             window.localStorage.setItem(Constants.tokenKeys, "tokenKeys");
             window.localStorage.setItem(Constants.stateLogin, "stateLogin");
@@ -230,10 +230,10 @@ describe("CacheStorage.ts Class - Local Storage", function () {
 
             cacheStorage.resetCacheItems();
 
-            expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("");
-            expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("");
-            expect(cacheStorage.getItem(Constants.idTokenKey)).to.be.eq("");
-            expect(cacheStorage.getItem(Constants.nonceIdToken)).to.be.eq("");
+            expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.null;
+            expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.null;
+            expect(cacheStorage.getItem(Constants.idTokenKey)).to.be.null;
+            expect(cacheStorage.getItem(Constants.nonceIdToken)).to.be.null;
             expect(cacheStorage.getItem(Constants.renewStatus)).to.be.null;
             expect(cacheStorage.getItem(Constants.stateLogin)).to.be.null;
         });

--- a/lib/msal-core/test/Storage.sessionStorage.spec.ts
+++ b/lib/msal-core/test/Storage.sessionStorage.spec.ts
@@ -214,7 +214,7 @@ describe("CacheStorage.ts Class - Session Storage", function () {
             expect(cacheStorage.getItem(authorityKey)).to.be.null;
         });
 
-        it("resetCacheItems resets all msal related cache items", function () {
+        it("resetCacheItems deletes all msal related cache items", function () {
             window.sessionStorage.setItem(Constants.msalClientInfo, "clientInfo");
             window.sessionStorage.setItem(Constants.tokenKeys, "tokenKeys");
             window.sessionStorage.setItem(Constants.stateLogin, "stateLogin");
@@ -231,10 +231,10 @@ describe("CacheStorage.ts Class - Session Storage", function () {
 
             cacheStorage.resetCacheItems();
 
-            expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.eq("");
-            expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.eq("");
-            expect(cacheStorage.getItem(Constants.idTokenKey)).to.be.eq("");
-            expect(cacheStorage.getItem(Constants.nonceIdToken)).to.be.eq("");
+            expect(cacheStorage.getItem(Constants.msalClientInfo)).to.be.null;
+            expect(cacheStorage.getItem(Constants.tokenKeys)).to.be.null;
+            expect(cacheStorage.getItem(Constants.idTokenKey)).to.be.null;
+            expect(cacheStorage.getItem(Constants.nonceIdToken)).to.be.null;
             expect(cacheStorage.getItem(Constants.renewStatus)).to.be.null;
             expect(cacheStorage.getItem(Constants.stateLogin)).to.be.null;
         });


### PR DESCRIPTION
This PR is created to delete cache entries relating to the MSAL library.