### PR TITLE
proof of concept login provider

### DIFF
--- a/lib/msal-core/package-lock.json
+++ b/lib/msal-core/package-lock.json
@@ -3464,12 +3464,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3484,17 +3486,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3611,7 +3616,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3623,6 +3629,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3637,6 +3644,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3644,12 +3652,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3668,6 +3678,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3748,7 +3759,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3760,6 +3772,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3881,6 +3894,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/lib/msal-core/src/login/LoginProvider.ts
+++ b/lib/msal-core/src/login/LoginProvider.ts
@@ -1,0 +1,123 @@
+import { AuthenticationParameters } from "../AuthenticationParameters";
+import { UserAgentApplication, ResponseTypes } from "../UserAgentApplication";
+import { ClientConfigurationError } from "../error/ClientConfigurationError";
+import { ClientAuthError } from "../error/ClientAuthError";
+import { buildResponseStateOnly } from "../AuthResponse";
+import { Utils } from "../Utils";
+import { Account } from "../Account";
+import { Logger } from "../Logger";
+import { ServerRequestParameters } from "../ServerRequestParameters";
+import { Constants } from "../Constants";
+
+export default class LoginProvider {
+
+    private userAgentApplicationInstance: UserAgentApplication;
+    private logger: Logger;
+
+    constructor(uaaInstance: UserAgentApplication, logger: Logger) {
+        this.userAgentApplicationInstance = uaaInstance;
+        this.logger = logger;
+    }
+
+    public loginRedirect(request: AuthenticationParameters): void {
+        // Throw error if callbacks are not set before redirect
+        if (!this.userAgentApplicationInstance.redirectCallbacksAreSet()) {
+            throw ClientConfigurationError.createRedirectCallbacksNotSetError();
+        }
+        // Creates navigate url; saves value in cache; redirect user to AAD
+        if (this.userAgentApplicationInstance.loginIsInProgress()) {
+            this.userAgentApplicationInstance.redirectErrorHandler(
+                ClientAuthError.createLoginInProgressError(), buildResponseStateOnly(request && request.state)
+            );
+            return;
+        }
+
+        // if extraScopesToConsent is passed, append them to the login request
+        let scopes: Array<string> = this.userAgentApplicationInstance.appendScopes(request);
+
+        // Validate and filter scopes (the validate function will throw if validation fails)
+        this.userAgentApplicationInstance.validateInputScope(scopes, false);
+
+        const account: Account = this.userAgentApplicationInstance.getAccount();
+
+        // defer queryParameters generation to Helper if developer passes account/sid/login_hint
+        if (Utils.isSSOParam(request)) {
+            // if account is not provided, we pass null
+            this.loginRedirectHelper(account, request, scopes);
+        }
+        // else handle the library data
+        else {
+            // extract ADAL id_token if exists
+            let adalIdToken = this.userAgentApplicationInstance.extractADALIdToken();
+
+            // silent login if ADAL id_token is retrieved successfully - SSO
+            if (adalIdToken && !scopes) {
+                this.logger.info("ADAL's idToken exists. Extracting login information from ADAL's idToken ");
+                let tokenRequest: AuthenticationParameters = this.userAgentApplicationInstance.buildIDTokenRequest(request);
+
+                this.userAgentApplicationInstance.setSilentLogin(true);
+                this.userAgentApplicationInstance.acquireTokenSilent(tokenRequest).then(response => {
+                    this.userAgentApplicationInstance.setSilentLogin(false);
+                    this.logger.info("Unified cache call is successful");
+
+                    if (this.userAgentApplicationInstance.redirectCallbacksAreSet()) {
+                        this.userAgentApplicationInstance.redirectSuccessHandler(response);
+                    }
+                    return;
+                }, (error) => {
+                    this.userAgentApplicationInstance.setSilentLogin(false);
+                    this.logger.error("Error occurred during unified cache ATS");
+
+                    // call the loginRedirectHelper later with no user account context
+                    this.loginRedirectHelper(null, request, scopes);
+                });
+            }
+            // else proceed to login
+            else {
+            // call the loginRedirectHelper later with no user account context
+            this.loginRedirectHelper(null, request, scopes);
+            }
+        }
+    }
+
+    private loginRedirectHelper(account: Account, request?: AuthenticationParameters, scopes?: Array<string>) {
+        // Track login in progress
+        this.userAgentApplicationInstance.setLoginInProgress(true);
+
+        this.userAgentApplicationInstance.authorityInstance.resolveEndpointsAsync().then(() => {
+
+          // create the Request to be sent to the Server
+          let serverAuthenticationRequest = new ServerRequestParameters(
+            this.userAgentApplicationInstance.authorityInstance,
+            this.userAgentApplicationInstance.clientId,
+            scopes,
+            ResponseTypes.id_token,
+            this.userAgentApplicationInstance.getRedirectUri(),
+            request && request.state
+          );
+
+          // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
+          serverAuthenticationRequest = this.userAgentApplicationInstance.populateQueryParams(account, request, serverAuthenticationRequest);
+
+          // if the user sets the login start page - angular only??
+          let loginStartPage = this.userAgentApplicationInstance.cacheStorage.getItem(Constants.angularLoginRequest);
+          if (!loginStartPage || loginStartPage === "") {
+            loginStartPage = window.location.href;
+          } else {
+            this.userAgentApplicationInstance.cacheStorage.setItem(Constants.angularLoginRequest, "");
+          }
+
+          this.userAgentApplicationInstance.updateCacheEntries(serverAuthenticationRequest, account, loginStartPage);
+
+          // build URL to navigate to proceed with the login
+          let urlNavigate = serverAuthenticationRequest.createNavigateUrl(scopes) + Constants.response_mode_fragment;
+
+          // Redirect user to login URL
+          this.userAgentApplicationInstance.promptUser(urlNavigate);
+        }).catch((err) => {
+          this.logger.warning("could not resolve endpoints");
+          this.userAgentApplicationInstance.redirectErrorHandler(ClientAuthError.createEndpointResolutionError(err.toString), buildResponseStateOnly(request && request.state));
+        });
+      }
+
+}


### PR DESCRIPTION
Proof of concept of how we can split the business logic out of UAA

Terms:

*Resource* - The piece of the application responsible as the interface to consumers.  UserAgentApplication would be the resource / client.  Its sole responsibility would be to expose methods like `acquireTokenSilent` or `loginPopup`, not to implement them.

*Provider* - Instantiated by the resource, but not responsible for exposing anything externally to customers.  It encapsulates the business logic / recipe for what `loginPopup` means, or the steps needed to execute that.

*Store* [Not Seen Here]  - Responsible for the applicaiton state of the entire app.  Instead of UAA holding references like this.loginInProgress, it would be encasulated and managed by a <something>Store class.  This could eventually be broken up into many stores, but it keeps state out of resources and providers but allows them to be accessed. 


What would moving to this pattern look like

1. All public apis in UAA are simply wrappers, and the business logic is pulled into providers.
we would have.
```js
/providers
   LoginProvider.ts [loginRedirect, loginPopup]  // these can all be separate fils
   TokenProvider.ts [acquireTokenSilent, popup, Redirect] 
```

For now, UAA would still have state, but we could pass an instance of UAA into each provider so they have what they need to keep working

- When step 1 is done, the code is separated but the problems that still exist are 
 * state in UAA with an instance being passed around
* Utils that dont belong in UAA are still there 
* Things are now public that don't belong in the public scope.

2. Factor out all the state independent utilities from UAA 
    now that the business logic functions are gone, we can pull all the state independent things into utilities.  Basically every function we had to make public that doesn't use `this`

Problems that still exist after this 
*   UAA still has state and every provider needs to know about its calling resource

3.  Encapsulate app state in a store.
pull out app state into a singleton class responsible for managing state.  UAA no longer has any state, but is responsible for initializing the store and provders

```js
class UAA {
   constructor(config){
        this.applicationStore = new ApplicationStore(config);
       
        this.tokenProvder = new TokenProvider(this.applicationStore, this.logger);
        this.loginProvider = new LoginProvider(this.applicationStore, this.logger, this.tokenProvider);
    }


    loginRedirect() {
       return this.loginProvdider.loginRedirect
   }
   
   loginPopup() { 
       return this.loginProvdider.loginPopup();
   }

   acquireTokenSilen() {
       return this.tokenProvider.acquireTokenSilent();
   }
}
```

UAA is now free from state, utils, and business logic.
Providers encapsulate business logic and can be cleanly understood and changed 