### PR TITLE
Switch to file-based sourcemaps for msal.js and msal.min.js

### DIFF
--- a/lib/msal-core/webpack.config.js
+++ b/lib/msal-core/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
     extensions: ['.ts', '.tsx', '.js']
   },
 
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   plugins: [
       new ForkTsCheckerWebpackPlugin(),
       new webpack.BannerPlugin({
@@ -37,7 +37,8 @@ module.exports = {
   optimization: {
     minimize: true,
     minimizer: [new UglifyJsPlugin({
-      include: /\.min\.js$/
+      include: /\.min\.js$/,
+      sourceMap: true
     })]
   },
   module: {


### PR DESCRIPTION
Currently, we only generate source maps for non-minified CDN build, which is done inline, greatly increasing the size of `msal.js` for the CDN. This changes source maps to be a file and generates them for both the minified and non-minified CDN builds.

Devtools docs: https://webpack.js.org/configuration/devtool/
Uglify docs: https://webpack.js.org/plugins/uglifyjs-webpack-plugin/#sourcemap

Before:

<img width="703" alt="Annotation 2020-04-20 140432" src="https://user-images.githubusercontent.com/443409/79801265-a939aa00-8312-11ea-883d-d0344c80c636.png">

After:

<img width="704" alt="Annotation 2020-04-20 140600" src="https://user-images.githubusercontent.com/443409/79801263-a8a11380-8312-11ea-8ca9-3dc9cec98adc.png">

These source map files will be pulled in when you open the devtools to debug an application using the CDN version of MSAL.