### PR TITLE
[msal-common][msal-browser] Fix issue where config was being overwritten by undefined values

### DIFF
--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { AuthOptions, SystemOptions, LoggerOptions, INetworkModule, LogLevel } from "@azure/msal-common";
+import { AuthOptions, SystemOptions, LoggerOptions, INetworkModule, LogLevel, DEFAULT_SYSTEM_OPTIONS } from "@azure/msal-common";
 import { BrowserUtils } from "../utils/BrowserUtils";
 import { BrowserConstants } from "../utils/BrowserConstants";
 
@@ -96,7 +96,8 @@ const DEFAULT_LOGGER_OPTIONS: LoggerOptions = {
 };
 
 // Default system options for browser
-const DEFAULT_SYSTEM_OPTIONS: BrowserSystemOptions = {
+const DEFAULT_BROWSER_SYSTEM_OPTIONS: BrowserSystemOptions = {
+    ...DEFAULT_SYSTEM_OPTIONS,
     loggerOptions: DEFAULT_LOGGER_OPTIONS,
     networkClient: BrowserUtils.getBrowserNetworkClient(),
     windowHashTimeout: DEFAULT_POPUP_TIMEOUT_MS,
@@ -114,11 +115,11 @@ const DEFAULT_SYSTEM_OPTIONS: BrowserSystemOptions = {
  *
  * @returns TConfiguration object
  */
-export function buildConfiguration({ auth, cache = {}, system = {}}: Configuration): Configuration {
+export function buildConfiguration({ auth: userInputAuth, cache: userInputCache, system: userInputSystem }: Configuration): Configuration {
     const overlayedConfig: Configuration = {
-        auth: { ...DEFAULT_AUTH_OPTIONS, ...auth },
-        cache: { ...DEFAULT_CACHE_OPTIONS, ...cache },
-        system: { ...DEFAULT_SYSTEM_OPTIONS, ...system }
+        auth: { ...DEFAULT_AUTH_OPTIONS, ...userInputAuth },
+        cache: { ...DEFAULT_CACHE_OPTIONS, ...userInputCache },
+        system: { ...DEFAULT_BROWSER_SYSTEM_OPTIONS, ...userInputSystem }
     };
     return overlayedConfig;
 }

--- a/lib/msal-browser/test/config/Configuration.spec.ts
+++ b/lib/msal-browser/test/config/Configuration.spec.ts
@@ -48,8 +48,8 @@ describe("Configuration.ts Class Unit Tests", () => {
         expect(emptyConfig.system.networkClient).to.be.not.null.and.not.undefined;
         expect(emptyConfig.system.windowHashTimeout).to.be.not.null.and.not.undefined;
         expect(emptyConfig.system.windowHashTimeout).to.be.eq(DEFAULT_POPUP_TIMEOUT_MS);
-        expect(emptyConfig.system.tokenRenewalOffsetSeconds).to.be.undefined;
-        expect(emptyConfig.system.telemetry).to.be.undefined;
+        expect(emptyConfig.system.tokenRenewalOffsetSeconds).to.be.eq(300);
+        expect(emptyConfig.system.telemetry).to.be.null;
     });
 
     it("Tests default logger", () => {

--- a/lib/msal-common/src/client/SPAClient.ts
+++ b/lib/msal-common/src/client/SPAClient.ts
@@ -213,13 +213,7 @@ export class SPAClient extends BaseClient {
             // Get current cached tokens
             const cachedTokenItem = this.getCachedTokens(requestScopes, acquireTokenAuthority.canonicalAuthority, request.resource, account && account.homeAccountIdentifier);
             const expirationSec = Number(cachedTokenItem.value.expiresOnSec);
-            console.log(TimeUtils.nowSeconds());
-            console.log(this.config.systemOptions.tokenRenewalOffsetSeconds);
             const offsetCurrentTimeSec = TimeUtils.nowSeconds() + this.config.systemOptions.tokenRenewalOffsetSeconds;
-            // console.log(cachedTokenItem);
-            // console.log(expirationSec);
-            console.log(offsetCurrentTimeSec);
-            // console.log(expirationSec > offsetCurrentTimeSec);
             // Check if refresh is forced, or if tokens are expired. If neither are true, return a token response with the found token entry.
             if (!request.forceRefresh && expirationSec && expirationSec > offsetCurrentTimeSec) {
                 const cachedScopes = ScopeSet.fromString(cachedTokenItem.key.scopes, this.config.authOptions.clientId, true);
@@ -358,16 +352,12 @@ export class SPAClient extends BaseClient {
         if (tokenCacheItems.length === 0) {
             throw ClientAuthError.createNoTokensFoundError(requestScopes.printScopes());
         }
-        console.log("All matching tokens");
-        console.log(tokenCacheItems);
 
         // Filter cache items based on available scopes.
         const filteredCacheItems: Array<AccessTokenCacheItem> = tokenCacheItems.filter(cacheItem => {
             const cachedScopes = ScopeSet.fromString(cacheItem.key.scopes, this.config.authOptions.clientId, true);
             return cachedScopes.containsScopeSet(requestScopes);
         });
-        console.log("Filtering");
-        console.log(filteredCacheItems);
 
         // If cache items contains too many matching tokens, throw error.
         if (filteredCacheItems.length > 1) {

--- a/lib/msal-common/src/client/SPAClient.ts
+++ b/lib/msal-common/src/client/SPAClient.ts
@@ -213,7 +213,13 @@ export class SPAClient extends BaseClient {
             // Get current cached tokens
             const cachedTokenItem = this.getCachedTokens(requestScopes, acquireTokenAuthority.canonicalAuthority, request.resource, account && account.homeAccountIdentifier);
             const expirationSec = Number(cachedTokenItem.value.expiresOnSec);
+            console.log(TimeUtils.nowSeconds());
+            console.log(this.config.systemOptions.tokenRenewalOffsetSeconds);
             const offsetCurrentTimeSec = TimeUtils.nowSeconds() + this.config.systemOptions.tokenRenewalOffsetSeconds;
+            // console.log(cachedTokenItem);
+            // console.log(expirationSec);
+            console.log(offsetCurrentTimeSec);
+            // console.log(expirationSec > offsetCurrentTimeSec);
             // Check if refresh is forced, or if tokens are expired. If neither are true, return a token response with the found token entry.
             if (!request.forceRefresh && expirationSec && expirationSec > offsetCurrentTimeSec) {
                 const cachedScopes = ScopeSet.fromString(cachedTokenItem.key.scopes, this.config.authOptions.clientId, true);
@@ -352,12 +358,16 @@ export class SPAClient extends BaseClient {
         if (tokenCacheItems.length === 0) {
             throw ClientAuthError.createNoTokensFoundError(requestScopes.printScopes());
         }
+        console.log("All matching tokens");
+        console.log(tokenCacheItems);
 
         // Filter cache items based on available scopes.
         const filteredCacheItems: Array<AccessTokenCacheItem> = tokenCacheItems.filter(cacheItem => {
             const cachedScopes = ScopeSet.fromString(cacheItem.key.scopes, this.config.authOptions.clientId, true);
             return cachedScopes.containsScopeSet(requestScopes);
         });
+        console.log("Filtering");
+        console.log(filteredCacheItems);
 
         // If cache items contains too many matching tokens, throw error.
         if (filteredCacheItems.length > 1) {

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -97,7 +97,7 @@ const DEFAULT_AUTH_OPTIONS: AuthOptions = {
     postLogoutRedirectUri: ""
 };
 
-const DEFAULT_SYSTEM_OPTIONS: SystemOptions = {
+export const DEFAULT_SYSTEM_OPTIONS: SystemOptions = {
     tokenRenewalOffsetSeconds: DEFAULT_TOKEN_RENEWAL_OFFSET_SEC,
     telemetry: null
 };

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -3,7 +3,7 @@ export { SPAClient } from "./client/SPAClient";
 export { AuthorizationCodeClient } from "./client/AuthorizationCodeClient";
 export { DeviceCodeClient } from "./client/DeviceCodeClient";
 export { RefreshTokenClient } from "./client/RefreshTokenClient";
-export { AuthOptions, SystemOptions, LoggerOptions, TelemetryOptions } from "./config/ClientConfiguration";
+export { AuthOptions, SystemOptions, LoggerOptions, TelemetryOptions, DEFAULT_SYSTEM_OPTIONS } from "./config/ClientConfiguration";
 export { ClientConfiguration } from "./config/ClientConfiguration";
 // Account
 export { Account } from "./account/Account";

--- a/lib/msal-common/src/request/ScopeSet.ts
+++ b/lib/msal-common/src/request/ScopeSet.ts
@@ -195,7 +195,6 @@ export class ScopeSet {
         const sizeOtherScopes = otherScopes.containsScope(Constants.OFFLINE_ACCESS_SCOPE)? otherScopes.getScopeCount() - 1 : otherScopes.getScopeCount();
         const sizeThisScopes = this.containsScope(Constants.OFFLINE_ACCESS_SCOPE)? this.getScopeCount() - 1: this.getScopeCount();
         const sizeUnionScopes = unionScopes.has(Constants.OFFLINE_ACCESS_SCOPE)? unionScopes.size - 1: unionScopes.size;
-
         return sizeUnionScopes < (sizeThisScopes + sizeOtherScopes);
     }
 

--- a/lib/msal-common/test/config/Configuration.spec.ts
+++ b/lib/msal-common/test/config/Configuration.spec.ts
@@ -9,7 +9,7 @@ import { version } from "../../package.json";
 import {TEST_CONFIG} from "../utils/StringConstants";
 
 
-describe("Configuration.ts Class Unit Tests", () => {
+describe("ClientConfiguration.ts Class Unit Tests", () => {
 
     it("buildConfiguration assigns default functions", async () => {
         const emptyConfig: ClientConfiguration = buildClientConfiguration({});


### PR DESCRIPTION
This PR fixes an issue where the default system configuration in `msal-common` was being overwritten by the undefined values in `msal-browser`. This PR adds the default system values to `msal-common` exports and uses them in the `msal-browser` package.

This should fix #1623.