### PR TITLE
[msal-core] Fix circular dependency for B2C Authority

### DIFF
--- a/lib/msal-core/src/authority/AuthorityFactory.ts
+++ b/lib/msal-core/src/authority/AuthorityFactory.ts
@@ -7,13 +7,11 @@
  * @hidden
  */
 import { AadAuthority } from "./AadAuthority";
-import { B2cAuthority } from "./B2cAuthority";
+import { B2cAuthority, B2CTrustedHostList } from "./B2cAuthority";
 import { Authority, AuthorityType } from "./Authority";
 import { StringUtils } from "../utils/StringUtils";
 import { UrlUtils } from "../utils/UrlUtils";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
-
-export const B2CTrustedHostList: object = {};
 
 export class AuthorityFactory {
     /**

--- a/lib/msal-core/src/authority/B2cAuthority.ts
+++ b/lib/msal-core/src/authority/B2cAuthority.ts
@@ -6,7 +6,8 @@
 import { Authority } from "./Authority";
 import { AuthorityType } from "./Authority";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
-import { AuthorityFactory, B2CTrustedHostList } from "./AuthorityFactory";
+
+export const B2CTrustedHostList: object = {};
 
 /**
  * @hidden

--- a/lib/msal-core/test/authority/AuthorityFactory.spec.ts
+++ b/lib/msal-core/test/authority/AuthorityFactory.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 import { ClientConfigurationError, ClientConfigurationErrorMessage } from "../../src/error/ClientConfigurationError";
-import { AuthorityFactory, B2CTrustedHostList } from "../../src/authority/AuthorityFactory";
+import { AuthorityFactory } from "../../src/authority/AuthorityFactory";
 import { AadAuthority } from "../../src/authority/AadAuthority";
-import { B2cAuthority } from "../../src/authority/B2cAuthority";
+import { B2cAuthority, B2CTrustedHostList } from "../../src/authority/B2cAuthority";
 import { B2C_TEST_CONFIG, TEST_CONFIG } from "../TestConstants";
 
 describe("AuthorityFactory.ts Class", function () {

--- a/lib/msal-core/test/authority/B2cAuthority.spec.ts
+++ b/lib/msal-core/test/authority/B2cAuthority.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from "chai";
 import { ClientConfigurationError, ClientConfigurationErrorMessage } from "../../src/error/ClientConfigurationError";
 import { AuthorityType } from "../../src/authority/Authority";
-import { B2cAuthority } from "../../src/authority/B2cAuthority";
+import { B2cAuthority, B2CTrustedHostList } from "../../src/authority/B2cAuthority";
 import { B2C_TEST_CONFIG } from "../TestConstants";
-import { B2CTrustedHostList, AuthorityFactory } from "../../src/authority/AuthorityFactory";
+import { AuthorityFactory } from "../../src/authority/AuthorityFactory";
 
 describe("B2cAuthority.ts Class", function () {
     let authority = null;


### PR DESCRIPTION
- Moves B2CTrustedHostList to B2cAuthority class to fix circular dependency with AuthorityFactory