### PR TITLE
WIP: Initial proof of possesion implementation

### DIFF
--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -29,6 +29,7 @@
     "clean": "shx rm -rf dist docs lib-commonjs lib-es6",
     "doc": "typedoc --mode modules --excludePrivate --excludeProtected --out ./docs ./src/ --gitRevision dev",
     "build:modules": "tsc && tsc -m es6 --outDir lib-es6",
+    "build:modules:watch": "tsc -m es6 --outDir lib-es6 --watch",
     "build": "npm run clean && npm run doc && npm run build:modules && npm run lint && npm run build:webpack && npm test",
     "test": "karma start --single-run --browsers PhantomJS karma.conf.js",
     "lint": "tslint -c tslint.json src/**/*.ts",

--- a/lib/msal-core/samples/react-sample-app/src/AuthProvider.js
+++ b/lib/msal-core/samples/react-sample-app/src/AuthProvider.js
@@ -27,6 +27,7 @@ export default C =>
 
         async acquireToken(request, redirect) {
             return msalApp.acquireTokenSilent(request).catch(error => {
+                console.error(error);
                 // Call acquireTokenPopup (popup window) in case of acquireTokenSilent failure
                 // due to consent or interaction required ONLY
                 if (requiresInteraction(error.errorCode)) {
@@ -60,19 +61,23 @@ export default C =>
                     GRAPH_REQUESTS.LOGIN
                 );
 
-                const graphProfile = await fetchMsGraph(
-                    GRAPH_ENDPOINTS.ME,
-                    tokenResponse.accessToken
-                ).catch(() => {
-                    this.setState({
-                        error: "Unable to fetch Graph profile."
+                console.log('tokenResponse', tokenResponse);
+                if (tokenResponse) {
+                    const graphProfile = await fetchMsGraph(
+                        GRAPH_ENDPOINTS.ME,
+                        tokenResponse.accessToken,
+                        tokenResponse.accessToken.accessTokenType === 'pop'
+                    ).catch(() => {
+                        this.setState({
+                            error: "Unable to fetch Graph profile."
+                        });
                     });
-                });
 
-                if (graphProfile) {
-                    this.setState({
-                        graphProfile
-                    });
+                    if (graphProfile) {
+                        this.setState({
+                            graphProfile
+                        });
+                    }
                 }
             }
         }
@@ -92,14 +97,16 @@ export default C =>
             });
 
             if (tokenResponse) {
+                console.log('tokenResponse', tokenResponse);
                 return this.readMail(tokenResponse.accessToken);
             }
         }
 
-        async readMail(accessToken) {
+        async readMail(accessToken, pop) {
             const emailMessages = await fetchMsGraph(
                 GRAPH_ENDPOINTS.MAIL,
-                accessToken
+                accessToken,
+                pop
             ).catch(() => {
                 this.setState({
                     error: "Unable to fetch email messages."
@@ -138,10 +145,13 @@ export default C =>
                     useRedirectFlow
                 );
 
+
                 if (tokenResponse) {
+                    console.log('tokenResponse', tokenResponse);
                     const graphProfile = await fetchMsGraph(
                         GRAPH_ENDPOINTS.ME,
-                        tokenResponse.accessToken
+                        tokenResponse.accessToken,
+                        tokenResponse.accessTokenType === 'pop'
                     ).catch(() => {
                         this.setState({
                             error: "Unable to fetch Graph profile."
@@ -154,8 +164,8 @@ export default C =>
                         });
                     }
 
-                    if (tokenResponse.scopes.includes(GRAPH_SCOPES.MAIL_READ)) {
-                        return this.readMail(tokenResponse.accessToken);
+                    if (tokenResponse.scopes.indexOf(GRAPH_SCOPES.MAIL_READ) > -1) {
+                        return this.readMail(tokenResponse.accessToken, tokenResponse.accessTokenType === 'pop');
                     }
                 }
             }

--- a/lib/msal-core/samples/react-sample-app/src/auth-utils.js
+++ b/lib/msal-core/samples/react-sample-app/src/auth-utils.js
@@ -12,10 +12,11 @@ export const requiresInteraction = errorMessage => {
     );
 };
 
-export const fetchMsGraph = async (url, accessToken) => {
+export const fetchMsGraph = async (url: string, accessToken: string, pop: boolean) => {
+    const scheme = pop ? 'PoP' : 'Bearer';
     const response = await fetch(url, {
         headers: {
-            Authorization: `Bearer ${accessToken}`
+            Authorization: `${scheme} ${accessToken}`
         }
     });
 
@@ -51,10 +52,16 @@ export const GRAPH_REQUESTS = {
             GRAPH_SCOPES.OPENID,
             GRAPH_SCOPES.PROFILE,
             GRAPH_SCOPES.USER_READ
-        ]
+        ],
+        requestMethod: 'GET',
+        requestUri: GRAPH_ENDPOINTS.ME,
+        authenticationType: 'pop'
     },
     EMAIL: {
-        scopes: [GRAPH_SCOPES.MAIL_READ]
+        scopes: [GRAPH_SCOPES.MAIL_READ],
+        requestMethod: 'GET',
+        requestUri: GRAPH_ENDPOINTS.MAIL,
+        authenticationType: 'pop'
     }
 };
 

--- a/lib/msal-core/src/AccessTokenValue.ts
+++ b/lib/msal-core/src/AccessTokenValue.ts
@@ -7,12 +7,14 @@
 export class AccessTokenValue {
 
   accessToken: string;
+  accessTokenType: string;
   idToken: string;
   expiresIn: string;
   homeAccountIdentifier: string;
 
-  constructor(accessToken: string, idToken: string, expiresIn: string, homeAccountIdentifier: string) {
+  constructor(accessToken: string, idToken: string, expiresIn: string, homeAccountIdentifier: string, accessTokenType: string) {
     this.accessToken = accessToken;
+    this.accessTokenType = accessTokenType;
     this.idToken = idToken;
     this.expiresIn = expiresIn;
     this.homeAccountIdentifier = homeAccountIdentifier;

--- a/lib/msal-core/src/AuthResponse.ts
+++ b/lib/msal-core/src/AuthResponse.ts
@@ -13,6 +13,7 @@ export type AuthResponse = {
     tokenType: string;
     idToken: IdToken;
     accessToken: string;
+    accessTokenType: string;
     scopes: Array<string>;
     expiresOn: Date;
     account: Account;
@@ -26,6 +27,7 @@ export function buildResponseStateOnly(state: string) : AuthResponse {
         tokenType: "",
         idToken: null,
         accessToken: "",
+        accessTokenType: "",
         scopes: null,
         expiresOn: null,
         account: null,

--- a/lib/msal-core/src/AuthenticationParameters.ts
+++ b/lib/msal-core/src/AuthenticationParameters.ts
@@ -9,6 +9,11 @@ import { ClientConfigurationError } from "./error/ClientConfigurationError";
  */
 export type QPDict = {[key: string]: string};
 
+export enum AuthenticationType {
+    PoP = 'pop',
+    Bearer = 'bearer'
+}
+
 /**
  * @link AuthenticationParameters}AuthenticationParameters
  */
@@ -24,6 +29,9 @@ export type AuthenticationParameters = {
     account?: Account;
     sid?: string;
     loginHint?: string;
+    requestMethod?: string;
+    requestUri?: string;
+    authenticationType?: AuthenticationType;
 };
 
 export function validateClaimsRequest(request: AuthenticationParameters) {

--- a/lib/msal-core/src/BrowserCrypto.ts
+++ b/lib/msal-core/src/BrowserCrypto.ts
@@ -1,0 +1,134 @@
+import { KeyGenAlgorithm, HashAlgorithm, KeyFormat, getArrayBufferFromString, getStringFromArrayBuffer, isIE11, getJwkString } from './PopTokenCommon';
+
+/**
+ * Thin wrapper around browser Web Crypto APIs.
+ * Docs: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto
+ *
+ * Includes support for IE11 msCrypto methods.
+ * Docs: https://msdn.microsoft.com/en-us/ie/dn904640(v=vs.94)
+ */
+export class BrowserCrypto {
+    private _algorithmOptions: RsaHashedKeyGenParams;
+
+    constructor(keyGenAlgorithm: KeyGenAlgorithm, hashAlgorithm: HashAlgorithm, modulusLength: number, publicExponent: Uint8Array) {
+        this._algorithmOptions = {
+            name: keyGenAlgorithm,
+            hash: hashAlgorithm,
+            modulusLength,
+            publicExponent
+        }
+    }
+
+    async sign(key: CryptoKey, data: ArrayBuffer): Promise<ArrayBuffer> {
+        if (isIE11()) {
+            return new Promise((resolve, reject) => {
+                const signOperation = window['msCrypto'].subtle.sign(this._algorithmOptions, key, data);
+                signOperation.addEventListener('complete', (e: { target: { result: ArrayBuffer | PromiseLike<ArrayBuffer>; }; }) => {
+                    resolve(e.target.result);
+                });
+                signOperation.addEventListener('error', (error: any) => {
+                    reject(error);
+                });
+            });
+        }
+
+        return window.crypto.subtle.sign(this._algorithmOptions, key, data);
+    }
+
+    async verify(key: CryptoKey, signature: ArrayBuffer, data: ArrayBuffer): Promise<boolean> {
+        if (isIE11()) {
+            return new Promise((resolve, reject) => {
+                const verifySignatureOperation = window['msCrypto'].subtle.verify(this._algorithmOptions, key, signature, data);
+                verifySignatureOperation.addEventListener('complete', (e: { target: { result: boolean | PromiseLike<boolean>; }; }) => {
+                    resolve(e.target.result);
+                });
+                verifySignatureOperation.addEventListener('error', (error: any) => {
+                    reject(error);
+                });
+            });
+        }
+
+        return window.crypto.subtle.verify(this._algorithmOptions, key, signature, data);
+    }
+
+    async generateKey(extractable: boolean, usages: Array<string>): Promise<CryptoKeyPair> {
+        if (isIE11()) {
+            return new Promise((resolve, reject) => {
+                const generateKeyOperation = window['msCrypto'].subtle.generateKey(this._algorithmOptions, extractable, usages);
+                generateKeyOperation.addEventListener('complete', (e: { target: { result: CryptoKeyPair | PromiseLike<CryptoKeyPair>; }; }) => {
+                    resolve(e.target.result);
+                });
+                generateKeyOperation.addEventListener('error', (error: any) => {
+                    reject(error);
+                });
+            });
+        }
+
+        return window.crypto.subtle.generateKey(this._algorithmOptions, extractable, usages);
+    }
+
+    async exportKey(key: CryptoKey, format: KeyFormat): Promise<JsonWebKey> {
+        if (isIE11()) {
+            return new Promise((resolve, reject) => {
+                const exportKeyOperation = window['msCrypto'].subtle.exportKey(format, key);
+                exportKeyOperation.addEventListener('complete', (e: { target: { result: ArrayBuffer; }; }) => {
+                    const resultBuffer: ArrayBuffer = e.target.result;
+                    const resultString = getStringFromArrayBuffer(resultBuffer)
+                        .replace(/\r/g, '')
+                        .replace(/\n/g, '')
+                        .replace(/\t/g, '')
+                        .split(' ').join('')
+                        .replace("\u0000", '');
+
+                    try {
+                        resolve(JSON.parse(resultString));
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+                exportKeyOperation.addEventListener('error', (error: any) => {
+                    reject(error);
+                })
+            });
+        }
+
+        return window.crypto.subtle.exportKey(format, key);
+    }
+
+    async importKey(key: JsonWebKey, format: KeyFormat, extractable: boolean, usages: Array<string>): Promise<CryptoKey> {
+        if (isIE11()) {
+            const keyString = getJwkString(key);
+            const keyBuffer = getArrayBufferFromString(keyString);
+
+            return new Promise((resolve, reject) => {
+                const importOperation = window['msCrypto'].subtle.importKey(format, keyBuffer, this._algorithmOptions, extractable, usages);
+                importOperation.addEventListener('complete', (e: { target: { result: CryptoKey | PromiseLike<CryptoKey>; }; }) => {
+                    resolve(e.target.result);
+                });
+                importOperation.addEventListener('error', (error: any) => {
+                    reject(error);
+                });
+            });
+        }
+
+        return window.crypto.subtle.importKey(format, key, this._algorithmOptions, extractable, usages);
+    }
+
+    async digest(algo: HashAlgorithm, dataString: string): Promise<ArrayBuffer> {
+        const data = getArrayBufferFromString(dataString);
+
+        if (isIE11()) {
+            return new Promise((resolve, reject) => {
+                const digestOperation = window['msCrypto'].subtle.digest(algo, data);
+                digestOperation.addEventListener('complete', (e: { target: { result: ArrayBuffer | PromiseLike<ArrayBuffer>; }; }) => {
+                    resolve(e.target.result);
+                });
+                digestOperation.addEventListener('error', (error: any) => {
+                    reject(error);
+                });
+            });
+        }
+
+        return window.crypto.subtle.digest(algo, data);
+    }
+}

--- a/lib/msal-core/src/DatabaseCache.ts
+++ b/lib/msal-core/src/DatabaseCache.ts
@@ -1,0 +1,65 @@
+interface IDBOpenDBRequestEvent extends Event {
+    target: IDBOpenDBRequest & EventTarget;
+}
+
+interface IDBOpenOnUpgradeNeededEvent extends IDBVersionChangeEvent {
+    target: IDBOpenDBRequest & EventTarget;
+}
+
+interface IDBRequestEvent extends Event {
+    target: IDBRequest & EventTarget;
+}
+
+export class DatabaseCache<T> {
+    private _db : IDBDatabase;
+    private _dbName: string;
+    private _tableName: string;
+    private _version: number;
+
+    constructor(dbName: string, tableName: string, version: number) {
+        this._dbName = dbName;
+        this._tableName = tableName;
+        this._version = version;
+    }
+
+    async open(): Promise<void> {
+        const openOperation = window.indexedDB.open(this._dbName, this._version);
+
+        openOperation.addEventListener('upgradeneeded', (e: IDBOpenOnUpgradeNeededEvent) => {
+            e.target.result.createObjectStore(this._tableName);
+        })
+
+        return new Promise((resolve, reject) => {
+            openOperation.addEventListener('success', (e: IDBOpenDBRequestEvent) => {
+                this._db = e.target.result;
+                resolve();
+            });
+
+            openOperation.addEventListener('error', error => reject(error))
+        })
+    }
+
+    async get(key: string): Promise<T> {
+        const transaction = this._db.transaction([ this._tableName ], "readonly");
+        const objectStore = transaction.objectStore(this._tableName);
+
+        const getOperation = objectStore.get(key);
+
+        return new Promise((resolve, reject) => {
+            getOperation.addEventListener('success', (e: IDBRequestEvent) => resolve(e.target.result));
+            getOperation.addEventListener('error', e => reject(e));
+        });
+    }
+
+    async put(key: string, payload: T): Promise<T> {
+        const transaction = this._db.transaction([ this._tableName ], "readwrite");
+        const objectStore = transaction.objectStore(this._tableName);
+
+        const putOperation = objectStore.put(payload, key);
+
+        return new Promise((resolve, reject) => {
+            putOperation.addEventListener('success', (e: IDBRequestEvent) => resolve(e.target.result));
+            putOperation.addEventListener('error', e => reject(e));
+        });
+    }
+}

--- a/lib/msal-core/src/IUri.ts
+++ b/lib/msal-core/src/IUri.ts
@@ -11,4 +11,5 @@ export interface IUri {
   Search: string;
   Hash: string;
   PathSegments: string[];
+  QueryString: string;
 }

--- a/lib/msal-core/src/PopTokenCommon.ts
+++ b/lib/msal-core/src/PopTokenCommon.ts
@@ -1,0 +1,61 @@
+export enum HashAlgorithm {
+    sha256 = 'SHA-256'
+};
+
+export enum KeyGenAlgorithm {
+    rsassa_pkcs1_v15 = "RSASSA-PKCS1-v1_5"
+}
+
+export enum KeyUsages {
+    sign = "sign",
+    verify = "verify"
+}
+
+export enum KeyFormat {
+    jwk = "jwk"
+}
+
+export function getStringFromArrayBuffer(data: ArrayBuffer): string {
+    return String.fromCharCode.apply(null, new Uint8Array(data));
+}
+
+export function getArrayBufferFromString(dataString: string): ArrayBuffer {
+    const data = new ArrayBuffer(dataString.length);
+    const dataView = new Uint8Array(data);
+    for (let i: number = 0; i < dataString.length; i++) {
+        dataView[i] = dataString.charCodeAt(i);
+    }
+    return data;
+}
+
+export function getJwkString(key: JsonWebKey): string {
+    return JSON.stringify(key, Object.keys(key).sort());
+}
+
+export function utf8Encode(input: string): string {
+    input = input.replace(/\r\n/g, "\n");
+    var utftext = "";
+
+    for (var n = 0; n < input.length; n++) {
+        var c = input.charCodeAt(n);
+
+        if (c < 128) {
+            utftext += String.fromCharCode(c);
+        }
+        else if ((c > 127) && (c < 2048)) {
+            utftext += String.fromCharCode((c >> 6) | 192);
+            utftext += String.fromCharCode((c & 63) | 128);
+        }
+        else {
+            utftext += String.fromCharCode((c >> 12) | 224);
+            utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+            utftext += String.fromCharCode((c & 63) | 128);
+        }
+    }
+
+    return utftext;
+}
+
+export function isIE11(): boolean {
+    return "msCrypto" in window;
+}

--- a/lib/msal-core/src/PopTokenGenerator.ts
+++ b/lib/msal-core/src/PopTokenGenerator.ts
@@ -1,0 +1,153 @@
+import { BrowserCrypto } from './BrowserCrypto';
+import { Base64 } from 'js-base64';
+import { HashAlgorithm, getStringFromArrayBuffer, KeyFormat, utf8Encode, getArrayBufferFromString, KeyUsages, KeyGenAlgorithm, getJwkString } from './PopTokenCommon';
+import { Utils } from './Utils';
+import { DatabaseCache } from './DatabaseCache';
+import { AuthenticationParameters } from './AuthenticationParameters';
+
+type CachedKeyPair = {
+    publicKey: CryptoKey,
+    privateKey: CryptoKey,
+    requestMethod: string,
+    requestUri: string
+}
+
+export class PopTokenGenerator {
+    private _crypto: BrowserCrypto;
+
+    private static DB_VERSION = 1;
+    private static DB_NAME = 'msal.db';
+    private static TABLE_NAME =`${PopTokenGenerator.DB_NAME}.keys`;
+    private _cache: DatabaseCache<CachedKeyPair>;
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/RsaHashedKeyGenParams
+    private static MODULUS_LENGTH: number = 2048;
+    private static PUBLIC_EXPONENT: Uint8Array = new Uint8Array([0x01, 0x00, 0x01]);
+    private static HASH_LENGTH = 43; // 256 bit digest / 6 bits per char = 43
+
+    private static KEY_USAGES = [KeyUsages.sign, KeyUsages.verify];
+    private static EXTRACTABLE = true;
+
+    constructor() {
+        this._crypto = new BrowserCrypto(KeyGenAlgorithm.rsassa_pkcs1_v15,HashAlgorithm.sha256, PopTokenGenerator.MODULUS_LENGTH, PopTokenGenerator.PUBLIC_EXPONENT);
+
+        this._cache = new DatabaseCache<CachedKeyPair>(PopTokenGenerator.DB_NAME, PopTokenGenerator.TABLE_NAME, PopTokenGenerator.DB_VERSION);
+        this._cache.open();
+    }
+
+    /**
+     * Generates a new proof-of-possession token.
+     */
+    async getNewToken(request: AuthenticationParameters): Promise<string> {
+        // Generate new key pair
+        const { publicKey, privateKey } = await this._crypto.generateKey(PopTokenGenerator.EXTRACTABLE, PopTokenGenerator.KEY_USAGES);
+
+        // Export public to jwk, private key to unextractable CryptoKey
+        const publicKeyJwk = await this._crypto.exportKey(publicKey, KeyFormat.jwk);
+        const privateKeyJwk = await this._crypto.exportKey(privateKey, KeyFormat.jwk);
+        const unextractablePrivateKey = await this._crypto.importKey(privateKeyJwk, KeyFormat.jwk, false, [ KeyUsages.sign ]);
+
+        // Generate hash of public key
+        const publicJwkString = getJwkString(publicKeyJwk);
+        const publicJwkBuffer = await this._crypto.digest(HashAlgorithm.sha256, publicJwkString);
+        const publicKeyDigest = getStringFromArrayBuffer(publicJwkBuffer);
+
+        const publicKeyHash = Utils.encode(publicKeyDigest).substr(0, PopTokenGenerator.HASH_LENGTH);
+
+        // Save key pair in cache
+        await this._cache.put(publicKeyHash, {
+            publicKey,
+            privateKey: unextractablePrivateKey,
+            requestMethod: request.requestMethod,
+            requestUri: request.requestUri
+        });
+
+        const popTokenString = JSON.stringify({
+            kid: publicKeyHash
+        })
+
+        return popTokenString;
+    }
+
+    /**
+     * Signs an access token with the given pop key.
+     * @param publicKeyHash Public key to sign payload with
+     * @param payload Payload to sign
+     */
+    async signToken(accessToken: string): Promise<string> {
+        const {
+            cnf: {
+                jwk: {
+                    kid: publicKeyHash
+                }
+            }
+        } = Utils.extractIdToken(accessToken);
+
+        const {
+            publicKey,
+            privateKey,
+            requestMethod,
+            requestUri
+        } = await this._cache.get(publicKeyHash);
+
+        const publicKeyJwk = await this._crypto.exportKey(publicKey, KeyFormat.jwk);
+        const publicJwkString = getJwkString(publicKeyJwk);
+
+        const header = {
+            alg: publicKeyJwk.alg,
+            type: KeyFormat.jwk,
+            jwk: JSON.parse(publicJwkString)
+        };
+
+        const encodedHeader = Utils.base64EncodeStringUrlSafe(utf8Encode(JSON.stringify(header)));
+
+        const urlComponents = Utils.GetUrlComponents(requestUri);
+        const uriPath = (urlComponents.AbsolutePath || "").replace(/\/+$/, "");
+        const uriHost = urlComponents.HostNameAndPort || "";
+        const uriQueryString = urlComponents.QueryString || "";
+
+        const pS256 = await this._crypto.digest(HashAlgorithm.sha256, uriPath);
+        const qS256 = await this._crypto.digest(HashAlgorithm.sha256, uriQueryString);
+
+        const payload = {
+            at: accessToken,
+            ts: Utils.now(),
+            m: requestMethod.toUpperCase(),
+            u: uriHost,
+            "p#S256": Utils.base64EncodeStringUrlSafe(getStringFromArrayBuffer(pS256)),
+            "q#S256": Utils.base64EncodeStringUrlSafe(getStringFromArrayBuffer(qS256))
+        }
+
+        const encodedPayload = Utils.base64EncodeStringUrlSafe(utf8Encode(JSON.stringify(payload)));
+
+        const tokenString = `${encodedHeader}.${encodedPayload}`;
+        const tokenBuffer = getArrayBufferFromString(tokenString);
+
+        const signatureBuffer = await this._crypto.sign(privateKey, tokenBuffer);
+        const encodedSignature = Utils.base64EncodeStringUrlSafe(getStringFromArrayBuffer(signatureBuffer));
+        const signedToken = `${tokenString}.${encodedSignature}`;
+
+        return signedToken;
+    }
+
+    /**
+     * Verifies a token is signed with the given pop key.
+     * @param publicKeyHash Public key used to sign token
+     * @param signedToken Signed pop token
+     */
+    async verifyToken(publicKeyHash: string, signedToken: string) {
+        const [
+            header,
+            payload,
+            signature
+        ] = signedToken.split(".");
+
+        const tokenString = `${header}.${payload}`;
+        const tokenBuffer = getArrayBufferFromString(tokenString);
+        const signatureBuffer = getArrayBufferFromString(Base64.decode(signature));
+
+        const { publicKey } = await this._cache.get(publicKeyHash);
+
+        return this._crypto.verify(publicKey, signatureBuffer, tokenBuffer);
+    }
+}

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -28,6 +28,7 @@ export class ServerRequestParameters {
 
   promptValue: string;
   claimsValue: string;
+  popToken: string;
 
   queryParameters: string;
   extraQueryParameters: string;
@@ -45,10 +46,11 @@ export class ServerRequestParameters {
    * @param redirectUri
    * @param state
    */
-  constructor (authority: Authority, clientId: string, scope: Array<string>, responseType: string, redirectUri: string, state: string ) {
+  constructor (authority: Authority, clientId: string, scope: Array<string>, responseType: string, redirectUri: string, state: string, popToken?: string ) {
     this.authorityInstance = authority;
     this.clientId = clientId;
     this.scopes = scope;
+    this.popToken = popToken;
 
     this.nonce = Utils.createNewGuid();
     this.state = state && !Utils.isEmpty(state) ?  Utils.createNewGuid() + "|" + state   : Utils.createNewGuid();
@@ -114,6 +116,10 @@ export class ServerRequestParameters {
 
     if (this.claimsValue) {
       str.push("claims=" + encodeURIComponent(this.claimsValue));
+    }
+
+    if (this.popToken) {
+        str.push("pop_jwk=" + encodeURIComponent(this.popToken));
     }
 
     if (this.queryParameters) {

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -231,7 +231,7 @@ export class Utils {
    */
   static base64EncodeStringUrlSafe(input: string): string {
     // html5 should support atob function for decoding
-    return Base64.encode(input);
+    return Base64.encode(input, true);
   }
 
   /**
@@ -476,7 +476,8 @@ export class Utils {
     let urlComponents = <IUri>{
       Protocol: match[1],
       HostNameAndPort: match[4],
-      AbsolutePath: match[5]
+      AbsolutePath: match[5],
+      QueryString: match[7]
     };
 
     let pathSegments = urlComponents.AbsolutePath.split("/");

--- a/lib/msal-core/src/index.ts
+++ b/lib/msal-core/src/index.ts
@@ -8,6 +8,8 @@ export { CacheResult } from "./UserAgentApplication";
 export { CacheLocation, Configuration } from "./Configuration";
 export { AuthenticationParameters } from "./AuthenticationParameters";
 export { AuthResponse } from "./AuthResponse";
+export { BrowserCrypto } from './BrowserCrypto';
+export { PopTokenGenerator } from './PopTokenGenerator';
 
 // Errors
 export { AuthError } from "./error/AuthError";


### PR DESCRIPTION
Initial implementation for proof of possession tokens.

PoP flow:

1. When the client application wants an access token, it can indicate that it wants an access token protected by PoP by passing `authenticationType: 'pop'` in the request object. It will also be required to provide the request uri and method that the access token will be used for.
2. If that value is set, `UserAgentApplication` will use `PopTokenGenerator.getNewToken()` to generate a new pop token. This will store the public/private keys in the Pop cache, and return back to `UserAgentApplication` the value to be used for the `pop_jwk` query parameter in `ServerRequestParameters` that needs to be added to access tokens request to receive an access token that is of type `pop`. This string is intended to be opaque to `UserAgentApplication`.
3. When the access token response is received, a new field will be added to the token cache called `accessTokenType`, will be either `pop` or `bearer`. This is so that when the token is retrieved from the cache, we can tell whether or not it is a pop token without inspecting the token itself.
4. When we read the access token out of the cache, we check the `accessTokenType` field, and if it is a pop token, create a new wrapping token that contains the original access token and is signed with the private key that was used to generate the original request.

TODO:

- [ ] Check that the signed tokens are in the correct format
- [ ] Complete error handling
- [ ] Telemetry?
- [ ] Test with mobile devices
- [ ] Documentation
- [ ] Samples
- [ ] Comments
