### PR TITLE
Add fromCache flag to AuthResponse to indicate token was returned from cache

### DIFF
--- a/lib/msal-core/src/AuthResponse.ts
+++ b/lib/msal-core/src/AuthResponse.ts
@@ -18,6 +18,7 @@ export type AuthResponse = {
     expiresOn: Date;
     account: Account;
     accountState: string;
+    fromCache?: boolean
 };
 
 export function buildResponseStateOnly(state: string) : AuthResponse {

--- a/lib/msal-core/src/AuthResponse.ts
+++ b/lib/msal-core/src/AuthResponse.ts
@@ -18,7 +18,7 @@ export type AuthResponse = {
     expiresOn: Date;
     account: Account;
     accountState: string;
-    fromCache?: boolean
+    fromCache: boolean
 };
 
 export function buildResponseStateOnly(state: string) : AuthResponse {
@@ -32,6 +32,7 @@ export function buildResponseStateOnly(state: string) : AuthResponse {
         scopes: null,
         expiresOn: null,
         account: null,
-        accountState: state
+        accountState: state,
+        fromCache: false
     };
 }

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1193,7 +1193,8 @@ export class UserAgentApplication {
                     scopes: accessTokenCacheItem.key.scopes.split(" "),
                     expiresOn: new Date(expired * 1000),
                     account: account,
-                    accountState: aState
+                    accountState: aState,
+                    fromCache: true
                 };
                 ResponseUtils.setResponseIdToken(response, idTokenObj);
                 return response;

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1387,6 +1387,7 @@ export class UserAgentApplication {
             expiresOn: null,
             account: null,
             accountState: "",
+            fromCache: false
         };
 
         let error: AuthError;

--- a/lib/msal-core/test/utils/ResponseUtils.spec.ts
+++ b/lib/msal-core/test/utils/ResponseUtils.spec.ts
@@ -18,6 +18,7 @@ describe("ResponseUtils.ts class", () => {
         expiresOn: null,
         account: null,
         accountState: "",
+        fromCache: false
     };
 
     let idTokenObj: IdToken;


### PR DESCRIPTION
This will allow applications to programmatically tell if the token was returned from the cache or from the network, which can be helpful for performance measurements of token requests.