### PR TITLE
Fix expiresIn calculation

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1712,15 +1712,15 @@ export class UserAgentApplication {
       }
 
       // Generate and cache accessTokenKey and accessTokenValue
-      const expiresIn = Utils.expiresIn(parameters[Constants.expiresIn]);
+      const expiresIn = Utils.parseExpiresIn(parameters[Constants.expiresIn]);
+      expiration = Utils.now() + expiresIn;
       const accessTokenKey = new AccessTokenKey(authority, this.clientId, scope, clientObj.uid, clientObj.utid);
-      const accessTokenValue = new AccessTokenValue(parameters[Constants.accessToken], response.idToken.rawIdToken, (expiresIn + Utils.now()).toString(), clientInfo);
+      const accessTokenValue = new AccessTokenValue(parameters[Constants.accessToken], response.idToken.rawIdToken, expiration.toString(), clientInfo);
 
       this.cacheStorage.setItem(JSON.stringify(accessTokenKey), JSON.stringify(accessTokenValue));
 
       accessTokenResponse.accessToken  = parameters[Constants.accessToken];
       accessTokenResponse.scopes = consentedScopes;
-      expiration = Utils.now() + expiresIn;
     }
     // if the response does not contain "scope" - scope is usually client_id and the token will be id_token
     else {
@@ -1728,12 +1728,12 @@ export class UserAgentApplication {
 
       // Generate and cache accessTokenKey and accessTokenValue
       const accessTokenKey = new AccessTokenKey(authority, this.clientId, scope, clientObj.uid, clientObj.utid);
+      expiration = Number(response.idToken.expiration);
 
-      const accessTokenValue = new AccessTokenValue(parameters[Constants.idToken], parameters[Constants.idToken], response.idToken.expiration.toString(), clientInfo);
+      const accessTokenValue = new AccessTokenValue(parameters[Constants.idToken], parameters[Constants.idToken], expiration.toString(), clientInfo);
       this.cacheStorage.setItem(JSON.stringify(accessTokenKey), JSON.stringify(accessTokenValue));
       accessTokenResponse.scopes = [scope];
       accessTokenResponse.accessToken = parameters[Constants.idToken];
-      expiration = Number(response.idToken.expiration);
     }
     if (expiration) {
       accessTokenResponse.expiresOn = new Date(expiration * 1000);

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1733,7 +1733,7 @@ export class UserAgentApplication {
       // Generate and cache accessTokenKey and accessTokenValue
       const accessTokenKey = new AccessTokenKey(authority, this.clientId, scope, clientObj.uid, clientObj.utid);
 
-      const accessTokenValue = new AccessTokenValue(parameters[Constants.idToken], parameters[Constants.idToken], response.idToken.expiration, clientInfo);
+      const accessTokenValue = new AccessTokenValue(parameters[Constants.idToken], parameters[Constants.idToken], response.idToken.expiration.toString(), clientInfo);
       this.cacheStorage.setItem(JSON.stringify(accessTokenKey), JSON.stringify(accessTokenValue));
       accessTokenResponse.scopes = [scope];
       accessTokenResponse.accessToken = parameters[Constants.idToken];

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1689,6 +1689,7 @@ export class UserAgentApplication {
     let scope: string;
     let accessTokenResponse = { ...response };
     const clientObj: ClientInfo = new ClientInfo(clientInfo);
+    let expiration: number;
 
     // if the response contains "scope"
     if (parameters.hasOwnProperty("scope")) {
@@ -1711,20 +1712,15 @@ export class UserAgentApplication {
       }
 
       // Generate and cache accessTokenKey and accessTokenValue
-      const expiresIn = Utils.expiresIn(parameters[Constants.expiresIn]).toString();
+      const expiresIn = Utils.expiresIn(parameters[Constants.expiresIn]);
       const accessTokenKey = new AccessTokenKey(authority, this.clientId, scope, clientObj.uid, clientObj.utid);
-      const accessTokenValue = new AccessTokenValue(parameters[Constants.accessToken], response.idToken.rawIdToken, expiresIn, clientInfo);
+      const accessTokenValue = new AccessTokenValue(parameters[Constants.accessToken], response.idToken.rawIdToken, (expiresIn + Utils.now()).toString(), clientInfo);
 
       this.cacheStorage.setItem(JSON.stringify(accessTokenKey), JSON.stringify(accessTokenValue));
 
       accessTokenResponse.accessToken  = parameters[Constants.accessToken];
       accessTokenResponse.scopes = consentedScopes;
-      let exp = Number(expiresIn);
-      if (exp) {
-        accessTokenResponse.expiresOn = new Date((Utils.now() + exp) * 1000);
-      } else {
-        this.logger.error("Could not parse expiresIn parameter. Given value: " + expiresIn);
-      }
+      expiration = Utils.now() + expiresIn;
     }
     // if the response does not contain "scope" - scope is usually client_id and the token will be id_token
     else {
@@ -1737,12 +1733,12 @@ export class UserAgentApplication {
       this.cacheStorage.setItem(JSON.stringify(accessTokenKey), JSON.stringify(accessTokenValue));
       accessTokenResponse.scopes = [scope];
       accessTokenResponse.accessToken = parameters[Constants.idToken];
-      let exp = Number(response.idToken.expiration);
-      if (exp) {
-        accessTokenResponse.expiresOn = new Date(exp * 1000);
-      } else {
-        this.logger.error("Could not parse expiresIn parameter");
-      }
+      expiration = Number(response.idToken.expiration);
+    }
+    if (expiration) {
+      accessTokenResponse.expiresOn = new Date(expiration * 1000);
+    } else {
+      this.logger.error("Could not parse expiresIn parameter");
     }
     return accessTokenResponse;
   }

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -711,6 +711,10 @@ export class Utils {
       response.uniqueId = response.idToken.subject;
     }
     response.tenantId = response.idToken.tenantId;
+    let exp = Number(response.idToken.expiration);
+    if (exp && !response.expiresOn) {
+      response.expiresOn = new Date(exp * 1000);
+    }
     return response;
   }
 

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -136,14 +136,14 @@ export class Utils {
   /**
    * Returns time in seconds for expiration based on string value passed in.
    *
-   * @param expires
+   * @param expiresIn
    */
-  static expiresIn(expires: string): number {
+  static parseExpiresIn(expiresIn: string): number {
     // if AAD did not send "expires_in" property, use default expiration of 3599 seconds, for some reason AAD sends 3599 as "expires_in" value instead of 3600
-    if (!expires) {
-      expires = "3599";
+    if (!expiresIn) {
+      expiresIn = "3599";
     }
-    return parseInt(expires, 10);
+    return parseInt(expiresIn, 10);
   }
 
   /**

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -140,10 +140,10 @@ export class Utils {
    */
   static expiresIn(expires: string): number {
     // if AAD did not send "expires_in" property, use default expiration of 3599 seconds, for some reason AAD sends 3599 as "expires_in" value instead of 3600
-     if (!expires) {
-         expires = "3599";
-      }
-    return this.now() + parseInt(expires, 10);
+    if (!expires) {
+      expires = "3599";
+    }
+    return parseInt(expires, 10);
   }
 
   /**

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -64,16 +64,28 @@ describe("UserAgentApplication.ts Class", function () {
     const TEST_INVALID_JSON_CLIENT_INFO = `{"uid":"${TEST_UID}""utid":"${TEST_UTID}"`;
     const TEST_RAW_CLIENT_INFO = "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9";
     const TEST_CLIENT_INFO_B64ENCODED = "eyJ1aWQiOiIxMjM0NSIsInV0aWQiOiI2Nzg5MCJ9";
+
+    // Test Account Params
+    const TEST_HOME_ACCOUNT_ID = "MTIzLXRlc3QtdWlk.NDU2LXRlc3QtdXRpZA==";
+
+    // Test Expiration Vals
+    const DEFAULT_EXPIRES_IN = 3599;
+    const BASELINE_DATE_CHECK = Utils.now();
+    const TEST_ID_TOKEN_ISSUED = 1561749650;
     
     // Test Hash Params
     const TEST_ID_TOKEN = "eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ"
-    + ".ewogImlzcyI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAidGVzdF9ub25jZSIsCiAiZXhwIjogMTMxMTI4MTk3MCwKICJpYXQiOiAxMzExMjgwOTcwLAogIm5hbWUiOiAiSmFuZSBEb2UiLAogImdpdmVuX25hbWUiOiAiSmFuZSIsCiAiZmFtaWx5X25hbWUiOiAiRG9lIiwKICJnZW5kZXIiOiAiZmVtYWxlIiwKICJ0aWQiOiAiMTI0ZHMzMjQtNDNkZS1uODltLTc0NzctNDY2ZmVmczQ1YTg1IiwKICJiaXJ0aGRhdGUiOiAiMDAwMC0xMC0zMSIsCiAiZW1haWwiOiAiamFuZWRvZUBleGFtcGxlLmNvbSIsCiAicGljdHVyZSI6ICJodHRwOi8vZXhhbXBsZS5jb20vamFuZWRvZS9tZS5qcGciCn0="
+    + ".ewogImlzcyI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAidGVzdF9ub25jZSIsCiAiZXhwIjogMTU2MTc0OTY1MCwKICJpYXQiOiAxNTYxNzQ5NjUwLAogIm5hbWUiOiAiSmFuZSBEb2UiLAogImdpdmVuX25hbWUiOiAiSmFuZSIsCiAiZmFtaWx5X25hbWUiOiAiRG9lIiwKICJnZW5kZXIiOiAiZmVtYWxlIiwKICJ0aWQiOiAiMTI0ZHMzMjQtNDNkZS1uODltLTc0NzctNDY2ZmVmczQ1YTg1IiwKICJiaXJ0aGRhdGUiOiAiMDAwMC0xMC0zMSIsCiAiZW1haWwiOiAiamFuZWRvZUBleGFtcGxlLmNvbSIsCiAicGljdHVyZSI6ICJodHRwOi8vZXhhbXBsZS5jb20vamFuZWRvZS9tZS5qcGciCn0="
     + ".rHQjEmBqn9Jre0OLykYNnspA10Qql2rvx4FsD00jwlB0Sym4NzpgvPKsDjn_wMkHxcp6CilPcoKrWHcipR2iAjzLvDNAReF97zoJqq880ZD1bwY82JDauCXELVR9O6_B0w3K-E7yM2macAAgNCUwtik6SjoSUZRcf-O5lygIyLENx882p6MtmwaL1hd6qn5RZOQ0TLrOYu0532g9Exxcm-ChymrB4xLykpDj3lUivJt63eEGGN6DH5K6o33TcxkIjNrCD4XB1CKKumZvCedgHHF3IAK4dVEDSUoGlH9z4pP_eWYNXvqQOjGs-rDaQzUHl6cQQWNiDpWOl_lxXjQEvQ";
+    const TEST_ACCESS_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9"
+    + ".eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwic3ViIjoiMjQ4Mjg5NzYxMDAxIiwiYXVkIjoiczZCaGRSa3F0MyIsImV4cCI6MTU2MTc0OTY1MCwiaWF0IjoxNTYxNzQ1NzUwLCJuYmYiOjE1NjE3NDU3NTAsIm5hbWUiOiJKYW5lIERvZSIsInByZWZlcnJlZF91c2VybmFtZSI6ImphbmVkb2VAZXhhbXBsZS5jb20iLCJvaWQiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMTIzNC0xMjM0NWFlNjc4OSIsInRpZCI6Inh4eHh4eC14eHh4LXh4eHgteHh4eHgiLCJzY3AiOiJ0ZXN0In0="
+    + ".Ztsxk8912PBaweKw0UFKcLsHL4yNnKj6MVd-ZCtKK8KxzAVCinaxepSJIlRB_p-9UBDCkFAOycbrSXYs7nA7fo9AtYxgAH5MHyuAT_K-Ev49LgD6oyLU3JLmRKthi9vVcMD2V9W93NPUxQG5JHhiruMAGDY4ISg0sD9MICZr0SMFlRxvhiEWkWuWwYhgctmOoB6dn17qrQEmTlQnZZlvQ2gLflBJmvvQ6OQxTFZi_5QxVBJkc6wyP4gArIfjUmeHK8Y9_WTTrCf7ZBNUyOvRVN4QTcl1JpYlIlU2GTg-QChpkiqQ8Weu4QaZFb_7UwLf7rnZeBKpEeBtVfsIqF39zw";
     const TEST_ERROR_CODE = "error_code";
-    const TEST_ERROR_DESC = "msal error description"
+    const TEST_ERROR_DESC = "msal error description";
 
     // Test Hashes
-    const TEST_SUCCESS_HASH = `#id_token=${TEST_ID_TOKEN}&client_info=${TEST_RAW_CLIENT_INFO}&state=RANDOM-GUID-HERE|`;
+    const TEST_SUCCESS_ID_TOKEN_HASH = `#id_token=${TEST_ID_TOKEN}&client_info=${TEST_RAW_CLIENT_INFO}&state=RANDOM-GUID-HERE|`;
+    const TEST_SUCCESS_ACCESS_TOKEN_HASH = `#access_token=${TEST_ACCESS_TOKEN}&id_token=${TEST_ID_TOKEN}&scope=test&expiresIn=${DEFAULT_EXPIRES_IN}&client_info=${TEST_RAW_CLIENT_INFO}&state=RANDOM-GUID-HERE|`;
     const TEST_ERROR_HASH = "#error=error_code&error_description=msal+error+description&state=RANDOM-GUID-HERE|";
     const TEST_INTERACTION_REQ_ERROR_HASH1 = "#error=interaction_required&error_description=msal+error+description&state=RANDOM-GUID-HERE|";
     const TEST_INTERACTION_REQ_ERROR_HASH2 = "#error=interaction_required&error_description=msal+error+description+interaction_required&state=RANDOM-GUID-HERE|";
@@ -139,18 +151,18 @@ describe("UserAgentApplication.ts Class", function () {
             authority: validAuthority,
             clientId: "0813e1d1-ad72-46a9-8665-399bba48c201",
             scopes: "S1",
-            homeAccountIdentifier: "1234"
+            homeAccountIdentifier: TEST_HOME_ACCOUNT_ID
         };
         accessTokenValue = {
             accessToken: "accessToken1",
             idToken: "idToken",
             expiresIn: "150000000000000",
-            homeAccountIdentifier: ""
+            homeAccountIdentifier: TEST_HOME_ACCOUNT_ID
         };
         account = {
             accountIdentifier: "1234",
             environment: "js",
-            homeAccountIdentifier: "1234",
+            homeAccountIdentifier: TEST_HOME_ACCOUNT_ID,
             idToken: "idToken",
             name: "Test Account",
             sid: "123451435",
@@ -548,7 +560,7 @@ describe("UserAgentApplication.ts Class", function () {
         it("Calls the token callback if two callbacks are sent", function (done) {
             cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
             cacheStorage.setItem(Constants.nonceIdToken, TEST_NONCE);
-            cacheStorage.setItem(Constants.urlHash, TEST_SUCCESS_HASH + TEST_USER_STATE_NUM);
+            cacheStorage.setItem(Constants.urlHash, TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM);
 
             const checkResponseFromServer = function(response: AuthResponse) {
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
@@ -564,7 +576,7 @@ describe("UserAgentApplication.ts Class", function () {
         it("Calls the response callback if single callback is sent", function (done) {
             cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
             cacheStorage.setItem(Constants.nonceIdToken, TEST_NONCE);
-            cacheStorage.setItem(Constants.urlHash, TEST_SUCCESS_HASH + TEST_USER_STATE_NUM);
+            cacheStorage.setItem(Constants.urlHash, TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM);
 
             const checkResponseFromServer = function(error: AuthError, response: AuthResponse) {
                 expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
@@ -873,7 +885,7 @@ describe("UserAgentApplication.ts Class", function () {
         });
 
         it("tests saveTokenForHash in case of response", function(done) {
-            let successHash = TEST_SUCCESS_HASH + TEST_USER_STATE_NUM;
+            let successHash = TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
             cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
             cacheStorage.setItem(Constants.nonceIdToken, TEST_NONCE);
             cacheStorage.setItem(Constants.urlHash, successHash);
@@ -931,6 +943,45 @@ describe("UserAgentApplication.ts Class", function () {
             expect(msal.isCallback("#access_token=token123")).to.be.true;
             expect(msal.isCallback("#id_token=idtoken234")).to.be.true;
             done();
+        });
+
+        it("tests that expiresIn returns the correct date for access tokens", function (done) {
+            sinon.stub(Utils, "now").returns(BASELINE_DATE_CHECK);
+            let acquireTokenAccountKey = Storage.generateAcquireTokenAccountKey(account.homeAccountIdentifier, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
+            cacheStorage.setItem(acquireTokenAccountKey, JSON.stringify(account));
+            let successHash = TEST_SUCCESS_ACCESS_TOKEN_HASH + TEST_USER_STATE_NUM;
+            cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
+            cacheStorage.setItem(Constants.nonceIdToken, TEST_NONCE);
+            cacheStorage.setItem(Constants.urlHash, successHash);
+            let checkRespFromServer = function(response: AuthResponse) {
+                expect(response.uniqueId).to.be.eq(TEST_UNIQUE_ID);
+                expect(response.tokenType).to.be.eq(Constants.accessToken);
+                expect(response.tenantId).to.be.eq(MSAL_TENANT_ID);
+                expect(response.accountState).to.be.eq(TEST_USER_STATE_NUM);
+                expect(response.expiresOn.getTime()).to.be.eq((BASELINE_DATE_CHECK + DEFAULT_EXPIRES_IN) * 1000);
+                expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
+                done();
+            };
+            msal.handleRedirectCallback(checkRespFromServer, errorReceivedCallback);
+        });
+
+        it("tests that expiresIn returns the correct date for id tokens", function (done) {
+            let acquireTokenAccountKey = Storage.generateAcquireTokenAccountKey(account.homeAccountIdentifier, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
+            cacheStorage.setItem(acquireTokenAccountKey, JSON.stringify(account));
+            let successHash = TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+            cacheStorage.setItem(Constants.stateLogin, "RANDOM-GUID-HERE|" + TEST_USER_STATE_NUM);
+            cacheStorage.setItem(Constants.nonceIdToken, TEST_NONCE);
+            cacheStorage.setItem(Constants.urlHash, successHash);
+            let checkRespFromServer = function(response: AuthResponse) {
+                expect(response.uniqueId).to.be.eq(TEST_UNIQUE_ID);
+                expect(response.tokenType).to.be.eq(Constants.idToken);
+                expect(response.tenantId).to.be.eq(MSAL_TENANT_ID);
+                expect(response.accountState).to.be.eq(TEST_USER_STATE_NUM);
+                expect(response.expiresOn.getTime()).to.be.eq(TEST_ID_TOKEN_ISSUED * 1000);
+                expect(cacheStorage.getItem(Constants.urlHash)).to.be.null;
+                done();
+            };
+            msal.handleRedirectCallback(checkRespFromServer, errorReceivedCallback);
         });
     });
 


### PR DESCRIPTION
This PR is to fix the issue raised in PR #790 and add unit tests to ensure future calculations are as expected.

This issue was attempted to be fixed in PR #791 but 791 did not have all of the changes and tests necessary to ensure this use case worked moving forward.

Summary of Changes:
- Changes to expiration time calculation for access token and id token flows
- Utils.expiresIn now returns expiresIn time, not expiresOn
- Utils.setResponseIdToken now also sets expiration
- Simplified saveAccessToken expiration calculation
- Ensure that expiration is always saved as a string in the cache
- Added tests
