### PR TITLE
Ensure state is decoded before it is processed

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1093,12 +1093,11 @@ export class UserAgentApplication {
             throw AuthError.createUnexpectedError("Hash was not parsed correctly.");
         }
         if (parameters.hasOwnProperty(ServerHashParamKeys.STATE)) {
-            const decodedState = decodeURIComponent(parameters.state);
-            const parsedState = RequestUtils.parseLibraryState(decodedState);
+            const parsedState = RequestUtils.parseLibraryState(parameters.state);
 
             stateResponse = {
                 requestType: Constants.unknown,
-                state: decodedState,
+                state: parameters.state,
                 timestamp: parsedState.ts,
                 method: parsedState.method,
                 stateMatch: false
@@ -1384,8 +1383,7 @@ export class UserAgentApplication {
 
             // Generate and cache accessTokenKey and accessTokenValue
             const expiresIn = TimeUtils.parseExpiresIn(parameters[ServerHashParamKeys.EXPIRES_IN]);
-            const decodedState = decodeURIComponent(parameters[ServerHashParamKeys.STATE]);
-            const parsedState = RequestUtils.parseLibraryState(decodedState);
+            const parsedState = RequestUtils.parseLibraryState(parameters[ServerHashParamKeys.STATE]);
             expiration = parsedState.ts + expiresIn;
             const accessTokenKey = new AccessTokenKey(authority, this.clientId, scope, clientObj.uid, clientObj.utid);
             const accessTokenValue = new AccessTokenValue(parameters[ServerHashParamKeys.ACCESS_TOKEN], idTokenObj.rawIdToken, expiration.toString(), clientInfo);

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1093,11 +1093,12 @@ export class UserAgentApplication {
             throw AuthError.createUnexpectedError("Hash was not parsed correctly.");
         }
         if (parameters.hasOwnProperty(ServerHashParamKeys.STATE)) {
-            const parsedState = RequestUtils.parseLibraryState(parameters.state);
+            const decodedState = decodeURIComponent(parameters.state);
+            const parsedState = RequestUtils.parseLibraryState(decodedState);
 
             stateResponse = {
                 requestType: Constants.unknown,
-                state: parameters.state,
+                state: decodedState,
                 timestamp: parsedState.ts,
                 method: parsedState.method,
                 stateMatch: false
@@ -1383,7 +1384,8 @@ export class UserAgentApplication {
 
             // Generate and cache accessTokenKey and accessTokenValue
             const expiresIn = TimeUtils.parseExpiresIn(parameters[ServerHashParamKeys.EXPIRES_IN]);
-            const parsedState = RequestUtils.parseLibraryState(parameters[ServerHashParamKeys.STATE]);
+            const decodedState = decodeURIComponent(parameters[ServerHashParamKeys.STATE]);
+            const parsedState = RequestUtils.parseLibraryState(decodedState);
             expiration = parsedState.ts + expiresIn;
             const accessTokenKey = new AccessTokenKey(authority, this.clientId, scope, clientObj.uid, clientObj.utid);
             const accessTokenValue = new AccessTokenValue(parameters[ServerHashParamKeys.ACCESS_TOKEN], idTokenObj.rawIdToken, expiration.toString(), clientInfo);

--- a/lib/msal-core/src/utils/CryptoUtils.ts
+++ b/lib/msal-core/src/utils/CryptoUtils.ts
@@ -157,7 +157,8 @@ export class CryptoUtils {
         const obj: {} = {};
         match = search.exec(query);
         while (match) {
-            obj[decode(match[1])] = decode(match[2]);
+            // Some values (e.g. state) may need to be decoded twice
+            obj[decode(match[1])] = decode(decode(match[2]));
             match = search.exec(query);
         }
         return obj;

--- a/lib/msal-core/src/utils/RequestUtils.ts
+++ b/lib/msal-core/src/utils/RequestUtils.ts
@@ -168,7 +168,7 @@ export class RequestUtils {
      * @returns Parsed values from the encoded state value
      */
     static parseLibraryState(state: string): LibraryStateObject {
-        const libraryState = state.split(Constants.resourceDelimiter)[0];
+        const libraryState = decodeURIComponent(state).split(Constants.resourceDelimiter)[0];
 
         if (CryptoUtils.isGuid(libraryState)) {
             // If state is guid, assume timestamp is now and is redirect, as redirect should be only method where this can happen.

--- a/lib/msal-core/test/utils/RequestUtils.spec.ts
+++ b/lib/msal-core/test/utils/RequestUtils.spec.ts
@@ -105,6 +105,13 @@ describe("RequestUtils.ts class", () => {
         nowStub.restore();
     });
 
+    it("properly handles encoded state", () => {
+        const state = "eyJpZCI6IjJkZWQwNGU5LWYzZGYtNGU0Ny04YzRlLWY0MDMyMTU3YmJlOCIsInRzIjoxNTg1OTMyNzg5LCJtZXRob2QiOiJzaWxlbnRJbnRlcmFjdGlvbiJ9%7Chello";
+
+        const parsedState = RequestUtils.parseLibraryState(state);
+        expect(CryptoUtils.isGuid(parsedState.id)).to.be.equal(true);
+    });
+
     it("parses old guid state format", () => {
         const now = TimeUtils.now();
         const nowStub = sinon.stub(TimeUtils, "now").returns(now);

--- a/lib/msal-core/test/utils/UrlUtils.spec.ts
+++ b/lib/msal-core/test/utils/UrlUtils.spec.ts
@@ -4,7 +4,7 @@ import { UrlUtils } from "../../src/utils/UrlUtils";
 import { TEST_CONFIG, TEST_RESPONSE_TYPE, TEST_URIS } from "../TestConstants";
 import { AuthorityFactory } from "../../src/authority/AuthorityFactory";
 import { ServerRequestParameters } from "../../src/ServerRequestParameters";
-import { ServerHashParamKeys } from "../../src/utils/Constants";
+import { ServerHashParamKeys, Constants } from "../../src/utils/Constants";
 
 describe("UrlUtils.ts class", () => {
 
@@ -95,4 +95,17 @@ describe("UrlUtils.ts class", () => {
         });
     });
 
+    describe("deserializeHash", () => {
+        it("properly decodes a twice encoded value", () => {
+            // This string is double encoded
+            // "%257C" = | encoded twice
+            const hash = "#state=eyJpZCI6IjJkZWQwNGU5LWYzZGYtNGU0Ny04YzRlLWY0MDMyMTU3YmJlOCIsInRzIjoxNTg1OTMyNzg5LCJtZXRob2QiOiJzaWxlbnRJbnRlcmFjdGlvbiJ9%257Chello";
+
+            const { state } = UrlUtils.deserializeHash(hash);
+
+            const stateParts = state.split(Constants.resourceDelimiter);
+            expect(stateParts[0]).to.equal("eyJpZCI6IjJkZWQwNGU5LWYzZGYtNGU0Ny04YzRlLWY0MDMyMTU3YmJlOCIsInRzIjoxNTg1OTMyNzg5LCJtZXRob2QiOiJzaWxlbnRJbnRlcmFjdGlvbiJ9");
+            expect(stateParts[1]).to.equal("hello");
+        });
+    })
 });


### PR DESCRIPTION
The library will encode the state value, and in the scenario were there is an error, it appears that the service will encode the state parameter again when it is sent back to the library. This means the library will need to decode it twice before it is in the right format to be parsed. Ensure that the deserialize function decodes twice, and that the parseLibraryState also decodes just in case. 