### PR TITLE
[msal-node] Switch strictNullChecks: true for msal-node

### DIFF
--- a/lib/msal-node/src/cache/Storage.ts
+++ b/lib/msal-node/src/cache/Storage.ts
@@ -32,7 +32,7 @@ export class Storage implements ICacheStorage {
     constructor(clientId: string, cacheConfig: CacheOptions) {
         this.cacheConfig = cacheConfig;
         this.fileStorage = this.initializeFileStorage(
-            this.cacheConfig.cacheLocation
+            this.cacheConfig.cacheLocation!
         );
         this.clientId = clientId;
     }

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -18,13 +18,6 @@ export abstract class ClientApplication {
     // Input configuration by developer/user
     protected config: ClientConfiguration;
 
-    // Crypto interface implementation
-    protected crypto: CryptoProvider;
-
-    // Storage interface implementation
-    protected storage: Storage;
-
-
     /**
      * @constructor
      * Constructor for the ClientApplication to instantiate the PublicClientApplication object
@@ -47,18 +40,8 @@ export abstract class ClientApplication {
      * @param {@link (Configuration:type)} configuration object for the MSAL PublicClientApplication instance
      */
     protected constructor(configuration: ClientConfiguration) {
-        // Set the configuration.
+
         this.config = buildConfiguration(configuration);
-
-        // Initialize the crypto class.
-        this.crypto = new CryptoProvider();
-        // Initialize the network module class.
-
-        // Initialize the browser storage class.
-        this.storage = new Storage(
-            this.config.auth.clientId,
-            this.config.cache
-        );
     }
 
     /**
@@ -94,15 +77,19 @@ export abstract class ClientApplication {
     }
 
     protected buildOauthClientConfiguration(): Configuration {
+        // using null assertion operator as we ensure that all config values have default values in buildConfiguration()
         return {
             authOptions: this.config.auth,
             loggerOptions: {
-                loggerCallback: this.config.system.loggerOptions.loggerCallback,
-                piiLoggingEnabled: this.config.system.loggerOptions.piiLoggingEnabled,
+                loggerCallback: this.config.system!.loggerOptions!.loggerCallback,
+                piiLoggingEnabled: this.config.system!.loggerOptions!.piiLoggingEnabled,
             },
-            cryptoInterface: this.crypto,
-            networkInterface: this.config.system.networkClient,
-            storageInterface: this.storage,
+            cryptoInterface: new CryptoProvider(),
+            networkInterface: this.config.system!.networkClient,
+            storageInterface: new Storage(
+                this.config.auth!.clientId,
+                this.config.cache!
+            ),
         };
     }
 }

--- a/lib/msal-node/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-node/test/config/ClientConfiguration.spec.ts
@@ -11,10 +11,10 @@ describe('ClientConfiguration tests', () => {
         const config: ClientConfiguration = buildConfiguration({});
 
         // network options
-        expect(config.system.networkClient).toBeDefined();
-        expect(config.system.networkClient).toBeInstanceOf(HttpClient);
-        expect(config.system.networkClient.sendGetRequestAsync).toBeDefined();
-        expect(config.system.networkClient.sendPostRequestAsync).toBeDefined();
+        expect(config.system!.networkClient).toBeDefined();
+        expect(config.system!.networkClient).toBeInstanceOf(HttpClient);
+        expect(config.system!.networkClient!.sendGetRequestAsync).toBeDefined();
+        expect(config.system!.networkClient!.sendPostRequestAsync).toBeDefined();
 
         // logger options checks
         console.error = jest.fn();
@@ -22,14 +22,14 @@ describe('ClientConfiguration tests', () => {
         console.debug = jest.fn();
         console.warn = jest.fn();
 
-        expect(config.system.loggerOptions).toBeDefined();
-        expect(config.system.loggerOptions.piiLoggingEnabled).toBe(false);
+        expect(config.system!.loggerOptions).toBeDefined();
+        expect(config.system!.loggerOptions!.piiLoggingEnabled).toBe(false);
 
-        config.system.loggerOptions.loggerCallback(LogLevel.Error,"error", false);
-        config.system.loggerOptions.loggerCallback(LogLevel.Info,"info", false);
-        config.system.loggerOptions.loggerCallback(LogLevel.Verbose,"verbose", false);
-        config.system.loggerOptions.loggerCallback(LogLevel.Warning,"warning", false);
-        config.system.loggerOptions.loggerCallback(LogLevel.Warning,"warning", true);
+        config.system!.loggerOptions!.loggerCallback!(LogLevel.Error,"error", false);
+        config.system!.loggerOptions!.loggerCallback!(LogLevel.Info,"info", false);
+        config.system!.loggerOptions!.loggerCallback!(LogLevel.Verbose,"verbose", false);
+        config.system!.loggerOptions!.loggerCallback!(LogLevel.Warning,"warning", false);
+        config.system!.loggerOptions!.loggerCallback!(LogLevel.Warning,"warning", true);
 
         expect(console.error).toHaveBeenLastCalledWith("error");
         expect(console.info).toHaveBeenLastCalledWith("info");
@@ -39,12 +39,12 @@ describe('ClientConfiguration tests', () => {
 
 
         // auth options
-        expect(config.auth.authority).toEqual("");
-        expect(config.auth.clientId).toEqual("");
+        expect(config.auth!.authority).toEqual("");
+        expect(config.auth!.clientId).toEqual("");
 
         // cache options
-        expect(config.cache.cacheLocation).toEqual(CACHE.FILE_CACHE);
-        expect(config.cache.storeAuthStateInCookie).toEqual(false);
+        expect(config.cache!.cacheLocation).toEqual(CACHE.FILE_CACHE);
+        expect(config.cache!.storeAuthStateInCookie).toEqual(false);
     });
 
     test('builds configuration and assigns default functions', () => {
@@ -92,19 +92,19 @@ describe('ClientConfiguration tests', () => {
         };
 
         // network options
-        expect(config.system.networkClient.sendGetRequestAsync(TEST_CONSTANTS.AUTH_CODE_URL, testNetworkOptions)).resolves.toEqual(testNetworkResult);
-        expect(config.system.networkClient.sendPostRequestAsync(TEST_CONSTANTS.AUTH_CODE_URL, testNetworkOptions)).resolves.toEqual(testNetworkResult);
+        expect(config.system!.networkClient!.sendGetRequestAsync(TEST_CONSTANTS.AUTH_CODE_URL, testNetworkOptions)).resolves.toEqual(testNetworkResult);
+        expect(config.system!.networkClient!.sendPostRequestAsync(TEST_CONSTANTS.AUTH_CODE_URL, testNetworkOptions)).resolves.toEqual(testNetworkResult);
 
         // Logger options checks
-        expect(config.system.loggerOptions).toBeDefined();
-        expect(config.system.loggerOptions.piiLoggingEnabled).toBe(true);
+        expect(config.system!.loggerOptions).toBeDefined();
+        expect(config.system!.loggerOptions!.piiLoggingEnabled).toBe(true);
 
         // auth options
-        expect(config.auth.authority).toEqual(TEST_CONSTANTS.AUTHORITY);
-        expect(config.auth.clientId).toEqual(TEST_CONSTANTS.CLIENT_ID);
+        expect(config.auth!.authority).toEqual(TEST_CONSTANTS.AUTHORITY);
+        expect(config.auth!.clientId).toEqual(TEST_CONSTANTS.CLIENT_ID);
 
         // cache options
-        expect(config.cache.cacheLocation).toEqual(TEST_CONSTANTS.CACHE_LOCATION);
-        expect(config.cache.storeAuthStateInCookie).toEqual(true);
+        expect(config.cache!.cacheLocation).toEqual(TEST_CONSTANTS.CACHE_LOCATION);
+        expect(config.cache!.storeAuthStateInCookie).toEqual(true);
     });
 });

--- a/lib/msal-node/tsconfig.json
+++ b/lib/msal-node/tsconfig.json
@@ -10,7 +10,7 @@
     "rootDir": "./",
     "strict": true,
     "noImplicitAny": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "strictFunctionTypes": true,
     "strictPropertyInitialization": false,
     "noImplicitThis": true,


### PR DESCRIPTION
Set strictNullChecks = true for MsalNode. Using null assertion operator, as we ensure that all configuration values are assigned default values when we build the configuration, so we can assume that they will not be null. 