### PR TITLE
The x-client-Ver query string in the login URL hides the keep me signed in login flow

### DIFF
--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -55,7 +55,6 @@ export class UrlUtils {
 
         str.push("client_info=1");
         str.push(`x-client-SKU=${serverRequestParams.xClientSku}`);
-        str.push(`x-client-Ver=${serverRequestParams.xClientVer}`);
         if (serverRequestParams.promptValue) {
             str.push("prompt=" + encodeURIComponent(serverRequestParams.promptValue));
         }


### PR DESCRIPTION
This query string doesn't allow to see the 'Do you want to keep the session open?' question when login in at login.microsoftonline.com if you have it enabled in your AzureAD tenant.

I guess this is not just msal.js fault but is also on microsoftonline.com endpoint side