### PR TITLE
Fixing navigateToLoginRequestUrl in Auth Code Library

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -114,8 +114,19 @@ export class PublicClientApplication {
         const cachedHash = this.browserStorage.getItem(TemporaryCacheKeys.URL_HASH);
         try {
             // If hash exists, handle in window. Otherwise, cancel any current requests and continue.
-            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.config.auth.navigateToLoginRequestUrl);
-            const responseHash = UrlString.hashContainsKnownProperties(hash) ? hash : cachedHash;
+            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage);
+            let responseHash: string;
+            if (this.config.auth.navigateToLoginRequestUrl && UrlString.hashContainsKnownProperties(hash)) {
+                this.browserStorage.setItem(TemporaryCacheKeys.URL_HASH, hash);
+                interactionHandler.navigateToRequestUrl();
+                return;
+            } else if (!this.config.auth.navigateToLoginRequestUrl) {
+                responseHash = UrlString.hashContainsKnownProperties(hash) ? hash : cachedHash;
+                window.location.hash = "";
+            } else {
+                responseHash = cachedHash;
+            }
+
             if (responseHash) {
                 const tokenResponse = await interactionHandler.handleCodeResponse(responseHash);
                 this.authCallback(null, tokenResponse);
@@ -146,7 +157,7 @@ export class PublicClientApplication {
 
         try {
             // Create redirect interaction handler.
-            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.config.auth.navigateToLoginRequestUrl);
+            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage);
 
             // Create login url, which will by default append the client id scope to the call.
             this.authModule.createLoginUrl(request).then((navigateUrl) => {
@@ -180,7 +191,7 @@ export class PublicClientApplication {
 
         try {
             // Create redirect interaction handler.
-            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage, this.config.auth.navigateToLoginRequestUrl);
+            const interactionHandler = new RedirectHandler(this.authModule, this.browserStorage);
 
             // Create acquire token url.
             this.authModule.createAcquireTokenUrl(request).then((navigateUrl) => {

--- a/lib/msal-common/rollup.config.js
+++ b/lib/msal-common/rollup.config.js
@@ -26,7 +26,7 @@ export default [
             {
                 file: "./lib/msal-common.js",
                 format: "umd",
-                name: "msal",
+                name: "msal-common",
                 banner: fileHeader,
                 sourcemap: "inline"
             }
@@ -49,7 +49,7 @@ export default [
             {
                 file: "./lib/msal-common.min.js",
                 format: "umd",
-                name: "msal",
+                name: "msal-common",
                 banner: useStrictHeader,
                 sourcemap: true
             }

--- a/lib/msal-common/src/cache/CacheHelpers.ts
+++ b/lib/msal-common/src/cache/CacheHelpers.ts
@@ -165,9 +165,17 @@ export class CacheHelpers {
         });
     }
 
+    /**
+     * Checks that any parameters are exact matches for key value, since key.match in the above functions only do contains checks, not exact matches.
+     * @param atKey 
+     * @param clientId 
+     * @param authority 
+     * @param resource 
+     * @param homeAccountIdentifier 
+     */
     private checkForExactKeyMatch(atKey: AccessTokenKey, clientId: string, authority: string, resource?: string, homeAccountIdentifier?: string): boolean {
         const hasClientId = (atKey.clientId === clientId);
-        const hasAuthorityUri = (atKey.authority === authority);
+        const hasAuthorityUri = !StringUtils.isEmpty(authority) ? (atKey.authority === authority) : true;
         const hasResourceUri = !StringUtils.isEmpty(resource) ? (atKey.resource === resource) : true;
         const hasHomeAccountId = !StringUtils.isEmpty(homeAccountIdentifier) ? (atKey.homeAccountIdentifier === homeAccountIdentifier) : true;
 


### PR DESCRIPTION
This PR fixes an issue with looping redirects during the navigateToLoginRequestUrl flow in the 2.0 version of the MSAL library. 

It also changes the name of the msal-common export from `msal` to `msal-common`.