### PR TITLE
Not Review Ready: Redirect API support for apps in iframes

### DIFF
--- a/lib/msal-core/src/Configuration.ts
+++ b/lib/msal-core/src/Configuration.ts
@@ -96,6 +96,17 @@ export type FrameworkOptions = {
 };
 
 /**
+ * Options to specify communication between embedded (iframed) apps and the Top Frame
+ *
+ * - topFrameOrigin             - origin check to restrict messages to the top frame origin only
+ * - embeddedFrameOrigin        - origin check to restrict messages to the top frame origin only
+ */
+export type BrokerOptions = {
+    topFrameOrigin?: string;
+    embeddedFrameOrigin?: string;
+};
+
+/**
  * Use the configuration object to configure MSAL and initialize the UserAgentApplication.
  *
  * This object allows you to configure important elements of MSAL functionality:
@@ -108,15 +119,16 @@ export type Configuration = {
     auth: AuthOptions,
     cache?: CacheOptions,
     system?: SystemOptions,
-    framework?: FrameworkOptions
+    framework?: FrameworkOptions,
+    broker?: BrokerOptions
 };
 
 const DEFAULT_AUTH_OPTIONS: AuthOptions = {
     clientId: "",
     authority: null,
     validateAuthority: true,
-    redirectUri: () => UrlUtils.getDefaultRedirectUri(),
-    postLogoutRedirectUri: () => UrlUtils.getDefaultRedirectUri(),
+    redirectUri: () => UrlUtils.getCurrentUrl(),
+    postLogoutRedirectUri: () => UrlUtils.getCurrentUrl(),
     navigateToLoginRequestUrl: true
 };
 
@@ -138,23 +150,30 @@ const DEFAULT_FRAMEWORK_OPTIONS: FrameworkOptions = {
     protectedResourceMap: new Map<string, Array<string>>()
 };
 
+const DEFAULT_BROKER_OPTIONS: BrokerOptions = {
+    topFrameOrigin: null,
+    embeddedFrameOrigin: null,
+};
+
 /**
  * MSAL function that sets the default options when not explicitly configured from app developer
  *
- * @param TAuthOptions
- * @param TCacheOptions
- * @param TSystemOptions
- * @param TFrameworkOptions
+ * @param AuthOptions
+ * @param CacheOptions
+ * @param SystemOptions
+ * @param FrameworkOptions
+ * @param BrokerOptions
  *
- * @returns TConfiguration object
+ * @returns Configuration object
  */
 
-export function buildConfiguration({ auth, cache = {}, system = {}, framework = {}}: Configuration): Configuration {
+export function buildConfiguration({ auth, cache = {}, system = {}, framework = {}, broker = {}}: Configuration): Configuration {
     const overlayedConfig: Configuration = {
         auth: { ...DEFAULT_AUTH_OPTIONS, ...auth },
         cache: { ...DEFAULT_CACHE_OPTIONS, ...cache },
         system: { ...DEFAULT_SYSTEM_OPTIONS, ...system },
-        framework: { ...DEFAULT_FRAMEWORK_OPTIONS, ...framework }
+        framework: { ...DEFAULT_FRAMEWORK_OPTIONS, ...framework },
+        broker: { ...DEFAULT_BROKER_OPTIONS, ...broker }
     };
     return overlayedConfig;
 }

--- a/lib/msal-core/src/messaging/MessageCache.ts
+++ b/lib/msal-core/src/messaging/MessageCache.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { MessageType } from "./MessageHelper";
+import { AuthCache } from "./../cache/AuthCache";
+
+/**
+ * Handles Message cache operations
+ * @hidden
+ */
+export class MessageCache {
+
+    private storage: AuthCache = null;
+
+    /**
+     * initialize the class with Storage type
+     * @param cacheStorage
+     */
+    constructor(cacheStorage: AuthCache) {
+        this.storage = cacheStorage;
+    }
+
+    /**
+     * Writes the message to the cache
+     * @param key
+     * @param data
+     */
+    write(key: MessageType, data: string) {
+        this.storage.setItem(key, data);
+    }
+
+    /**
+     * retrieves the message from the cache
+     * @param key
+     */
+    read(key: MessageType) {
+        return this.storage.getItem(key);
+    }
+
+    /**
+     * erase the message from the cache
+     * @param key
+     */
+    erase(key: MessageType) {
+        this.storage.removeItem(key);
+    }
+
+}

--- a/lib/msal-core/src/messaging/MessageDispatcher.ts
+++ b/lib/msal-core/src/messaging/MessageDispatcher.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Message } from "./MessageHelper";
+
+export class MessageDispatcher {
+
+    static dispatchMessage(target: Window, message: Message, originCheck?: string) {
+        target.postMessage(message, originCheck || "*");
+    }
+}

--- a/lib/msal-core/src/messaging/MessageHelper.ts
+++ b/lib/msal-core/src/messaging/MessageHelper.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { WindowUtils } from "./../utils/WindowUtils";
+import { MessageCache } from "./MessageCache";
+import { Logger } from "./../Logger";
+import { MessageDispatcher } from "./MessageDispatcher";
+
+// type of the message
+export enum MessageType {
+    REDIRECT_REQUEST = "redirect_request",
+    HASH = "hash",
+    URL_TOP_FRAME = "url_top_frame",
+    URL_NAVIGATE = "url_navigate"
+};
+
+// helps differentiate topframe and iframe context
+export enum WindowType {
+    TOP_FRAME,
+    IFRAME
+};
+
+// message payload
+export type Message = {
+    type: MessageType,
+    payload?: string
+};
+
+export class MessageHelper {
+
+    /**
+     * returns the current window type: Top Frame app or Iframed app
+     */
+    static currentWindow(): WindowType {
+        if(WindowUtils.isWindowOnTop())     {
+            return WindowType.TOP_FRAME;
+        }
+        else if(WindowUtils.isInIframe())   {
+            return WindowType.IFRAME;
+        }
+        return null;
+    }
+
+    /**
+     * Builds a message in the format: MESSAGE_SCHEMA
+     *
+     * @param messageType
+     * @param contentType
+     * @param messageData
+     */
+    static buildMessage(messageType: MessageType, messageData?: string): Message {
+        const message: Message = {
+            type: messageType,
+            payload: messageData
+        };
+
+        return message;
+    }
+
+    /**
+     * utility to handle redirect(302) from the service on behalf of the iframed application
+     *
+     * @param messageCache
+     * @param urlTopFrame
+     * @param urlHash
+     * @param logger
+     */
+    static handleTopFrameRedirect(messageCache: MessageCache, urlTopFrame: string, urlHash: string, logger: Logger) {
+        // write the hash to the cache of the redirect URI, clear the cache(and hence the state) for the Top Frame delegation indication
+        messageCache.write(MessageType.HASH, urlHash);
+        messageCache.erase(MessageType.URL_TOP_FRAME);
+
+        // navigate to the saved URL
+        WindowUtils.navigateWindow(urlTopFrame, logger);
+    }
+
+    /**
+     * Handle the redirect delegation at the topframe on behalf of the embedded (iframed) application
+     *
+     * @param messageCache
+     * @param urlNavigate
+     */
+    static redirectDelegationRequest(messageCache: MessageCache, urlNavigate: string, topFrameOrigin?: string) {
+        // save the URL to navigate in the cache and send a request to the topframe
+        messageCache.write(MessageType.URL_NAVIGATE, urlNavigate);
+
+        // dispatch the message to the top window to start redirect flow by delegation
+        const targetWindow = window.top;
+        const message: Message = MessageHelper.buildMessage(MessageType.REDIRECT_REQUEST);
+        MessageDispatcher.dispatchMessage(targetWindow, message, topFrameOrigin);
+    }
+}

--- a/lib/msal-core/src/messaging/MessageListener.ts
+++ b/lib/msal-core/src/messaging/MessageListener.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { WindowType, MessageHelper, Message, MessageType } from "./MessageHelper";
+import { WindowUtils } from "./../utils/WindowUtils";
+import { MessageCache } from "./MessageCache";
+import { MessageDispatcher } from "./MessageDispatcher";
+import { Logger } from "./../Logger";
+import { iframeRedirectCallback } from "./../UserAgentApplication";
+
+export class MessageListener {
+
+    private messageCache: MessageCache;
+    private logger: Logger;
+    private topFrameOrigin: string;
+    private embeddedFrameOrigin: string;
+    private iframeRedirectCallback: iframeRedirectCallback;
+
+    /**
+     * initialize the message listener, and register the callback to process messages
+     */
+    constructor(messageCache: MessageCache, logger: Logger, topFrameOrigin?: string, embeddedFrameOrigin?: string) {
+        this.messageCache = messageCache;
+        this.logger = logger;
+        this.topFrameOrigin = topFrameOrigin;
+        this.embeddedFrameOrigin = embeddedFrameOrigin;
+
+        // listen to all incoming messages
+        window.addEventListener("message", this.receiveMessage, false);
+    }
+
+    public setCallBack(callback: iframeRedirectCallback) {
+        this.iframeRedirectCallback = callback;
+    }
+
+    /**
+     * top frame application calls this function to ack to proceed
+     * @param message
+     */
+    processIframeRedirectCallback(url: string) {
+        return () => WindowUtils.navigateWindow(url, this.logger);
+    }
+
+    /**
+     * Parses the messages receieved
+     * This will be a unique handler per message, we will allow only one active request at a time
+     * @param event
+     */
+    private receiveMessage(event: any) {
+
+        const windowType = MessageHelper.currentWindow();
+        const receivedMessage: Message = { ...event.data};
+
+        switch(windowType) {
+
+            // Top framed application: handles the delegation on behalf of the iframed app
+            case WindowType.TOP_FRAME: {
+
+                switch(receivedMessage.type) {
+
+                    case MessageType.REDIRECT_REQUEST: {
+                        // acknowlege the redirect on behalf of the iframed app by sending the current location
+                        const message = MessageHelper.buildMessage(MessageType.URL_TOP_FRAME, window.location.href);
+                        MessageDispatcher.dispatchMessage(event.source, message, this.embeddedFrameOrigin);
+                        break;
+                    }
+
+                    case MessageType.URL_NAVIGATE: {
+                        // if the response is the URL to navigate for token acquisition, navigate to STS
+                        this.logger.info("navigating to the Service on behalf of the iframed app");
+
+                        if(this.iframeRedirectCallback) {
+                            this.iframeRedirectCallback(this.processIframeRedirectCallback(receivedMessage.payload));
+                        }
+                        else {
+                            WindowUtils.navigateWindow(receivedMessage.payload, this.logger);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            // embedded (in an iframe) application
+            case WindowType.IFRAME: {
+
+                // check the origin, should match window.top always; message channel may be more secure
+                if (window.top !== event.source) {
+                    this.logger.warning("The message origin is not verified");
+                    return;
+                }
+
+                switch(receivedMessage.type) {
+                    case MessageType.URL_TOP_FRAME: {
+                        // record the ack from the top frame - store the URL
+                        this.messageCache.write(MessageType.URL_TOP_FRAME, receivedMessage.payload);
+
+                        // respond with the URL to navigate for token acquisition
+                        const urlNavigate = this.messageCache.read(MessageType.URL_NAVIGATE);
+                        const message = MessageHelper.buildMessage(MessageType.URL_NAVIGATE, urlNavigate);
+                        MessageDispatcher.dispatchMessage(event.source, message, this.topFrameOrigin);
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+    }
+}

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -9,7 +9,6 @@ import { ServerRequestParameters } from "../ServerRequestParameters";
 import { ScopeSet } from "../ScopeSet";
 import { StringUtils } from "./StringUtils";
 import { CryptoUtils } from "./CryptoUtils";
-import { ClientConfigurationError } from "./../error/ClientConfigurationError";
 
 /**
  * @hidden
@@ -98,7 +97,7 @@ export class UrlUtils {
     /**
      * Returns current window URL as redirect uri
      */
-    static getDefaultRedirectUri(): string {
+    static getCurrentUrl(): string {
         return window.location.href.split("?")[0].split("#")[0];
     }
 

--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -3,6 +3,10 @@ import { UrlUtils } from "./UrlUtils";
 import { Logger } from "../Logger";
 import { AuthCache } from "../cache/AuthCache";
 import { TemporaryCacheKeys, Constants } from "../utils/Constants";
+import { StringUtils } from "./StringUtils";
+import { AuthError } from "./../error/AuthError";
+import { MessageCache } from "../messaging/MessageCache";
+import { MessageHelper } from "../messaging/MessageHelper";
 
 export class WindowUtils {
     /**
@@ -28,6 +32,15 @@ export class WindowUtils {
      */
     static isInPopup(): boolean {
         return !!(window.opener && window.opener !== window);
+    }
+
+    /**
+     * @hidden
+     * Checks if the current page is running in an iframe.
+     * @ignore
+     */
+    static isWindowOnTop(): boolean {
+        return window.top === window;
     }
 
     /**
@@ -242,6 +255,44 @@ export class WindowUtils {
             const splitCache = redirectCache.split(Constants.resourceDelimiter);
             const state = splitCache.length > 1 ? splitCache[splitCache.length-1]: null;
             cacheStorage.resetTempCacheItems(state);
+        }
+    }
+
+    /**
+     * @hidden
+     * Used to redirect the browser to the STS authorization endpoint
+     * @param {string} urlNavigate - URL of the authorization endpoint
+     */
+    static navigateWindow(urlNavigate: string, logger: Logger, popupWindow?: Window) {
+        // Navigate if valid URL
+        if (!StringUtils.isEmpty(urlNavigate)) {
+            const navigateWindow: Window = popupWindow ? popupWindow : window;
+            const logMessage: string = popupWindow ? "Navigated Popup window to:" + urlNavigate : "Navigate to:" + urlNavigate;
+            logger.infoPii(logMessage);
+            navigateWindow.location.replace(urlNavigate);
+        }
+        else {
+            logger.info("Navigate url is empty");
+            throw AuthError.createUnexpectedError("Navigate url is empty");
+        }
+    }
+
+    /**
+     * IFRAMEDAPPS: if we are redirecting in an iframe, post a message to the topFrame; else navigate to the popup Window
+     * @param popUpWindow
+     * @param urlNavigate
+     * @param messageCache
+     * @param logger
+     * @param topFrameOrigin
+     */
+    static navigateHelper(popUpWindow: Window, urlNavigate: string, messageCache: MessageCache, logger: Logger, topFrameOrigin?: string) {
+        // IFRAMEDAPPS: if we are redirecting in an iframe, post a message to the topFrame
+        if(WindowUtils.isInIframe() && !popUpWindow) {
+            MessageHelper.redirectDelegationRequest(messageCache, urlNavigate, topFrameOrigin);
+        }
+        // prompt user for interaction
+        else {
+            WindowUtils.navigateWindow(urlNavigate, logger, popUpWindow);
         }
     }
 }


### PR DESCRIPTION
This PR in conjunction with #939 provides an option for applications living out of an iframe to handle interactive requests using "redirect".

**Problem description:**
Some identity flows cannot be completed in an iframe. In particular:

- Credential Entry
- Consent

Clickjacking is an attack whereby a malicious site iframes a trusted site and displays it to the user while simultaneously providing a transparent iframe on top of the trusted site. This transparent iframe is invisible to the user, but is able to record keystrokes (e.g. the password). Alternatively, a malicious site can move the trusted iframes it shows, permitting them to always move the "Consent" button to directly under the users mouse. Without going into detail, the only mitigation here is to forbid iframes on these flows. Identity permits services to use iframes only in combination with prompt=none, which ensures that these flows are not hit.

These limitations placed by Identity Service block any user interaction in an iframe app. This effectively requires all applications to be able to use a top-frame (either the current frame or a pop-up frame) to solve user interaction required prompts.

To mitigate this and have applications perform authentication in iframes, we already added support for  `loginPopup()`, `acquireTokenPopup()` & `acquireTokenSilent()`.

#1201 (this PR) supports the `redirect` APIs: `loginRedirect()` and `acquireTokenRedirect()` by establishing a trusted relationship with the parent application (the top frame). As expanded above, the iframed application is prohibited from any interaction by microsoft identity service and hence this can be supported only with a trusted relationship with the parent application (which is a full window and hence can render interactive screens)

Detailed documentation on the protocol applied [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/files/4054744/RedirectIframes.pdf) will be published with the release of both these PRs.

This replaces #975 as the original merge was delayed in favor of doing this release in stages.