### PR TITLE
MSAL should log when we remove sid and login_hint from extraQueryParameters

### DIFF
--- a/lib/msal-core/src/Constants.ts
+++ b/lib/msal-core/src/Constants.ts
@@ -107,6 +107,11 @@ export const SSOTypes = {
     DOMAIN_REQ: "domain_req"
 };
 
+export const BlacklistedEQParams = [
+  SSOTypes.SID,
+  SSOTypes.LOGIN_HINT
+];
+
 /**
  * we considered making this "enum" in the request instead of string, however it looks like the allowed list of
  * prompt values kept changing over past couple of years. There are some undocumented prompt values for some

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -7,7 +7,7 @@ import { AccessTokenValue } from "./AccessTokenValue";
 import { ServerRequestParameters } from "./ServerRequestParameters";
 import { Authority } from "./Authority";
 import { ClientInfo } from "./ClientInfo";
-import { Constants, SSOTypes, PromptState } from "./Constants";
+import { Constants, SSOTypes, PromptState, BlacklistedEQParams } from "./Constants";
 import { IdToken } from "./IdToken";
 import { Logger } from "./Logger";
 import { Storage } from "./Storage";
@@ -2585,8 +2585,12 @@ export class UserAgentApplication {
       this.logger.warning("Removed duplicate claims from extraQueryParameters. Please use either the claimsRequest field OR pass as extraQueryParameter - not both.");
       delete eQParams[Constants.claims];
     }
-    delete eQParams[SSOTypes.SID];
-    delete eQParams[SSOTypes.LOGIN_HINT];
+    BlacklistedEQParams.forEach(param => {
+      if (eQParams[param]) {
+        this.logger.warning("Removed duplicate " + param + " from extraQueryParameters. Please use the " + param + " field in request object.");
+        delete eQParams[param];
+      }
+    });
     return eQParams;
   }
 


### PR DESCRIPTION
When we collect extraQueryParameters from the request object, we sanitize them and remove the sid and login_hint. We should log this so that we aren't silently deleting user given info.