### PR TITLE
[msal-browser] Fix encoding issues

### DIFF
--- a/lib/msal-browser/src/cache/BrowserStorage.ts
+++ b/lib/msal-browser/src/cache/BrowserStorage.ts
@@ -215,7 +215,7 @@ export class BrowserStorage extends CacheManager {
         let key: string;
         for (key in this.windowStorage) {
             // Check if key contains msal prefix; For now, we are clearing all the cache items created by MSAL.js
-            if (this.windowStorage.hasOwnProperty(key) && (key.indexOf(Constants.CACHE_PREFIX) !== -1) && (key.indexOf(this.clientId) !== -1)) {
+            if (this.windowStorage.hasOwnProperty(key) && ((key.indexOf(Constants.CACHE_PREFIX) !== -1) || (key.indexOf(this.clientId) !== -1))) {
                 this.removeItem(key);
             }
         }
@@ -228,7 +228,7 @@ export class BrowserStorage extends CacheManager {
      * @param expires
      */
     setItemCookie(cookieName: string, cookieValue: string, expires?: number): void {
-        let cookieStr = `${cookieName}=${cookieValue};path=/;`;
+        let cookieStr = `${encodeURIComponent(cookieName)}=${encodeURIComponent(cookieValue)};path=/;`;
         if (expires) {
             const expireTime = this.getCookieExpirationTime(expires);
             cookieStr += `expires=${expireTime};`;
@@ -242,7 +242,7 @@ export class BrowserStorage extends CacheManager {
      * @param cookieName
      */
     getItemCookie(cookieName: string): string {
-        const name = `${cookieName}=`;
+        const name = `${encodeURIComponent(cookieName)}=`;
         const cookieList = document.cookie.split(";");
         for (let i = 0; i < cookieList.length; i++) {
             let cookie = cookieList[i];
@@ -250,7 +250,7 @@ export class BrowserStorage extends CacheManager {
                 cookie = cookie.substring(1);
             }
             if (cookie.indexOf(name) === 0) {
-                return cookie.substring(name.length, cookie.length);
+                return decodeURIComponent(cookie.substring(name.length, cookie.length));
             }
         }
         return "";

--- a/lib/msal-browser/test/cache/BrowserStorage.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserStorage.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { BrowserAuthErrorMessage, BrowserAuthError } from "../../src/error/BrowserAuthError";
 import { BrowserStorage } from "../../src/cache/BrowserStorage";
-import { TEST_CONFIG, TEST_TOKENS, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID, TEST_URIS } from "../utils/StringConstants";
+import { TEST_CONFIG, TEST_TOKENS, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID, TEST_URIS, TEST_STATE_VALUES } from "../utils/StringConstants";
 import { CacheOptions } from "../../src/config/Configuration";
 import { BrowserConfigurationAuthErrorMessage, BrowserConfigurationAuthError } from "../../src/error/BrowserConfigurationAuthError";
 import { CacheManager, Constants, PersistentCacheKeys, AuthorizationCodeRequest, CacheSchemaType } from "@azure/msal-common";
@@ -232,6 +232,59 @@ describe("BrowserStorage() tests", () => {
         });
 
         it("clear()", () => {
+            browserSessionStorage.setItem(msalCacheKey, cacheVal, CacheSchemaType.TEMPORARY);
+            browserSessionStorage.clear();
+            expect(browserSessionStorage.getKeys()).to.be.empty;
+            expect(document.cookie).to.be.empty;
+            browserLocalStorage.setItem(msalCacheKey, cacheVal, CacheSchemaType.TEMPORARY);
+            browserLocalStorage.clear();
+            expect(browserLocalStorage.getKeys()).to.be.empty;
+            expect(document.cookie).to.be.empty;
+        });
+
+        it("setItem() with item that contains ==", () => {
+            msalCacheKey = `${Constants.CACHE_PREFIX}.${TEST_STATE_VALUES.ENCODED_LIB_STATE}`;
+            browserSessionStorage.setItem(msalCacheKey, cacheVal, CacheSchemaType.TEMPORARY);
+            expect(window.sessionStorage.getItem(msalCacheKey)).to.be.eq(cacheVal);
+            expect(document.cookie).to.be.eq(`${encodeURIComponent(msalCacheKey)}=${cacheVal}`);
+            browserSessionStorage.clearItemCookie(msalCacheKey);
+            browserLocalStorage.setItem(msalCacheKey, cacheVal, CacheSchemaType.TEMPORARY);
+            expect(window.localStorage.getItem(msalCacheKey)).to.be.eq(cacheVal);
+            expect(document.cookie).to.be.eq(`${encodeURIComponent(msalCacheKey)}=${cacheVal}`);
+            browserLocalStorage.clearItemCookie(msalCacheKey);
+        });
+
+        it("getItem() with item that contains ==", () => {
+            msalCacheKey = `${Constants.CACHE_PREFIX}.${TEST_STATE_VALUES.ENCODED_LIB_STATE}`;
+            const getCookieSpy = sinon.spy(BrowserStorage.prototype, "getItemCookie");
+            window.sessionStorage.setItem(msalCacheKey, cacheVal);
+            window.localStorage.setItem(msalCacheKey, cacheVal);
+            browserSessionStorage.setItemCookie(msalCacheKey, cacheVal);
+            expect(browserSessionStorage.getItem(msalCacheKey, CacheSchemaType.TEMPORARY)).to.be.eq(cacheVal);
+            expect(getCookieSpy.returned(cacheVal)).to.be.true;
+            expect(getCookieSpy.calledOnce).to.be.true;
+            expect(browserLocalStorage.getItem(msalCacheKey, CacheSchemaType.TEMPORARY)).to.be.eq(cacheVal);
+            expect(getCookieSpy.returned(cacheVal)).to.be.true;
+            expect(getCookieSpy.calledTwice).to.be.true;
+        });
+
+        it("removeItem() with item that contains ==", () => {
+            msalCacheKey = `${Constants.CACHE_PREFIX}.${TEST_STATE_VALUES.ENCODED_LIB_STATE}`;
+            const clearCookieSpy = sinon.spy(BrowserStorage.prototype, "clearItemCookie");
+            browserSessionStorage.setItem(msalCacheKey, cacheVal, CacheSchemaType.TEMPORARY);
+            browserSessionStorage.removeItem(msalCacheKey);
+            expect(window.sessionStorage.getItem(msalCacheKey)).to.be.null;
+            expect(document.cookie).to.be.empty;
+            expect(clearCookieSpy.calledOnce).to.be.true;
+            browserLocalStorage.setItem(msalCacheKey, cacheVal, CacheSchemaType.TEMPORARY);
+            browserLocalStorage.removeItem(msalCacheKey);
+            expect(window.localStorage.getItem(msalCacheKey)).to.be.null;
+            expect(document.cookie).to.be.empty;
+            expect(clearCookieSpy.calledTwice).to.be.true;
+        });
+
+        it("clear() with item that contains ==", () => {
+            msalCacheKey = `${Constants.CACHE_PREFIX}.${TEST_STATE_VALUES.ENCODED_LIB_STATE}`;
             browserSessionStorage.setItem(msalCacheKey, cacheVal, CacheSchemaType.TEMPORARY);
             browserSessionStorage.clear();
             expect(browserSessionStorage.getKeys()).to.be.empty;

--- a/lib/msal-common/src/authority/TrustedAuthority.ts
+++ b/lib/msal-common/src/authority/TrustedAuthority.ts
@@ -15,7 +15,7 @@ export class TrustedAuthority {
      * @param knownAuthorities 
      * @param cloudDiscoveryMetadata
      */
-    public static setTrustedAuthoritiesFromConfig(knownAuthorities: Array<string>, cloudDiscoveryMetadata: string): void {
+    static setTrustedAuthoritiesFromConfig(knownAuthorities: Array<string>, cloudDiscoveryMetadata: string): void {
         if (!this.getTrustedHostList().length){
             if (knownAuthorities.length > 0 && !StringUtils.isEmpty(cloudDiscoveryMetadata)) {
                 throw ClientConfigurationError.createKnownAuthoritiesCloudDiscoveryMetadataError();

--- a/lib/msal-common/src/utils/StringUtils.ts
+++ b/lib/msal-common/src/utils/StringUtils.ts
@@ -50,7 +50,7 @@ export class StringUtils {
         let match: Array<string>; // Regex for replacing addition symbol with a space
         const pl = /\+/g;
         const search = /([^&=]+)=([^&]*)/g;
-        const decode = (s: string): string => decodeURIComponent(s.replace(pl, " "));
+        const decode = (s: string): string => decodeURIComponent(decodeURIComponent(s.replace(pl, " ")));
         const obj: {} = {};
         match = search.exec(query);
         while (match) {

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -24,7 +24,8 @@ import {
     TEST_TOKENS,
     TEST_URIS,
     TEST_DATA_CLIENT_INFO,
-    RANDOM_TEST_GUID
+    RANDOM_TEST_GUID,
+    TEST_STATE_VALUES
 } from "../utils/StringConstants";
 import { ClientConfiguration } from "../../src/config/ClientConfiguration";
 import { BaseClient } from "../../src/client/BaseClient";
@@ -191,7 +192,7 @@ describe("AuthorizationCodeClient unit tests", () => {
         it("returns valid server code response", async () => {
             sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
             const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
-            const testSuccessHash = `#code=thisIsATestCode&client_info=${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}&state=${RANDOM_TEST_GUID}`;
+            const testSuccessHash = `#code=thisIsATestCode&client_info=${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}&state=${encodeURIComponent(TEST_STATE_VALUES.ENCODED_LIB_STATE)}`;
             config.cryptoInterface.base64Decode = (input: string): string => {
                 switch (input) {
                     case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
@@ -211,20 +212,47 @@ describe("AuthorizationCodeClient unit tests", () => {
                 }
             };
             const client: AuthorizationCodeClient = new AuthorizationCodeClient(config);
-            const code = client.handleFragmentResponse(testSuccessHash, RANDOM_TEST_GUID);
+            const code = client.handleFragmentResponse(testSuccessHash, TEST_STATE_VALUES.ENCODED_LIB_STATE);
+            expect(code).to.be.eq(`thisIsATestCode`);
+        });
+
+        it("returns valid server code response when state is encoded twice", async () => {
+            sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
+            const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+            const testSuccessHash = `#code=thisIsATestCode&client_info=${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}&state=${encodeURIComponent(encodeURIComponent(TEST_STATE_VALUES.ENCODED_LIB_STATE))}`;
+            config.cryptoInterface.base64Decode = (input: string): string => {
+                switch (input) {
+                    case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
+                        return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    default:
+                        return input;
+                }
+            };
+            config.cryptoInterface.base64Encode = (input: string): string => {
+                switch (input) {
+                    case "123-test-uid":
+                        return "MTIzLXRlc3QtdWlk";
+                    case "456-test-utid":
+                        return "NDU2LXRlc3QtdXRpZA==";
+                    default:
+                        return input;
+                }
+            };
+            const client: AuthorizationCodeClient = new AuthorizationCodeClient(config);
+            const code = client.handleFragmentResponse(testSuccessHash, TEST_STATE_VALUES.ENCODED_LIB_STATE);
             expect(code).to.be.eq(`thisIsATestCode`);
         });
 
         it("throws server error when error is in hash", async () => {
-            const testErrorHash = `#error=error_code&error_description=msal+error+description&state=${RANDOM_TEST_GUID}`;
+            const testErrorHash = `#error=error_code&error_description=msal+error+description&state=${encodeURIComponent(TEST_STATE_VALUES.ENCODED_LIB_STATE)}`;
             sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
             const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
             const client: AuthorizationCodeClient = new AuthorizationCodeClient(config);
             const cacheStorageMock = config.storageInterface as MockStorageClass;
-            expect(() => client.handleFragmentResponse(testErrorHash, RANDOM_TEST_GUID)).to.throw("msal error description");
+            expect(() => client.handleFragmentResponse(testErrorHash, TEST_STATE_VALUES.ENCODED_LIB_STATE)).to.throw("msal error description");
             expect(cacheStorageMock.store).to.be.empty;
 
-            expect(() => client.handleFragmentResponse(testErrorHash, RANDOM_TEST_GUID)).to.throw(ServerError);
+            expect(() => client.handleFragmentResponse(testErrorHash, TEST_STATE_VALUES.ENCODED_LIB_STATE)).to.throw(ServerError);
             expect(cacheStorageMock.store).to.be.empty;
         });
     });

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -3,7 +3,7 @@ import { RANDOM_TEST_GUID, TEST_CONFIG } from "../utils/StringConstants";
 import { AuthorityFactory } from "../../src";
 import { TrustedAuthority } from "../../src/authority/TrustedAuthority";
 import sinon from "sinon";
-import { IInstanceDiscoveryMetadata } from "../../src/authority/ICloudDiscoveryMetadata";
+import { CloudDiscoveryMetadata } from "../../src/authority/CloudDiscoveryMetadata";
 import { CacheManager } from "../../src/cache/CacheManager";
 
 export class MockStorageClass extends CacheManager {
@@ -107,7 +107,7 @@ export class ClientTestUtils {
 
     static setCloudDiscoveryMetadataStubs(): void {
         sinon.stub(TrustedAuthority, "IsInTrustedHostList").returns(true);
-        const stubbedCloudDiscoveryMetadata: ICloudDiscoveryMetadata = {
+        const stubbedCloudDiscoveryMetadata: CloudDiscoveryMetadata = {
             preferred_cache: "login.windows.net",
             preferred_network: "login.microsoftonline.com",
             aliases: ["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]};

--- a/lib/msal-common/test/utils/StringConstants.ts
+++ b/lib/msal-common/test/utils/StringConstants.ts
@@ -2,6 +2,8 @@
  * This file contains the string constants used by the test classes.
  */
 
+import { Constants } from "../../src/utils/Constants";
+
 // Test Tokens
 export const TEST_TOKENS = {
     // idTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
@@ -99,6 +101,14 @@ export const TEST_CONFIG = {
 };
 
 export const RANDOM_TEST_GUID = "11553a9b-7116-48b1-9d48-f6d4a8ff8371";
+
+export const TEST_STATE_VALUES = {
+    USER_STATE: "userState",
+    TEST_TIMESTAMP: 1592846482,
+    DECODED_LIB_STATE: `{"id":"${RANDOM_TEST_GUID}","ts":1592846482}`,
+    ENCODED_LIB_STATE: `eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ==`,
+    TEST_STATE: `eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ==${Constants.RESOURCE_DELIM}userState`
+};
 
 export const TEST_HOST_LIST = [
     "login.windows.net",


### PR DESCRIPTION
This PR fixes a couple issues
- Cookies were not encoded before being saved, which resulted in cookie key:value errors when setting b64 values with trailing `=` characters. 
- State was being double encoded in some cases on the server-side, adding an additional `decodeURIComponent` should fix those issues.