### PR TITLE
Correlation Id - pass the client set correlation-id to service

### DIFF
--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -65,7 +65,6 @@ export class ServerRequestParameters {
         this.nonce = CryptoUtils.createNewGuid();
         this.state = state && !StringUtils.isEmpty(state) ?  CryptoUtils.createNewGuid() + "|" + state   : CryptoUtils.createNewGuid();
 
-        // TODO: Change this to user passed vs generated with the new PR
         this.correlationId = correlationId || CryptoUtils.createNewGuid();
 
         // telemetry information

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -53,7 +53,7 @@ export class ServerRequestParameters {
      * @param redirectUri
      * @param state
      */
-    constructor (authority: Authority, clientId: string, scope: Array<string>, responseType: string, redirectUri: string, state: string) {
+    constructor (authority: Authority, clientId: string, scope: Array<string>, responseType: string, redirectUri: string, state: string, correlationId?: string) {
         this.authorityInstance = authority;
         this.clientId = clientId;
         if (!scope) {
@@ -66,7 +66,7 @@ export class ServerRequestParameters {
         this.state = state && !StringUtils.isEmpty(state) ?  CryptoUtils.createNewGuid() + "|" + state   : CryptoUtils.createNewGuid();
 
         // TODO: Change this to user passed vs generated with the new PR
-        this.correlationId = CryptoUtils.createNewGuid();
+        this.correlationId = correlationId || CryptoUtils.createNewGuid();
 
         // telemetry information
         this.xClientSku = "MSAL.JS";

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -59,10 +59,7 @@ export class ServerRequestParameters {
         this.nonce = CryptoUtils.createNewGuid();
 
         // validate and populate state and correlationId
-        const values = this.validateUserSetServerParams(scopes, state, correlationId, this.clientId);
-        this.scopes = values.scopes;
-        this.state  = values.state;
-        this.correlationId = values.correlationId;
+        this.setRequestServerParams(scopes, state, correlationId, this.clientId);
 
         // telemetry information
         this.xClientSku = "MSAL.JS";
@@ -357,21 +354,18 @@ export class ServerRequestParameters {
      * Validate  scopes/state/correlationId set in the request by the user
      * @param request
      */
-    private validateUserSetServerParams(scopes: Array<string>, state: string, correlationId: string, clientId: string) {
-
+    private setRequestServerParams(scopes: Array<string>, state: string, correlationId: string, clientId: string) {
         // set scope to clientId if null
-        const reqScopes = scopes? [ ...scopes] : [clientId];
+        this.scopes = scopes? [ ...scopes] : [clientId];
 
         // append GUID to user set state  or set one for the user if null
-        const reqState = state && !StringUtils.isEmpty(state) ? CryptoUtils.createNewGuid() + "|" + state : CryptoUtils.createNewGuid();
+        this.state = state && !StringUtils.isEmpty(state) ? CryptoUtils.createNewGuid() + "|" + state : CryptoUtils.createNewGuid();
 
         // validate user set correlationId or set one for the user if null
         if(correlationId && !CryptoUtils.isGuid(correlationId)) {
             throw ClientConfigurationError.createInvalidCorrelationIdError();
         }
-        const reqCcorrelationId = correlationId && CryptoUtils.isGuid(correlationId)? correlationId : CryptoUtils.createNewGuid();
-
-        return {scopes: reqScopes, state: reqState, correlationId: reqCcorrelationId};
+        this.correlationId = correlationId && CryptoUtils.isGuid(correlationId)? correlationId : CryptoUtils.createNewGuid();
     }
 
     // #endregion

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -490,7 +490,8 @@ export class UserAgentApplication {
                 scopes,
                 responseType,
                 this.getRedirectUri(),
-                request && request.state
+                request && request.state,
+                request && request.correlationId
             );
 
             this.updateCacheEntries(serverAuthenticationRequest, account, loginStartPage);
@@ -602,7 +603,8 @@ export class UserAgentApplication {
                 request.scopes,
                 responseType,
                 this.getRedirectUri(),
-                request && request.state
+                request.state,
+                request.correlationId
             );
             // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
             if (ServerRequestParameters.isSSOParam(request) || account) {
@@ -1805,7 +1807,7 @@ export class UserAgentApplication {
      * @param state
      * @return {@link AuthResponse} AuthResponse
      */
-    protected getCachedTokenInternal(scopes : Array<string> , account: Account, state: string): AuthResponse {
+    protected getCachedTokenInternal(scopes : Array<string> , account: Account, state: string, correlationId?: string): AuthResponse {
         // Get the current session's account object
         const accountObject: Account = account || this.getAccount();
         if (!accountObject) {
@@ -1821,7 +1823,8 @@ export class UserAgentApplication {
             scopes,
             responseType,
             this.getRedirectUri(),
-            state
+            state,
+            correlationId
         );
 
         // get cached token

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -89,18 +89,6 @@ export type ResponseStateInfo = {
 };
 
 /**
- * @hidden
- * @ignore
- *
- * Data type to contain userset request params sent to  -> server parameters
- */
-export type UserSetRequestParams = {
-    scopes: Array<string>,
-    state: string,
-    correlationId: string
-};
-
-/**
  * A type alias for an authResponseCallback function.
  * {@link (authResponseCallback:type)}
  * @param authErr error created for failure cases
@@ -496,18 +484,14 @@ export class UserAgentApplication {
                 }
             }
 
-            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(
-                scopes,
-                request && request.state,
-                request && request.correlationId,
-                this.clientId);
-
             serverAuthenticationRequest = new ServerRequestParameters(
                 acquireTokenAuthority,
                 this.clientId,
                 responseType,
                 this.getRedirectUri(),
-                reqParams
+                scopes,
+                request && request.state,
+                request && request.correlationId
             );
 
             this.updateCacheEntries(serverAuthenticationRequest, account, loginStartPage);
@@ -611,20 +595,18 @@ export class UserAgentApplication {
                 return reject(ClientAuthError.createUserLoginRequiredError());
             }
 
+            // set the response type based on the current cache status / scopes set
             const responseType = this.getTokenType(account, request.scopes, true);
 
-            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(
-                request.scopes,
-                request.state,
-                request.correlationId,
-                this.clientId);
-
+            // create a serverAuthenticationRequest populating the `queryParameters` to be sent to the Server
             const serverAuthenticationRequest = new ServerRequestParameters(
                 AuthorityFactory.CreateInstance(request.authority, this.config.auth.validateAuthority),
                 this.clientId,
                 responseType,
                 this.getRedirectUri(),
-                reqParams
+                request.scopes,
+                request.state,
+                request.correlationId,
             );
 
             // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
@@ -1839,18 +1821,14 @@ export class UserAgentApplication {
         const newAuthority = this.authorityInstance ? this.authorityInstance : AuthorityFactory.CreateInstance(this.authority, this.config.auth.validateAuthority);
         const responseType = this.getTokenType(accountObject, scopes, true);
 
-        const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(
-            scopes,
-            state,
-            correlationId,
-            this.clientId);
-
         const serverAuthenticationRequest = new ServerRequestParameters(
             newAuthority,
             this.clientId,
             responseType,
             this.getRedirectUri(),
-            reqParams
+            scopes,
+            state,
+            correlationId
         );
 
         // get cached token

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -89,6 +89,18 @@ export type ResponseStateInfo = {
 };
 
 /**
+ * @hidden
+ * @ignore
+ *
+ * Data type to contain userset request params sent to  -> server parameters
+ */
+export type UserSetRequestParams = {
+    scopes: Array<string>,
+    state: string,
+    correlationId: string
+};
+
+/**
  * A type alias for an authResponseCallback function.
  * {@link (authResponseCallback:type)}
  * @param authErr error created for failure cases
@@ -484,14 +496,18 @@ export class UserAgentApplication {
                 }
             }
 
+            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(
+                scopes,
+                request && request.state,
+                request && request.correlationId,
+                this.clientId);
+
             serverAuthenticationRequest = new ServerRequestParameters(
                 acquireTokenAuthority,
                 this.clientId,
-                scopes,
                 responseType,
                 this.getRedirectUri(),
-                request && request.state,
-                request && request.correlationId
+                reqParams
             );
 
             this.updateCacheEntries(serverAuthenticationRequest, account, loginStartPage);
@@ -597,15 +613,20 @@ export class UserAgentApplication {
 
             const responseType = this.getTokenType(account, request.scopes, true);
 
+            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(
+                request.scopes,
+                request.state,
+                request.correlationId,
+                this.clientId);
+
             const serverAuthenticationRequest = new ServerRequestParameters(
                 AuthorityFactory.CreateInstance(request.authority, this.config.auth.validateAuthority),
                 this.clientId,
-                request.scopes,
                 responseType,
                 this.getRedirectUri(),
-                request.state,
-                request.correlationId
+                reqParams
             );
+
             // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
             if (ServerRequestParameters.isSSOParam(request) || account) {
                 serverAuthenticationRequest.populateQueryParams(account, request);
@@ -1817,14 +1838,19 @@ export class UserAgentApplication {
         // Construct AuthenticationRequest based on response type
         const newAuthority = this.authorityInstance ? this.authorityInstance : AuthorityFactory.CreateInstance(this.authority, this.config.auth.validateAuthority);
         const responseType = this.getTokenType(accountObject, scopes, true);
+
+        const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(
+            scopes,
+            state,
+            correlationId,
+            this.clientId);
+
         const serverAuthenticationRequest = new ServerRequestParameters(
             newAuthority,
             this.clientId,
-            scopes,
             responseType,
             this.getRedirectUri(),
-            state,
-            correlationId
+            reqParams
         );
 
         // get cached token

--- a/lib/msal-core/src/error/ClientConfigurationError.ts
+++ b/lib/msal-core/src/error/ClientConfigurationError.ts
@@ -74,6 +74,10 @@ export const ClientConfigurationErrorMessage = {
         code: "empty_request_error",
         desc: "Request object is required."
     },
+    invalidCorrelationIdError: {
+        code: "invalid_guid_sent_as_correlationId",
+        desc: "Please set the correlationId as a valid guid"
+    },
     telemetryConfigError: {
         code: "telemetry_config_error",
         desc: "Telemetry config is not configured with required values"
@@ -143,6 +147,11 @@ export class ClientConfigurationError extends ClientAuthError {
     static createEmptyRequestError(): ClientConfigurationError {
         const { code, desc } = ClientConfigurationErrorMessage.emptyRequestError;
         return new ClientConfigurationError(code, desc);
+    }
+
+    static createInvalidCorrelationIdError(): ClientConfigurationError {
+        return new ClientConfigurationError(ClientConfigurationErrorMessage.invalidCorrelationIdError.code,
+            ClientConfigurationErrorMessage.invalidCorrelationIdError.desc);
     }
 
     static createTelemetryConfigError(config: TelemetryOptions): ClientConfigurationError {

--- a/lib/msal-core/src/index.ts
+++ b/lib/msal-core/src/index.ts
@@ -8,6 +8,7 @@ export { CacheResult } from "./UserAgentApplication";
 export { CacheLocation, Configuration } from "./Configuration";
 export { AuthenticationParameters } from "./AuthenticationParameters";
 export { AuthResponse } from "./AuthResponse";
+export { CryptoUtils } from "./utils/CryptoUtils";
 
 // Errors
 export { AuthError } from "./error/AuthError";

--- a/lib/msal-core/src/utils/CryptoUtils.ts
+++ b/lib/msal-core/src/utils/CryptoUtils.ts
@@ -84,6 +84,15 @@ export class CryptoUtils {
     }
 
     /**
+     * verifies if a string is  GUID
+     * @param guid
+     */
+    static isGuid(guid: string) {
+        const regexGuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+        return regexGuid.test(guid);
+    }
+
+    /**
      * Decimal to Hex
      *
      * @param num

--- a/lib/msal-core/test/ServerRequestParameters.spec.ts
+++ b/lib/msal-core/test/ServerRequestParameters.spec.ts
@@ -1,9 +1,11 @@
 import { expect } from "chai";
 import { ServerRequestParameters } from "../src/ServerRequestParameters";
-import { Authority } from "../src";
+import { Authority, ClientConfigurationError } from "../src";
 import { AuthorityFactory } from "../src/authority/AuthorityFactory";
 import { UrlUtils } from "../src/utils/UrlUtils";
+import { UserSetRequestParams } from "../src/UserAgentApplication";
 import { TEST_CONFIG, TEST_RESPONSE_TYPE, TEST_URIS } from "./TestConstants";
+import { ClientConfigurationErrorMessage } from "../src/error/ClientConfigurationError"
 import sinon from "sinon";
 
 describe("ServerRequestParameters.ts Class", function () {
@@ -11,16 +13,16 @@ describe("ServerRequestParameters.ts Class", function () {
     describe("Object creation", function () {
 
         it("Scope array pointer is not passed into constructor", function () {
-            let scopes = ["S1"];
-            let authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
+            const scopes = ["S1"];
+            const authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
             sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
-            let req = new ServerRequestParameters(
+            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(scopes, TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
+            const req = new ServerRequestParameters(
                 authority,
                 TEST_CONFIG.MSAL_CLIENT_ID,
-                scopes,
                 TEST_RESPONSE_TYPE.token,
                 TEST_URIS.TEST_REDIR_URI,
-                TEST_CONFIG.STATE
+                reqParams
             );
             expect(req.scopes).to.not.be.equal(scopes);
             expect(req.scopes.length).to.be.eql(1);
@@ -28,15 +30,15 @@ describe("ServerRequestParameters.ts Class", function () {
         });
 
         it("Scopes are set to client id if null or empty scopes object passed", function () {
-            let authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
+            const authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
             sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
-            let req = new ServerRequestParameters(
+            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams( null, TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
+            const req = new ServerRequestParameters(
                 authority,
                 TEST_CONFIG.MSAL_CLIENT_ID,
-                null,
                 TEST_RESPONSE_TYPE.token,
                 TEST_URIS.TEST_REDIR_URI,
-                TEST_CONFIG.STATE
+                reqParams
             );
             expect(req.scopes).to.be.eql([TEST_CONFIG.MSAL_CLIENT_ID]);
             expect(req.scopes.length).to.be.eql(1);
@@ -50,20 +52,48 @@ describe("ServerRequestParameters.ts Class", function () {
             let authenticationRequestParameters: ServerRequestParameters;
             let authority: Authority;
             authority = AuthorityFactory.CreateInstance("https://login.microsoftonline.com/common/", this.validateAuthority);
-            authenticationRequestParameters = new ServerRequestParameters(authority, "0813e1d1-ad72-46a9-8665-399bba48c201", ["user.read"], "id_token", "", "12345");
-            var result;
-            result = UrlUtils.createNavigationUrlString(authenticationRequestParameters);
-            expect(decodeURIComponent(result[4])).to.include("12345");
+            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(["user.read"],TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
+            authenticationRequestParameters = new ServerRequestParameters(authority, "0813e1d1-ad72-46a9-8665-399bba48c201", "id_token", "", reqParams);
+            const result = UrlUtils.createNavigationUrlString(authenticationRequestParameters);
+            expect(decodeURIComponent(result[4])).to.include(TEST_CONFIG.STATE);
         });
 
         it('test if authenticateRequestParameter generates state correctly, if state is a url', function () {
             let authenticationRequestParameters: ServerRequestParameters;
             let authority: Authority;
             authority = AuthorityFactory.CreateInstance("https://login.microsoftonline.com/common/", this.validateAuthority);
-            authenticationRequestParameters = new ServerRequestParameters(authority, "0813e1d1-ad72-46a9-8665-399bba48c201", ["user.read"], "id_token", "", "https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2");
-            var result;
-            result = UrlUtils.createNavigationUrlString(authenticationRequestParameters);
+            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(["user.read"], "https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2", TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
+            authenticationRequestParameters = new ServerRequestParameters(authority, "0813e1d1-ad72-46a9-8665-399bba48c201", "id_token", "", reqParams);
+            const result = UrlUtils.createNavigationUrlString(authenticationRequestParameters);
             expect(decodeURIComponent(result[4])).to.include("https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2");
+        });
+    });
+
+    describe("CorrelationId Tests", function () {
+
+        it("tests correlation Id passed by the user is set correctly", function () {
+            let authenticationRequestParameters: ServerRequestParameters;
+            let authority: Authority;
+            authority = AuthorityFactory.CreateInstance("https://login.microsoftonline.com/common/", this.validateAuthority);
+            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(["user.read"], TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
+            authenticationRequestParameters = new ServerRequestParameters(authority, "0813e1d1-ad72-46a9-8665-399bba48c201", "id_token", "", reqParams);
+            const result = UrlUtils.createNavigationUrlString(authenticationRequestParameters);
+            expect(decodeURIComponent(result[result.length-1])).to.include(TEST_CONFIG.CorrelationId);
+        });
+
+        it("tests correlation Id passed by the user is validated correctly", function () {
+            let err:ClientConfigurationError;
+            let reqParams: UserSetRequestParams;
+            try {
+                reqParams = ServerRequestParameters.validateUserSetServerParams(["user.read"], TEST_CONFIG.STATE, "Hello", TEST_CONFIG.MSAL_CLIENT_ID);
+            }
+            catch (e) {
+                expect(e).to.be.instanceOf(ClientConfigurationError);
+                err = e;
+            }
+
+            expect(err.errorCode).to.equal(ClientConfigurationErrorMessage.invalidCorrelationIdError.code);
+            expect(err.errorMessage).to.include(ClientConfigurationErrorMessage.invalidCorrelationIdError.desc);
         });
     });
 });

--- a/lib/msal-core/test/ServerRequestParameters.spec.ts
+++ b/lib/msal-core/test/ServerRequestParameters.spec.ts
@@ -3,7 +3,6 @@ import { ServerRequestParameters } from "../src/ServerRequestParameters";
 import { Authority, ClientConfigurationError } from "../src";
 import { AuthorityFactory } from "../src/authority/AuthorityFactory";
 import { UrlUtils } from "../src/utils/UrlUtils";
-import { UserSetRequestParams } from "../src/UserAgentApplication";
 import { TEST_CONFIG, TEST_RESPONSE_TYPE, TEST_URIS } from "./TestConstants";
 import { ClientConfigurationErrorMessage } from "../src/error/ClientConfigurationError"
 import sinon from "sinon";
@@ -16,13 +15,14 @@ describe("ServerRequestParameters.ts Class", function () {
             const scopes = ["S1"];
             const authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
             sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
-            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(scopes, TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
             const req = new ServerRequestParameters(
                 authority,
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 TEST_RESPONSE_TYPE.token,
                 TEST_URIS.TEST_REDIR_URI,
-                reqParams
+                scopes,
+                TEST_CONFIG.STATE,
+                TEST_CONFIG.CorrelationId
             );
             expect(req.scopes).to.not.be.equal(scopes);
             expect(req.scopes.length).to.be.eql(1);
@@ -32,13 +32,14 @@ describe("ServerRequestParameters.ts Class", function () {
         it("Scopes are set to client id if null or empty scopes object passed", function () {
             const authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
             sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
-            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams( null, TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
             const req = new ServerRequestParameters(
                 authority,
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 TEST_RESPONSE_TYPE.token,
                 TEST_URIS.TEST_REDIR_URI,
-                reqParams
+                null,
+                TEST_CONFIG.STATE,
+                TEST_CONFIG.CorrelationId
             );
             expect(req.scopes).to.be.eql([TEST_CONFIG.MSAL_CLIENT_ID]);
             expect(req.scopes.length).to.be.eql(1);
@@ -52,8 +53,15 @@ describe("ServerRequestParameters.ts Class", function () {
             let authenticationRequestParameters: ServerRequestParameters;
             let authority: Authority;
             authority = AuthorityFactory.CreateInstance("https://login.microsoftonline.com/common/", this.validateAuthority);
-            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(["user.read"],TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
-            authenticationRequestParameters = new ServerRequestParameters(authority, "0813e1d1-ad72-46a9-8665-399bba48c201", "id_token", "", reqParams);
+            const scopes = ["user.read"];
+            authenticationRequestParameters = new ServerRequestParameters(
+                authority,
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                TEST_RESPONSE_TYPE.id_token,
+                "",
+                scopes,
+                TEST_CONFIG.STATE,
+                TEST_CONFIG.CorrelationId);
             const result = UrlUtils.createNavigationUrlString(authenticationRequestParameters);
             expect(decodeURIComponent(result[4])).to.include(TEST_CONFIG.STATE);
         });
@@ -62,8 +70,17 @@ describe("ServerRequestParameters.ts Class", function () {
             let authenticationRequestParameters: ServerRequestParameters;
             let authority: Authority;
             authority = AuthorityFactory.CreateInstance("https://login.microsoftonline.com/common/", this.validateAuthority);
-            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(["user.read"], "https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2", TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
-            authenticationRequestParameters = new ServerRequestParameters(authority, "0813e1d1-ad72-46a9-8665-399bba48c201", "id_token", "", reqParams);
+
+            const scopes = ["user.read"];
+            const state = "https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2";
+            authenticationRequestParameters = new ServerRequestParameters(
+                authority,
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                TEST_RESPONSE_TYPE.id_token,
+                "",
+                scopes,
+                state,
+                TEST_CONFIG.CorrelationId);
             const result = UrlUtils.createNavigationUrlString(authenticationRequestParameters);
             expect(decodeURIComponent(result[4])).to.include("https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-implicit-grant-flow?name=value&name2=value2");
         });
@@ -75,17 +92,36 @@ describe("ServerRequestParameters.ts Class", function () {
             let authenticationRequestParameters: ServerRequestParameters;
             let authority: Authority;
             authority = AuthorityFactory.CreateInstance("https://login.microsoftonline.com/common/", this.validateAuthority);
-            const reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(["user.read"], TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
-            authenticationRequestParameters = new ServerRequestParameters(authority, "0813e1d1-ad72-46a9-8665-399bba48c201", "id_token", "", reqParams);
+
+            const scopes = ["user.read"];
+            authenticationRequestParameters = new ServerRequestParameters(
+                authority,
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                TEST_RESPONSE_TYPE.id_token,
+                "",
+                scopes,
+                TEST_CONFIG.STATE,
+                TEST_CONFIG.CorrelationId);
             const result = UrlUtils.createNavigationUrlString(authenticationRequestParameters);
             expect(decodeURIComponent(result[result.length-1])).to.include(TEST_CONFIG.CorrelationId);
         });
 
         it("tests correlation Id passed by the user is validated correctly", function () {
             let err:ClientConfigurationError;
-            let reqParams: UserSetRequestParams;
             try {
-                reqParams = ServerRequestParameters.validateUserSetServerParams(["user.read"], TEST_CONFIG.STATE, "Hello", TEST_CONFIG.MSAL_CLIENT_ID);
+                let authenticationRequestParameters: ServerRequestParameters;
+                let authority: Authority;
+                authority = AuthorityFactory.CreateInstance("https://login.microsoftonline.com/common/", this.validateAuthority);
+
+                const scopes = ["user.read"];
+                authenticationRequestParameters = new ServerRequestParameters(
+                    authority,
+                    TEST_CONFIG.MSAL_CLIENT_ID,
+                    TEST_RESPONSE_TYPE.id_token,
+                    "",
+                    scopes,
+                    TEST_CONFIG.STATE,
+                    "Hello");
             }
             catch (e) {
                 expect(e).to.be.instanceOf(ClientConfigurationError);

--- a/lib/msal-core/test/TestConstants.ts
+++ b/lib/msal-core/test/TestConstants.ts
@@ -60,7 +60,8 @@ export const TEST_CONFIG = {
     alternateValidAuthority: TEST_URIS.ALTERNATE_INSTANCE + "common",
     applicationName: "msal.js-tests",
     applicationVersion: "msal.js-tests.1.0.fake",
-    STATE: "1234"
+    STATE: "1234",
+    CorrelationId: "ed2a3125-a597-416f-9d12-68b9add1c268"
 };
 
 export const TEST_RESPONSE_TYPE = {

--- a/lib/msal-core/test/error/ClientConfigurationError.spec.ts
+++ b/lib/msal-core/test/error/ClientConfigurationError.spec.ts
@@ -187,6 +187,24 @@ describe("ClientConfigurationError.ts Class", () => {
     expect(err.stack).to.include("ClientConfigurationError.spec.ts");
   });
 
+  it("createInvalidCorrelationIdError creates a ClientConfigurationError object", () => {
+
+    const invalidCorrelationId = ClientConfigurationError.createInvalidCorrelationIdError();
+    let err: ClientConfigurationError;
+
+    try {
+      throw invalidCorrelationId;
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err.errorCode).to.equal(ClientConfigurationErrorMessage.invalidCorrelationIdError.code);
+    expect(err.errorMessage).to.include(ClientConfigurationErrorMessage.invalidCorrelationIdError.desc);
+    expect(err.message).to.include(ClientConfigurationErrorMessage.invalidCorrelationIdError.desc);
+    expect(err.name).to.equal("ClientConfigurationError");
+    expect(err.stack).to.include("ClientConfigurationError.spec.ts");
+  });
+
   it("createTelemetryConfigError creates a ClientConfigurationError object", () => {
     // @ts-ignore
     const telemConfigErr: ClientConfigurationError = ClientConfigurationError.createTelemetryConfigError({

--- a/lib/msal-core/test/utils/CryptoUtils.spec.ts
+++ b/lib/msal-core/test/utils/CryptoUtils.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { CryptoUtils } from "../../src/utils/CryptoUtils";
+import { TEST_RESPONSE_TYPE } from "./../TestConstants";
 
 describe("CryptoUtils.ts class", () => {
 
@@ -65,6 +66,39 @@ describe("CryptoUtils.ts class", () => {
             };
 
             expect(CryptoUtils.base64Decode(ID_TOKEN_STRING)).to.be.equal(JSON.stringify(ID_TOKEN));
+        });
+    });
+
+    describe("test if a string is GUID", () => {
+        it('Regular text', () => {
+            expect(CryptoUtils.isGuid("Hello")).to.be.eq(false);
+        });
+
+        it('GUID', () => {
+            expect(CryptoUtils.isGuid("a3cd2952-64dd-43b4-9720-f48c093394a3")).to.be.eq(true);
+        });
+    });
+
+    describe("test createNewGuid() generates a GUID", () => {
+        it('Generate and validate a GUID', () => {
+            expect(CryptoUtils.isGuid(CryptoUtils.createNewGuid())).to.be.eq(true);
+        });
+    });
+
+    describe("test decimal to hex conversion utility", () => {
+        it('test  if we are  generating a hex number', () => {
+            const h: string = CryptoUtils.decimalToHex(1234);
+            const d = parseInt(h,16);
+
+            expect(d.toString(16)).to.be.equal(h);
+        });
+    });
+
+    describe("test the deserializing utility function", () => {
+        it('validate the deserializing utility function', () => {
+            const query: string = CryptoUtils.deserialize("id_token=MSAL_TEST_IDTOKEN&access_token=MSAL_TEST_ACCESS_TOKEN");
+            expect(query.hasOwnProperty("id_token"));
+            expect(query.hasOwnProperty("access_token"));
         });
     });
 });

--- a/lib/msal-core/test/utils/UrlUtils.spec.ts
+++ b/lib/msal-core/test/utils/UrlUtils.spec.ts
@@ -5,7 +5,6 @@ import { TEST_CONFIG, TEST_RESPONSE_TYPE, TEST_URIS } from "../TestConstants";
 import { AuthorityFactory } from "../../src/authority/AuthorityFactory";
 import { ServerRequestParameters } from "../../src/ServerRequestParameters";
 import { ServerHashParamKeys } from "../../src/utils/Constants";
-import { UserSetRequestParams } from "../../src/UserAgentApplication";
 
 describe("UrlUtils.ts class", () => {
 
@@ -51,13 +50,14 @@ describe("UrlUtils.ts class", () => {
         const scopes = ["S1"];
         const authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
         sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
-        let reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(scopes, TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
         const req = new ServerRequestParameters(
             authority,
             TEST_CONFIG.MSAL_CLIENT_ID,
             TEST_RESPONSE_TYPE.token,
             TEST_URIS.TEST_REDIR_URI,
-            reqParams
+            scopes,
+            TEST_CONFIG.STATE,
+            TEST_CONFIG.CorrelationId
         );
         const uriString = UrlUtils.createNavigateUrl(req);
 

--- a/lib/msal-core/test/utils/UrlUtils.spec.ts
+++ b/lib/msal-core/test/utils/UrlUtils.spec.ts
@@ -5,6 +5,7 @@ import { TEST_CONFIG, TEST_RESPONSE_TYPE, TEST_URIS } from "../TestConstants";
 import { AuthorityFactory } from "../../src/authority/AuthorityFactory";
 import { ServerRequestParameters } from "../../src/ServerRequestParameters";
 import { ServerHashParamKeys } from "../../src/utils/Constants";
+import { UserSetRequestParams } from "../../src/UserAgentApplication";
 
 describe("UrlUtils.ts class", () => {
 
@@ -50,13 +51,13 @@ describe("UrlUtils.ts class", () => {
         const scopes = ["S1"];
         const authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
         sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
+        let reqParams: UserSetRequestParams = ServerRequestParameters.validateUserSetServerParams(scopes, TEST_CONFIG.STATE, TEST_CONFIG.CorrelationId, TEST_CONFIG.MSAL_CLIENT_ID);
         const req = new ServerRequestParameters(
             authority,
             TEST_CONFIG.MSAL_CLIENT_ID,
-            scopes,
             TEST_RESPONSE_TYPE.token,
             TEST_URIS.TEST_REDIR_URI,
-            TEST_CONFIG.STATE
+            reqParams
         );
         const uriString = UrlUtils.createNavigateUrl(req);
 


### PR DESCRIPTION
`msal js` needs to pass the user set correlation-id per request if the application sets it. Currently we are only generating the random guid and ignoring any app passed values.

Todo:
Tests pending