### PR TITLE
[msal-browser] Fix issues in @azure/msal-browser where types are not exported correctly

### DIFF
--- a/lib/msal-browser/package-lock.json
+++ b/lib/msal-browser/package-lock.json
@@ -1,14 +1,9 @@
 {
     "name": "@azure/msal-browser",
-    "version": "2.0.0-alpha.0",
+    "version": "2.0.0-beta.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@azure/msal-common": {
-            "version": "1.0.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-1.0.0-alpha.0.tgz",
-            "integrity": "sha512-1LNNspyyiVFglCOt+PweQeJR/gQMZyaD0GppkrBaf3ALvo7L3KmRXvcge/drX3gVK90vOKJaHM8afVhFpG/xwA=="
-        },
         "@babel/code-frame": {
             "version": "7.5.5",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -5577,6 +5572,14 @@
                 "shelljs": "^0.8.3",
                 "typedoc-default-themes": "^0.7.2",
                 "typescript": "3.7.x"
+            },
+            "dependencies": {
+                "typescript": {
+                    "version": "3.7.5",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+                    "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+                    "dev": true
+                }
             }
         },
         "typedoc-default-themes": {
@@ -5592,9 +5595,9 @@
             }
         },
         "typescript": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-            "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
         "uglify-js": {

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -88,7 +88,7 @@
         "tslib": "^1.10.0",
         "tslint": "^5.20.0",
         "typedoc": "^0.16.11",
-        "typescript": "^3.6.4"
+        "typescript": "^3.8.3"
     },
     "dependencies": {
         "@azure/msal-common": "1.0.0-beta.0"

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -2,6 +2,9 @@
 export { PublicClientApplication } from "./app/PublicClientApplication";
 export { Configuration } from "./app/Configuration";
 
+// AuthCallback type
+export type { AuthCallback } from "./types/AuthCallback";
+
 // Common Object Formats
 export {
     // Request

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -2,6 +2,10 @@
 export { PublicClientApplication } from "./app/PublicClientApplication";
 export { Configuration } from "./app/Configuration";
 
+// Browser Errors
+export { BrowserAuthError, BrowserAuthErrorMessage } from "./error/BrowserAuthError";
+export { BrowserConfigurationAuthError, BrowserConfigurationAuthErrorMessage } from "./error/BrowserConfigurationAuthError";
+
 // AuthCallback type
 export type { AuthCallback } from "./types/AuthCallback";
 

--- a/lib/msal-browser/src/types/AuthCallback.ts
+++ b/lib/msal-browser/src/types/AuthCallback.ts
@@ -11,4 +11,3 @@ import { AuthError, AuthResponse } from "@azure/msal-common";
  * @param response response containing token strings in success cases, or just state value in error cases
  */
 export type AuthCallback = (authErr: AuthError, response?: AuthResponse) => void;
-

--- a/lib/msal-browser/tsconfig.json
+++ b/lib/msal-browser/tsconfig.json
@@ -15,8 +15,8 @@
         "esModuleInterop": true,
         "resolveJsonModule": true
     },
-    "files": [
-        "./src/index.ts"
+    "include": [
+        "src/**/*"
     ],
     "exclude": [
         "node_modules"

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -777,7 +777,7 @@ export class UserAgentApplication {
             const top = ((height / 2) - (popUpHeight / 2)) + winTop;
 
             // open the window
-            const popupWindow = window.open(urlNavigate, title, "width=" + popUpWidth + ", height=" + popUpHeight + ", top=" + top + ", left=" + left + ', scrollbars=yes');
+            const popupWindow = window.open(urlNavigate, title, "width=" + popUpWidth + ", height=" + popUpHeight + ", top=" + top + ", left=" + left + ", scrollbars=yes");
             if (!popupWindow) {
                 throw ClientAuthError.createPopupWindowError();
             }

--- a/lib/msal-core/src/XHRClient.ts
+++ b/lib/msal-core/src/XHRClient.ts
@@ -9,7 +9,6 @@
  * @hidden
  */
 
-
 export class XhrClient {
 
     public sendRequestAsync(url: string, method: string, enableCaching?: boolean): Promise<XhrResponse> {
@@ -71,4 +70,4 @@ export class XhrClient {
 export type XhrResponse = {
     body: any,
     statusCode: number
-}
+};

--- a/lib/msal-core/src/telemetry/HttpEvent.ts
+++ b/lib/msal-core/src/telemetry/HttpEvent.ts
@@ -24,7 +24,7 @@ export default class HttpEvent extends TelemetryEvent {
     }
 
     public set url(url: string) {
-        const scrubbedUri = scrubTenantFromUri(url)
+        const scrubbedUri = scrubTenantFromUri(url);
         this.event[EVENT_KEYS.URL] = scrubbedUri && scrubbedUri.toLowerCase();
     }
 

--- a/lib/msal-core/src/telemetry/TelemetryManager.ts
+++ b/lib/msal-core/src/telemetry/TelemetryManager.ts
@@ -12,7 +12,7 @@ import DefaultEvent from "./DefaultEvent";
 import { libraryVersion, Constants } from "../utils/Constants";
 import ApiEvent, { API_EVENT_IDENTIFIER } from "./ApiEvent";
 import { Logger } from "../Logger";
-import HttpEvent from './HttpEvent';
+import HttpEvent from "./HttpEvent";
 
 // for use in cache events
 const MSAL_CACHE_EVENT_VALUE_PREFIX = "msal.token";

--- a/lib/msal-core/src/telemetry/TelemetryUtils.ts
+++ b/lib/msal-core/src/telemetry/TelemetryUtils.ts
@@ -10,9 +10,11 @@ export const scrubTenantFromUri = (uri: string): String => {
 
     // validate trusted host
     if (!AADTrustedHostList[url.HostNameAndPort.toLocaleLowerCase()]) {
-        // returning what was passed because the library needs to work with uris that are non
-        // AAD trusted but passed by users such as B2C or others.
-        // HTTP Events for instance can take a url to the open id config endpoint
+        /**
+         * returning what was passed because the library needs to work with uris that are non
+         * AAD trusted but passed by users such as B2C or others.
+         * HTTP Events for instance can take a url to the open id config endpoint
+         */ 
         return uri;
     }
 


### PR DESCRIPTION
This PR fixes the issues raised in #1510 and #1507. 

Types were not being exported because of import elision in Typescript. Typescript version has been updated to 3.8.x and import/export is fixed.

BrowserAuthError and BrowserConfigurationError and their corresponding message classes have now also been added to the exports to allow for better error handling.

Also includes minor changes to msal-core to fix linting errors.