### PR TITLE
Ensure silent operations timeout if the iframe never returns to the app domain

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -797,7 +797,7 @@ export class UserAgentApplication {
             WindowUtils.loadFrameSync(urlNavigate, frameName, this.logger);
 
         try {
-            const hash = await WindowUtils.monitorWindowForHash(iframe.contentWindow, this.config.system.loadFrameTimeout, urlNavigate);
+            const hash = await WindowUtils.monitorWindowForHash(iframe.contentWindow, this.config.system.loadFrameTimeout, urlNavigate, true);
 
             if (hash) {
                 this.handleAuthenticationResponse(hash);

--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -35,7 +35,7 @@ export class WindowUtils {
      * Monitors a window until it loads a url with a hash
      * @ignore
      */
-    static monitorWindowForHash(contentWindow: Window, timeout: number, urlNavigate: string): Promise<string> {
+    static monitorWindowForHash(contentWindow: Window, timeout: number, urlNavigate: string, isSilentCall?: boolean): Promise<string> {
         return new Promise((resolve, reject) => {
             const maxTicks = timeout / WindowUtils.POLLING_INTERVAL_MS;
             let ticks = 0;
@@ -57,15 +57,27 @@ export class WindowUtils {
                     href = contentWindow.location.href;
                 } catch (e) {}
 
-                // Don't process blank pages or cross domain
-                if (!href || href === "about:blank") {
-                    return;
+                if (isSilentCall) {
+                    /*
+                     * Always run clock for silent calls
+                     * as silent operations should be short,
+                     * and to ensure they always at worst timeout.
+                     */
+                    ticks++;
+                } else {
+                    // Don't process blank pages or cross domain
+                    if (!href || href === "about:blank") {
+                        return;
+                    }
+
+                    /*
+                     * Only run clock when we are on same domain for popups
+                     * as popup operations can take a long time.
+                     */
+                    ticks++;
                 }
 
-                // Only run clock when we are on same domain
-                ticks++;
-
-                if (UrlUtils.urlContainsHash(href)) {
+                if (href && UrlUtils.urlContainsHash(href)) {
                     clearInterval(intervalId);
                     resolve(contentWindow.location.hash);
                 } else if (ticks > maxTicks) {

--- a/lib/msal-core/test/utils/WindowUtils.spec.ts
+++ b/lib/msal-core/test/utils/WindowUtils.spec.ts
@@ -5,7 +5,7 @@ import { ClientAuthError } from "../../src/error/ClientAuthError";
 
 describe("WindowUtils", () => {
     describe("monitorWindowForHash", () => {
-        it("times out", done => {
+        it("times out (popup)", done => {
             const iframe = {
                 contentWindow: {
                     location: {
@@ -17,6 +17,21 @@ describe("WindowUtils", () => {
 
             // @ts-ignore
             WindowUtils.monitorWindowForHash(iframe.contentWindow, 500)
+                .catch((err: ClientAuthError) => {
+                    done();
+                });
+        });
+
+        it("times out (iframe)", done => {
+            const iframe = {
+                contentWindow: {
+                    // @ts-ignore
+                    location: null // example of scenario that would never otherwise resolve
+                }
+            };
+
+            // @ts-ignore
+            WindowUtils.monitorWindowForHash(iframe.contentWindow, 500, "http://login.microsoftonline.com", true)
                 .catch((err: ClientAuthError) => {
                     done();
                 });


### PR DESCRIPTION
There are scenarios where the iframe used for `acquireTokenSilent` would not return to the app domain. `monitorWindowForHash` is naively written to assume the iframe will always return to the app domain at some point, which is when the timeout clock would start. For silent calls, the time spent on STS should be short, and we need to ensure that at worst, `acquireTokenSilent` resolves with a timeout error.

This PR changes `monitorWindowForHash` to ensure it will timeout for silent calls if the iframe never returns to the app domain.

I believe this is the cause for #1306 and #1230. 