### PR TITLE
Add note to build msal-core before running samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,6 @@ lib-commonjs/
 lib-es6/
 lib/msal-core/lib-commonjs
 lib/msal-core/lib-es6
+
+# VS Code
+.vscode

--- a/lib/msal-core/samples/VanillaJSTestApp-b2c/Readme.md
+++ b/lib/msal-core/samples/VanillaJSTestApp-b2c/Readme.md
@@ -1,15 +1,16 @@
 What is this sample?
 --------------------
-This is a simple JavaScript Simple page application 
-showcasing how to use MSAL.js to authenticate users 
-via Azure Active Directory B2C, 
-and access a Web API with the resulting tokens. 
+This is a simple JavaScript Simple page application
+showcasing how to use MSAL.js to authenticate users
+via Azure Active Directory B2C,
+and access a Web API with the resulting tokens.
 
 
 How to run this AzureAD B2C sample
 ----------------------------------
 Pre-requisite
 - Install node.js if needed (https://nodejs.org/en/)
+- Build the `msal-core` project.
 
 Resolving the server.js references
 - In a command prompt, run npm install
@@ -24,5 +25,5 @@ Running the sample
   alternatively sign-in with a gmail account
 - Once signed-in, the "Logout" button appears
 - Click on "Call Web Api" to call the Web APi application (which source code is in https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi)
- 
+
  Signing-in with an MSA or a Twitter account does not work yet.

--- a/lib/msal-core/samples/VanillaJSTestApp/Readme.md
+++ b/lib/msal-core/samples/VanillaJSTestApp/Readme.md
@@ -1,6 +1,6 @@
 What are the dev apps?
 ----------------------
-index_loginPopup.html shows how to send an email with the Microsoft Graph, using msal.js loginPopup()/acquireTokenSilent-acquireTokenPopup() APIs. The authentication happens in a popup window of the browser. 
+index_loginPopup.html shows how to send an email with the Microsoft Graph, using msal.js loginPopup()/acquireTokenSilent-acquireTokenPopup() APIs. The authentication happens in a popup window of the browser.
 
 indexRedirect.html shows how to send an email with the Microsoft Graph, using msal.js loginRedirect()/acquireTokenSilent-acquireTokenRedirect() APIs. The page for the application is replaced by the authentication page, and when authentication has happened, the application is called back (on its redirectUri) with the user's idToken.
 
@@ -8,6 +8,7 @@ How to run the dev apps:
 --------------------
 Pre-requisite
 - Install node.js if needed (https://nodejs.org/en/)
+- Build the `msal-core` project.
 
 Resolving the server.js references
 - In a command prompt, run `npm install`


### PR DESCRIPTION
## I'm submitting a...
<!-- Check one of the following options with "x" -->
<pre><code>
[ ] Regression (a behavior that used to work and stopped working in a new release)
[ ] Bug report  <!-- Please search GitHub for a similar issue or PR before submitting -->
[ ] Performance issue
[ ] Feature request
[x] Documentation issue or request
[ ] Other... Please describe:
</code></pre>

## Browser:
- [ ] Chrome version XX
- [ ] Firefox version XX
- [ ] IE version XX
- [ ] Edge version XX
- [ ] Safari version XX

## Library version

Library version: 1.0.1
<!-- Check whether this is still an issue in the most recent version -->


## Current behavior
<!-- Describe how the issue manifests. -->

Running the vannila js sample without building `msal-core` results in the sample not working.


## Expected behavior
<!-- Describe what the desired behavior would be. -->

Running the samples requires that the build artifacts from `msal-core` are present in the `dist` folder, which requires that project to be built first.