### PR TITLE
Clean up imports in msal-common tests

### DIFF
--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -1,5 +1,4 @@
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
+import { expect } from "chai";
 import sinon from "sinon";
 import {
     Authority,
@@ -20,9 +19,6 @@ import {
 import {BaseClient} from "../../src/client/BaseClient";
 import {AADServerParamKeys, PromptValue, ResponseMode, SSOTypes} from "../../src/utils/Constants";
 import {ClientTestUtils} from "./ClientTestUtils";
-
-const expect = chai.expect;
-chai.use(chaiAsPromised);
 
 describe("AuthorizationCodeClient unit tests", () => {
 

--- a/lib/msal-common/test/client/BaseClient.spec.ts
+++ b/lib/msal-common/test/client/BaseClient.spec.ts
@@ -1,7 +1,4 @@
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-const expect = chai.expect;
-chai.use(chaiAsPromised);
+import { expect } from "chai";
 import { BaseClient } from "../../src/client/BaseClient";
 import { Configuration } from "../../src/config/Configuration";
 import {Constants} from "../../src";
@@ -62,7 +59,7 @@ describe("BaseClient.ts Class Unit Tests", () => {
     let config: Configuration;
     beforeEach(() => {
         config = ClientTestUtils.createTestClientConfiguration();
-        });
+    });
 
     afterEach(() => {
         sinon.restore();

--- a/lib/msal-common/test/client/DeviceCodeClient.spect.ts
+++ b/lib/msal-common/test/client/DeviceCodeClient.spect.ts
@@ -1,7 +1,4 @@
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-const expect = chai.expect;
-chai.use(chaiAsPromised);
+import { expect } from "chai";
 import sinon from "sinon";
 import {
     Authority, ClientAuthErrorMessage,

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -1,5 +1,4 @@
-import chai, { expect } from "chai";
-import chaiAsPromised from "chai-as-promised";
+import { expect } from "chai";
 import sinon from "sinon";
 import {
     Authority,
@@ -16,8 +15,6 @@ import {
 import {BaseClient} from "../../src/client/BaseClient";
 import {AADServerParamKeys, GrantType} from "../../src/utils/Constants";
 import {ClientTestUtils} from "./ClientTestUtils";
-
-chai.use(chaiAsPromised);
 
 describe("RefreshTokenClient unit tests", () => {
 

--- a/lib/msal-common/test/client/SPAClient.spec.ts
+++ b/lib/msal-common/test/client/SPAClient.spec.ts
@@ -1,8 +1,4 @@
-import * as Mocha from "mocha";
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-const expect = chai.expect;
-chai.use(chaiAsPromised);
+import { expect } from "chai";
 import { SPAClient } from "../../src/client/SPAClient";
 import { TEST_CONFIG, TEST_URIS, RANDOM_TEST_GUID, DEFAULT_OPENID_CONFIG_RESPONSE, TEST_TOKENS, ALTERNATE_OPENID_CONFIG_RESPONSE, TEST_DATA_CLIENT_INFO, TEST_TOKEN_LIFETIMES } from "../utils/StringConstants";
 import { BaseClient } from "../../src/client/BaseClient";

--- a/lib/msal-common/test/config/Configuration.spec.ts
+++ b/lib/msal-common/test/config/Configuration.spec.ts
@@ -1,6 +1,4 @@
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-import sinon from "sinon";
+import { expect } from "chai";
 import { Configuration, buildConfiguration } from "../../src/config/Configuration";
 import { PkceCodes } from "../../src/crypto/ICrypto";
 import { AuthError } from "../../src/error/AuthError";
@@ -10,13 +8,11 @@ import { Constants } from "../../src";
 import { version } from "../../package.json";
 import {TEST_CONFIG} from "../utils/StringConstants";
 
-const expect = chai.expect;
-chai.use(chaiAsPromised);
 
 describe("Configuration.ts Class Unit Tests", () => {
 
     it("buildConfiguration assigns default functions", async () => {
-        let emptyConfig: Configuration = buildConfiguration({});
+        const emptyConfig: Configuration = buildConfiguration({});
         // Crypto interface checks
         expect(emptyConfig.cryptoInterface).to.be.not.null;
         expect(emptyConfig.cryptoInterface.base64Decode).to.be.not.null;
@@ -92,7 +88,7 @@ describe("Configuration.ts Class Unit Tests", () => {
     const testKeySet = ["testKey1", "testKey2"];
 
     it("buildConfiguration correctly assigns new values", () => {
-        let newConfig: Configuration = buildConfiguration({
+        const newConfig: Configuration = buildConfiguration({
             cryptoInterface: {
                 createNewGuid: (): string => {
                     return "newGuid";

--- a/lib/msal-common/test/config/PublicClientSPAConfiguration.spec.ts
+++ b/lib/msal-common/test/config/PublicClientSPAConfiguration.spec.ts
@@ -1,7 +1,4 @@
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-const expect = chai.expect;
-chai.use(chaiAsPromised);
+import { expect } from "chai";
 import { SPAConfiguration, buildPublicClientSPAConfiguration } from "../../src/config/SPAConfiguration";
 import { PkceCodes } from "../../src/crypto/ICrypto";
 import { TEST_CONFIG, TEST_URIS } from "../utils/StringConstants";

--- a/lib/msal-common/test/mochaSetup.js
+++ b/lib/msal-common/test/mochaSetup.js
@@ -1,1 +1,4 @@
 require("@babel/register")({ extensions: ['.js', '.jsx', '.ts', '.tsx'] });
+const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);

--- a/lib/msal-common/test/request/RequestValidator.spec.ts
+++ b/lib/msal-common/test/request/RequestValidator.spec.ts
@@ -1,5 +1,4 @@
-import chai from "chai";
-const expect = chai.expect;
+import { expect } from "chai";
 import {
     ClientConfigurationError
 } from "../../src";

--- a/lib/msal-common/test/server/RequestParameterBuilder.spec.ts
+++ b/lib/msal-common/test/server/RequestParameterBuilder.spec.ts
@@ -6,9 +6,9 @@ import {
     TEST_TOKENS,
     DEVICE_CODE_RESPONSE
 } from "../utils/StringConstants";
-import {RequestParameterBuilder} from "../../src/server/RequestParameterBuilder";
-import {ScopeSet} from "../../src/request/ScopeSet";
-import {ClientAuthErrorMessage, ClientConfigurationError, ClientConfigurationErrorMessage} from "../../src";
+import { RequestParameterBuilder } from "../../src/server/RequestParameterBuilder";
+import { ScopeSet } from "../../src/request/ScopeSet";
+import { ClientConfigurationError } from "../../src";
 
 describe("RequestParameterBuilder unit tests", () => {
 


### PR DESCRIPTION
Add commonly used imports to mochaSetup.js