### PR TITLE
render iframe synchronously if the user sets zero navigateToFrame time

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -793,8 +793,8 @@ export class UserAgentApplication {
 
         // render the iframe synchronously if app chooses no timeout, else wait for the set timer to expire
         const iframe: HTMLIFrameElement = this.config.system.navigateFrameWait ?
-            WindowUtils.loadFrameSync(urlNavigate, frameName, this.logger):
-            await WindowUtils.loadFrame(urlNavigate, frameName, this.config.system.navigateFrameWait, this.logger);
+            await WindowUtils.loadFrame(urlNavigate, frameName, this.config.system.navigateFrameWait, this.logger):
+            WindowUtils.loadFrameSync(urlNavigate, frameName, this.logger);
 
         try {
             const hash = await WindowUtils.monitorWindowForHash(iframe.contentWindow, this.config.system.loadFrameTimeout, urlNavigate);

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -792,13 +792,9 @@ export class UserAgentApplication {
         this.cacheStorage.setItem(`${TemporaryCacheKeys.RENEW_STATUS}${Constants.resourceDelimiter}${expectedState}`, Constants.inProgress);
 
         // render the iframe synchronously if app chooses no timeout, else wait for the set timer to expire
-        let iframe: HTMLIFrameElement;
-        if(this.config.system.navigateFrameWait == 0) {
-            iframe = WindowUtils.syncLoadFrame(urlNavigate, frameName, this.logger);
-        }
-        else {
-            iframe = await WindowUtils.loadFrame(urlNavigate, frameName, this.config.system.navigateFrameWait, this.logger);
-        }
+        const iframe: HTMLIFrameElement = this.config.system.navigateFrameWait ?
+            WindowUtils.loadFrameSync(urlNavigate, frameName, this.logger):
+            await WindowUtils.loadFrame(urlNavigate, frameName, this.config.system.navigateFrameWait, this.logger);
 
         try {
             const hash = await WindowUtils.monitorWindowForHash(iframe.contentWindow, this.config.system.loadFrameTimeout, urlNavigate);

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -791,7 +791,14 @@ export class UserAgentApplication {
         this.logger.verbose("Set loading state to pending for: " + scope + ":" + expectedState);
         this.cacheStorage.setItem(`${TemporaryCacheKeys.RENEW_STATUS}${Constants.resourceDelimiter}${expectedState}`, Constants.inProgress);
 
-        const iframe = await WindowUtils.loadFrame(urlNavigate, frameName, this.config.system.navigateFrameWait, this.logger);
+        // render the iframe synchronously if app chooses no timeout, else wait for the set timer to expire
+        let iframe: HTMLIFrameElement;
+        if(this.config.system.navigateFrameWait == 0) {
+            iframe = WindowUtils.syncLoadFrame(urlNavigate, frameName, this.logger);
+        }
+        else {
+            iframe = await WindowUtils.loadFrame(urlNavigate, frameName, this.config.system.navigateFrameWait, this.logger);
+        }
 
         try {
             const hash = await WindowUtils.monitorWindowForHash(iframe.contentWindow, this.config.system.loadFrameTimeout, urlNavigate);

--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -109,6 +109,23 @@ export class WindowUtils {
 
     /**
      * @hidden
+     * Loads the iframe synchronously when the navigateTimeFrame is set to `0`
+     * @param urlNavigate
+     * @param frameName
+     * @param logger
+     */
+    static syncLoadFrame(urlNavigate: string, frameName: string, logger: Logger): HTMLIFrameElement{
+        const frameHandle = WindowUtils.addHiddenIFrame(frameName, logger);
+        if (frameHandle.src === "" || frameHandle.src === "about:blank") {
+            frameHandle.src = urlNavigate;
+            logger.infoPii("Frame Name : " + frameName + " Navigated to: " + urlNavigate);
+        }
+
+        return frameHandle;
+    }
+
+    /**
+     * @hidden
      * Adds the hidden iframe for silent token renewal.
      * @ignore
      */

--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -90,16 +90,11 @@ export class WindowUtils {
 
         return new Promise((resolve, reject) => {
             setTimeout(() => {
-                const frameHandle = WindowUtils.addHiddenIFrame(frameName, logger);
+                const frameHandle = this.loadFrameSync(urlNavigate, frameName, logger);
 
                 if (!frameHandle) {
                     reject(`Unable to load iframe with name: ${frameName}`);
                     return;
-                }
-
-                if (frameHandle.src === "" || frameHandle.src === "about:blank") {
-                    frameHandle.src = urlNavigate;
-                    logger.infoPii("Frame Name : " + frameName + " Navigated to: " + urlNavigate);
                 }
 
                 resolve(frameHandle);
@@ -114,9 +109,14 @@ export class WindowUtils {
      * @param frameName
      * @param logger
      */
-    static syncLoadFrame(urlNavigate: string, frameName: string, logger: Logger): HTMLIFrameElement{
+    static loadFrameSync(urlNavigate: string, frameName: string, logger: Logger): HTMLIFrameElement{
         const frameHandle = WindowUtils.addHiddenIFrame(frameName, logger);
-        if (frameHandle.src === "" || frameHandle.src === "about:blank") {
+
+        // returning to handle null in loadFrame, also to avoid null object access errors
+        if (!frameHandle) {
+            return null;
+        }
+        else if (frameHandle.src === "" || frameHandle.src === "about:blank") {
             frameHandle.src = urlNavigate;
             logger.infoPii("Frame Name : " + frameName + " Navigated to: " + urlNavigate);
         }


### PR DESCRIPTION
Eliminate setTimeOut() calls when a user sets `navigateFrameWait` in `msal` config  to `0` to improve performance.

Currently MSAL JS while loading iframes for silent calls always makes an async call to `loadFrame` and slowing down performance intensive apps. This is introduced for IE which requires delay in loading a frame and the modern browsers seem to do alright with no time out (feedback from users who have this in production).

This PR would thus allow for better perf by eliminating the asynchronous call for the modern browsers when the timeout is set to `0`