### PR TITLE
Stale Action - Remove debug flag and update messages

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,12 +13,11 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
+        stale-issue-message: 'This issue has not seen activity in 14 days. It may be closed if it remains stale.'
+        stale-pr-message: 'This PR has not seen activity in 14 days. It may be closed if it remains stale.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
         exempt-issue-labels: 'internal, feature'
         exempt-pr-labels: 'work-in-progress'
         days-before-stale: 14
         days-before-close: -1
-        debug-only: true


### PR DESCRIPTION
Stale Action we enabled on Friday was only running in debug mode. This PR enables the Action and updates the messages that will be commented on the Issue/PR when the label is applied.