### PR TITLE
Add redirectStartPage property to AuthenticationParameters to allow apps to indicate which page triggered the redirect. 

### DIFF
--- a/lib/msal-angular/src/msal-guard.service.ts
+++ b/lib/msal-angular/src/msal-guard.service.ts
@@ -38,7 +38,10 @@ export class MsalGuard implements CanActivate {
                     .catch(() => false);
             }
 
+            const routePath = `${window.location.origin}${state.url}`;
+
             this.authService.loginRedirect({
+                redirectStartPage: routePath,
                 scopes: this.msalAngularConfig.consentScopes,
                 extraQueryParameters: this.msalAngularConfig.extraQueryParameters
             });

--- a/lib/msal-core/src/AuthenticationParameters.ts
+++ b/lib/msal-core/src/AuthenticationParameters.ts
@@ -24,6 +24,7 @@ export type AuthenticationParameters = {
     loginHint?: string;
     forceRefresh?: boolean;
     redirectUri?: string;
+    redirectStartPage?: string;
 };
 
 export function validateClaimsRequest(request: AuthenticationParameters) {

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -497,17 +497,8 @@ export class UserAgentApplication {
         acquireTokenAuthority.resolveEndpointsAsync().then(async () => {
             // On Fulfillment
             const responseType: string = isLoginCall ? ResponseTypes.id_token : this.getTokenType(account, request.scopes, false);
-            let loginStartPage: string;
 
-            if (isLoginCall) {
-                // if the user sets the login start page - angular only??
-                loginStartPage = this.cacheStorage.getItem(`${TemporaryCacheKeys.ANGULAR_LOGIN_REQUEST}${Constants.resourceDelimiter}${request.state}`);
-                if (!loginStartPage || loginStartPage === "") {
-                    loginStartPage = window.location.href;
-                } else {
-                    this.cacheStorage.setItem(`${TemporaryCacheKeys.ANGULAR_LOGIN_REQUEST}${Constants.resourceDelimiter}${request.state}`, "");
-                }
-            }
+            const loginStartPage = request.redirectStartPage || window.location.href;
 
             serverAuthenticationRequest = new ServerRequestParameters(
                 acquireTokenAuthority,

--- a/lib/msal-core/src/utils/Constants.ts
+++ b/lib/msal-core/src/utils/Constants.ts
@@ -82,7 +82,6 @@ export enum TemporaryCacheKeys {
     LOGIN_REQUEST = "login.request",
     RENEW_STATUS = "token.renew.status",
     URL_HASH = "urlHash",
-    ANGULAR_LOGIN_REQUEST = "angular.login.request",
     INTERACTION_STATUS = "interaction_status",
     REDIRECT_REQUEST = "redirect_request"
 }


### PR DESCRIPTION
Fixes Angular guard bug where using redirect would send the user to the redirect URI, instead of the resource they were trying to reach.