### PR TITLE
Adding SRI Hash to CDN Tags

### DIFF
--- a/lib/msal-core/README.md
+++ b/lib/msal-core/README.md
@@ -25,7 +25,7 @@ Latest Microsoft CDN Version:
 
     <!-- Latest compiled and minified JavaScript -->
     <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-kYijiCrNWywvKX1VI7259ktIf0ebXhlDeVD2dBEX+GeVbmY1GEboq3dsDDvYuDP/" crossorigin="anonymous"></script>
 
 Note: We recommend including the [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) Hash with all script tags when using `msal.js` or `msal.min.js`. When providing the SRI Hash, you *must* also provide the `crossorigin="anonymous"` field in the same tag.
 

--- a/lib/msal-core/README.md
+++ b/lib/msal-core/README.md
@@ -18,22 +18,27 @@ The MSAL library for JavaScript enables client-side JavaScript web applications,
 ### Via Latest Microsoft CDN Version:
 
     <!-- Latest compiled and minified JavaScript -->
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js"></script>
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js"></script>
+    
+    <!-- Alternate region URLs -->
+    <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.js"></script>
+    <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.min.js"></script>
+
+### Via Latest Microsoft CDN Version (with SRI Hash):
+
+    <!-- Latest compiled and minified JavaScript -->
     <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-kYijiCrNWywvKX1VI7259ktIf0ebXhlDeVD2dBEX+GeVbmY1GEboq3dsDDvYuDP/" crossorigin="anonymous"></script>
 
+    <!-- Alternate region URLs -->
+    <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-kYijiCrNWywvKX1VI7259ktIf0ebXhlDeVD2dBEX+GeVbmY1GEboq3dsDDvYuDP/" crossorigin="anonymous"></script>
+
 #### Notes: 
-- [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hashes are optional fields in the MSAL library.
-- All hashes are unique to the version of MSAL. You can find the previous hashes on the [MSAL Wiki page]().
-- We recommend including the SRI Hash with all script tags when using `msal.js` or `msal.min.js`. When providing the SRI Hash, you *must* also provide the `crossorigin="anonymous"` field in the same tag.
-
-### CDN Resilience:
-
-If you would like to utilize resilient import from Microsoft's CDN, you can include the following tags as below in your code:
-
-    <script type="text/javascript" src="https://alcdn.msauth.net/lib/{version}/js/msal.js" integrity="sha{alg}-{checksum}" crossorigin="anonymous"></script>
-    <script type="text/javascript">
-    if(typeof Msal ==='undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/{version}/js/msal.js' type='text/javascript' integrity='sha{alg}-{checksum}' crossorigin='anonymous'%3E%3C/script%3E"));
-    </script>
+- [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) attributes are optional in the script tag.
+- All hashes are unique to the version of MSAL. You can find the previous hashes on the [MSAL Wiki page](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/MSAL-JS-CDN-URL-and-SRI-Hash).
+- We recommend including the SRI Hash with all script tags when using `msal.js` or `msal.min.js` (including when using a third-party CDN). When providing the SRI Hash, you *must* also provide the `crossorigin="anonymous"` field in the same tag.
 
 Internet Explorer does not have native `Promise` support, and so you will need to include a polyfill for promises such as `bluebird`.
 

--- a/lib/msal-core/README.md
+++ b/lib/msal-core/README.md
@@ -18,13 +18,30 @@ Via NPM:
 Via CDN:
 
     <!-- Latest compiled and minified JavaScript -->
-    <script src="https://secure.aadcdn.microsoftonline-p.com/lib/<version>/js/msal.js"></script>
-    <script src="https://secure.aadcdn.microsoftonline-p.com/lib/<version>/js/msal.min.js"></script>
+    <script type="text/javascript" src="https://{CDN-URL}/msal.js" integrity="sha{alg}-{checksum}" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://{CDN-URL}/msal.min.js" integrity="sha{alg}-{checksum}" crossorigin="anonymous"></script>
+
+Latest Microsoft CDN Version:
+
+    <!-- Latest compiled and minified JavaScript -->
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
+
+Note: We recommend including the [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) Hash with all script tags when using `msal.js` or `msal.min.js`. When providing the SRI Hash, you *must* also provide the `crossorigin="anonymous"` field in the same tag.
 
 Internet Explorer does not have native `Promise` support, and so you will need to include a polyfill for promises such as `bluebird`.
 
     <!-- IE support: add promises polyfill before msal.js  -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js" class="pre"></script>
+
+CDN Resilience:
+
+If you would like to utilize resilient import from Microsoft's CDN, you can include the following tags as below in your code:
+
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/{version}/js/msal.js" integrity="sha{alg}-{checksum}" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+    if(typeof##MSAL##=='undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/{version}/js/msal.js' type='text/javascript' integrity='sha{alg}-{checksum}' crossorigin='anonymous'%3E%3C/script%3E"));
+    </script>
 
 See here for more details on [supported browsers and known compatability issues](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/FAQs#q4-what-browsers-is-msaljs-supported-on).
 

--- a/lib/msal-core/README.md
+++ b/lib/msal-core/README.md
@@ -11,37 +11,34 @@ The MSAL library for JavaScript enables client-side JavaScript web applications,
 [![Build Status](https://travis-ci.org/AzureAD/microsoft-authentication-library-for-js.png?branch=dev)](https://travis-ci.org/AzureAD/microsoft-authentication-library-for-js)[![npm version](https://img.shields.io/npm/v/msal.svg?style=flat)](https://www.npmjs.com/package/msal)[![npm version](https://img.shields.io/npm/dm/msal.svg)](https://nodei.co/npm/msal/)
 
 ## Installation
-Via NPM:
+### Via NPM:
 
     npm install msal
 
-Via CDN:
-
-    <!-- Latest compiled and minified JavaScript -->
-    <script type="text/javascript" src="https://{CDN-URL}/msal.js" integrity="sha{alg}-{checksum}" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://{CDN-URL}/msal.min.js" integrity="sha{alg}-{checksum}" crossorigin="anonymous"></script>
-
-Latest Microsoft CDN Version:
+### Via Latest Microsoft CDN Version:
 
     <!-- Latest compiled and minified JavaScript -->
     <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-kYijiCrNWywvKX1VI7259ktIf0ebXhlDeVD2dBEX+GeVbmY1GEboq3dsDDvYuDP/" crossorigin="anonymous"></script>
 
-Note: We recommend including the [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) Hash with all script tags when using `msal.js` or `msal.min.js`. When providing the SRI Hash, you *must* also provide the `crossorigin="anonymous"` field in the same tag.
+#### Notes: 
+- [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hashes are optional fields in the MSAL library.
+- All hashes are unique to the version of MSAL. You can find the previous hashes on the [MSAL Wiki page]().
+- We recommend including the SRI Hash with all script tags when using `msal.js` or `msal.min.js`. When providing the SRI Hash, you *must* also provide the `crossorigin="anonymous"` field in the same tag.
 
-Internet Explorer does not have native `Promise` support, and so you will need to include a polyfill for promises such as `bluebird`.
-
-    <!-- IE support: add promises polyfill before msal.js  -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js" class="pre"></script>
-
-CDN Resilience:
+### CDN Resilience:
 
 If you would like to utilize resilient import from Microsoft's CDN, you can include the following tags as below in your code:
 
     <script type="text/javascript" src="https://alcdn.msauth.net/lib/{version}/js/msal.js" integrity="sha{alg}-{checksum}" crossorigin="anonymous"></script>
     <script type="text/javascript">
-    if(typeof##MSAL##=='undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/{version}/js/msal.js' type='text/javascript' integrity='sha{alg}-{checksum}' crossorigin='anonymous'%3E%3C/script%3E"));
+    if(typeof Msal ==='undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/{version}/js/msal.js' type='text/javascript' integrity='sha{alg}-{checksum}' crossorigin='anonymous'%3E%3C/script%3E"));
     </script>
+
+Internet Explorer does not have native `Promise` support, and so you will need to include a polyfill for promises such as `bluebird`.
+
+    <!-- IE support: add promises polyfill before msal.js  -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js" class="pre"></script>
 
 See here for more details on [supported browsers and known compatability issues](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/FAQs#q4-what-browsers-is-msaljs-supported-on).
 

--- a/samples/VanillaJSTestApp/index.html
+++ b/samples/VanillaJSTestApp/index.html
@@ -3,7 +3,10 @@
 <head>
     <title>Quickstart for MSAL JS</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>
-    <script src="dist/msal.min.js"></script>
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+        if(typeof Msal =='undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/1.1.3/js/msal.js' type='text/javascript' integrity='sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1' crossorigin='anonymous'%3E%3C/script%3E"));
+    </script>
 </head>
 
 <body>

--- a/samples/VanillaJSTestApp/index.html
+++ b/samples/VanillaJSTestApp/index.html
@@ -5,7 +5,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>
     <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
     <script type="text/javascript">
-        if(typeof Msal =='undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/1.1.3/js/msal.js' type='text/javascript' integrity='sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1' crossorigin='anonymous'%3E%3C/script%3E"));
+        if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/1.1.3/js/msal.js' type='text/javascript' integrity='sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1' crossorigin='anonymous'%3E%3C/script%3E"));
     </script>
 </head>
 


### PR DESCRIPTION
This PR will add the Subresource integrity field to our CDN docs to describe how to use this feature.

There is an error message that pops up when you use the resilient import function:
![image](https://user-images.githubusercontent.com/6913227/65806368-0df6a280-e13e-11e9-8b80-c116eb73502b.png)

This may warrant further investigation.