### PR TITLE
Fix for expiration date calculation

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1721,7 +1721,7 @@ export class UserAgentApplication {
       accessTokenResponse.scopes = consentedScopes;
       let exp = Number(expiresIn);
       if (exp) {
-        accessTokenResponse.expiresOn = new Date((Utils.now() + exp) * 1000);
+        accessTokenResponse.expiresOn = new Date(exp * 1000);
       } else {
         this.logger.error("Could not parse expiresIn parameter. Given value: " + expiresIn);
       }

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -143,7 +143,7 @@ export class Utils {
      if (!expires) {
          expires = "3599";
       }
-    return parseInt(expires, 10);
+    return this.now() + parseInt(expires, 10);
   }
 
   /**

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -143,7 +143,7 @@ export class Utils {
      if (!expires) {
          expires = "3599";
       }
-    return this.now() + parseInt(expires, 10);
+    return parseInt(expires, 10);
   }
 
   /**


### PR DESCRIPTION
Potential fix for #790 

`expiresIn` function is used in only one place, so the fix should be 'safe'
that why I think would be better to remove `this.now()` or we have to rename this function to `expiresOn`