### PR TITLE
Add response_mode=fragment to silent renewal call, fixes #1088

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,6 @@
     "lib/*",
     "samples/*"
   ],
-  "version": "independent"
+  "version": "independent",
+  "concurrency": 2
 }

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1253,7 +1253,7 @@ export class UserAgentApplication {
         this.logger.verbose("Renew token Expected state: " + serverAuthenticationRequest.state);
 
         // Build urlNavigate with "prompt=none" and navigate to URL in hidden iFrame
-        const urlNavigate = UrlUtils.urlRemoveQueryStringParameter(UrlUtils.createNavigateUrl(serverAuthenticationRequest), Constants.prompt) + Constants.prompt_none;
+        const urlNavigate = UrlUtils.urlRemoveQueryStringParameter(UrlUtils.createNavigateUrl(serverAuthenticationRequest), Constants.prompt) + Constants.prompt_none + Constants.response_mode_fragment;
 
         window.renewStates.push(serverAuthenticationRequest.state);
         window.requestType = Constants.renewToken;
@@ -1278,7 +1278,7 @@ export class UserAgentApplication {
         this.logger.verbose("Renew Idtoken Expected state: " + serverAuthenticationRequest.state);
 
         // Build urlNavigate with "prompt=none" and navigate to URL in hidden iFrame
-        const urlNavigate = UrlUtils.urlRemoveQueryStringParameter(UrlUtils.createNavigateUrl(serverAuthenticationRequest), Constants.prompt) + Constants.prompt_none;
+        const urlNavigate = UrlUtils.urlRemoveQueryStringParameter(UrlUtils.createNavigateUrl(serverAuthenticationRequest), Constants.prompt) + Constants.prompt_none + Constants.response_mode_fragment;
 
         if (this.silentLogin) {
             window.requestType = Constants.login;


### PR DESCRIPTION
Ensures that when there is an error in the silent call, that the error is returned as a fragment, instead of a query parameter, fixes #1088.