### PR TITLE
Fix processing and redirection of acquireTokenRedirect

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -2173,10 +2173,14 @@ export class UserAgentApplication {
      * @ignore
      */
     private updateCacheEntries(serverAuthenticationRequest: ServerRequestParameters, account: Account, isLoginCall: boolean, loginStartPage?: string) {
+        // Cache Request Originator Page
+        if (loginStartPage) {
+            this.cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}${Constants.resourceDelimiter}${serverAuthenticationRequest.state}`, loginStartPage, this.inCookie);
+        }
+
         // Cache account and authority
         if (isLoginCall) {
-            // Cache the state, nonce, and login request data
-            this.cacheStorage.setItem(`${TemporaryCacheKeys.LOGIN_REQUEST}${Constants.resourceDelimiter}${serverAuthenticationRequest.state}`, loginStartPage, this.inCookie);
+            // Cache the state
             this.cacheStorage.setItem(`${TemporaryCacheKeys.STATE_LOGIN}${Constants.resourceDelimiter}${serverAuthenticationRequest.state}`, serverAuthenticationRequest.state, this.inCookie);
         } else {
             this.setAccountCache(account, serverAuthenticationRequest.state);

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -805,6 +805,31 @@ describe("UserAgentApplication.ts Class", function () {
             msal.acquireTokenRedirect(tokenRequest);
         });
 
+        it("LoginStartPage is cached on acquireTokenRedirect call", (done) => {
+            const tokenRequest: AuthenticationParameters = {
+                scopes: ["S1"], 
+                account: account
+            };
+
+            window.location = {
+                ...oldWindowLocation,
+                assign: function (url) {
+                    try {
+                        const loginRequestUrl = window.location.href;
+                        const state = UrlUtils.deserializeHash(url).state;
+
+                        expect(cacheStorage.getItem(`${TemporaryCacheKeys.LOGIN_REQUEST}${Constants.resourceDelimiter}${state}`)).to.be.equal(loginRequestUrl);
+                        done();
+                    } catch (e) {
+                        console.error(e);
+                    }
+                }
+            };
+
+            msal.handleRedirectCallback(authCallback);
+            msal.acquireTokenRedirect(tokenRequest);
+        });
+
         it("tests if error is thrown when null scopes are passed", function (done) {
             msal.handleRedirectCallback(authCallback);
             let authErr: AuthError;

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/auth.js
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/auth.js
@@ -1,0 +1,90 @@
+// Browser check variables
+// If you support IE, our recommendation is that you sign-in using Redirect APIs
+// If you as a developer are testing using Edge InPrivate mode, please add "isEdge" to the if check
+const ua = window.navigator.userAgent;
+const msie = ua.indexOf("MSIE ");
+const msie11 = ua.indexOf("Trident/");
+const msedge = ua.indexOf("Edge/");
+const isIE = msie > 0 || msie11 > 0;
+const isEdge = msedge > 0;
+
+let signInType;
+
+// Create the main myMSALObj instance
+// configuration parameters are located at authConfig.js
+const myMSALObj = new Msal.UserAgentApplication(msalConfig);
+
+// Register Callbacks for Redirect flow
+myMSALObj.handleRedirectCallback(authRedirectCallBack);
+
+function authRedirectCallBack(error, response) {
+    if (error) {
+        console.log(error);
+    } else {
+        if (response.tokenType === "id_token" && myMSALObj.getAccount() && !myMSALObj.isCallback(window.location.hash)) {
+            console.log('id_token acquired at: ' + new Date().toString());
+            showWelcomeMessage(myMSALObj.getAccount());
+        } else if (response.tokenType === "access_token") {
+            console.log('access_token acquired at: ' + new Date().toString());
+            callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+            profileButtonPopup.style.display = 'none';
+            profileButtonRedirect.style.display = 'none';
+        } else {
+            console.log("token type is:" + response.tokenType);
+        }
+    }
+}
+
+// Redirect: once login is successful and redirects with tokens, call Graph API
+if (myMSALObj.getAccount() && !myMSALObj.isCallback(window.location.hash)) {
+    // avoid duplicate code execution on page load in case of iframe and Popup window.
+    showWelcomeMessage(myMSALObj.getAccount());
+}
+
+function signIn(method) {
+    signInType = isIE ? "loginRedirect" : method;
+    if (signInType === "loginPopup") {
+        myMSALObj.loginPopup(loginRequest)
+            .then(loginResponse => {
+            console.log(loginResponse);
+            if (myMSALObj.getAccount()) {
+                showWelcomeMessage(myMSALObj.getAccount());
+            }
+        }).catch(function (error) {
+            console.log(error);
+        });
+    } else if (signInType === "loginRedirect") {
+        myMSALObj.loginRedirect(loginRequest)
+    }
+}
+
+function signOut() {
+    myMSALObj.logout();
+}
+
+// This function can be removed if you do not need to support IE
+function getTokenRedirect(request) {
+    myMSALObj.acquireTokenRedirect(request)
+}
+
+function getTokenPopup(request) {
+    return myMSALObj.acquireTokenPopup(request)
+}
+
+function seeProfilePopup() {
+    if (myMSALObj.getAccount()) {
+        getTokenPopup(loginRequest).then(response => {
+            callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+            profileButtonPopup.style.display = 'none';
+            profileButtonRedirect.style.display = 'none';
+        }).catch(error => {
+            console.log(error);
+        });
+    }
+}
+
+function seeProfileRedirect() {
+    if (myMSALObj.getAccount()) {
+        getTokenRedirect(loginRequest);
+    }
+}

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/authConfig.js
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/authConfig.js
@@ -1,0 +1,27 @@
+// Config object to be passed to Msal on creation
+const msalConfig = {
+    auth: {
+        clientId: "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
+        redirectUri: "http://localhost:30662/",
+        navigateToLoginRequestUrl: true
+    },
+    cache: {
+        cacheLocation: "localStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        telemetry: {
+            applicationName: 'msalVanillaTestApp',
+            applicationVersion: 'test1.0',
+            telemetryEmitter: (events) => {
+                console.log("Telemetry Events", events);
+            }
+        }
+    }
+};
+
+// Add here scopes for id token to be used at MS Identity Platform endpoints.
+const loginRequest = {
+    scopes: ["openid", "profile", "User.Read"],
+    forceRefresh: false // Set this to "true" to skip a cached token and go to the server to get a new token
+};

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/graph.js
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/graph.js
@@ -1,0 +1,25 @@
+// Add here the endpoints for MS Graph API services you would like to use.
+const graphConfig = {
+    graphMeEndpoint: "https://graph.microsoft.com/v1.0/me"
+};
+
+// Helper function to call MS Graph API endpoint
+// using authorization bearer token scheme
+function callMSGraph(endpoint, accessToken, callback) {
+    const headers = new Headers();
+    const bearer = `Bearer ${accessToken}`;
+
+    headers.append("Authorization", bearer);
+
+    const options = {
+        method: "GET",
+        headers: headers
+    };
+
+    console.log('request made to Graph API at: ' + new Date().toString());
+
+    fetch(endpoint, options)
+        .then(response => response.json())
+        .then(response => callback(response, endpoint))
+        .catch(error => console.log(error));
+}

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/index.html
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>Quickstart | MSAL.JS Vanilla JavaScript SPA</title>
+    
+    <!-- IE support: add promises polyfill before msal.js  -->    
+    <script type="text/javascript" src="//cdn.jsdelivr.net/npm/bluebird@3.7.2/js/browser/bluebird.min.js"></script>
+    <script src="./dist/msal.js"></script>
+    
+    <!-- adding Bootstrap 4 for UI components  -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <a class="navbar-brand" href="/">MS Identity Platform</a>
+      <div class="btn-group ml-auto dropleft">
+          <button type="button" id="SignIn" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Sign In
+          </button>
+          <div class="dropdown-menu">
+            <button class="dropdown-item" id="loginPopup" onclick="signIn(this.id)">Sign in using Popup</button>
+            <button class="dropdown-item" id="loginRedirect" onclick="signIn(this.id)">Sign in using Redirect</button>
+          </div>
+      </div>
+    </nav>
+    <br>
+    <h5 class="card-header text-center">Vanilla JavaScript SPA calling MS Graph API with MSAL.JS</h5>
+    <br>
+    <div class="row" style="margin:auto" >
+    <div id="card-div" class="col-md-3" style="display:none">
+    <div class="card text-center">
+      <div class="card-body">
+        <h5 class="card-title" id="WelcomeMessage">Please sign-in to see your profile and read your mails</h5>
+        <div id="profile-div"></div>
+        <br>
+        <br>
+        <button class="btn btn-primary" id="seeProfileRedirect" onclick="seeProfileRedirect()">See Profile (Redirect)</button>
+        <br>
+        <br>
+        <button class="btn btn-primary" id="seeProfilePopup" onclick="seeProfilePopup()">See Profile (Popup)</button>
+      </div>
+    </div>
+    </div>
+    <br>
+    <br>
+      <div class="col-md-4">
+        <div class="list-group" id="list-tab" role="tablist">
+        </div>
+      </div>
+      <div class="col-md-5">
+        <div class="tab-content" id="nav-tabContent">
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+
+    <!-- importing bootstrap.js and supporting js libraries -->
+    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>  
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    
+    <!-- importing app scripts | load order is important -->
+    <script type="text/javascript" src="./authConfig.js"></script>
+    <script type="text/javascript" src="./ui.js"></script>  
+    <script type="text/javascript" src="./graph.js"></script>
+    <script type="text/javascript" src="./auth.js"></script>
+  </body>
+</html>

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
@@ -105,6 +105,7 @@ describe("Browser tests", function () {
         // Acquire Access Token using acquireTokenRedirect
         await page.click("#seeProfileRedirect");
         await page.waitForNavigation({ waitUntil: "networkidle0"});
+        await page.waitForSelector('#profile-info');
         await takeScreenshot(page, testName, `samplePageGotToken`);
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
@@ -136,6 +137,7 @@ describe("Browser tests", function () {
         // Acquire Access Token using acquireTokenRedirect
         await page.click("#seeProfileRedirect");
         await page.waitForNavigation({ waitUntil: "networkidle0"});
+        await page.waitForSelector('#profile-info');
         await takeScreenshot(page, testName, `samplePageGotToken`);
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
@@ -145,7 +147,7 @@ describe("Browser tests", function () {
     it("Performs loginPopup then acquireTokenRedirect from page with custom query params", async () => {
         const customQueryPage = 'http://localhost:30662/?testQueryParam=test'
         await page.goto(customQueryPage);
-        const testName = "acquireTokenRedirectCustomHashCase";
+        const testName = "acquireTokenRedirectCustomQueryCase";
         // Home Page
         await takeScreenshot(page, testName, `samplePageInit`);
         // Click Sign In
@@ -168,6 +170,7 @@ describe("Browser tests", function () {
         // Acquire Access Token using acquireTokenRedirect
         await page.click("#seeProfileRedirect");
         await page.waitForNavigation({ waitUntil: "networkidle0"});
+        await page.waitForSelector('#profile-info');
         await takeScreenshot(page, testName, `samplePageGotToken`);
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
@@ -196,15 +199,11 @@ describe("Browser tests", function () {
         expect(popupPage.isClosed()).to.be.true;
 
         // Acquire Access Token using acquireTokenPopup
-        const newPopupConsentWindowPromise = new Promise<puppeteer.Page>(resolve => page.once('popup', resolve));
         await page.click("#seeProfilePopup");
-        const popupConsentPage = await newPopupConsentWindowPromise;
-        const popupConsentWindowClosed = new Promise<void>(resolve => popupConsentPage.once("close", resolve));
+        await page.waitForSelector('#profile-info');
 
-        await popupConsentWindowClosed;
         await takeScreenshot(page, testName, `samplePageGotToken`);
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
-        expect(popupConsentPage.isClosed()).to.be.true;
     });
 });

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
@@ -1,0 +1,209 @@
+import * as Mocha from "mocha";
+import puppeteer from "puppeteer";
+import { expect } from "chai";
+import fs from "fs";
+import { LabClient } from "../../../e2eTests/LabClient";
+
+const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
+let SCREENSHOT_NUM = 0;
+let username = "";
+let accountPwd = "";
+
+function setupScreenshotDir() {
+    if (!fs.existsSync(`${SCREENSHOT_BASE_FOLDER_NAME}`)) {
+        fs.mkdirSync(SCREENSHOT_BASE_FOLDER_NAME);
+    }
+}
+
+async function setupCredentials() {
+    const testCreds = new LabClient();
+    const envResponse = await testCreds.getUserVarsByCloudEnvironment("azurecloud");
+    const testEnv = envResponse[0];
+    if (testEnv.upn) {
+        username = testEnv.upn;
+    }
+
+    const testPwdSecret = await testCreds.getSecret(testEnv.labName);
+
+    accountPwd = testPwdSecret.value;
+}
+
+async function takeScreenshot(page: puppeteer.Page, testName: string, screenshotName: string): Promise<void> {
+    const screenshotFolderName = `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
+    if (!fs.existsSync(`${screenshotFolderName}`)) {
+        fs.mkdirSync(screenshotFolderName);
+    }
+    await page.screenshot({ path: `${screenshotFolderName}/${++SCREENSHOT_NUM}_${screenshotName}.png` });
+}
+
+async function enterCredentials(page: puppeteer.Page, testName: string): Promise<void> {
+    await page.waitForNavigation({ waitUntil: "networkidle0"});
+    await page.waitForSelector("#i0116");
+    await takeScreenshot(page, testName, `loginPage`);
+    await page.type("#i0116", username);
+    await page.click("#idSIButton9");
+    await page.waitForNavigation({ waitUntil: "networkidle0"});
+    await takeScreenshot(page, testName, `pwdInputPage`);
+    await page.waitForSelector("#i0118");
+    await page.type("#i0118", accountPwd);
+    await page.click("#idSIButton9");
+}
+
+describe("Browser tests", function () {
+    this.timeout(8000);
+    this.retries(1);
+
+    let browser: puppeteer.Browser;
+    before(async () => {
+        setupScreenshotDir();
+        setupCredentials();
+        browser = await puppeteer.launch({
+            headless: true,
+            ignoreDefaultArgs: ['--no-sandbox', '–disable-setuid-sandbox']
+        });
+    });
+
+    let context: puppeteer.BrowserContext;
+    let page: puppeteer.Page;
+    beforeEach(async () => {
+        SCREENSHOT_NUM = 0;
+        context = await browser.createIncognitoBrowserContext();
+        page = await context.newPage();
+        await page.goto('http://localhost:30662/');
+    });
+
+    afterEach(async () => {
+        await page.close();
+    });
+
+    after(async () => {
+        await context.close();
+        await browser.close();
+    });
+
+    it("Performs loginPopup then acquireTokenRedirect", async () => {
+        const testName = "acquireTokenRedirectBaseCase";
+        // Home Page
+        await takeScreenshot(page, testName, `samplePageInit`);
+        // Click Sign In
+        await page.click("#SignIn");
+        await takeScreenshot(page, testName, `signInClicked`);
+        // Click Sign In With Popup
+        const newPopupWindowPromise = new Promise<puppeteer.Page>(resolve => page.once('popup', resolve));
+        await page.click("#loginPopup");
+        const popupPage = await newPopupWindowPromise;
+        const popupWindowClosed = new Promise<void>(resolve => popupPage.once("close", resolve));
+        // Enter credentials
+        await enterCredentials(popupPage, testName);
+        // Wait until popup window closes and see that we are logged in
+        await popupWindowClosed;
+        await takeScreenshot(page, testName, `samplePageLoggedIn`);
+        let localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        expect(Object.keys(localStorage).length).to.be.eq(5);
+        expect(popupPage.isClosed()).to.be.true;
+
+        // Acquire Access Token using acquireTokenRedirect
+        await page.click("#seeProfileRedirect");
+        await page.waitForNavigation({ waitUntil: "networkidle0"});
+        await takeScreenshot(page, testName, `samplePageGotToken`);
+        localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        expect(Object.keys(localStorage).length).to.be.eq(6);
+    });
+
+    it("Performs loginPopup then acquireTokenRedirect from page with custom hash", async () => {
+        const customHashPage = 'http://localhost:30662/#testHash'
+        await page.goto(customHashPage);
+        const testName = "acquireTokenRedirectCustomHashCase";
+        // Home Page
+        await takeScreenshot(page, testName, `samplePageInit`);
+        // Click Sign In
+        await page.click("#SignIn");
+        await takeScreenshot(page, testName, `signInClicked`);
+        // Click Sign In With Popup
+        const newPopupWindowPromise = new Promise<puppeteer.Page>(resolve => page.once('popup', resolve));
+        await page.click("#loginPopup");
+        const popupPage = await newPopupWindowPromise;
+        const popupWindowClosed = new Promise<void>(resolve => popupPage.once("close", resolve));
+        // Enter credentials
+        await enterCredentials(popupPage, testName);
+        // Wait until popup window closes and see that we are logged in
+        await popupWindowClosed;
+        await takeScreenshot(page, testName, `samplePageLoggedIn`);
+        let localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        expect(Object.keys(localStorage).length).to.be.eq(5);
+        expect(popupPage.isClosed()).to.be.true;
+
+        // Acquire Access Token using acquireTokenRedirect
+        await page.click("#seeProfileRedirect");
+        await page.waitForNavigation({ waitUntil: "networkidle0"});
+        await takeScreenshot(page, testName, `samplePageGotToken`);
+        localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        expect(Object.keys(localStorage).length).to.be.eq(6);
+        expect(page.url).to.be.eq(customHashPage);
+    });
+
+    it("Performs loginPopup then acquireTokenRedirect from page with custom query params", async () => {
+        const customQueryPage = 'http://localhost:30662/?testQueryParam=test'
+        await page.goto(customQueryPage);
+        const testName = "acquireTokenRedirectCustomHashCase";
+        // Home Page
+        await takeScreenshot(page, testName, `samplePageInit`);
+        // Click Sign In
+        await page.click("#SignIn");
+        await takeScreenshot(page, testName, `signInClicked`);
+        // Click Sign In With Popup
+        const newPopupWindowPromise = new Promise<puppeteer.Page>(resolve => page.once('popup', resolve));
+        await page.click("#loginPopup");
+        const popupPage = await newPopupWindowPromise;
+        const popupWindowClosed = new Promise<void>(resolve => popupPage.once("close", resolve));
+        // Enter credentials
+        await enterCredentials(popupPage, testName);
+        // Wait until popup window closes and see that we are logged in
+        await popupWindowClosed;
+        await takeScreenshot(page, testName, `samplePageLoggedIn`);
+        let localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        expect(Object.keys(localStorage).length).to.be.eq(5);
+        expect(popupPage.isClosed()).to.be.true;
+
+        // Acquire Access Token using acquireTokenRedirect
+        await page.click("#seeProfileRedirect");
+        await page.waitForNavigation({ waitUntil: "networkidle0"});
+        await takeScreenshot(page, testName, `samplePageGotToken`);
+        localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        expect(Object.keys(localStorage).length).to.be.eq(6);
+        expect(page.url).to.be.eq(customQueryPage);
+    });
+
+    it("Performs loginPopup then acquireTokenPopup", async () => {
+        const testName = "acquireTokenPopupBaseCase";
+        // Home Page
+        await takeScreenshot(page, testName, `samplePageInit`);
+        // Click Sign In
+        await page.click("#SignIn");
+        await takeScreenshot(page, testName, `signInClicked`);
+        // Click Sign In With Popup
+        const newPopupWindowPromise = new Promise<puppeteer.Page>(resolve => page.once('popup', resolve));
+        await page.click("#loginPopup");
+        const popupPage = await newPopupWindowPromise;
+        const popupWindowClosed = new Promise<void>(resolve => popupPage.once("close", resolve));
+        // Enter credentials
+        await enterCredentials(popupPage, testName);
+        // Wait until popup window closes and see that we are logged in
+        await popupWindowClosed;
+        await takeScreenshot(page, testName, `samplePageLoggedIn`);
+        let localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        expect(Object.keys(localStorage).length).to.be.eq(5);
+        expect(popupPage.isClosed()).to.be.true;
+
+        // Acquire Access Token using acquireTokenPopup
+        const newPopupConsentWindowPromise = new Promise<puppeteer.Page>(resolve => page.once('popup', resolve));
+        await page.click("#seeProfilePopup");
+        const popupConsentPage = await newPopupConsentWindowPromise;
+        const popupConsentWindowClosed = new Promise<void>(resolve => popupPage.once("close", resolve));
+
+        await popupConsentWindowClosed;
+        localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        expect(Object.keys(localStorage).length).to.be.eq(6);
+        expect(popupConsentPage.isClosed()).to.be.true;
+    });
+});

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
@@ -139,7 +139,7 @@ describe("Browser tests", function () {
         await takeScreenshot(page, testName, `samplePageGotToken`);
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
-        expect(page.url).to.be.eq(customHashPage);
+        expect(page.url()).to.be.eq(customHashPage);
     });
 
     it("Performs loginPopup then acquireTokenRedirect from page with custom query params", async () => {
@@ -171,7 +171,7 @@ describe("Browser tests", function () {
         await takeScreenshot(page, testName, `samplePageGotToken`);
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
-        expect(page.url).to.be.eq(customQueryPage);
+        expect(page.url()).to.be.eq(customQueryPage);
     });
 
     it("Performs loginPopup then acquireTokenPopup", async () => {

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
@@ -171,7 +171,7 @@ describe("Browser tests", function () {
         await takeScreenshot(page, testName, `samplePageGotToken`);
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
-        expect(page.url()).to.be.eq(customQueryPage);
+        expect(page.url()).to.be.eq(customQueryPage + "#"); // Redirect will leave empty hash on the url
     });
 
     it("Performs loginPopup then acquireTokenPopup", async () => {
@@ -199,9 +199,10 @@ describe("Browser tests", function () {
         const newPopupConsentWindowPromise = new Promise<puppeteer.Page>(resolve => page.once('popup', resolve));
         await page.click("#seeProfilePopup");
         const popupConsentPage = await newPopupConsentWindowPromise;
-        const popupConsentWindowClosed = new Promise<void>(resolve => popupPage.once("close", resolve));
+        const popupConsentWindowClosed = new Promise<void>(resolve => popupConsentPage.once("close", resolve));
 
         await popupConsentWindowClosed;
+        await takeScreenshot(page, testName, `samplePageGotToken`);
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
         expect(popupConsentPage.isClosed()).to.be.true;

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/ui.js
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/ui.js
@@ -1,0 +1,66 @@
+// Select DOM elements to work with
+const welcomeDiv = document.getElementById("WelcomeMessage");
+const signInButton = document.getElementById("SignIn");
+const cardDiv = document.getElementById("card-div");
+const profileButtonRedirect = document.getElementById("seeProfileRedirect");
+const profileButtonPopup = document.getElementById("seeProfilePopup");
+const profileDiv = document.getElementById("profile-div");
+
+function showWelcomeMessage(account) {
+    // Reconfiguring DOM elements
+    cardDiv.style.display = 'initial';
+    welcomeDiv.innerHTML = `Welcome ${account.name}`;
+    signInButton.nextElementSibling.style.display = 'none';
+    signInButton.setAttribute("onclick", "signOut();");
+    signInButton.setAttribute('class', "btn btn-success")
+    signInButton.innerHTML = "Sign Out";
+}
+
+function updateUI(data, endpoint) {
+    console.log('Graph API responded at: ' + new Date().toString());
+
+    if (endpoint === graphConfig.graphMeEndpoint) {
+        const title = document.createElement('p');
+        title.innerHTML = "<strong>Title: </strong>" + data.jobTitle;
+        const email = document.createElement('p');
+        email.innerHTML = "<strong>Mail: </strong>" + data.mail;
+        const phone = document.createElement('p');
+        phone.innerHTML = "<strong>Phone: </strong>" + data.businessPhones[0];
+        const address = document.createElement('p');
+        address.innerHTML = "<strong>Location: </strong>" + data.officeLocation;
+        profileDiv.appendChild(title);
+        profileDiv.appendChild(email);
+        profileDiv.appendChild(phone);
+        profileDiv.appendChild(address);
+    } else if (endpoint === graphConfig.graphMailEndpoint) {
+        if (data.value.length < 1) {
+            alert("Your mailbox is empty!")
+        } else {
+            const tabList = document.getElementById("list-tab");
+            const tabContent = document.getElementById("nav-tabContent");
+
+            data.value.map((d, i) => {
+                // Keeping it simple
+                if (i < 10) {
+                    const listItem = document.createElement("a");
+                    listItem.setAttribute("class", "list-group-item list-group-item-action")
+                    listItem.setAttribute("id", "list" + i + "list")
+                    listItem.setAttribute("data-toggle", "list")
+                    listItem.setAttribute("href", "#list" + i)
+                    listItem.setAttribute("role", "tab")
+                    listItem.setAttribute("aria-controls", i)
+                    listItem.innerHTML = d.subject;
+                    tabList.appendChild(listItem)
+
+                    const contentItem = document.createElement("div");
+                    contentItem.setAttribute("class", "tab-pane fade")
+                    contentItem.setAttribute("id", "list" + i)
+                    contentItem.setAttribute("role", "tabpanel")
+                    contentItem.setAttribute("aria-labelledby", "list" + i + "list")
+                    contentItem.innerHTML = "<strong> from: " + d.from.emailAddress.address + "</strong><br><br>" + d.bodyPreview + "...";
+                    tabContent.appendChild(contentItem);
+                }
+            });
+        }
+    }
+}

--- a/samples/VanillaJSTestApp/app/get_access_token_interactively/ui.js
+++ b/samples/VanillaJSTestApp/app/get_access_token_interactively/ui.js
@@ -20,6 +20,9 @@ function updateUI(data, endpoint) {
     console.log('Graph API responded at: ' + new Date().toString());
 
     if (endpoint === graphConfig.graphMeEndpoint) {
+        const profileInfo = document.createElement('div');
+        profileInfo.id = "profile-info";
+        profileDiv.appendChild(profileInfo);
         const title = document.createElement('p');
         title.innerHTML = "<strong>Title: </strong>" + data.jobTitle;
         const email = document.createElement('p');
@@ -28,10 +31,10 @@ function updateUI(data, endpoint) {
         phone.innerHTML = "<strong>Phone: </strong>" + data.businessPhones[0];
         const address = document.createElement('p');
         address.innerHTML = "<strong>Location: </strong>" + data.officeLocation;
-        profileDiv.appendChild(title);
-        profileDiv.appendChild(email);
-        profileDiv.appendChild(phone);
-        profileDiv.appendChild(address);
+        profileInfo.appendChild(title);
+        profileInfo.appendChild(email);
+        profileInfo.appendChild(phone);
+        profileInfo.appendChild(address);
     } else if (endpoint === graphConfig.graphMailEndpoint) {
         if (data.value.length < 1) {
             alert("Your mailbox is empty!")

--- a/samples/VanillaJSTestApp/e2eTests/testRunner.ts
+++ b/samples/VanillaJSTestApp/e2eTests/testRunner.ts
@@ -20,20 +20,6 @@ const sampleFolders = fs.readdirSync(APP_DIR, { withFileTypes: true }).filter(fu
     return file.name;
 });
 
-// console.log(path.resolve(`${APP_DIR}/default/index.html`));
-
-//initialize express.
-const app = express();
-
-// Initialize variables.
-let port = DEFAULT_PORT; // 30662;
-
-// Configure morgan module to log all requests.
-app.use(morgan('dev'));
-
-// Set the front-end folder to serve public assets.
-app.use("/dist", express.static(path.join(PARENT_DIR, "../../lib/msal-core/dist")));
-
 // Clear require cache and create new mocha object to run new set of tests
 function createMochaObject(sampleName: string) {
     // Required to allow mocha to run multiple times
@@ -57,13 +43,25 @@ function createMochaObject(sampleName: string) {
 
 // Recursive test runner for each sample
 function runMochaTests(sampleIndex: number) {
+    //initialize express.
+    const app = express();
+
+    // Initialize variables.
+    let port = DEFAULT_PORT; // 30662;
+
+    // Configure morgan module to log all requests.
+    app.use(morgan('dev'));
+
+    // Set the front-end folder to serve public assets.
+    app.use("/lib", express.static(path.join(PARENT_DIR, "../../lib/msal-browser/lib")));
+    
     let sampleName = sampleFolders[sampleIndex];
     const mocha = createMochaObject(sampleName);
     app.use(express.static(`${APP_DIR}/${sampleName}`));
 
     // Set up a route for index.html.
     app.get('*', function (req, res) {
-        res.sendFile(path.resolve(`${APP_DIR}/${sampleName}/index.html`));
+        res.sendFile(path.join(`${APP_DIR}/${sampleName}/index.html`));
     });
 
     let server = app.listen(port);

--- a/samples/VanillaJSTestApp/e2eTests/testRunner.ts
+++ b/samples/VanillaJSTestApp/e2eTests/testRunner.ts
@@ -53,7 +53,7 @@ function runMochaTests(sampleIndex: number) {
     app.use(morgan('dev'));
 
     // Set the front-end folder to serve public assets.
-    app.use("/lib", express.static(path.join(PARENT_DIR, "../../lib/msal-browser/lib")));
+    app.use("/lib", express.static(path.join(PARENT_DIR, "../../lib/msal-core/dist")));
     
     let sampleName = sampleFolders[sampleIndex];
     const mocha = createMochaObject(sampleName);

--- a/samples/VanillaJSTestApp/e2eTests/testRunner.ts
+++ b/samples/VanillaJSTestApp/e2eTests/testRunner.ts
@@ -53,7 +53,7 @@ function runMochaTests(sampleIndex: number) {
     app.use(morgan('dev'));
 
     // Set the front-end folder to serve public assets.
-    app.use("/lib", express.static(path.join(PARENT_DIR, "../../lib/msal-core/dist")));
+    app.use("/dist", express.static(path.join(PARENT_DIR, "../../lib/msal-core/dist")));
     
     let sampleName = sampleFolders[sampleIndex];
     const mocha = createMochaObject(sampleName);


### PR DESCRIPTION
This PR fixes #1755, #1713 and #1763

`loginStartPage` is only being cached for login calls. This means that when `navigateToLoginRequestUrl: true` and calling `acquireTokenRedirect` the user will be redirected back to the root of their application and the response hash will not be processed.

Diff largely due to new Sample + E2E tests. Relevant code changes are just in `UserAgentApplication`