### PR TITLE
Remove .finally from discoverendpoint promise chain as it isnt available in all promise polyfills

### DIFF
--- a/lib/msal-core/src/authority/Authority.ts
+++ b/lib/msal-core/src/authority/Authority.ts
@@ -127,6 +127,7 @@ export abstract class Authority {
         return client.sendRequestAsync(openIdConfigurationEndpoint, httpMethod, /* enableCaching: */ true)
             .then((response: XhrResponse) => {
                 httpEvent.httpResponseStatus = response.statusCode;
+                telemetryManager.stopEvent(httpEvent);
                 return <ITenantDiscoveryResponse>{
                     AuthorizationEndpoint: response.body.authorization_endpoint,
                     EndSessionEndpoint: response.body.end_session_endpoint,
@@ -135,10 +136,8 @@ export abstract class Authority {
             })
             .catch(err => {
                 httpEvent.serverErrorCode = err;
-                throw err;
-            })
-            .finally(() => {
                 telemetryManager.stopEvent(httpEvent);
+                throw err;
             });
     }
 

--- a/samples/react-sample-app/package-lock.json
+++ b/samples/react-sample-app/package-lock.json
@@ -8308,9 +8308,9 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "msal": {
-            "version": "1.2.2-beta.3",
-            "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.2-beta.3.tgz",
-            "integrity": "sha512-UifKAEPPCbXWaUx2UCyuXBJVdDt3DKx7qbo8HzU2p7JQ9qa1Ab9ycNGluOXc6Ik73aA9sqdPuyV5coQAuX2z9A==",
+            "version": "1.3.0-beta.1",
+            "resolved": "https://registry.npmjs.org/msal/-/msal-1.3.0-beta.1.tgz",
+            "integrity": "sha512-c22A+5qF0df3lSCc5g3AWozTqx6uuKXSFD55IWbKPvq/EOskqkHupnjXMCq4AAo1gb1gwFttduvmE5ufS3bzeA==",
             "requires": {
                 "tslib": "^1.9.3"
             }

--- a/samples/react-sample-app/package.json
+++ b/samples/react-sample-app/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "msal": "^1.2.2-beta.3",
+        "msal": "^1.3.0-beta.1",
         "prop-types": "^15.7.2",
         "react": "^16.8.6",
         "react-app-polyfill": "^1.0.1",


### PR DESCRIPTION
Not all promise polyfills (such as the one that ships with Create React App, which is used in the React sample) come with a `.finally`, so removing it to prevent breakages. 