### PR TITLE
Authorization Code Flow for Single Page Applications: Cleanup Popup Flows and Window Nav

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -146,14 +146,21 @@ export class PublicClientApplication {
             return;
         }
 
-        // Create redirect interaction handler.
-        const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.config.auth.navigateToLoginRequestUrl);
+        try {
+            // Create redirect interaction handler.
+            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.config.auth.navigateToLoginRequestUrl);
 
-        // Create login url, which will by default append the client id scope to the call.
-        this.authModule.createLoginUrl(request).then((navigateUrl) => {
-            // Show the UI once the url has been created. Response will come back in the hash, which will be handled in the handleRedirectCallback function.
-            interactionHandler.showUI(navigateUrl);
-        });
+            // Create login url, which will by default append the client id scope to the call.
+            this.authModule.createLoginUrl(request).then((navigateUrl) => {
+                // Show the UI once the url has been created. Response will come back in the hash, which will be handled in the handleRedirectCallback function.
+                interactionHandler.showUI(navigateUrl);
+            });
+        } catch (e) {
+            // Interaction is completed - remove interaction status.
+            this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
+            this.authModule.cancelRequest();
+            throw e;
+        }
     }
 
     /**
@@ -175,14 +182,22 @@ export class PublicClientApplication {
             return;
         }
 
-        // Create redirect interaction handler.
-        const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.config.auth.navigateToLoginRequestUrl);
-        // Create acquire token url.
-        this.authModule.createAcquireTokenUrl(request).then((navigateUrl) => {
-            // Show the UI once the url has been created. Response will come back in the hash, which will be handled in the handleRedirectCallback function.
-            interactionHandler.showUI(navigateUrl);
-        });
-    }
+        try {
+            // Create redirect interaction handler.
+            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.config.auth.navigateToLoginRequestUrl);
+
+            // Create acquire token url.
+            this.authModule.createAcquireTokenUrl(request).then((navigateUrl) => {
+                // Show the UI once the url has been created. Response will come back in the hash, which will be handled in the handleRedirectCallback function.
+                interactionHandler.showUI(navigateUrl);
+            });
+        } catch (e) {
+            // Interaction is completed - remove interaction status.
+            this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
+            this.authModule.cancelRequest();
+            throw e;
+        }
+     }
 
     // #endregion
 
@@ -243,6 +258,8 @@ export class PublicClientApplication {
             // Handle response from hash string.
             return interactionHandler.handleCodeResponse(hash);
         } catch (e) {
+            // Interaction is completed - remove interaction status.
+            this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
             this.authModule.cancelRequest();
             throw e;
         }

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -226,14 +226,19 @@ export class PublicClientApplication {
      * @param navigateUrl 
      */
     private async popupTokenHelper(navigateUrl: string): Promise<TokenResponse> {
-        // Create popup interaction handler.
-        const interactionHandler = new PopupHandler(this.authModule, this.browserStorage);
-        // Show the UI once the url has been created. Get the window handle for the popup.
-        const popupWindow = interactionHandler.showUI(navigateUrl);
-        // Monitor the window for the hash. Return the string value and close the popup when the hash is received. Default timeout is 60 seconds.
-        const hash = await interactionHandler.monitorWindowForHash(popupWindow, this.config.system.windowHashTimeout, navigateUrl);
-        // Handle response from hash string.
-        return interactionHandler.handleCodeResponse(hash);
+        try {
+            // Create popup interaction handler.
+            const interactionHandler = new PopupHandler(this.authModule, this.browserStorage);
+            // Show the UI once the url has been created. Get the window handle for the popup.
+            const popupWindow = interactionHandler.showUI(navigateUrl);
+            // Monitor the window for the hash. Return the string value and close the popup when the hash is received. Default timeout is 60 seconds.
+            const hash = await interactionHandler.monitorWindowForHash(popupWindow, this.config.system.windowHashTimeout, navigateUrl);
+            // Handle response from hash string.
+            return interactionHandler.handleCodeResponse(hash);
+        } catch (e) {
+            this.authModule.cancelRequest();
+            throw e;
+        }
     }
 
     // #region Silent Flow

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -197,7 +197,7 @@ export class PublicClientApplication {
             this.authModule.cancelRequest();
             throw e;
         }
-     }
+    }
 
     // #endregion
 

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -265,6 +265,8 @@ export class PublicClientApplication {
         }
     }
 
+    // #endregion
+
     // #region Silent Flow
 
     /**

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -120,9 +120,7 @@ export class PublicClientApplication {
                 const tokenResponse = await interactionHandler.handleCodeResponse(responseHash);
                 this.authCallback(null, tokenResponse);
             } else {
-                // Interaction is completed - remove interaction status.
-                this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
-                this.authModule.cancelRequest();
+                this.cleanRequest();
             }
         } catch (err) {
             this.authCallback(err);
@@ -156,9 +154,7 @@ export class PublicClientApplication {
                 interactionHandler.showUI(navigateUrl);
             });
         } catch (e) {
-            // Interaction is completed - remove interaction status.
-            this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
-            this.authModule.cancelRequest();
+            this.cleanRequest();
             throw e;
         }
     }
@@ -192,9 +188,7 @@ export class PublicClientApplication {
                 interactionHandler.showUI(navigateUrl);
             });
         } catch (e) {
-            // Interaction is completed - remove interaction status.
-            this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
-            this.authModule.cancelRequest();
+            this.cleanRequest();
             throw e;
         }
     }
@@ -258,9 +252,7 @@ export class PublicClientApplication {
             // Handle response from hash string.
             return interactionHandler.handleCodeResponse(hash);
         } catch (e) {
-            // Interaction is completed - remove interaction status.
-            this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
-            this.authModule.cancelRequest();
+            this.cleanRequest();
             throw e;
         }
     }
@@ -340,9 +332,21 @@ export class PublicClientApplication {
 
     // #region Helpers
 
+    /**
+     * Helper to check whether interaction is in progress
+     */
     private interactionInProgress(): boolean {
         // Check whether value in cache is present and equal to expected value
         return this.browserStorage.getItem(BrowserConstants.INTERACTION_STATUS_KEY) === BrowserConstants.INTERACTION_IN_PROGRESS_VALUE;
+    }
+
+    /**
+     * Helper to remove interaction status and remove tempoarary request data.
+     */
+    private cleanRequest(): void {
+        // Interaction is completed - remove interaction status.
+        this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
+        this.authModule.cancelRequest();
     }
 
     // #endregion

--- a/lib/msal-browser/src/interaction_handler/PopupHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/PopupHandler.ts
@@ -72,6 +72,8 @@ export class PopupHandler extends InteractionHandler {
 
             const intervalId = setInterval(() => {
                 if (contentWindow.closed) {
+                    // Interaction is completed - remove interaction status.
+                    this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
                     clearInterval(intervalId);
                     reject(BrowserAuthError.createUserCancelledError());
                     return;
@@ -99,9 +101,12 @@ export class PopupHandler extends InteractionHandler {
                     clearInterval(intervalId);
                     resolve(contentWindow.location.hash);
                 } else if (ticks > maxTicks) {
+                    // Interaction is completed - remove interaction status.
+                    this.browserStorage.removeItem(BrowserConstants.INTERACTION_STATUS_KEY);
                     clearInterval(intervalId);
                     contentWindow.close();
-                    reject(BrowserAuthError.createPopupWindowTimeoutError(urlNavigate)); // better error?
+                    reject(BrowserAuthError.createPopupWindowTimeoutError(urlNavigate));
+                    return;
                 }
             }, BrowserConstants.POPUP_POLL_INTERVAL_MS);
         });

--- a/lib/msal-browser/src/interaction_handler/PopupHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/PopupHandler.ts
@@ -72,6 +72,7 @@ export class PopupHandler extends InteractionHandler {
 
             const intervalId = setInterval(() => {
                 if (contentWindow.closed) {
+                    // Window is closed
                     this.cleanPopup();
                     clearInterval(intervalId);
                     reject(BrowserAuthError.createUserCancelledError());
@@ -97,12 +98,14 @@ export class PopupHandler extends InteractionHandler {
                 ticks++;
 
                 if (UrlString.hashContainsKnownProperties(href)) {
+                    // Success case
                     const contentHash = contentWindow.location.hash;
                     this.cleanPopup(contentWindow);
                     clearInterval(intervalId);
                     resolve(contentHash);
                     return;
                 } else if (ticks > maxTicks) {
+                    // Timeout error
                     this.cleanPopup(contentWindow);
                     clearInterval(intervalId);
                     reject(BrowserAuthError.createPopupWindowTimeoutError(urlNavigate));

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -273,7 +273,7 @@ export class AuthorizationCodeModule extends AuthModule {
     }
 
     /**
-     * 
+     * Clears cache of items related to current request.
      */
     public cancelRequest(): void {
         const cachedState = this.cacheStorage.getItem(TemporaryCacheKeys.REQUEST_STATE);

--- a/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
+++ b/lib/msal-common/src/app/module/AuthorizationCodeModule.ts
@@ -272,6 +272,14 @@ export class AuthorizationCodeModule extends AuthModule {
         }
     }
 
+    /**
+     * 
+     */
+    public cancelRequest(): void {
+        const cachedState = this.cacheStorage.getItem(TemporaryCacheKeys.REQUEST_STATE);
+        this.cacheManager.resetTempCacheItems(cachedState || "");
+    }
+
     // #region Logout
 
     /**

--- a/lib/msal-common/src/cache/CacheHelpers.ts
+++ b/lib/msal-common/src/cache/CacheHelpers.ts
@@ -112,6 +112,7 @@ export class CacheHelpers {
         });
         // delete generic interactive request parameters
         this.cacheStorage.removeItem(TemporaryCacheKeys.REQUEST_STATE);
+        this.cacheStorage.removeItem(TemporaryCacheKeys.REQUEST_PARAMS);
         this.cacheStorage.removeItem(TemporaryCacheKeys.ORIGIN_URI);
         this.cacheStorage.removeItem(TemporaryCacheKeys.REDIRECT_REQUEST);
     }

--- a/lib/msal-common/test/app/config/PublicClientSPAConfiguration.spec.ts
+++ b/lib/msal-common/test/app/config/PublicClientSPAConfiguration.spec.ts
@@ -11,7 +11,7 @@ import { LogLevel } from "../../../src/logger/Logger";
 
 describe("PublicClientSPAConfiguration.ts Class Unit Tests", () => {
 
-    it("buildConfiguration assigns default functions", async () => {
+    it("buildPublicClientSPAConfiguration assigns default functions", async () => {
         let emptyConfig: PublicClientSPAConfiguration = buildPublicClientSPAConfiguration({auth: null});
         // Auth config checks
         expect(emptyConfig.auth).to.be.not.null;
@@ -86,7 +86,7 @@ describe("PublicClientSPAConfiguration.ts Class Unit Tests", () => {
     };
 
     const testKeySet = ["testKey1", "testKey2"];
-    it("buildConfiguration correctly assigns new values", () => {
+    it("buildPublicClientSPAConfiguration correctly assigns new values", () => {
         let newConfig: PublicClientSPAConfiguration = buildPublicClientSPAConfiguration({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,

--- a/lib/msal-common/test/app/module/AuthModule.spec.ts
+++ b/lib/msal-common/test/app/module/AuthModule.spec.ts
@@ -6,7 +6,6 @@ chai.use(chaiAsPromised);
 import { AuthModule } from "../../../src/app/module/AuthModule";
 import { ModuleConfiguration } from "../../../src/app/config/ModuleConfiguration";
 import { AuthenticationParameters } from "../../../src/request/AuthenticationParameters";
-import { TEST_HASHES } from "../../utils/StringConstants";
 import { TokenResponse } from "../../../src/response/TokenResponse";
 import { CodeResponse } from "../../../src/response/CodeResponse";
 import { TokenRenewParameters } from "../../../src/request/TokenRenewParameters";
@@ -59,9 +58,12 @@ describe("AuthModule.ts Class Unit Tests", () => {
             expect(authModule).to.be.not.null;
             expect(authModule instanceof AuthModule).to.be.true;
         });
+    });
 
-        it("Handles the authentication response - currently return null", () => {
-            expect(() => authModule.handleFragmentResponse(TEST_HASHES.TEST_SUCCESS_ID_TOKEN_HASH)).to.throw("Method not implemented");
-        }) 
+    describe("getAccount()", () => {
+
+        it("returns null if nothing is in the cache", () => {
+
+        });
     });
 });

--- a/samples/VanillaJSTestApp/index_authCode.html
+++ b/samples/VanillaJSTestApp/index_authCode.html
@@ -41,7 +41,7 @@
     };
 
     const tokenRequest = {
-        scopes: ["Mail.Read"],
+        scopes: ["User.Read"],
         forceRefresh: true
     };
 
@@ -53,11 +53,15 @@
     // instantiate MSAL
     const myMSALObj = new msal.PublicClientApplication(msalConfig);
     // register callback for redirect usecases
-    myMSALObj.handleRedirectCallback(authRedirectCallBack);
+    // myMSALObj.handleRedirectCallback(authRedirectCallBack);
     // signin and acquire a token silently with POPUP flow. Fall back in case of failure with silent acquisition to popup
     function signIn() {
         try {
-            myMSALObj.loginRedirect(loginRequest);
+            myMSALObj.loginPopup(loginRequest).then(tokenResponse => {
+                console.log("Response: " + JSON.stringify(tokenResponse));
+            }).catch(error => {
+                console.error("Auth Error: " + error);
+            });
         } catch (e) {
             console.log(e);
         }


### PR DESCRIPTION
This PR adds cleanup for different popup related errors, as well as window navigation actions such as redirect and refresh. This does not affect token acquisition, but does force users to be aware that handleRedirectCallback() should not be used with the popup APIs, as it will cause the window to handle the response in the popup, rather than the main window.

This should fix the issue raised in #1231.