### PR TITLE
Feature: Allow MSAL Configuration to be set at runtime

### DIFF
--- a/lib/msal-angular/src/msal.module.ts
+++ b/lib/msal-angular/src/msal.module.ts
@@ -5,7 +5,6 @@ import { MsalService, MSAL_CONFIG} from "./msal.service";
 import {MsalGuard} from "./msal-guard.service";
 import {BroadcastService} from "./broadcast.service";
 
-
 Injectable()
 export class WindowWrapper extends Window {
 
@@ -18,11 +17,17 @@ export class WindowWrapper extends Window {
   providers: [MsalGuard, BroadcastService],
 })
 export class MsalModule {
-   static forRoot(config: MsalConfig ): ModuleWithProviders {
+   static forRoot(config: (MsalConfig | (() => MsalConfig))): ModuleWithProviders {
     return {
       ngModule: MsalModule,
       providers: [
-          {provide: MSAL_CONFIG, useValue: config} ,   MsalService ,{provide :WindowWrapper, useValue: window}
+        {
+            provide: MSAL_CONFIG,
+            useValue: typeof config === 'function' ? undefined : config,
+            useFactory: typeof config === 'function' ? config : undefined,
+        },
+        MsalService ,
+        {provide :WindowWrapper, useValue: window}
       ]
     }
   }


### PR DESCRIPTION
Currently module configuration can only be set at compile time. There
are instances when configuration settings are loaded dynamically and
cannot be set after the module has already been imported in AoT mode.
Allowing the config to be a static object or a function will let the
configuration token to be set after the application has already been
compiled.