### PR TITLE
Switch to using internal uuid implementation instead of uuid library to support es modules

### DIFF
--- a/lib/msal-core/package-lock.json
+++ b/lib/msal-core/package-lock.json
@@ -9511,7 +9511,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.0.3",

--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -36,8 +36,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "tslib": "^1.9.3",
-    "uuid": "^3.3.2"
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/lib/msal-core/src/telemetry/TelemetryEvent.ts
+++ b/lib/msal-core/src/telemetry/TelemetryEvent.ts
@@ -1,5 +1,3 @@
-
-import { v4 as uuid } from "uuid";
 import { TELEMETRY_BLOB_EVENT_NAMES } from "./TelemetryConstants";
 import {
     EVENT_NAME_KEY,
@@ -7,6 +5,7 @@ import {
     ELAPSED_TIME_KEY
 } from "./TelemetryConstants";
 import { prependEventNamePrefix } from "./TelemetryUtils";
+import { Utils } from '../Utils';
 
 export default class TelemetryEvent {
 
@@ -17,7 +16,7 @@ export default class TelemetryEvent {
     constructor(eventName: string, correlationId: string) {
 
         this.startTimestamp = Date.now();
-        this.eventId = uuid();
+        this.eventId = Utils.createNewGuid();
         this.event = {
             [prependEventNamePrefix(EVENT_NAME_KEY)]: eventName,
             [prependEventNamePrefix(START_TIME_KEY)]: this.startTimestamp,

--- a/lib/msal-core/test/telemetry/ApiEvent.spec.ts
+++ b/lib/msal-core/test/telemetry/ApiEvent.spec.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from "uuid";
 import ApiEvent, {
     API_EVENT_IDENTIFIER,
     API_CODE,
@@ -8,10 +7,11 @@ import { Logger } from "../../src";
 import { expect } from "chai";
 import { TELEMETRY_BLOB_EVENT_NAMES } from "../../src/telemetry/TelemetryConstants";
 import { hashPersonalIdentifier } from "../../src/telemetry/TelemetryUtils";
+import { Utils } from '../../src/Utils';
 
 describe("ApiEvent", () => {
     it("constructs and carries exepcted values", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const logger = new Logger(() => { });
 
         const event = new ApiEvent(correlationId, logger).get();
@@ -21,7 +21,7 @@ describe("ApiEvent", () => {
     });
 
     it("sets simple values on event", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const logger = new Logger(() => { });
 
         const apiEvent = new ApiEvent(correlationId, logger);
@@ -49,7 +49,7 @@ describe("ApiEvent", () => {
     });
 
     it("sets values on event that are scrubbed or altered", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const logger = new Logger(() => { });
 
         const apiEvent = new ApiEvent(correlationId, logger);
@@ -65,15 +65,15 @@ describe("ApiEvent", () => {
     });
 
     it("doesn't set private alues on event if pii is not enabled", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const logger = new Logger(() => { }, {
             piiLoggingEnabled: false //defaults to false
         });
 
         const apiEvent = new ApiEvent(correlationId, logger);
 
-        const fakeTenantId = uuid();
-        const fakeAccountId = uuid();
+        const fakeTenantId = Utils.createNewGuid();
+        const fakeAccountId = Utils.createNewGuid();
         const fakeLoginHint = "fakeHint";
 
         apiEvent.tenantId = fakeTenantId;
@@ -88,16 +88,16 @@ describe("ApiEvent", () => {
     });
 
     it("sets and hashes private values on event if pii is enabled", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const logger = new Logger(() => { }, {
             piiLoggingEnabled: true
         });
 
         const apiEvent = new ApiEvent(correlationId, logger);
 
-        const fakeTenantId = uuid();
+        const fakeTenantId = Utils.createNewGuid();
         const fakeExpectedTenantId = hashPersonalIdentifier(fakeTenantId);
-        const fakeAccountId = uuid();
+        const fakeAccountId = Utils.createNewGuid();
         const fakeExpectedAccountId = hashPersonalIdentifier(fakeAccountId);
         const fakeLoginHint = "fakeHint";
         const fakeExpectedHint = hashPersonalIdentifier(fakeLoginHint);

--- a/lib/msal-core/test/telemetry/CacheEvent.spec.ts
+++ b/lib/msal-core/test/telemetry/CacheEvent.spec.ts
@@ -1,17 +1,17 @@
-import { v4 as uuid } from "uuid";
 import { expect } from "chai";
 import CacheEvent, { CACHE_EVENT_TYPES, TOKEN_TYPES, TOKEN_TYPE_KEY } from "../../src/telemetry/CacheEvent";
+import { Utils } from '../../src/Utils';
 
 describe("CacheEvent", () => {
     it("constructs and carries exepcted values", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const event = new CacheEvent(CACHE_EVENT_TYPES.TokenCacheLookup, correlationId).get();
         expect(event["msal.event_name"]).to.eq(CACHE_EVENT_TYPES.TokenCacheLookup);
         expect(event["msal.elapsed_time"]).to.eq(-1);
     });
 
     it("sets values", () =>{
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const cacheEvent = new CacheEvent(CACHE_EVENT_TYPES.TokenCacheBeforeAccess, correlationId);
 
         cacheEvent.tokenType = TOKEN_TYPES.AT;

--- a/lib/msal-core/test/telemetry/DefaultEvent.spec.ts
+++ b/lib/msal-core/test/telemetry/DefaultEvent.spec.ts
@@ -1,12 +1,12 @@
 import { expect } from "chai";
-import { v4 as uuid } from "uuid";
 import DefaultEvent from "../../src/telemetry/DefaultEvent";
 import { TelemetryPlatform, EventCount } from "../../src/telemetry/TelemetryTypes";
+import { Utils } from '../../src/Utils';
 
 describe("DefaultEvent", () => {
     it("DefaultEvent constructs and carries expected  values", () => {
-        const correlationId = uuid();
-        const clientId = uuid();
+        const correlationId = Utils.createNewGuid();
+        const clientId = Utils.createNewGuid();
         const eventCount: EventCount = {
             "msal.ui_event": 100,
             "msal.http_event": 200

--- a/lib/msal-core/test/telemetry/HttpEvent.spec.ts
+++ b/lib/msal-core/test/telemetry/HttpEvent.spec.ts
@@ -1,10 +1,10 @@
-import { v4 as uuid } from "uuid";
 import { expect } from "chai";
 import HttpEvent, { EVENT_KEYS } from "../../src/telemetry/HttpEvent";
+import { Utils } from '../../src/Utils';
 
 describe("HttpEvent", () => {
     it("constructs and carries exepcted values", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
 
         const event = new HttpEvent(correlationId).get();
 
@@ -13,7 +13,7 @@ describe("HttpEvent", () => {
     });
 
     it("sets simply set values", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
 
         const httpEvent = new HttpEvent(correlationId);
 
@@ -51,7 +51,7 @@ describe("HttpEvent", () => {
     });
 
     it("sets values that are changed", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
 
         const httpEvent = new HttpEvent(correlationId);
 

--- a/lib/msal-core/test/telemetry/TelemetryEvent.spec.ts
+++ b/lib/msal-core/test/telemetry/TelemetryEvent.spec.ts
@@ -1,11 +1,10 @@
 import { expect } from "chai";
 import TelemetryEvent from "../../src/telemetry/TelemetryEvent";
-import { v4 as uuid } from "uuid";
-
+import { Utils } from '../../src/Utils';
 
 describe("TelemetryEvent", () =>{
     it("constructed with correct params", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const eventName = "fakeEvent";
         const telemetryEvent: TelemetryEvent = new TelemetryEvent(
             eventName,
@@ -17,7 +16,7 @@ describe("TelemetryEvent", () =>{
 
     it("stop event and get elapsed time", done => {
         const time = 500;
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const eventName = "coolEvent";
         const telemetryEvent: TelemetryEvent = new TelemetryEvent(
             eventName,

--- a/lib/msal-core/test/telemetry/TelemetryManager.spec.ts
+++ b/lib/msal-core/test/telemetry/TelemetryManager.spec.ts
@@ -1,10 +1,10 @@
 import { expect } from "chai";
-import { v4 as uuid } from "uuid";
 import TelemetryManager from "../../src/telemetry/TelemetryManager";
 import { TelemetryConfig, TelemetryPlatform } from "../../src/telemetry/TelemetryTypes";
 import TelemetryEvent from "../../src/telemetry/TelemetryEvent";
+import { Utils } from '../../src/Utils';
 
-const TEST_CLIENT_ID = uuid();
+const TEST_CLIENT_ID = Utils.createNewGuid();
 const TEST_PLATFORM: TelemetryPlatform = {
     applicationName: "testApp",
     applicationVersion: "12.0.1",
@@ -31,7 +31,7 @@ describe("TelemetryManager", () => {
             platform: TEST_PLATFORM,
             onlySendFailureTelemetry: false
         };
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const eventHandler = events => {
             expect(events).to.have.length(2);
             expect(events[0]['msal.event_name']).to.eq("fakeEvent");
@@ -62,7 +62,7 @@ describe("TelemetryManager", () => {
             platform: TEST_PLATFORM,
             onlySendFailureTelemetry: false
         };
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const eventHandler = events => {
             expect(events).to.have.length(4);
             expect(events[0]['msal.event_name']).to.eq("fakeEvent");
@@ -106,7 +106,7 @@ describe("TelemetryManager", () => {
             platform: TEST_PLATFORM,
             onlySendFailureTelemetry: false
         };
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const eventHandler = events => {
             expect(events).to.have.length(4);
             expect(events[0]['msal.event_name']).to.eq("fakeEvent");
@@ -149,7 +149,7 @@ describe("TelemetryManager", () => {
             platform: TEST_PLATFORM,
             onlySendFailureTelemetry: false
         };
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         let calledOnce = false;
         const eventHandler = events => {
             // if calledOnce is already true we shouldnt ever get back to this callback.

--- a/lib/msal-core/test/telemetry/UiEvent.spect.ts
+++ b/lib/msal-core/test/telemetry/UiEvent.spect.ts
@@ -1,17 +1,17 @@
 import UiEvent, { EVENT_KEYS } from "../../src/telemetry/UiEvent";
-import { v4 as uuid } from "uuid";
+import { Utils } from '../../src/Utils';
 import { expect } from "chai";
 
 describe("UiEvent", () => {
     it("constructs and carries exepcted values", () => {
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const event = new UiEvent(correlationId).get();
         expect(event["msal.event_name"]).to.eq("msal.ui_event");
         expect(event["msal.elapsed_time"]).to.eq(-1);
     });
 
     it("sets values", () =>{
-        const correlationId = uuid();
+        const correlationId = Utils.createNewGuid();
         const uiEvent = new UiEvent(correlationId);
 
         const fakeUserCancelled = true;


### PR DESCRIPTION
`uuid` library is not compatible with ES modules, and we already have our own implementation of `uuid`, so switch to using that instead.

Fixes #874 