### PR TITLE
[msal-common][msal-browser] Remove RT from acquire token entries and make it top-level in cache 

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Account, SPAClient, AuthenticationParameters, INetworkModule, TokenResponse, UrlString, TemporaryCacheKeys, TokenRenewParameters, StringUtils, PromptValue, ServerError } from "@azure/msal-common";
+import { Account, SPAClient, AuthenticationParameters, INetworkModule, TokenResponse, UrlString, TemporaryCacheKeys, TokenRenewParameters, StringUtils, PromptValue, ServerError, Constants } from "@azure/msal-common";
 import { Configuration, buildConfiguration } from "../config/Configuration";
 import { BrowserStorage } from "../cache/BrowserStorage";
 import { CryptoOps } from "../crypto/CryptoOps";
@@ -391,7 +391,7 @@ export class PublicClientApplication {
             return await this.authModule.getValidToken(silentRequest);
         } catch (e) {
             const isServerError = e instanceof ServerError;
-            const isInvalidGrantError = (e.errorCode === BrowserConstants.INVALID_GRANT_ERROR);
+            const isInvalidGrantError = (e.errorCode === Constants.INVALID_GRANT_ERROR);
             if (isServerError && isInvalidGrantError) {
                 const tokenRequest: AuthenticationParameters = {
                     ...silentRequest,

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -15,8 +15,6 @@ export const BrowserConstants = {
     INTERACTION_STATUS_KEY: "interaction.status",
     // Interaction in progress cache value
     INTERACTION_IN_PROGRESS_VALUE: "interaction_in_progress",
-    // Invalid grant error code
-    INVALID_GRANT_ERROR: "invalid_grant",
     // Default popup window width
     POPUP_WIDTH: 483,
     // Default popup window height

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -139,7 +139,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     idToken: testServerTokenResponse.body.id_token,
                     idTokenClaims: testIdTokenClaims,
                     accessToken: testServerTokenResponse.body.access_token,
-                    refreshToken: testServerTokenResponse.body.refresh_token,
                     expiresOn: new Date(Date.now() + (testServerTokenResponse.body.expires_in * 1000)),
                     account: testAccount,
                     userRequestState: ""
@@ -164,7 +163,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(tokenResponse.idToken).to.be.eq(testTokenResponse.idToken);
                     expect(tokenResponse.idTokenClaims).to.be.contain(testTokenResponse.idTokenClaims);
                     expect(tokenResponse.accessToken).to.be.eq(testTokenResponse.accessToken);
-                    expect(tokenResponse.refreshToken).to.be.eq(testTokenResponse.refreshToken);
                     expect(testTokenResponse.expiresOn.getMilliseconds() >= tokenResponse.expiresOn.getMilliseconds()).to.be.true;
                     expect(tokenResponse.account.accountIdentifier).to.be.deep.eq(testTokenResponse.account.accountIdentifier);
                     expect(tokenResponse.account.environment).to.be.deep.eq(testTokenResponse.account.environment);
@@ -175,7 +173,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(tokenResponse.account.sid).to.be.deep.eq(testTokenResponse.account.sid);
                     expect(tokenResponse.account.userName).to.be.deep.eq(testTokenResponse.account.userName);
                 });
-                expect(window.sessionStorage.length).to.be.eq(3);
+                expect(window.sessionStorage.length).to.be.eq(4);
             });
 
             it("gets hash from cache and processes error", () => {
@@ -242,7 +240,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     idToken: testServerTokenResponse.body.id_token,
                     idTokenClaims: testIdTokenClaims,
                     accessToken: testServerTokenResponse.body.access_token,
-                    refreshToken: testServerTokenResponse.body.refresh_token,
                     expiresOn: new Date(Date.now() + (testServerTokenResponse.body.expires_in * 1000)),
                     account: testAccount,
                     userRequestState: ""
@@ -267,7 +264,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(tokenResponse.idToken).to.be.eq(testTokenResponse.idToken);
                     expect(tokenResponse.idTokenClaims).to.be.contain(testTokenResponse.idTokenClaims);
                     expect(tokenResponse.accessToken).to.be.eq(testTokenResponse.accessToken);
-                    expect(tokenResponse.refreshToken).to.be.eq(testTokenResponse.refreshToken);
                     expect(testTokenResponse.expiresOn.getMilliseconds() >= tokenResponse.expiresOn.getMilliseconds()).to.be.true;
                     expect(tokenResponse.account.accountIdentifier).to.be.deep.eq(testTokenResponse.account.accountIdentifier);
                     expect(tokenResponse.account.environment).to.be.deep.eq(testTokenResponse.account.environment);
@@ -278,7 +274,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(tokenResponse.account.sid).to.be.deep.eq(testTokenResponse.account.sid);
                     expect(tokenResponse.account.userName).to.be.deep.eq(testTokenResponse.account.userName);
                 });
-                expect(window.sessionStorage.length).to.be.eq(3);
+                expect(window.sessionStorage.length).to.be.eq(4);
                 expect(window.location.hash).to.be.empty;
             });
         });
@@ -406,7 +402,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     idToken: testServerTokenResponse.id_token,
                     idTokenClaims: testIdTokenClaims,
                     accessToken: testServerTokenResponse.access_token,
-                    refreshToken: testServerTokenResponse.refresh_token,
                     expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
                     account: testAccount,
                     userRequestState: ""
@@ -475,7 +470,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     idToken: testServerTokenResponse.id_token,
                     idTokenClaims: testIdTokenClaims,
                     accessToken: testServerTokenResponse.access_token,
-                    refreshToken: testServerTokenResponse.refresh_token,
                     expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
                     account: testAccount,
                     userRequestState: ""
@@ -558,7 +552,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 idToken: testServerTokenResponse.id_token,
                 idTokenClaims: testIdTokenClaims,
                 accessToken: testServerTokenResponse.access_token,
-                refreshToken: testServerTokenResponse.refresh_token,
                 expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
                 account: testAccount,
                 userRequestState: ""                    
@@ -607,7 +600,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 idToken: testServerTokenResponse.id_token,
                 idTokenClaims: testIdTokenClaims,
                 accessToken: testServerTokenResponse.access_token,
-                refreshToken: testServerTokenResponse.refresh_token,
                 expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
                 account: testAccount,
                 userRequestState: ""
@@ -663,7 +655,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 idToken: testServerTokenResponse.id_token,
                 idTokenClaims: testIdTokenClaims,
                 accessToken: testServerTokenResponse.access_token,
-                refreshToken: testServerTokenResponse.refresh_token,
                 expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
                 account: testAccount,
                 userRequestState: ""                    

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -5,7 +5,7 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 import { PublicClientApplication } from "../../src/app/PublicClientApplication";
 import { TEST_CONFIG, TEST_URIS, TEST_HASHES, TEST_TOKENS, TEST_DATA_CLIENT_INFO, TEST_TOKEN_LIFETIMES, RANDOM_TEST_GUID, DEFAULT_OPENID_CONFIG_RESPONSE, testNavUrl, testLogoutUrl } from "../utils/StringConstants";
-import { AuthError, ServerError, AuthResponse, LogLevel, Constants, TemporaryCacheKeys, TokenResponse, Account, TokenExchangeParameters, IdTokenClaims, SPAClient, PromptValue, AuthenticationParameters } from "@azure/msal-common";
+import { AuthError, ServerError, AuthResponse, LogLevel, Constants, TemporaryCacheKeys, TokenResponse, Account, TokenExchangeParameters, IdTokenClaims, SPAClient, PromptValue, AuthenticationParameters, PersistentCacheKeys } from "@azure/msal-common";
 import { AuthCallback } from "../../src/types/AuthCallback";
 import { BrowserConfigurationAuthErrorMessage, BrowserConfigurationAuthError } from "../../src/error/BrowserConfigurationAuthError";
 import sinon from "sinon";
@@ -174,6 +174,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(tokenResponse.account.userName).to.be.deep.eq(testTokenResponse.account.userName);
                 });
                 expect(window.sessionStorage.length).to.be.eq(4);
+                expect(window.sessionStorage.getItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${PersistentCacheKeys.ID_TOKEN}`)).to.be.eq(TEST_TOKENS.IDTOKEN_V2);
+                expect(window.sessionStorage.getItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${PersistentCacheKeys.REFRESH_TOKEN}`)).to.be.eq(TEST_TOKENS.REFRESH_TOKEN);
             });
 
             it("gets hash from cache and processes error", () => {
@@ -275,6 +277,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(tokenResponse.account.userName).to.be.deep.eq(testTokenResponse.account.userName);
                 });
                 expect(window.sessionStorage.length).to.be.eq(4);
+                expect(window.sessionStorage.getItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${PersistentCacheKeys.ID_TOKEN}`)).to.be.eq(TEST_TOKENS.IDTOKEN_V2);
+                expect(window.sessionStorage.getItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${PersistentCacheKeys.REFRESH_TOKEN}`)).to.be.eq(TEST_TOKENS.REFRESH_TOKEN);
                 expect(window.location.hash).to.be.empty;
             });
         });

--- a/lib/msal-common/src/cache/AccessTokenValue.ts
+++ b/lib/msal-common/src/cache/AccessTokenValue.ts
@@ -11,15 +11,13 @@ export class AccessTokenValue {
     tokenType: string;
     accessToken: string;
     idToken: string;
-    refreshToken: string;
     expiresOnSec: string;
     extExpiresOnSec: string;
 
-    constructor(tokenType: string, accessToken: string, idToken: string, refreshToken: string, expiresOn: string, extExpiresOn: string) {
+    constructor(tokenType: string, accessToken: string, idToken: string, expiresOn: string, extExpiresOn: string) {
         this.tokenType = tokenType;
         this.accessToken = accessToken;
         this.idToken = idToken;
-        this.refreshToken = refreshToken;
         this.expiresOnSec = expiresOn;
         this.extExpiresOnSec = extExpiresOn;
     }

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -42,7 +42,7 @@ export class RefreshTokenClient extends BaseClient {
 
         const scopeSet = new ScopeSet(request.scopes || [],
             this.config.authOptions.clientId,
-            true);
+            false);
         parameterBuilder.addScopes(scopeSet);
         parameterBuilder.addClientId(this.config.authOptions.clientId);
         parameterBuilder.addGrantType(GrantType.REFRESH_TOKEN_GRANT);

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -154,13 +154,18 @@ export class ResponseHandler {
         const expirationSec = TimeUtils.nowSeconds() + expiresIn;
         const extendedExpirationSec = expirationSec + serverTokenResponse.ext_expires_in;
 
-        // Get id token
+        // Get and save id token
         if (!StringUtils.isEmpty(originalTokenResponse.idToken)) {
             this.cacheStorage.setItem(PersistentCacheKeys.ID_TOKEN, originalTokenResponse.idToken);
         }
 
+        // Get and save refresh token
+        if (serverTokenResponse && !StringUtils.isEmpty(serverTokenResponse.refresh_token)) {
+            this.cacheStorage.setItem(PersistentCacheKeys.REFRESH_TOKEN, serverTokenResponse.refresh_token);
+        }
+
         // Save access token in cache
-        const newAccessTokenValue = new AccessTokenValue(serverTokenResponse.token_type, serverTokenResponse.access_token, originalTokenResponse.idToken, serverTokenResponse.refresh_token, expirationSec.toString(), extendedExpirationSec.toString());
+        const newAccessTokenValue = new AccessTokenValue(serverTokenResponse.token_type, serverTokenResponse.access_token, originalTokenResponse.idToken, expirationSec.toString(), extendedExpirationSec.toString());
         const homeAccountIdentifier = originalTokenResponse.account && originalTokenResponse.account.homeAccountIdentifier;
         const accessTokenCacheItems = this.cacheManager.getAllAccessTokens(this.clientId, authority || "", resource || "", homeAccountIdentifier || "");
 
@@ -198,7 +203,6 @@ export class ResponseHandler {
             tokenType: serverTokenResponse.token_type,
             scopes: responseScopeArray,
             accessToken: serverTokenResponse.access_token,
-            refreshToken: serverTokenResponse.refresh_token,
             expiresOn: new Date(expirationSec * 1000)
         };
     }
@@ -231,7 +235,6 @@ export class ResponseHandler {
             idToken: null,
             idTokenClaims: null,
             accessToken: "",
-            refreshToken: "",
             scopes: [],
             expiresOn: null,
             account: null,

--- a/lib/msal-common/src/response/TokenResponse.ts
+++ b/lib/msal-common/src/response/TokenResponse.ts
@@ -7,14 +7,13 @@ import { Account } from "../account/Account";
 import { StringDict } from "../utils/MsalTypes";
 
 /**
- * TokenResponse type returned by library containing id, access and/or refresh tokens.
+ * TokenResponse type returned by library containing id and/or access tokens.
  * - uniqueId: account object id
  * - tenantId: id of home tenant for logged in user
  * - tokenType: type of token response - either idToken or accessToken
  * - idToken: id token jwt string
  * - idTokenClaims: claims in id token
  * - accessToken: access token jwt string
- * - refreshToken: refresh token string
  * - expiresOn: expiration of access token or id token (depends on token type)
  * - account: logged in account object
  */
@@ -26,7 +25,6 @@ export type TokenResponse = AuthResponse & {
     idToken: string;
     idTokenClaims: StringDict;
     accessToken: string;
-    refreshToken: string;
     expiresOn: Date;
     account: Account;
 };

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -37,7 +37,9 @@ export const Constants = {
     QUERY_RESPONSE_MODE: "query",
     S256_CODE_CHALLENGE_METHOD: "S256",
     URL_FORM_CONTENT_TYPE: "application/x-www-form-urlencoded;charset=utf-8",
-    AUTHORIZATION_PENDING: "authorization_pending"
+    AUTHORIZATION_PENDING: "authorization_pending",
+    // Invalid grant error code
+    INVALID_GRANT_ERROR: "invalid_grant",
 };
 
 /**
@@ -68,6 +70,7 @@ export enum TemporaryCacheKeys {
  */
 export enum PersistentCacheKeys {
     ID_TOKEN = "idtoken",
+    REFRESH_TOKEN = "rt",
     CLIENT_INFO = "client.info",
     ADAL_ID_TOKEN = "adal.idtoken",
     ERROR = "error",

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -54,7 +54,7 @@ describe("RefreshTokenClient unit tests", () => {
         expect(JSON.parse(authResult)).to.deep.eq(AUTHENTICATION_RESULT.body);
         expect(createTokenRequestBodySpy.calledWith(refreshTokenRequest)).to.be.true;
 
-        expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.SCOPE}=${TEST_CONFIG.DEFAULT_GRAPH_SCOPE}%20${Constants.OFFLINE_ACCESS_SCOPE}`);
+        expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.SCOPE}=${TEST_CONFIG.DEFAULT_GRAPH_SCOPE}%20${Constants.OPENID_SCOPE}%20${Constants.PROFILE_SCOPE}%20${Constants.OFFLINE_ACCESS_SCOPE}`);
         expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`);
         expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.REFRESH_TOKEN}=${TEST_TOKENS.REFRESH_TOKEN}`);
         expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.GRANT_TYPE}=${GrantType.REFRESH_TOKEN_GRANT}`);

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -125,7 +125,6 @@ describe("ResponseHandler.ts Class Unit Tests", () => {
                 idToken: "",
                 idTokenClaims: null,
                 accessToken: TEST_TOKENS.ACCESS_TOKEN,
-                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
                 expiresOn: null,
                 account: testAccount,
                 userRequestState: TEST_CONFIG.STATE
@@ -155,7 +154,6 @@ describe("ResponseHandler.ts Class Unit Tests", () => {
                 idToken: "",
                 idTokenClaims: null,
                 accessToken: TEST_TOKENS.ACCESS_TOKEN,
-                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
                 expiresOn: null,
                 account: testAccount,
                 userRequestState: TEST_CONFIG.STATE
@@ -314,7 +312,6 @@ describe("ResponseHandler.ts Class Unit Tests", () => {
                 idToken: idToken.rawIdToken,
                 idTokenClaims: idToken.claims,
                 accessToken: TEST_TOKENS.ACCESS_TOKEN,
-                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
                 expiresOn: null,
                 account: testAccount,
                 userRequestState: ""
@@ -331,7 +328,6 @@ describe("ResponseHandler.ts Class Unit Tests", () => {
                 tokenType: TEST_CONFIG.TOKEN_TYPE_BEARER,
                 accessToken: TEST_TOKENS.ACCESS_TOKEN,
                 idToken: TEST_TOKENS.IDTOKEN_V2,
-                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
                 expiresOnSec: `${TimeUtils.nowSeconds() + TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN}`,
                 extExpiresOnSec: `${TimeUtils.nowSeconds() + TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN + TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN}`
             };
@@ -410,7 +406,6 @@ describe("ResponseHandler.ts Class Unit Tests", () => {
             expect(tokenResponse.idToken).to.be.eq(expectedTokenResponse.idToken);
             expect(tokenResponse.idTokenClaims).to.be.deep.eq(expectedTokenResponse.idTokenClaims);
             expect(tokenResponse.accessToken).to.be.eq(expectedTokenResponse.accessToken);
-            expect(tokenResponse.refreshToken).to.be.eq(expectedTokenResponse.refreshToken);
             expect(tokenResponse.expiresOn.getTime() / 1000 <= TimeUtils.nowSeconds() + TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN);
             expect(tokenResponse.account).to.be.deep.eq(expectedTokenResponse.account);
             expect(tokenResponse.userRequestState).to.be.eq(expectedTokenResponse.userRequestState);
@@ -445,11 +440,10 @@ describe("ResponseHandler.ts Class Unit Tests", () => {
             expect(tokenResponse.idToken).to.be.eq(expectedTokenResponse.idToken);
             expect(tokenResponse.idTokenClaims).to.be.deep.eq(expectedTokenResponse.idTokenClaims);
             expect(tokenResponse.accessToken).to.be.eq(expectedTokenResponse.accessToken);
-            expect(tokenResponse.refreshToken).to.be.eq(expectedTokenResponse.refreshToken);
             expect(tokenResponse.expiresOn.getTime() / 1000 <= TimeUtils.nowSeconds() + TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN);
             expect(tokenResponse.account).to.be.deep.eq(expectedTokenResponse.account);
             expect(tokenResponse.userRequestState).to.be.eq(expectedTokenResponse.userRequestState);
-            expect(cacheStorage.getKeys().length).to.be.eq(4);
+            expect(cacheStorage.getKeys().length).to.be.eq(5);
         });
 
         it("Successfully creates a new token if the scopes are not intersecting", () => {
@@ -487,16 +481,14 @@ describe("ResponseHandler.ts Class Unit Tests", () => {
             expect(tokenResponse.idToken).to.be.eq(expectedTokenResponse.idToken);
             expect(tokenResponse.idTokenClaims).to.be.deep.eq(expectedTokenResponse.idTokenClaims);
             expect(tokenResponse.accessToken).to.be.eq(expectedTokenResponse.accessToken);
-            expect(tokenResponse.refreshToken).to.be.eq(expectedTokenResponse.refreshToken);
             expect(tokenResponse.expiresOn.getTime() / 1000 <= TimeUtils.nowSeconds() + TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN);
             expect(tokenResponse.account).to.be.deep.eq(expectedTokenResponse.account);
             expect(tokenResponse.userRequestState).to.be.eq(expectedTokenResponse.userRequestState);
-            expect(cacheStorage.getKeys().length).to.be.eq(5);
+            expect(cacheStorage.getKeys().length).to.be.eq(6);
             expect(cacheStorage.containsKey(JSON.stringify(atKey))).to.be.true;
             expect(cacheStorage.containsKey(JSON.stringify(expectedNewAtKey))).to.be.true;
             expect(cacheStorage.getItem(JSON.stringify(atKey))).to.be.eq(JSON.stringify(atValue));
             expect(cacheStorage.getItem(JSON.stringify(expectedNewAtKey))).to.be.eq(JSON.stringify(expectedNewAtValue));
-
         });
     });
 });


### PR DESCRIPTION
This PR removes the refresh token that is cached with access token entries today and creates a top-level Persistent Cache Item (similar to ID token) that is used to obtain new tokens from the service. This item has a 24 hour lifetime, and a new value is received on receipt of a new token.

We have also removed the refresh token from the response object, as it should not be returned to applications.

This PR also include a small change to the RefreshTokenClient that will add default scopes to the call.

This PR is an intermediate step until the full changes for the cache are ready.