### PR TITLE
[msal-browser] Remove cache cleanup code from constructor

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -110,13 +110,6 @@ export class PublicClientApplication implements IPublicClientApplication {
         TrustedAuthority.setTrustedAuthoritiesFromConfig(this.config.auth.knownAuthorities, this.config.auth.cloudDiscoveryMetadata);
 
         this.defaultAuthority = null;
-
-        const { location: { hash } } = window;
-        const cachedHash = this.browserStorage.getItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.URL_HASH), CacheSchemaType.TEMPORARY) as string;
-        if (StringUtils.isEmpty(hash) && StringUtils.isEmpty(cachedHash)) {
-            // There is no hash - assume we are in clean state and clear any current request data.
-            this.browserStorage.cleanRequest();
-        }
     }
 
     // #region Redirect Flow
@@ -177,8 +170,9 @@ export class PublicClientApplication implements IPublicClientApplication {
 	 * @param interactionHandler
 	 */
     private async handleHash(responseHash: string): Promise<AuthenticationResult> {
-        // There is no hash - return null.
+        // There is no hash - clean cache and return null.
         if (StringUtils.isEmpty(responseHash)) {
+            this.browserStorage.cleanRequest();
             return null;
         }
 


### PR DESCRIPTION
This PR removes the checks that the constructor does to clean the cache. All redirect handling logic is exclusively done in handleRedirectPromise().