### PR TITLE
Always send back the accessToken and scopes if the response includes them

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1495,6 +1495,7 @@ export class UserAgentApplication {
                 // Process access_token
                 if (hashParams.hasOwnProperty(ServerHashParamKeys.ACCESS_TOKEN)) {
                     this.logger.info("Fragment has access token");
+                    response.accessToken = hashParams[ServerHashParamKeys.ACCESS_TOKEN];
 
                     // retrieve the id_token from response if present
                     if (hashParams.hasOwnProperty(ServerHashParamKeys.ID_TOKEN)) {

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1497,6 +1497,10 @@ export class UserAgentApplication {
                     this.logger.info("Fragment has access token");
                     response.accessToken = hashParams[ServerHashParamKeys.ACCESS_TOKEN];
 
+                    if (hashParams.hasOwnProperty(ServerHashParamKeys.SCOPE)) {
+                        response.scopes = hashParams[ServerHashParamKeys.SCOPE].split(" ");
+                    }
+
                     // retrieve the id_token from response if present
                     if (hashParams.hasOwnProperty(ServerHashParamKeys.ID_TOKEN)) {
                         idTokenObj = new IdToken(hashParams[ServerHashParamKeys.ID_TOKEN]);


### PR DESCRIPTION
Per #1293, there is a regression in `msal@1` where we aren't always including the accessToken in the response if one is included. See ticket for complete context.

Open question: Is there any reason not to do that? Later on in the processing, `saveAccessToken` does [include the token](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/9ba8124ecaed5a5a5897c45ae92e2d02448fd56a/lib/msal-core/src/UserAgentApplication.ts#L1390), however, `saveAccessToken` is not called in this scenario.