### PR TITLE
Removes claim dependency 

### DIFF
--- a/lib/msal-angular/src/msal-guard.service.ts
+++ b/lib/msal-angular/src/msal-guard.service.ts
@@ -24,7 +24,7 @@ export class MsalGuard implements CanActivate {
         this.authService.getLogger().verbose("location change event from old url to new url");
 
         this.authService.updateDataFromCache([this.config.clientID]);
-        if (!this.authService._oauthData.isAuthenticated && !this.authService._oauthData.userName) {
+        if (!this.authService._oauthData.isAuthenticated && !this.isObjectEmpty(this.authService._oauthData.idToken)) {
             if (state.url) {
 
                 if (!this.authService._renewActive && !this.authService.loginInProgress()) {
@@ -88,6 +88,10 @@ export class MsalGuard implements CanActivate {
 
     isEmpty = function (str: any) {
         return (typeof str === "undefined" || !str || 0 === str.length);
+    };
+
+    isObjectEmpty(obj: Object) {
+        return Object.keys(obj).length === 0;
     };
 
 }


### PR DESCRIPTION
Since the claim name is not required to exist in the id token (https://openid.net/specs/openid-connect-core-1_0.html#IDToken), having the check depending on that claim is breaking some angular users.
In case of this claim name been not returned, the MsalGuard process to acquire a token silently just fails and the redirect to the identity provider takes place.

Fixing the code to check if the idToken is populated than a specific claim.