### PR TITLE
Remove base64-js dependency due to incompatibility with es modules, remove unused encoding functions

### DIFF
--- a/lib/msal-core/package-lock.json
+++ b/lib/msal-core/package-lock.json
@@ -4829,11 +4829,6 @@
         "handlebars": "^4.1.0"
       }
     },
-    "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -36,7 +36,6 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "js-base64": "^2.5.1",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"
   },

--- a/lib/msal-core/src/AccessTokenKey.ts
+++ b/lib/msal-core/src/AccessTokenKey.ts
@@ -17,6 +17,6 @@ export class AccessTokenKey {
     this.authority = Utils.CanonicalizeUri(authority);
     this.clientId = clientId;
     this.scopes = scopes;
-    this.homeAccountIdentifier = Utils.base64EncodeStringUrlSafe(uid) + "." + Utils.base64EncodeStringUrlSafe(utid);
+    this.homeAccountIdentifier = Utils.base64Encode(uid) + "." + Utils.base64Encode(utid);
   }
 }

--- a/lib/msal-core/src/Account.ts
+++ b/lib/msal-core/src/Account.ts
@@ -65,7 +65,7 @@ export class Account {
 
         let homeAccountIdentifier: string;
         if (!Utils.isEmpty(uid) && !Utils.isEmpty(utid)) {
-            homeAccountIdentifier = Utils.base64EncodeStringUrlSafe(uid) + "." + Utils.base64EncodeStringUrlSafe(utid);
+            homeAccountIdentifier = Utils.base64Encode(uid) + "." + Utils.base64Encode(utid);
         }
         return new Account(accountIdentifier, homeAccountIdentifier, idToken.preferredName, idToken.name, idToken.claims, idToken.sid, idToken.issuer);
     }

--- a/lib/msal-core/src/ClientInfo.ts
+++ b/lib/msal-core/src/ClientInfo.ts
@@ -35,7 +35,7 @@ export class ClientInfo {
     }
 
     try {
-      const decodedClientInfo: string = Utils.base64DecodeStringUrlSafe(rawClientInfo);
+      const decodedClientInfo: string = Utils.base64Decode(rawClientInfo);
       const clientInfo: ClientInfo = <ClientInfo>JSON.parse(decodedClientInfo);
       if (clientInfo) {
         if (clientInfo.hasOwnProperty("uid")) {

--- a/lib/msal-core/src/Utils.ts
+++ b/lib/msal-core/src/Utils.ts
@@ -7,9 +7,7 @@ import {Constants, SSOTypes, PromptState} from "./Constants";
 import { AuthenticationParameters } from "./AuthenticationParameters";
 import { AuthResponse } from "./AuthResponse";
 import { IdToken } from "./IdToken";
-import { ClientAuthError } from "./error/ClientAuthError";
 import { Library } from "./Constants";
-import { Base64 } from "js-base64";
 import { StringDict } from "./MsalTypes";
 
 /**
@@ -207,7 +205,7 @@ export class Utils {
     }
     try {
       const base64IdToken = decodedToken.JWSPayload;
-      const base64Decoded = this.base64DecodeStringUrlSafe(base64IdToken);
+      const base64Decoded = this.base64Decode(base64IdToken);
       if (!base64Decoded) {
         //this._requestContext.logger.info("The returned id_token could not be base64 url safe decoded.");
         return null;
@@ -225,14 +223,18 @@ export class Utils {
 
   //#region Encode and Decode
 
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#Solution_4_%E2%80%93_escaping_the_string_before_encoding_it
+
   /**
    * encoding string to base64 - platform specific check
    *
    * @param input
    */
-  static base64EncodeStringUrlSafe(input: string): string {
-    // html5 should support atob function for decoding
-    return Base64.encode(input);
+  static base64Encode(input: string): string {
+    return btoa(encodeURIComponent(input).replace(/%([0-9A-F]{2})/g,
+        function toSolidBytes(match, p1) {
+            return String.fromCharCode(Number("0x" + p1));
+    }));
   }
 
   /**
@@ -240,121 +242,10 @@ export class Utils {
    *
    * @param base64IdToken
    */
-  static base64DecodeStringUrlSafe(base64IdToken: string): string {
-    // html5 should support atob function for decoding
-    base64IdToken = base64IdToken.replace(/-/g, "+").replace(/_/g, "/");
-    return decodeURIComponent(encodeURIComponent(Base64.decode(base64IdToken))); // jshint ignore:line
-  }
-
-  /**
-   * base64 encode a string
-   *
-   * @param input
-   */
-  // TODO: Rename to specify type of encoding
-  static encode(input: string): string {
-    const keyStr: string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-    let output = "";
-    let chr1: number, chr2: number, chr3: number, enc1: number, enc2: number, enc3: number, enc4: number;
-    var i = 0;
-
-    input = this.utf8Encode(input);
-
-    while (i < input.length) {
-      chr1 = input.charCodeAt(i++);
-      chr2 = input.charCodeAt(i++);
-      chr3 = input.charCodeAt(i++);
-
-      enc1 = chr1 >> 2;
-      enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
-      enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
-      enc4 = chr3 & 63;
-
-      if (isNaN(chr2)) {
-        enc3 = enc4 = 64;
-      } else if (isNaN(chr3)) {
-        enc4 = 64;
-      }
-
-      output = output + keyStr.charAt(enc1) + keyStr.charAt(enc2) + keyStr.charAt(enc3) + keyStr.charAt(enc4);
-    }
-
-    return output.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-  }
-
-  /**
-   * utf8 encode a string
-   *
-   * @param input
-   */
-  static utf8Encode(input: string): string {
-    input = input.replace(/\r\n/g, "\n");
-    var utftext = "";
-
-    for (var n = 0; n < input.length; n++) {
-      var c = input.charCodeAt(n);
-
-      if (c < 128) {
-        utftext += String.fromCharCode(c);
-      }
-      else if ((c > 127) && (c < 2048)) {
-        utftext += String.fromCharCode((c >> 6) | 192);
-        utftext += String.fromCharCode((c & 63) | 128);
-      }
-      else {
-        utftext += String.fromCharCode((c >> 12) | 224);
-        utftext += String.fromCharCode(((c >> 6) & 63) | 128);
-        utftext += String.fromCharCode((c & 63) | 128);
-      }
-    }
-
-    return utftext;
-  }
-
-  /**
-   * decode a base64 token string
-   *
-   * @param base64IdToken
-   */
-  // TODO: Rename to specify type of encoding
-  static decode(base64IdToken: string): string {
-    var codes = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-    base64IdToken = String(base64IdToken).replace(/=+$/, "");
-    var length = base64IdToken.length;
-    if (length % 4 === 1) {
-      throw ClientAuthError.createTokenEncodingError(base64IdToken);
-    }
-    let h1: number, h2: number, h3: number, h4: number, bits: number, c1: number, c2: number, c3: number, decoded = "";
-    for (var i = 0; i < length; i += 4) {
-      //Every 4 base64 encoded character will be converted to 3 byte string, which is 24 bits
-      // then 6 bits per base64 encoded character
-      h1 = codes.indexOf(base64IdToken.charAt(i));
-      h2 = codes.indexOf(base64IdToken.charAt(i + 1));
-      h3 = codes.indexOf(base64IdToken.charAt(i + 2));
-      h4 = codes.indexOf(base64IdToken.charAt(i + 3));
-      // For padding, if last two are "="
-      if (i + 2 === length - 1) {
-        bits = h1 << 18 | h2 << 12 | h3 << 6;
-        c1 = bits >> 16 & 255;
-        c2 = bits >> 8 & 255;
-        decoded += String.fromCharCode(c1, c2);
-        break;
-      }
-      // if last one is "="
-      else if (i + 1 === length - 1) {
-        bits = h1 << 18 | h2 << 12;
-        c1 = bits >> 16 & 255;
-        decoded += String.fromCharCode(c1);
-        break;
-      }
-      bits = h1 << 18 | h2 << 12 | h3 << 6 | h4;
-      // then convert to 3 byte chars
-      c1 = bits >> 16 & 255;
-      c2 = bits >> 8 & 255;
-      c3 = bits & 255;
-      decoded += String.fromCharCode(c1, c2, c3);
-    }
-    return decoded;
+  static base64Decode(input: string): string {
+    return decodeURIComponent(atob(input).split("").map(function(c) {
+        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(""));
   }
 
   /**
@@ -642,8 +533,8 @@ export class Utils {
       }
       case SSOTypes.HOMEACCOUNT_ID: {
         let homeAccountId = ssoData.split(".");
-        const uid = Utils.base64DecodeStringUrlSafe(homeAccountId[0]);
-        const utid = Utils.base64DecodeStringUrlSafe(homeAccountId[1]);
+        const uid = Utils.base64Decode(homeAccountId[0]);
+        const utid = Utils.base64Decode(homeAccountId[1]);
 
         // TODO: domain_req and login_req are not needed according to eSTS team
         ssoParam[SSOTypes.LOGIN_REQ] = uid;

--- a/lib/msal-core/src/telemetry/TelemetryUtils.ts
+++ b/lib/msal-core/src/telemetry/TelemetryUtils.ts
@@ -31,5 +31,5 @@ export const hashPersonalIdentifier = (valueToHash: string) => {
     // TODO sha256 this
     // Current test runner is being funny with node libs that are webpacked anyway
     // need a different solution
-    return Utils.base64EncodeStringUrlSafe(valueToHash);
+    return Utils.base64Encode(valueToHash);
 };

--- a/lib/msal-core/test/Account.spec.ts
+++ b/lib/msal-core/test/Account.spec.ts
@@ -23,7 +23,7 @@ describe("Account.ts Class", function() {
     it("verifies homeAccountIdentifier matches", function () {
 
         const account = Account.createAccount(idToken, clientInfo);
-        const homeAccountIdentifier = Utils.base64EncodeStringUrlSafe(TEST_DATA_CLIENT_INFO.TEST_UID) + "." + Utils.base64EncodeStringUrlSafe(TEST_DATA_CLIENT_INFO.TEST_UTID);
+        const homeAccountIdentifier = Utils.base64Encode(TEST_DATA_CLIENT_INFO.TEST_UID) + "." + Utils.base64Encode(TEST_DATA_CLIENT_INFO.TEST_UTID);
 
         expect(account.homeAccountIdentifier).to.equal(homeAccountIdentifier);
     });

--- a/lib/msal-core/test/ClientInfo.spec.ts
+++ b/lib/msal-core/test/ClientInfo.spec.ts
@@ -70,7 +70,7 @@ describe("Client Info", function () {
         });
 
         it("throws an error if the decoded string is not a valid JSON object.", function () {
-            sinon.stub(Utils, "base64DecodeStringUrlSafe").returns(TEST_DATA_CLIENT_INFO.TEST_INVALID_JSON_CLIENT_INFO);
+            sinon.stub(Utils, "base64Decode").returns(TEST_DATA_CLIENT_INFO.TEST_INVALID_JSON_CLIENT_INFO);
             let authErr : AuthError;
             try {
                 // What we pass in here doesn't matter since we are stubbing
@@ -88,7 +88,7 @@ describe("Client Info", function () {
         });
 
         it("correct sets uid and utid if parsing is done correctly", function () {
-            sinon.stub(Utils, "base64DecodeStringUrlSafe").returns(TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO);
+            sinon.stub(Utils, "base64Decode").returns(TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO);
             // What we pass in here doesn't matter since we are stubbing
             clientInfoObj = new ClientInfo(TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO);
             expect(clientInfoObj).to.not.be.null;

--- a/lib/msal-core/test/Utils.spec.ts
+++ b/lib/msal-core/test/Utils.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import { Utils } from "../src/Utils";
-import { IdToken } from "../src/IdToken";
 
 describe("Utils.ts class", () => {
     it("get getLibraryVersion()", () => {
@@ -16,21 +15,25 @@ describe("Utils.ts class", () => {
         console.log(Utils.replaceTenantPath("http://a.com/common", "1234-5678"));
     });
 
-    it("test Base64 encode decode", () => {
-        // english
-        expect(Utils.base64EncodeStringUrlSafe("msaljs")).to.be.equal("bXNhbGpz");
-        expect(Utils.base64DecodeStringUrlSafe("bXNhbGpz")).to.be.equal("msaljs");
+    describe("test Base64 encode decode", () => {
+        it('english', () => {
+            expect(Utils.base64Encode("msaljs")).to.be.equal("bXNhbGpz");
+            expect(Utils.base64Decode("bXNhbGpz")).to.be.equal("msaljs");
+        });
 
-        // Icelandic
-        expect(Utils.base64EncodeStringUrlSafe("Björn Ironside")).to.be.equal("QmrDtnJuIElyb25zaWRl");
-        expect(Utils.base64DecodeStringUrlSafe("QmrDtnJuIElyb25zaWRl")).to.be.equal("Björn Ironside");
+        it('Icelandic', () => {
+            expect(Utils.base64Encode("Björn Ironside")).to.be.equal("QmrDtnJuIElyb25zaWRl");
+            expect(Utils.base64Decode("QmrDtnJuIElyb25zaWRl")).to.be.equal("Björn Ironside");
+        });
 
-        // hebrew
-        expect(Utils.base64EncodeStringUrlSafe("בְּצַלְאֵל")).to.be.equal("15HWvNaw16bWt9ec1rDXkNa115w=");
-        expect(Utils.base64DecodeStringUrlSafe("15HWvNaw16bWt9ec1rDXkNa115w=")).to.be.equal("בְּצַלְאֵל");
+        it('hebrew', () => {
+            expect(Utils.base64Encode("בְּצַלְאֵל")).to.be.equal("15HWvNaw16bWt9ec1rDXkNa115w=");
+            expect(Utils.base64Decode("15HWvNaw16bWt9ec1rDXkNa115w=")).to.be.equal("בְּצַלְאֵל");
+        });
 
-         // spanish
-         expect(Utils.base64EncodeStringUrlSafe("Avrán")).to.be.equal("QXZyw6Fu");
-         expect(Utils.base64DecodeStringUrlSafe("QXZyw6Fu")).to.be.equal("Avrán");
+        it('spanish', () => {
+            expect(Utils.base64Encode("Avrán")).to.be.equal("QXZyw6Fu");
+            expect(Utils.base64Decode("QXZyw6Fu")).to.be.equal("Avrán");
+        });
     });
 });


### PR DESCRIPTION
Removes the dependency on `js-base64` due to incompatibility with ES modules, as reported in #746. Replaced base64 encoding functionality with implementation provided on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#Solution_4_%E2%80%93_escaping_the_string_before_encoding_it).

Also removes unused encoding functions that performed similar functionality. 
