### PR TITLE
Ensure interceptor uses ID token property if response is of type id_token

### DIFF
--- a/lib/msal-angular/karma.conf.js
+++ b/lib/msal-angular/karma.conf.js
@@ -29,6 +29,7 @@ module.exports = function (config) {
 
             { pattern: 'node_modules/babel-polyfill/browser.js', instrument: false},
             { pattern: 'tests/MSALSpec.ts', watched: false },
+            { pattern: 'tests/MSALInterceptorSpec.ts', watched: false },
         ],
 
         // list of files to exclude
@@ -38,7 +39,8 @@ module.exports = function (config) {
         // preprocess matching files before serving them to the browser
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
-            'tests/MSALSpec.ts': ['webpack', 'sourcemap']
+            'tests/MSALSpec.ts': ['webpack', 'sourcemap'],
+            'tests/MSALInterceptorSpec.ts': ['webpack', 'sourcemap']
         },
 
         // webpack

--- a/lib/msal-angular/tests/MSALInterceptorSpec.ts
+++ b/lib/msal-angular/tests/MSALInterceptorSpec.ts
@@ -1,0 +1,130 @@
+import { TestBed, inject, getTestBed } from "@angular/core/testing";
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from "@angular/common/http/testing";
+import { MsalInterceptor } from "../src/msal.interceptor";
+import { HTTP_INTERCEPTORS, HttpClient } from "@angular/common/http";
+import { MsalService, MSAL_CONFIG, MSAL_CONFIG_ANGULAR, MsalAngularConfiguration, BroadcastService } from "../public_api";
+import { Configuration, ServerHashParamKeys, UserAgentApplication } from "msal";
+import {} from "jasmine";
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from "@angular/platform-browser-dynamic/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+
+describe(`MSALInterceptor`, () => {
+    let httpMock: HttpTestingController;
+    let httpClient: HttpClient;
+
+    beforeEach(() => {
+        const clientId = "6226576d-37e9-49eb-b201-ec1eeb0029b6";
+        TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule, RouterTestingModule],
+        providers: [
+            MsalService,
+            {
+                provide: MSAL_CONFIG,
+                useValue: {
+                    auth: {
+                        clientId,
+                        authority: "https://login.microsoftonline.com/microsoft.onmicrosoft.com/",
+                        validateAuthority: true,
+                        redirectUri: "http://localhost:4200/",
+                        postLogoutRedirectUri: "http://localhost:4200/",
+                        navigateToLoginRequestUrl: true,
+                    },
+                    cache: {
+                        cacheLocation: "localStorage",
+                        storeAuthStateInCookie: false
+                    }
+                } as Configuration
+            },
+            {
+                provide: MSAL_CONFIG_ANGULAR,
+                useValue: {
+                    popUp: false,
+                    consentScopes: ["user.read", "mail.send"],
+                    protectedResourceMap: [
+                        ["https://graph.microsoft.com/v1.0/me", ["user.read"]]
+                    ]
+                } as MsalAngularConfiguration
+            },
+            BroadcastService,
+            {
+                provide: Storage,
+                useClass: {
+                    mockLocalStorage: "localStorage"
+                }
+            },
+            {
+                provide: HTTP_INTERCEPTORS,
+                useClass: MsalInterceptor,
+                multi: true,
+            },
+        ],
+        });
+
+        getTestBed().initTestEnvironment(
+            BrowserDynamicTestingModule,
+            platformBrowserDynamicTesting()
+        );
+
+        httpMock = TestBed.get(HttpTestingController);
+        httpClient = TestBed.get(HttpClient);
+    });
+
+    afterEach(() => {
+        getTestBed().resetTestEnvironment();
+    });
+
+    it("does not attach authorization header for unprotected resource", () => {
+        httpClient.get("http://localhost/api").subscribe(response => expect(response).toBeTruthy());
+
+        const request = httpMock.expectOne("http://localhost/api");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toBeUndefined;
+        httpMock.verify();
+    });
+
+    it("attaches authorization header with access token for protected resource", done => {
+        spyOn(UserAgentApplication.prototype, "acquireTokenSilent").and.returnValue((
+            new Promise((resolve) => {
+                resolve({
+                    accessToken: "access-token",
+                    tokenType: ServerHashParamKeys.ACCESS_TOKEN
+                });
+            })
+        ));
+
+        httpClient.get("https://graph.microsoft.com/v1.0/me").subscribe();
+        setTimeout(() => {
+            const request = httpMock.expectOne("https://graph.microsoft.com/v1.0/me");
+            request.flush({ data: "test" });
+            expect(request.request.headers.get("Authorization")).toEqual("Bearer access-token");
+            httpMock.verify();
+            done();
+        }, 200);
+    });
+
+    it("attaches authorization header with id token for protected resource", done => {
+        spyOn(UserAgentApplication.prototype, "acquireTokenSilent").and.returnValue((
+            new Promise((resolve) => {
+                resolve({
+                    accessToken: "access-token",
+                    idToken: {
+                        rawIdToken: "id-token",
+                    },
+                    tokenType: ServerHashParamKeys.ID_TOKEN
+                });
+            })
+        ));
+
+        httpClient.get("https://graph.microsoft.com/v1.0/me").subscribe();
+        setTimeout(() => {
+            const request = httpMock.expectOne("https://graph.microsoft.com/v1.0/me");
+            request.flush({ data: "test" });
+            expect(request.request.headers.get("Authorization")).toEqual("Bearer id-token");
+            httpMock.verify();
+            done();
+        }, 200);
+    });
+});

--- a/lib/msal-core/src/index.ts
+++ b/lib/msal-core/src/index.ts
@@ -2,7 +2,7 @@ export { UserAgentApplication, authResponseCallback, errorReceivedCallback, toke
 export { Logger } from "./Logger";
 export { LogLevel } from "./Logger";
 export { Account } from "./Account";
-export { Constants } from "./utils/Constants";
+export { Constants, ServerHashParamKeys } from "./utils/Constants";
 export { Authority } from "./authority/Authority";
 export { CacheResult } from "./UserAgentApplication";
 export { CacheLocation, Configuration } from "./Configuration";


### PR DESCRIPTION
Since it is technically possible to use an ID token to protect a route, the interceptor needs to properly differentiate between access tokens and id tokens and use the correct properties. 

Currently, in situations where an ID token is used to protect a route, the interceptor will attach a `Bearer null` header to outgoing requests, because it naively assumes that the token will always be present on the `accessToken` property. This is because when we retrieve a cached ID token, the response sets the ID token as `accessToken`, however, we retrieving a new ID token from the network, the ID token is only set as `idToken`.

This PR ensures we inspect the `tokenType` value first, and properly use the correct field instead of relying on `accessToken` always being set.

Fixes:
- #1475