### PR TITLE
Use getAccountAsync instead of getAccount

### DIFF
--- a/lib/msal-react-native-android-poc/android/src/main/java/com/reactlibrary/MSALModule.java
+++ b/lib/msal-react-native-android-poc/android/src/main/java/com/reactlibrary/MSALModule.java
@@ -120,13 +120,13 @@ public class MSALModule extends ReactContextBaseJavaModule {
     private ISingleAccountPublicClientApplication.CurrentAccountCallback getAccountCallback(final Promise promise) {
         return new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
             @Override
-            public void onAccountLoaded(@Nullable IAccount activeAccount) {
+            public void onAccountLoaded(IAccount activeAccount) {
                 Log.d(TAG, "Account: " + activeAccount.getUsername());
                 promise.resolve(mapAccount(activeAccount));
             }
 
             @Override
-            public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
+            public void onAccountChanged(IAccount priorAccount, IAccount currentAccount) {
                 Log.d(TAG, "Previous Account: " + priorAccount.getUsername());
                 Log.d(TAG, "Current Account: " + currentAccount.getUsername());
                 promise.resolve(mapAccount(currentAccount));

--- a/lib/msal-react-native-android-poc/package.json
+++ b/lib/msal-react-native-android-poc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azuread/msal-react-native-android-poc",
   "title": "MSALModule",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "main": "index.js",
   "files": [
     "README.md",

--- a/samples/msal-react-native-android-poc-sample/package-lock.json
+++ b/samples/msal-react-native-android-poc-sample/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@azuread/msal-react-native-android-poc": {
-      "version": "1.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@azuread/msal-react-native-android-poc/1.0.1/f85be2006124e1bb20e0be9c272493d16e5cd2f4574b4e81f345a2a5a3893a6d",
-      "integrity": "sha512-dNNiLBhxgtHVaxvSs2Mb+QnK+OLaY4/nRuAaU1WdBZNIXO+Jl78E0MUWcqbloRGUEXPTiR7IpwQkP8Z2dLt/kw=="
+      "version": "1.0.2",
+      "resolved": "https://npm.pkg.github.com/download/@azuread/msal-react-native-android-poc/1.0.2/a0a4a5961fd04442b8e4d90bb05457692954d13a03fb5be0c1871e4e3086f113",
+      "integrity": "sha512-AntvwkogYPRecDgNkK/93SyCknaqudD6FO0CCD2GBitJQLuQ5/4+BemvrbIowp9j3y7YAZ0/NH2bHZxYKfXEBQ=="
     },
     "@babel/code-frame": {
       "version": "7.10.1",

--- a/samples/msal-react-native-android-poc-sample/package-lock.json
+++ b/samples/msal-react-native-android-poc-sample/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@azuread/msal-react-native-android-poc": {
-      "version": "1.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@azuread/msal-react-native-android-poc/1.0.2/a0a4a5961fd04442b8e4d90bb05457692954d13a03fb5be0c1871e4e3086f113",
-      "integrity": "sha512-AntvwkogYPRecDgNkK/93SyCknaqudD6FO0CCD2GBitJQLuQ5/4+BemvrbIowp9j3y7YAZ0/NH2bHZxYKfXEBQ=="
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@azuread/msal-react-native-android-poc/1.0.3/f94ad2726092ca921c31c1faa8ad302e0e94c14a1ce94ef6397641dbaf93512d",
+      "integrity": "sha512-8Z8PLnxE3Ep8ny0lNuQnVE81ECUi8gY2qkcktPHK5fvphbCS6PygXIUft+Ms/qtg0dOsqxfz0uCBzcTwmx8irw=="
     },
     "@babel/code-frame": {
       "version": "7.10.1",

--- a/samples/msal-react-native-android-poc-sample/package.json
+++ b/samples/msal-react-native-android-poc-sample/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@azuread/msal-react-native-android-poc": "^1.0.1",
+    "@azuread/msal-react-native-android-poc": "^1.0.2",
     "@fluentui/react-native": "^0.15.63",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "@react-native-community/toolbar-android": "0.1.0-rc.2",

--- a/samples/msal-react-native-android-poc-sample/package.json
+++ b/samples/msal-react-native-android-poc-sample/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@azuread/msal-react-native-android-poc": "^1.0.2",
+    "@azuread/msal-react-native-android-poc": "^1.0.3",
     "@fluentui/react-native": "^0.15.63",
     "@microsoft/microsoft-graph-client": "^2.0.0",
     "@react-native-community/toolbar-android": "0.1.0-rc.2",


### PR DESCRIPTION
Modified the React method`getAccount()` to use the MSAL Android method `getAccountAsync()` instead of `getAccount`. 
Although `getAccount` was functionally working fine before, using an async function would make the corresponding React method truly async and it would match the styling of the other React methods. 
'getAccount` calls `getAccountAsync()`, which takes a callback as a parameter. This `CurrentAccountCallback` is implemented with the same resolve values that the original `getAccount` would have. 
`loadAccount` is still kept as a private method for the `acquireTokenSilent` function but is no longer used in `getAccount`. 