### PR TITLE
Fix bugs in cookie storage by setting cookie path

### DIFF
--- a/lib/msal-core/src/cache/BrowserStorage.ts
+++ b/lib/msal-core/src/cache/BrowserStorage.ts
@@ -73,7 +73,7 @@ export class BrowserStorage {// Singleton
      * @param expires
      */
     setItemCookie(cName: string, cValue: string, expires?: number): void {
-        let cookieStr = cName + "=" + cValue + ";";
+        let cookieStr = cName + "=" + cValue + ";path=/;";
         if (expires) {
             const expireTime = this.getCookieExpirationTime(expires);
             cookieStr += "expires=" + expireTime + ";";


### PR DESCRIPTION
This fixes two bugs with cookie storage.

The first occurs if MSAL saves its state in a directory that is not a parent of the directory the user is returned to. The cookie will not be active at this path because the cookie path defaults to the current
path.

The second bug occurs if identity provider does not return from a flow (This can occur if the user closes the tab before being redirected back), and then a new flow is started on a different path is started. Because the default path for cookie is the current paths, and cookies with different paths can have the same key, the msal.state.login cookie is written twice with the same key. Under certain conditions, the wrong cookie can be found when returning from a flow, and the state does not match.

I was unable to write any test cases for these conditions, since jsdom does not allow the URL to be changed, and duplicate cookies cannot be created when the path is `/`, which is what the testing environment is currently setup to use. This can be changed, but I was hesitant to do so without deeper understanding of the test environment.