### PR TITLE
[msal-angular] Fix error broadcast in handleRedirectCallback

### DIFF
--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -125,7 +125,7 @@ export class MsalService extends UserAgentApplication {
     handleRedirectCallback(authOrTokenCallback: authResponseCallback | tokenReceivedCallback, errorReceivedCallback?: errorReceivedCallback): void {
         super.handleRedirectCallback((authError: AuthError, authResponse: AuthResponse) => {
             if (authError) {
-                if (authResponse.tokenType === "id_token") {
+                if (!this.getAccount()) {
                     this.broadcastService.broadcast("msal:loginFailure", authError);
 
                 } else {

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -124,20 +124,7 @@ export class MsalService extends UserAgentApplication {
     handleRedirectCallback(authCallback: authResponseCallback): void;
     handleRedirectCallback(authOrTokenCallback: authResponseCallback | tokenReceivedCallback, errorReceivedCallback?: errorReceivedCallback): void {
         super.handleRedirectCallback((authError: AuthError, authResponse: AuthResponse) => {
-            if (authResponse) {
-                if (authResponse.tokenType === "id_token") {
-                    this.broadcastService.broadcast("msal:loginSuccess", authResponse);
-                } else {
-                    this.broadcastService.broadcast("msal:acquireTokenSuccess", authResponse);
-                }
-
-                if (errorReceivedCallback) {
-                    (authOrTokenCallback as tokenReceivedCallback)(authResponse);
-                } else {
-                    (authOrTokenCallback as authResponseCallback)(null, authResponse);
-                }
-
-            } else if (authError) {
+            if (authError) {
                 if (authResponse.tokenType === "id_token") {
                     this.broadcastService.broadcast("msal:loginFailure", authError);
 
@@ -149,6 +136,19 @@ export class MsalService extends UserAgentApplication {
                     errorReceivedCallback(authError, authResponse.accountState);
                 } else {
                     (authOrTokenCallback as authResponseCallback)(authError);
+                }
+
+            } else if (authResponse) {
+                if (authResponse.tokenType === "id_token") {
+                    this.broadcastService.broadcast("msal:loginSuccess", authResponse);
+                } else {
+                    this.broadcastService.broadcast("msal:acquireTokenSuccess", authResponse);
+                }
+
+                if (errorReceivedCallback) {
+                    (authOrTokenCallback as tokenReceivedCallback)(authResponse);
+                } else {
+                    (authOrTokenCallback as authResponseCallback)(null, authResponse);
                 }
 
             }

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -135,7 +135,7 @@ export class MsalService extends UserAgentApplication {
                 if (errorReceivedCallback) {
                     errorReceivedCallback(authError, authResponse.accountState);
                 } else {
-                    (authOrTokenCallback as authResponseCallback)(authError);
+                    (authOrTokenCallback as authResponseCallback)(authError, authResponse);
                 }
 
             } else if (authResponse) {

--- a/lib/msal-angular/tests/MSALSpec.ts
+++ b/lib/msal-angular/tests/MSALSpec.ts
@@ -21,261 +21,283 @@ import {
 import {RouterTestingModule} from '@angular/router/testing';
 import {} from 'jasmine';
 import { Configuration, UserAgentApplication, AuthResponse, AuthError } from "msal";
+import { RequestUtils } from "../../msal-core/src/utils/RequestUtils";
+import { Constants, TemporaryCacheKeys } from "../../msal-core/src/utils/Constants";
+import { testHashesForState, TEST_TOKENS } from "./TestConstants";
+import { AuthCache } from "msal/src/cache/AuthCache";
+
+let authService: MsalService;
+let broadcastService: BroadcastService;
+
+const clientId = "6226576d-37e9-49eb-b201-ec1eeb0029b6";
+
+function initializeMsal() {
+    TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
+        providers: [
+            MsalService,
+            {
+                provide: MSAL_CONFIG,
+                useValue: {
+                    auth: {
+                        clientId,
+                        authority: "https://login.microsoftonline.com/microsoft.onmicrosoft.com/",
+                        validateAuthority: true,
+                        redirectUri: "http://localhost:4200/",
+                        postLogoutRedirectUri: "http://localhost:4200/",
+                        navigateToLoginRequestUrl: true,
+                    },
+                    cache: {
+                        cacheLocation: "localStorage",
+                        storeAuthStateInCookie: false
+                    }
+                } as Configuration
+            },
+            {
+                provide: MSAL_CONFIG_ANGULAR,
+                useValue: {
+                    popUp: false,
+                    consentScopes: ["user.read", "mail.send"],
+                    protectedResourceMap: [
+                        ["https://graph.microsoft.com/v1.0/me", ["user.read"]]
+                    ]
+                } as MsalAngularConfiguration
+            },
+            BroadcastService,
+            {
+                provide: Storage,
+                useClass: {
+                    mockLocalStorage: "localStorage"
+                }
+            }
+        ]
+    })
+    
+    getTestBed().initTestEnvironment(
+        BrowserDynamicTestingModule,
+        platformBrowserDynamicTesting()
+    );
+
+    authService = TestBed.get(MsalService);
+    broadcastService = TestBed.get(BroadcastService);
+};
 
 describe('Msal Angular Pubic API tests', function () {
+    describe('login and acquireToken methods', () => {
+        beforeAll(initializeMsal);
+        afterAll(() => {
+            TestBed.resetTestEnvironment();
+            TestBed.resetTestingModule();
+            authService = null;
+            broadcastService = null;
+        })
 
-    let authService: MsalService;
-    let broadcastService: BroadcastService;
+        describe('loginPopup', () => {
+            it('success', done => {
+                const sampleIdToken = {
+                    idToken: "123abc"
+                };
 
-    const clientId = "6226576d-37e9-49eb-b201-ec1eeb0029b6";
+                spyOn(UserAgentApplication.prototype, 'loginPopup').and.returnValue((
+                    new Promise((resolve) => {
+                        resolve(sampleIdToken);
+                    })
+                ));
 
-    beforeAll(() => {
-        TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
-            providers: [
-                MsalService,
-                {
-                    provide: MSAL_CONFIG,
-                    useValue: {
-                        auth: {
-                            clientId,
-                            authority: "https://login.microsoftonline.com/microsoft.onmicrosoft.com/",
-                            validateAuthority: true,
-                            redirectUri: "http://localhost:4200/",
-                            postLogoutRedirectUri: "http://localhost:4200/",
-                            navigateToLoginRequestUrl: true,
-                        },
-                        cache: {
-                            cacheLocation: "localStorage",
-                            storeAuthStateInCookie: false
-                        }
-                    } as Configuration
-                },
-                {
-                    provide: MSAL_CONFIG_ANGULAR,
-                    useValue: {
-                        popUp: false,
-                        consentScopes: ["user.read", "mail.send"],
-                        protectedResourceMap: [
-                            ["https://graph.microsoft.com/v1.0/me", ["user.read"]]
-                        ]
-                    } as MsalAngularConfiguration
-                },
-                BroadcastService,
-                {
-                    provide: Storage,
-                    useClass: {
-                        mockLocalStorage: "localStorage"
-                    }
-                }
-            ]
+                broadcastService.subscribe("msal:loginSuccess", (payload: AuthResponse) => {
+                    expect(payload.idToken).toBe(sampleIdToken.idToken);
+
+                    done();
+                });
+
+                const request = {
+                    scopes: ["user.read"]
+                };
+
+                authService.loginPopup(request)
+                .then((response: AuthResponse) => {
+                    expect(response.idToken).toBe(sampleIdToken.idToken);
+                });
+
+                expect(UserAgentApplication.prototype.loginPopup).toHaveBeenCalledWith(request);
+            });
+
+            it('failure', done => {
+                const sampleError = new AuthError("123", "message");
+
+                spyOn(UserAgentApplication.prototype, 'loginPopup').and.returnValue((
+                    new Promise((resolve, reject) => {
+                        reject(sampleError);
+                    })
+                ));
+
+                broadcastService.subscribe("msal:loginFailure", (error: AuthError) => {
+                    expect(error.message).toBe(sampleError.message);
+                    done();
+                });
+
+                const request = {
+                    scopes: ["wrong.scope"]
+                };
+
+                authService.loginPopup(request)
+                .catch((error: AuthError) => {
+                    expect(error.message).toBe(sampleError.message);
+                });
+
+                expect(UserAgentApplication.prototype.loginPopup).toHaveBeenCalledWith(request);
+            });
         });
 
-        getTestBed().initTestEnvironment(
-            BrowserDynamicTestingModule,
-            platformBrowserDynamicTesting()
-        );
+        describe('loginRedirect', () => {
+            it('success', () => {
+                spyOn(UserAgentApplication.prototype, 'loginRedirect');
 
-        authService = TestBed.get(MsalService);
-        broadcastService = TestBed.get(BroadcastService);
-    });
+                authService.loginRedirect({
+                    scopes: ["user.read"]
+                });
 
-    describe('loginPopup', () => {
-        it('success', done => {
-            const sampleIdToken = {
-                idToken: "123abc"
-            };
-
-            spyOn(UserAgentApplication.prototype, 'loginPopup').and.returnValue((
-                new Promise((resolve) => {
-                    resolve(sampleIdToken);
-                })
-            ));
-
-            broadcastService.subscribe("msal:loginSuccess", (payload: AuthResponse) => {
-                expect(payload.idToken).toBe(sampleIdToken.idToken);
-
-                done();
+                expect(UserAgentApplication.prototype.loginRedirect).toHaveBeenCalled();
             });
-
-            const request = {
-                scopes: ["user.read"]
-            };
-
-            authService.loginPopup(request)
-            .then((response: AuthResponse) => {
-                expect(response.idToken).toBe(sampleIdToken.idToken);
-            });
-
-            expect(UserAgentApplication.prototype.loginPopup).toHaveBeenCalledWith(request);
         });
 
-        it('failure', done => {
-            const sampleError = new AuthError("123", "message");
-
-            spyOn(UserAgentApplication.prototype, 'loginPopup').and.returnValue((
-                new Promise((resolve, reject) => {
-                    reject(sampleError);
-                })
-            ));
-
-            broadcastService.subscribe("msal:loginFailure", (error: AuthError) => {
-                expect(error.message).toBe(sampleError.message);
-                done();
+        describe('acquireTokenSilent', () => {
+            it('success', done => {
+                const sampleAccessToken = {
+                    accessToken: "123abc"
+                };
+    
+                spyOn(UserAgentApplication.prototype, 'acquireTokenSilent').and.returnValue((
+                    new Promise((resolve) => {
+                        resolve(sampleAccessToken);
+                    })
+                ));
+    
+                broadcastService.subscribe("msal:acquireTokenSuccess", (payload: any) => {
+                    expect(payload.accessToken).toBe(sampleAccessToken.accessToken);
+    
+                    done();
+                });
+    
+                const request = {
+                    scopes: ["user.read"]
+                };
+    
+                authService.acquireTokenSilent(request)
+                .then((response) => {
+                    expect(response.accessToken).toBe(sampleAccessToken.accessToken);
+                });
+    
+                expect(UserAgentApplication.prototype.acquireTokenSilent).toHaveBeenCalledWith(request);
             });
-
-            const request = {
-                scopes: ["wrong.scope"]
-            };
-
-            authService.loginPopup(request)
-            .catch((error: AuthError) => {
-                expect(error.message).toBe(sampleError.message);
+    
+            it('failure', function(done) {
+                const sampleError = new AuthError("123", "message");
+    
+                spyOn(UserAgentApplication.prototype, 'acquireTokenSilent').and.returnValue((
+                    new Promise((resolve, reject) => {
+                        reject(sampleError);
+                    })
+                ));
+    
+                broadcastService.subscribe("msal:acquireTokenFailure", (error: AuthError) => {
+                    expect(error.message).toBe(sampleError.message);
+                    done();
+                });
+    
+                const request = {
+                    scopes: ["wrong.scope"]
+                };
+    
+                authService.acquireTokenSilent(request)
+                .catch((error: AuthError) => {
+                    expect(error.message).toBe(sampleError.message);
+                });
+    
+                expect(UserAgentApplication.prototype.acquireTokenSilent).toHaveBeenCalledWith(request);
             });
-
-            expect(UserAgentApplication.prototype.loginPopup).toHaveBeenCalledWith(request);
         });
-    });
-
-    describe('loginRedirect', () => {
-        it('success', () => {
-            spyOn(UserAgentApplication.prototype, 'loginRedirect');
-
-            authService.loginRedirect({
-                scopes: ["user.read"]
+    
+        describe('acquireTokenRedirect', () => {
+            it('success', () => {
+                spyOn(UserAgentApplication.prototype, 'acquireTokenRedirect');
+    
+                authService.acquireTokenRedirect({
+                    scopes: ["user.read"]
+                });
+    
+                expect(UserAgentApplication.prototype.acquireTokenRedirect).toHaveBeenCalled();
             });
-
-            expect(UserAgentApplication.prototype.loginRedirect).toHaveBeenCalled();
         });
-    });
-
-    describe('acquireTokenSilent', () => {
-        it('success', done => {
-            const sampleAccessToken = {
-                accessToken: "123abc"
-            };
-
-            spyOn(UserAgentApplication.prototype, 'acquireTokenSilent').and.returnValue((
-                new Promise((resolve) => {
-                    resolve(sampleAccessToken);
-                })
-            ));
-
-            broadcastService.subscribe("msal:acquireTokenSuccess", (payload: any) => {
-                expect(payload.accessToken).toBe(sampleAccessToken.accessToken);
-
-                done();
+    
+        describe('acquireTokenPopup', () => {
+            it('success', done => {
+                const sampleAccessToken = {
+                    accessToken: "123abc"
+                };
+    
+                spyOn(UserAgentApplication.prototype, 'acquireTokenPopup').and.returnValue((
+                    new Promise((resolve) => {
+                        resolve(sampleAccessToken);
+                    })
+                ));
+    
+                broadcastService.subscribe("msal:acquireTokenSuccess", (payload: AuthResponse) => {
+                    expect(payload.accessToken).toBe(sampleAccessToken.accessToken);
+    
+                    done();
+                });
+    
+                const request = {
+                    scopes: ["user.read"]
+                };
+    
+                authService.acquireTokenPopup(request)
+                .then((response: AuthResponse) => {
+                    expect(response.accessToken).toBe(sampleAccessToken.accessToken);
+                });
+    
+                expect(UserAgentApplication.prototype.acquireTokenPopup).toHaveBeenCalledWith(request);
             });
-
-            const request = {
-                scopes: ["user.read"]
-            };
-
-            authService.acquireTokenSilent(request)
-            .then((response) => {
-                expect(response.accessToken).toBe(sampleAccessToken.accessToken);
+    
+            it('failure', done => {
+                const sampleError = new AuthError("123", "message");
+    
+                spyOn(UserAgentApplication.prototype, 'acquireTokenPopup').and.returnValue((
+                    new Promise((resolve, reject) => {
+                        reject(sampleError);
+                    })
+                ));
+    
+                broadcastService.subscribe("msal:acquireTokenFailure", (error: AuthError) => {
+                    expect(error.message).toBe(sampleError.message);
+                    done();
+                });
+    
+                const request = {
+                    scopes: ["wrong.scope"]
+                };
+    
+                authService.acquireTokenPopup(request)
+                .catch((error: AuthError) => {
+                    expect(error.message).toBe(sampleError.message);
+                });
+    
+                expect(UserAgentApplication.prototype.acquireTokenPopup).toHaveBeenCalledWith(request);
             });
-
-            expect(UserAgentApplication.prototype.acquireTokenSilent).toHaveBeenCalledWith(request);
-        });
-
-        it('failure', function(done) {
-            const sampleError = new AuthError("123", "message");
-
-            spyOn(UserAgentApplication.prototype, 'acquireTokenSilent').and.returnValue((
-                new Promise((resolve, reject) => {
-                    reject(sampleError);
-                })
-            ));
-
-            broadcastService.subscribe("msal:acquireTokenFailure", (error: AuthError) => {
-                expect(error.message).toBe(sampleError.message);
-                done();
-            });
-
-            const request = {
-                scopes: ["wrong.scope"]
-            };
-
-            authService.acquireTokenSilent(request)
-            .catch((error: AuthError) => {
-                expect(error.message).toBe(sampleError.message);
-            });
-
-            expect(UserAgentApplication.prototype.acquireTokenSilent).toHaveBeenCalledWith(request);
-        });
-    });
-
-    describe('acquireTokenRedirect', () => {
-        it('success', () => {
-            spyOn(UserAgentApplication.prototype, 'acquireTokenRedirect');
-
-            authService.acquireTokenRedirect({
-                scopes: ["user.read"]
-            });
-
-            expect(UserAgentApplication.prototype.acquireTokenRedirect).toHaveBeenCalled();
-        });
-    });
-
-    describe('acquireTokenPopup', () => {
-        it('success', done => {
-            const sampleAccessToken = {
-                accessToken: "123abc"
-            };
-
-            spyOn(UserAgentApplication.prototype, 'acquireTokenPopup').and.returnValue((
-                new Promise((resolve) => {
-                    resolve(sampleAccessToken);
-                })
-            ));
-
-            broadcastService.subscribe("msal:acquireTokenSuccess", (payload: AuthResponse) => {
-                expect(payload.accessToken).toBe(sampleAccessToken.accessToken);
-
-                done();
-            });
-
-            const request = {
-                scopes: ["user.read"]
-            };
-
-            authService.acquireTokenPopup(request)
-            .then((response: AuthResponse) => {
-                expect(response.accessToken).toBe(sampleAccessToken.accessToken);
-            });
-
-            expect(UserAgentApplication.prototype.acquireTokenPopup).toHaveBeenCalledWith(request);
         });
 
-        it('failure', done => {
-            const sampleError = new AuthError("123", "message");
-
-            spyOn(UserAgentApplication.prototype, 'acquireTokenPopup').and.returnValue((
-                new Promise((resolve, reject) => {
-                    reject(sampleError);
-                })
-            ));
-
-            broadcastService.subscribe("msal:acquireTokenFailure", (error: AuthError) => {
-                expect(error.message).toBe(sampleError.message);
-                done();
-            });
-
-            const request = {
-                scopes: ["wrong.scope"]
-            };
-
-            authService.acquireTokenPopup(request)
-            .catch((error: AuthError) => {
-                expect(error.message).toBe(sampleError.message);
-            });
-
-            expect(UserAgentApplication.prototype.acquireTokenPopup).toHaveBeenCalledWith(request);
-        });
     });
 
     describe("getScopesForEndpoint", () => {
+        beforeAll(initializeMsal);
+        afterAll(() => {
+            TestBed.resetTestEnvironment();
+            TestBed.resetTestingModule();
+            authService = null;
+            broadcastService = null;
+        });
+
         it("protected resource", () => {
             const scopes = authService.getScopesForEndpoint("https://graph.microsoft.com/v1.0/me");
 
@@ -298,6 +320,104 @@ describe('Msal Angular Pubic API tests', function () {
             const scopes = authService.getScopesForEndpoint("http://localhost:4200/api");
 
             expect(scopes).toEqual([ clientId ]);
+        });
+    });
+
+    describe('handleRedirectCallback', () => {
+        let TEST_LIBRARY_STATE: string;
+        let TEST_NONCE: string;
+        let TEST_USER_STATE_NUM: string;
+        let cacheStorage: AuthCache;
+
+        beforeAll(() => {
+            TEST_USER_STATE_NUM = "1234"
+            TEST_NONCE = "123523";
+            TEST_LIBRARY_STATE = RequestUtils.generateLibraryState(Constants.interactionTypeRedirect);
+            cacheStorage = new AuthCache(clientId, "localStorage", true);
+        });
+        afterEach(() => {
+            TestBed.resetTestEnvironment();
+            TestBed.resetTestingModule();
+            authService = null;
+            broadcastService = null;
+            window.location.hash = ""
+        });
+        afterAll(() => {
+            cacheStorage.clear();
+        });
+
+        it('success with token type id_token', done => {
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+            window.location.hash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+            initializeMsal();
+
+            function redirectReturn(error: AuthError, response: AuthResponse){
+                expect(response).toBeTruthy();
+                expect(error).toBeNull();
+            }
+
+            broadcastService.subscribe("msal:loginSuccess", (response: AuthResponse) => {
+                expect(response.idToken.rawIdToken).toEqual(TEST_TOKENS.IDTOKEN_V2);
+                expect(response.tokenType).toEqual('id_token');
+                done();
+            });
+
+            authService.handleRedirectCallback(redirectReturn);
+        });
+
+        it('success with token type access_token', done => {
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_ACQ_TOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+            window.location.hash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ACCESS_TOKEN_HASH + TEST_USER_STATE_NUM;
+            initializeMsal();
+
+            function redirectReturn(error: AuthError, response: AuthResponse){
+                expect(response).toBeTruthy();
+                expect(error).toBeNull();
+            }
+
+            broadcastService.subscribe("msal:acquireTokenSuccess", (response: AuthResponse) => {
+                expect(response.accessToken).toEqual(TEST_TOKENS.ACCESSTOKEN);
+                expect(response.tokenType).toEqual('access_token')
+                done();
+            });
+
+            authService.handleRedirectCallback(redirectReturn);
+        });
+
+        it('failure with token type access_token', done => {
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_ACQ_TOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+            window.location.hash = testHashesForState(TEST_LIBRARY_STATE).TEST_ERROR_HASH + TEST_USER_STATE_NUM;
+            initializeMsal();
+
+            let expectedResponse : AuthResponse = {
+                uniqueId: "",
+                tenantId: "",
+                tokenType: "",
+                idToken: null,
+                idTokenClaims: null,
+                accessToken: "",
+                scopes: null,
+                expiresOn: null,
+                account: null,
+                accountState: TEST_USER_STATE_NUM,
+                fromCache: false
+            };
+
+            function redirectReturn(error: AuthError, response: AuthResponse){
+                expect(response).toBeTruthy();
+                expect(response).toEqual(expectedResponse);
+                expect(error).toBeTruthy();
+            }
+
+            broadcastService.subscribe("msal:acquireTokenFailure", (error: AuthError) => {
+                expect(error.message).toEqual("msal error description")
+                done();
+            });
+
+            authService.handleRedirectCallback(redirectReturn);
         });
     });
 });

--- a/lib/msal-angular/tests/TestConstants.ts
+++ b/lib/msal-angular/tests/TestConstants.ts
@@ -1,0 +1,30 @@
+// Test Tokens
+export const TEST_TOKENS = {
+    // idTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
+    // accessTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
+    IDTOKEN_V2: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
+    ACCESSTOKEN: "thisIs.an.accessT0ken"
+};
+
+// Test CLIENT_INFO
+export const TEST_DATA_CLIENT_INFO = {
+    TEST_UID: "123-test-uid",
+    TEST_UTID: "456-test-utid",
+    TEST_DECODED_CLIENT_INFO: `{"uid":"123-test-uid","utid":"456-test-utid"}`,
+    TEST_INVALID_JSON_CLIENT_INFO: `{"uid":"123-test-uid""utid":"456-test-utid"}`,
+    TEST_RAW_CLIENT_INFO: "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9",
+    TEST_CLIENT_INFO_B64ENCODED: "eyJ1aWQiOiIxMjM0NSIsInV0aWQiOiI2Nzg5MCJ9",
+    TEST_HOME_ACCOUNT_ID: "MTIzLXRlc3QtdWlk.NDU2LXRlc3QtdXRpZA=="
+};
+
+// Test Expiration Vals
+export const TEST_TOKEN_LIFETIMES = {
+    DEFAULT_EXPIRES_IN: 3599
+};
+
+// Test Hashes
+export const testHashesForState = state => ({
+    TEST_SUCCESS_ID_TOKEN_HASH: `#id_token=${TEST_TOKENS.IDTOKEN_V2}&client_info=${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}&state=${state}|`,
+    TEST_SUCCESS_ACCESS_TOKEN_HASH: `#access_token=${TEST_TOKENS.ACCESSTOKEN}&id_token=${TEST_TOKENS.IDTOKEN_V2}&scope=test&expiresIn=${TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN}&client_info=${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}&state=${state}|`,
+    TEST_ERROR_HASH: `#error=error_code&error_description=msal+error+description&state=${state}|`,
+});


### PR DESCRIPTION
The order in which the angular handleRedirectCallback determines whether to return a success or failure is backwards. A response object will always be populated with at least state, whereas error will only be populated if there is an error. Therefore we need to check for error to be truthy first and if not, only then do we return a success.

This PR fixes: #1406 and #1554 
