### PR TITLE
Promote 1.2.2 to stable release, remove hidden iframes

### DIFF
--- a/lib/msal-core/changelog.md
+++ b/lib/msal-core/changelog.md
@@ -11,6 +11,7 @@
 * Properly remove temporary cache entries. (#1339)
 * Always send back the accessToken and scopes if the response includes them. (#1351)
 * Ensure silent operations timeout if the iframe never returns to the app domain. (#1354)
+* Ensure hidden iframes are properly removed. (#1415)
 
 ## Logging / Telemetry
 * Add telemetry for `acquireTokenSilent`. (#1388)

--- a/lib/msal-core/package-lock.json
+++ b/lib/msal-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msal",
-  "version": "1.2.2-beta.3",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "1.2.2-beta.3",
+  "version": "1.2.2",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",

--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -178,7 +178,7 @@ export class WindowUtils {
      * @ignore
      */
     static removeHiddenIframe(iframe: HTMLIFrameElement) {
-        if (document.body !== iframe.parentNode) {
+        if (document.body === iframe.parentNode) {
             document.body.removeChild(iframe);
         }
     }


### PR DESCRIPTION
It appears the conditions for removing hidden iframes were wrong. Not sure how that happened 🙃

Also promotes `1.2.2` to stable release.