### PR TITLE
Export WindowUtils, UrlUtils, and redirect callback types for MSAL Angular

### DIFF
--- a/lib/msal-angular/src/msal-guard.service.ts
+++ b/lib/msal-angular/src/msal-guard.service.ts
@@ -7,11 +7,9 @@ import {
 import { MsalService } from "./msal.service";
 import { Location, PlatformLocation } from "@angular/common";
 import { BroadcastService } from "./broadcast.service";
-import { Configuration, AuthResponse, AuthError, InteractionRequiredAuthError } from "msal";
+import { Configuration, AuthError, InteractionRequiredAuthError, UrlUtils, WindowUtils } from "msal";
 import { MsalAngularConfiguration } from "./msal-angular.configuration";
 import { MSAL_CONFIG, MSAL_CONFIG_ANGULAR } from "./constants";
-import { UrlUtils } from "msal/lib-commonjs/utils/UrlUtils";
-import { WindowUtils } from "msal/lib-commonjs/utils/WindowUtils";
 
 @Injectable()
 export class MsalGuard implements CanActivate {

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -1,21 +1,19 @@
-import {Inject, Injectable, InjectionToken} from "@angular/core";
+import { Inject, Injectable } from "@angular/core";
 import {
     UserAgentApplication,
     Configuration,
     AuthenticationParameters,
     AuthResponse,
     AuthError,
-    Logger
+    authResponseCallback,
+    errorReceivedCallback,
+    tokenReceivedCallback,
+    UrlUtils
 } from "msal";
-import {
-     Router
-} from "@angular/router";
+import { Router } from "@angular/router";
 import {BroadcastService} from "./broadcast.service";
-import {MSALError} from "./MSALError";
-import { AuthCache } from "msal/lib-commonjs/cache/AuthCache";
+import { MSALError } from "./MSALError";
 import { MsalAngularConfiguration } from "./msal-angular.configuration";
-import { authResponseCallback, errorReceivedCallback, tokenReceivedCallback } from "msal/lib-commonjs/UserAgentApplication";
-import { UrlUtils } from "msal/lib-commonjs/utils/UrlUtils";
 import { MSAL_CONFIG, MSAL_CONFIG_ANGULAR } from "./constants";
 
 const buildMsalConfig = (config: Configuration) : Configuration => {
@@ -80,10 +78,6 @@ export class MsalService extends UserAgentApplication {
 
     private isEmpty(str: string): boolean {
         return (typeof str === "undefined" || !str || 0 === str.length);
-    }
-
-    public getCacheStorage(): AuthCache {
-        return this.cacheStorage;
     }
 
     public loginPopup(request?: AuthenticationParameters): Promise<any> {

--- a/lib/msal-core/src/index.ts
+++ b/lib/msal-core/src/index.ts
@@ -1,4 +1,4 @@
-export { UserAgentApplication } from "./UserAgentApplication";
+export { UserAgentApplication, authResponseCallback, errorReceivedCallback, tokenReceivedCallback } from "./UserAgentApplication";
 export { Logger } from "./Logger";
 export { LogLevel } from "./Logger";
 export { Account } from "./Account";
@@ -9,6 +9,8 @@ export { CacheLocation, Configuration } from "./Configuration";
 export { AuthenticationParameters } from "./AuthenticationParameters";
 export { AuthResponse } from "./AuthResponse";
 export { CryptoUtils } from "./utils/CryptoUtils";
+export { UrlUtils } from "./utils/UrlUtils";
+export { WindowUtils } from "./utils/WindowUtils";
 
 // Errors
 export { AuthError } from "./error/AuthError";


### PR DESCRIPTION
Currently, MSAL Angular reaches into the package of msal to get `UrlUtils`, `WindowUtils`, and others. Instead, we should be importing them from the public API. This removes warnings from Angular that advise that importing like that can be problematic.