### PR TITLE
Check if request is null in populateQueryParams

### DIFF
--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -113,7 +113,7 @@ export class ServerRequestParameters {
         queryParameters = this.addHintParameters(account, queryParameters);
 
         // sanity check for developer passed extraQueryParameters
-        const eQParams: StringDict = request ? request.extraQueryParameters : null;
+        const eQParams: StringDict|null = request?.extraQueryParameters;
 
         // Populate the extraQueryParameters to be sent to the server
         this.queryParameters = ServerRequestParameters.generateQueryParametersString(queryParameters);

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -82,7 +82,7 @@ export class ServerRequestParameters {
      * @param request
      * @param serverAuthenticationRequest
      */
-    populateQueryParams(account: Account, request: AuthenticationParameters, adalIdTokenObject?: object, silentCall?: boolean): void {
+    populateQueryParams(account: Account, request: AuthenticationParameters|null, adalIdTokenObject?: object, silentCall?: boolean): void {
         let queryParameters: StringDict = {};
 
         if (request) {
@@ -113,7 +113,7 @@ export class ServerRequestParameters {
         queryParameters = this.addHintParameters(account, queryParameters);
 
         // sanity check for developer passed extraQueryParameters
-        const eQParams: StringDict = request.extraQueryParameters;
+        const eQParams: StringDict = request ? request.extraQueryParameters : null;
 
         // Populate the extraQueryParameters to be sent to the server
         this.queryParameters = ServerRequestParameters.generateQueryParametersString(queryParameters);
@@ -245,8 +245,8 @@ export class ServerRequestParameters {
      * Utility to generate a QueryParameterString from a Key-Value mapping of extraQueryParameters passed
      * @param extraQueryParameters
      */
-    static generateQueryParametersString(queryParameters: StringDict, silentCall?: boolean): string {
-        let paramsString: string = null;
+    static generateQueryParametersString(queryParameters?: StringDict, silentCall?: boolean): string|null {
+        let paramsString: string|null = null;
 
         if (queryParameters) {
             Object.keys(queryParameters).forEach((key: string) => {

--- a/lib/msal-core/src/ServerRequestParameters.ts
+++ b/lib/msal-core/src/ServerRequestParameters.ts
@@ -113,7 +113,7 @@ export class ServerRequestParameters {
         queryParameters = this.addHintParameters(account, queryParameters);
 
         // sanity check for developer passed extraQueryParameters
-        const eQParams: StringDict|null = request?.extraQueryParameters;
+        const eQParams: StringDict|null = request ? request.extraQueryParameters : null;
 
         // Populate the extraQueryParameters to be sent to the server
         this.queryParameters = ServerRequestParameters.generateQueryParametersString(queryParameters);


### PR DESCRIPTION
Restore a null test removed in https://github.com/AzureAD/microsoft-authentication-library-for-js/commit/bf86b898d120760e4a1c62126becd088deb78b55#diff-01b40b5f69b6021ac7031ce85ef0d452L120-L123

This addresses #1411, #1237, and #1254. I don’t know why some of these type errors are passing compilation as they should be breaking it?

Untested, edited code in browser window.

There should probably be some tests added to CI for this as the last version that works seems to be 1.1.3.