### PR TITLE
Remove class attribute from script tag

### DIFF
--- a/lib/msal-core/README.md
+++ b/lib/msal-core/README.md
@@ -74,7 +74,7 @@ Below is an example of how to use one CDN as a fallback when the other CDN is no
 Internet Explorer does not have native `Promise` support, and so you will need to include a polyfill for promises such as `bluebird`.
 
     <!-- IE support: add promises polyfill before msal.js  -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js" class="pre"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>
 
 See here for more details on [supported browsers and known compatability issues](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/FAQs#q4-what-browsers-is-msaljs-supported-on).
 


### PR DESCRIPTION
Small fix. Class attr on script tag doesn't add anything as far as I know, and there was an issue raised a while back (#117). 