### PR TITLE
Fixing issue with tokenType when renewing Id Token

### DIFF
--- a/lib/msal-core/samples/VanillaJSTestApp/index_renewIdToken.html
+++ b/lib/msal-core/samples/VanillaJSTestApp/index_renewIdToken.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Quickstart for MSAL JS</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>
+    <script src="dist/msal.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="/style.css">
+</head>
+
+<body>
+    <div class="container">
+        <div class="leftContainer">
+            <p id="WelcomeMessage">Welcome to the Microsoft Authentication Library For Javascript Quickstart</p>
+            <button id="SignIn" onclick="signIn()">Sign In</button>
+            <button id="ReadMail" onclick="readMail()">Read Email</button>
+        </div>
+        <div class="rightContainer">
+            <pre id="json"></pre>
+        </div>
+    </div>
+    <script>
+    /*var applicationConfig = {
+            clientID: "245e9392-c666-4d51-8f8a-bfd9e55b2456",
+            authority: "https://login.microsoftonline.com/common",
+            graphScopes: ["user.read", "Mail.Send"],
+            graphEndpoint: "https://graph.microsoft.com/v1.0/me",
+            loginType: 'POPUP'
+    };*/
+
+    var msalConfig = {
+        auth: {
+            clientId: "79d1dd3f-4de3-4b69-ac25-f2fc5eefe773",
+            authority: "https://login.microsoftonline.com/msidlab4.onmicrosoft.com/",
+            validateAuthority: true
+        },
+        cache: {
+            cacheLocation: "localStorage",
+            storeAuthStateInCookie: true
+        }
+    };
+
+    var silentLoginRequest = {
+        scopes: [msalConfig.auth.clientId],
+        forceRefresh: true
+    }
+
+    var loginRequest = {
+        scopes: ["openid", "profile", "User.Read"]
+    }
+
+    var tokenRequest = {
+        scopes: ["Mail.Read"]
+    };
+
+    var graphConfig = {
+        graphMeEndpoint: "https://graph.microsoft.com/v1.0/me",
+        graphMailEndpoint: "https://graph.microsoft.com/v1.0/me/messages"
+    };
+
+
+    var myMSALObj = new Msal.UserAgentApplication(msalConfig);
+    myMSALObj.handleRedirectCallback(authRedirectCallBack);
+
+    function signIn() {
+        /*let loginRequest = {
+            scopes: graphConfig.loginScopes
+        };*/
+        myMSALObj.acquireTokenSilent(silentLoginRequest).then(function (tokenResponse) {
+            console.log("response token type: ", tokenResponse.tokenType);
+            console.log("Full response: ", JSON.stringify(tokenResponse));
+            showWelcomeMessage();
+            acquireTokenPopupAndCallMSGraph(graphConfig.graphMeEndpoint, tokenRequest);
+        }).catch(function (error) {
+            if (error.errorCode.indexOf("user_login_error") !== -1)  {
+                myMSALObj.loginPopup(loginRequest).then(function (loginResponse) {
+                    //Login Success
+                    console.log(loginResponse);
+                    showWelcomeMessage();
+                    acquireTokenPopupAndCallMSGraph(graphConfig.graphMeEndpoint, tokenRequest);
+                }).catch(function (error) {
+                    console.log(error);
+                });
+            } else {
+                console.log("Login ATS Err: ");
+                console.log(error);
+            }
+        });
+        
+    }
+
+    function acquireTokenPopupAndCallMSGraph(endpoint, request) {
+        //Call acquireTokenSilent (iframe) to obtain a token for Microsoft Graph
+        /*
+        let tokenRequest = {
+            scopes: applicationConfig.graphScopes
+        };
+        */
+        myMSALObj.acquireTokenSilent(request).then(function (tokenResponse) {
+            console.log("acquireTokenSilent scopes: ", tokenResponse.scopes);
+            callMSGraph(endpoint, tokenResponse.accessToken, graphAPICallback);
+        }).catch(function (error) {
+            console.log(error);
+            // Call acquireTokenPopup (popup window) in case of acquireTokenSilent failure due to consent or interaction required ONLY
+            if (requiresInteraction(error.errorCode)) {
+                myMSALObj.acquireTokenPopup(request).then(function (tokenResponse) {
+                    callMSGraph(endpoint, tokenResponse.accessToken, graphAPICallback);
+                }).catch(function (error) {
+                    console.log(error);
+                });
+            }
+        });
+    }
+
+    function callMSGraph(theUrl, accessToken, callback) {
+        var xmlHttp = new XMLHttpRequest();
+        xmlHttp.onreadystatechange = function () {
+            if (this.readyState == 4 && this.status == 200)
+                callback(JSON.parse(this.responseText));
+        }
+        xmlHttp.open("GET", theUrl, true); // true for asynchronous
+        xmlHttp.setRequestHeader('Authorization', 'Bearer ' + accessToken);
+        xmlHttp.send();
+    }
+
+    function graphAPICallback(data) {
+        document.getElementById("json").innerHTML = JSON.stringify(data, null, 2);
+    }
+
+    function showWelcomeMessage() {
+        var divWelcome = document.getElementById('WelcomeMessage');
+        divWelcome.innerHTML = 'Welcome ' + myMSALObj.getAccount().userName + " to Microsoft Graph API";
+        var loginbutton = document.getElementById('SignIn');
+        loginbutton.innerHTML = 'Sign Out';
+        loginbutton.setAttribute('onclick', 'signOut();');
+    }
+
+    function readMail() {
+        acquireTokenPopupAndCallMSGraph(graphConfig.graphMailEndpoint, tokenRequest);
+    }
+
+    function signOut() {
+        myMSALObj.logout();
+    }
+
+   // This function can be removed if you do not need to support IE
+   function acquireTokenRedirectAndCallMSGraph(endpoint, request) {
+        //Call acquireTokenSilent (iframe) to obtain a token for Microsoft Graph
+        /*let tokenRequest = {
+            scopes: graphConfig.scopes
+        };*/
+        myMSALObj.acquireTokenSilent(request).then(function (tokenResponse) {
+            callMSGraph(endpoint, tokenResponse.accessToken, graphAPICallback);
+        }).catch(function (error) {
+            console.log("error is: "+ error);
+            console.log("stack:" + error.stack);
+            //Call acquireTokenRedirect in case of acquireToken Failure
+            if (requiresInteraction(error.errorCode)) {
+                myMSALObj.acquireTokenRedirect(request);
+            }
+        });
+    }
+
+    function authRedirectCallBack(error, response) {
+        if (error) {
+            console.log(error);
+        } else {
+            if (response.tokenType === "id_token") {
+                showWelcomeMessage();
+                acquireTokenRedirectAndCallMSGraph(graphConfig.graphMeEndpoint, loginRequest);
+            } else if (response.tokenType === "access_token") {
+                callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, graphAPICallback);
+            } else {
+                console.log("token type is:" + response.tokenType);
+            }
+        }
+    }
+
+    function requiresInteraction(errorMessage) {
+        if (!errorMessage || !errorMessage.length) {
+            return false;
+        }
+
+        console.log("requiresinteraction is:" + errorMessage );
+        return errorMessage.indexOf("consent_required") !== -1 ||
+            errorMessage.indexOf("interaction_required") !== -1 ||
+            errorMessage.indexOf("login_required") !== -1 ;
+    }
+
+    // Browser check variables
+    var ua = window.navigator.userAgent;
+    var msie = ua.indexOf('MSIE ');
+    var msie11 = ua.indexOf('Trident/');
+    var msedge = ua.indexOf('Edge/');
+    var isIE = msie > 0 || msie11 > 0;
+    var isEdge = msedge > 0;
+
+    //If you support IE, our recommendation is that you sign-in using Redirect APIs
+    //If you as a developer are testing using Edge InPrivate mode, please add "isEdge" to the if check
+    if (!isIE) {
+        signIn();
+        if (myMSALObj.getAccount()) {// avoid duplicate code execution on page load in case of iframe and popup window.
+            showWelcomeMessage();
+            acquireTokenPopupAndCallMSGraph(graphConfig.graphMeEndpoint, loginRequest);
+        }
+    }
+    else {
+        document.getElementById("SignIn").onclick = function () {
+            myMSALObj.loginRedirect(loginRequest);
+        };
+
+        document.getElementById("ReadMail").onclick = function () {
+            readMail();
+        };
+
+
+        if (myMSALObj.getAccount() && !myMSALObj.isCallback(window.location.hash)) {// avoid duplicate code execution on page load in case of iframe and popup window.
+            showWelcomeMessage();
+            acquireTokenRedirectAndCallMSGraph(graphConfig.graphMeEndpoint, loginRequest);
+        } else {
+            signIn();
+        }
+    }
+</script>
+</body>
+</html>

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -655,6 +655,7 @@ export class UserAgentApplication {
               // App uses idToken to send to api endpoints
               // Default scope is tracked as clientId to store this token
               this.logger.verbose("renewing idToken");
+              this.silentLogin = true;
               this.renewIdToken(request.scopes, resolve, reject, account, serverAuthenticationRequest);
             } else {
               // renew access token


### PR DESCRIPTION
This PR is to fix part of an issue describe in issue #736 where the tokenType in the response for a acquireTokenSilent call which was renewing an id token was incorrectly displaying the "access_token" type. 