### PR TITLE
Change location.replace to location.assign

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -934,7 +934,7 @@ export class UserAgentApplication {
             const navigateWindow: Window = popupWindow ? popupWindow : window;
             const logMessage: string = popupWindow ? "Navigated Popup window to:" + urlNavigate : "Navigate to:" + urlNavigate;
             this.logger.infoPii(logMessage);
-            navigateWindow.location.replace(urlNavigate);
+            navigateWindow.location.assign(urlNavigate);
         }
         else {
             this.logger.info("Navigate url is empty");

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -226,7 +226,7 @@ describe("UserAgentApplication.ts Class", function () {
         it("navigates user to login and prompt parameter is not passed by default", (done) => {
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -249,7 +249,7 @@ describe("UserAgentApplication.ts Class", function () {
         it("navigates user to login and prompt=select_account parameter is passed in request", (done) => {
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -274,7 +274,7 @@ describe("UserAgentApplication.ts Class", function () {
         it("navigates user to login and prompt=none parameter is passed in request", (done) => {
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -309,7 +309,7 @@ describe("UserAgentApplication.ts Class", function () {
             };
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -348,7 +348,7 @@ describe("UserAgentApplication.ts Class", function () {
             };
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -380,7 +380,7 @@ describe("UserAgentApplication.ts Class", function () {
             };
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -418,7 +418,7 @@ describe("UserAgentApplication.ts Class", function () {
             };
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -445,7 +445,7 @@ describe("UserAgentApplication.ts Class", function () {
             };
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -473,7 +473,7 @@ describe("UserAgentApplication.ts Class", function () {
             };
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -496,7 +496,7 @@ describe("UserAgentApplication.ts Class", function () {
         it("navigates user to redirectURI passed in constructor config", (done) => {
             window.location = {
                 ...oldWindowLocation,
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/authorize?response_type=id_token&scope=openid%20profile");
                         expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);
@@ -524,7 +524,7 @@ describe("UserAgentApplication.ts Class", function () {
             window.location = {
                 ...oldWindowLocation,
                 hash: "",
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include("&redirect_uri=" + encodeURIComponent(TEST_URIS.TEST_REDIR_URI));
                         done();
@@ -1308,7 +1308,7 @@ describe("UserAgentApplication.ts Class", function () {
             window.location = {
                 ...oldWindowLocation,
                 hash: "",
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         done();
                     } catch (e) {
@@ -1327,7 +1327,7 @@ describe("UserAgentApplication.ts Class", function () {
             window.location = {
                 ...oldWindowLocation,
                 hash: "",
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(encodeURIComponent(TEST_URIS.TEST_LOGOUT_URI));
                         done();
@@ -1342,7 +1342,7 @@ describe("UserAgentApplication.ts Class", function () {
             window.location = {
                 ...oldWindowLocation,
                 hash: "",
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(validOpenIdConfigurationResponse.EndSessionEndpoint);
                         done();
@@ -1359,7 +1359,7 @@ describe("UserAgentApplication.ts Class", function () {
             window.location = {
                 ...oldWindowLocation,
                 hash: "",
-                replace: function (url) {
+                assign: function (url) {
                     try {
                         expect(url).to.include(TEST_URIS.DEFAULT_INSTANCE + TEST_CONFIG.TENANT + "/oauth2/v2.0/logout?");
                         done();


### PR DESCRIPTION
This PR is to fix an issue raised in #588 where history is not being pushed due to the use of window.location.replace. So far no major issues are identified with using assign instead of replace, but further investigation should be done before merging.