### PR TITLE
[msal-core] Fix token caching for acquireToken calls

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -514,7 +514,7 @@ export class UserAgentApplication {
                 request.correlationId
             );
 
-            this.updateCacheEntries(serverAuthenticationRequest, account, loginStartPage);
+            this.updateCacheEntries(serverAuthenticationRequest, account, isLoginCall, loginStartPage);
 
             // populate QueryParameters (sid/login_hint) and any other extraQueryParameters set by the developer
             serverAuthenticationRequest.populateQueryParams(account, request);
@@ -1305,7 +1305,7 @@ export class UserAgentApplication {
         const frameName = `msalRenewFrame${scope}`;
         const frameHandle = WindowUtils.addHiddenIFrame(frameName, this.logger);
 
-        this.updateCacheEntries(serverAuthenticationRequest, account);
+        this.updateCacheEntries(serverAuthenticationRequest, account, false);
         this.logger.verbose("Renew token Expected state: " + serverAuthenticationRequest.state);
 
         // Build urlNavigate with "prompt=none" and navigate to URL in hidden iFrame
@@ -1329,7 +1329,7 @@ export class UserAgentApplication {
         const frameName = "msalIdTokenFrame";
         const frameHandle = WindowUtils.addHiddenIFrame(frameName, this.logger);
 
-        this.updateCacheEntries(serverAuthenticationRequest, account);
+        this.updateCacheEntries(serverAuthenticationRequest, account, false);
 
         this.logger.verbose("Renew Idtoken Expected state: " + serverAuthenticationRequest.state);
 
@@ -2054,9 +2054,9 @@ export class UserAgentApplication {
      * @hidden
      * @ignore
      */
-    private updateCacheEntries(serverAuthenticationRequest: ServerRequestParameters, account: Account, loginStartPage?: any) {
+    private updateCacheEntries(serverAuthenticationRequest: ServerRequestParameters, account: Account, isLoginCall: boolean, loginStartPage?: string) {
         // Cache account and authority
-        if (loginStartPage) {
+        if (isLoginCall) {
             // Cache the state, nonce, and login request data
             this.cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}${Constants.resourceDelimiter}${serverAuthenticationRequest.state}`, loginStartPage, this.inCookie);
             this.cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}${Constants.resourceDelimiter}${serverAuthenticationRequest.state}`, serverAuthenticationRequest.state, this.inCookie);

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -648,6 +648,55 @@ describe("UserAgentApplication.ts Class", function () {
             done();
         });
 
+        it("Account is cached on acquireTokenRedirect call", (done) => {
+            const tokenRequest: AuthenticationParameters = {
+                scopes: ["S1"], 
+                account: account
+            };
+
+            window.location = {
+                ...oldWindowLocation,
+                assign: function (url) {
+                    try {
+                        const state = UrlUtils.deserializeHash(url).state;
+                        const accountKey = AuthCache.generateAcquireTokenAccountKey(account.homeAccountIdentifier, state)
+
+                        expect(cacheStorage.getItem(accountKey)).equals(JSON.stringify(account));
+                        done();
+                    } catch (e) {
+                        console.error(e);
+                    }
+                }
+            };
+
+            msal.handleRedirectCallback(authCallback);
+            msal.acquireTokenRedirect(tokenRequest);
+        });
+
+        it("State is cached on acquireTokenRedirect call", (done) => {
+            const tokenRequest: AuthenticationParameters = {
+                scopes: ["S1"], 
+                account: account
+            };
+
+            window.location = {
+                ...oldWindowLocation,
+                assign: function (url) {
+                    try {
+                        const state = UrlUtils.deserializeHash(url).state;
+
+                        expect(cacheStorage.getItem(`${TemporaryCacheKeys.STATE_ACQ_TOKEN}${Constants.resourceDelimiter}${state}`)).to.be.equal(state);
+                        done();
+                    } catch (e) {
+                        console.error(e);
+                    }
+                }
+            };
+
+            msal.handleRedirectCallback(authCallback);
+            msal.acquireTokenRedirect(tokenRequest);
+        });
+
         it("tests if error is thrown when null scopes are passed", function (done) {
             msal.handleRedirectCallback(authCallback);
             let authErr: AuthError;
@@ -1634,6 +1683,7 @@ describe("UserAgentApplication.ts Class", function () {
         const oldWindow = window;
 
         beforeEach(function() {
+            cacheStorage = new AuthCache(TEST_CONFIG.MSAL_CLIENT_ID, "sessionStorage", true);
             const config: Configuration = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -1642,11 +1692,13 @@ describe("UserAgentApplication.ts Class", function () {
             };
             msal = new UserAgentApplication(config);
             setAuthInstanceStubs();
+            setTestCacheItems();
 
             delete window.location;
         });
 
         afterEach(function() {
+            window = oldWindow;
             window.location = oldWindowLocation;
             cacheStorage.clear();
             sinon.restore();
@@ -1669,6 +1721,42 @@ describe("UserAgentApplication.ts Class", function () {
             expect(acquireTokenPromise instanceof Promise).to.be.true;
             acquireTokenPromise.catch(error => {});
         });
+
+        it("Account is cached on acquireTokenPopup call", (done) => {
+            const tokenRequest: AuthenticationParameters = {
+                scopes: ["S1"], 
+                account: account
+            };
+
+            const TEST_LIBRARY_STATE_POPUP = RequestUtils.generateLibraryState(Constants.interactionTypePopup)
+
+            window = {
+                ...oldWindow,
+                location: {
+                    ...oldWindowLocation,
+                    href: TEST_URIS.TEST_REDIR_URI + "/" + testHashesForState(TEST_LIBRARY_STATE_POPUP).TEST_SUCCESS_ACCESS_TOKEN_HASH + TEST_USER_STATE_NUM,
+                    hash: testHashesForState(TEST_LIBRARY_STATE_POPUP).TEST_SUCCESS_ACCESS_TOKEN_HASH + TEST_USER_STATE_NUM,
+                    assign: function (url) {
+                        const state = UrlUtils.deserializeHash(url).state;
+                        const accountKey = AuthCache.generateAcquireTokenAccountKey(account.homeAccountIdentifier, state)
+
+                        expect(cacheStorage.getItem(accountKey)).equals(JSON.stringify(account));
+                        done();
+                    }   
+                },
+                open: function (url?, target?, features?, replace?): Window {
+                    return window
+                },
+                close: function(): void {},
+                focus: null
+            };
+
+            const acquireTokenPromise = msal.acquireTokenPopup(tokenRequest);
+            expect(acquireTokenPromise instanceof Promise).to.be.true;
+
+            acquireTokenPromise.catch(error => {console.log(error)});
+        });
+
     });
 
     describe("Silent Flow", function () {


### PR DESCRIPTION
Using loginStartPage as the condition for setting the account cache prevented access tokens from being cached in interactive flows since loginStartPage is always set. This PR changes the conditional check to more accurately differentiate between login calls and access token calls.

This PR fixes issues: 
#1505 
#1509 
