### PR TITLE
Fix base64 decoding to properly handle claims with unicode characters such as Japanese

### DIFF
--- a/lib/msal-core/src/utils/CryptoUtils.ts
+++ b/lib/msal-core/src/utils/CryptoUtils.ts
@@ -50,13 +50,13 @@ export class CryptoUtils {
             buffer[8] &= 0xbf; // buffer[8] & 10111111 will set the 6 bit to 0.
 
             return CryptoUtils.decimalToHex(buffer[0]) + CryptoUtils.decimalToHex(buffer[1])
-            + CryptoUtils.decimalToHex(buffer[2]) + CryptoUtils.decimalToHex(buffer[3])
-            + "-" + CryptoUtils.decimalToHex(buffer[4]) + CryptoUtils.decimalToHex(buffer[5])
-            + "-" + CryptoUtils.decimalToHex(buffer[6]) + CryptoUtils.decimalToHex(buffer[7])
-            + "-" + CryptoUtils.decimalToHex(buffer[8]) + CryptoUtils.decimalToHex(buffer[9])
-            + "-" + CryptoUtils.decimalToHex(buffer[10]) + CryptoUtils.decimalToHex(buffer[11])
-            + CryptoUtils.decimalToHex(buffer[12]) + CryptoUtils.decimalToHex(buffer[13])
-            + CryptoUtils.decimalToHex(buffer[14]) + CryptoUtils.decimalToHex(buffer[15]);
+                + CryptoUtils.decimalToHex(buffer[2]) + CryptoUtils.decimalToHex(buffer[3])
+                + "-" + CryptoUtils.decimalToHex(buffer[4]) + CryptoUtils.decimalToHex(buffer[5])
+                + "-" + CryptoUtils.decimalToHex(buffer[6]) + CryptoUtils.decimalToHex(buffer[7])
+                + "-" + CryptoUtils.decimalToHex(buffer[8]) + CryptoUtils.decimalToHex(buffer[9])
+                + "-" + CryptoUtils.decimalToHex(buffer[10]) + CryptoUtils.decimalToHex(buffer[11])
+                + CryptoUtils.decimalToHex(buffer[12]) + CryptoUtils.decimalToHex(buffer[13])
+                + CryptoUtils.decimalToHex(buffer[14]) + CryptoUtils.decimalToHex(buffer[15]);
         }
         else {
             const guidHolder: string = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
@@ -66,7 +66,7 @@ export class CryptoUtils {
             for (let i: number = 0; i < 36; i++) {
                 if (guidHolder[i] !== "-" && guidHolder[i] !== "4") {
                     // each x and y needs to be random
-                    r = Math.random()  * 16 | 0;
+                    r = Math.random() * 16 | 0;
                 }
                 if (guidHolder[i] === "x") {
                     guidResponse += hex[r];
@@ -95,7 +95,7 @@ export class CryptoUtils {
         }
         return hex;
     }
-    
+
     // See: https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#Solution_4_%E2%80%93_escaping_the_string_before_encoding_it
 
     /**
@@ -111,12 +111,26 @@ export class CryptoUtils {
     }
 
     /**
-     * decoding base64 token - platform specific check
+     * Decodes a base64 encoded string.
      *
-     * @param base64IdToken
+     * @param input
      */
     static base64Decode(input: string): string {
-        return decodeURIComponent(atob(input).split("").map(function(c) {
+        let encodedString = input.replace(/-/g, "+").replace(/_/g, "/");
+        switch (encodedString.length % 4) {
+            case 0:
+                break;
+            case 2:
+                encodedString += "==";
+                break;
+            case 3:
+                encodedString += "=";
+                break;
+            default:
+                throw new Error("Invalid base64 string");
+        }
+
+        return decodeURIComponent(atob(encodedString).split("").map(function (c) {
             return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
         }).join(""));
     }

--- a/lib/msal-core/test/utils/CryptoUtils.spec.ts
+++ b/lib/msal-core/test/utils/CryptoUtils.spec.ts
@@ -15,6 +15,9 @@ describe("CryptoUtils.ts class", () => {
     const ES_PLAINTEXT = "Avrán";
     const ES_B64_ENCODED = "QXZyw6Fu";
 
+    const JA_PLAINTEXT = "日本語憂鬱髙";
+    const JA_B64_ENCODED = "5pel5pys6Kqe5oaC6ayx6auZ";
+
     describe("test Base64 encode decode", () => {
         it('english', () => {
             expect(CryptoUtils.base64Encode(EN_PLAINTEXT)).to.be.equal(EN_B64_ENCODED);
@@ -34,6 +37,34 @@ describe("CryptoUtils.ts class", () => {
         it('spanish', () => {
             expect(CryptoUtils.base64Encode(ES_PLAINTEXT)).to.be.equal(ES_B64_ENCODED);
             expect(CryptoUtils.base64Decode(ES_B64_ENCODED)).to.be.equal(ES_PLAINTEXT);
+        });
+
+        it('japanese', () => {
+            expect(CryptoUtils.base64Encode(JA_PLAINTEXT)).to.be.equal(JA_B64_ENCODED);
+            expect(CryptoUtils.base64Decode(JA_B64_ENCODED)).to.be.equal(JA_PLAINTEXT);
+        });
+
+        it('id token', () => {
+            const ID_TOKEN_STRING = "eyJhdWQiOiI3MzE1YmE0MS1lZDYwLTQwYjUtOTY3Zi1hOTBlNTUzZmM3MTgiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vY2QxOWNlNjQtMDI4Mi00YTJkLTgxMjktNDdhYTBiMjdmYjdiL3YyLjAiLCJpYXQiOjE1NzA0ODM3NTIsIm5iZiI6MTU3MDQ4Mzc1MiwiZXhwIjoxNTcwNDg3NjUyLCJhaW8iOiJBVFFBeS84TkFBQUFEYW0weDZWdTQ3TU9FTGU0TGlJVDNzWFFULzNNcmFFbGFDS0t2dUt4a0NNSjl4ckt0ekxOaG5jNVlCZllpSVI0IiwibmFtZSI6Iua-geeUsCDlj6Hnn6UiLCJub25jZSI6IjcwNmFiM2QwLThmYmItNGVkYS1hYmU5LTc1Y2JmNzc2NmM3NiIsIm9pZCI6IjhjYzEwZjM5LTE4MTYtNDJiNS05M2ZmLWUwZjkyZGU2ZTIxOCIsInByZWZlcnJlZF91c2VybmFtZSI6ImpwLXRlc3RAamFudXR0ZXJ0ZXN0Lm9ubWljcm9zb2Z0LmNvbSIsInN1YiI6IkdkWkE4R255UEE4RmRvM3ZINDMwdTNYVHJzaFIzeHZNZ29KeVFDOUcwS0kiLCJ0aWQiOiJjZDE5Y2U2NC0wMjgyLTRhMmQtODEyOS00N2FhMGIyN2ZiN2IiLCJ1dGkiOiJMcnpsU2wzX0hFYUFWd2l3aDM5WUFBIiwidmVyIjoiMi4wIn0";
+
+            const ID_TOKEN = {
+                "aud": "7315ba41-ed60-40b5-967f-a90e553fc718",
+                "iss": "https://login.microsoftonline.com/cd19ce64-0282-4a2d-8129-47aa0b27fb7b/v2.0",
+                "iat": 1570483752,
+                "nbf": 1570483752,
+                "exp": 1570487652,
+                "aio": "ATQAy/8NAAAADam0x6Vu47MOELe4LiIT3sXQT/3MraElaCKKvuKxkCMJ9xrKtzLNhnc5YBfYiIR4",
+                "name": "澁田 叡知",
+                "nonce": "706ab3d0-8fbb-4eda-abe9-75cbf7766c76",
+                "oid": "8cc10f39-1816-42b5-93ff-e0f92de6e218",
+                "preferred_username": "jp-test@januttertest.onmicrosoft.com",
+                "sub": "GdZA8GnyPA8Fdo3vH430u3XTrshR3xvMgoJyQC9G0KI",
+                "tid": "cd19ce64-0282-4a2d-8129-47aa0b27fb7b",
+                "uti": "LrzlSl3_HEaAVwiwh39YAA",
+                "ver": "2.0"
+            };
+
+            expect(CryptoUtils.base64Decode(ID_TOKEN_STRING)).to.be.equal(JSON.stringify(ID_TOKEN));
         });
     });
 });


### PR DESCRIPTION
Our base64 decoding was not properly handling when STS generated an id_token for a user with Japanese characters, due to unicode characters. Example id_token included as a test case.

Repro by creating a user with a name with unicode characters (such as those in the test case) and having them sign into the Vanilla JS sample.

Fixes: #985 