### PR TITLE
Set sideEffects to false to enable better tree-shaking

### DIFF
--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -22,6 +22,7 @@
   "main": "./lib-commonjs/index.js",
   "module": "./lib-es6/index.js",
   "types": "./lib-commonjs/index.d.ts",
+  "sideEffects": false,
   "engines": {
     "node": ">=0.8.0"
   },


### PR DESCRIPTION
This flag tells webpack that the package does not perform any side effects when imported, allowing for better tree shaking.

Docs: https://webpack.js.org/guides/tree-shaking/

Fixes #1153 