### PR TITLE
Authorization Code Flow for Single Page Applications: Adding Logger class

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
     ],
     "eslint.quiet": true,
     "files.eol": "\n",
-    "github-pr.targetBranch": "dev"
+    "github-pr.targetBranch": "dev",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
 }

--- a/lib/msal-browser/src/app/Configuration.ts
+++ b/lib/msal-browser/src/app/Configuration.ts
@@ -105,12 +105,16 @@ const DEFAULT_LOGGER_OPTIONS: BrowserLoggerOptions = {
         switch (level) {
             case LogLevel.Error:
                 console.error(message);
+                return;
             case LogLevel.Info:
                 console.info(message);
+                return;
             case LogLevel.Verbose:
                 console.debug(message);
+                return;
             case LogLevel.Warning:
                 console.warn(message);
+                return;
         }
     },
     piiLoggingEnabled: false

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -14,7 +14,7 @@ import { CryptoOps } from "../crypto/CryptoOps";
  * @param authErr error created for failure cases
  * @param response response containing token strings in success cases, or just state value in error cases
  */
-export type authCallback = (authErr: AuthError, response?: AuthResponse) => void;
+export type AuthCallback = (authErr: AuthError, response?: AuthResponse) => void;
 
 /**
  * Key-Value type to support queryParams, extraQueryParams and claims
@@ -34,7 +34,7 @@ export class PublicClientApplication {
     private authModule: AuthorizationCodeModule;
 
     // callback for error/token response
-    private authCallback: authCallback = null;
+    private authCallback: AuthCallback = null;
 
     // Crypto interface implementation
     private browserCrypto: CryptoOps;
@@ -81,6 +81,7 @@ export class PublicClientApplication {
         // Create auth module
         this.authModule = new AuthorizationCodeModule({
             auth: this.config.auth,
+            loggerOptions: this.config.system.loggerOptions,
             cryptoInterface: this.browserCrypto,
             networkInterface: this.networkClient,
             storageInterface: this.browserStorage
@@ -91,12 +92,12 @@ export class PublicClientApplication {
 
     /**
      * Set the callback functions for the redirect flow to send back the success or error object.
-     * @param {@link (authCallback:type)} authCallback - Callback which contains
+     * @param {@link (AuthCallback:type)} authCallback - Callback which contains
      * an AuthError object, containing error data from either the server
      * or the library, depending on the origin of the error, or the AuthResponse object 
      * containing data from the server (returned with a null or non-blocking error).
      */
-    handleRedirectCallback(authCallback: authCallback): void {
+    handleRedirectCallback(authCallback: AuthCallback): void {
         throw new Error("Method not implemented.");
     }
 

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -81,7 +81,10 @@ export class PublicClientApplication {
         // Create auth module
         this.authModule = new AuthorizationCodeModule({
             auth: this.config.auth,
-            loggerOptions: this.config.system.loggerOptions,
+            loggerOptions: {
+                loggerCallbackInterface: this.config.system.loggerOptions.loggerCallback,
+                piiLoggingEnabled: this.config.system.loggerOptions.piiLoggingEnabled
+            },
             cryptoInterface: this.browserCrypto,
             networkInterface: this.networkClient,
             storageInterface: this.browserStorage
@@ -108,7 +111,7 @@ export class PublicClientApplication {
      */
     loginRedirect(request: AuthenticationParameters): void {
         this.authModule.createLoginUrl(request).then((urlNavigate) => {
-            console.log(urlNavigate);
+            this.authModule.logger.info(urlNavigate);
         });
     }
 

--- a/lib/msal-common/src/app/config/ModuleConfiguration.ts
+++ b/lib/msal-common/src/app/config/ModuleConfiguration.ts
@@ -6,19 +6,35 @@ import { ICacheStorage } from "../../cache/ICacheStorage";
 import { INetworkModule, NetworkRequestOptions } from "../../network/INetworkModule";
 import { ICrypto, PkceCodes } from "../../crypto/ICrypto";
 import { AuthError } from "../../error/AuthError";
+import { ILoggerCallback, LogLevel } from "../../logger/Logger";
 
 /**
  * Use the configuration object to configure MSAL Modules and initialize the base interfaces for MSAL.
  *
  * This object allows you to configure important elements of MSAL functionality:
+ * - logger: logging for application
  * - storage: this is where you configure storage implementation.
  * - network: this is where you can configure network implementation.
  * - crypto: implementation of crypto functions
  */
 export type ModuleConfiguration = {
+    loggerOptions?: LoggerOptions,
     storageInterface?: ICacheStorage,
     networkInterface?: INetworkModule,
     cryptoInterface?: ICrypto
+};
+
+/**
+ * Logger options to configure the logging that MSAL does.
+ */
+export type LoggerOptions = {
+    loggerCallbackInterface?: ILoggerCallback,
+    piiLoggingEnabled?: boolean
+};
+
+const DEFAULT_LOGGER_IMPLEMENTATION: LoggerOptions = {
+    loggerCallbackInterface: null,
+    piiLoggingEnabled: false
 };
 
 const DEFAULT_STORAGE_IMPLEMENTATION: ICacheStorage = {
@@ -99,8 +115,9 @@ const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
  *
  * @returns MsalConfiguration object
  */
-export function buildModuleConfiguration({ storageInterface: storageImplementation, networkInterface: networkImplementation, cryptoInterface: cryptoImplementation }: ModuleConfiguration): ModuleConfiguration {
+export function buildModuleConfiguration({ loggerOptions: userLoggerOption, storageInterface: storageImplementation, networkInterface: networkImplementation, cryptoInterface: cryptoImplementation }: ModuleConfiguration): ModuleConfiguration {
     const overlayedConfig: ModuleConfiguration = {
+        loggerOptions: userLoggerOption || DEFAULT_LOGGER_IMPLEMENTATION,
         storageInterface: storageImplementation || DEFAULT_STORAGE_IMPLEMENTATION,
         networkInterface: networkImplementation || DEFAULT_NETWORK_IMPLEMENTATION,
         cryptoInterface: cryptoImplementation || DEFAULT_CRYPTO_IMPLEMENTATION

--- a/lib/msal-common/src/app/config/ModuleConfiguration.ts
+++ b/lib/msal-common/src/app/config/ModuleConfiguration.ts
@@ -33,39 +33,36 @@ export type LoggerOptions = {
 };
 
 const DEFAULT_LOGGER_IMPLEMENTATION: LoggerOptions = {
-    loggerCallbackInterface: null,
+    loggerCallbackInterface: () => {
+        const notImplErr = "Logger - loggerCallbackInterface() has not been implemented.";
+        throw AuthError.createUnexpectedError(notImplErr);
+    },
     piiLoggingEnabled: false
 };
 
 const DEFAULT_STORAGE_IMPLEMENTATION: ICacheStorage = {
     clear: () => {
         const notImplErr = "Storage interface - clear() has not been implemented for the cacheStorage interface.";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     containsKey: (key: string): boolean => {
         const notImplErr = "Storage interface - containsKey() has not been implemented for the cacheStorage interface.";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     getItem: (key: string): string => {
         const notImplErr = "Storage interface - getItem() has not been implemented for the cacheStorage interface.";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     getKeys: (): string[] => {
         const notImplErr = "Storage interface - getKeys() has not been implemented for the cacheStorage interface.";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     removeItem: (key: string) => {
         const notImplErr = "Storage interface - removeItem() has not been implemented for the cacheStorage interface.";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     setItem: (key: string, value: string) => {
         const notImplErr = "Storage interface - setItem() has not been implemented for the cacheStorage interface.";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     }
 };
@@ -73,12 +70,10 @@ const DEFAULT_STORAGE_IMPLEMENTATION: ICacheStorage = {
 const DEFAULT_NETWORK_IMPLEMENTATION: INetworkModule = {
     async sendGetRequestAsync(url: string, options?: NetworkRequestOptions): Promise<any> {
         const notImplErr = "Network interface - sendGetRequestAsync() has not been implemented";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     async sendPostRequestAsync(url: string, options?: NetworkRequestOptions): Promise<any> {
         const notImplErr = "Network interface - sendPostRequestAsync() has not been implemented";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     }
 };
@@ -86,22 +81,18 @@ const DEFAULT_NETWORK_IMPLEMENTATION: INetworkModule = {
 const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
     createNewGuid: (): string => {
         const notImplErr = "Crypto interface - createNewGuid() has not been implemented";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     base64Decode: (input: string): string => {
         const notImplErr = "Crypto interface - base64Decode() has not been implemented";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     base64Encode: (input: string): string => {
         const notImplErr = "Crypto interface - base64Encode() has not been implemented";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     },
     async generatePkceCodes(): Promise<PkceCodes> {
         const notImplErr = "Crypto interface - generatePkceCodes() has not been implemented";
-        console.warn(notImplErr);
         throw AuthError.createUnexpectedError(notImplErr);
     }
 };

--- a/lib/msal-common/src/app/config/PublicClientSPAConfiguration.ts
+++ b/lib/msal-common/src/app/config/PublicClientSPAConfiguration.ts
@@ -55,8 +55,8 @@ const DEFAULT_AUTH_OPTIONS: AuthOptions = {
  *
  * @returns TConfiguration object
  */
-export function buildPublicClientSPAConfiguration({ auth, storageInterface, networkInterface, cryptoInterface }: PublicClientSPAConfiguration): PublicClientSPAConfiguration {
-    const baseConfig = buildModuleConfiguration({storageInterface, networkInterface, cryptoInterface});
+export function buildPublicClientSPAConfiguration({ auth, loggerOptions, storageInterface, networkInterface, cryptoInterface }: PublicClientSPAConfiguration): PublicClientSPAConfiguration {
+    const baseConfig = buildModuleConfiguration({loggerOptions, storageInterface, networkInterface, cryptoInterface});
     const overlayedConfig: PublicClientSPAConfiguration = {
         auth: { ...DEFAULT_AUTH_OPTIONS, ...auth },
         ...baseConfig

--- a/lib/msal-common/src/app/module/AuthModule.ts
+++ b/lib/msal-common/src/app/module/AuthModule.ts
@@ -21,6 +21,7 @@ import { StringUtils } from "../../utils/StringUtils";
 import { IdToken } from "../../auth/IdToken";
 import { buildClientInfo } from "../../auth/ClientInfo";
 import { CacheHelpers } from "../../cache/CacheHelpers";
+import { Logger } from "../../logger/Logger";
 
 /**
  * @hidden
@@ -39,6 +40,9 @@ export type ResponseStateInfo = {
  * 
  */
 export abstract class AuthModule {
+
+    // Logger object
+    public logger: Logger;
 
     // Application config
     private config: ModuleConfiguration;
@@ -64,6 +68,9 @@ export abstract class AuthModule {
     constructor(configuration: ModuleConfiguration) {
         // Set the configuration
         this.config = buildModuleConfiguration(configuration);
+
+        // Initialize the logger
+        this.logger = new Logger(configuration.loggerOptions.loggerCallbackInterface, configuration.loggerOptions.piiLoggingEnabled);
 
         // Initialize crypto
         this.cryptoObj = this.config.cryptoInterface;

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -29,6 +29,7 @@ export class AuthorizationCodeModule extends AuthModule {
 
     constructor(configuration: PublicClientSPAConfiguration) {
         super({
+            loggerOptions: configuration.loggerOptions,
             storageInterface: configuration.storageInterface,
             networkInterface: configuration.networkInterface,
             cryptoInterface: configuration.cryptoInterface

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -18,9 +18,12 @@ export { TokenExchangeParameters } from "./request/TokenExchangeParameters";
 export { AuthResponse, buildResponseStateOnly } from "./response/AuthResponse";
 export { TokenResponse } from "./response/TokenResponse";
 export { CodeResponse } from "./response/CodeResponse";
+// Logger Callback
+export { ILoggerCallback, LogLevel } from "./logger/Logger";
 // Errors
 export { AuthError, AuthErrorMessage } from "./error/AuthError";
 export { ClientAuthError, ClientAuthErrorMessage } from "./error/ClientAuthError";
 export { ClientConfigurationError, ClientConfigurationErrorMessage } from "./error/ClientConfigurationError";
-// Constants
+// Constants and Utils
 export { Constants, TemporaryCacheKeys, PersistentCacheKeys, ErrorCacheKeys } from "./utils/Constants";
+export { StringUtils } from "./utils/StringUtils";

--- a/lib/msal-common/src/logger/Logger.ts
+++ b/lib/msal-common/src/logger/Logger.ts
@@ -58,13 +58,8 @@ export class Logger {
             return;
         }
         const timestamp = new Date().toUTCString();
-        let log: string;
-        if (!StringUtils.isEmpty(this.correlationId)) {
-            log = timestamp + ":" + this.correlationId + "-" + pkg.version + "-" + LogLevel[options.logLevel] + " " + logMessage;
-        }
-        else {
-            log = timestamp + ":" + pkg.version + "-" + LogLevel[options.logLevel] + " " + logMessage;
-        }
+        let logHeader: string = StringUtils.isEmpty(this.correlationId) ? `[${timestamp}] : ` : `[${timestamp}] : [${this.correlationId}]`;
+        const log = `${logHeader} : ${pkg.version} : ${LogLevel[options.logLevel]} - ${logMessage}`;
         this.executeCallback(options.logLevel, log, options.containsPii);
     }
 

--- a/lib/msal-common/src/logger/Logger.ts
+++ b/lib/msal-common/src/logger/Logger.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { StringUtils } from "../utils/StringUtils";
+import pkg from "../../package.json";
+
+export type LoggerMessageOptions = {
+    logLevel: LogLevel,
+    correlationId?: string,
+    containsPii?: boolean
+};
+
+export enum LogLevel {
+    Error,
+    Warning,
+    Info,
+    Verbose
+};
+
+export interface ILoggerCallback {
+    (level: LogLevel, message: string, containsPii: boolean): void;
+}
+
+export class Logger {
+
+    /**
+     * @hidden
+     */
+    private correlationId: string;
+
+    /**
+     * @hidden
+     */
+    private level: LogLevel = LogLevel.Info;
+
+    /**
+     * @hidden
+     */
+    private piiLoggingEnabled: boolean;
+
+    /**
+     * @hidden
+     */
+    private localCallback: ILoggerCallback;
+
+    constructor(localCallback: ILoggerCallback, piiLoggingEnabled: boolean) {
+        this.localCallback = localCallback;
+        this.piiLoggingEnabled = piiLoggingEnabled;
+    }
+
+    /**
+     * @hidden
+     */
+    private logMessage(logMessage: string, options: LoggerMessageOptions): void {
+        if ((options.logLevel > this.level) || (!this.piiLoggingEnabled && options.containsPii)) {
+            return;
+        }
+        const timestamp = new Date().toUTCString();
+        let log: string;
+        if (!StringUtils.isEmpty(this.correlationId)) {
+            log = timestamp + ":" + this.correlationId + "-" + pkg.version + "-" + LogLevel[options.logLevel] + " " + logMessage;
+        }
+        else {
+            log = timestamp + ":" + pkg.version + "-" + LogLevel[options.logLevel] + " " + logMessage;
+        }
+        this.executeCallback(options.logLevel, log, options.containsPii);
+    }
+
+    /**
+     * @hidden
+     */
+    executeCallback(level: LogLevel, message: string, containsPii: boolean) {
+        if (this.localCallback) {
+            this.localCallback(level, message, containsPii);
+        }
+    }
+
+    /**
+     * @hidden
+     */
+    error(message: string, correlationId?: string): void {
+        this.logMessage(message, {
+            logLevel: LogLevel.Error,
+            containsPii: false,
+            correlationId: correlationId || ""
+        });
+    }
+
+    /**
+     * @hidden
+     */
+    errorPii(message: string, correlationId?: string): void {
+        this.logMessage(message, {
+            logLevel: LogLevel.Error,
+            containsPii: true,
+            correlationId: correlationId || ""
+        });
+    }
+
+    /**
+     * @hidden
+     */
+    warning(message: string, correlationId?: string): void {
+        this.logMessage(message, {
+            logLevel: LogLevel.Warning,
+            containsPii: false,
+            correlationId: correlationId || ""
+        });
+    }
+
+    /**
+     * @hidden
+     */
+    warningPii(message: string, correlationId?: string): void {
+        this.logMessage(message, {
+            logLevel: LogLevel.Warning,
+            containsPii: true,
+            correlationId: correlationId || ""
+        });
+    }
+
+    /**
+     * @hidden
+     */
+    info(message: string, correlationId?: string): void {
+        this.logMessage(message, {
+            logLevel: LogLevel.Info,
+            containsPii: false,
+            correlationId: correlationId || ""
+        });
+    }
+
+    /**
+     * @hidden
+     */
+    infoPii(message: string, correlationId?: string): void {
+        this.logMessage(message, {
+            logLevel: LogLevel.Info,
+            containsPii: true,
+            correlationId: correlationId || ""
+        });
+    }
+
+    /**
+     * @hidden
+     */
+    verbose(message: string, correlationId?: string): void {
+        this.logMessage(message, {
+            logLevel: LogLevel.Verbose,
+            containsPii: false,
+            correlationId: correlationId || ""
+        });
+    }
+
+    /**
+     * @hidden
+     */
+    verbosePii(message: string, correlationId?: string): void {
+        this.logMessage(message, {
+            logLevel: LogLevel.Verbose,
+            containsPii: true,
+            correlationId: correlationId || ""
+        });
+    }
+
+    isPiiLoggingEnabled(): boolean {
+        return this.piiLoggingEnabled;
+    }
+}

--- a/lib/msal-common/src/server/CodeRequestParameters.ts
+++ b/lib/msal-common/src/server/CodeRequestParameters.ts
@@ -167,7 +167,6 @@ export class CodeRequestParameters {
         const pkceCodes = await this.cryptoObj.generatePkceCodes();
         str.push(`code_challenge=${encodeURIComponent(pkceCodes.challenge)}`);
         str.push("code_challenge_method=S256");
-        console.log(`PKCE Codes: ${JSON.stringify(pkceCodes)}`);
 
         if (this.userRequest.prompt) {
             str.push("prompt=" + encodeURIComponent(this.userRequest.prompt));


### PR DESCRIPTION
This PR adds a logger class to the Authorization Code Flow version of the MSAL library. It also removes instances of console.log from the common package.