### PR TITLE
Update urlContainsHash() API as a public API as documented

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -277,6 +277,14 @@ export class UserAgentApplication {
         }
     }
 
+    /**
+     * Adding public interface for urlContainsHash
+     * @param hash
+     */
+    public urlContainsHash(hash: string) {
+        return UrlUtils.urlContainsHash(hash);
+    }
+
     private authResponseHandler(interactionType: InteractionType, response: AuthResponse, resolve?: any) : void {
         if (interactionType === Constants.interactionTypeRedirect) {
             if (this.errorReceivedCallback) {

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -278,7 +278,7 @@ export class UserAgentApplication {
     }
 
     /**
-     * Adding public interface for urlContainsHash
+     * Public API to verify if the URL contains the hash with known properties
      * @param hash
      */
     public urlContainsHash(hash: string) {


### PR DESCRIPTION
Fixes #1151; Add `urlContainsHash()` to the public interface as documented, instead of `isCallBack()`