### PR TITLE
Cache cleanup: Nonce

### DIFF
--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -109,6 +109,7 @@ export class Storage {// Singleton
                             this.removeItem(Constants.stateLogin);
                             this.removeItem(Constants.stateAcquireToken);
                             this.removeItem(Constants.nonceIdToken);
+                            this.removeItem(Constants.loginRequest);
                             this.setItemCookie(key, "", -1);
                         }
                     }

--- a/lib/msal-core/src/Storage.ts
+++ b/lib/msal-core/src/Storage.ts
@@ -108,6 +108,7 @@ export class Storage {// Singleton
                             this.removeItem(Constants.renewStatus + state);
                             this.removeItem(Constants.stateLogin);
                             this.removeItem(Constants.stateAcquireToken);
+                            this.removeItem(Constants.nonceIdToken);
                             this.setItemCookie(key, "", -1);
                         }
                     }

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1549,8 +1549,6 @@ export class UserAgentApplication {
      */
     protected saveTokenFromHash(hash: string, stateInfo: ResponseStateInfo): AuthResponse {
         this.logger.info("State status:" + stateInfo.stateMatch + "; Request type:" + stateInfo.requestType);
-        this.cacheStorage.setItem(Constants.msalError, "");
-        this.cacheStorage.setItem(Constants.msalErrorDescription, "");
 
         let response : AuthResponse = {
             uniqueId: "",

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -2257,12 +2257,7 @@ export class UserAgentApplication {
         if (loginStartPage) {
             // Cache the state, nonce, and login request data
             this.cacheStorage.setItem(Constants.loginRequest, loginStartPage, this.inCookie);
-            this.cacheStorage.setItem(Constants.loginError, "");
-
             this.cacheStorage.setItem(Constants.stateLogin, serverAuthenticationRequest.state, this.inCookie);
-
-            this.cacheStorage.setItem(Constants.msalError, "");
-            this.cacheStorage.setItem(Constants.msalErrorDescription, "");
         } else {
             this.setAccountCache(account, serverAuthenticationRequest.state);
         }


### PR DESCRIPTION
This PR fixes two issues in the transient cache (cache items needed during a request-response cycle):

- Nonce is not cleared in the cache in MSAL JS after a response for a token request is processed. This is causing nonce mismatches in some use-cases.
- We are also creating "error" related cache independent of success/failure. This PR restricts the creation of "error" cache only to failure use-cases.