### PR TITLE
If framework.protectedResourceMap/unprotectedResources is empty, use msalAngularConfig.protectedResourceMap/unprotectedResources

### DIFF
--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -173,11 +173,12 @@ export class MsalService extends UserAgentApplication {
             return null;
         }
 
-        if (this.msalConfig.framework && this.msalConfig.framework.protectedResourceMap) {
+        const frameworkProtectedResourceMap = this.msalConfig.framework && this.msalConfig.framework.protectedResourceMap;
+        if (frameworkProtectedResourceMap) {
             this.getLogger().info("msalConfig.framework.protectedResourceMap is deprecated, use msalAngularConfig.protectedResourceMap");
         }
 
-        const protectedResourceMap = (this.msalConfig.framework && this.msalConfig.framework.protectedResourceMap) || new Map(this.msalAngularConfig.protectedResourceMap);
+        const protectedResourceMap = frameworkProtectedResourceMap && frameworkProtectedResourceMap.size ? frameworkProtectedResourceMap : new Map(this.msalAngularConfig.protectedResourceMap);
 
         // process all protected resources and send the matched one
         const keyForEndpoint = Array.from(protectedResourceMap.keys()).find(key => endpoint.indexOf(key) > -1);

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -70,7 +70,10 @@ export class MsalService extends UserAgentApplication {
     }
 
     private isUnprotectedResource(url: string): boolean {
-        const unprotectedResources = (this.msalConfig.framework && this.msalConfig.framework.unprotectedResources) || this.msalAngularConfig.unprotectedResources || [];
+        const frameworkUnprotectedResources = this.msalConfig.framework && this.msalConfig.framework.unprotectedResources;
+        const configUnprotectedResources = this.msalAngularConfig.unprotectedResources || [];
+
+        const unprotectedResources = frameworkUnprotectedResources && frameworkUnprotectedResources.length ? frameworkUnprotectedResources : configUnprotectedResources;
 
         return unprotectedResources.some(resource => url.indexOf(resource) > -1);
     }


### PR DESCRIPTION
Ensures that is `msalConfig.framework.protectedResourceMap` is an empty map, to still fallback to `msalAngularConfig.protectedResourceMap`. 

Fixes #1341 