### PR TITLE
[msal-browser] Move authority initialization from constructor

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -110,6 +110,13 @@ export class PublicClientApplication implements IPublicClientApplication {
         TrustedAuthority.setTrustedAuthoritiesFromConfig(this.config.auth.knownAuthorities, this.config.auth.cloudDiscoveryMetadata);
 
         this.defaultAuthority = null;
+
+        const { location: { hash } } = window;
+        const cachedHash = this.browserStorage.getItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.URL_HASH), CacheSchemaType.TEMPORARY) as string;
+        if (StringUtils.isEmpty(hash) && StringUtils.isEmpty(cachedHash)) {
+            // There is no hash - assume we are in clean state and clear any current request data.
+            this.browserStorage.cleanRequest();
+        }
     }
 
     // #region Redirect Flow
@@ -170,9 +177,8 @@ export class PublicClientApplication implements IPublicClientApplication {
 	 * @param interactionHandler
 	 */
     private async handleHash(responseHash: string): Promise<AuthenticationResult> {
-        // There is no hash - clean cache and return null.
+        // There is no hash - return null.
         if (StringUtils.isEmpty(responseHash)) {
-            this.browserStorage.cleanRequest();
             return null;
         }
 

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -64,7 +64,7 @@ export class PublicClientApplication implements IPublicClientApplication {
     private config: Configuration;
 
     // Default authority
-    private defaultAuthorityPromise: Promise<Authority>;
+    private defaultAuthority: Authority;
 
     // Logger
     private logger: Logger;
@@ -109,7 +109,7 @@ export class PublicClientApplication implements IPublicClientApplication {
         // Initialize default authority instance
         TrustedAuthority.setTrustedAuthoritiesFromConfig(this.config.auth.knownAuthorities, this.config.auth.cloudDiscoveryMetadata);
 
-        this.defaultAuthorityPromise = AuthorityFactory.createDiscoveredInstance(this.config.auth.authority, this.networkClient);
+        this.defaultAuthority = null;
 
         const { location: { hash } } = window;
         const cachedHash = this.browserStorage.getItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.URL_HASH), CacheSchemaType.TEMPORARY) as string;
@@ -444,28 +444,7 @@ export class PublicClientApplication implements IPublicClientApplication {
 
     // #endregion
 
-    // #region Getters and setters
-
-    /**
-     *
-     * Use to get the redirect uri configured in MSAL or null.
-     * Evaluates redirectUri if its a function, otherwise simply returns its value.
-     * @returns {string} redirect URL
-     *
-     */
-    private getRedirectUri(requestRedirectUri?: string): string {
-        return requestRedirectUri || this.config.auth.redirectUri || BrowserUtils.getCurrentUri();
-    }
-
-    /**
-     * Use to get the post logout redirect uri configured in MSAL or null.
-     * Evaluates postLogoutredirectUri if its a function, otherwise simply returns its value.
-     *
-     * @returns {string} post logout redirect URL
-     */
-    private getPostLogoutRedirectUri(requestPostLogoutRedirectUri?: string): string {
-        return requestPostLogoutRedirectUri || this.config.auth.postLogoutRedirectUri || BrowserUtils.getCurrentUri();
-    }
+    // #region Account APIs
 
     /**
      * Returns all accounts that MSAL currently has data for.
@@ -491,6 +470,37 @@ export class PublicClientApplication implements IPublicClientApplication {
     // #endregion
 
     // #region Helpers
+
+    /**
+     *
+     * Use to get the redirect uri configured in MSAL or null.
+     * Evaluates redirectUri if its a function, otherwise simply returns its value.
+     * @returns {string} redirect URL
+     *
+     */
+    private getRedirectUri(requestRedirectUri?: string): string {
+        return requestRedirectUri || this.config.auth.redirectUri || BrowserUtils.getCurrentUri();
+    }
+
+    /**
+     * Use to get the post logout redirect uri configured in MSAL or null.
+     * Evaluates postLogoutredirectUri if its a function, otherwise simply returns its value.
+     *
+     * @returns {string} post logout redirect URL
+     */
+    private getPostLogoutRedirectUri(requestPostLogoutRedirectUri?: string): string {
+        return requestPostLogoutRedirectUri || this.config.auth.postLogoutRedirectUri || BrowserUtils.getCurrentUri();
+    }
+
+    /**
+     * Used to get a discovered version of the default authority.
+     */
+    private async getDiscoveredDefaultAuthority(): Promise<Authority> {
+        if (!this.defaultAuthority) {
+            this.defaultAuthority = await AuthorityFactory.createDiscoveredInstance(this.config.auth.authority, this.config.system.networkClient);
+        }
+        return this.defaultAuthority;
+    }
 
     /**
      * Helper to check whether interaction is in progress.
@@ -521,12 +531,13 @@ export class PublicClientApplication implements IPublicClientApplication {
     }
 
     /**
-     * Creates a Client Configuration object with the given authority, or the default authority.
-     * @param authorityUri 
+     * Creates a Client Configuration object with the given request authority, or the default authority.
+     * @param requestAuthority 
      */
-    private async getClientConfiguration(authorityUri?: string): Promise<ClientConfiguration> {
-        const discoveredAuthority = authorityUri ? await AuthorityFactory.createDiscoveredInstance(authorityUri, this.config.system.networkClient) 
-            : await this.defaultAuthorityPromise;
+    private async getClientConfiguration(requestAuthority?: string): Promise<ClientConfiguration> {
+        // If the requestAuthority is passed and is not equivalent to the default configured authority, create new authority and discover endpoints. Return default authority otherwise.
+        const discoveredAuthority = (!StringUtils.isEmpty(requestAuthority) && requestAuthority !== this.config.auth.authority) ? await AuthorityFactory.createDiscoveredInstance(requestAuthority, this.config.system.networkClient) 
+            : await this.getDiscoveredDefaultAuthority();
         return {
             authOptions: {
                 clientId: this.config.auth.clientId,

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -110,13 +110,6 @@ export class PublicClientApplication implements IPublicClientApplication {
         TrustedAuthority.setTrustedAuthoritiesFromConfig(this.config.auth.knownAuthorities, this.config.auth.cloudDiscoveryMetadata);
 
         this.defaultAuthority = null;
-
-        const { location: { hash } } = window;
-        const cachedHash = this.browserStorage.getItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.URL_HASH), CacheSchemaType.TEMPORARY) as string;
-        if (StringUtils.isEmpty(hash) && StringUtils.isEmpty(cachedHash)) {
-            // There is no hash - assume we are in clean state and clear any current request data.
-            this.browserStorage.cleanRequest();
-        }
     }
 
     // #region Redirect Flow
@@ -177,8 +170,9 @@ export class PublicClientApplication implements IPublicClientApplication {
 	 * @param interactionHandler
 	 */
     private async handleHash(responseHash: string): Promise<AuthenticationResult> {
-        // There is no hash - return null.
+        // There is no hash - clean cache and return null.
         if (StringUtils.isEmpty(responseHash)) {
+            this.browserStorage.cleanRequest();
             return null;
         }
 


### PR DESCRIPTION
This PR updates the constructor to remove async authority creation and have it occur only on the first API call.