### PR TITLE
Fix angular samples

### DIFF
--- a/lib/msal-angular/samples/MSALAngularDemoApp/package.json
+++ b/lib/msal-angular/samples/MSALAngularDemoApp/package.json
@@ -20,11 +20,11 @@
     "@angular/platform-browser": "^5.0.0",
     "@angular/platform-browser-dynamic": "^5.0.0",
     "@angular/router": "^5.0.0",
+    "@azure/msal-angular": "0.1.2",
     "core-js": "^2.4.1",
     "rxjs": "^5.1.0",
     "ts-helpers": "^1.1.1",
-    "zone.js": "^0.8.4",
-    "@azure/msal-angular": "file:../.."
+    "zone.js": "^0.8.4"
   },
   "devDependencies": {
     "@angular/cli": "^1.0.1",

--- a/lib/msal-angularjs/samples/MsalAngularjsDemoApp/package.json
+++ b/lib/msal-angularjs/samples/MsalAngularjsDemoApp/package.json
@@ -12,8 +12,9 @@
     "@azure/msal-angularjs": "0.1.1"
   },
   "devDependencies": {
-    "webpack": "^2.4.1",
-    "webpack-dev-server": "^3.1.11",
-    "angular": "^1.7.0"
+    "angular": "^1.7.0",
+    "webpack": "^4.35.3",
+    "webpack-cli": "^3.3.5",
+    "webpack-dev-server": "^3.7.2"
   }
 }

--- a/lib/msal-angularjs/samples/MsalAngularjsDemoApp/webpack.config.js
+++ b/lib/msal-angularjs/samples/MsalAngularjsDemoApp/webpack.config.js
@@ -1,6 +1,7 @@
 var path = require('path');
 
 module.exports = {
+  mode: "development",
   entry: path.resolve(__dirname, 'app.js'),
   output: {
     path: path.resolve(__dirname),


### PR DESCRIPTION
- Fixes #807 where AngularJS sample wasn't building
- Reverted Angular sample to use published version of `msal-angular` until we improve our lerna setup.