### PR TITLE
hone surface for msal extension library

### DIFF
--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -67,6 +67,10 @@ export const ClientConfigurationErrorMessage = {
     untrustedAuthority: {
         code: "untrusted_authority",
         desc: "The provided authority is not a trusted authority. If using B2C, please include this authority in the knownAuthorities config parameter."
+    },
+    cachePluginNotProvided: {
+        code: "cache_plugin_not_provided",
+        desc: "Cache Plugin functions not implemented, can not call storage intiating apis without configuring pluing properly."
     }
 };
 
@@ -212,5 +216,9 @@ export class ClientConfigurationError extends ClientAuthError {
     static createUntrustedAuthorityError(): ClientConfigurationError {
         return new ClientConfigurationError(ClientConfigurationErrorMessage.untrustedAuthority.code,
             ClientConfigurationErrorMessage.untrustedAuthority.desc);
+    }
+
+    static createCachePluginNotProvided(): ClientConfigurationError {
+        return new ClientConfigurationError(ClientConfigurationErrorMessage.cachePluginNotProvided.code, ClientConfigurationErrorMessage.cachePluginNotProvided.desc);
     }
 }

--- a/lib/msal-node/src/cache/ICachePlugin.ts
+++ b/lib/msal-node/src/cache/ICachePlugin.ts
@@ -1,0 +1,6 @@
+import { JsonCache } from '@azure/msal-common';
+
+export interface ICachePlugin {
+    readFromStorage: () => Promise<JsonCache>;
+    writeToStorage: (cache: JsonCache) => Promise<void>;
+}

--- a/lib/msal-node/src/cache/Storage.ts
+++ b/lib/msal-node/src/cache/Storage.ts
@@ -4,7 +4,8 @@
  */
 import {
     ICacheStorage,
-    InMemoryCache
+    InMemoryCache,
+    Deserializer
 } from '@azure/msal-common';
 import { CacheOptions } from '../config/Configuration';
 
@@ -13,13 +14,14 @@ import { CacheOptions } from '../config/Configuration';
  */
 export class Storage implements ICacheStorage {
     // Cache configuration, either set by user or default values.
-    private cacheConfig: CacheOptions;;
     private inMemoryCache: InMemoryCache;
 
     constructor(cacheConfig: CacheOptions) {
-        this.cacheConfig = cacheConfig;
-        if (this.cacheConfig.cacheLocation! === "fileCache")
-            this.inMemoryCache = this.cacheConfig.cacheInMemory!;
+        const instanceConfiguredCache = cacheConfig.cacheInMemory;
+
+        if (instanceConfiguredCache) {
+            this.inMemoryCache = Deserializer.deserializeAllCache(instanceConfiguredCache);
+        }
     }
 
     /**

--- a/lib/msal-node/src/config/Configuration.ts
+++ b/lib/msal-node/src/config/Configuration.ts
@@ -7,11 +7,11 @@ import {
     LoggerOptions,
     INetworkModule,
     LogLevel,
-    InMemoryCache,
+    JsonCache
 } from '@azure/msal-common';
 import { NetworkUtils } from '../utils/NetworkUtils';
-import { CACHE } from '../utils/Constants';
 import debug from "debug";
+import { ICachePlugin } from 'cache/ICachePlugin';
 
 export type NodeAuthOptions = AuthOptions;
 
@@ -20,12 +20,13 @@ export type NodeAuthOptions = AuthOptions;
  *
  * - cacheLocation            - Used to specify the cacheLocation user wants to set. Valid values are "localStorage" and "sessionStorage"
  * - storeAuthStateInCookie   - If set, MSAL store's the auth request state required for validation of the auth flows in the browser cookies. By default this flag is set to false.
+ * - cachePlugin for persistence provided to library
  */
 // TODO Temporary placeholder - this will be rewritten by cache PR.
 export type CacheOptions = {
-    cacheLocation?: string;
     storeAuthStateInCookie?: boolean;
-    cacheInMemory?: InMemoryCache;
+    cacheInMemory?: JsonCache;
+    cachePlugin?: ICachePlugin;
 };
 
 /**
@@ -60,14 +61,13 @@ const DEFAULT_AUTH_OPTIONS: NodeAuthOptions = {
 };
 
 const DEFAULT_CACHE_OPTIONS: CacheOptions = {
-    cacheLocation: CACHE.FILE_CACHE,
     storeAuthStateInCookie: false,
     cacheInMemory: {
-        accounts: {},
-        idTokens: {},
-        accessTokens: {},
-        refreshTokens: {},
-        appMetadata: {},
+        Account: {},
+        IdToken: {},
+        AccessToken: {},
+        RefreshToken: {},
+        AppMetadata: {},
     },
 };
 


### PR DESCRIPTION
Trying to hone the surface for extension library

This is what I would love to see from the developer experience


```js
  npm install msal-node msal-node-extension
``

```js
import { PublicClientApplication } from "msal";
import { getExtensionCachePlugin } from "msal-node-extension";

const publicClientApplication = new PublicClientApplication({
    auth: {...},
    cache: {
       cachePlugin: getExtensionCachePlugin(extensionConfigIfAny)
    }
});

publicClientApplication.readFromProvidedCache();

// Do Stuff, maybe get a token etc...

publicClientApplication.writeToProvidedCache();

```