### PR TITLE
Add onRedirectNavigate callback to stop navigatation and get redirect url

### DIFF
--- a/lib/msal-core/src/AuthenticationParameters.ts
+++ b/lib/msal-core/src/AuthenticationParameters.ts
@@ -25,7 +25,8 @@ export type AuthenticationParameters = {
     forceRefresh?: boolean;
     redirectUri?: string;
     redirectStartPage?: string;
-    authorityMetadata?: string
+    authorityMetadata?: string;
+    onRedirectNavigate?: ((url: string) => void | boolean)
 };
 
 export function validateClaimsRequest(request: AuthenticationParameters) {

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -588,8 +588,24 @@ export class UserAgentApplication {
                     }
                 }
             } else {
-                // prompt user for interaction
-                this.navigateWindow(urlNavigate, popUpWindow);
+                // If onRedirectNavigate is implemented, invoke it and provide urlNavigate
+                if (request.onRedirectNavigate) {
+                    this.logger.verbose("Invoking onRedirectNavigate callback");
+
+                    const navigate = request.onRedirectNavigate(urlNavigate);
+
+                    // Returning false from onRedirectNavigate will stop navigation
+                    if (navigate !== false) {
+                        this.logger.verbose("onRedirectNavigate did not return false, navigating");
+                        this.navigateWindow(urlNavigate);
+                    } else {
+                        this.logger.verbose("onRedirectNavigate returned false, stopping navigation");
+                    }
+                } else {
+                    // Otherwise, perform navigation
+                    this.logger.verbose("Navigating window to urlNavigate");
+                    this.navigateWindow(urlNavigate);
+                }
             }
         } catch (err) {
             this.logger.error(err);

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -605,6 +605,114 @@ describe("UserAgentApplication.ts Class", function () {
             msal.loginRedirect({});
         });
 
+        it("loginRedirect does not navigate if onRedirectNavigate is implemented and returns false", done => {
+            const config: Configuration = {
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                }
+            };
+
+            window.location = {
+                ...oldWindowLocation,
+                hash: "",
+                assign: function (url) {
+                    throw new Error("window.location.assign should not be called when onRedirectNavigate returns false");
+                }
+            };
+
+            msal = new UserAgentApplication(config);
+            msal.handleRedirectCallback(authCallback);
+            msal.loginRedirect({
+                onRedirectNavigate: url => {
+                    expect(url).to.be.not.null;
+
+                    done();
+                    return false;
+                }
+            })
+        });
+
+        it("acquireTokenRedirect does not navigate if onRedirectNavigate is implemented and returns false", done => {
+            const config: Configuration = {
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                }
+            };
+
+            window.location = {
+                ...oldWindowLocation,
+                hash: "",
+                assign: function (url) {
+                    throw new Error("window.location.assign should not be called when onRedirectNavigate returns false");
+                }
+            };
+
+            msal = new UserAgentApplication(config);
+            msal.handleRedirectCallback(authCallback);
+            msal.acquireTokenRedirect({
+                scopes: [ "user.read" ],
+                account,
+                onRedirectNavigate: url => {
+                    expect(url).to.be.not.null;
+
+                    done();
+                    return false;
+                }
+            })
+        });
+
+        it("navigates if onRedirectNavigate returns null", done => {
+            const config: Configuration = {
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                }
+            };
+
+            window.location = {
+                ...oldWindowLocation,
+                hash: "",
+                assign: function (url) {
+                    expect(url).to.not.be.null;
+                    done();
+                }
+            };
+
+            msal = new UserAgentApplication(config);
+            msal.handleRedirectCallback(authCallback);
+            msal.loginRedirect({
+                onRedirectNavigate: url => {
+                    expect(url).to.be.not.null;
+                }
+            })
+        });
+
+        it("navigates if onRedirectNavigate returns true", done => {
+            const config: Configuration = {
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                }
+            };
+
+            window.location = {
+                ...oldWindowLocation,
+                hash: "",
+                assign: function (url) {
+                    expect(url).to.not.be.null;
+                    done();
+                }
+            };
+
+            msal = new UserAgentApplication(config);
+            msal.handleRedirectCallback(authCallback);
+            msal.loginRedirect({
+                onRedirectNavigate: url => {
+                    expect(url).to.be.not.null;
+
+                    return true
+                }
+            })
+        });
+
         it("exits login function with error if interaction is true", function (done) {
             cacheStorage.setItem(TemporaryCacheKeys.INTERACTION_STATUS, Constants.inProgress);
             window.location = oldWindowLocation;


### PR DESCRIPTION
This adds a new callback for `loginRedirect` and `acquireTokenRedirect` to allow applications to get the URL that would be navigated to, and to stop navigation. This is to support scenarios where applications want to perform the redirect themselves, instead of relying on MSAL.

Usage:

```js
msal.loginRedirect({
  onRedirectNavigate: url => {
    // url that would be navigated to
    console.log(url);
   
     // Applications must explicitly return false to stop navigation
     return false;
  }
})
```
