### PR TITLE
Add IPublicClientApplication interface

### DIFF
--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -1,0 +1,19 @@
+import { AuthenticationResult, AuthorizationUrlRequest } from "@azure/msal-common";
+import { SilentFlowRequest, EndSessionRequest, AccountInfo } from "../";
+
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+export interface IPublicClientApplication {
+    acquireTokenPopup(request: AuthorizationUrlRequest): Promise<AuthenticationResult>;
+    acquireTokenRedirect(request: AuthorizationUrlRequest): Promise<void>;
+    acquireTokenSilent(silentRequest: SilentFlowRequest): Promise<AuthenticationResult>;
+    getAccountByUsername(userName: string): AccountInfo;
+    getAllAccounts(): AccountInfo[];
+    handleRedirectPromise(): Promise<AuthenticationResult | null>;
+    loginPopup(request: AuthorizationUrlRequest): Promise<AuthenticationResult>;
+    loginRedirect(request: AuthorizationUrlRequest): Promise<void>;
+    logout(logoutRequest?: EndSessionRequest): Promise<void>;
+    ssoSilent(request: AuthorizationUrlRequest): Promise<AuthenticationResult>;
+}

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -35,16 +35,16 @@ import { RedirectHandler } from "../interaction_handler/RedirectHandler";
 import { PopupHandler } from "../interaction_handler/PopupHandler";
 import { SilentHandler } from "../interaction_handler/SilentHandler";
 import { BrowserAuthError } from "../error/BrowserAuthError";
-import { BrowserConfigurationAuthError } from "../error/BrowserConfigurationAuthError";
 import { BrowserConstants, TemporaryCacheKeys } from "../utils/BrowserConstants";
 import { BrowserUtils } from "../utils/BrowserUtils";
 import { version } from "../../package.json";
+import { IPublicClientApplication } from "./IPublicClientApplication";
 
 /**
  * The PublicClientApplication class is the object exposed by the library to perform authentication and authorization functions in Single Page Applications
  * to obtain JWT tokens as described in the OAuth 2.0 Authorization Code Flow with PKCE specification.
  */
-export class PublicClientApplication {
+export class PublicClientApplication implements IPublicClientApplication {
 
     // Crypto interface implementation
     private readonly browserCrypto: CryptoOps;
@@ -442,7 +442,7 @@ export class PublicClientApplication {
      * @returns {string} redirect URL
      *
      */
-    public getRedirectUri(requestRedirectUri?: string): string {
+    private getRedirectUri(requestRedirectUri?: string): string {
         return requestRedirectUri || this.config.auth.redirectUri || BrowserUtils.getCurrentUri();
     }
 
@@ -452,7 +452,7 @@ export class PublicClientApplication {
      *
      * @returns {string} post logout redirect URL
      */
-    public getPostLogoutRedirectUri(requestPostLogoutRedirectUri?: string): string {
+    private getPostLogoutRedirectUri(requestPostLogoutRedirectUri?: string): string {
         return requestPostLogoutRedirectUri || this.config.auth.postLogoutRedirectUri || BrowserUtils.getCurrentUri();
     }
 
@@ -462,7 +462,7 @@ export class PublicClientApplication {
      * or null when no state is found
      * @returns {@link IAccount[]} - Array of account objects in cache
      */
-    public getAllAccounts(): AccountInfo[] {
+    getAllAccounts(): AccountInfo[] {
         return this.browserStorage.getAllAccounts();
     }
 
@@ -472,7 +472,7 @@ export class PublicClientApplication {
      * or null when no state is found
      * @returns {@link IAccount} - the account object stored in MSAL
      */
-    public getAccountByUsername(userName: string): AccountInfo {
+    getAccountByUsername(userName: string): AccountInfo {
         const allAccounts = this.getAllAccounts();
         return allAccounts.filter(accountObj => accountObj.username === userName)[0];
     }

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -6,6 +6,9 @@ export { Configuration } from "./config/Configuration";
 export { BrowserAuthError, BrowserAuthErrorMessage } from "./error/BrowserAuthError";
 export { BrowserConfigurationAuthError, BrowserConfigurationAuthErrorMessage } from "./error/BrowserConfigurationAuthError";
 
+// Interfaces
+export { IPublicClientApplication } from "./app/IPublicClientApplication";
+
 // Common Object Formats
 export {
     // Account


### PR DESCRIPTION
Adds an `IPublicClientApplication` interface, properly documenting what the supported public API for `PublicClientApplication` will be.