### PR TITLE
Do not merge : When rendered in an iframe, silent rejects

### DIFF
--- a/lib/msal-core/src/error/EnvironmentError.ts
+++ b/lib/msal-core/src/error/EnvironmentError.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AuthError } from "./AuthError";
+import { IdToken } from "../IdToken";
+import { StringUtils } from "../utils/StringUtils";
+
+export const EnvironmentErrorMessage = {
+    noResolveInIframe: {
+        code: "no_resolve_in_iframe",
+        desc: `Msal.js does not currently support resolving a silent token request in an iframe`
+    }
+};
+
+/**
+ * Error thrown when there is an error in the client code running on the browser.
+ */
+export class EnvironmentError extends AuthError {
+
+    constructor(errorCode: string, errorMessage?: string) {
+        super(errorCode, errorMessage);
+        this.name = "EnvironmentError";
+
+        Object.setPrototypeOf(this, EnvironmentError.prototype);
+    }
+
+    static createNoResolveInIframeError(): EnvironmentError {
+        const { code, desc } = EnvironmentErrorMessage.noResolveInIframe
+        return new EnvironmentError(code, desc);
+    }
+
+
+}

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -27,6 +27,7 @@ import { ServerRequestParameters } from "../src/ServerRequestParameters";
 import { TEST_URIS, TEST_DATA_CLIENT_INFO, TEST_HASHES, TEST_TOKENS, TEST_CONFIG, TEST_TOKEN_LIFETIMES } from "./TestConstants";
 import { IdToken } from "../src/IdToken";
 import { TimeUtils } from "../src/utils/TimeUtils";
+import { EnvironmentError } from "../src/error/EnvironmentError";
 
 type kv = {
     [key: string]: string;
@@ -1416,4 +1417,29 @@ describe("UserAgentApplication.ts Class", function () {
         });
 
     });
+
+
+    describe("iframe resolution of silent token request", () => {
+        beforeEach(function() {
+            const config: Configuration = {
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    redirectUri: TEST_URIS.TEST_REDIR_URI
+                }
+            };
+            msal = new UserAgentApplication(config);
+        });
+        it("throws an EnvironmentError if rendred in an iframe", done => {
+            sinon.stub(msal, "isInIframe").returns(true);
+            msal.acquireTokenSilent({scopes: [TEST_CONFIG.MSAL_CLIENT_ID]})
+            .then(() => {
+                done("acquireTokenSilent Should not resolve if rendered in an iframe");``
+            })
+            .catch((err) => {
+                expect(err).to.be.instanceOf(EnvironmentError);
+                done();
+            });
+        });
+    });
 });
+

--- a/lib/msal-core/test/error/EnvironmentError.spec.ts
+++ b/lib/msal-core/test/error/EnvironmentError.spec.ts
@@ -1,0 +1,50 @@
+import * as mocha from "mocha";
+import { expect } from "chai";
+import { EnvironmentError, EnvironmentErrorMessage } from "../../src/error/EnvironmentError";
+import { AuthError } from "../../src";
+
+describe("EnvironmentError.ts Class", () => {
+  it("EnvironmentError object can be created", () => {
+
+    const TEST_ERROR_CODE: string = "test";
+    const TEST_ERROR_MSG: string = "This is a test error";
+    let environmentError = new EnvironmentError(TEST_ERROR_CODE, TEST_ERROR_MSG);
+    let err: EnvironmentError;
+
+    try {
+      throw environmentError;
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err instanceof EnvironmentError).to.be.true;
+    expect(err instanceof AuthError).to.be.true;
+    expect(err instanceof Error).to.be.true;
+    expect(err.errorCode).to.equal(TEST_ERROR_CODE);
+    expect(err.errorMessage).to.equal(TEST_ERROR_MSG);
+    expect(err.message).to.equal(TEST_ERROR_MSG);
+    expect(err.name).to.equal("EnvironmentError");
+    expect(err.stack).to.include("EnvironmentError.spec.js");
+  });
+
+  it("createNoResolveInIframeError creates a EnvironmentError object", () => {
+
+    const serverUnavailableError = EnvironmentError.createNoResolveInIframeError();
+    let err: EnvironmentError;
+
+    try {
+      throw serverUnavailableError;
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err.errorCode).to.equal(EnvironmentErrorMessage.noResolveInIframe.code);
+    expect(err.errorMessage).to.equal(EnvironmentErrorMessage.noResolveInIframe.desc);
+    expect(err.message).to.equal(EnvironmentErrorMessage.noResolveInIframe.desc);
+    expect(err.name).to.equal("EnvironmentError");
+    expect(err.stack).to.include("EnvironmentError.spec.js");
+  });
+
+
+});
+


### PR DESCRIPTION
... with an appropriate error.
* Get rid of the decorator function because it is only used once
* Add EnvironmentError
* tests

resolves #902