### PR TITLE
Authorization Code Flow for Single Page Applications: Adding Redirect Handling Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
     ],
     "eslint.quiet": true,
     "files.eol": "\n",
-    "github-pr.targetBranch": "dev"
+    "github-pr.targetBranch": "dev",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
 }

--- a/lib/msal-browser/src/app/Configuration.ts
+++ b/lib/msal-browser/src/app/Configuration.ts
@@ -18,7 +18,7 @@ const NAVIGATE_FRAME_WAIT = 500;
 
 export type BrowserAuthOptions = AuthOptions & {
     navigateToLoginRequestUrl?: boolean;
-}
+};
 
 /**
  * Use this to configure the below cache configuration options:

--- a/lib/msal-browser/src/app/Configuration.ts
+++ b/lib/msal-browser/src/app/Configuration.ts
@@ -16,6 +16,10 @@ const FRAME_TIMEOUT = 6000;
 const OFFSET = 300;
 const NAVIGATE_FRAME_WAIT = 500;
 
+export type BrowserAuthOptions = AuthOptions & {
+    navigateToLoginRequestUrl?: boolean;
+}
+
 /**
  * Use this to configure the below cache configuration options:
  *
@@ -77,12 +81,12 @@ export type BrowserLoggerOptions = {
  * - framework: this is where you can configure the running mode of angular. More to come here soon.
  */
 export type Configuration = {
-    auth?: AuthOptions,
+    auth?: BrowserAuthOptions,
     cache?: CacheOptions,
     system?: SystemOptions
 };
 
-const DEFAULT_AUTH_OPTIONS: AuthOptions = {
+const DEFAULT_AUTH_OPTIONS: BrowserAuthOptions = {
     clientId: "",
     clientSecret: "",
     authority: null,

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -7,6 +7,8 @@ import { AuthError, AuthResponse, AuthorizationCodeModule, AuthenticationParamet
 import { BrowserStorage } from "../cache/BrowserStorage";
 import { Configuration, buildConfiguration } from "./Configuration";
 import { CryptoOps } from "../crypto/CryptoOps";
+import { IInteractionHandler } from "../interaction_handler/IInteractionHandler";
+import { RedirectHandler } from "../interaction_handler/RedirectHandler";
 
 /**
  * A type alias for an authResponseCallback function.
@@ -32,6 +34,8 @@ export class PublicClientApplication {
 
     // auth functions imported from msal-common module
     private authModule: AuthorizationCodeModule;
+
+    private interactionHandler: IInteractionHandler;
 
     // callback for error/token response
     private authCallback: AuthCallback = null;
@@ -110,8 +114,9 @@ export class PublicClientApplication {
      * @param {@link (AuthenticationParameters:type)}
      */
     loginRedirect(request: AuthenticationParameters): void {
+        this.interactionHandler = new RedirectHandler(this.authModule);
         this.authModule.createLoginUrl(request).then((urlNavigate) => {
-            this.authModule.logger.info(urlNavigate);
+            this.interactionHandler.showUI(urlNavigate);
         });
     }
 

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -105,16 +105,16 @@ export class PublicClientApplication {
      * or the library, depending on the origin of the error, or the AuthResponse object 
      * containing data from the server (returned with a null or non-blocking error).
      */
-    handleRedirectCallback(authCallback: AuthCallback): void {
+    async handleRedirectCallback(authCallback: AuthCallback): Promise<void> {
         if(!authCallback) {
             throw BrowserConfigurationAuthError.createInvalidCallbackObjectError(authCallback);
         }
 
         this.authCallback = authCallback;
-        const urlHash = window.location.hash;
-        if (UrlString.hashContainsKnownProperties(urlHash)) {
+        const { location: { hash }} = window;
+        if (UrlString.hashContainsKnownProperties(hash)) {
             this.interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.authCallback);
-            this.interactionHandler.handleCodeResponse(urlHash);
+            this.interactionHandler.handleCodeResponse(hash);
         }
     }
 

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -111,7 +111,7 @@ export class PublicClientApplication {
         }
 
         this.authCallback = authCallback;
-        const { location: { hash }} = window;
+        const { location: { hash } } = window;
         if (UrlString.hashContainsKnownProperties(hash)) {
             this.interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.authCallback);
             this.interactionHandler.handleCodeResponse(hash);

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -36,8 +36,6 @@ export class PublicClientApplication {
     // auth functions imported from msal-common module
     private authModule: AuthorizationCodeModule;
 
-    private interactionHandler: IInteractionHandler;
-
     // callback for error/token response
     private authCallback: AuthCallback = null;
 
@@ -113,8 +111,8 @@ export class PublicClientApplication {
         this.authCallback = authCallback;
         const { location: { hash } } = window;
         if (UrlString.hashContainsKnownProperties(hash)) {
-            this.interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.authCallback);
-            this.interactionHandler.handleCodeResponse(hash);
+            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.authCallback);
+            interactionHandler.handleCodeResponse(hash);
         }
     }
 
@@ -124,8 +122,8 @@ export class PublicClientApplication {
      * @param {@link (AuthenticationParameters:type)}
      */
     loginRedirect(request: AuthenticationParameters): void {
-        this.interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.authCallback);
-        this.interactionHandler.showUI(request);
+        const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.authCallback);
+        interactionHandler.showUI(request);
     }
 
     /**

--- a/lib/msal-browser/src/error/BrowserAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserAuthError.ts
@@ -23,6 +23,10 @@ export const BrowserAuthErrorMessage = {
     httpMethodNotImplementedError: {
         code: "http_method_not_implemented",
         desc: "The HTTP method given has not been implemented in this library."
+    },
+    emptyRedirectUriError: {
+        code: "empty_redirect_ur",
+        desc: "Redirect URI is empty. Please check stack trace for more info."
     }
 };
 
@@ -42,18 +46,22 @@ export class BrowserAuthError extends AuthError {
         return new BrowserAuthError(BrowserAuthErrorMessage.noWindowObjectError.code, BrowserAuthErrorMessage.noWindowObjectError.desc);
     }
 
-    static createPkceNotGeneratedError(errDetail: string) {
+    static createPkceNotGeneratedError(errDetail: string): BrowserAuthError {
         return new BrowserAuthError(BrowserAuthErrorMessage.pkceNotGenerated.code,
             `${BrowserAuthErrorMessage.pkceNotGenerated.desc} Detail:${errDetail}`);
     }
 
-    static createCryptoNotAvailableError(errDetail: string) {
+    static createCryptoNotAvailableError(errDetail: string): BrowserAuthError {
         return new BrowserAuthError(BrowserAuthErrorMessage.cryptoDoesNotExist.code, 
             `${BrowserAuthErrorMessage.cryptoDoesNotExist.desc} Detail:${errDetail}`);
     }
 
-    static createHttpMethodNotImplementedError(method: string) {
+    static createHttpMethodNotImplementedError(method: string): BrowserAuthError {
         return new BrowserAuthError(BrowserAuthErrorMessage.httpMethodNotImplementedError.code,
             `${BrowserAuthErrorMessage.httpMethodNotImplementedError.desc} Given Method: ${method}`);
+    }
+
+    static createEmptyRedirectUriError(): BrowserAuthError {
+        return new BrowserAuthError(BrowserAuthErrorMessage.emptyRedirectUriError.code, BrowserAuthErrorMessage.emptyRedirectUriError.desc);
     }
 }

--- a/lib/msal-browser/src/error/BrowserAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserAuthError.ts
@@ -25,8 +25,12 @@ export const BrowserAuthErrorMessage = {
         desc: "The HTTP method given has not been implemented in this library."
     },
     emptyRedirectUriError: {
-        code: "empty_redirect_ur",
+        code: "empty_redirect_uri",
         desc: "Redirect URI is empty. Please check stack trace for more info."
+    },
+    hashEmptyError: {
+        code: "hash_empty_error",
+        desc: "Hash value cannot be processed because it is empty."
     }
 };
 
@@ -63,5 +67,9 @@ export class BrowserAuthError extends AuthError {
 
     static createEmptyRedirectUriError(): BrowserAuthError {
         return new BrowserAuthError(BrowserAuthErrorMessage.emptyRedirectUriError.code, BrowserAuthErrorMessage.emptyRedirectUriError.desc);
+    }
+
+    static createEmptyHashError(hashValue: string): BrowserAuthError {
+        return new BrowserAuthError(BrowserAuthErrorMessage.hashEmptyError.code, `${BrowserAuthErrorMessage.hashEmptyError.desc} Given Url: ${hashValue}`);
     }
 }

--- a/lib/msal-browser/src/error/BrowserConfigurationAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserConfigurationAuthError.ts
@@ -11,7 +11,17 @@ export const BrowserConfigurationAuthErrorMessage = {
     storageNotSupportedError: {
         code: "storage_not_supported",
         desc: "Given storage configuration option was not supported."
-    }
+    },
+    noRedirectCallbacksSet: {
+        code: "no_redirect_callbacks",
+        desc: "No redirect callbacks have been set. Please call setRedirectCallbacks() with the appropriate function arguments before continuing. " +
+            "More information is available here: https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/MSAL-basics."
+    },
+    invalidCallbackObject: {
+        code: "invalid_callback_object",
+        desc: "The object passed for the callback was invalid. " +
+          "More information is available here: https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/MSAL-basics."
+    },
 };
 
 /**
@@ -28,5 +38,14 @@ export class BrowserConfigurationAuthError extends AuthError {
 
     static createStorageNotSupportedError(givenStorageLocation: string): BrowserConfigurationAuthError {
         return new BrowserConfigurationAuthError(BrowserConfigurationAuthErrorMessage.storageNotSupportedError.code, `${BrowserConfigurationAuthErrorMessage.storageNotSupportedError.desc} Given Location: ${givenStorageLocation}`);
+    }
+
+    static createInvalidCallbackObjectError(callbackObject: object): BrowserConfigurationAuthError {
+        return new BrowserConfigurationAuthError(BrowserConfigurationAuthErrorMessage.invalidCallbackObject.code,
+            `${BrowserConfigurationAuthErrorMessage.invalidCallbackObject.desc} Given value for callback function: ${callbackObject}`);
+    }
+
+    static createRedirectCallbacksNotSetError(): BrowserConfigurationAuthError {
+        return new BrowserConfigurationAuthError(BrowserConfigurationAuthErrorMessage.noRedirectCallbacksSet.code, BrowserConfigurationAuthErrorMessage.noRedirectCallbacksSet.desc);
     }
 }

--- a/lib/msal-browser/src/interaction_handler/IInteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/IInteractionHandler.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { AuthorizationCodeModule } from "msal-common";
+
+export abstract class IInteractionHandler {
+
+    protected authModule: AuthorizationCodeModule;
+
+    constructor(authCodeModule: AuthorizationCodeModule) {
+        this.authModule = authCodeModule;
+    }
+    
+    /**
+     * Function to handle user interaction.
+     * @param urlNavigate 
+     */
+    abstract showUI(urlNavigate: string): void;
+}

--- a/lib/msal-browser/src/interaction_handler/IInteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/IInteractionHandler.ts
@@ -2,19 +2,29 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { AuthorizationCodeModule } from "msal-common";
+import { AuthorizationCodeModule, AuthenticationParameters } from "msal-common";
+import { BrowserAuthOptions } from "../app/Configuration";
+import { BrowserStorage } from "../cache/BrowserStorage";
 
 export abstract class IInteractionHandler {
 
     protected authModule: AuthorizationCodeModule;
+    protected browserStorage: BrowserStorage;
 
-    constructor(authCodeModule: AuthorizationCodeModule) {
+    constructor(authCodeModule: AuthorizationCodeModule, storageImpl: BrowserStorage) {
         this.authModule = authCodeModule;
+        this.browserStorage = storageImpl;
     }
     
     /**
-     * Function to handle user interaction.
+     * Function to enable user interaction.
      * @param urlNavigate 
      */
-    abstract showUI(urlNavigate: string): void;
+    abstract showUI(authRequest: AuthenticationParameters): void;
+
+    /**
+     * Function to handle response parameters from hash.
+     * @param hash 
+     */
+    abstract handleCodeResponse(hash: string): void;
 }

--- a/lib/msal-browser/src/interaction_handler/IInteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/IInteractionHandler.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 import { AuthorizationCodeModule, AuthenticationParameters } from "msal-common";
-import { BrowserAuthOptions } from "../app/Configuration";
 import { BrowserStorage } from "../cache/BrowserStorage";
 
 export abstract class IInteractionHandler {

--- a/lib/msal-browser/src/interaction_handler/IInteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/IInteractionHandler.ts
@@ -14,7 +14,7 @@ export abstract class IInteractionHandler {
         this.authModule = authCodeModule;
         this.browserStorage = storageImpl;
     }
-    
+
     /**
      * Function to enable user interaction.
      * @param urlNavigate 
@@ -25,5 +25,5 @@ export abstract class IInteractionHandler {
      * Function to handle response parameters from hash.
      * @param hash 
      */
-    abstract handleCodeResponse(hash: string): void;
+    abstract async handleCodeResponse(hash: string): Promise<void>;
 }

--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -4,27 +4,76 @@
  */
 import { IInteractionHandler } from "./IInteractionHandler";
 import { BrowserAuthError } from "../error/BrowserAuthError";
-import { StringUtils, AuthorizationCodeModule } from "msal-common";
+import { StringUtils, AuthorizationCodeModule, TemporaryCacheKeys, AuthenticationParameters, AuthError, AuthResponse } from "msal-common";
+import { AuthCallback } from "../app/PublicClientApplication";
+import { BrowserConfigurationAuthError } from "../error/BrowserConfigurationAuthError";
+import { BrowserStorage } from "../cache/BrowserStorage";
 
 export class RedirectHandler extends IInteractionHandler {
 
-    constructor(authCodeModule: AuthorizationCodeModule) {
-        super(authCodeModule);
+    private authCallback: AuthCallback;
+
+    constructor(authCodeModule: AuthorizationCodeModule, storageImpl: BrowserStorage,  redirectCallback: AuthCallback) {
+        super(authCodeModule, storageImpl);
+        if (!redirectCallback) {
+            throw BrowserConfigurationAuthError.createRedirectCallbacksNotSetError();
+        }
+        this.authCallback = redirectCallback;
     }
 
     /**
      * Redirects window to given URL.
      * @param urlNavigate 
      */
-    showUI(urlNavigate: string): void {
-        // Navigate if valid URL
-        if (urlNavigate && !StringUtils.isEmpty(urlNavigate)) {
-            this.authModule.logger.infoPii("Navigate to:" + urlNavigate);
-            window.location.assign(urlNavigate);
+    showUI(authRequest: AuthenticationParameters): void {
+        this.browserStorage.setItem(TemporaryCacheKeys.ORIGIN_URI, window.location.href);
+        this.authModule.createLoginUrl(authRequest).then((urlNavigate) => {
+            // Navigate if valid URL
+            if (urlNavigate && !StringUtils.isEmpty(urlNavigate)) {
+                this.authModule.logger.infoPii("Navigate to:" + urlNavigate);
+                window.location.assign(urlNavigate);
+            }
+            else {
+                this.authModule.logger.info("Navigate url is empty");
+                throw BrowserAuthError.createEmptyRedirectUriError();
+            }
+        });
+    }
+
+    /**
+     * Handle authorization code response in the window.
+     * @param hash 
+     */
+    handleCodeResponse(hash: string, navigateToLoginRequestUrl?: boolean): void {
+        // retrieve the hash
+        const locationHash = hash || window.location.hash;
+
+        if (navigateToLoginRequestUrl) {
+            this.browserStorage.setItem(TemporaryCacheKeys.URL_HASH, locationHash);
+            if (window.parent === window) {
+                const loginRequestUrl = this.browserStorage.getItem(TemporaryCacheKeys.ORIGIN_URI);
+
+                // Redirect to home page if login request url is null (real null or the string null)
+                if (!loginRequestUrl || loginRequestUrl === "null") {
+                    this.authModule.logger.error("Unable to get valid login request url from cache, redirecting to home page");
+                    window.location.href = "/";
+                } else {
+                    window.location.href = loginRequestUrl;
+                }
+            }
+            return;
+        } else {
+            window.location.hash = "";
         }
-        else {
-            this.authModule.logger.info("Navigate url is empty");
-            throw BrowserAuthError.createEmptyRedirectUriError();
+
+        let authResponse: AuthResponse = null;
+        let authErr: AuthError = null;
+        try {
+            this.authModule.handleFragmentResponse(locationHash);
+        } catch (err) {
+            authErr = err;
         }
+
+        this.authCallback(authErr, authResponse);
     }
 }

--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -45,7 +45,7 @@ export class RedirectHandler extends IInteractionHandler {
      * @param hash 
      */
     async handleCodeResponse(locationHash: string, navigateToLoginRequestUrl?: boolean): Promise<void> {
-        if (!locationHash) {
+        if (StringUtils.isEmpty(locationHash)) {
             throw BrowserAuthError.createEmptyHashError(locationHash);
         }
 

--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -66,7 +66,7 @@ export class RedirectHandler extends IInteractionHandler {
             window.location.hash = "";
         }
 
-        let authResponse: AuthResponse = null;
+        const authResponse: AuthResponse = null;
         let authErr: AuthError = null;
         try {
             this.authModule.handleFragmentResponse(locationHash);

--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -4,7 +4,7 @@
  */
 import { IInteractionHandler } from "./IInteractionHandler";
 import { BrowserAuthError } from "../error/BrowserAuthError";
-import { StringUtils, AuthorizationCodeModule, TemporaryCacheKeys, AuthenticationParameters, AuthError, TokenResponse, ClientAuthError } from "msal-common";
+import { StringUtils, AuthorizationCodeModule, TemporaryCacheKeys, AuthenticationParameters, AuthError, TokenResponse } from "msal-common";
 import { AuthCallback } from "../app/PublicClientApplication";
 import { BrowserConfigurationAuthError } from "../error/BrowserConfigurationAuthError";
 import { BrowserStorage } from "../cache/BrowserStorage";
@@ -69,9 +69,6 @@ export class RedirectHandler extends IInteractionHandler {
 
         try {
             const codeResponse = this.authModule.handleFragmentResponse(locationHash);
-            if (!codeResponse || !codeResponse.code) {
-                throw ClientAuthError.createAuthCodeNullOrEmptyError();
-            }
             const tokenResponse: TokenResponse = await this.authModule.acquireToken(null, codeResponse);
             this.authCallback(null, tokenResponse);
         } catch (err) {

--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { IInteractionHandler } from "./IInteractionHandler";
+import { BrowserAuthError } from "../error/BrowserAuthError";
+import { StringUtils, AuthorizationCodeModule } from "msal-common";
+
+export class RedirectHandler extends IInteractionHandler {
+
+    constructor(authCodeModule: AuthorizationCodeModule) {
+        super(authCodeModule);
+    }
+
+    /**
+     * Redirects window to given URL.
+     * @param urlNavigate 
+     */
+    showUI(urlNavigate: string): void {
+        // Navigate if valid URL
+        if (urlNavigate && !StringUtils.isEmpty(urlNavigate)) {
+            this.authModule.logger.infoPii("Navigate to:" + urlNavigate);
+            window.location.assign(urlNavigate);
+        }
+        else {
+            this.authModule.logger.info("Navigate url is empty");
+            throw BrowserAuthError.createEmptyRedirectUriError();
+        }
+    }
+}

--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -4,7 +4,7 @@
  */
 import { IInteractionHandler } from "./IInteractionHandler";
 import { BrowserAuthError } from "../error/BrowserAuthError";
-import { StringUtils, AuthorizationCodeModule, TemporaryCacheKeys, AuthenticationParameters, AuthError, TokenResponse } from "msal-common";
+import { StringUtils, AuthorizationCodeModule, TemporaryCacheKeys, AuthenticationParameters, AuthError, TokenResponse, ClientAuthError } from "msal-common";
 import { AuthCallback } from "../app/PublicClientApplication";
 import { BrowserConfigurationAuthError } from "../error/BrowserConfigurationAuthError";
 import { BrowserStorage } from "../cache/BrowserStorage";
@@ -69,7 +69,10 @@ export class RedirectHandler extends IInteractionHandler {
 
         try {
             const codeResponse = this.authModule.handleFragmentResponse(locationHash);
-            const tokenResponse: TokenResponse = await this.authModule.acquireTokenAuto(codeResponse);
+            if (!codeResponse || !codeResponse.code) {
+                throw ClientAuthError.createAuthCodeNullOrEmptyError();
+            }
+            const tokenResponse: TokenResponse = await this.authModule.acquireToken(null, codeResponse);
             this.authCallback(null, tokenResponse);
         } catch (err) {
             this.authCallback(err as AuthError, null);

--- a/lib/msal-common/src/app/config/PublicClientSPAConfiguration.ts
+++ b/lib/msal-common/src/app/config/PublicClientSPAConfiguration.ts
@@ -22,7 +22,6 @@ export type AuthOptions = {
     validateAuthority?: boolean;
     redirectUri?: string | (() => string);
     postLogoutRedirectUri?: string | (() => string);
-    navigateToLoginRequestUrl?: boolean;
 };
 
 /**
@@ -41,8 +40,7 @@ const DEFAULT_AUTH_OPTIONS: AuthOptions = {
     authority: null,
     validateAuthority: true,
     redirectUri: "",
-    postLogoutRedirectUri: "",
-    navigateToLoginRequestUrl: true
+    postLogoutRedirectUri: ""
 };
 
 /**

--- a/lib/msal-common/src/app/module/AuthModule.ts
+++ b/lib/msal-common/src/app/module/AuthModule.ts
@@ -6,8 +6,6 @@
 import { ModuleConfiguration, buildModuleConfiguration } from "../config/ModuleConfiguration";
 // request
 import { AuthenticationParameters } from "../../request/AuthenticationParameters";
-// response
-import { AuthResponse } from "../../response/AuthResponse";
 // cache
 import { ICacheStorage } from "../../cache/ICacheStorage";
 // network

--- a/lib/msal-common/src/app/module/AuthModule.ts
+++ b/lib/msal-common/src/app/module/AuthModule.ts
@@ -91,14 +91,6 @@ export abstract class AuthModule {
     abstract async createAcquireTokenUrl(request: AuthenticationParameters): Promise<string>;
 
     // #endregion
-
-    // #region Response Handling
-
-    public handleFragmentResponse(hashFragment: string): AuthResponse {
-        return null;
-    }
-
-    // #endregion
     
     // #region Getters and Setters
 

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -19,8 +19,6 @@ import { CodeResponse } from "../../response/CodeResponse";
 import { UrlString } from "../../url/UrlString";
 import { ServerAuthorizationCodeResponse, validateServerAuthorizationCodeResponse } from "../../server/ServerAuthorizationCodeResponse";
 import { ClientAuthError } from "../../error/ClientAuthError";
-import { buildClientInfo } from "../../auth/ClientInfo";
-import { ServerError } from "../../error/ServerError";
 import { ProtocolUtils } from "../../utils/ProtocolUtils";
 import { TemporaryCacheKeys, PersistentCacheKeys } from "../../utils/Constants";
 
@@ -107,7 +105,7 @@ export class AuthorizationCodeModule extends AuthModule {
             this.cacheStorage.removeItem(TemporaryCacheKeys.REQUEST_PARAMS);
         } catch (err) {
             throw err;
-        }       
+        }
         return null;
     }
 

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -93,24 +93,20 @@ export class AuthorizationCodeModule extends AuthModule {
         throw new Error("Method not implemented.");
     }
 
-    async acquireTokenAuto(codeResponse: CodeResponse): Promise<TokenResponse> {
-        if (!codeResponse || !codeResponse.code) {
-            throw ClientAuthError.createAuthCodeNullOrEmptyError();
+    async acquireToken(request: TokenExchangeParameters, codeResponse: CodeResponse): Promise<TokenResponse> {
+        let encodedTokenRequest;
+        if (!request) {
+            encodedTokenRequest = this.cacheStorage.getItem(TemporaryCacheKeys.REQUEST_PARAMS);
         }
-
-        const encodedTokenRequest = this.cacheStorage.getItem(TemporaryCacheKeys.REQUEST_PARAMS);
+        
         try {
             const tokenRequest = JSON.parse(this.cryptoObj.base64Decode(encodedTokenRequest)) as TokenExchangeParameters;
             tokenRequest.code = codeResponse.code;
             tokenRequest.userRequestState = codeResponse.userRequestState;
             this.cacheStorage.removeItem(TemporaryCacheKeys.REQUEST_PARAMS);
-            return this.acquireToken(tokenRequest);
         } catch (err) {
             throw err;
-        }        
-    }
-
-    async acquireToken(request: TokenExchangeParameters): Promise<TokenResponse> {
+        }       
         return null;
     }
 

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -104,8 +104,6 @@ export class AuthorizationCodeModule extends AuthModule {
         
         try {
             const tokenRequest = JSON.parse(this.cryptoObj.base64Decode(encodedTokenRequest)) as TokenExchangeParameters;
-            tokenRequest.code = codeResponse.code;
-            tokenRequest.userRequestState = codeResponse.userRequestState;
             this.cacheStorage.removeItem(TemporaryCacheKeys.REQUEST_PARAMS);
         } catch (err) {
             throw err;

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -15,6 +15,7 @@ import { TokenResponse } from "../../response/TokenResponse";
 import { ClientConfigurationError } from "../../error/ClientConfigurationError";
 import { AuthorityFactory } from "../../auth/authority/AuthorityFactory";
 import { CodeRequestParameters } from "../../server/CodeRequestParameters";
+import { CodeResponse } from "../../response/CodeResponse";
 
 /**
  * AuthorizationCodeModule class
@@ -74,6 +75,17 @@ export class AuthorizationCodeModule extends AuthModule {
     async acquireToken(request: TokenExchangeParameters): Promise<TokenResponse> {
         throw new Error("Method not implemented.");
     }
+
+    // #region Response Handling
+
+    public handleFragmentResponse(hashFragment: string): CodeResponse {
+        return {
+            scopes: ["test_scopes"],
+            state: "test_state"
+        };
+    }
+
+    // #endregion
 
     // #region Getters and setters
 

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -99,16 +99,18 @@ export class AuthorizationCodeModule extends AuthModule {
         }
 
         const encodedTokenRequest = this.cacheStorage.getItem(TemporaryCacheKeys.REQUEST_PARAMS);
-        const tokenRequest = JSON.parse(this.cryptoObj.base64Decode(encodedTokenRequest)) as TokenExchangeParameters;
-        tokenRequest.code = codeResponse.code;
-        tokenRequest.userRequestState = codeResponse.userRequestState;
-
-        this.cacheStorage.removeItem(TemporaryCacheKeys.REQUEST_PARAMS);
-        return this.acquireToken(tokenRequest);
+        try {
+            const tokenRequest = JSON.parse(this.cryptoObj.base64Decode(encodedTokenRequest)) as TokenExchangeParameters;
+            tokenRequest.code = codeResponse.code;
+            tokenRequest.userRequestState = codeResponse.userRequestState;
+            this.cacheStorage.removeItem(TemporaryCacheKeys.REQUEST_PARAMS);
+            return this.acquireToken(tokenRequest);
+        } catch (err) {
+            throw err;
+        }        
     }
 
     async acquireToken(request: TokenExchangeParameters): Promise<TokenResponse> {
-        console.log(request);
         return null;
     }
 

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -17,6 +17,12 @@ import { AuthorityFactory } from "../../auth/authority/AuthorityFactory";
 import { CodeRequestParameters } from "../../server/CodeRequestParameters";
 import { CodeResponse } from "../../response/CodeResponse";
 import { UrlString } from "../../url/UrlString";
+import { ServerAuthorizationCodeResponse, validateServerAuthorizationCodeResponse } from "../../server/ServerAuthorizationCodeResponse";
+import { ClientAuthError } from "../../error/ClientAuthError";
+import { buildClientInfo } from "../../auth/ClientInfo";
+import { ServerError } from "../../error/ServerError";
+import { ProtocolUtils } from "../../utils/ProtocolUtils";
+import { TemporaryCacheKeys, PersistentCacheKeys } from "../../utils/Constants";
 
 /**
  * AuthorizationCodeModule class
@@ -66,23 +72,69 @@ export class AuthorizationCodeModule extends AuthModule {
         // Populate query parameters (sid/login_hint/domain_hint) and any other extraQueryParameters set by the developer
         requestParameters.populateQueryParams();
 
-        return requestParameters.createNavigateUrl();
+        const urlNavigate = await requestParameters.createNavigateUrl();
+
+        // Cache token request
+        const tokenRequest: TokenExchangeParameters = {
+            scopes: requestParameters.scopes.getOriginalScopesAsArray(),
+            resource: request.resource,
+            codeVerifier: requestParameters.generatedPkce.verifier,
+            extraQueryParameters: request.extraQueryParameters,
+            authority: requestParameters.authorityInstance.canonicalAuthority,
+            correlationId: requestParameters.correlationId,            
+        };
+
+        this.cacheStorage.setItem(TemporaryCacheKeys.REQUEST_PARAMS, this.cryptoObj.base64Encode(JSON.stringify(tokenRequest)));
+
+        return urlNavigate;
     }
 
     async createAcquireTokenUrl(request: AuthenticationParameters): Promise<string> {
         throw new Error("Method not implemented.");
     }
 
+    async acquireTokenAuto(codeResponse: CodeResponse): Promise<TokenResponse> {
+        if (!codeResponse || !codeResponse.code) {
+            throw ClientAuthError.createAuthCodeNullOrEmptyError();
+        }
+
+        const encodedTokenRequest = this.cacheStorage.getItem(TemporaryCacheKeys.REQUEST_PARAMS);
+        const tokenRequest = JSON.parse(this.cryptoObj.base64Decode(encodedTokenRequest)) as TokenExchangeParameters;
+        tokenRequest.code = codeResponse.code;
+        tokenRequest.userRequestState = codeResponse.userRequestState;
+
+        this.cacheStorage.removeItem(TemporaryCacheKeys.REQUEST_PARAMS);
+        return this.acquireToken(tokenRequest);
+    }
+
     async acquireToken(request: TokenExchangeParameters): Promise<TokenResponse> {
-        throw new Error("Method not implemented.");
+        console.log(request);
+        return null;
     }
 
     // #region Response Handling
 
     public handleFragmentResponse(hashFragment: string): CodeResponse {
+        // Deserialize and validate hash fragment response parameters
         const hashUrlString = new UrlString(hashFragment);
-        console.log(hashUrlString.getDeserializedHash<any>());
-        return null;
+        const hashParams = hashUrlString.getDeserializedHash<ServerAuthorizationCodeResponse>();
+        try {
+            validateServerAuthorizationCodeResponse(hashParams, this.cacheStorage.getItem(TemporaryCacheKeys.REQUEST_STATE), this.cryptoObj);
+        } catch(e) {
+            this.cacheManager.resetTempCacheItems(hashParams && hashParams.state);
+            throw e;
+        }
+
+        // Cache client info
+        this.cacheStorage.setItem(PersistentCacheKeys.CLIENT_INFO, hashParams.client_info);
+
+        // Create response object
+        const response: CodeResponse = {
+            code: hashParams.code,
+            userRequestState: ProtocolUtils.getUserRequestState(hashParams.state)
+        };
+
+        return response;
     }
 
     // #endregion

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -16,6 +16,7 @@ import { ClientConfigurationError } from "../../error/ClientConfigurationError";
 import { AuthorityFactory } from "../../auth/authority/AuthorityFactory";
 import { CodeRequestParameters } from "../../server/CodeRequestParameters";
 import { CodeResponse } from "../../response/CodeResponse";
+import { UrlString } from "../../url/UrlString";
 
 /**
  * AuthorizationCodeModule class
@@ -79,10 +80,9 @@ export class AuthorizationCodeModule extends AuthModule {
     // #region Response Handling
 
     public handleFragmentResponse(hashFragment: string): CodeResponse {
-        return {
-            scopes: ["test_scopes"],
-            state: "test_state"
-        };
+        const hashUrlString = new UrlString(hashFragment);
+        console.log(hashUrlString.getDeserializedHash<any>());
+        return null;
     }
 
     // #endregion

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -94,6 +94,9 @@ export class AuthorizationCodeModule extends AuthModule {
     }
 
     async acquireToken(request: TokenExchangeParameters, codeResponse: CodeResponse): Promise<TokenResponse> {
+        if (!codeResponse || !codeResponse.code) {
+            throw ClientAuthError.createAuthCodeNullOrEmptyError();
+        }
         let encodedTokenRequest;
         if (!request) {
             encodedTokenRequest = this.cacheStorage.getItem(TemporaryCacheKeys.REQUEST_PARAMS);

--- a/lib/msal-common/src/auth/ScopeSet.ts
+++ b/lib/msal-common/src/auth/ScopeSet.ts
@@ -157,6 +157,13 @@ export class ScopeSet {
     }
 
     /**
+     * Returns the original scopes as an array (no extra scopes to consent)
+     */
+    getOriginalScopesAsArray(): Array<string> {
+        return Array.from(this.originalScopes);
+    } 
+
+    /**
      * Prints scopes into a space-delimited string
      */
     printScopes(): string {

--- a/lib/msal-common/src/error/ClientAuthError.ts
+++ b/lib/msal-common/src/error/ClientAuthError.ts
@@ -4,7 +4,6 @@
  */
 
 import { AuthError } from "./AuthError";
-
 /**
  * ClientAuthErrorMessage class containing string constants used by error codes and messages.
  */
@@ -31,8 +30,24 @@ export const ClientAuthErrorMessage = {
     },
     invalidAuthorityType: {
         code: "invalid_authority_type",
-        desc: "The given authority is not a valid type of authority supported by MSAL. Please see here for valid authority configuration options: https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-initializing-client-applications#configuration-options"
+        desc: "The given authority is not a valid type of authority supported by MSAL. Please review the trace to determine the root cause."
     },
+    hashNotDeserialized: {
+        code: "hash_not_deserialized",
+        desc: "The hash parameters could not be deserialized. Please review the trace to determine the root cause."
+    },
+    blankGuidGenerated: {
+        code: "blank_guid_generated",
+        desc: "The guid generated was blank. Please review the trace to determine the root cause."
+    },
+    stateMismatchError: {
+        code: "state_mismatch",
+        desc: "State mismatch error. Please check your network. Continued requests may cause cache overflow."
+    },
+    authCodeNullOrEmptyError: {
+        code: "auth_code_null_or_empty",
+        desc: "The authorization code or code response was null. Please check the stack trace and logs for more information."
+    }
 };
 
 /**
@@ -94,8 +109,30 @@ export class ClientAuthError extends AuthError {
      * Creates an error thrown if authority type is not valid.
      * @param invalidAuthorityError 
      */
-    static createInvalidAuthorityTypeError(givenUrl: string) {
-        return new ClientAuthError(ClientAuthErrorMessage.invalidAuthorityType.code, `${ClientAuthErrorMessage.invalidAuthorityType.desc} ${givenUrl}`);
+    static createInvalidAuthorityTypeError(givenUrl: string): ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.invalidAuthorityType.code, `${ClientAuthErrorMessage.invalidAuthorityType.desc} Given Url: ${givenUrl}`);
+    }
+
+    /**
+     * Creates an error thrown when the hash cannot be deserialized.
+     * @param invalidAuthorityError 
+     */
+    static createHashNotDeserializedError(hashParamObj: any): ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.hashNotDeserialized.code, `${ClientAuthErrorMessage.hashNotDeserialized.desc} Given Object: ${hashParamObj}`);
+    }
+
+    /**
+     * Creates an error thrown when two states do not match.
+     */
+    static createStateMismatchError(): ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.stateMismatchError.code, ClientAuthErrorMessage.stateMismatchError.desc);
+    }
+
+    /**
+     * Creates an error thrown when the authorization code required for a token request is null or empty.
+     */
+    static createAuthCodeNullOrEmptyError(): ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.authCodeNullOrEmptyError.code, ClientAuthErrorMessage.authCodeNullOrEmptyError.desc);
     }
 
 }

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -23,7 +23,7 @@ export const ClientConfigurationErrorMessage = {
     },
     authorityUriInsecure: {
         code: "authority_uri_insecure",
-        desc: "Authority URIs must use https."
+        desc: "Authority URIs must use https.  Please see here for valid authority configuration options: https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-initializing-client-applications#configuration-options"
     },
     urlParseError: {
         code: "url_parse_error",
@@ -51,7 +51,7 @@ export const ClientConfigurationErrorMessage = {
     },
     invalidPrompt: {
         code: "invalid_prompt_value",
-        desc: "Supported prompt values are 'login', 'select_account', 'consent' and 'none'",
+        desc: "Supported prompt values are 'login', 'select_account', 'consent' and 'none'.  Please see here for valid configuration options: https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-initializing-client-applications#configuration-options",
     },
 };
 
@@ -152,6 +152,10 @@ export class ClientConfigurationError extends ClientAuthError {
             `${ClientConfigurationErrorMessage.clientIdSingleScopeError.desc} Given Scopes: ${inputScopes.toString()}`);
     }
 
+    /**
+     * Error thrown when prompt is not an allowed type.
+     * @param promptValue 
+     */
     static createInvalidPromptError(promptValue: any): ClientConfigurationError {
         return new ClientConfigurationError(ClientConfigurationErrorMessage.invalidPrompt.code,
             `${ClientConfigurationErrorMessage.invalidPrompt.desc} Given value: ${promptValue}`);

--- a/lib/msal-common/src/error/ServerError.ts
+++ b/lib/msal-common/src/error/ServerError.ts
@@ -5,16 +5,6 @@
 
 import { AuthError } from "./AuthError";
 
-export const ServerErrorMessage = {
-    serverUnavailable: {
-        code: "server_unavailable",
-        desc: "Server is temporarily unavailable."
-    },
-    unknownServerError: {
-        code: "unknown_server_error"
-    },
-};
-
 /**
  * Error thrown when there is an error with the server code, for example, unavailability.
  */

--- a/lib/msal-common/src/error/ServerError.ts
+++ b/lib/msal-common/src/error/ServerError.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AuthError } from "./AuthError";
+
+export const ServerErrorMessage = {
+    serverUnavailable: {
+        code: "server_unavailable",
+        desc: "Server is temporarily unavailable."
+    },
+    unknownServerError: {
+        code: "unknown_server_error"
+    },
+};
+
+/**
+ * Error thrown when there is an error with the server code, for example, unavailability.
+ */
+export class ServerError extends AuthError {
+
+    constructor(errorCode: string, errorMessage?: string) {
+        super(errorCode, errorMessage);
+        this.name = "ServerError";
+
+        Object.setPrototypeOf(this, ServerError.prototype);
+    }
+}

--- a/lib/msal-common/src/request/AuthenticationParameters.ts
+++ b/lib/msal-common/src/request/AuthenticationParameters.ts
@@ -15,7 +15,7 @@ import { ClientConfigurationError } from "../error/ClientConfigurationError";
  * - extraQueryParameters: string to string map of custom query parameters
  * - claimsRequest: stringified claims object to request additional claims in a token
  * - authority: authority to request tokens from
- * - state: state parameter to ensure request/response integrity
+ * - userRequestState: state parameter to ensure request/response integrity
  * - correlationId: custom correlationId given by user
  * - account: Account object to perform SSO
  * - sid: session id for SSO
@@ -24,12 +24,13 @@ import { ClientConfigurationError } from "../error/ClientConfigurationError";
  */
 export type AuthenticationParameters = {
     scopes?: Array<string>;
+    resource?: string;
     extraScopesToConsent?: Array<string>;
     prompt?: string;
     extraQueryParameters?: StringDict;
     claimsRequest?: string;
     authority?: string;
-    state?: string;
+    userRequestState?: string;
     correlationId?: string;
     account?: Account;
     sid?: string;

--- a/lib/msal-common/src/request/TokenExchangeParameters.ts
+++ b/lib/msal-common/src/request/TokenExchangeParameters.ts
@@ -17,10 +17,8 @@ import { StringDict } from "../utils/MsalTypes";
 export type TokenExchangeParameters = {
     scopes?: Array<string>;
     resource?: string;
-    code?: string;
     codeVerifier?: string;
     extraQueryParameters?: StringDict;
     authority?: string;
-    userRequestState?: string;
     correlationId?: string;
 };

--- a/lib/msal-common/src/request/TokenExchangeParameters.ts
+++ b/lib/msal-common/src/request/TokenExchangeParameters.ts
@@ -11,15 +11,16 @@ import { StringDict } from "../utils/MsalTypes";
  * - code_verifier: verifier to complete PKCE protocol
  * - extraQueryParameters: string to string map of custom query parameters
  * - authority: authority to request tokens from
- * - state: state parameter to ensure request/response integrity
+ * - userRequestState: state parameter to ensure request/response integrity
  * - correlationId: custom correlationId given by user
  */
 export type TokenExchangeParameters = {
     scopes?: Array<string>;
+    resource?: string;
     code?: string;
     codeVerifier?: string;
     extraQueryParameters?: StringDict;
     authority?: string;
-    state?: string;
+    userRequestState?: string;
     correlationId?: string;
 };

--- a/lib/msal-common/src/response/AuthResponse.ts
+++ b/lib/msal-common/src/response/AuthResponse.ts
@@ -5,12 +5,11 @@
 
 /**
  * AuthResponse base type returned by MSAL library on success
- * - state: User given state
+ * - userRequestState: User given state
  * - scopes: consented scopes
  */
 export type AuthResponse = {
-    scopes: Array<string>;
-    state: string;
+    userRequestState: string;
 };
 
 /**
@@ -19,7 +18,6 @@ export type AuthResponse = {
  */
 export function buildResponseStateOnly(responseState: string) : AuthResponse {
     return {
-        scopes: null,
-        state: responseState
+        userRequestState: responseState
     };
 }

--- a/lib/msal-common/src/response/CodeResponse.ts
+++ b/lib/msal-common/src/response/CodeResponse.ts
@@ -8,6 +8,7 @@ import { AuthResponse } from "./AuthResponse";
 /**
  * CodeResponse type returned by library containing authorization code.
  * - code: authorization code returned from interactive call
+ * - userRequestState: User given state
  */
 export type CodeResponse = AuthResponse & {
     code: string

--- a/lib/msal-common/src/response/TokenResponse.ts
+++ b/lib/msal-common/src/response/TokenResponse.ts
@@ -22,6 +22,7 @@ import { AuthResponse } from "./AuthResponse";
 export type TokenResponse = AuthResponse & {
     uniqueId: string;
     tenantId: string;
+    scopes: Array<string>;
     tokenType: string;
     idToken: string;
     idTokenClaims: StringDict;

--- a/lib/msal-common/src/server/ServerAuthorizationCodeResponse.ts
+++ b/lib/msal-common/src/server/ServerAuthorizationCodeResponse.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { TemporaryCacheKeys } from "../utils/Constants";
+import { ClientAuthError } from "../error/ClientAuthError";
+import { ServerError } from "../error/ServerError";
+import { buildClientInfo } from "../auth/ClientInfo";
+import { ICrypto } from "../crypto/ICrypto";
+
+/**
+ * Deserialized response object from server authorization code request.
+ * - code: authorization code from server
+ * - client_info: client info object
+ * - state: OAuth2 request state
+ */
+export type ServerAuthorizationCodeResponse = {
+    code?: string;
+    client_info?: string;
+    state?: string;
+    error?: string,
+    error_description?: string;
+};
+
+export function validateServerAuthorizationCodeResponse(serverResponseHash: ServerAuthorizationCodeResponse, cachedState: string, cryptoObj: ICrypto): void {
+    if (serverResponseHash.state !== cachedState) {
+        throw ClientAuthError.createStateMismatchError();
+    }
+
+    // Check for error
+    if (serverResponseHash.error || serverResponseHash.error_description) {
+        throw new ServerError(serverResponseHash.error, serverResponseHash.error_description);
+    }
+
+    buildClientInfo(serverResponseHash.client_info, cryptoObj);
+}

--- a/lib/msal-common/src/url/UrlString.ts
+++ b/lib/msal-common/src/url/UrlString.ts
@@ -7,6 +7,7 @@ import { AADAuthorityConstants, AADServerHashParamKeys } from "../utils/Constant
 import { StringUtils } from "../utils/StringUtils";
 import { IUri } from "./IUri";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
+import { ClientAuthError } from "../error/ClientAuthError";
 
 /**
  * Url object class which can perform various transformations on url strings.
@@ -121,7 +122,11 @@ export class UrlString {
      */
     getDeserializedHash<T>(): T {
         const hash = this.getHash();
-        return StringUtils.queryStringToObject<T>(hash);
+        const deserializedHash: T = StringUtils.queryStringToObject<T>(hash);
+        if (!deserializedHash) {
+            throw ClientAuthError.createHashNotDeserializedError(deserializedHash);
+        }
+        return deserializedHash;
     }
 
     /**

--- a/lib/msal-common/src/url/UrlString.ts
+++ b/lib/msal-common/src/url/UrlString.ts
@@ -119,9 +119,9 @@ export class UrlString {
      * Returns deserialized portion of URL hash
      * @ignore
      */
-    getDeserializedHash() {
+    getDeserializedHash<T>(): T {
         const hash = this.getHash();
-        return StringUtils.queryStringToObject(hash);
+        return StringUtils.queryStringToObject<T>(hash);
     }
 
     /**
@@ -165,12 +165,10 @@ export class UrlString {
      */
     static hashContainsKnownProperties(url: string): boolean {
         const urlString = new UrlString(url);
-        const parameters = urlString.getDeserializedHash();
+        const parameters = urlString.getDeserializedHash<any>();
         return (
             parameters.hasOwnProperty(AADServerHashParamKeys.ERROR_DESCRIPTION) ||
             parameters.hasOwnProperty(AADServerHashParamKeys.ERROR) ||
-            parameters.hasOwnProperty(AADServerHashParamKeys.ACCESS_TOKEN) ||
-            parameters.hasOwnProperty(AADServerHashParamKeys.ID_TOKEN) ||
             parameters.hasOwnProperty(AADServerHashParamKeys.CODE)
         );
     }

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -4,6 +4,7 @@
  */
 
 export const Constants = {
+    LIBRARY_NAME: "MSAL.JS",
     // Prefix for all library cache entries
     CACHE_PREFIX: "msal",
     // Resource delimiter - used for certain cache entries
@@ -21,6 +22,8 @@ export const Constants = {
     OPENID_SCOPE: "openid",
     PROFILE_SCOPE: "profile",
     OFFLINE_ACCESS_SCOPE: "offline_access",
+    // Default response type for authorization code flow
+    CODE_RESPONSE_TYPE: "code"
 };
 
 /**

--- a/lib/msal-common/src/utils/ProtocolUtils.ts
+++ b/lib/msal-common/src/utils/ProtocolUtils.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { StringUtils } from "./StringUtils";
+import { Constants } from "./Constants";
+
+/**
+ * Class which provides helpers for OAuth 2.0 protocol specific values
+ */
+export class ProtocolUtils {
+
+    /**
+     * Appends user state with random guid, or returns random guid.
+     * @param userState 
+     * @param randomGuid 
+     */
+    static setRequestState(userState: string, randomGuid: string): string {
+        return userState && !StringUtils.isEmpty(userState) ? `${randomGuid}${Constants.RESOURCE_DELIM}${userState}` : randomGuid;
+    }
+
+    /**
+     *
+     * Extracts user state value from the state sent with the authentication request.
+     * @returns {string} scope.
+     * @ignore
+     */
+    static getUserRequestState(serverResponseState: string): string {
+        if (serverResponseState) {
+            const splitIndex = serverResponseState.indexOf(Constants.RESOURCE_DELIM);
+            if (splitIndex > -1 && splitIndex + 1 < serverResponseState.length) {
+                return serverResponseState.substring(splitIndex + 1);
+            }
+        }
+        return "";
+    }
+}

--- a/lib/msal-common/src/utils/StringUtils.ts
+++ b/lib/msal-common/src/utils/StringUtils.ts
@@ -45,7 +45,7 @@ export class StringUtils {
      *
      * @param query
      */
-    static queryStringToObject(query: string): any {
+    static queryStringToObject<T>(query: string): T {
         let match: Array<string>; // Regex for replacing addition symbol with a space
         const pl = /\+/g;
         const search = /([^&=]+)=([^&]*)/g;
@@ -56,7 +56,7 @@ export class StringUtils {
             obj[decode(match[1])] = decode(match[2]);
             match = search.exec(query);
         }
-        return obj;
+        return obj as T;
     }
 
     /**

--- a/samples/VanillaJSTestApp/index.html
+++ b/samples/VanillaJSTestApp/index.html
@@ -25,7 +25,7 @@
     // initialize MSAL
     const msalConfig = {
         auth: {
-            clientId: "16b0c3aa-11cc-4afc-a44a-12f25e5872b6",
+            clientId: "Enter_your_client_id",
             // clientId: "245e9392-c666-4d51-8f8a-bfd9e55b2456",
             authority: "https://login.microsoftonline.com/common",
             validateAuthority: true

--- a/samples/VanillaJSTestApp/index.html
+++ b/samples/VanillaJSTestApp/index.html
@@ -25,7 +25,7 @@
     // initialize MSAL
     const msalConfig = {
         auth: {
-            clientId: "Enter_your_client_id",
+            clientId: "16b0c3aa-11cc-4afc-a44a-12f25e5872b6",
             // clientId: "245e9392-c666-4d51-8f8a-bfd9e55b2456",
             authority: "https://login.microsoftonline.com/common",
             validateAuthority: true

--- a/samples/VanillaJSTestApp/index_authCode.html
+++ b/samples/VanillaJSTestApp/index_authCode.html
@@ -20,8 +20,8 @@
     // initialize MSAL
     const msalConfig = {
         auth: {
-            clientId: "16b0c3aa-11cc-4afc-a44a-12f25e5872b6",
-            clientSecret: ":1L:d/2EZOQNE0-g8wvr=@=nTGyV59y-",
+            clientId: "Enter_your_client_id",
+            clientSecret: "",
             authority: "https://login.microsoftonline.com/common",
             validateAuthority: true,
             navigateToLoginRequestUrl: false

--- a/samples/VanillaJSTestApp/index_authCode.html
+++ b/samples/VanillaJSTestApp/index_authCode.html
@@ -20,7 +20,7 @@
     // initialize MSAL
     const msalConfig = {
         auth: {
-            clientId: "16b0c3aa-11cc-4afc-a44a-12f25e5872b6",
+            clientId: "Enter_your_client_id",
             clientSecret: "",
             authority: "https://login.microsoftonline.com/common",
             validateAuthority: true,
@@ -42,7 +42,7 @@
     // instantiate MSAL
     const myMSALObj = new msal.PublicClientApplication(msalConfig);
     // register callback for redirect usecases
-    // myMSALObj.handleRedirectCallback(authRedirectCallBack);
+    myMSALObj.handleRedirectCallback(authRedirectCallBack);
     // signin and acquire a token silently with POPUP flow. Fall back in case of failure with silent acquisition to popup
     function signIn() {
         try {

--- a/samples/VanillaJSTestApp/index_authCode.html
+++ b/samples/VanillaJSTestApp/index_authCode.html
@@ -20,8 +20,8 @@
     // initialize MSAL
     const msalConfig = {
         auth: {
-            clientId: "Enter_your_client_id",
-            clientSecret: "",
+            clientId: "16b0c3aa-11cc-4afc-a44a-12f25e5872b6",
+            clientSecret: ":1L:d/2EZOQNE0-g8wvr=@=nTGyV59y-",
             authority: "https://login.microsoftonline.com/common",
             validateAuthority: true,
             navigateToLoginRequestUrl: false

--- a/samples/VanillaJSTestApp/index_authCode.html
+++ b/samples/VanillaJSTestApp/index_authCode.html
@@ -20,8 +20,8 @@
     // initialize MSAL
     const msalConfig = {
         auth: {
-            clientId: "Enter_your_client_id",
-            clientSecret: "Enter_your_client_secret",
+            clientId: "16b0c3aa-11cc-4afc-a44a-12f25e5872b6",
+            clientSecret: "",
             authority: "https://login.microsoftonline.com/common",
             validateAuthority: true,
             navigateToLoginRequestUrl: false


### PR DESCRIPTION
This PR adds interaction to the Authorization Code Flow version of the MSAL library. 

The current implementation of MSAL determines the type of interaction at processing time instead of when the specific API is called. This PR introduces an IInteractionHandler abstract class which specifies which functions need to be handled when performing different methods of interaction. There will be a separate PR which extends this class for popup scenarios.