### PR TITLE
Fixing issue where input scopes parameter was being mutated

### DIFF
--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -54,7 +54,11 @@ export class ServerRequestParameters {
   constructor (authority: Authority, clientId: string, scope: Array<string>, responseType: string, redirectUri: string, state: string) {
     this.authorityInstance = authority;
     this.clientId = clientId;
-    this.scopes = scope;
+    if (!scope) {
+      this.scopes = [clientId];
+    } else {
+      this.scopes = scope.slice(0);
+    }
 
     this.nonce = Utils.createNewGuid();
     this.state = state && !Utils.isEmpty(state) ?  Utils.createNewGuid() + "|" + state   : Utils.createNewGuid();

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -57,7 +57,7 @@ export class ServerRequestParameters {
     if (!scope) {
       this.scopes = [clientId];
     } else {
-      this.scopes = scope.slice(0);
+      this.scopes = scope.slice();
     }
 
     this.nonce = Utils.createNewGuid();

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -57,7 +57,7 @@ export class ServerRequestParameters {
     if (!scope) {
       this.scopes = [clientId];
     } else {
-      this.scopes = scope.slice();
+      this.scopes = [ ...scope ];
     }
 
     this.nonce = Utils.createNewGuid();

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -593,7 +593,6 @@ export class UserAgentApplication {
         this.getRedirectUri(),
         request && request.state
       );
-
       // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
       if (ServerRequestParameters.isSSOParam(request) || account) {
         serverAuthenticationRequest.populateQueryParams(account, request);

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -36,9 +36,6 @@ export class UrlUtils {
    */
   static createNavigationUrlString(serverRequestParams: ServerRequestParameters): Array<string> {
     let scopes = serverRequestParams.scopes;
-    if (!scopes) {
-      scopes = [serverRequestParams.clientId];
-    }
 
     if (scopes.indexOf(serverRequestParams.clientId) === -1) {
       scopes.push(serverRequestParams.clientId);

--- a/lib/msal-core/test/ServerRequestParameters.spec.ts
+++ b/lib/msal-core/test/ServerRequestParameters.spec.ts
@@ -3,8 +3,46 @@ import { ServerRequestParameters } from "../src/ServerRequestParameters";
 import { Authority } from "../src";
 import { AuthorityFactory } from "../src/AuthorityFactory";
 import { UrlUtils } from "../src/utils/UrlUtils";
+import { TEST_CONFIG, TEST_RESPONSE_TYPE, TEST_URIS } from "./TestConstants";
+import sinon from "sinon";
 
 describe("ServerRequestParameters.ts Class", function () {
+
+    describe("Object creation", function () {
+
+        it("Scope array pointer is not passed into constructor", function () {
+            let scopes = ["S1"];
+            let authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
+            sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
+            let req = new ServerRequestParameters(
+                authority,
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                scopes,
+                TEST_RESPONSE_TYPE.token,
+                TEST_URIS.TEST_REDIR_URI,
+                TEST_CONFIG.STATE
+            );
+            expect(req.scopes).to.not.be.equal(scopes);
+            expect(req.scopes.length).to.be.eql(1);
+            expect(scopes.length).to.be.eql(1);
+        });
+
+        it("Scopes are set to client id if null or empty scopes object passed", function () {
+            let authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
+            sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
+            let req = new ServerRequestParameters(
+                authority,
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                null,
+                TEST_RESPONSE_TYPE.token,
+                TEST_URIS.TEST_REDIR_URI,
+                TEST_CONFIG.STATE
+            );
+            expect(req.scopes).to.be.eql([TEST_CONFIG.MSAL_CLIENT_ID]);
+            expect(req.scopes.length).to.be.eql(1);
+        });
+
+    });
 
     describe("State Generation", function () {
 

--- a/lib/msal-core/test/TestConstants.ts
+++ b/lib/msal-core/test/TestConstants.ts
@@ -26,7 +26,8 @@ export const TEST_URIS = {
     DEFAULT_INSTANCE: "https://login.microsoftonline.com/",
     ALTERNATE_INSTANCE: "https://login.windows.net/",
     TEST_REDIR_URI: "https://localhost:8081/redirect.html",
-    TEST_LOGOUT_URI: "https://localhost:8081/logout.html"
+    TEST_LOGOUT_URI: "https://localhost:8081/logout.html",
+    TEST_AUTH_ENDPT: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
 };
 
 // Test Expiration Vals
@@ -58,8 +59,13 @@ export const TEST_CONFIG = {
     validAuthority: TEST_URIS.DEFAULT_INSTANCE + "common",
     alternateValidAuthority: TEST_URIS.ALTERNATE_INSTANCE + "common",
     applicationName: "msal.js-tests",
-    applicationVersion: "msal.js-tests.1.0.fake"
+    applicationVersion: "msal.js-tests.1.0.fake",
+    STATE: "1234"
 };
 
-
+export const TEST_RESPONSE_TYPE = {
+    id_token: "id_token",
+    token: "token",
+    id_token_token: "id_token token"
+}
 

--- a/lib/msal-core/test/utils/UrlUtils.spec.ts
+++ b/lib/msal-core/test/utils/UrlUtils.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from "chai";
+import sinon from "sinon";
 import { Utils } from "../../src/utils/Utils";
-import { UrlUtils } from "../../src/utils/UrlUtils"
+import { UrlUtils } from "../../src/utils/UrlUtils";
+import { TEST_CONFIG, TEST_RESPONSE_TYPE, TEST_URIS } from "../TestConstants";
+import { AuthorityFactory } from "../../src/AuthorityFactory";
+import { ServerRequestParameters } from "../../src/ServerRequestParameters";
 
 describe("UrlUtils.ts class", () => {
 
@@ -70,4 +74,24 @@ describe("UrlUtils.ts class", () => {
 
         expect(hash).to.be.equal(TEST_URL_NO_HASH);
     });
+
+    it("Scopes are from serverRequestParameters are mutated, but not user-given scopes", function () {
+        let scopes = ["S1"];
+        let authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
+        sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
+        let req = new ServerRequestParameters(
+            authority,
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            scopes,
+            TEST_RESPONSE_TYPE.token,
+            TEST_URIS.TEST_REDIR_URI,
+            TEST_CONFIG.STATE
+        );
+        let uriString = UrlUtils.createNavigateUrl(req);
+
+        expect(req.scopes).to.not.be.equal(scopes);
+        expect(req.scopes.length).to.be.eql(3);
+        expect(scopes.length).to.be.eql(1);
+    });
+
 });


### PR DESCRIPTION
Please review PR #805 and #806 before reviewing this one.

This fixes the other part of the issue in #736 where the scopes object that is passed in by the user is being mutated to add "openid" and "profile". This behavior has been moved rectified by using the Array.slice() method.