### PR TITLE
feat(msal-guard): accept angular routes for denied and failed

### DIFF
--- a/lib/msal-angular/src/msal-angular.configuration.ts
+++ b/lib/msal-angular/src/msal-angular.configuration.ts
@@ -1,15 +1,17 @@
 export type MsalAngularConfiguration = {
     consentScopes?: Array<string>;
     popUp?: boolean;
-    extraQueryParameters?: {[key: string]: string};
+    extraQueryParameters?: { [key: string]: string };
     unprotectedResources?: string[];
-    protectedResourceMap?: [string, string[]][] | Map<string, Array<string>>
+    protectedResourceMap?: [string, string[]][] | Map<string, Array<string>>;
+    loginDeniedRoute?: string;
+    loginFailedRoute?: string;
 };
 
-export const defaultMsalAngularConfiguration : MsalAngularConfiguration = {
+export const defaultMsalAngularConfiguration: MsalAngularConfiguration = {
     consentScopes: [],
     popUp: false,
     extraQueryParameters: {},
     unprotectedResources: [],
-    protectedResourceMap: []
+    protectedResourceMap: [],
 };

--- a/lib/msal-angular/src/msal-guard.service.ts
+++ b/lib/msal-angular/src/msal-guard.service.ts
@@ -1,39 +1,180 @@
+import { Location } from "@angular/common";
 import { Inject, Injectable } from "@angular/core";
 import {
-    ActivatedRoute,
-    ActivatedRouteSnapshot, CanActivate, Router,
+    ActivatedRouteSnapshot,
+    CanActivate,
+    CanActivateChild,
+    CanLoad,
+    Route,
+    Router,
     RouterStateSnapshot,
+    UrlSegment,
+    UrlTree,
 } from "@angular/router";
-import { MsalService } from "./msal.service";
-import { Location, PlatformLocation } from "@angular/common";
-import { BroadcastService } from "./broadcast.service";
-import { Configuration, AuthError, InteractionRequiredAuthError, UrlUtils, WindowUtils } from "msal";
-import { MsalAngularConfiguration } from "./msal-angular.configuration";
+import {
+    AuthError,
+    Configuration,
+    InteractionRequiredAuthError,
+    UrlUtils,
+    WindowUtils,
+} from "msal";
 import { MSAL_CONFIG, MSAL_CONFIG_ANGULAR } from "./constants";
+import { MsalAngularConfiguration } from "./msal-angular.configuration";
+import { MsalService } from "./msal.service";
 
-@Injectable()
-export class MsalGuard implements CanActivate {
+@Injectable({
+    providedIn: "root",
+})
+export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
+    private readonly loginDeniedRoute?: UrlTree;
+    private readonly loginFailedRoute?: UrlTree;
 
-    constructor(
-        @Inject(MSAL_CONFIG) private msalConfig: Configuration,
-        @Inject(MSAL_CONFIG_ANGULAR) private msalAngularConfig: MsalAngularConfiguration,
-        private authService: MsalService,
-        private router: Router,
-        private activatedRoute: ActivatedRoute,
-        private location: Location,
-        private platformLocation: PlatformLocation,
-        private broadcastService: BroadcastService
-    ) {}
+    public constructor(
+        @Inject(MSAL_CONFIG) private readonly msalConfig: Configuration,
+        @Inject(MSAL_CONFIG_ANGULAR)
+        private readonly msalAngularConfig: MsalAngularConfiguration,
+        private readonly router: Router,
+        private readonly authService: MsalService,
+        private readonly location: Location
+    ) {
+        if (msalAngularConfig.loginDeniedRoute) {
+            this.loginDeniedRoute = this.router.parseUrl(
+                msalAngularConfig.loginDeniedRoute
+            );
+        }
+        if (msalAngularConfig.loginFailedRoute) {
+            this.loginFailedRoute = this.router.parseUrl(
+                msalAngularConfig.loginFailedRoute
+            );
+        }
+    }
+
+    public async canLoad(
+        route: Route,
+        _segments: UrlSegment[]
+    ): Promise<boolean> {
+        if (!route.path) {
+            // TODO not sure when the path would be undefined so just deny
+            return false;
+        }
+
+        return this.isAuthenticated(route.path);
+    }
+
+    public async canActivate(
+        _next: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot
+    ): Promise<boolean | UrlTree> {
+        this.authService
+            .getLogger()
+            .verbose("location change event from old url to new url");
+
+        return this.handleLogin(state.url);
+    }
+
+    private async handleLogin(url: string): Promise<boolean | UrlTree> {
+        // If a page with MSAL Guard is set as the redirect for acquireTokenSilent,
+        // short-circuit to prevent redirecting or popups.
+        if (
+            UrlUtils.urlContainsHash(window.location.hash) &&
+            WindowUtils.isInIframe()
+        ) {
+            this.authService
+                .getLogger()
+                .warning(
+                    "redirectUri set to page with MSAL Guard. It is recommended to not set redirectUri to a page that requires authentication."
+                );
+            return false;
+        }
+
+        return this.isAuthenticated(url).then(
+            (isAuthenticated) =>
+                isAuthenticated ? true : this.loginDeniedRoute ?? false,
+            () => this.loginFailedRoute ?? false
+        );
+    }
+
+    private async isAuthenticated(url: string): Promise<boolean> {
+        const isAuthenticated = !!this.authService.getAccount();
+
+        return isAuthenticated
+            ? this.loginSilently(url)
+            : this.loginInteractively(url);
+    }
+
+    /**
+     * Interactively prompt the user to login
+     * @param url Path of the requested page
+     */
+    private async loginInteractively(url: string): Promise<boolean> {
+        if (this.msalAngularConfig.popUp) {
+            return this.authService
+                .loginPopup({
+                    extraQueryParameters: this.msalAngularConfig
+                        .extraQueryParameters,
+                    scopes: this.msalAngularConfig.consentScopes,
+                })
+                .then(() => true)
+                .catch(() => false);
+        }
+
+        const redirectStartPage = this.getDestinationUrl(url);
+
+        this.authService.loginRedirect({
+            extraQueryParameters: this.msalAngularConfig.extraQueryParameters,
+            redirectStartPage,
+            scopes: this.msalAngularConfig.consentScopes,
+        });
+
+        // reject access, for now
+        // when the user returns after the redirect they'll be authenticated
+        // and thous not reach this
+        return false;
+    }
+
+    private async loginSilently(url: string): Promise<boolean> {
+        return this.authService
+            .acquireTokenSilent({
+                // TODO msal released a ssoSilent API - relevant here?
+                scopes: [this.msalConfig.auth.clientId],
+            })
+            .then(() => true)
+            .catch((error: AuthError) => {
+                if (
+                    InteractionRequiredAuthError.isInteractionRequiredError(
+                        error.errorCode
+                    )
+                ) {
+                    this.authService
+                        .getLogger()
+                        .info(
+                            `Interaction required error in AuthGuard, prompting for interaction.`
+                        );
+
+                    return this.loginInteractively(url);
+                }
+
+                this.authService
+                    .getLogger()
+                    .error(
+                        `Non-interaction error in AuthGuard: ${error.errorMessage}`
+                    );
+
+                return false;
+            });
+    }
 
     /**
      * Builds the absolute url for the destination page
      * @param path Relative path of requested page
      * @returns Full destination url
      */
-    getDestinationUrl(path: string): string {
+    private getDestinationUrl(path: string): string {
         // Absolute base url for the application (default to origin if base element not present)
         const baseElements = document.getElementsByTagName("base");
-        const baseUrl = this.location.normalize(baseElements.length ? baseElements[0].href : window.location.origin);
+        const baseUrl = this.location.normalize(
+            baseElements.length ? baseElements[0].href : window.location.origin
+        );
 
         // Path of page (including hash, if using hash routing)
         const pathUrl = this.location.prepareExternalUrl(path);
@@ -44,60 +185,7 @@ export class MsalGuard implements CanActivate {
         }
 
         // If using path location strategy, pathUrl will include the relative portion of the base path (e.g. /base/page).
-        // Since baseUrl also includes /base, can just concatentate baseUrl + path
+        // Since baseUrl also includes /base, can just concatenate baseUrl + path
         return `${baseUrl}${path}`;
     }
-
-    /**
-     * Interactively prompt the user to login
-     * @param url Path of the requested page
-     */
-    async loginInteractively(url: string) {
-        if (this.msalAngularConfig.popUp) {
-            return this.authService.loginPopup({
-                scopes: this.msalAngularConfig.consentScopes,
-                extraQueryParameters: this.msalAngularConfig.extraQueryParameters
-            })
-                .then(() => true)
-                .catch(() => false);
-        }
-
-        const redirectStartPage = this.getDestinationUrl(url);
-
-        this.authService.loginRedirect({
-            redirectStartPage,
-            scopes: this.msalAngularConfig.consentScopes,
-            extraQueryParameters: this.msalAngularConfig.extraQueryParameters
-        });
-    }
-
-    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Promise<boolean> {
-        this.authService.getLogger().verbose("location change event from old url to new url");
-
-        // If a page with MSAL Guard is set as the redirect for acquireTokenSilent,
-        // short-circuit to prevent redirecting or popups.
-        if (UrlUtils.urlContainsHash(window.location.hash) && WindowUtils.isInIframe()) {
-            this.authService.getLogger().warning("redirectUri set to page with MSAL Guard. It is recommended to not set redirectUri to a page that requires authentication.");
-            return false;
-        }
-
-        if (!this.authService.getAccount()) {
-            return this.loginInteractively(state.url);
-        }
-
-        return this.authService.acquireTokenSilent({
-            scopes: [this.msalConfig.auth.clientId]
-        })
-            .then(() => true)
-            .catch((error: AuthError) => {
-                if (InteractionRequiredAuthError.isInteractionRequiredError(error.errorCode)) {
-                    this.authService.getLogger().info(`Interaction required error in MSAL Guard, prompting for interaction.`);
-                    return this.loginInteractively(state.url);
-                }
-
-                this.authService.getLogger().error(`Non-interaction error in MSAL Guard: ${error.errorMessage}`);
-                throw error;
-            });
-    }
-
 }


### PR DESCRIPTION
example config:
```ts
// MsalAngularConfiguration
{
  loginDeniedRoute: '/access-denied',
  loginFailedRoute: '/login-failed',
}
```

fix #703

I was unable to build/run/test as your build guide doesn't work. However a version of this is running in a live system.