### PR TITLE
Fix types file location in msal-browser

### DIFF
--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -23,7 +23,7 @@
     ],
     "main": "./dist/index.js",
     "module": "./dist/index.es.js",
-    "types": "./dist/index.d.ts",
+    "types": "./dist/src/index.d.ts",
     "engines": {
         "node": ">=0.8.0"
     },


### PR DESCRIPTION
The types file location was pointing to the wrong place. This PR updates the file location.