### PR TITLE
Remove sandboxing from hidden iframe, due to change in eSTS redirect

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -774,6 +774,7 @@ export class UserAgentApplication {
         if (hash) {
             this.handleAuthenticationResponse(hash);
         }
+        WindowUtils.removeHiddenIframe(iframe);
     }
 
     // #endregion

--- a/lib/msal-core/src/cache/AuthCache.ts
+++ b/lib/msal-core/src/cache/AuthCache.ts
@@ -69,7 +69,7 @@ export class AuthCache extends BrowserStorage {// Singleton
             JSON.parse(key);
             return key;
         } catch (e) {
-            if (key.startsWith(`${Constants.cachePrefix}`) || key.startsWith(PersistentCacheKeys.ADAL_ID_TOKEN)) {
+            if (key.indexOf(`${Constants.cachePrefix}`) === 0 || key.indexOf(PersistentCacheKeys.ADAL_ID_TOKEN) === 0) {
                 return key;
             }
             return addInstanceId ? `${Constants.cachePrefix}.${this.clientId}.${key}` : `${Constants.cachePrefix}.${key}`;

--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -126,7 +126,6 @@ export class WindowUtils {
                 ifr.style.position = "absolute";
                 ifr.style.width = ifr.style.height = "0";
                 ifr.style.border = "0";
-                ifr.setAttribute("sandbox", "allow-same-origin");
                 adalFrame = (document.getElementsByTagName("body")[0].appendChild(ifr) as HTMLIFrameElement);
             } else if (document.body && document.body.insertAdjacentHTML) {
                 document.body.insertAdjacentHTML("beforeend", "<iframe name='" + iframeId + "' id='" + iframeId + "' style='display:none'></iframe>");
@@ -142,17 +141,29 @@ export class WindowUtils {
 
     /**
      * @hidden
+     * Removes a hidden iframe from the page.
+     * @ignore
+     */
+    static removeHiddenIframe(iframe: HTMLIFrameElement) {
+        document.body.removeChild(iframe);
+    }
+
+    /**
+     * @hidden
      * Find and return the iframe element with the given hash
      * @ignore
      */
-    static getIframeWithHash(hash: string) {
-        return Array.from(document.getElementsByTagName("iframe")).find(iframe => {
+    static getIframeWithHash(hash: string): HTMLIFrameElement {
+        const iframes = document.getElementsByTagName("iframe");
+        const iframeArray: Array<HTMLIFrameElement> = Array.apply(null, Array(iframes.length)).map((iframe: HTMLIFrameElement, index: number) => iframes.item(index)); // eslint-disable-line prefer-spread
+
+        return iframeArray.filter((iframe: HTMLIFrameElement) => {
             try {
                 return iframe.contentWindow.location.hash === hash;
             } catch (e) {
                 return false;
             }
-        });
+        })[0];
     }
 
     /**
@@ -174,13 +185,13 @@ export class WindowUtils {
      * @ignore
      */
     static getPopUpWithHash(hash: string): Window {
-        return WindowUtils.getPopups().find(popup => {
+        return WindowUtils.getPopups().filter(popup => {
             try {
                 return popup.location.hash === hash;
             } catch (e) {
                 return false;
             }
-        });
+        })[0];
     }
 
     /**

--- a/samples/react-sample-app/src/AuthProvider.js
+++ b/samples/react-sample-app/src/AuthProvider.js
@@ -81,7 +81,7 @@ export default C =>
                         });
                     }
 
-                    if (tokenResponse.scopes.includes(GRAPH_SCOPES.MAIL_READ)) {
+                    if (tokenResponse.scopes.indexOf(GRAPH_SCOPES.MAIL_READ) > 0) {
                         return this.readMail(tokenResponse.accessToken);
                     }
                 }
@@ -164,7 +164,7 @@ export default C =>
                         });
                     }
 
-                    if (tokenResponse.scopes.includes(GRAPH_SCOPES.MAIL_READ)) {
+                    if (tokenResponse.scopes.indexOf(GRAPH_SCOPES.MAIL_READ) > 0) {
                         return this.readMail(tokenResponse.accessToken);
                     }
                 }


### PR DESCRIPTION
STS now performs its redirects client-side in JavaScript, meaning we can no longer sandbox hidden iframes, as it will prevent the redirect from happening at all. Added code to immediately remove the iframe once we have the hash from the url, to mitigate MSAL code rerunning in the iframe (this is similar to what we do for popups, which we also can't sandbox).

Also removed ES6 JS that wasn't working in IE11 and replaced with ES5 code.