### PR TITLE
remove iframe restriction for token resolution in MSAL JS

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -113,27 +113,6 @@ export type tokenReceivedCallback = (response: AuthResponse) => void;
 export type errorReceivedCallback = (authErr: AuthError, accountState: string) => void;
 
 /**
- * @hidden
- * @ignore
- * A wrapper to handle the token response/error within the iFrame always
- *
- * @param target
- * @param propertyKey
- * @param descriptor
- */
-const resolveTokenOnlyIfOutOfIframe = (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
-    const tokenAcquisitionMethod = descriptor.value;
-    descriptor.value = function (...args: any[]) {
-        return this.isInIframe()
-            ? new Promise(() => {
-                return;
-            })
-            : tokenAcquisitionMethod.apply(this, args);
-    };
-    return descriptor;
-};
-
-/**
  * UserAgentApplication class
  *
  * Object Instance that the developer can use to make loginXX OR acquireTokenXX functions
@@ -562,7 +541,6 @@ export class UserAgentApplication {
      * @returns {Promise.<AuthResponse>} - a promise that is fulfilled when this function has completed, or rejected if an error was raised. Returns the {@link AuthResponse} object
      *
      */
-    @resolveTokenOnlyIfOutOfIframe
     acquireTokenSilent(request: AuthenticationParameters): Promise<AuthResponse> {
         if (!request) {
             throw ClientConfigurationError.createEmptyRequestError();
@@ -1119,7 +1097,7 @@ export class UserAgentApplication {
                 this.authErrorHandler(Constants.interactionTypeRedirect, authErr, buildResponseStateOnly(accountState));
                 return;
             }
-          
+
             parentCallback(response, authErr);
         } catch (err) {
             this.logger.error("Error occurred in token received callback function: " + err);


### PR DESCRIPTION
This PR in conjunction with PR #939 should help developers acquire tokens using acquireTokenSilent even when the app resides within an iframe.

Please note:

- This PR only enables loginPopup(), acquireTokenPopup(), acquireTokenSilent() calls for embedded applications residing in an iframe
- Work to support redirect by providing a trust relationship with the parent application of the embedded app is in progress, details and documentation of the same will follow in a new PR.