### PR TITLE
Authorization Code Flow for Single Page Applications: Response Handling Code

### DIFF
--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -11,7 +11,7 @@ import { PublicClientSPAConfiguration, buildPublicClientSPAConfiguration } from 
 import { AuthenticationParameters } from "../../request/AuthenticationParameters";
 import { TokenExchangeParameters } from "../../request/TokenExchangeParameters";
 // response
-import { TokenResponse } from "../../response/TokenResponse";
+import { TokenResponse, setResponseIdToken } from "../../response/TokenResponse";
 import { ClientConfigurationError } from "../../error/ClientConfigurationError";
 import { AuthorityFactory } from "../../auth/authority/AuthorityFactory";
 import { ServerCodeRequestParameters } from "../../server/ServerCodeRequestParameters";
@@ -23,6 +23,11 @@ import { ProtocolUtils } from "../../utils/ProtocolUtils";
 import { TemporaryCacheKeys, PersistentCacheKeys } from "../../utils/Constants";
 import { AuthError } from "../../error/AuthError";
 import { ServerTokenRequestParameters } from "../../server/ServerTokenRequestParameters";
+import { ServerAuthorizationTokenResponse, validateServerAuthorizationTokenResponse } from "../../server/ServerAuthorizationTokenResponse";
+import { IdToken } from "../../auth/IdToken";
+import { buildClientInfo } from "../../auth/ClientInfo";
+import { Account } from "../../auth/Account";
+import { ScopeSet } from "../../auth/ScopeSet";
 
 /**
  * AuthorizationCodeModule class
@@ -81,7 +86,8 @@ export class AuthorizationCodeModule extends AuthModule {
             codeVerifier: requestParameters.generatedPkce.verifier,
             extraQueryParameters: request.extraQueryParameters,
             authority: requestParameters.authorityInstance.canonicalAuthority,
-            correlationId: requestParameters.correlationId,            
+            correlationId: requestParameters.correlationId,
+            userRequestState: ProtocolUtils.getUserRequestState(requestParameters.state)
         };
 
         this.cacheStorage.setItem(TemporaryCacheKeys.REQUEST_PARAMS, this.cryptoObj.base64Encode(JSON.stringify(tokenRequest)));
@@ -133,7 +139,7 @@ export class AuthorizationCodeModule extends AuthModule {
             this.cryptoObj
         );
 
-        const acquiredTokenResponse = this.networkClient.sendPostRequestAsync(
+        const acquiredTokenResponse = await this.networkClient.sendPostRequestAsync<ServerAuthorizationTokenResponse>(
             tokenEndpoint,
             {
                 body: await tokenReqParams.createRequestBody(),
@@ -141,7 +147,14 @@ export class AuthorizationCodeModule extends AuthModule {
             }
         );
 
-        return null;
+        try {
+            validateServerAuthorizationTokenResponse(acquiredTokenResponse);
+        } catch (e) {
+            this.cacheManager.resetTempCacheItems(tokenReqParams.state);
+            throw e;
+        }
+
+        return this.createTokenResponse(acquiredTokenResponse, tokenReqParams.state);
     }
 
     // #region Response Handling
@@ -163,10 +176,89 @@ export class AuthorizationCodeModule extends AuthModule {
         // Create response object
         const response: CodeResponse = {
             code: hashParams.code,
-            userRequestState: ProtocolUtils.getUserRequestState(hashParams.state)
+            userRequestState: hashParams.state
         };
 
         return response;
+    }
+
+    private createTokenResponse(serverTokenResponse: ServerAuthorizationTokenResponse, state: string): TokenResponse {
+        const tokenResponse: TokenResponse = {
+            uniqueId: "",
+            tenantId: "",
+            tokenType: "",
+            idToken: null,
+            idTokenClaims: null,
+            accessToken: "",
+            refreshToken: "",
+            scopes: [],
+            expiresOn: null,
+            account: null,
+            userRequestState: ""
+        };
+        // Set consented scopes in response
+        const requestScopes = ScopeSet.fromString(serverTokenResponse.scope, this.clientConfig.auth.clientId, false);
+        tokenResponse.scopes = requestScopes.asArray();
+
+        // Retrieve current id token object
+        let idTokenObj: IdToken;
+        const cachedIdToken: IdToken = new IdToken(this.cacheStorage.getItem(PersistentCacheKeys.ID_TOKEN), this.cryptoObj);
+        if (serverTokenResponse.id_token) {
+            idTokenObj = new IdToken(serverTokenResponse.id_token, this.cryptoObj);
+            setResponseIdToken(tokenResponse, idTokenObj);
+        } else if (cachedIdToken) {
+            idTokenObj = cachedIdToken;
+            setResponseIdToken(tokenResponse, idTokenObj);
+        } else {
+            // TODO: No account scenario?
+        }
+
+        // check nonce integrity if idToken has nonce - throw an error if not matched
+        const nonce = this.cacheStorage.getItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${state}`);
+
+        if (!idTokenObj || idTokenObj.claims.nonce) {
+            throw ClientAuthError.createInvalidIdTokenError(idTokenObj);
+        }
+
+        if (idTokenObj.claims.nonce !== nonce) {
+            this.account = null;
+            throw ClientAuthError.createNonceMismatchError();
+        }
+
+        // TODO: This will be used when saving tokens
+        // const authorityKey: string = this.cacheManager.generateAuthorityKey(state);
+        // const cachedAuthority: string = this.cacheStorage.getItem(authorityKey);
+
+        // TODO: Save id token here
+        
+        // Retrieve client info
+        const clientInfo = buildClientInfo(this.cacheStorage.getItem(PersistentCacheKeys.CLIENT_INFO), this.cryptoObj);
+
+        // Create account object for request
+        this.account = Account.createAccount(idTokenObj, clientInfo, this.cryptoObj);
+        tokenResponse.account = this.account;
+
+        // Set token type
+        tokenResponse.tokenType = serverTokenResponse.token_type;
+
+        // Save the access token if it exists
+        if (serverTokenResponse.access_token) {
+            const accountKey = this.cacheManager.generateAcquireTokenAccountKey(this.account.homeAccountIdentifier);
+            
+            const cachedAccount = JSON.parse(this.cacheStorage.getItem(accountKey)) as Account;
+
+            if (!cachedAccount || Account.compareAccounts(cachedAccount, this.account)) {
+                tokenResponse.accessToken = serverTokenResponse.access_token;
+                tokenResponse.refreshToken = serverTokenResponse.refresh_token;
+                // TODO: Save the access token
+            } else {
+                throw ClientAuthError.createAccountMismatchError();
+            }
+        }
+
+        // Return user set state in the response
+        tokenResponse.userRequestState = ProtocolUtils.getUserRequestState(state);
+        return tokenResponse;
     }
 
     // #endregion

--- a/lib/msal-common/src/cache/CacheHelpers.ts
+++ b/lib/msal-common/src/cache/CacheHelpers.ts
@@ -34,6 +34,10 @@ export class CacheHelpers {
         return `${TemporaryCacheKeys.AUTHORITY}${Constants.RESOURCE_DELIM}${state}`;
     }
 
+    generateNonceKey(state: string): string {
+        return `${TemporaryCacheKeys.NONCE_IDTOKEN}${Constants.RESOURCE_DELIM}${state}`;
+    }
+
     /**
      * @hidden
      * @ignore

--- a/lib/msal-common/src/cache/CacheHelpers.ts
+++ b/lib/msal-common/src/cache/CacheHelpers.ts
@@ -22,8 +22,8 @@ export class CacheHelpers {
      * @param accountId
      * @param state
      */
-    generateAcquireTokenAccountKey(accountId: any, state: string): string {
-        return `${TemporaryCacheKeys.ACQUIRE_TOKEN_ACCOUNT}${Constants.RESOURCE_DELIM}${accountId}${Constants.RESOURCE_DELIM}${state}`;
+    generateAcquireTokenAccountKey(accountId: any): string {
+        return `${TemporaryCacheKeys.ACQUIRE_TOKEN_ACCOUNT}${Constants.RESOURCE_DELIM}${accountId}`;
     }
 
     /**
@@ -43,11 +43,11 @@ export class CacheHelpers {
      * @param state
      * @hidden
      */
-    setAccountCache(account: Account, state: string) {
+    setAccountCache(account: Account) {
         // Cache acquireTokenAccountKey
         const accountId = account && account.homeAccountIdentifier ? account.homeAccountIdentifier : Constants.NO_ACCOUNT;
 
-        const acquireTokenAccountKey = this.generateAcquireTokenAccountKey(accountId, state);
+        const acquireTokenAccountKey = this.generateAcquireTokenAccountKey(accountId);
         this.cacheStorage.setItem(acquireTokenAccountKey, JSON.stringify(account));
     }
 
@@ -76,11 +76,14 @@ export class CacheHelpers {
     updateCacheEntries(serverAuthenticationRequest: ServerCodeRequestParameters, account: Account): void {
         // Cache account and state
         if (account) {
-            this.setAccountCache(account, serverAuthenticationRequest.state);
+            this.setAccountCache(account);
         }
 
         // Cache the request state
         this.cacheStorage.setItem(TemporaryCacheKeys.REQUEST_STATE, serverAuthenticationRequest.state);
+
+        // Cache the nonce
+        this.cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${serverAuthenticationRequest.state}`, serverAuthenticationRequest.nonce);
 
         // Cache authorityKey
         this.setAuthorityCache(serverAuthenticationRequest.authorityInstance, serverAuthenticationRequest.state);

--- a/lib/msal-common/src/cache/CacheHelpers.ts
+++ b/lib/msal-common/src/cache/CacheHelpers.ts
@@ -34,6 +34,10 @@ export class CacheHelpers {
         return `${TemporaryCacheKeys.AUTHORITY}${Constants.RESOURCE_DELIM}${state}`;
     }
 
+    /**
+     * Create Nonce key to cache nonce
+     * @param state 
+     */
     generateNonceKey(state: string): string {
         return `${TemporaryCacheKeys.NONCE_IDTOKEN}${Constants.RESOURCE_DELIM}${state}`;
     }
@@ -87,7 +91,7 @@ export class CacheHelpers {
         this.cacheStorage.setItem(TemporaryCacheKeys.REQUEST_STATE, serverAuthenticationRequest.state);
 
         // Cache the nonce
-        this.cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${serverAuthenticationRequest.state}`, serverAuthenticationRequest.nonce);
+        this.cacheStorage.setItem(this.generateNonceKey(serverAuthenticationRequest.state), serverAuthenticationRequest.nonce);
 
         // Cache authorityKey
         this.setAuthorityCache(serverAuthenticationRequest.authorityInstance, serverAuthenticationRequest.state);

--- a/lib/msal-common/src/error/ClientAuthError.ts
+++ b/lib/msal-common/src/error/ClientAuthError.ts
@@ -4,6 +4,7 @@
  */
 
 import { AuthError } from "./AuthError";
+import { IdToken } from "../auth/IdToken";
 /**
  * ClientAuthErrorMessage class containing string constants used by error codes and messages.
  */
@@ -43,6 +44,18 @@ export const ClientAuthErrorMessage = {
     stateMismatchError: {
         code: "state_mismatch",
         desc: "State mismatch error. Please check your network. Continued requests may cause cache overflow."
+    },
+    nonceMismatchError: {
+        code: "nonce_mismatch",
+        desc: "Nonce mismatch error. Please check whether concurrent requests are causing this issue."
+    },
+    accountMismatchError: {
+        code: "account_mismatch",
+        desc: "The cached account and account which made the token request do not match."
+    },
+    invalidIdToken: {
+        code: "invalid_id_token",
+        desc: "Invalid ID token format."
     },
     authCodeNullOrEmptyError: {
         code: "auth_code_null_or_empty",
@@ -126,6 +139,26 @@ export class ClientAuthError extends AuthError {
      */
     static createStateMismatchError(): ClientAuthError {
         return new ClientAuthError(ClientAuthErrorMessage.stateMismatchError.code, ClientAuthErrorMessage.stateMismatchError.desc);
+    }
+
+    /**
+     * Creates an error thrown when the nonce does not match.
+     */
+    static createNonceMismatchError(): ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.nonceMismatchError.code, ClientAuthErrorMessage.nonceMismatchError.desc);
+    }
+
+    static createAccountMismatchError(): ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.accountMismatchError.code, ClientAuthErrorMessage.accountMismatchError.desc);
+    }
+
+    /**
+     * Throws error if idToken is not correctly formed
+     * @param idToken 
+     */
+    static createInvalidIdTokenError(idToken: IdToken) : ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.invalidIdToken.code,
+            `${ClientAuthErrorMessage.invalidIdToken.desc} Given token: ${idToken}`);
     }
 
     /**

--- a/lib/msal-common/src/error/ClientAuthError.ts
+++ b/lib/msal-common/src/error/ClientAuthError.ts
@@ -51,7 +51,7 @@ export const ClientAuthErrorMessage = {
     },
     nonceMismatchError: {
         code: "nonce_mismatch",
-        desc: "Nonce mismatch error. Please check whether concurrent requests are causing this issue."
+        desc: "Nonce mismatch error. This may be caused by a race condition in concurrent requests."
     },
     accountMismatchError: {
         code: "account_mismatch",

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -38,9 +38,9 @@ export class ResponseHandler {
             return originalResponse;
         }
     
-        const exp = Number(idTokenObj.claims.exp);
-        if (exp && !originalResponse.expiresOn) {
-            originalResponse.expiresOn = new Date(exp * 1000);
+        const expiresSeconds = Number(idTokenObj.claims.exp);
+        if (expiresSeconds && !originalResponse.expiresOn) {
+            originalResponse.expiresOn = new Date(expiresSeconds * 1000);
         }
     
         return {
@@ -114,7 +114,7 @@ export class ResponseHandler {
             const accountKey = this.cacheManager.generateAcquireTokenAccountKey(tokenResponse.account.homeAccountIdentifier);
             
             const cachedAccount = JSON.parse(this.cacheStorage.getItem(accountKey)) as Account;
-    
+
             if (!cachedAccount || Account.compareAccounts(cachedAccount, tokenResponse.account)) {
                 tokenResponse.accessToken = serverTokenResponse.access_token;
                 tokenResponse.refreshToken = serverTokenResponse.refresh_token;
@@ -123,7 +123,7 @@ export class ResponseHandler {
                 throw ClientAuthError.createAccountMismatchError();
             }
         }
-    
+
         // Return user set state in the response
         tokenResponse.userRequestState = ProtocolUtils.getUserRequestState(state);
         return tokenResponse;

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { IdToken } from "../auth/IdToken";
+import { CacheHelpers } from "../cache/CacheHelpers";
+import { ServerAuthorizationTokenResponse } from "../server/ServerAuthorizationTokenResponse";
+import { ScopeSet } from "../auth/ScopeSet";
+import { buildClientInfo } from "../auth/ClientInfo";
+import { Account } from "../auth/Account";
+import { ProtocolUtils } from "../utils/ProtocolUtils";
+import { ICrypto } from "../crypto/ICrypto";
+import { ICacheStorage } from "../cache/ICacheStorage";
+import { TokenResponse } from "./TokenResponse";
+import { PersistentCacheKeys } from "../utils/Constants";
+import { ClientAuthError } from "../error/ClientAuthError";
+
+/**
+ * Class that handles response parsing.
+ */
+export class ResponseHandler {
+    private clientId: string;
+    private cacheStorage: ICacheStorage;
+    private cacheManager: CacheHelpers;
+    private cryptoObj: ICrypto;
+
+    constructor(clientId: string, cacheStorage: ICacheStorage, cacheManager: CacheHelpers, cryptoObj: ICrypto) {
+        this.clientId = clientId;
+        this.cacheStorage = cacheStorage;
+        this.cacheManager = cacheManager;
+        this.cryptoObj = cryptoObj;
+    }
+
+    public setResponseIdToken(originalResponse: TokenResponse, idTokenObj: IdToken) : TokenResponse {
+        if (!originalResponse) {
+            return null;
+        } else if (!idTokenObj) {
+            return originalResponse;
+        }
+    
+        const exp = Number(idTokenObj.claims.exp);
+        if (exp && !originalResponse.expiresOn) {
+            originalResponse.expiresOn = new Date(exp * 1000);
+        }
+    
+        return {
+            ...originalResponse,
+            idToken: idTokenObj.rawIdToken,
+            idTokenClaims: idTokenObj.claims,
+            uniqueId: idTokenObj.claims.oid || idTokenObj.claims.sub,
+            tenantId: idTokenObj.claims.tid,
+        };
+    }
+    
+    public createTokenResponse(serverTokenResponse: ServerAuthorizationTokenResponse, state: string): TokenResponse {
+        let tokenResponse: TokenResponse = {
+            uniqueId: "",
+            tenantId: "",
+            tokenType: "",
+            idToken: null,
+            idTokenClaims: null,
+            accessToken: "",
+            refreshToken: "",
+            scopes: [],
+            expiresOn: null,
+            account: null,
+            userRequestState: ""
+        };
+        // Set consented scopes in response
+        const requestScopes = ScopeSet.fromString(serverTokenResponse.scope, this.clientId, false);
+        tokenResponse.scopes = requestScopes.asArray();
+    
+        // Retrieve current id token object
+        let idTokenObj: IdToken;
+        const cachedIdToken: string = this.cacheStorage.getItem(PersistentCacheKeys.ID_TOKEN);
+        if (serverTokenResponse.id_token) {
+            idTokenObj = new IdToken(serverTokenResponse.id_token, this.cryptoObj);
+            tokenResponse = this.setResponseIdToken(tokenResponse, idTokenObj);
+        } else if (cachedIdToken) {
+            idTokenObj = new IdToken(cachedIdToken, this.cryptoObj);
+            tokenResponse = this.setResponseIdToken(tokenResponse, idTokenObj);
+        } else {
+            // TODO: No account scenario?
+        }
+    
+        // check nonce integrity if idToken has nonce - throw an error if not matched
+        const nonce = this.cacheStorage.getItem(this.cacheManager.generateNonceKey(state));
+    
+        if (!idTokenObj || !idTokenObj.claims.nonce) {
+            throw ClientAuthError.createInvalidIdTokenError(idTokenObj);
+        }
+    
+        if (idTokenObj.claims.nonce !== nonce) {
+            throw ClientAuthError.createNonceMismatchError();
+        }
+    
+        // TODO: This will be used when saving tokens
+        // const authorityKey: string = this.cacheManager.generateAuthorityKey(state);
+        // const cachedAuthority: string = this.cacheStorage.getItem(authorityKey);
+    
+        // TODO: Save id token here
+        
+        // Retrieve client info
+        const clientInfo = buildClientInfo(this.cacheStorage.getItem(PersistentCacheKeys.CLIENT_INFO), this.cryptoObj);
+    
+        // Create account object for request
+        tokenResponse.account = Account.createAccount(idTokenObj, clientInfo, this.cryptoObj);
+    
+        // Set token type
+        tokenResponse.tokenType = serverTokenResponse.token_type;
+    
+        // Save the access token if it exists
+        if (serverTokenResponse.access_token) {
+            const accountKey = this.cacheManager.generateAcquireTokenAccountKey(tokenResponse.account.homeAccountIdentifier);
+            
+            const cachedAccount = JSON.parse(this.cacheStorage.getItem(accountKey)) as Account;
+    
+            if (!cachedAccount || Account.compareAccounts(cachedAccount, tokenResponse.account)) {
+                tokenResponse.accessToken = serverTokenResponse.access_token;
+                tokenResponse.refreshToken = serverTokenResponse.refresh_token;
+                // TODO: Save the access token
+            } else {
+                throw ClientAuthError.createAccountMismatchError();
+            }
+        }
+    
+        // Return user set state in the response
+        tokenResponse.userRequestState = ProtocolUtils.getUserRequestState(state);
+        return tokenResponse;
+    }
+}

--- a/lib/msal-common/src/response/TokenResponse.ts
+++ b/lib/msal-common/src/response/TokenResponse.ts
@@ -6,7 +6,6 @@
 import { Account } from "../auth/Account";
 import { StringDict } from "../utils/MsalTypes";
 import { AuthResponse } from "./AuthResponse";
-import { IdToken } from "../auth/IdToken";
 
 /**
  * TokenResponse type returned by library containing id, access and/or refresh tokens.
@@ -32,24 +31,3 @@ export type TokenResponse = AuthResponse & {
     expiresOn: Date;
     account: Account;
 };
-
-export function setResponseIdToken(originalResponse: TokenResponse, idTokenObj: IdToken) : TokenResponse {
-    if (!originalResponse) {
-        return null;
-    } else if (!idTokenObj) {
-        return originalResponse;
-    }
-
-    const exp = Number(idTokenObj.claims.exp);
-    if (exp && !originalResponse.expiresOn) {
-        originalResponse.expiresOn = new Date(exp * 1000);
-    }
-
-    return {
-        ...originalResponse,
-        idToken: idTokenObj.rawIdToken,
-        idTokenClaims: idTokenObj.claims,
-        uniqueId: idTokenObj.claims.oid || idTokenObj.claims.sub,
-        tenantId: idTokenObj.claims.tid,
-    };
-}

--- a/lib/msal-common/src/response/TokenResponse.ts
+++ b/lib/msal-common/src/response/TokenResponse.ts
@@ -6,6 +6,7 @@
 import { Account } from "../auth/Account";
 import { StringDict } from "../utils/MsalTypes";
 import { AuthResponse } from "./AuthResponse";
+import { IdToken } from "../auth/IdToken";
 
 /**
  * TokenResponse type returned by library containing id, access and/or refresh tokens.
@@ -31,3 +32,24 @@ export type TokenResponse = AuthResponse & {
     expiresOn: Date;
     account: Account;
 };
+
+export function setResponseIdToken(originalResponse: TokenResponse, idTokenObj: IdToken) : TokenResponse {
+    if (!originalResponse) {
+        return null;
+    } else if (!idTokenObj) {
+        return originalResponse;
+    }
+
+    const exp = Number(idTokenObj.claims.exp);
+    if (exp && !originalResponse.expiresOn) {
+        originalResponse.expiresOn = new Date(exp * 1000);
+    }
+
+    return {
+        ...originalResponse,
+        idToken: idTokenObj.rawIdToken,
+        idTokenClaims: idTokenObj.claims,
+        uniqueId: idTokenObj.claims.oid || idTokenObj.claims.sub,
+        tenantId: idTokenObj.claims.tid,
+    };
+}

--- a/lib/msal-common/src/server/ServerAuthorizationCodeResponse.ts
+++ b/lib/msal-common/src/server/ServerAuthorizationCodeResponse.ts
@@ -12,6 +12,8 @@ import { ICrypto } from "../crypto/ICrypto";
  * - code: authorization code from server
  * - client_info: client info object
  * - state: OAuth2 request state
+ * - error: error sent back in hash
+ * - error: description
  */
 export type ServerAuthorizationCodeResponse = {
     code?: string;

--- a/lib/msal-common/src/server/ServerAuthorizationTokenResponse.ts
+++ b/lib/msal-common/src/server/ServerAuthorizationTokenResponse.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { ServerError } from "../error/ServerError";
+
+/**
+ * Deserialized response object from server authorization code request.
+ * - 
+ */
+export type ServerAuthorizationTokenResponse = {
+    // Success
+    token_type?: string;
+    scope?: string;
+    expires_in?: number;
+    ext_expires_in?: number;
+    access_token?: string;
+    refresh_token?: string;
+    id_token?: string;
+    // Error
+    error?: string;
+    error_description?: string;
+    error_codes?: Array<string>;
+    timestamp?: string;
+    trace_id?: string;
+    correlation_id?: string;
+};
+
+export function validateServerAuthorizationTokenResponse(serverResponse: ServerAuthorizationTokenResponse): void {
+    // Check for error
+    if (serverResponse.error || serverResponse.error_description) {
+        const errString = `${serverResponse.error_codes} - [${serverResponse.timestamp}]: ${serverResponse.error_description} - Correlation ID: ${serverResponse.correlation_id} - Trace ID: ${serverResponse.trace_id}`;
+        throw new ServerError(serverResponse.error, errString);
+    }
+}

--- a/lib/msal-common/src/server/ServerTokenRequestParameters.ts
+++ b/lib/msal-common/src/server/ServerTokenRequestParameters.ts
@@ -20,8 +20,7 @@ export class ServerTokenRequestParameters extends ServerRequestParameters {
 
         this.scopes = new ScopeSet(this.tokenRequest && this.tokenRequest.scopes, this.clientId, false);
 
-        const randomGuid = this.cryptoObj.createNewGuid();
-        this.state = ProtocolUtils.setRequestState(this.tokenRequest && this.tokenRequest.userRequestState, randomGuid);
+        this.state = tokenRequest.userRequestState;
 
         this.correlationId = this.tokenRequest.correlationId || this.cryptoObj.createNewGuid();
     }


### PR DESCRIPTION
This PR adds the response handling to the authorization code flow for single page applications.

This PR does NOT cover token caching or cache cleanup, those will be addressed in the next immediate PR. Please review PRs #1164 and #1181 before reviewing this PR.