### PR TITLE
Fix Issue #733: acquireTokenSilent error not InteractionRequiredAuthError as documented

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1805,7 +1805,7 @@ export class UserAgentApplication {
         acquireTokenAccountKey = Storage.generateAcquireTokenAccountKey(accountId, stateInfo.state);
       }
 
-      if (this.isInteractionRequired(hashParams[Constants.errorDescription])) {
+      if (this.isInteractionRequired(hashParams[Constants.error]) || this.isInteractionRequired(hashParams[Constants.errorDescription])) {
         error = new InteractionRequiredAuthError(hashParams[Constants.error], hashParams[Constants.errorDescription]);
       } else {
         error = new ServerError(hashParams[Constants.error], hashParams[Constants.errorDescription]);

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -23,6 +23,7 @@ import { Utils } from "../src/Utils";
 import { SSOTypes } from "../src/Constants";
 import { ClientAuthErrorMessage } from "../src/error/ClientAuthError";
 import { ClientConfigurationErrorMessage } from "../src/error/ClientConfigurationError";
+import { InteractionRequiredAuthErrorMessage } from "../src/error/InteractionRequiredAuthError";
 
 type kv = {
     [key: string]: string;
@@ -30,34 +31,44 @@ type kv = {
 
 describe("UserAgentApplication.ts Class", function () {
 
+    // Test URIs
     const DEFAULT_INSTANCE = "https://login.microsoftonline.com/";
     const ALTERNATE_INSTANCE = "https://login.windows.net/"
     const TEST_REDIR_URI = "https://localhost:8081/redirect.html";
     const TEST_LOGOUT_URI = "https://localhost:8081/logout.html";
-    const TEST_ERROR_CODE = "error_code";
-    const TEST_INTERACTION_REQ_ERROR_CODE = "interaction_required";
-    const TEST_LOGIN_REQ_ERROR_CODE = "login_required";
-    const TEST_CONSENT_REQ_ERROR_CODE = "consent_required";
-    const TEST_ERROR_DESC = "msal error description"
-    const TEST_USER_STATE_NUM = "1234";
-    const TEST_USER_STATE_URL = "https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow/scope1";
-    const TEST_STATE = "6789|" + TEST_USER_STATE_NUM;
-    const TEST_UID = "123-test-uid";
-    const TEST_UTID = "456-test-utid";
-    const TEST_NONCE = "test_nonce";
-    const TEST_UNIQUE_ID = "248289761001";
-    const TEST_DECODED_CLIENT_INFO = `{"uid":"123-test-uid","utid":"456-test-utid"}`;
-    const TEST_INVALID_JSON_CLIENT_INFO = `{"uid":"${TEST_UID}""utid":"${TEST_UTID}"`;
-    const TEST_RAW_CLIENT_INFO = "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9";
-    const TEST_CLIENT_INFO_B64ENCODED = "eyJ1aWQiOiIxMjM0NSIsInV0aWQiOiI2Nzg5MCJ9";
+
+    // Test MSAL config params
     const TENANT = 'common';
     const MSAL_CLIENT_ID = "0813e1d1-ad72-46a9-8665-399bba48c201";
     const MSAL_TENANT_ID = "124ds324-43de-n89m-7477-466fefs45a85";
     const validAuthority = DEFAULT_INSTANCE + TENANT;
     const alternateValidAuthority = ALTERNATE_INSTANCE + TENANT;
+
+    // Test state params
+    const TEST_USER_STATE_NUM = "1234";
+    const TEST_USER_STATE_URL = "https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow/scope1";
+    const TEST_STATE = "6789|" + TEST_USER_STATE_NUM;
+    
+    // Test Unique Params
+    const TEST_NONCE = "test_nonce";
+    const TEST_UNIQUE_ID = "248289761001";
+
+    // Test Client Info Params
+    const TEST_UID = "123-test-uid";
+    const TEST_UTID = "456-test-utid";
+    const TEST_DECODED_CLIENT_INFO = `{"uid":"123-test-uid","utid":"456-test-utid"}`;
+    const TEST_INVALID_JSON_CLIENT_INFO = `{"uid":"${TEST_UID}""utid":"${TEST_UTID}"`;
+    const TEST_RAW_CLIENT_INFO = "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9";
+    const TEST_CLIENT_INFO_B64ENCODED = "eyJ1aWQiOiIxMjM0NSIsInV0aWQiOiI2Nzg5MCJ9";
+    
+    // Test Hash Params
     const TEST_ID_TOKEN = "eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ"
     + ".ewogImlzcyI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAidGVzdF9ub25jZSIsCiAiZXhwIjogMTMxMTI4MTk3MCwKICJpYXQiOiAxMzExMjgwOTcwLAogIm5hbWUiOiAiSmFuZSBEb2UiLAogImdpdmVuX25hbWUiOiAiSmFuZSIsCiAiZmFtaWx5X25hbWUiOiAiRG9lIiwKICJnZW5kZXIiOiAiZmVtYWxlIiwKICJ0aWQiOiAiMTI0ZHMzMjQtNDNkZS1uODltLTc0NzctNDY2ZmVmczQ1YTg1IiwKICJiaXJ0aGRhdGUiOiAiMDAwMC0xMC0zMSIsCiAiZW1haWwiOiAiamFuZWRvZUBleGFtcGxlLmNvbSIsCiAicGljdHVyZSI6ICJodHRwOi8vZXhhbXBsZS5jb20vamFuZWRvZS9tZS5qcGciCn0="
     + ".rHQjEmBqn9Jre0OLykYNnspA10Qql2rvx4FsD00jwlB0Sym4NzpgvPKsDjn_wMkHxcp6CilPcoKrWHcipR2iAjzLvDNAReF97zoJqq880ZD1bwY82JDauCXELVR9O6_B0w3K-E7yM2macAAgNCUwtik6SjoSUZRcf-O5lygIyLENx882p6MtmwaL1hd6qn5RZOQ0TLrOYu0532g9Exxcm-ChymrB4xLykpDj3lUivJt63eEGGN6DH5K6o33TcxkIjNrCD4XB1CKKumZvCedgHHF3IAK4dVEDSUoGlH9z4pP_eWYNXvqQOjGs-rDaQzUHl6cQQWNiDpWOl_lxXjQEvQ";
+    const TEST_ERROR_CODE = "error_code";
+    const TEST_ERROR_DESC = "msal error description"
+
+    // Test Hashes
     const TEST_SUCCESS_HASH = `#id_token=${TEST_ID_TOKEN}&client_info=${TEST_RAW_CLIENT_INFO}&state=RANDOM-GUID-HERE|`;
     const TEST_ERROR_HASH = "#error=error_code&error_description=msal+error+description&state=RANDOM-GUID-HERE|";
     const TEST_INTERACTION_REQ_ERROR_HASH1 = "#error=interaction_required&error_description=msal+error+description&state=RANDOM-GUID-HERE|";
@@ -66,6 +77,8 @@ describe("UserAgentApplication.ts Class", function () {
     const TEST_LOGIN_REQ_ERROR_HASH2 = "#error=login_required&error_description=msal+error+description+login_required&state=RANDOM-GUID-HERE|";
     const TEST_CONSENT_REQ_ERROR_HASH1 = "#error=consent_required&error_description=msal+error+description&state=RANDOM-GUID-HERE|";
     const TEST_CONSENT_REQ_ERROR_HASH2 = "#error=consent_required&error_description=msal+error+description+consent_required&state=RANDOM-GUID-HERE|";
+    
+    // Sample OpenId Configurations
     const validOpenIdConfigString = `{"authorization_endpoint":"${validAuthority}/oauth2/v2.0/authorize","token_endpoint":"https://token_endpoint","issuer":"https://fakeIssuer", "end_session_endpoint":"https://end_session_endpoint"}`;
     const validOpenIdConfigurationResponse: ITenantDiscoveryResponse = {
         AuthorizationEndpoint: `${validAuthority}/oauth2/v2.0/authorize`,
@@ -901,7 +914,7 @@ describe("UserAgentApplication.ts Class", function () {
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
                 expect(error instanceof InteractionRequiredAuthError).to.be.true;
                 expect(error.name).to.include("InteractionRequiredAuthError");
-                expect(error.errorCode).to.include(TEST_INTERACTION_REQ_ERROR_CODE);
+                expect(error.errorCode).to.include(InteractionRequiredAuthErrorMessage.interactionRequired.code);
                 expect(error.errorMessage).to.include(TEST_ERROR_DESC);
                 expect(error.message).to.include(TEST_ERROR_DESC);
                 expect(error.stack).to.include("UserAgentApplication.spec.js");
@@ -917,11 +930,11 @@ describe("UserAgentApplication.ts Class", function () {
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
                 expect(error instanceof InteractionRequiredAuthError).to.be.true;
                 expect(error.name).to.include("InteractionRequiredAuthError");
-                expect(error.errorCode).to.include(TEST_INTERACTION_REQ_ERROR_CODE);
+                expect(error.errorCode).to.include(InteractionRequiredAuthErrorMessage.interactionRequired.code);
                 expect(error.errorMessage).to.include(TEST_ERROR_DESC);
                 expect(error.message).to.include(TEST_ERROR_DESC);
-                expect(error.errorMessage).to.include(TEST_INTERACTION_REQ_ERROR_CODE);
-                expect(error.message).to.include(TEST_INTERACTION_REQ_ERROR_CODE);
+                expect(error.errorMessage).to.include(InteractionRequiredAuthErrorMessage.interactionRequired.code);
+                expect(error.message).to.include(InteractionRequiredAuthErrorMessage.interactionRequired.code);
                 expect(error.stack).to.include("UserAgentApplication.spec.js");
                 done();
             };
@@ -935,7 +948,7 @@ describe("UserAgentApplication.ts Class", function () {
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
                 expect(error instanceof InteractionRequiredAuthError).to.be.true;
                 expect(error.name).to.include("InteractionRequiredAuthError");
-                expect(error.errorCode).to.include(TEST_LOGIN_REQ_ERROR_CODE);
+                expect(error.errorCode).to.include(InteractionRequiredAuthErrorMessage.loginRequired.code);
                 expect(error.errorMessage).to.include(TEST_ERROR_DESC);
                 expect(error.message).to.include(TEST_ERROR_DESC);
                 expect(error.stack).to.include("UserAgentApplication.spec.js");
@@ -951,11 +964,11 @@ describe("UserAgentApplication.ts Class", function () {
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
                 expect(error instanceof InteractionRequiredAuthError).to.be.true;
                 expect(error.name).to.include("InteractionRequiredAuthError");
-                expect(error.errorCode).to.include(TEST_LOGIN_REQ_ERROR_CODE);
+                expect(error.errorCode).to.include(InteractionRequiredAuthErrorMessage.loginRequired.code);
                 expect(error.errorMessage).to.include(TEST_ERROR_DESC);
                 expect(error.message).to.include(TEST_ERROR_DESC);
-                expect(error.errorMessage).to.include(TEST_LOGIN_REQ_ERROR_CODE);
-                expect(error.message).to.include(TEST_LOGIN_REQ_ERROR_CODE);
+                expect(error.errorMessage).to.include(InteractionRequiredAuthErrorMessage.loginRequired.code);
+                expect(error.message).to.include(InteractionRequiredAuthErrorMessage.loginRequired.code);
                 expect(error.stack).to.include("UserAgentApplication.spec.js");
                 done();
             };
@@ -969,7 +982,7 @@ describe("UserAgentApplication.ts Class", function () {
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
                 expect(error instanceof InteractionRequiredAuthError).to.be.true;
                 expect(error.name).to.include("InteractionRequiredAuthError");
-                expect(error.errorCode).to.include(TEST_CONSENT_REQ_ERROR_CODE);
+                expect(error.errorCode).to.include(InteractionRequiredAuthErrorMessage.consentRequired.code);
                 expect(error.errorMessage).to.include(TEST_ERROR_DESC);
                 expect(error.message).to.include(TEST_ERROR_DESC);
                 expect(error.stack).to.include("UserAgentApplication.spec.js");
@@ -985,11 +998,11 @@ describe("UserAgentApplication.ts Class", function () {
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
                 expect(error instanceof InteractionRequiredAuthError).to.be.true;
                 expect(error.name).to.include("InteractionRequiredAuthError");
-                expect(error.errorCode).to.include(TEST_CONSENT_REQ_ERROR_CODE);
+                expect(error.errorCode).to.include(InteractionRequiredAuthErrorMessage.consentRequired.code);
                 expect(error.errorMessage).to.include(TEST_ERROR_DESC);
                 expect(error.message).to.include(TEST_ERROR_DESC);
-                expect(error.errorMessage).to.include(TEST_CONSENT_REQ_ERROR_CODE);
-                expect(error.message).to.include(TEST_CONSENT_REQ_ERROR_CODE);
+                expect(error.errorMessage).to.include(InteractionRequiredAuthErrorMessage.consentRequired.code);
+                expect(error.message).to.include(InteractionRequiredAuthErrorMessage.consentRequired.code);
                 expect(error.stack).to.include("UserAgentApplication.spec.js");
                 done();
             };


### PR DESCRIPTION
This is a PR to fix the issue described in #733 where the acquireTokenSilent method was throwing errors of the incorrect type. I have updated the type checking and added tests to ensure we are correctly throwing the error.