### PR TITLE
docs: fix position of code end

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -25,7 +25,7 @@ PLEASE HELP US TO HELP YOU BETTER AND FASTER BY PROVIDING THE FOLLOWING INFORMAT
 <pre><code>
 Library version: X.Y.Z
 <!-- Check whether this is still an issue in the most recent version -->
-
+</code></pre>
 
 ## Current behavior
 <!-- Describe how the issue manifests. -->
@@ -39,4 +39,4 @@ Library version: X.Y.Z
 <!-- please provide the *STEPS TO REPRODUCE* -->
 
 
-</code></pre>
+


### PR DESCRIPTION
The position of the `</code></pre>` looks misplaced. Move it to a better suiting place