### PR TITLE
Don't broadcast msal:login events from Angular Guard

### DIFF
--- a/lib/msal-angular/src/msal-guard.service.ts
+++ b/lib/msal-angular/src/msal-guard.service.ts
@@ -58,14 +58,8 @@ export class MsalGuard implements CanActivate {
             return this.authService.acquireTokenSilent({
                 scopes: [this.msalConfig.auth.clientId]
             })
-                .then((result: AuthResponse) => {
-                    this.broadcastService.broadcast("msal:loginSuccess",  result);
-                    return true;
-                })
-                .catch((error: AuthError) => {
-                    this.broadcastService.broadcast("msal:loginFailure", error);
-                    return false;
-                });
+                .then(() => true)
+                .catch(() => false);
         }
 
     }


### PR DESCRIPTION
Currently, if the user is logged in, the MSAL guard will call `acquireTokenSilent` and then emit `msal:loginSuccess`. This results in broadcasting two events, `msal:acquireTokenSuccess` (for the ATS call) and `msal:loginSuccess`. This is confusing and counterintuitive, so this simplifies the guard to not broadcast related events when the user is already logged in.

Fixes:
#1404 
#1392 