### PR TITLE
Revert IE11 angular fix for main export in #785

### DIFF
--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -18,9 +18,8 @@
     "msal",
     "oauth"
   ],
-  "main": "./lib-commonjs/index.js",
-  "module": "./lib-es6/index.js",
-  "types": "./lib-commonjs/index.d.ts",
+  "main": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
   "engines": {
     "node": ">=0.8.0"
   },


### PR DESCRIPTION
Reverts the attempted fix for IE11 in #785, which broke aot compiling. This should be merged before any further commits to the Angular package.