### PR TITLE
Bump version and add changelog for 1.3.0-beta.0

### DIFF
--- a/lib/msal-core/changelog.md
+++ b/lib/msal-core/changelog.md
@@ -1,3 +1,10 @@
+# 1.3.0
+
+## Enhancements
+* Turn library state into encoded string that contains guid and timestamp. (#1395)
+* Fix behavior of `handleRedirectCallback`, and make it no longer required. (#1358)
+* `domain_hint` is no longer supported in silent calls or when `sid` or `login_hint` is passed. (#1299)
+
 # 1.2.2
 
 ## Features

--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "1.2.2",
+  "version": "1.3.0-beta.0",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",

--- a/lib/msal-core/src/utils/Constants.ts
+++ b/lib/msal-core/src/utils/Constants.ts
@@ -148,5 +148,5 @@ export const PromptState = {
  * MSAL JS Library Version
  */
 export function libraryVersion(): string {
-    return "1.2.2";
+    return "1.3.0";
 }


### PR DESCRIPTION
# 1.3.0-beta.0

## Enhacements
* Turn library state into encoded string that contains guid and timestamp. (#1395)
* Fix behavior of `handleRedirectCallback`, and make it no longer required. (#1358)
* `domain_hint` is no longer supported in silent calls or when `sid` or `login_hint` is passed. (#1299)