### PR TITLE
Fix casing of module name in webpack

### DIFF
--- a/lib/msal-core/webpack.config.js
+++ b/lib/msal-core/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
     path: PATHS.bundles,
     filename: '[name].js',
     libraryTarget: 'umd',
-    library: 'Msal',
+    library: 'msal',
     umdNamedDefine: true
   },
   resolve: {


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/1118