### PR TITLE
Update exempt labels from Stale Issue Bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
         stale-pr-message: 'This PR has not seen activity in 14 days. It may be closed if it remains stale.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
-        exempt-issue-labels: 'internal, feature'
+        exempt-issue-labels: 'internal, feature, enhancement, known-issue'
         exempt-pr-labels: 'work-in-progress'
         days-before-stale: 14
         days-before-close: -1


### PR DESCRIPTION
Adds `Enhancement` and `Known-issue` labels to be exempt from being marked stale