### PR TITLE
Authorization Code Flow for Single Page Applications: Rollup Build Files

### DIFF
--- a/lib/msal-browser/.huskyrc
+++ b/lib/msal-browser/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-      "pre-commit": ""
+      "pre-commit": "npm run build"
   }
 }

--- a/lib/msal-browser/rollup.config.js
+++ b/lib/msal-browser/rollup.config.js
@@ -1,0 +1,76 @@
+import typescript from "rollup-plugin-typescript2";
+import { uglify } from "rollup-plugin-uglify";
+import resolve from "rollup-plugin-node-resolve";
+import pkg from "./package.json";
+
+const libraryHeader = `/*! ${pkg.name} v${pkg.version} ${new Date().toISOString().split('T')[0]} */`;
+const useStrictHeader = `'use strict';`;
+const fileHeader = `${libraryHeader}\n${useStrictHeader}`;
+
+export default [
+    {
+        input: "src/index.ts",
+        output: [
+            {
+                file: pkg.main,
+                format: "cjs",
+                banner: fileHeader,
+                sourcemap: "inline"
+            },
+            {
+                file: pkg.module,
+                format: "es",
+                banner: fileHeader,
+                sourcemap: "inline"
+            },
+            {
+                file: "./lib/msal-browser.js",
+                format: "umd",
+                name: "Msal",
+                banner: fileHeader,
+                sourcemap: "inline"
+            }
+        ],
+        external: [
+            ...Object.keys(pkg.dependencies || {}),
+            ...Object.keys(pkg.peerDependencies || {})
+        ],
+        plugins: [
+            typescript({
+                typescript: require('typescript')
+            }),
+            resolve({
+                only: ["msal-common"]
+            })
+        ]
+    },
+    // Minified version of msal
+    {
+        input: "src/index.ts",
+        output: [
+            {
+                file: "./lib/msal-browser.min.js",
+                format: "umd",
+                name: "Msal",
+                banner: useStrictHeader
+            }
+        ],
+        external: [
+            ...Object.keys(pkg.dependencies || {}),
+            ...Object.keys(pkg.peerDependencies || {})
+        ],
+        plugins: [
+            typescript({
+                typescript: require('typescript')
+            }),
+            resolve({
+                only: ["msal-common"]
+            }),
+            uglify({
+                output: {
+                    preamble: libraryHeader
+                }
+            })
+        ]
+    }
+]

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export class PublicClientApplication {
+    
+}

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -1,0 +1,2 @@
+// App
+export { PublicClientApplication } from "./app/PublicClientApplication";

--- a/lib/msal-common/.huskyrc
+++ b/lib/msal-common/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-      "pre-commit": ""
+      "pre-commit": "npm run build"
   }
 }

--- a/lib/msal-common/.huskyrc
+++ b/lib/msal-common/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-      "pre-commit": "npm run build"
+      "pre-commit": "npm run lint"
   }
 }

--- a/lib/msal-common/rollup.config.js
+++ b/lib/msal-common/rollup.config.js
@@ -1,0 +1,70 @@
+import typescript from "rollup-plugin-typescript2";
+import { uglify } from "rollup-plugin-uglify";
+import pkg from "./package.json";
+
+const libraryHeader = `/*! ${pkg.name} v${pkg.version} ${new Date().toISOString().split('T')[0]} */`;
+const useStrictHeader = `'use strict';`;
+const fileHeader = `${libraryHeader}\n${useStrictHeader}`;
+
+export default [
+    {
+        input: "src/index.ts",
+        output: [
+            {
+                file: pkg.main,
+                format: "cjs",
+                banner: fileHeader,
+                sourcemap: "inline"
+            },
+            {
+                file: pkg.module,
+                format: "es",
+                banner: fileHeader,
+                sourcemap: "inline"
+            },
+            {
+                file: "./lib/msal-common.js",
+                format: "umd",
+                name: "Msal",
+                banner: fileHeader,
+                sourcemap: "inline"
+            }
+        ],
+        external: [
+            ...Object.keys(pkg.dependencies || {}),
+            ...Object.keys(pkg.peerDependencies || {})
+        ],
+        plugins: [
+            typescript({
+                typescript: require('typescript')
+            }),
+        ]
+    },
+    // Minified version of msal
+    {
+        input: "src/index.ts",
+        output: [
+            {
+                file: "./lib/msal-common.min.js",
+                format: "umd",
+                name: "Msal",
+                banner: useStrictHeader,
+                sourcemap: "inline"
+            }
+        ],
+        external: [
+            ...Object.keys(pkg.dependencies || {}),
+            ...Object.keys(pkg.peerDependencies || {})
+        ],
+        plugins: [
+            typescript({
+                typescript: require('typescript')
+            }),
+            uglify({
+                output: {
+                    preamble: libraryHeader
+                }
+            })
+        ]
+    }
+]

--- a/lib/msal-common/src/app/module/AuthModule.ts
+++ b/lib/msal-common/src/app/module/AuthModule.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @hidden
+ * @ignore
+ * Data type to hold information about state returned from the server
+ */
+export type ResponseStateInfo = {
+    state: string;
+    stateMatch: boolean;
+};
+
+/**
+ * CodeAuthModule class
+ * 
+ * Object instance which will construct requests to send to and handle responses from the Microsoft STS using the authorization code flow.
+ * 
+ */
+export abstract class AuthModule {
+
+}

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// inheritance
+import { AuthModule } from "./AuthModule";
+
+/**
+ * AuthorizationCodeModule class
+ * 
+ * Object instance which will construct requests to send to and handle responses from the Microsoft STS using the authorization code flow.
+ * 
+ */
+export class AuthorizationCodeModule extends AuthModule {
+
+}

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -1,0 +1,2 @@
+// App Auth Module
+export { AuthorizationCodeModule } from "./app/module/AuthorizationCodeModule";


### PR DESCRIPTION
This is the first PR required to be merged into the base branch to support the Authorization Code Flow for Single Page Applications.

This PR introduces [Rollup](https://rollupjs.org/guide/en/) as the module bundler for the Authorization Code Flow instead of webpack as used in the current msal-core implementation. 

# Rollup vs Webpack
- Rollup has node polyfills for import/export, which makes it a little easier to support JS project structures. Webpack does not have these polyfills
- Rollup has support for relative paths, so no need to use path.resolve/path.join
- Use plugins instead of loaders for transformations and bundling in Rollup vs Webpack
- Tree shaking is enabled by default in Rollup, which eliminates dead code and unused exports. There is extra configuration required to do this in Webpack. This ensures we can keep the library as lightweight as possible.
- Rollup does not have comprehensive support for code splitting while Webpack does. This is a noted feature in Webpack, whereas Rollup has recently implemented it and may not have as much feature support.
- Rollup is generally faster than webpack for bundling, which would save us time when we are rolling out updates to multiple packages.
- A general rule of thumb is to use Webpack for apps, and Rollup for libraries (though as both technologies have matured, this has become less true). 
