### PR TITLE
MSAL Guard should properly support hash routing and non-root base urls

### DIFF
--- a/lib/msal-angular/package-lock.json
+++ b/lib/msal-angular/package-lock.json
@@ -6429,6 +6429,15 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "msal": {
+      "version": "1.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.3.0-beta.0.tgz",
+      "integrity": "sha512-ee6lubiBwgN3I59Q6xVqu3Ujl7Kx6u3LLbpMorfMgOZzfr7dl/5+GKYdvYp40hPuPjFUK7mFHLLyU+aE71VFLg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@angular/common": ">= 6.0.0",
     "@angular/core": ">= 6.0.0",
-    "msal": "^1.2.2-beta.2",
+    "msal": "^1.3.0-beta.0",
     "rxjs": "^6.0.0"
   },
   "devDependencies": {
@@ -74,7 +74,7 @@
     "karma-spec-reporter": "0.0.32",
     "karma-verbose-reporter": "0.0.6",
     "karma-webpack": "^3.0.0",
-    "msal": "^1.2.2-beta.0",
+    "msal": "^1.3.0-beta.0",
     "ng-packagr": "^9.0.2",
     "phantomjs-polyfill": "0.0.2",
     "reflect-metadata": "^0.1.3",

--- a/lib/msal-angular/src/msal-guard.service.ts
+++ b/lib/msal-angular/src/msal-guard.service.ts
@@ -33,8 +33,9 @@ export class MsalGuard implements CanActivate {
      * @returns Full destination url
      */
     getDestinationUrl(path: string): string {
-        // Absolute base url for the application
-        const baseUrl = this.location.normalize(document.getElementsByTagName("base")[0].href);
+        // Absolute base url for the application (default to origin if base element not present)
+        const baseElements = document.getElementsByTagName("base");
+        const baseUrl = this.location.normalize(baseElements.length ? baseElements[0].href : window.location.origin);
 
         // Path of page (including hash, if using hash routing)
         const pathUrl = this.location.prepareExternalUrl(path);

--- a/lib/msal-angular/src/msal-guard.service.ts
+++ b/lib/msal-angular/src/msal-guard.service.ts
@@ -27,6 +27,28 @@ export class MsalGuard implements CanActivate {
         private broadcastService: BroadcastService
     ) {}
 
+    /**
+     * Builds the absolute url for the destination page
+     * @param path Relative path of requested page
+     * @returns Full destination url
+     */
+    getDestinationUrl(path: string): string {
+        // Absolute base url for the application
+        const baseUrl = this.location.normalize(document.getElementsByTagName("base")[0].href);
+
+        // Path of page (including hash, if using hash routing)
+        const pathUrl = this.location.prepareExternalUrl(path);
+
+        // Hash location strategy
+        if (pathUrl.startsWith("#")) {
+            return `${baseUrl}/${pathUrl}`;
+        }
+
+        // If using path location strategy, pathUrl will include the relative portion of the base path (e.g. /base/page).
+        // Since baseUrl also includes /base, can just concatentate baseUrl + path
+        return `${baseUrl}${path}`;
+    }
+
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Promise<boolean> {
         this.authService.getLogger().verbose("location change event from old url to new url");
 
@@ -47,10 +69,10 @@ export class MsalGuard implements CanActivate {
                     .catch(() => false);
             }
 
-            const routePath = `${window.location.origin}${state.url}`;
+            const redirectStartPage = this.getDestinationUrl(state.url);
 
             this.authService.loginRedirect({
-                redirectStartPage: routePath,
+                redirectStartPage,
                 scopes: this.msalAngularConfig.consentScopes,
                 extraQueryParameters: this.msalAngularConfig.extraQueryParameters
             });

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1067,7 +1067,14 @@ export class UserAgentApplication {
                 window.location.href = "/";
                 return;
             } else if (currentUrl !== loginRequestUrl) {
-                window.location.href = `${loginRequestUrl}${hash}`;
+                // If loginRequestUrl contains a hash (e.g. Angular routing), process the hash now then redirect to prevent both hashes in url
+                if (loginRequestUrl.indexOf("#") > -1) {
+                    this.logger.info("loginRequestUrl contains hash, processing response hash immediately then redirecting");
+                    this.processCallBack(hash, stateInfo, null);
+                    window.location.href = loginRequestUrl;
+                } else {
+                    window.location.href = `${loginRequestUrl}${hash}`;
+                }
                 return;
             }
         }

--- a/samples/angular8-sample-app/package-lock.json
+++ b/samples/angular8-sample-app/package-lock.json
@@ -1057,19 +1057,9 @@
       }
     },
     "@azure/msal-angular": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-angular/-/msal-angular-1.0.0-beta.2.tgz",
-      "integrity": "sha512-MuH5c60EmagAPz7j19zpnrNaugDkMBfjqWa2jyOqAJNoOrqP6P/mx2gPwcFcx9fpP209KeDppdIRMu8fX8PeVA==",
-      "requires": {
-        "tslib": "1.7.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
-          "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
-        }
-      }
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-angular/-/msal-angular-1.0.0-beta.4.tgz",
+      "integrity": "sha512-y6EOu7qXSa+F5IjDgaoT+3Evw/VXQpZvSrkHpLFgKcWIgJ41HVaFf91+OUUyHl3OuqOlMJP9vLEtN20mGL7CWw=="
     },
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -7758,9 +7748,9 @@
       "dev": true
     },
     "msal": {
-      "version": "1.2.2-beta.0",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.2-beta.0.tgz",
-      "integrity": "sha512-7cfJxEt8oCSmExOgTsxezKbRxRpyG/p/4agjuf39L9OLtPRjfAuyd0btdJQPwaM+JI7VgMf4jrTFENNmUBDtEg==",
+      "version": "1.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.3.0-beta.0.tgz",
+      "integrity": "sha512-ee6lubiBwgN3I59Q6xVqu3Ujl7Kx6u3LLbpMorfMgOZzfr7dl/5+GKYdvYp40hPuPjFUK7mFHLLyU+aE71VFLg==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/samples/angular8-sample-app/package.json
+++ b/samples/angular8-sample-app/package.json
@@ -21,8 +21,8 @@
     "@angular/platform-browser": "~8.2.14",
     "@angular/platform-browser-dynamic": "~8.2.14",
     "@angular/router": "~8.2.14",
-    "@azure/msal-angular": "^1.0.0-beta.2",
-    "msal": "^1.2.2-beta.0",
+    "@azure/msal-angular": "^1.0.0-beta.4",
+    "msal": "^1.3.0-beta.0",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",
     "zone.js": "~0.9.1"


### PR DESCRIPTION
This PR addresses the issues raised in #1447: 
- Properly construct the `redirectStartUrl` if hash routing is used.
- Properly construct the `redirectStartUri` if the application uses a different root url than `/`

It also fixes the behavior in `msal` when `redirectStartUri` itself contains a hash. If this occurs, `msal` will process the response hash immediately, then redirect to the `redirectStartUri`. This is to prevent both hash values from being concatenated together, which confuses both msal and the Angular router.

Unfortunately, this may lead to `redirectStartUri` not receiving the `handleRedirectCallback` response (this would happen if `redirectUri` and `redirectStartUri` are not the same base url, e.g. `/redirect` and `/profile#edit`). I wasn't able to find a graceful way to handle this scenario, given the changes that were made in #1358.

Fixes:
- #1447 
- #1422 