### PR TITLE
Fix SRI hashes in readme, also fix some formatting

### DIFF
--- a/lib/msal-core/README.md
+++ b/lib/msal-core/README.md
@@ -45,12 +45,26 @@ The MSAL library for JavaScript enables client-side JavaScript web applications,
 ```
 
 #### Alternate region URLs
+
+To help ensure reliability, Microsoft provides a second CDN:
+
 ```html
 <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.js" integrity="sha384-m/3NDUcz4krpIIiHgpeO0O8uxSghb+lfBTngquAo2Zuy2fEF+YgFeP08PWFo5FiJ" crossorigin="anonymous"></script>
 ```
 ```html
 <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-dA0Vw9s8Y8YiIYiE44WOORFrt3cwi0rYXwpetCRnFYziAtXEZ4miG8TMSGo8BIyL" crossorigin="anonymous"></script>
 ```
+
+Below is an example of how to use one CDN as a fallback when the other CDN is not working:
+
+```html
+<script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js"></script>
+<script type="text/javascript">
+    if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/1.1.3/js/msal.js' type='text/javascript' %3E%3C/script%3E"));
+</script>
+```
+
+**Note:** This method of using `document.write` may be blocked in certain browsers in certain situations. More information can be found [here](https://www.chromestatus.com/feature/5718547946799104).
 
 #### Notes:
 - [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) attributes are optional in the script tag.

--- a/lib/msal-core/README.md
+++ b/lib/msal-core/README.md
@@ -17,25 +17,42 @@ The MSAL library for JavaScript enables client-side JavaScript web applications,
 
 ### Via Latest Microsoft CDN Version:
 
-    <!-- Latest compiled and minified JavaScript -->
-    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js"></script>
-    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js"></script>
-    
-    <!-- Alternate region URLs -->
-    <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.js"></script>
-    <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.min.js"></script>
+#### Latest compiled and minified JavaScript
+```html
+<script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js"></script>
+```
+```html
+<script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js"></script>
+````
+
+#### Alternate region URLs
+```html
+<script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.js"></script>
+```
+```html
+<script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.min.js"></script>
+```
 
 ### Via Latest Microsoft CDN Version (with SRI Hash):
 
-    <!-- Latest compiled and minified JavaScript -->
-    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-kYijiCrNWywvKX1VI7259ktIf0ebXhlDeVD2dBEX+GeVbmY1GEboq3dsDDvYuDP/" crossorigin="anonymous"></script>
+#### Latest compiled and minified JavaScript
 
-    <!-- Alternate region URLs -->
-    <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-kYijiCrNWywvKX1VI7259ktIf0ebXhlDeVD2dBEX+GeVbmY1GEboq3dsDDvYuDP/" crossorigin="anonymous"></script>
+```html
+<script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-m/3NDUcz4krpIIiHgpeO0O8uxSghb+lfBTngquAo2Zuy2fEF+YgFeP08PWFo5FiJ" crossorigin="anonymous"></script>
+```
+```html
+<script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-dA0Vw9s8Y8YiIYiE44WOORFrt3cwi0rYXwpetCRnFYziAtXEZ4miG8TMSGo8BIyL" crossorigin="anonymous"></script>
+```
 
-#### Notes: 
+#### Alternate region URLs
+```html
+<script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.js" integrity="sha384-m/3NDUcz4krpIIiHgpeO0O8uxSghb+lfBTngquAo2Zuy2fEF+YgFeP08PWFo5FiJ" crossorigin="anonymous"></script>
+```
+```html
+<script type="text/javascript" src="https://alcdn.msftauth.net/lib/1.1.3/js/msal.min.js" integrity="sha384-dA0Vw9s8Y8YiIYiE44WOORFrt3cwi0rYXwpetCRnFYziAtXEZ4miG8TMSGo8BIyL" crossorigin="anonymous"></script>
+```
+
+#### Notes:
 - [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) attributes are optional in the script tag.
 - All hashes are unique to the version of MSAL. You can find the previous hashes on the [MSAL Wiki page](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/MSAL-JS-CDN-URL-and-SRI-Hash).
 - We recommend including the SRI Hash with all script tags when using `msal.js` or `msal.min.js` (including when using a third-party CDN). When providing the SRI Hash, you *must* also provide the `crossorigin="anonymous"` field in the same tag.

--- a/samples/VanillaJSTestApp/index.html
+++ b/samples/VanillaJSTestApp/index.html
@@ -3,9 +3,9 @@
 <head>
     <title>Quickstart for MSAL JS</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>
-    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-m/3NDUcz4krpIIiHgpeO0O8uxSghb+lfBTngquAo2Zuy2fEF+YgFeP08PWFo5FiJ" crossorigin="anonymous"></script>
     <script type="text/javascript">
-        if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/1.1.3/js/msal.js' type='text/javascript' integrity='sha384-3cT22wEPS/umVHpe5hGwbRF8PLObcSXaaFncKfbzutTBzn/aEMQ6aIlxaa6J2TG1' crossorigin='anonymous'%3E%3C/script%3E"));
+        if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/1.1.3/js/msal.js' type='text/javascript' integrity='sha384-m/3NDUcz4krpIIiHgpeO0O8uxSghb+lfBTngquAo2Zuy2fEF+YgFeP08PWFo5FiJ' crossorigin='anonymous'%3E%3C/script%3E"));
     </script>
 </head>
 


### PR DESCRIPTION
The integrity hashes in the README were incorrect, so I fixed those (verified locally and with https://www.srihash.org/). I also put each script tag into its own code block to make them easier to copy/paste (the bottom script tags were difficult to copy/paste when they are all in the same block).