### PR TITLE
Add sandbox attribute back to iframes with "allow-scripts"

### DIFF
--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -126,6 +126,7 @@ export class WindowUtils {
                 ifr.style.position = "absolute";
                 ifr.style.width = ifr.style.height = "0";
                 ifr.style.border = "0";
+                ifr.setAttribute("sandbox", "allow-scripts allow-same-origin");
                 adalFrame = (document.getElementsByTagName("body")[0].appendChild(ifr) as HTMLIFrameElement);
             } else if (document.body && document.body.insertAdjacentHTML) {
                 document.body.insertAdjacentHTML("beforeend", "<iframe name='" + iframeId + "' id='" + iframeId + "' style='display:none'></iframe>");


### PR DESCRIPTION
Following up with SPO update using  the latest beta `msal.1.2.0-beta.2`:

SPO cannot use the most recent version of MSAL as it removes the sandbox attribute from the token fetching iframe. In certain edge cases (such as a missing reply url), a call to retrieve an OAuth token silently will result in ESTS performing a full page direction on the host page (not the iframe). An iframe causing a full page redirect without consent is a terrible experience for most enterprise applications like Sharepoint. Even if the redirection occurs, the end user wouldn’t be able to resolve this configuration issue unless they were the admin user.

To support this we are adding the `sandbox attribute` to our iframe creation, allowing script execution enabling the redirect from the STS.