### PR TITLE
Fix redirection to urls containing query strings

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1113,16 +1113,19 @@ export class UserAgentApplication {
                 this.logger.error("Unable to get valid login request url from cache, redirecting to home page");
                 window.location.href = "/";
                 return;
-            } else if (currentUrl !== loginRequestUrl) {
-                // If loginRequestUrl contains a hash (e.g. Angular routing), process the hash now then redirect to prevent both hashes in url
-                if (loginRequestUrl.indexOf("#") > -1) {
-                    this.logger.info("loginRequestUrl contains hash, processing response hash immediately then redirecting");
-                    this.processCallBack(hash, stateInfo, null);
-                    window.location.href = loginRequestUrl;
-                } else {
+            } else {
+                if (!UrlUtils.isSamePage(currentUrl, loginRequestUrl)) {
                     window.location.href = `${loginRequestUrl}${hash}`;
+                    return;
+                } else {
+                    let loginRequestUrlComponents = UrlUtils.GetUrlComponents(loginRequestUrl);
+                    if (loginRequestUrlComponents.Hash){
+                        window.location.hash = loginRequestUrlComponents.Hash;
+                    }
+                    if (loginRequestUrlComponents.Search){
+                        window.location.search = loginRequestUrlComponents.Search;
+                    }
                 }
-                return;
             }
         }
 

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1106,7 +1106,6 @@ export class UserAgentApplication {
         // if set to navigate to loginRequest page post login
         if (this.config.auth.navigateToLoginRequestUrl && window.parent === window) {
             const loginRequestUrl = this.cacheStorage.getItem(`${TemporaryCacheKeys.LOGIN_REQUEST}${Constants.resourceDelimiter}${stateInfo.state}`, this.inCookie);
-            const currentUrl = UrlUtils.getCurrentUrl();
 
             // Redirect to home page if login request url is null (real null or the string null)
             if (!loginRequestUrl || loginRequestUrl === "null") {
@@ -1114,17 +1113,15 @@ export class UserAgentApplication {
                 window.location.assign("/");
                 return;
             } else {
-                if (!UrlUtils.isSamePage(currentUrl, loginRequestUrl)) {
-                    const finalRedirectUrl = UrlUtils.getBaseUrl(loginRequestUrl);
+                const currentUrl = UrlUtils.removeHashFromUrl(window.location.href);
+                const finalRedirectUrl = UrlUtils.removeHashFromUrl(loginRequestUrl);
+                if (currentUrl !== finalRedirectUrl) {
                     window.location.assign(`${finalRedirectUrl}${hash}`);
                     return;
                 } else {
                     const loginRequestUrlComponents = UrlUtils.GetUrlComponents(loginRequestUrl);
                     if (loginRequestUrlComponents.Hash){
                         window.location.hash = loginRequestUrlComponents.Hash;
-                    }
-                    if (loginRequestUrlComponents.Search){
-                        window.location.search = loginRequestUrlComponents.Search;
                     }
                 }
             }

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1115,11 +1115,11 @@ export class UserAgentApplication {
                 return;
             } else {
                 if (!UrlUtils.isSamePage(currentUrl, loginRequestUrl)) {
-                    let finalRedirectUrl = UrlUtils.getBaseUrl(loginRequestUrl);
+                    const finalRedirectUrl = UrlUtils.getBaseUrl(loginRequestUrl);
                     window.location.assign(`${finalRedirectUrl}${hash}`);
                     return;
                 } else {
-                    let loginRequestUrlComponents = UrlUtils.GetUrlComponents(loginRequestUrl);
+                    const loginRequestUrlComponents = UrlUtils.GetUrlComponents(loginRequestUrl);
                     if (loginRequestUrlComponents.Hash){
                         window.location.hash = loginRequestUrlComponents.Hash;
                     }

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1111,11 +1111,11 @@ export class UserAgentApplication {
             // Redirect to home page if login request url is null (real null or the string null)
             if (!loginRequestUrl || loginRequestUrl === "null") {
                 this.logger.error("Unable to get valid login request url from cache, redirecting to home page");
-                window.location.href = "/";
+                window.location.assign("/");
                 return;
             } else {
                 if (!UrlUtils.isSamePage(currentUrl, loginRequestUrl)) {
-                    window.location.href = `${loginRequestUrl}${hash}`;
+                    window.location.assign(`${loginRequestUrl}${hash}`);
                     return;
                 } else {
                     let loginRequestUrlComponents = UrlUtils.GetUrlComponents(loginRequestUrl);

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1115,7 +1115,8 @@ export class UserAgentApplication {
                 return;
             } else {
                 if (!UrlUtils.isSamePage(currentUrl, loginRequestUrl)) {
-                    window.location.assign(`${loginRequestUrl}${hash}`);
+                    let finalRedirectUrl = UrlUtils.getBaseUrl(loginRequestUrl);
+                    window.location.assign(`${finalRedirectUrl}${hash}`);
                     return;
                 } else {
                     let loginRequestUrlComponents = UrlUtils.GetUrlComponents(loginRequestUrl);

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -148,7 +148,25 @@ export class UrlUtils {
         let pathSegments = urlComponents.AbsolutePath.split("/");
         pathSegments = pathSegments.filter((val) => val && val.length > 0); // remove empty elements
         urlComponents.PathSegments = pathSegments;
+
+        if (match[6]){
+            urlComponents.Search = match[6]
+        }
+        if (match[8]){
+            urlComponents.Hash = match[8]
+        }
+        
         return urlComponents;
+    }
+
+    static isSamePage(url1: string, url2: string){
+        let urlComponents1 = UrlUtils.GetUrlComponents(url1);
+        let urlComponents2 = UrlUtils.GetUrlComponents(url2);
+
+        let urlPath1 = urlComponents1.HostNameAndPort + urlComponents1.AbsolutePath;
+        let urlPath2 = urlComponents2.HostNameAndPort + urlComponents2.AbsolutePath;
+
+        return urlPath1 === urlPath2;
     }
 
     /**

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -173,13 +173,10 @@ export class UrlUtils {
      * @param url2
      */
     static isSamePage(url1: string, url2: string){
-        let urlComponents1 = UrlUtils.GetUrlComponents(url1);
-        let urlComponents2 = UrlUtils.GetUrlComponents(url2);
+        let baseUrl1 = UrlUtils.getBaseUrl(url1);
+        let baseUrl2 = UrlUtils.getBaseUrl(url2);
 
-        let urlPath1 = urlComponents1.HostNameAndPort + urlComponents1.AbsolutePath;
-        let urlPath2 = urlComponents2.HostNameAndPort + urlComponents2.AbsolutePath;
-
-        return urlPath1 === urlPath2;
+        return baseUrl1 === baseUrl2;
     }
 
     /**

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -103,6 +103,13 @@ export class UrlUtils {
     }
 
     /**
+     * Returns given URL with hash and query string removed
+     */
+    static getBaseUrl(url: string): string {
+        return url.split("?")[0].split("#")[0];
+    }
+
+    /**
      * Given a url like https://a:b/common/d?e=f#g, and a tenantId, returns https://a:b/tenantId/d
      * @param href The url
      * @param tenantId The tenant id to replace

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -157,10 +157,10 @@ export class UrlUtils {
         urlComponents.PathSegments = pathSegments;
 
         if (match[6]){
-            urlComponents.Search = match[6]
+            urlComponents.Search = match[6];
         }
         if (match[8]){
-            urlComponents.Hash = match[8]
+            urlComponents.Hash = match[8];
         }
         
         return urlComponents;

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -159,6 +159,12 @@ export class UrlUtils {
         return urlComponents;
     }
 
+    /**
+     * Given 2 urls determine if they are on the same the same path
+     *
+     * @param url1
+     * @param url2
+     */
     static isSamePage(url1: string, url2: string){
         let urlComponents1 = UrlUtils.GetUrlComponents(url1);
         let urlComponents2 = UrlUtils.GetUrlComponents(url2);

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -173,8 +173,8 @@ export class UrlUtils {
      * @param url2
      */
     static isSamePage(url1: string, url2: string){
-        let baseUrl1 = UrlUtils.getBaseUrl(url1);
-        let baseUrl2 = UrlUtils.getBaseUrl(url2);
+        const baseUrl1 = UrlUtils.getBaseUrl(url1);
+        const baseUrl2 = UrlUtils.getBaseUrl(url2);
 
         return baseUrl1 === baseUrl2;
     }

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -103,10 +103,10 @@ export class UrlUtils {
     }
 
     /**
-     * Returns given URL with hash and query string removed
+     * Returns given URL with query string removed
      */
-    static getBaseUrl(url: string): string {
-        return url.split("?")[0].split("#")[0];
+    static removeHashFromUrl(url: string): string {
+        return url.split("#")[0];
     }
 
     /**
@@ -164,19 +164,6 @@ export class UrlUtils {
         }
         
         return urlComponents;
-    }
-
-    /**
-     * Given 2 urls determine if they are on the same the same path
-     *
-     * @param url1
-     * @param url2
-     */
-    static isSamePage(url1: string, url2: string){
-        const baseUrl1 = UrlUtils.getBaseUrl(url1);
-        const baseUrl2 = UrlUtils.getBaseUrl(url2);
-
-        return baseUrl1 === baseUrl2;
     }
 
     /**

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -1273,16 +1273,17 @@ describe("UserAgentApplication.ts Class", function () {
             msal = new UserAgentApplication(config);
         });
 
-        it("tests navigation to loginRequestUrl inc. user hash after first redirect", function(done) {
+        it("tests navigation to loginRequestUrl after first redirect", function(done) {
             config.auth.navigateToLoginRequestUrl = true;
-            const loginStartPage = "http://localhost:8081/test/#testHash"
+            const baseStartUrl = "http://localhost:8081/test/"
+            const loginStartPage = baseStartUrl + "#testHash"
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
             window.location = {
                 ...oldWindowLocation,
                 assign: function (url) {
                     try {
-                        expect(url).to.equal(loginStartPage + successHash);
+                        expect(url).to.equal(baseStartUrl + successHash);
                         done();
                     } catch (e) {
                         console.error(e);
@@ -1303,14 +1304,15 @@ describe("UserAgentApplication.ts Class", function () {
 
         it("tests navigation to loginRequestUrl inc. user querystring after first redirect", function(done) {
             config.auth.navigateToLoginRequestUrl = true;
-            const loginStartPage = "http://localhost:8081/test/?testKey=testVal"
+            const baseStartUrl = "http://localhost:8081/test/"
+            const loginStartPage = baseStartUrl + "?testKey=testVal"
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
             window.location = {
                 ...oldWindowLocation,
                 assign: function (url) {
                     try {
-                        expect(url).to.equal(loginStartPage + successHash);
+                        expect(url).to.equal(baseStartUrl + successHash);
                         done();
                     } catch (e) {
                         console.error(e);

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -1212,10 +1212,14 @@ describe("UserAgentApplication.ts Class", function () {
 
             setAuthInstanceStubs();
             setTestCacheItems();
+            
+            delete window.location;
+            window.location = {
+                ...oldWindowLocation
+            };
         });
 
         afterEach(function() {
-            window.location.hash = "";
             config = {auth: {clientId: ""}};
             cacheStorage.clear();
             sinon.restore();
@@ -1239,6 +1243,192 @@ describe("UserAgentApplication.ts Class", function () {
                 done();
             };
             msal.handleRedirectCallback(checkRespFromServer, errorReceivedCallback);
+        });
+
+        it("tests navigation to loginRequestUrl after first redirect", function(done) {
+            config.auth.navigateToLoginRequestUrl = true;
+            const loginStartPage = "http://localhost:8081/test/"
+            const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+
+            window.location = {
+                ...oldWindowLocation,
+                assign: function (url) {
+                    try {
+                        expect(url).to.equal(loginStartPage + successHash);
+                        done();
+                    } catch (e) {
+                        console.error(e);
+                    }
+                },
+                href: "http://localhost:8081/"
+            };
+
+            sinon.stub(window, "parent").returns(window);
+
+            window.location.hash = successHash;
+            cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, loginStartPage);
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+
+            msal = new UserAgentApplication(config);
+        });
+
+        it("tests navigation to loginRequestUrl inc. user hash after first redirect", function(done) {
+            config.auth.navigateToLoginRequestUrl = true;
+            const loginStartPage = "http://localhost:8081/test/#testHash"
+            const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+
+            window.location = {
+                ...oldWindowLocation,
+                assign: function (url) {
+                    try {
+                        expect(url).to.equal(loginStartPage + successHash);
+                        done();
+                    } catch (e) {
+                        console.error(e);
+                    }
+                },
+                href: "http://localhost:8081/"
+            };
+
+            sinon.stub(window, "parent").returns(window);
+
+            window.location.hash = successHash;
+            cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, loginStartPage);
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+
+            msal = new UserAgentApplication(config);
+        });
+
+        it("tests navigation to loginRequestUrl inc. user querystring after first redirect", function(done) {
+            config.auth.navigateToLoginRequestUrl = true;
+            const loginStartPage = "http://localhost:8081/test/?testKey=testVal"
+            const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+
+            window.location = {
+                ...oldWindowLocation,
+                assign: function (url) {
+                    try {
+                        expect(url).to.equal(loginStartPage + successHash);
+                        done();
+                    } catch (e) {
+                        console.error(e);
+                    }
+                },
+                href: "http://localhost:8081/"
+            };
+
+            sinon.stub(window, "parent").returns(window);
+
+            window.location.hash = successHash;
+            cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, loginStartPage);
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+
+            msal = new UserAgentApplication(config);
+        });
+
+        it("tests user hash is added back to url on final page and token response is cached", function() {
+            config.auth.navigateToLoginRequestUrl = true;
+            const loginUrl = "http://localhost:8081/test/"
+            const userHash = "#testHash"
+            const loginStartPage = loginUrl + userHash
+            const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+
+            window.location.href = loginUrl;
+
+            sinon.stub(window, "parent").returns(window);
+            sinon.stub(window.location, "href").returns(loginStartPage + successHash)
+
+            window.location.hash = successHash;
+            cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, loginStartPage);
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+
+            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.hash).to.equal(successHash);
+            msal = new UserAgentApplication(config);
+            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.hash).to.equal(userHash);
+            expect(cacheStorage.getItem(PersistentCacheKeys.IDTOKEN)).to.equal(TEST_TOKENS.IDTOKEN_V2);
+        });
+
+        it("tests user query string is added back to url on final page and token response is cached", function() {
+            config.auth.navigateToLoginRequestUrl = true;
+            const loginUrl = "http://localhost:8081/test/"
+            const userQueryString = "?testKey=testVal"
+            const loginStartPage = loginUrl + userQueryString;
+            const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+
+            window.location.href = loginUrl;
+
+            sinon.stub(window, "parent").returns(window);
+            sinon.stub(window.location, "href").returns(loginStartPage + successHash)
+
+            window.location.hash = successHash;
+            cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, loginStartPage);
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+
+            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.hash).to.equal(successHash);
+            expect(window.location.search).to.equal("");
+            msal = new UserAgentApplication(config);
+            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.hash).to.equal("");
+            expect(window.location.search).to.equal(userQueryString);
+            expect(cacheStorage.getItem(PersistentCacheKeys.IDTOKEN)).to.equal(TEST_TOKENS.IDTOKEN_V2);
+        });
+
+        it("tests user query string and hash are added back to url on final page and token response is cached", function() {
+            config.auth.navigateToLoginRequestUrl = true;
+            const loginUrl = "http://localhost:8081/test/"
+            const userQueryString = "?testKey=testVal"
+            const userHash = "#testHash"
+            const loginStartPage = loginUrl + userQueryString + userHash;
+            const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+
+            window.location.href = loginUrl;
+
+            sinon.stub(window, "parent").returns(window);
+            sinon.stub(window.location, "href").returns(loginStartPage + successHash)
+
+            window.location.hash = successHash;
+            cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, loginStartPage);
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+
+            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.hash).to.equal(successHash);
+            expect(window.location.search).to.equal("");
+            msal = new UserAgentApplication(config);
+            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.hash).to.equal(userHash);
+            expect(window.location.search).to.equal(userQueryString);
+            expect(cacheStorage.getItem(PersistentCacheKeys.IDTOKEN)).to.equal(TEST_TOKENS.IDTOKEN_V2);
+        });
+
+        it("tests navigation to homepage after first redirect if loginStartPage not set", function(done) {
+            config.auth.navigateToLoginRequestUrl = true;
+            const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
+
+            window.location.assign = function (url) {
+                try {
+                    expect(url).to.equal("/");
+                    done();
+                } catch (e) {
+                    console.error(e);
+                }
+            };
+
+            sinon.stub(window, "parent").returns(window);
+
+            window.location.hash = successHash;
+            cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
+            cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
+
+            msal = new UserAgentApplication(config);
         });
 
         it("tests saveTokenForHash in case of error", function(done) {

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -1312,7 +1312,7 @@ describe("UserAgentApplication.ts Class", function () {
                 ...oldWindowLocation,
                 assign: function (url) {
                     try {
-                        expect(url).to.equal(baseStartUrl + successHash);
+                        expect(url).to.equal(loginStartPage + successHash);
                         done();
                     } catch (e) {
                         console.error(e);
@@ -1356,14 +1356,15 @@ describe("UserAgentApplication.ts Class", function () {
             expect(cacheStorage.getItem(PersistentCacheKeys.IDTOKEN)).to.equal(TEST_TOKENS.IDTOKEN_V2);
         });
 
-        it("tests user query string is added back to url on final page and token response is cached", function() {
+        it("tests user query string present on final page url and token response is cached", function() {
             config.auth.navigateToLoginRequestUrl = true;
             const loginUrl = "http://localhost:8081/test/"
             const userQueryString = "?testKey=testVal"
             const loginStartPage = loginUrl + userQueryString;
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
-            window.location.href = loginUrl;
+            window.location.href = loginStartPage;
+            window.location.search = userQueryString;
 
             sinon.stub(window, "parent").returns(window);
             sinon.stub(window.location, "href").returns(loginStartPage + successHash)
@@ -1373,17 +1374,17 @@ describe("UserAgentApplication.ts Class", function () {
             cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
             cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
 
-            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.href).to.equal(loginStartPage);
             expect(window.location.hash).to.equal(successHash);
-            expect(window.location.search).to.equal("");
+            expect(window.location.search).to.equal(userQueryString);
             msal = new UserAgentApplication(config);
-            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.href).to.equal(loginStartPage);
             expect(window.location.hash).to.equal("");
             expect(window.location.search).to.equal(userQueryString);
             expect(cacheStorage.getItem(PersistentCacheKeys.IDTOKEN)).to.equal(TEST_TOKENS.IDTOKEN_V2);
         });
 
-        it("tests user query string and hash are added back to url on final page and token response is cached", function() {
+        it("tests user hash is added back to url and query string exists on final page url and token response is cached", function() {
             config.auth.navigateToLoginRequestUrl = true;
             const loginUrl = "http://localhost:8081/test/"
             const userQueryString = "?testKey=testVal"
@@ -1391,7 +1392,8 @@ describe("UserAgentApplication.ts Class", function () {
             const loginStartPage = loginUrl + userQueryString + userHash;
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
-            window.location.href = loginUrl;
+            window.location.href = loginUrl + userQueryString;
+            window.location.search = userQueryString;
 
             sinon.stub(window, "parent").returns(window);
             sinon.stub(window.location, "href").returns(loginStartPage + successHash)
@@ -1401,11 +1403,11 @@ describe("UserAgentApplication.ts Class", function () {
             cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
             cacheStorage.setItem(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`, TEST_NONCE);
 
-            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.href).to.equal(loginUrl + userQueryString);
             expect(window.location.hash).to.equal(successHash);
-            expect(window.location.search).to.equal("");
+            expect(window.location.search).to.equal(userQueryString);
             msal = new UserAgentApplication(config);
-            expect(window.location.href).to.equal(loginUrl);
+            expect(window.location.href).to.equal(loginUrl + userQueryString);
             expect(window.location.hash).to.equal(userHash);
             expect(window.location.search).to.equal(userQueryString);
             expect(cacheStorage.getItem(PersistentCacheKeys.IDTOKEN)).to.equal(TEST_TOKENS.IDTOKEN_V2);

--- a/lib/msal-core/test/utils/UrlUtils.spec.ts
+++ b/lib/msal-core/test/utils/UrlUtils.spec.ts
@@ -6,6 +6,7 @@ import { AuthorityFactory } from "../../src/authority/AuthorityFactory";
 import { ServerRequestParameters } from "../../src/ServerRequestParameters";
 import { ServerHashParamKeys, Constants } from "../../src/utils/Constants";
 import { IUri } from "../../src/IUri";
+import { IdToken } from "../../src/IdToken";
 
 describe("UrlUtils.ts class", () => {
 
@@ -167,49 +168,27 @@ describe("UrlUtils.ts class", () => {
         });
     });
 
-    describe("isSamePage", () => {
-        let url;
+    describe("removeHashFromUrl", () => {
+        const url = "https://localhost:30662/";
 
-        beforeEach(() => {
-            url = "https://localhost:30662/";
+        it("returns same url if hash not present in url", () => {
+            expect(UrlUtils.removeHashFromUrl(url)).to.eq(url);
         });
 
-        it("returns true if urls are equal", () => {
-            const samePage = UrlUtils.isSamePage(url, url);
-
-            expect(samePage).to.be.true; 
+        it("returns base url if hash is present in url", () => {
+            const testUrl = url + "#testHash";
+            expect(UrlUtils.removeHashFromUrl(testUrl)).to.eq(url);
         });
 
-        it("returns true if urls are equal but have different hashes", () => {
-            let url1 = url + "#testhash"
-            let url2 = url + "#differenttesthash"
-            const samePage = UrlUtils.isSamePage(url1, url2);
-
-            expect(samePage).to.be.true; 
+        it("returns url with query string if hash not present on url", () => {
+            const testUrl = url + "?testPage=1";
+            expect(UrlUtils.removeHashFromUrl(testUrl)).to.eq(testUrl);
         });
 
-        it("returns true if urls are equal but have different query strings", () => {
-            let url1 = url + "?testkey=testval"
-            let url2 = url + "?test=test"
-            const samePage = UrlUtils.isSamePage(url1, url2);
-
-            expect(samePage).to.be.true; 
-        });
-
-        it("returns false if urls have different path", () => {
-            let url1 = url + "testPage/"
-            let url2 = url + "differenttestpage/"
-            const samePage = UrlUtils.isSamePage(url1, url2);
-
-            expect(samePage).to.be.false; 
-        });
-
-        it("returns false if urls have different host", () => {
-            let url1 = url
-            let url2 = "https://testhost:30662/"
-            const samePage = UrlUtils.isSamePage(url1, url2);
-
-            expect(samePage).to.be.false; 
+        it("returns url with query string if both hash and query string present in url", () => {
+            const urlWithQueryString = url + "?testPage=1";
+            const testUrl = urlWithQueryString + "#testHash";
+            expect(UrlUtils.removeHashFromUrl(testUrl)).to.eq(urlWithQueryString);
         });
     });
 });

--- a/lib/msal-core/test/utils/UrlUtils.spec.ts
+++ b/lib/msal-core/test/utils/UrlUtils.spec.ts
@@ -5,6 +5,7 @@ import { TEST_CONFIG, TEST_RESPONSE_TYPE, TEST_URIS } from "../TestConstants";
 import { AuthorityFactory } from "../../src/authority/AuthorityFactory";
 import { ServerRequestParameters } from "../../src/ServerRequestParameters";
 import { ServerHashParamKeys, Constants } from "../../src/utils/Constants";
+import { IUri } from "../../src/IUri";
 
 describe("UrlUtils.ts class", () => {
 
@@ -108,4 +109,107 @@ describe("UrlUtils.ts class", () => {
             expect(stateParts[1]).to.equal("hello");
         });
     })
+
+    describe("getUrlComponents", () => {
+        let url;
+
+        beforeEach(() => {
+            url = "https://localhost:30662/";
+        });
+
+        it("properly splits up basic url", () => {
+            const urlComponents = UrlUtils.GetUrlComponents(url);
+
+            expect(urlComponents.Protocol).to.equal("https:");
+            expect(urlComponents.HostNameAndPort).to.equal("localhost:30662");
+            expect(urlComponents.AbsolutePath).to.equal("/");
+        });
+
+        it("properly splits up url with path", () => {
+            url += "testPage1/testPage2/"
+            const urlComponents = UrlUtils.GetUrlComponents(url);
+
+            expect(urlComponents.Protocol).to.equal("https:");
+            expect(urlComponents.HostNameAndPort).to.equal("localhost:30662");
+            expect(urlComponents.AbsolutePath).to.equal("/testPage1/testPage2/");
+        });
+
+        it("properly splits up url with query string", () => {
+            url += "?testkey1=testval1&testkey2=testval2"
+            const urlComponents = UrlUtils.GetUrlComponents(url);
+
+            expect(urlComponents.Protocol).to.equal("https:");
+            expect(urlComponents.HostNameAndPort).to.equal("localhost:30662");
+            expect(urlComponents.AbsolutePath).to.equal("/");
+            expect(urlComponents.Search).to.equal("?testkey1=testval1&testkey2=testval2");
+        });
+
+        it("properly splits up url with hash", () => {
+            url += "#testhash"
+            const urlComponents = UrlUtils.GetUrlComponents(url);
+
+            expect(urlComponents.Protocol).to.equal("https:");
+            expect(urlComponents.HostNameAndPort).to.equal("localhost:30662");
+            expect(urlComponents.AbsolutePath).to.equal("/");
+            expect(urlComponents.Hash).to.equal("#testhash");          
+        });
+
+        it("properly splits up url with hash and query string", () => {
+            url += "?testkey1=testval1&testkey2=testval2"
+            url += "#testhash"
+            const urlComponents = UrlUtils.GetUrlComponents(url);
+
+            expect(urlComponents.Protocol).to.equal("https:");
+            expect(urlComponents.HostNameAndPort).to.equal("localhost:30662");
+            expect(urlComponents.AbsolutePath).to.equal("/");
+            expect(urlComponents.Search).to.equal("?testkey1=testval1&testkey2=testval2"); 
+            expect(urlComponents.Hash).to.equal("#testhash");   
+        });
+    });
+
+    describe("isSamePage", () => {
+        let url;
+
+        beforeEach(() => {
+            url = "https://localhost:30662/";
+        });
+
+        it("returns true if urls are equal", () => {
+            const samePage = UrlUtils.isSamePage(url, url);
+
+            expect(samePage).to.be.true; 
+        });
+
+        it("returns true if urls are equal but have different hashes", () => {
+            let url1 = url + "#testhash"
+            let url2 = url + "#differenttesthash"
+            const samePage = UrlUtils.isSamePage(url1, url2);
+
+            expect(samePage).to.be.true; 
+        });
+
+        it("returns true if urls are equal but have different query strings", () => {
+            let url1 = url + "?testkey=testval"
+            let url2 = url + "?test=test"
+            const samePage = UrlUtils.isSamePage(url1, url2);
+
+            expect(samePage).to.be.true; 
+        });
+
+        it("returns false if urls have different path", () => {
+            let url1 = url + "testPage/"
+            let url2 = url + "differenttestpage/"
+            const samePage = UrlUtils.isSamePage(url1, url2);
+
+            expect(samePage).to.be.false; 
+        });
+
+        it("returns false if urls have different host", () => {
+            let url1 = url
+            let url2 = "https://testhost:30662/"
+            const samePage = UrlUtils.isSamePage(url1, url2);
+
+            expect(samePage).to.be.false; 
+        });
+    });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3259,24 +3259,16 @@
       }
     },
     "coveralls": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.11.tgz",
-      "integrity": "sha512-LZPWPR2NyGKyaABnc49dR0fpeP6UqhvGq4B5nUrTQ1UBy55z96+ga7r+/ChMdMJUwBgyJDXBi88UBgz2rs9IiQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
         "minimist": "^1.2.5",
-        "request": "^2.88.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
+        "request": "^2.88.2"
       }
     },
     "cp-file": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/preset-typescript": "^7.7.2",
     "@istanbuljs/nyc-config-babel": "^2.1.1",
     "babel-plugin-istanbul": "^5.2.0",
-    "coveralls": "^3.0.11",
+    "coveralls": "^3.1.0",
     "lerna": "^3.20.2",
     "nyc": "^14.1.1",
     "puppeteer": "^2.1.1",


### PR DESCRIPTION
This PR fixes #1602 by ensuring query strings don't disrupt the redirect flow. Msal compares the `currentUrl` to the `loginRequestUrl` to determine if another redirect is required. 

**Previous Behavior:** The `currentUrl` was being stripped of both hash and query string whereas the `loginRequestUrl` was left as is. This was fine for hash routing strategies because we had another check to see if a hash was present in the `loginRequestUrl`. However, with a query string present the Url comparison check will always fail and the token response hash will not be processed.

**New Behavior:** Both `currentUrl` and `loginRequestUrl` will be normalized and compared using the full url minus any non-msal hash to determine if a redirect is needed. If they are equal (final page has been reached), add any non-msal hash back onto the url and then process the msal hash.

TODO: 
- [x] Unit Tests
- [x] Sanity Checks