### PR TITLE
Default unprotectedResources to empty array to fix error when it is undefined/null

### DIFF
--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -72,7 +72,7 @@ export class MsalService extends UserAgentApplication {
     }
 
     private isUnprotectedResource(url: string): boolean {
-        const unprotectedResources = (this.msalConfig.framework && this.msalConfig.framework.unprotectedResources) || this.msalAngularConfig.unprotectedResources;
+        const unprotectedResources = (this.msalConfig.framework && this.msalConfig.framework.unprotectedResources) || this.msalAngularConfig.unprotectedResources || [];
 
         return unprotectedResources.some(resource => url.indexOf(resource) > -1);
     }

--- a/lib/msal-angular/tests/MSALSpec.ts
+++ b/lib/msal-angular/tests/MSALSpec.ts
@@ -51,7 +51,6 @@ describe('Msal Angular Pubic API tests', function () {
                     useValue: {
                         popUp: false,
                         consentScopes: ["user.read", "mail.send"],
-                        unprotectedResources: ["https://google.com"],
                         protectedResourceMap: [
                             ["https://graph.microsoft.com/v1.0/me", ["user.read"]]
                         ]


### PR DESCRIPTION
If `unprotectedResources` is not provided, `unprotectedResources.some` throws an exception. This will make sure it defaults to an empty array if null/undefined.