### PR TITLE
Fix msal-angular exports to properly support IE11, fixes #765 #414

### DIFF
--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -18,8 +18,9 @@
     "msal",
     "oauth"
   ],
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "./lib-commonjs/index.js",
+  "module": "./lib-es6/index.js",
+  "types": "./lib-commonjs/index.d.ts",
   "engines": {
     "node": ">=0.8.0"
   },

--- a/lib/msal-angular/samples/MSALAngularDemoApp/.npmrc
+++ b/lib/msal-angular/samples/MSALAngularDemoApp/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/msal-angular/samples/MSALAngularDemoApp/package.json
+++ b/lib/msal-angular/samples/MSALAngularDemoApp/package.json
@@ -24,7 +24,7 @@
     "rxjs": "^5.1.0",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.8.4",
-    "@azure/msal-angular": "0.1.2"
+    "@azure/msal-angular": "file:../.."
   },
   "devDependencies": {
     "@angular/cli": "^1.0.1",


### PR DESCRIPTION
The main export for the `msal-angular` library was the ES6 version of the library, which is not compatible with IE11 (I was able to reproduce this with the MSAL Angular sample). This updates the library's exports to properly export the CommonJS version of the library by default, with the ES6 version available under `module` ([which matches](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-core/package.json#L22-L24) the main `msal` package).

Before:

![msal-angular-ie11-before](https://user-images.githubusercontent.com/443409/60037489-7f6a1500-9666-11e9-8c2e-2ae794614f8b.PNG)

After:

![msal-angular-ie11](https://user-images.githubusercontent.com/443409/60036803-e5559d00-9664-11e9-9da1-3b6a1dd6025d.PNG)
