### PR TITLE
signOut() function added

### DIFF
--- a/lib/msal-react-native-android-poc/MSALModule/android/src/main/java/com/reactlibrary/MSALModule.java
+++ b/lib/msal-react-native-android-poc/MSALModule/android/src/main/java/com/reactlibrary/MSALModule.java
@@ -9,6 +9,8 @@ package com.reactlibrary;
 
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -134,6 +136,27 @@ public class MSALModule extends ReactContextBaseJavaModule {
             return null;
         }
         
+    }
+
+    /**
+     * signOut(): signs out the user currently signed in
+     * Parameters: Promise promise (resolve will return a boolean true if account was successfully signed out and reject will return the exception)
+     */
+    @ReactMethod
+    public void signOut(Promise promise) {
+        publicClientApplication.signOut (new ISingleAccountPublicClientApplication.SignOutCallback() {
+            @Override
+            public void onSignOut() {
+                Log.d(TAG, "User successfully signed out.");
+                promise.resolve(true);
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                Log.d(TAG, "Error while signing out: " + exception.toString());
+                promise.reject(exception);
+            }
+        });
     }
 
     /*

--- a/lib/msal-react-native-android-poc/SampleApp/App.js
+++ b/lib/msal-react-native-android-poc/SampleApp/App.js
@@ -144,7 +144,23 @@ class App extends Component {
                 style={styles.button}>
                   <Button 
                   title="Sign Out"
-                  color ='#2b88d8' />
+                  color ='#2b88d8'
+                  disabled = {!this.state.isSignedIn}
+                  onPress = {async () => {
+                    try {
+                      var result = await MSAL.signOut();
+                      this.setState({
+                        aUsername: null,
+                        aTenantId: null,
+                        aIdToken: null,
+                        aAuthority: null,
+                        aId: null,
+                        isSignedIn: false
+                      });
+                    } catch (exception) {
+                      console.log(exception)
+                    }
+                  }} />
                 </View>
               </View>
               <View

--- a/lib/msal-react-native-android-poc/SampleApp/android/app/src/main/java/com/sampleapp/MSALModule.java
+++ b/lib/msal-react-native-android-poc/SampleApp/android/app/src/main/java/com/sampleapp/MSALModule.java
@@ -9,6 +9,8 @@ package com.sampleapp;
 
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -113,7 +115,7 @@ public class MSALModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * loadAccount(): will load a currently signed in account. 
+     * loadAccount(): will load a currently signed in account.
      * Returns an IAccount if an account exists; returns null if no account is signed in or an error occurs
      */
 
@@ -134,7 +136,28 @@ public class MSALModule extends ReactContextBaseJavaModule {
             Log.d(TAG, "Error loading account: " + e.toString());
             return null;
         }
-        
+
+    }
+
+    /**
+     * signOut(): signs out the user currently signed in
+     * Parameters: Promise promise (resolve will return a boolean true if account was successfully signed out and reject will return the exception)
+     */
+    @ReactMethod
+    public void signOut(Promise promise) {
+        publicClientApplication.signOut (new ISingleAccountPublicClientApplication.SignOutCallback() {
+            @Override
+            public void onSignOut() {
+                Log.d(TAG, "User successfully signed out.");
+                promise.resolve(true);
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                Log.d(TAG, "Error while signing out: " + exception.toString());
+                promise.reject(exception);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
signOut() was added to MSALModule and the sample app. Calling the function within a react-native app will attempt to sign out the user currently signed in. If successful, a boolean "true" will be returned. If not, an exception is thrown that is logged in the Android console and passed to the react native app. 
The sample app was updated to utilize signOut() and clears the user's data within the app upon completion. A new user is able to sign in immediately afterwards.