### PR TITLE
Ensure errors thrown when monitoring window are caught and handled

### DIFF
--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -41,7 +41,8 @@ export class WindowUtils {
             const intervalId = setInterval(() => {
                 if (contentWindow.closed) {
                     clearInterval(intervalId);
-                    resolve();
+                    reject(ClientAuthError.createUserCancelledError());
+                    return;
                 }
 
                 let href;
@@ -146,7 +147,9 @@ export class WindowUtils {
      * @ignore
      */
     static removeHiddenIframe(iframe: HTMLIFrameElement) {
-        document.body.removeChild(iframe);
+        if (document.body !== iframe.parentNode) {
+            document.body.removeChild(iframe);
+        }
     }
 
     /**

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -1011,7 +1011,7 @@ describe("UserAgentApplication.ts Class", function () {
             });
             const cacheCallSpy = sinon.spy(msal, <any>"getCachedToken");
 
-            sinon.stub(msal, <any>"loadIframeTimeout").callsFake(function (url: string, frameName: string) {
+            sinon.stub(msal, <any>"loadIframeTimeout").callsFake(async function (url: string, frameName: string) {
                 expect(cacheCallSpy.notCalled).to.be.true;
                 expect(url).to.include(TEST_CONFIG.validAuthority + "/oauth2/v2.0/authorize?response_type=id_token token&scope=S1%20openid%20profile");
                 expect(url).to.include("&client_id=" + TEST_CONFIG.MSAL_CLIENT_ID);

--- a/lib/msal-core/test/utils/WindowUtils.spec.ts
+++ b/lib/msal-core/test/utils/WindowUtils.spec.ts
@@ -60,8 +60,8 @@ describe("WindowUtils", () => {
 
             // @ts-ignore
             WindowUtils.monitorWindowForHash(iframe.contentWindow, 1000)
-                .then((hash: string) => {
-                    expect(hash).to.be.undefined;
+                .catch((error: ClientAuthError) => {
+                    expect(error.errorCode).to.equal('user_cancelled');
                     done();
                 });
 

--- a/samples/react-sample-app/src/AuthProvider.js
+++ b/samples/react-sample-app/src/AuthProvider.js
@@ -34,6 +34,8 @@ export default C =>
                     return redirect
                         ? msalApp.acquireTokenRedirect(request)
                         : msalApp.acquireTokenPopup(request);
+                } else {
+                    console.error('Non-interactive error:', error.errorCode)
                 }
             });
         }

--- a/samples/react-sample-app/src/auth-utils.js
+++ b/samples/react-sample-app/src/auth-utils.js
@@ -71,6 +71,16 @@ export const msalApp = new UserAgentApplication({
         storeAuthStateInCookie: isIE()
     },
     system: {
-        navigateFrameWait: 0
+        navigateFrameWait: 0,
+        logger: {
+            error: console.error,
+            errorPii: console.error,
+            info: console.log,
+            infoPii: console.log,
+            verbose: console.log,
+            verbosePii: console.log,
+            warning: console.warn,
+            warningPii: console.warn
+        }
     }
 });


### PR DESCRIPTION
Currently, when `monitorWindowForHash` threw an error, it wasn't properly caught, which resulted in unhandled rejection errors (and the inability for apps to catch and handle these errors on their own). This PR ensures that these errors are caught, and properly passed up to the call site that initiate the request.