### PR TITLE
Support Unit tests to run on all test files in Unix environments

### DIFF
--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -30,8 +30,8 @@
     "doc": "typedoc --mode modules --excludePrivate --excludeProtected --out ./docs ./src/ --gitRevision dev",
     "build:modules": "tsc && tsc -m es6 --outDir lib-es6",
     "build": "npm run clean && npm run doc && npm run build:modules && npm run lint && npm run build:webpack && npm test",
-    "test": "mocha -r test/setup.js -r ts-node/register -r source-map-support/register ./test/**/*.spec.ts",
-    "test:coverage": "nyc mocha -r test/setup.js -r ts-node/register -r source-map-support/register ./test/**/*.spec.ts",
+    "test": "mocha -r test/setup.js -r ts-node/register -r source-map-support/register ./test/*.spec.ts ./test/**/*.spec.ts",
+    "test:coverage": "nyc mocha -r test/setup.js -r ts-node/register -r source-map-support/register ./test/*.spec.ts ./test/**/*.spec.ts",
     "lint": "eslint src --ext .ts",
     "build:webpack": "webpack",
     "prepack": "npm run build"


### PR DESCRIPTION
Unit tests are being skipped with the current command for unit tests, as mac does not support wild cards the way windows does. Adding the files to be tested explicitly with this PR.