### PR TITLE
Add abstraction for using custom XhrClient implementation

### DIFF
--- a/lib/msal-core/src/AadAuthority.ts
+++ b/lib/msal-core/src/AadAuthority.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Authority, AuthorityType } from "./Authority";
-import { XhrClient } from "./XHRClient";
+import { IXhrClient } from "./XHRClient";
 import { AADTrustedHostList } from "./Constants";
 
 /**
@@ -15,8 +15,8 @@ export class AadAuthority extends Authority {
       return `${AadAuthority.AadInstanceDiscoveryEndpoint}?api-version=1.0&authorization_endpoint=${this.CanonicalAuthority}oauth2/v2.0/authorize`;
   }
 
-  public constructor(authority: string, validateAuthority: boolean) {
-    super(authority, validateAuthority);
+  public constructor(authority: string, validateAuthority: boolean, xhrClient?: IXhrClient) {
+    super(authority, validateAuthority, xhrClient);
   }
 
   public get AuthorityType(): AuthorityType {
@@ -40,9 +40,7 @@ export class AadAuthority extends Authority {
       return resultPromise;
     }
 
-    let client: XhrClient = new XhrClient();
-
-    return client.sendRequestAsync(this.AadInstanceDiscoveryEndpointUrl, "GET", true)
+    return this.xhrClient.sendRequestAsync(this.AadInstanceDiscoveryEndpointUrl, "GET", true)
       .then((response) => {
         return response.tenant_discovery_endpoint;
       });

--- a/lib/msal-core/src/Authority.ts
+++ b/lib/msal-core/src/Authority.ts
@@ -5,7 +5,7 @@ import { IUri } from "./IUri";
 import { Utils } from "./Utils";
 import { ITenantDiscoveryResponse } from "./ITenantDiscoveryResponse";
 import { ClientConfigurationErrorMessage } from "./error/ClientConfigurationError";
-import { XhrClient } from "./XHRClient";
+import { XhrClient, IXhrClient } from "./XHRClient";
 
 /**
  * @hidden
@@ -20,12 +20,15 @@ export enum AuthorityType {
  * @hidden
  */
 export abstract class Authority {
-  constructor(authority: string, validateAuthority: boolean) {
+  constructor(authority: string, validateAuthority: boolean, xhrClient?: IXhrClient) {
     this.IsValidationEnabled = validateAuthority;
     this.CanonicalAuthority = authority;
+    this.xhrClient = xhrClient || new XhrClient();
 
     this.validateAsUri();
   }
+
+  protected xhrClient: IXhrClient;
 
   public abstract get AuthorityType(): AuthorityType;
 
@@ -112,8 +115,7 @@ export abstract class Authority {
    * Calls the OIDC endpoint and returns the response
    */
   private DiscoverEndpoints(openIdConfigurationEndpoint: string): Promise<ITenantDiscoveryResponse> {
-    const client = new XhrClient();
-    return client.sendRequestAsync(openIdConfigurationEndpoint, "GET", /*enableCaching: */ true)
+    return this.xhrClient.sendRequestAsync(openIdConfigurationEndpoint, "GET", /*enableCaching: */ true)
         .then((response: any) => {
             return <ITenantDiscoveryResponse>{
                 AuthorizationEndpoint: response.authorization_endpoint,

--- a/lib/msal-core/src/AuthorityFactory.ts
+++ b/lib/msal-core/src/AuthorityFactory.ts
@@ -5,6 +5,7 @@
  * @hidden
  */
 import { Utils } from "./Utils";
+import { IXhrClient } from "./XHRClient";
 import { AadAuthority } from "./AadAuthority";
 import { B2cAuthority } from "./B2cAuthority";
 import { Authority, AuthorityType } from "./Authority";
@@ -32,7 +33,7 @@ export class AuthorityFactory {
     * Create an authority object of the correct type based on the url
     * Performs basic authority validation - checks to see if the authority is of a valid type (eg aad, b2c)
     */
-    public static CreateInstance(authorityUrl: string, validateAuthority: boolean): Authority {
+    public static CreateInstance(authorityUrl: string, validateAuthority: boolean, xhrClient?: IXhrClient): Authority {
         if (Utils.isEmpty(authorityUrl)) {
             return null;
         }
@@ -40,9 +41,9 @@ export class AuthorityFactory {
         // Depending on above detection, create the right type.
         switch (type) {
             case AuthorityType.B2C:
-                return new B2cAuthority(authorityUrl, validateAuthority);
+                return new B2cAuthority(authorityUrl, validateAuthority, xhrClient);
             case AuthorityType.Aad:
-                return new AadAuthority(authorityUrl, validateAuthority);
+                return new AadAuthority(authorityUrl, validateAuthority, xhrClient);
             default:
                 throw ClientConfigurationErrorMessage.invalidAuthorityType;
         }

--- a/lib/msal-core/src/B2cAuthority.ts
+++ b/lib/msal-core/src/B2cAuthority.ts
@@ -5,14 +5,15 @@ import { AadAuthority } from "./AadAuthority";
 import { Authority, AuthorityType } from "./Authority";
 import { ClientConfigurationErrorMessage } from "./error/ClientConfigurationError";
 import { Utils } from "./Utils";
+import { IXhrClient } from "./XHRClient";
 
 /**
  * @hidden
  */
 export class B2cAuthority extends AadAuthority {
   public static B2C_PREFIX: String = "tfp";
-  public constructor(authority: string, validateAuthority: boolean) {
-    super(authority, validateAuthority);
+  public constructor(authority: string, validateAuthority: boolean, xhrClient?: IXhrClient) {
+    super(authority, validateAuthority, xhrClient);
     const urlComponents = Utils.GetUrlComponents(authority);
 
     const pathSegments = urlComponents.PathSegments;

--- a/lib/msal-core/src/Configuration.ts
+++ b/lib/msal-core/src/Configuration.ts
@@ -3,6 +3,7 @@
 
 import { Logger } from "./Logger";
 import { Utils } from "./Utils";
+import { IXhrClient } from "./XHRClient";
 
 /**
  * Cache location options supported by MSAL are:
@@ -57,12 +58,14 @@ export type CacheOptions = {
  * - loadFrameTimeout             - maximum time the library should wait for a frame to load
  * - tokenRenewalOffsetSeconds    - sets the window of offset needed to renew the token before expiry
  * - navigateFrameWait            - sets the wait time for hidden iFrame navigation
+ * - xhrClient                    - Enables use of a different IXhrClient implementation for authority resolution
  */
 export type SystemOptions = {
   logger?: Logger;
   loadFrameTimeout?: number;
   tokenRenewalOffsetSeconds?: number;
   navigateFrameWait?: number;
+  xhrClient?: IXhrClient
 };
 
 /**
@@ -142,4 +145,3 @@ export function buildConfiguration({ auth, cache = {}, system = {}, framework = 
   };
   return overlayedConfig;
 }
-

--- a/lib/msal-core/src/XHRClient.ts
+++ b/lib/msal-core/src/XHRClient.ts
@@ -2,11 +2,28 @@
 // Licensed under the MIT License.
 
 /**
+ * Provides a simple interface for sending a REST API request
+ * and returning the deserialized JSON response as an object.
+ */
+export interface IXhrClient {
+  /**
+   * Sends a request asyncrhonously to the specified URL and returns
+   * the deserialized JSON response as an object.
+   *
+   * @param url The Url to which the request will be sent.
+   * @param method The HTTP method to use for the request.
+   * @param enableCaching If true, enables response caching.
+   * @return An object containing the deserialized JSON response.
+   */
+  sendRequestAsync(url: string, method: string, enableCaching?: boolean): Promise<any>;
+}
+
+/**
  * XHR client for JSON endpoints
  * https://www.npmjs.com/package/async-promise
  * @hidden
  */
-export class XhrClient {
+export class XhrClient implements IXhrClient {
   public sendRequestAsync(url: string, method: string, enableCaching?: boolean): Promise<any> {
     return new Promise<string>((resolve, reject) => {
       var xhr = new XMLHttpRequest();

--- a/lib/msal-core/src/index.ts
+++ b/lib/msal-core/src/index.ts
@@ -8,6 +8,7 @@ export { CacheResult } from "./UserAgentApplication";
 export { CacheLocation, Configuration } from "./Configuration";
 export { AuthenticationParameters } from "./AuthenticationParameters";
 export { AuthResponse } from "./AuthResponse";
+export { IXhrClient } from "./XHRClient";
 
 // Errors
 export { AuthError } from "./error/AuthError";


### PR DESCRIPTION
Hi all!  I work on the [`@azure/identity` library](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity) that's part of the new wave of Azure SDK libraries in development by my team.  We've just started looking into browser-based authentication and wanted to integrate MSAL.js for that purpose since you already have a complete implementation.

@schaabs and I were wondering if there is a way to use our own HTTP pipeline for any requests that MSAL.js makes, but based on what I found in the code, `XhrClient` use is hardwired.  This PR is an attempt to make the `XhrClient` implementation configurable so that our own can be swapped in.

I'm not thrilled with calling the interface `IXhrClient` but thought it'd be the best starting point for discussion.  Perhaps it should be `RestClient` or something to that effect?