### PR TITLE
Add setLogger function to allow dynamically setting logger callback

### DIFF
--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -165,10 +165,6 @@ export class MsalService extends UserAgentApplication {
         });
     }
 
-    public getLogger(): Logger {
-        return super.getLogger();
-    }
-
     public getScopesForEndpoint(endpoint: string): string[] {
         return super.getScopesForEndpoint(endpoint);
     }

--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "1.2.1",
+  "version": "1.2.2-beta.0",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",

--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "1.2.2-beta.0",
+  "version": "1.2.1",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1899,7 +1899,15 @@ export class UserAgentApplication {
      * returns the logger handle
      */
     protected getLogger() {
-        return this.config.system.logger;
+        return this.logger;
+    }
+
+    /**
+     * Sets the logger callback.
+     * @param logger Logger callback
+     */
+    setLogger(logger: Logger) {
+        this.logger = logger;
     }
 
     // #endregion

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1898,7 +1898,7 @@ export class UserAgentApplication {
      *
      * returns the logger handle
      */
-    protected getLogger() {
+    getLogger() {
         return this.logger;
     }
 

--- a/lib/msal-core/src/utils/CryptoUtils.ts
+++ b/lib/msal-core/src/utils/CryptoUtils.ts
@@ -9,7 +9,7 @@
 export class CryptoUtils {
 
     /**
-     * Creates a new random GUID - used to populate state?
+     * Creates a new random GUID
      * @returns string (GUID)
      */
     static createNewGuid(): string {

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -12,7 +12,10 @@ import {
     ServerError,
     Authority,
     AuthResponse,
-    InteractionRequiredAuthError
+    InteractionRequiredAuthError,
+    Logger,
+    CryptoUtils,
+    LogLevel
 } from "../src/index";
 import sinon from "sinon";
 import { ITenantDiscoveryResponse } from "../src/authority/ITenantDiscoveryResponse";
@@ -1580,4 +1583,39 @@ describe("UserAgentApplication.ts Class", function () {
             };
         });
     });
+
+    describe('Logger', () => {
+        it('getLogger and setLogger', done => {
+            const config: Configuration = {
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    redirectUri: TEST_URIS.TEST_REDIR_URI
+                }
+            };
+
+            msal = new UserAgentApplication(config);
+
+            const correlationId = CryptoUtils.createNewGuid();
+
+            const logger = new Logger((level, message, containsPii) => {
+                expect(message).to.contain('Message');
+                expect(message).to.contain(correlationId);
+                expect(message).to.contain(LogLevel.Info);
+
+                expect(level).to.equal(LogLevel.Info);
+                expect(containsPii).to.be.false;
+
+                done();
+            }, {
+                correlationId,
+                piiLoggingEnabled: false
+            });
+
+            msal.setLogger(logger);
+
+            expect(msal.getLogger()).to.equal(logger);
+
+            msal.getLogger().info('Message');
+        });
+    })
 });

--- a/samples/angular6-sample-app/src/app/app.component.ts
+++ b/samples/angular6-sample-app/src/app/app.component.ts
@@ -1,12 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BroadcastService, MsalService } from '@azure/msal-angular';
+import { Logger, CryptoUtils } from 'msal';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'MSAL - Angular 6 Sample App';
   isIframe = false;
   loggedIn = false;
@@ -30,6 +31,13 @@ export class AppComponent {
 
       console.log('Redirect Success: ', response.accessToken);
     });
+
+    this.authService.setLogger(new Logger((logLevel, message, piiEnabled) => {
+      console.log('MSAL Logging: ', message);
+    }, {
+      correlationId: CryptoUtils.createNewGuid(),
+      piiLoggingEnabled: false
+    }));
   }
 
   checkoutAccount() {

--- a/samples/angular6-sample-app/src/app/app.module.ts
+++ b/samples/angular6-sample-app/src/app/app.module.ts
@@ -6,16 +6,11 @@ import { NgModule } from '@angular/core';
 import { MatToolbarModule, MatButtonModule, MatListModule } from '@angular/material';
 
 import { MsalModule, MsalInterceptor } from '@azure/msal-angular';
-import { Logger } from "msal";
 
 import { AppComponent } from './app.component';
 import { appRoutes } from './app.routes';
 import { ProfileComponent } from './profile/profile.component';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
-
-export function loggerCallback(logLevel, message, piiEnabled) {
-  console.log("client logging: " + message);
-}
 
 export const protectedResourceMap: [string, string[]][] = [
   ['https://graph.microsoft.com/v1.0/me', ['user.read']]
@@ -53,12 +48,6 @@ const isIE = window.navigator.userAgent.indexOf("MSIE ") > -1 || window.navigato
         unprotectedResources: ["https://www.microsoft.com/en-us/"],
         protectedResourceMap: new Map(protectedResourceMap)
       },
-      system: {
-        logger: new Logger(loggerCallback, {
-          correlationId: '1234',
-          piiLoggingEnabled: true
-        })
-      }
     },
       {
         popUp: !isIE,

--- a/samples/angular7-sample-app/src/app/app.component.ts
+++ b/samples/angular7-sample-app/src/app/app.component.ts
@@ -1,12 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BroadcastService, MsalService } from '@azure/msal-angular';
+import { Logger, CryptoUtils } from 'msal';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'MSAL - Angular 7 Sample App';
   isIframe = false;
   loggedIn = false;
@@ -30,6 +31,13 @@ export class AppComponent {
 
       console.log('Redirect Success: ', response.accessToken);
     });
+
+    this.authService.setLogger(new Logger((logLevel, message, piiEnabled) => {
+      console.log('MSAL Logging: ', message);
+    }, {
+      correlationId: CryptoUtils.createNewGuid(),
+      piiLoggingEnabled: false
+    }));
   }
 
   checkoutAccount() {

--- a/samples/angular7-sample-app/src/app/app.module.ts
+++ b/samples/angular7-sample-app/src/app/app.module.ts
@@ -9,12 +9,7 @@ import { AppComponent } from './app.component';
 import { ProfileComponent } from './profile/profile.component';
 
 import { MsalModule, MsalInterceptor } from '@azure/msal-angular';
-import { Logger } from "msal";
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
-
-export function loggerCallback(logLevel, message, piiEnabled) {
-  console.log("client logging: " + message);
-}
 
 export const protectedResourceMap: [string, string[]][] = [
   ['https://graph.microsoft.com/v1.0/me', ['user.read']]
@@ -52,12 +47,6 @@ const isIE = window.navigator.userAgent.indexOf("MSIE ") > -1 || window.navigato
         unprotectedResources: ["https://www.microsoft.com/en-us/"],
         protectedResourceMap: new Map(protectedResourceMap)
       },
-      system: {
-        logger: new Logger(loggerCallback, {
-          correlationId: '1234',
-          piiLoggingEnabled: true
-        })
-      }
     },
       {
         popUp: !isIE,

--- a/samples/angular8-sample-app/src/app/app.component.ts
+++ b/samples/angular8-sample-app/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { BroadcastService, MsalService } from '@azure/msal-angular';
+import { Logger, CryptoUtils } from 'msal';
 
 
 @Component({
@@ -31,6 +32,13 @@ export class AppComponent implements OnInit {
 
       console.log('Redirect Success: ', response.accessToken);
     });
+
+    this.authService.setLogger(new Logger((logLevel, message, piiEnabled) => {
+      console.log('MSAL Logging: ', message);
+    }, {
+      correlationId: CryptoUtils.createNewGuid(),
+      piiLoggingEnabled: false
+    }));
   }
 
   checkoutAccount() {

--- a/samples/angular8-sample-app/src/app/app.module.ts
+++ b/samples/angular8-sample-app/src/app/app.module.ts
@@ -10,12 +10,7 @@ import { ProfileComponent } from './profile/profile.component';
 
 
 import { MsalModule, MsalInterceptor } from '@azure/msal-angular';
-import { Logger } from "msal";
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
-
-export function loggerCallback(logLevel, message, piiEnabled) {
-  console.log("client logging: " + message);
-}
 
 export const protectedResourceMap: [string, string[]][] = [
   ['https://graph.microsoft.com/v1.0/me', ['user.read']]
@@ -54,12 +49,6 @@ const isIE = window.navigator.userAgent.indexOf("MSIE ") > -1 || window.navigato
         unprotectedResources: ["https://www.microsoft.com/en-us/"],
         protectedResourceMap: new Map(protectedResourceMap)
       },
-      system: {
-        logger: new Logger(loggerCallback, {
-          correlationId: '1234',
-          piiLoggingEnabled: true
-        })
-      }
     },
       {
         popUp: !isIE,


### PR DESCRIPTION
In Angular, function calls are not allowed in decorators when running in `aot` mode. This means if you call `new Logger`, Angular will throw the following error (as reported in #1213):

```
ERROR in src/app/app.module.ts(58,21): Error during template compile of 'AppModule'
  Function calls are not supported in decorators but 'Logger' was called.
```

Adding a `setLogger` function to `UserAgentApplication` mitigates this:

```js
    this.authService.setLogger(new Logger((logLevel, message, piiEnabled) => {
      console.log('MSAL Logging: ', message);
    }, {
      correlationId: CryptoUtils.createNewGuid(),
      piiLoggingEnabled: false
    }));
```