### PR TITLE
auth.html redirect sample

### DIFF
--- a/samples/VanillaJSTestApp/index_blankPageRedirectUri.html
+++ b/samples/VanillaJSTestApp/index_blankPageRedirectUri.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Quickstart for MSAL JS</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>
+    <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-m/3NDUcz4krpIIiHgpeO0O8uxSghb+lfBTngquAo2Zuy2fEF+YgFeP08PWFo5FiJ" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+        if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/lib/1.1.3/js/msal.js' type='text/javascript' integrity='sha384-m/3NDUcz4krpIIiHgpeO0O8uxSghb+lfBTngquAo2Zuy2fEF+YgFeP08PWFo5FiJ' crossorigin='anonymous'%3E%3C/script%3E"));
+    </script>
+</head>
+
+<body>
+    <div class="container">
+        <div class="leftContainer">
+            <p id="WelcomeMessage">Welcome to the Microsoft Authentication Library For Javascript Quickstart</p>
+            <button id="SignIn" onclick="signIn()">Sign In</button>
+            <button id="ReadMail" onclick="readMail()">Read Email</button>
+        </div>
+        <div class="rightContainer">
+            <pre id="json"></pre>
+        </div>
+    </div>
+    <script>
+
+    // initialize MSAL
+    const msalConfig = {
+        auth: {
+            // clientId: "Enter_your_client_id",
+            clientId: "245e9392-c666-4d51-8f8a-bfd9e55b2456",
+            authority: "https://login.microsoftonline.com/common",
+            validateAuthority: true
+        },
+        cache: {
+            cacheLocation: "localStorage",
+            storeAuthStateInCookie: false
+        }
+    };
+
+    const loginRequest = {
+        scopes: ["openid", "profile", "User.Read"],
+    }
+
+    const tokenRequest = {
+        scopes: ["Mail.Read"],
+        redirectUri: "http://localhost:30662/auth.html"
+    };
+
+    // resource endpoints
+    const graphConfig = {
+        graphMeEndpoint: "https://graph.microsoft.com/v1.0/me",
+        graphMailEndpoint: "https://graph.microsoft.com/v1.0/me/messages"
+    };
+
+    // instantiate MSAL
+    const myMSALObj = new Msal.UserAgentApplication(msalConfig);
+
+    // register callback for redirect usecases
+    myMSALObj.handleRedirectCallback(authRedirectCallBack);
+
+    // signin and acquire a token silently with POPUP flow. Fall back in case of failure with silent acquisition to popup
+    function signIn() {
+        myMSALObj.loginPopup(loginRequest).then(function (loginResponse) {
+            //Login Success
+            console.log(loginResponse);
+            showWelcomeMessage();
+            acquireTokenPopupAndCallMSGraph(graphConfig.graphMeEndpoint, tokenRequest);
+        }).catch(function (error) {
+            console.log(error);
+        });
+    }
+
+    // Call to the resource acquiring a token to a specific scope set
+    function acquireTokenPopupAndCallMSGraph(endpoint, request) {
+        //Call acquireTokenSilent (iframe) to obtain a token for Microsoft Graph
+        myMSALObj.acquireTokenSilent(request).then(function (tokenResponse) {
+            console.log("acquireTokenSilent scopes: ", tokenResponse.scopes);
+            callMSGraph(endpoint, tokenResponse.accessToken, graphAPICallback);
+        }).catch(function (error) {
+            console.log(error);
+            // Call acquireTokenPopup (popup window) in case of acquireTokenSilent failure due to consent or interaction required ONLY
+            if (requiresInteraction(error.errorCode)) {
+                myMSALObj.acquireTokenPopup(request).then(function (tokenResponse) {
+                    callMSGraph(endpoint, tokenResponse.accessToken, graphAPICallback);
+                }).catch(function (error) {
+                    console.log(error);
+                });
+            }
+        });
+    }
+
+    // Call Graph to fetch data
+    function callMSGraph(theUrl, accessToken, callback) {
+        var xmlHttp = new XMLHttpRequest();
+        xmlHttp.onreadystatechange = function () {
+            if (this.readyState == 4 && this.status == 200)
+                callback(JSON.parse(this.responseText));
+        }
+        xmlHttp.open("GET", theUrl, true); // true for asynchronous
+        xmlHttp.setRequestHeader('Authorization', 'Bearer ' + accessToken);
+        xmlHttp.send();
+    }
+
+    function graphAPICallback(data) {
+        document.getElementById("json").innerHTML = JSON.stringify(data, null, 2);
+    }
+
+    function showWelcomeMessage() {
+        var divWelcome = document.getElementById('WelcomeMessage');
+        divWelcome.innerHTML = 'Welcome ' + myMSALObj.getAccount().userName + " to Microsoft Graph API";
+        var loginbutton = document.getElementById('SignIn');
+        loginbutton.innerHTML = 'Sign Out';
+        loginbutton.setAttribute('onclick', 'signOut();');
+    }
+
+    function readMail() {
+        acquireTokenPopupAndCallMSGraph(graphConfig.graphMailEndpoint, tokenRequest);
+    }
+
+    // signout
+    function signOut() {
+        myMSALObj.logout();
+    }
+
+   // This function can be removed if you do not need to support IE
+   function acquireTokenRedirectAndCallMSGraph(endpoint, request) {
+        //Call acquireTokenSilent (iframe) to obtain a token for Microsoft Graph
+        myMSALObj.acquireTokenSilent(request).then(function (tokenResponse) {
+            callMSGraph(endpoint, tokenResponse.accessToken, graphAPICallback);
+        }).catch(function (error) {
+            console.log("error is: "+ error);
+            console.log("stack:" + error.stack);
+            //Call acquireTokenRedirect in case of acquireToken Failure
+            if (requiresInteraction(error.errorCode)) {
+                myMSALObj.acquireTokenRedirect(request);
+            }
+        });
+    }
+
+    // redirect call back
+    function authRedirectCallBack(error, response) {
+        if (error) {
+            console.log(error);
+        } else {
+            if (response.tokenType === "id_token") {
+                showWelcomeMessage();
+                acquireTokenRedirectAndCallMSGraph(graphConfig.graphMeEndpoint, loginRequest);
+            } else if (response.tokenType === "access_token") {
+                callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, graphAPICallback);
+            } else {
+                console.log("token type is:" + response.tokenType);
+            }
+        }
+    }
+
+    // utils to handle standard error set that would need user interaction
+    function requiresInteraction(errorMessage) {
+        if (!errorMessage || !errorMessage.length) {
+            return false;
+        }
+
+        console.log("requiresinteraction is:" + errorMessage );
+        return errorMessage.indexOf("consent_required") !== -1 ||
+            errorMessage.indexOf("interaction_required") !== -1 ||
+            errorMessage.indexOf("login_required") !== -1 ;
+    }
+
+    // Browser check variables
+    const ua = window.navigator.userAgent;
+    const msie = ua.indexOf('MSIE ');
+    const msie11 = ua.indexOf('Trident/');
+    const msedge = ua.indexOf('Edge/');
+    const isIE = msie > 0 || msie11 > 0;
+    const isEdge = msedge > 0;
+
+    //If you support IE, our recommendation is that you sign-in using Redirect APIs
+    //If you as a developer are testing using Edge InPrivate mode, please add "isEdge" to the if check
+    if (!isIE) {
+        if (myMSALObj.getAccount()) {// avoid duplicate code execution on page load in case of iframe and popup window.
+            showWelcomeMessage();
+            acquireTokenPopupAndCallMSGraph(graphConfig.graphMeEndpoint, loginRequest);
+        }
+    }
+    else {
+        document.getElementById("SignIn").onclick = function () {
+            myMSALObj.loginRedirect(loginRequest);
+        };
+
+        document.getElementById("ReadMail").onclick = function () {
+            readMail();
+        };
+
+
+        if (myMSALObj.getAccount() && !myMSALObj.isCallback(window.location.hash)) {// avoid duplicate code execution on page load in case of iframe and popup window.
+            showWelcomeMessage();
+            acquireTokenRedirectAndCallMSGraph(graphConfig.graphMeEndpoint, loginRequest);
+        }
+    }
+</script>
+</body>
+</html>

--- a/samples/VanillaJSTestApp/index_blankPageRedirectUri.html
+++ b/samples/VanillaJSTestApp/index_blankPageRedirectUri.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Quickstart for MSAL JS</title>
+    <title>MSAL JS Sample with auth.html as redirectURI for silent calls</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>
     <script type="text/javascript" src="https://alcdn.msauth.net/lib/1.1.3/js/msal.js" integrity="sha384-m/3NDUcz4krpIIiHgpeO0O8uxSghb+lfBTngquAo2Zuy2fEF+YgFeP08PWFo5FiJ" crossorigin="anonymous"></script>
     <script type="text/javascript">
@@ -12,7 +12,7 @@
 <body>
     <div class="container">
         <div class="leftContainer">
-            <p id="WelcomeMessage">Welcome to the Microsoft Authentication Library For Javascript Quickstart</p>
+            <p id="WelcomeMessage">Welcome to MSAL JS Sample: silent calls redirected to "auth.html"</p>
             <button id="SignIn" onclick="signIn()">Sign In</button>
             <button id="ReadMail" onclick="readMail()">Read Email</button>
         </div>

--- a/samples/VanillaJSTestApp/server.js
+++ b/samples/VanillaJSTestApp/server.js
@@ -19,7 +19,7 @@ app.use("/dist", express.static(path.join(__dirname, "../../lib/msal-core/dist")
 
 // Set up our one route to the index.html file.
 app.get('*', function (req, res) {
-    const reqPath = req.path === "/" ? "/index.html" : req.path;
+    const reqPath = req.path === "/" ? "/index_blankPageRedirectUri.html" : req.path;
     res.sendFile(path.join(__dirname + reqPath));
 });
 

--- a/samples/VanillaJSTestApp/server.js
+++ b/samples/VanillaJSTestApp/server.js
@@ -19,7 +19,7 @@ app.use("/dist", express.static(path.join(__dirname, "../../lib/msal-core/dist")
 
 // Set up our one route to the index.html file.
 app.get('*', function (req, res) {
-    const reqPath = req.path === "/" ? "/index_blankPageRedirectUri.html" : req.path;
+    const reqPath = req.path === "/" ? "/index.html" : req.path;
     res.sendFile(path.join(__dirname + reqPath));
 });
 


### PR DESCRIPTION
Sample to demonstrate `redirectUri` as a blank html for `acquireTokenSilent()` calls.