### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jasonnutter @tnorling @sameerag @pkanher617 @DarylThayil @jo-arroyo @jmckennon @technical-boy


### PR DESCRIPTION
This adds a CODEOWNERS file to our repo: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

We can use this to document who are the "owners" of certain parts of the codebase, which will show up in Github (and VS code with my extension), and automatically request reviews when certain parts of the repository has changed.

For now, this will mark the entire team as default owners.

VS Code extension: https://marketplace.visualstudio.com/items?itemName=jasonnutter.vscode-codeowners