### PR TITLE
Split the state correctly for temp cache clearance

### DIFF
--- a/lib/msal-core/src/cache/AuthCache.ts
+++ b/lib/msal-core/src/cache/AuthCache.ts
@@ -133,14 +133,10 @@ export class AuthCache extends BrowserStorage {// Singleton
         let key: string;
         // check state and remove associated cache
         for (key in storage) {
-            if (!state || key.indexOf(state) !== -1) {
-                const splitKey = key.split(Constants.resourceDelimiter);
-                const keyState = splitKey.length > 1 ?  splitKey.slice(1).join("|"): null;
-                if (keyState === state && !this.tokenRenewalInProgress(keyState)) {
-                    this.removeItem(key);
-                    this.setItemCookie(key, "", -1);
-                    this.clearMsalCookie(state);
-                }
+            if ((!state || key.indexOf(state) !== -1) && !this.tokenRenewalInProgress(state)) {
+                this.removeItem(key);
+                this.setItemCookie(key, "", -1);
+                this.clearMsalCookie(state);
             }
         }
         // delete the interaction status cache

--- a/lib/msal-core/src/cache/AuthCache.ts
+++ b/lib/msal-core/src/cache/AuthCache.ts
@@ -135,7 +135,7 @@ export class AuthCache extends BrowserStorage {// Singleton
         for (key in storage) {
             if (!state || key.indexOf(state) !== -1) {
                 const splitKey = key.split(Constants.resourceDelimiter);
-                const keyState = splitKey.length > 1 ? splitKey[splitKey.length-1]: null;
+                const keyState = splitKey.length > 1 ?  splitKey.slice(1).join("|"): null;
                 if (keyState === state && !this.tokenRenewalInProgress(keyState)) {
                     this.removeItem(key);
                     this.setItemCookie(key, "", -1);

--- a/lib/msal-core/test/Storage.localStorage.spec.ts
+++ b/lib/msal-core/test/Storage.localStorage.spec.ts
@@ -236,6 +236,24 @@ describe("CacheStorage.ts Class - Local Storage", function () {
             expect(msalCacheStorage.getItem(authorityKey)).to.be.null;
         });
 
+        it("resetTempCacheItems removes entries when user state includes resource delimeter", function () {
+            const userState = `stateValue1${Constants.resourceDelimiter}stateValue2`
+            const testState = `${TEST_STATE}${Constants.resourceDelimiter}${userState}`;
+
+            let acquireTokenAccountKey = AuthCache.generateAcquireTokenAccountKey(TEST_ACCOUNT_ID, testState);
+            let authorityKey = AuthCache.generateAuthorityKey(testState);
+
+            msalCacheStorage.setItem(acquireTokenAccountKey, JSON.stringify(ACCOUNT));
+            msalCacheStorage.setItem(authorityKey, validAuthority)
+
+            expect(msalCacheStorage.getItem(acquireTokenAccountKey)).to.be.eq(JSON.stringify(ACCOUNT));
+            expect(msalCacheStorage.getItem(authorityKey)).to.be.eq(validAuthority);
+
+            msalCacheStorage.resetTempCacheItems(testState);
+            expect(msalCacheStorage.getItem(acquireTokenAccountKey)).to.be.null;
+            expect(msalCacheStorage.getItem(authorityKey)).to.be.null;
+        });
+
         it("resetTempCacheItems removes specific acquireToken or authorityKey entries in the cache", function () {
             let acquireTokenAccountKey = AuthCache.generateAcquireTokenAccountKey(TEST_ACCOUNT_ID, TEST_STATE);
             let authorityKey = AuthCache.generateAuthorityKey(TEST_STATE);


### PR DESCRIPTION
This PR fixes #1333 where the `msal-core` lib assumes that "state" is always a GUID and does not have a delimiter within itself.

We fixed this by making sure that the `guid` the `msal` attaches before sending a request to `server` is always appended at the beginning and we rectify the split logic to reflect this.

Note: tests will be added before merging this.