### PR TITLE
Instantiate Logger instance for PublicClientApplication

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -27,7 +27,8 @@ import {
     ClientConfiguration,
     SilentFlowClient,
     EndSessionRequest,
-    BaseAuthRequest
+    BaseAuthRequest,
+    Logger
 } from "@azure/msal-common";
 import { buildConfiguration, Configuration } from "../config/Configuration";
 import { BrowserStorage } from "../cache/BrowserStorage";
@@ -65,6 +66,9 @@ export class PublicClientApplication implements IPublicClientApplication {
     // Default authority
     private defaultAuthorityPromise: Promise<Authority>;
 
+    // Logger
+    private logger: Logger;
+
     /**
      * @constructor
      * Constructor for the PublicClientApplication used to instantiate the PublicClientApplication object
@@ -98,6 +102,9 @@ export class PublicClientApplication implements IPublicClientApplication {
 
         // Initialize the browser storage class.
         this.browserStorage = new BrowserStorage(this.config.auth.clientId, this.config.cache);
+
+        // Initialize logger
+        this.logger = new Logger(this.config.system.loggerOptions);
 
         // Initialize default authority instance
         TrustedAuthority.setTrustedAuthoritiesFromConfig(this.config.auth.knownAuthorities, this.config.auth.cloudDiscoveryMetadata);
@@ -153,7 +160,7 @@ export class PublicClientApplication implements IPublicClientApplication {
             this.browserStorage.setItem(hashKey, hash, CacheSchemaType.TEMPORARY);
             if (StringUtils.isEmpty(loginRequestUrl) || loginRequestUrl === "null") {
                 // Redirect to home page if login request url is null (real null or the string null)
-                console.warn("Unable to get valid login request url from cache, redirecting to home page");
+                this.logger.warning("Unable to get valid login request url from cache, redirecting to home page");
                 BrowserUtils.navigateWindow("/", true);
             } else {
                 // Navigate to target url

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -82,25 +82,7 @@ const DEFAULT_CACHE_OPTIONS: CacheOptions = {
 
 // Default logger options for browser
 const DEFAULT_LOGGER_OPTIONS: LoggerOptions = {
-    loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {
-        if (containsPii) {
-            return;
-        }
-        switch (level) {
-            case LogLevel.Error:
-                console.error(message);
-                return;
-            case LogLevel.Info:
-                console.info(message);
-                return;
-            case LogLevel.Verbose:
-                console.debug(message);
-                return;
-            case LogLevel.Warning:
-                console.warn(message);
-                return;
-        }
-    },
+    loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {},
     piiLoggingEnabled: false
 };
 

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { SystemOptions, LoggerOptions, INetworkModule, LogLevel, DEFAULT_SYSTEM_OPTIONS, Constants } from "@azure/msal-common";
+import { SystemOptions, LoggerOptions, INetworkModule, DEFAULT_SYSTEM_OPTIONS, Constants } from "@azure/msal-common";
 import { BrowserUtils } from "../utils/BrowserUtils";
 import { BrowserConstants } from "../utils/BrowserConstants";
 
@@ -82,7 +82,7 @@ const DEFAULT_CACHE_OPTIONS: CacheOptions = {
 
 // Default logger options for browser
 const DEFAULT_LOGGER_OPTIONS: LoggerOptions = {
-    loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {},
+    loggerCallback: (): void => {},
     piiLoggingEnabled: false
 };
 

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -25,6 +25,7 @@ export {
     AuthErrorMessage,
     INetworkModule,
     // Logger Object
+    ILoggerCallback,
     Logger,
     LogLevel
 } from "@azure/msal-common";

--- a/lib/msal-browser/test/config/Configuration.spec.ts
+++ b/lib/msal-browser/test/config/Configuration.spec.ts
@@ -50,13 +50,38 @@ describe("Configuration.ts Class Unit Tests", () => {
         expect(emptyConfig.system.telemetry).to.be.null;
     });
 
-    it("Tests default logger", () => {
+    it("Tests logger", () => {
         const consoleErrorSpy = sinon.spy(console, "error");
         const consoleInfoSpy = sinon.spy(console, "info");
         const consoleDebugSpy = sinon.spy(console, "debug");
         const consoleWarnSpy = sinon.spy(console, "warn");
         const message = "log message";
-        let emptyConfig: Configuration = buildConfiguration({auth: null});
+        let emptyConfig: Configuration = buildConfiguration({
+            auth: null,
+            system: {
+                loggerOptions: {
+                    loggerCallback: (level, message, containsPii) => {
+                        if (containsPii) {
+                            return;
+                        }
+                        switch (level) {
+                            case LogLevel.Error:
+                                console.error(message);
+                                return;
+                            case LogLevel.Info:
+                                console.info(message);
+                                return;
+                            case LogLevel.Verbose:
+                                console.debug(message);
+                                return;
+                            case LogLevel.Warning:
+                                console.warn(message);
+                                return;
+                        }
+                    }
+                }
+            }
+        });
         emptyConfig.system.loggerOptions.loggerCallback(LogLevel.Error, message, true)
         expect(consoleErrorSpy.called).to.be.false;
         emptyConfig.system.loggerOptions.loggerCallback(LogLevel.Error, message, false)

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/default/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/default/authConfig.js
@@ -7,8 +7,31 @@ const msalConfig = {
     cache: {
         cacheLocation: "sessionStorage", // This configures where your cache will be stored
         storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        loggerOptions: {
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {	
+                    return;	
+                }	
+                switch (level) {	
+                    case msal.LogLevel.Error:	
+                        console.error(message);	
+                        return;	
+                    case msal.LogLevel.Info:	
+                        console.info(message);	
+                        return;	
+                    case msal.LogLevel.Verbose:	
+                        console.debug(message);	
+                        return;	
+                    case msal.LogLevel.Warning:	
+                        console.warn(message);	
+                        return;	
+                }
+            }
+        }
     }
-};  
+};
 
 // Add here scopes for id token to be used at MS Identity Platform endpoints.
 const loginRequest = {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multipleResources/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multipleResources/authConfig.js
@@ -7,8 +7,31 @@ const msalConfig = {
     cache: {
         cacheLocation: "sessionStorage", // This configures where your cache will be stored
         storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        loggerOptions: {
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {	
+                    return;	
+                }	
+                switch (level) {	
+                    case msal.LogLevel.Error:	
+                        console.error(message);	
+                        return;	
+                    case msal.LogLevel.Info:	
+                        console.info(message);	
+                        return;	
+                    case msal.LogLevel.Verbose:	
+                        console.debug(message);	
+                        return;	
+                    case msal.LogLevel.Warning:	
+                        console.warn(message);	
+                        return;	
+                }
+            }
+        }
     }
-};  
+};
 
 // Add here scopes for id token to be used at MS Identity Platform endpoints.
 const loginRequest = {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/onPageLoad/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/onPageLoad/authConfig.js
@@ -7,6 +7,29 @@ const msalConfig = {
     cache: {
         cacheLocation: "sessionStorage", // This configures where your cache will be stored
         storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        loggerOptions: {
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {	
+                    return;	
+                }	
+                switch (level) {	
+                    case msal.LogLevel.Error:	
+                        console.error(message);	
+                        return;	
+                    case msal.LogLevel.Info:	
+                        console.info(message);	
+                        return;	
+                    case msal.LogLevel.Verbose:	
+                        console.debug(message);	
+                        return;	
+                    case msal.LogLevel.Warning:	
+                        console.warn(message);	
+                        return;	
+                }
+            }
+        }
     }
 };
 

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilent/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilent/authConfig.js
@@ -7,8 +7,31 @@ const msalConfig = {
     cache: {
         cacheLocation: "sessionStorage", // This configures where your cache will be stored
         storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        loggerOptions: {
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {	
+                    return;	
+                }	
+                switch (level) {	
+                    case msal.LogLevel.Error:	
+                        console.error(message);	
+                        return;	
+                    case msal.LogLevel.Info:	
+                        console.info(message);	
+                        return;	
+                    case msal.LogLevel.Verbose:	
+                        console.debug(message);	
+                        return;	
+                    case msal.LogLevel.Warning:	
+                        console.warn(message);	
+                        return;	
+                }
+            }
+        }
     }
-};  
+};
 
 // Add here scopes for id token to be used at MS Identity Platform endpoints.
 const loginRequest = {


### PR DESCRIPTION
Adds a private logger instance to PublicClientApplication. Also makes the default loggerCallback a noop, as apps should only get console.logs if they implement them.