### PR TITLE
Complete Single Account Mode MSAL for React Native

### DIFF
--- a/lib/msal-react-native-android-poc/MSALModule/android/src/main/java/com/reactlibrary/Constants.java
+++ b/lib/msal-react-native-android-poc/MSALModule/android/src/main/java/com/reactlibrary/Constants.java
@@ -1,0 +1,9 @@
+//Constants class which will be imported by MSALModule
+package com.reactlibrary;
+
+public final class Constants {
+
+    private Constants() {}
+
+    public static final String[] DEFAULT_SCOPES = {"User.Read"};
+}

--- a/lib/msal-react-native-android-poc/MSALModule/android/src/main/java/com/reactlibrary/MSALModule.java
+++ b/lib/msal-react-native-android-poc/MSALModule/android/src/main/java/com/reactlibrary/MSALModule.java
@@ -22,6 +22,9 @@ import com.microsoft.identity.client.exception.MsalException;
 
 import static com.facebook.react.views.textinput.ReactTextInputManager.TAG;
 
+//import DEFAULT_SCOPES from Constants.java
+import static com.reactlibrary.Constants.DEFAULT_SCOPES;
+
 import java.util.Arrays;
 
 public class MSALModule extends ReactContextBaseJavaModule {

--- a/lib/msal-react-native-android-poc/MSALModule/android/src/main/java/com/reactlibrary/MSALModule.java
+++ b/lib/msal-react-native-android-poc/MSALModule/android/src/main/java/com/reactlibrary/MSALModule.java
@@ -176,6 +176,49 @@ public class MSALModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * acquireToken: attempts to obtain a token interactively
+     * Parameters: string scopesValue (string containing scopes separated by a " "), Promise promise (returned to an async function)
+     */
+    @ReactMethod
+    public void acquireToken(String scopesValue, Promise promise) {
+        if (!scopesValue.isEmpty()) {
+            publicClientApplication.acquireToken(getCurrentActivity(), scopesValue.toLowerCase().split(" "), getAuthInteractiveCallback(promise));
+        } else {
+            //the default is User.Read
+            String[] array = {"User.Read"};
+            publicClientApplication.acquireToken(getCurrentActivity(), array, getAuthInteractiveCallback(promise));
+        }
+    }
+
+    /**
+     * getAuthInteractiveCallback is the callback function for acquireToken.
+     * If successful, it will return a map of the IAuthenticationResult.
+     * If there's an error, the exception will be returned.
+     */
+
+    private AuthenticationCallback getAuthInteractiveCallback(final Promise promise) {
+        return new AuthenticationCallback() {
+            @Override
+            public void onCancel() {
+                Log.d(TAG, "User cancelled login (acquireToken).");
+                promise.reject("userCancel", "User cancelled login (acquireToken).");
+            }
+
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                Log.d(TAG, "Acquire token interactively success.");
+                promise.resolve(mapMSALResult(authenticationResult));
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                Log.d(TAG, "Error while acquiring token interactively: " + exception.toString());
+                promise.reject(exception);
+            }
+        };
+    }
+
+    /**
      * acquireTokenSilent: attempts to obtain a token silently from the cache
      * Parameters: string scopesValue (string containing scopes separated by a " "), Promise promise (returned to an async function)
      */
@@ -195,7 +238,7 @@ public class MSALModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * SilentAuthenticationCallback is the callback function for acquireTokenSlient.
+     * getAuthSilentCallback is the callback function for acquireTokenSlient.
      * If successful, it will return a map of the IAuthenticationResult.
      * If there's an error, the exception will be returned.
      */
@@ -204,13 +247,13 @@ public class MSALModule extends ReactContextBaseJavaModule {
         return new SilentAuthenticationCallback() {
             @Override
             public void onSuccess(IAuthenticationResult authenticationResult) {
-                Log.d(TAG, "Acquire tokens silently success.");
+                Log.d(TAG, "Acquire token silently success.");
                 promise.resolve(mapMSALResult(authenticationResult));
             }
 
             @Override
             public void onError(MsalException exception) {
-                Log.d(TAG, "Error while acquiring tokens silently: " + exception.toString());
+                Log.d(TAG, "Error while acquiring token silently: " + exception.toString());
                 promise.reject(exception);
             }
         };

--- a/lib/msal-react-native-android-poc/SampleApp/App.js
+++ b/lib/msal-react-native-android-poc/SampleApp/App.js
@@ -96,7 +96,7 @@ class App extends Component {
   startGetGraphDataSilently = async () => {
     try {
       var result = await MSAL.acquireTokenSilent(this.state.scopesValue);
-      //make api call
+      //api call to MSGraph
       var response = await fetch (
         this.state.URLValue, {
           method: 'GET',
@@ -108,6 +108,30 @@ class App extends Component {
       var json = await response.json();
       this.setState({
         graphResult: json
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  startGetGraphDataInteractively = async () => {
+    try {
+      var result = await MSAL.acquireToken(this.state.scopesValue);
+      //make api call
+      var response = await fetch (
+        this.state.URLValue, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${result.accessToken}`
+          }
+        }
+      );
+      var json = await response.json();
+      //update current account and state
+      await this.getAccount();
+      this.setState({
+        graphResult: json,
+        isSignedIn: true
       });
     } catch (exception) {
       console.log(exception);
@@ -193,7 +217,8 @@ class App extends Component {
                 style={styles.button}>
                   <Button 
                   title="Get Graph Data Interactively"
-                  color ='#2b88d8' />
+                  color ='#2b88d8'
+                  onPress = {this.startGetGraphDataInteractively} />
                 </View>
                 <View
                 style={styles.button}>

--- a/lib/msal-react-native-android-poc/SampleApp/android/app/src/main/java/com/sampleapp/Constants.java
+++ b/lib/msal-react-native-android-poc/SampleApp/android/app/src/main/java/com/sampleapp/Constants.java
@@ -1,0 +1,9 @@
+//Constants class which will be imported by MSALModule
+package com.sampleapp;
+
+public final class Constants {
+
+    private Constants() {}
+
+    public static final String[] DEFAULT_SCOPES = {"User.Read"};
+}

--- a/lib/msal-react-native-android-poc/SampleApp/android/app/src/main/java/com/sampleapp/MSALModule.java
+++ b/lib/msal-react-native-android-poc/SampleApp/android/app/src/main/java/com/sampleapp/MSALModule.java
@@ -23,6 +23,9 @@ import com.microsoft.identity.client.exception.MsalException;
 
 import static com.facebook.react.views.textinput.ReactTextInputManager.TAG;
 
+//import DEFAULT_SCOPES from Constants.java
+import static com.sampleapp.Constants.DEFAULT_SCOPES;
+
 import java.util.Arrays;
 
 public class MSALModule extends ReactContextBaseJavaModule {
@@ -63,8 +66,7 @@ public class MSALModule extends ReactContextBaseJavaModule {
             publicClientApplication.signIn(getCurrentActivity(), null, scopesValue.toLowerCase().split(" "), getLoginCallback(promise));
         } else {
             //the default is User.Read
-            String[] array = {"User.Read"};
-            publicClientApplication.signIn(getCurrentActivity(), null, array, getLoginCallback(promise));
+            publicClientApplication.signIn(getCurrentActivity(), null, DEFAULT_SCOPES, getLoginCallback(promise));
         }
     }
 
@@ -185,8 +187,7 @@ public class MSALModule extends ReactContextBaseJavaModule {
             publicClientApplication.acquireToken(getCurrentActivity(), scopesValue.toLowerCase().split(" "), getAuthInteractiveCallback(promise));
         } else {
             //the default is User.Read
-            String[] array = {"User.Read"};
-            publicClientApplication.acquireToken(getCurrentActivity(), array, getAuthInteractiveCallback(promise));
+            publicClientApplication.acquireToken(getCurrentActivity(), DEFAULT_SCOPES, getAuthInteractiveCallback(promise));
         }
     }
 
@@ -232,8 +233,7 @@ public class MSALModule extends ReactContextBaseJavaModule {
             publicClientApplication.acquireTokenSilentAsync(scopesValue.toLowerCase().split(" "), account.getAuthority(), getAuthSilentCallback(promise));
         } else {
             //the default is User.Read
-            String[] array = {"User.Read"};
-            publicClientApplication.acquireTokenSilentAsync(array, account.getAuthority(), getAuthSilentCallback(promise));
+            publicClientApplication.acquireTokenSilentAsync(DEFAULT_SCOPES, account.getAuthority(), getAuthSilentCallback(promise));
         }
     }
 

--- a/lib/msal-react-native-android-poc/SampleApp/android/app/src/main/java/com/sampleapp/MSALModule.java
+++ b/lib/msal-react-native-android-poc/SampleApp/android/app/src/main/java/com/sampleapp/MSALModule.java
@@ -176,6 +176,49 @@ public class MSALModule extends ReactContextBaseJavaModule {
     }
 
       /**
+     * acquireToken: attempts to obtain a token interactively
+     * Parameters: string scopesValue (string containing scopes separated by a " "), Promise promise (returned to an async function)
+     */
+    @ReactMethod
+    public void acquireToken(String scopesValue, Promise promise) {
+        if (!scopesValue.isEmpty()) {
+            publicClientApplication.acquireToken(getCurrentActivity(), scopesValue.toLowerCase().split(" "), getAuthInteractiveCallback(promise));
+        } else {
+            //the default is User.Read
+            String[] array = {"User.Read"};
+            publicClientApplication.acquireToken(getCurrentActivity(), array, getAuthInteractiveCallback(promise));
+        }
+    }
+
+    /**
+     * getAuthInteractiveCallback is the callback function for acquireToken.
+     * If successful, it will return a map of the IAuthenticationResult.
+     * If there's an error, the exception will be returned.
+     */
+
+    private AuthenticationCallback getAuthInteractiveCallback(final Promise promise) {
+        return new AuthenticationCallback() {
+            @Override
+            public void onCancel() {
+                Log.d(TAG, "User cancelled login (acquireToken).");
+                promise.reject("userCancel", "User cancelled login (acquireToken).");
+            }
+
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                Log.d(TAG, "Acquire token interactively success.");
+                promise.resolve(mapMSALResult(authenticationResult));
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                Log.d(TAG, "Error while acquiring token interactively: " + exception.toString());
+                promise.reject(exception);
+            }
+        };
+    }
+
+      /**
      * acquireTokenSilent: attempts to obtain a token silently from the cache
      * Parameters: string scopesValue (string containing scopes separated by a " "), Promise promise (returned to an async function)
      */
@@ -195,7 +238,7 @@ public class MSALModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * SilentAuthenticationCallback is the callback function for acquireTokenSlient.
+     * getAuthSilentCallback is the callback function for acquireTokenSilent.
      * If successful, it will return a map of the IAuthenticationResult.
      * If there's an error, the exception will be returned.
      */
@@ -204,13 +247,13 @@ public class MSALModule extends ReactContextBaseJavaModule {
         return new SilentAuthenticationCallback() {
             @Override
             public void onSuccess(IAuthenticationResult authenticationResult) {
-                Log.d(TAG, "Acquire tokens silently success.");
+                Log.d(TAG, "Acquire token silently success.");
                 promise.resolve(mapMSALResult(authenticationResult));
             }
 
             @Override
             public void onError(MsalException exception) {
-                Log.d(TAG, "Error while acquiring tokens silently: " + exception.toString());
+                Log.d(TAG, "Error while acquiring token silently: " + exception.toString());
                 promise.reject(exception);
             }
         };


### PR DESCRIPTION
This PR adds the acquireToken function to MSALModule and utilizes it in the sample app. 
So far, the module should be able to wrap MSAL for Android's single account mode functions for AAD, which is the minimum project goal I set for myself. It would be good to get all this polished before I move on to more features, which could include multiple accounts mode. 