### PR TITLE
demonstrate working error catching after redirect by disabling naviga…

### DIFF
--- a/lib/msal-core/samples/react-sample-app/src/AuthProvider.js
+++ b/lib/msal-core/samples/react-sample-app/src/AuthProvider.js
@@ -117,12 +117,11 @@ export default C =>
         async componentDidMount() {
             msalApp.handleRedirectCallback(error => {
                 if (error) {
-                    // This currently doesn't work,
-                    // as the component mounts multiple times
-                    // and state gets lost.
-                    // this.setState({
-                    //     error: "Unable to acquire access token."
-                    // });
+                    const errorMessage = error && error.errorMessage ? error.errorMessage : "Unable to acquire access token.";
+                    // setState works as long as navigateToLoginRequestUrl: false
+                    this.setState({
+                        error: errorMessage
+                    });
                 }
             });
 

--- a/lib/msal-core/samples/react-sample-app/src/AuthProvider.js
+++ b/lib/msal-core/samples/react-sample-app/src/AuthProvider.js
@@ -117,7 +117,7 @@ export default C =>
         async componentDidMount() {
             msalApp.handleRedirectCallback(error => {
                 if (error) {
-                    const errorMessage = error && error.errorMessage ? error.errorMessage : "Unable to acquire access token.";
+                    const errorMessage = error.errorMessage ? error.errorMessage : "Unable to acquire access token.";
                     // setState works as long as navigateToLoginRequestUrl: false
                     this.setState({
                         error: errorMessage

--- a/lib/msal-core/samples/react-sample-app/src/auth-utils.js
+++ b/lib/msal-core/samples/react-sample-app/src/auth-utils.js
@@ -63,7 +63,8 @@ export const msalApp = new UserAgentApplication({
         clientId: "245e9392-c666-4d51-8f8a-bfd9e55b2456",
         authority: "https://login.microsoftonline.com/common",
         validateAuthority: true,
-        postLogoutRedirectUri: "http://localhost:3000"
+        postLogoutRedirectUri: "http://localhost:3000",
+        navigateToLoginRequestUrl: false
     },
     cache: {
         cacheLocation: "sessionStorage",


### PR DESCRIPTION
The current React sample application does not demonstrate how to display errors from failed redirect login attempts.  This is a show stopper for any production application.  The solution here is to disable navigateToLoginRequestUrl.  This prevents refreshing and loosing component state.  

The downside is loosing the functionality of navigateToLoginRequestUrl, however this functionality can easily be implemented outside of MSAL.  