### PR TITLE
[DO NOT MERGE] Trim user scopes before using in any operations

### DIFF
--- a/lib/msal-core/package-lock.json
+++ b/lib/msal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msal",
-  "version": "1.2.0-beta.3",
+  "version": "1.2.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/msal-core/src/ScopeSet.ts
+++ b/lib/msal-core/src/ScopeSet.ts
@@ -16,7 +16,7 @@ export class ScopeSet {
      */
     // TODO: Rename this, intersecting scopes isn't a great name for duplicate checker
     static isIntersectingScopes(cachedScopes: Array<string>, scopes: Array<string>): boolean {
-        cachedScopes = this.convertToLowerCase(cachedScopes);
+        cachedScopes = this.convertScopesToLowerCase(cachedScopes);
         for (let i = 0; i < scopes.length; i++) {
             if (cachedScopes.indexOf(scopes[i].toLowerCase()) > -1) {
                 return true;
@@ -32,7 +32,7 @@ export class ScopeSet {
      * @param scopes
      */
     static containsScope(cachedScopes: Array<string>, scopes: Array<string>): boolean {
-        cachedScopes = this.convertToLowerCase(cachedScopes);
+        cachedScopes = this.convertScopesToLowerCase(cachedScopes);
         return scopes.every((value: any): boolean => cachedScopes.indexOf(value.toString().toLowerCase()) >= 0);
     }
 
@@ -41,9 +41,16 @@ export class ScopeSet {
      *
      * @param scopes
      */
-    // TODO: Rename this, too generic name for a function that only deals with scopes
-    static convertToLowerCase(scopes: Array<string>): Array<string> {
+    static convertScopesToLowerCase(scopes: Array<string>): Array<string> {
         return scopes.map(scope => scope.toLowerCase());
+    }
+
+    /**
+     * Trim scope values
+     * @param scopes 
+     */
+    static trimScopes(scopes: Array<string>): Array<string> {
+        return scopes ? scopes.map(scope => scope.trim()) : scopes;
     }
 
     /**
@@ -52,8 +59,7 @@ export class ScopeSet {
      * @param scopes
      * @param scope
      */
-    // TODO: Rename this, too generic name for a function that only deals with scopes
-    static removeElement(scopes: Array<string>, scope: string): Array<string> {
+    static removeScope(scopes: Array<string>, scope: string): Array<string> {
         return scopes.filter(value => value !== scope);
     }
 

--- a/lib/msal-core/src/ScopeSet.ts
+++ b/lib/msal-core/src/ScopeSet.ts
@@ -50,7 +50,7 @@ export class ScopeSet {
      * @param scopes 
      */
     static trimScopes(scopes: Array<string>): Array<string> {
-        return scopes ? scopes.map(scope => scope.trim()) : scopes;
+        return scopes && scopes.map(scope => scope.trim());
     }
 
     /**

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -58,7 +58,7 @@ export class ServerRequestParameters {
         this.nonce = CryptoUtils.createNewGuid();
 
         // set scope to clientId if null
-        this.scopes = scopes? [ ...scopes] : [clientId];
+        this.scopes = this.createScopes(scopes);
 
         // set state (already set at top level)
         this.state = state;
@@ -72,6 +72,10 @@ export class ServerRequestParameters {
 
         this.responseType = responseType;
         this.redirectUri = redirectUri;
+    }
+
+    private createScopes(scopeArr: Array<string>): Array<string> {
+        return scopeArr ? scopeArr.map(scope => scope.trim()) : [this.clientId];
     }
 
     /**

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -75,7 +75,7 @@ export class ServerRequestParameters {
     }
 
     private createScopes(scopeArr: Array<string>): Array<string> {
-        return scopeArr ? scopeArr.map(scope => scope.trim()) : [this.clientId];
+        return scopeArr ? scopeArr.map(scope => scope.trim().toLowerCase()) : [this.clientId];
     }
 
     /**

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -10,6 +10,7 @@ import { StringDict } from "./MsalTypes";
 import { Account } from "./Account";
 import { SSOTypes, Constants, PromptState, libraryVersion } from "./utils/Constants";
 import { StringUtils } from "./utils/StringUtils";
+import { ScopeSet } from "./ScopeSet";
 
 /**
  * Nonce: OIDC Nonce definition: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
@@ -75,7 +76,7 @@ export class ServerRequestParameters {
     }
 
     private createScopes(scopeArr: Array<string>): Array<string> {
-        return scopeArr ? scopeArr.map(scope => scope.trim()) : [this.clientId];
+        return scopeArr ? ScopeSet.trimScopes(scopeArr) : [this.clientId];
     }
 
     /**

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -75,7 +75,7 @@ export class ServerRequestParameters {
     }
 
     private createScopes(scopeArr: Array<string>): Array<string> {
-        return scopeArr ? scopeArr.map(scope => scope.trim().toLowerCase()) : [this.clientId];
+        return scopeArr ? scopeArr.map(scope => scope.trim()) : [this.clientId];
     }
 
     /**

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -516,7 +516,7 @@ export class UserAgentApplication {
 
             // populate QueryParameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
             serverAuthenticationRequest.populateQueryParams(account, request);
-            const scope = serverAuthenticationRequest.scopes.join(" ");
+            const scope = serverAuthenticationRequest.scopes.join(" ").toLowerCase();
             // Construct urlNavigate
             const urlNavigate = UrlUtils.createNavigateUrl(serverAuthenticationRequest) + Constants.response_mode_fragment;
 
@@ -1276,7 +1276,7 @@ export class UserAgentApplication {
      * @ignore
      */
     private renewToken(resolve: Function, reject: Function, account: Account, serverAuthenticationRequest: ServerRequestParameters): void {
-        const scope = serverAuthenticationRequest.scopes.join(" ").toLowerCase();
+        const scope = serverAuthenticationRequest.scopes.join(" ");
         this.logger.verbose("renewToken is called for scope:" + scope);
 
         const frameName = `msalRenewFrame${scope}`;

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1276,7 +1276,7 @@ export class UserAgentApplication {
      * @ignore
      */
     private renewToken(resolve: Function, reject: Function, account: Account, serverAuthenticationRequest: ServerRequestParameters): void {
-        const scope = serverAuthenticationRequest.scopes.join(" ");
+        const scope = serverAuthenticationRequest.scopes.join(" ").toLowerCase();
         this.logger.verbose("renewToken is called for scope:" + scope);
 
         const frameName = `msalRenewFrame${scope}`;

--- a/lib/msal-core/src/utils/RequestUtils.ts
+++ b/lib/msal-core/src/utils/RequestUtils.ts
@@ -44,9 +44,9 @@ export class RequestUtils {
         let extraQueryParameters: StringDict;
 
         if(request) {
+            const reqScopes = ScopeSet.trimScopes(request.scopes);
             // if extraScopesToConsent is passed in loginCall, append them to the login request; Validate and filter scopes (the validate function will throw if validation fails)
-            scopes = isLoginCall ? ScopeSet.appendScopes(request.scopes, request.extraScopesToConsent) : request.scopes;
-            scopes = scopes ? scopes.map(scope => scope.trim()) : scopes;
+            scopes = isLoginCall ? ScopeSet.appendScopes(reqScopes, ScopeSet.trimScopes(request.extraScopesToConsent)) : reqScopes;
             ScopeSet.validateInputScope(scopes, !isLoginCall, clientId);
 
             // validate prompt parameter

--- a/lib/msal-core/src/utils/RequestUtils.ts
+++ b/lib/msal-core/src/utils/RequestUtils.ts
@@ -46,7 +46,8 @@ export class RequestUtils {
         if(request) {
             // if extraScopesToConsent is passed in loginCall, append them to the login request; Validate and filter scopes (the validate function will throw if validation fails)
             scopes = isLoginCall ? ScopeSet.appendScopes(request.scopes, request.extraScopesToConsent) : request.scopes;
-            ScopeSet.validateInputScope(scopes.map(scope => scope.trim().toLowerCase()), !isLoginCall, clientId);
+            scopes = scopes ? scopes.map(scope => scope.trim()) : scopes;
+            ScopeSet.validateInputScope(scopes, !isLoginCall, clientId);
 
             // validate prompt parameter
             this.validatePromptParameter(request.prompt);

--- a/lib/msal-core/src/utils/RequestUtils.ts
+++ b/lib/msal-core/src/utils/RequestUtils.ts
@@ -46,7 +46,7 @@ export class RequestUtils {
         if(request) {
             // if extraScopesToConsent is passed in loginCall, append them to the login request; Validate and filter scopes (the validate function will throw if validation fails)
             scopes = isLoginCall ? ScopeSet.appendScopes(request.scopes, request.extraScopesToConsent) : request.scopes;
-            ScopeSet.validateInputScope(scopes, !isLoginCall, clientId);
+            ScopeSet.validateInputScope(scopes.map(scope => scope.trim().toLowerCase()), !isLoginCall, clientId);
 
             // validate prompt parameter
             this.validatePromptParameter(request.prompt);

--- a/lib/msal-core/test/ServerRequestParameters.spec.ts
+++ b/lib/msal-core/test/ServerRequestParameters.spec.ts
@@ -47,6 +47,23 @@ describe("ServerRequestParameters.ts Class", function () {
             expect(req.scopes.length).to.be.eql(1);
         });
 
+        it("Scopes are trimmed if scopes with leading or trailing spaces are passed", function () {
+            const scopes = ["  S1", "S2  ", "  S3  "];
+            const expectedScopes = ["S1", "S2", "S3"];
+            const authority = AuthorityFactory.CreateInstance(TEST_CONFIG.validAuthority, false);
+            sinon.stub(authority, "AuthorizationEndpoint").value(TEST_URIS.TEST_AUTH_ENDPT);
+            const req = new ServerRequestParameters(
+                authority,
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                TEST_RESPONSE_TYPE.token,
+                TEST_URIS.TEST_REDIR_URI,
+                scopes,
+                TEST_CONFIG.STATE,
+                TEST_CONFIG.CorrelationId
+            );
+            expect(req.scopes).to.be.deep.equal(expectedScopes);
+            expect(req.scopes.length).to.be.eql(expectedScopes.length);
+        });
     });
 
     describe("State Generation", function () {

--- a/lib/msal-core/test/utils/RequestUtils.spec.ts
+++ b/lib/msal-core/test/utils/RequestUtils.spec.ts
@@ -43,6 +43,21 @@ describe("RequestUtils.ts class", () => {
         expect(emptyScopesError.stack).to.include("RequestUtils.spec.ts");
     });
 
+    it.only("Scopes with leading or trailing spaces are trimmed before validation", () => {
+        let clientIdSingleScopeError;
+        try {
+            const userRequest: AuthenticationParameters = {scopes: [` ${TEST_CONFIG.MSAL_CLIENT_ID}  `, "S2"]};
+            const request: AuthenticationParameters = RequestUtils.validateRequest(userRequest, false, TEST_CONFIG.MSAL_CLIENT_ID);
+        } catch (e) {
+            clientIdSingleScopeError = e;
+        };
+        
+        expect(clientIdSingleScopeError instanceof ClientConfigurationError).to.be.true;
+        expect(clientIdSingleScopeError.errorCode).to.equal(ClientConfigurationErrorMessage.clientScope.code);
+        expect(clientIdSingleScopeError.name).to.equal("ClientConfigurationError");
+        expect(clientIdSingleScopeError.stack).to.include("RequestUtils.spec.ts");
+    });
+
     it("ClientId can be sent only as a single scope", () => {
 
         let improperScopes : ClientConfigurationError;

--- a/lib/msal-core/test/utils/RequestUtils.spec.ts
+++ b/lib/msal-core/test/utils/RequestUtils.spec.ts
@@ -43,7 +43,7 @@ describe("RequestUtils.ts class", () => {
         expect(emptyScopesError.stack).to.include("RequestUtils.spec.ts");
     });
 
-    it.only("Scopes with leading or trailing spaces are trimmed before validation", () => {
+    it("Scopes with leading or trailing spaces are trimmed before validation", () => {
         let clientIdSingleScopeError;
         try {
             const userRequest: AuthenticationParameters = {scopes: [` ${TEST_CONFIG.MSAL_CLIENT_ID}  `, "S2"]};


### PR DESCRIPTION
This PR is to solve the issue raised in #845 where leading or trailing spaces are not trimmed from scope strings.

In this PR, I have changed the scope creation to trim before sending the scopes to be used in URL creation, and also trim them before sending them to the validation function. I have added test cases for this use case.