### PR TITLE
Check if tokens are returned before attempting to create token entity

### DIFF
--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -143,44 +143,53 @@ export class ResponseHandler {
         }
 
         // IdToken
-        const cachedIdToken = IdTokenEntity.createIdTokenEntity(
-            this.homeAccountIdentifier,
-            env,
-            serverTokenResponse.id_token,
-            this.clientId,
-            idTokenObj.claims.tid
-        );
+        let cachedIdToken: IdTokenEntity;
+        if (!StringUtils.isEmpty(serverTokenResponse.id_token)) {
+            cachedIdToken = IdTokenEntity.createIdTokenEntity(
+                this.homeAccountIdentifier,
+                env,
+                serverTokenResponse.id_token,
+                this.clientId,
+                idTokenObj.claims.tid
+            );
+        }
 
         // AccessToken
-        const responseScopes = ScopeSet.fromString(serverTokenResponse.scope);
+        let cachedAccessToken: AccessTokenEntity;
+        if (!StringUtils.isEmpty(serverTokenResponse.access_token)) {
+            const responseScopes = ScopeSet.fromString(serverTokenResponse.scope);
 
-        // Expiration calculation
-        const currentTime = TimeUtils.nowSeconds();
+            // Expiration calculation
+            const currentTime = TimeUtils.nowSeconds();
 
-        // If the request timestamp was sent in the library state, use that timestamp to calculate expiration. Otherwise, use current time.
-        const timestamp = libraryState ? libraryState.ts : currentTime;
-        const tokenExpirationSeconds = timestamp + serverTokenResponse.expires_in;
-        const extendedTokenExpirationSeconds = tokenExpirationSeconds + serverTokenResponse.ext_expires_in;
+            // If the request timestamp was sent in the library state, use that timestamp to calculate expiration. Otherwise, use current time.
+            const timestamp = libraryState ? libraryState.ts : currentTime;
+            const tokenExpirationSeconds = timestamp + serverTokenResponse.expires_in;
+            const extendedTokenExpirationSeconds = tokenExpirationSeconds + serverTokenResponse.ext_expires_in;
 
-        const cachedAccessToken = AccessTokenEntity.createAccessTokenEntity(
-            this.homeAccountIdentifier,
-            env,
-            serverTokenResponse.access_token,
-            this.clientId,
-            idTokenObj.claims.tid,
-            responseScopes.printScopes(),
-            tokenExpirationSeconds,
-            extendedTokenExpirationSeconds
-        );
+            cachedAccessToken = AccessTokenEntity.createAccessTokenEntity(
+                this.homeAccountIdentifier,
+                env,
+                serverTokenResponse.access_token,
+                this.clientId,
+                idTokenObj.claims.tid,
+                responseScopes.printScopes(),
+                tokenExpirationSeconds,
+                extendedTokenExpirationSeconds
+            );
+        }
 
         // refreshToken
-        const cachedRefreshToken = RefreshTokenEntity.createRefreshTokenEntity(
-            this.homeAccountIdentifier,
-            env,
-            serverTokenResponse.refresh_token,
-            this.clientId,
-            serverTokenResponse.foci
-        );
+        let cachedRefreshToken: RefreshTokenEntity;
+        if (!StringUtils.isEmpty(serverTokenResponse.refresh_token)) {
+            cachedRefreshToken = RefreshTokenEntity.createRefreshTokenEntity(
+                this.homeAccountIdentifier,
+                env,
+                serverTokenResponse.refresh_token,
+                this.clientId,
+                serverTokenResponse.foci
+            );
+        }
 
         return new CacheRecord(cachedAccount, cachedIdToken, cachedAccessToken, cachedRefreshToken);
     }

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -223,19 +223,32 @@ export class ResponseHandler {
      * @param stateString 
      */
     static generateAuthenticationResult(cacheRecord: CacheRecord, idTokenObj: IdToken, fromTokenCache: boolean, stateString?: string): AuthenticationResult {
-        const responseScopes = ScopeSet.fromString(cacheRecord.accessToken.target);
+        let accessToken: string;
+        let responseScopes: Array<string>;
+        let expiresOn: Date;
+        let extExpiresOn: Date;
+        let familyId: string = null;
+        if (cacheRecord.accessToken) {
+            accessToken = cacheRecord.accessToken.secret;
+            responseScopes = ScopeSet.fromString(cacheRecord.accessToken.target).asArray();
+            expiresOn = new Date(Number(cacheRecord.accessToken.expiresOn) * 1000);
+            extExpiresOn = new Date(Number(cacheRecord.accessToken.extendedExpiresOn) * 1000);
+        }
+        if (cacheRecord.refreshToken) {
+            familyId = cacheRecord.refreshToken.familyId || null;
+        }
         return {
             uniqueId: idTokenObj.claims.oid || idTokenObj.claims.sub,
             tenantId: idTokenObj.claims.tid,
-            scopes: responseScopes.asArray(),
+            scopes: responseScopes,
             account: cacheRecord.account.getAccountInfo(),
             idToken: idTokenObj.rawIdToken,
             idTokenClaims: idTokenObj.claims,
-            accessToken: cacheRecord.accessToken.secret,
+            accessToken: accessToken,
             fromCache: fromTokenCache,
-            expiresOn: new Date(Number(cacheRecord.accessToken.expiresOn) * 1000),
-            extExpiresOn: new Date(Number(cacheRecord.accessToken.extendedExpiresOn) * 1000),
-            familyId: cacheRecord.refreshToken.familyId || null,
+            expiresOn: expiresOn,
+            extExpiresOn: extExpiresOn,
+            familyId: familyId,
             state: stateString || ""
         };
     }

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -143,7 +143,7 @@ export class ResponseHandler {
         }
 
         // IdToken
-        let cachedIdToken: IdTokenEntity;
+        let cachedIdToken: IdTokenEntity = null;
         if (!StringUtils.isEmpty(serverTokenResponse.id_token)) {
             cachedIdToken = IdTokenEntity.createIdTokenEntity(
                 this.homeAccountIdentifier,
@@ -155,7 +155,7 @@ export class ResponseHandler {
         }
 
         // AccessToken
-        let cachedAccessToken: AccessTokenEntity;
+        let cachedAccessToken: AccessTokenEntity = null;
         if (!StringUtils.isEmpty(serverTokenResponse.access_token)) {
             const responseScopes = ScopeSet.fromString(serverTokenResponse.scope);
 
@@ -180,7 +180,7 @@ export class ResponseHandler {
         }
 
         // refreshToken
-        let cachedRefreshToken: RefreshTokenEntity;
+        let cachedRefreshToken: RefreshTokenEntity = null;
         if (!StringUtils.isEmpty(serverTokenResponse.refresh_token)) {
             cachedRefreshToken = RefreshTokenEntity.createRefreshTokenEntity(
                 this.homeAccountIdentifier,
@@ -223,10 +223,10 @@ export class ResponseHandler {
      * @param stateString 
      */
     static generateAuthenticationResult(cacheRecord: CacheRecord, idTokenObj: IdToken, fromTokenCache: boolean, stateString?: string): AuthenticationResult {
-        let accessToken: string;
-        let responseScopes: Array<string>;
-        let expiresOn: Date;
-        let extExpiresOn: Date;
+        let accessToken: string = "";
+        let responseScopes: Array<string> = [];
+        let expiresOn: Date = null;
+        let extExpiresOn: Date = null;
         let familyId: string = null;
         if (cacheRecord.accessToken) {
             accessToken = cacheRecord.accessToken.secret;

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -1,0 +1,196 @@
+import * as Mocha from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+import { ServerAuthorizationTokenResponse } from "../../src/server/ServerAuthorizationTokenResponse";
+import { ResponseHandler } from "../../src/response/ResponseHandler";
+import { AUTHENTICATION_RESULT, RANDOM_TEST_GUID, TEST_CONFIG, ID_TOKEN_CLAIMS, TEST_DATA_CLIENT_INFO } from "../utils/StringConstants";
+import { Authority } from "../../src/authority/Authority";
+import { INetworkModule, NetworkRequestOptions } from "../../src/network/INetworkModule";
+import { CacheManager } from "../../src/cache/CacheManager";
+import { ICrypto, PkceCodes } from "../../src/crypto/ICrypto";
+import { IdToken } from "../../src/account/IdToken";
+import { IdTokenClaims } from "../../src/account/IdTokenClaims";
+import { ClientTestUtils } from "../client/ClientTestUtils";
+import { AccountEntity, TrustedAuthority, ClientAuthError, ClientAuthErrorMessage } from "../../src";
+
+const networkInterface: INetworkModule = {
+    sendGetRequestAsync<T>(url: string, options?: NetworkRequestOptions): T {
+        return null;
+    },
+    sendPostRequestAsync<T>(url: string, options?: NetworkRequestOptions): T {
+        return null;
+    }
+};
+
+const cryptoInterface: ICrypto = {
+    createNewGuid(): string {
+        return RANDOM_TEST_GUID;
+    },
+    base64Decode(input: string): string {
+        return input;
+    },
+    base64Encode(input: string): string {
+        return input;
+    },
+    async generatePkceCodes(): Promise<PkceCodes> {
+        return {
+            challenge: TEST_CONFIG.TEST_CHALLENGE,
+            verifier: TEST_CONFIG.TEST_VERIFIER,
+        };
+    },
+}
+
+let store = {};
+class TestCacheManager extends CacheManager {
+    setItem(key: string, value: string | object, type?: string): void {
+        store[key] = value as string;
+    }
+    getItem(key: string, type?: string): string | object {
+        return store[key];
+    }
+    removeItem(key: string, type?: string): boolean {
+        let result: boolean = false;
+        if (!!store[key]) {
+            delete store[key];
+            result = true;
+        }
+
+        return result;
+    }
+    containsKey(key: string, type?: string): boolean {
+        return !!store[key];
+    }
+    getKeys(): string[] {
+        return Object.keys(store);
+    }
+    clear(): void {
+        store = {};
+    }
+}
+const testCacheManager = new TestCacheManager;
+
+let authority = new Authority("https://login.microsoftonline.com/common", networkInterface);
+
+describe("ResponseHandler.ts", () => {
+    beforeEach(() => {
+        sinon.stub(IdToken, "extractIdToken").callsFake((encodedIdToken, crypto) => {
+            return ID_TOKEN_CLAIMS as IdTokenClaims;
+        });
+        sinon.stub(ResponseHandler.prototype, <any>"generateAccountEntity").returns(new AccountEntity());
+        sinon.stub(AccountEntity.prototype, "getAccountInfo").returns({
+            homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+            environment: "login.windows.net",
+            tenantId: "testTenantId",
+            username: "test@contoso.com"
+        });
+        ClientTestUtils.setCloudDiscoveryMetadataStubs();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    })
+
+    describe("generateCacheRecord", () => {
+        it("throws invalid cache environment error", (done) => {
+            sinon.restore();
+            sinon.stub(IdToken, "extractIdToken").callsFake((encodedIdToken, crypto) => {
+                return ID_TOKEN_CLAIMS as IdTokenClaims;
+            });
+            sinon.stub(ResponseHandler.prototype, <any>"generateAccountEntity").returns(new AccountEntity());
+            sinon.stub(AccountEntity.prototype, "getAccountInfo").returns({
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                environment: "login.windows.net",
+                tenantId: "testTenantId",
+                username: "test@contoso.com"
+            });
+            sinon.stub(TrustedAuthority, "getCloudDiscoveryMetadata").returns(null);
+
+            const testResponse: ServerAuthorizationTokenResponse = {...AUTHENTICATION_RESULT.body};
+            const responseHandler = new ResponseHandler("this-is-a-client-id", testCacheManager, cryptoInterface, null);
+
+            try {
+                responseHandler.handleServerTokenResponse(testResponse, authority);
+            } catch(e) {
+                expect(e).to.be.instanceOf(ClientAuthError);
+                expect(e.errorCode).to.be.eq(ClientAuthErrorMessage.invalidCacheEnvironment.code);
+                expect(e.errorMessage).to.be.eq(ClientAuthErrorMessage.invalidCacheEnvironment.desc);
+                done();
+            }
+        });
+
+        it("doesn't create AccessTokenEntity if access_token not in response", (done) => {
+            const testResponse: ServerAuthorizationTokenResponse = {...AUTHENTICATION_RESULT.body};
+            testResponse.access_token = null;
+
+            const responseHandler = new ResponseHandler("this-is-a-client-id", testCacheManager, cryptoInterface, null);
+
+            sinon.stub(ResponseHandler, "generateAuthenticationResult").callsFake((cacheRecord, idTokenObj, fromTokenCache, stateString) => {
+                expect(cacheRecord.idToken).to.not.be.null;
+                expect(cacheRecord.accessToken).to.be.null;
+                expect(cacheRecord.refreshToken).to.not.be.null;
+                done();
+                return null;
+            });
+
+            responseHandler.handleServerTokenResponse(testResponse, authority);
+        });
+
+        it("doesn't create RefreshTokenEntity if refresh_token not in response", (done) => {
+            const testResponse: ServerAuthorizationTokenResponse = {...AUTHENTICATION_RESULT.body};
+            testResponse.refresh_token = null;
+
+            const responseHandler = new ResponseHandler("this-is-a-client-id", testCacheManager, cryptoInterface, null);
+
+            sinon.stub(ResponseHandler, "generateAuthenticationResult").callsFake((cacheRecord, idTokenObj, fromTokenCache, stateString) => {
+                expect(cacheRecord.idToken).to.not.be.null;
+                expect(cacheRecord.accessToken).to.not.be.null;
+                expect(cacheRecord.refreshToken).to.be.null;
+                done();
+                return null;
+            });
+
+            responseHandler.handleServerTokenResponse(testResponse, authority);
+        });
+
+        it("create CacheRecord with all token entities", (done) => {
+            const testResponse: ServerAuthorizationTokenResponse = {...AUTHENTICATION_RESULT.body};
+
+            const responseHandler = new ResponseHandler("this-is-a-client-id", testCacheManager, cryptoInterface, null);
+
+            sinon.stub(ResponseHandler, "generateAuthenticationResult").callsFake((cacheRecord, idTokenObj, fromTokenCache, stateString) => {
+                expect(cacheRecord.idToken).to.not.be.null;
+                expect(cacheRecord.accessToken).to.not.be.null;
+                expect(cacheRecord.refreshToken).to.not.be.null;
+                done();
+                return null;
+            });
+
+            responseHandler.handleServerTokenResponse(testResponse, authority);
+        });
+    });
+
+    describe("generateAuthenticationResult", () => {
+        it("sets default values if access_token not in cacheRecord", () => {
+            const testResponse: ServerAuthorizationTokenResponse = {...AUTHENTICATION_RESULT.body};
+            testResponse.access_token = null;
+
+            const responseHandler = new ResponseHandler("this-is-a-client-id", testCacheManager, cryptoInterface, null);
+            const result = responseHandler.handleServerTokenResponse(testResponse, authority);
+
+            expect(result.accessToken).to.be.eq("");
+            expect(result.scopes).to.be.length(0);
+            expect(result.expiresOn).to.be.null;
+            expect(result.extExpiresOn).to.be.null;
+        });
+
+        it("sets default values if refresh_token not in cacheRecord", () => {
+            const testResponse: ServerAuthorizationTokenResponse = {...AUTHENTICATION_RESULT.body};
+            testResponse.refresh_token = null;
+
+            const responseHandler = new ResponseHandler("this-is-a-client-id", testCacheManager, cryptoInterface, null);
+            const result = responseHandler.handleServerTokenResponse(testResponse, authority);
+
+            expect(result.familyId).to.be.null;
+        });
+    });
+});

--- a/lib/msal-common/test/utils/StringConstants.ts
+++ b/lib/msal-common/test/utils/StringConstants.ts
@@ -22,6 +22,22 @@ export const TEST_TOKENS = {
     CACHE_IDTOKEN: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Imk2bEdrM0ZaenhSY1ViMkMzbkVRN3N5SEpsWSIsImtpZCI6Imk2bEdrM0ZaenhSY1ViMkMzbkVRN3N5SEpsWSJ9.eyJvaWQiOiAib2JqZWN0MTIzNCIsICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiSm9obiBEb2UiLCAic3ViIjogInN1YiJ9.D3H6pMUtQnoJAGq6AHd"
 };
 
+export const ID_TOKEN_CLAIMS = {
+    ver: "2.0",
+    iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+    sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+    aud: "6cb04018-a3f5-46a7-b995-940c78f5aef3",
+    exp: "1536361411",
+    iat: "1536274711",
+    nbf: "1536274711",
+    name: "Abe Lincoln",
+    preferred_username: "AbeLi@microsoft.com",
+    oid: "00000000-0000-0000-66f3-3332eca7ea81",
+    tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+    nonce: "123523",
+    aio: "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY"
+}
+
 // Test Expiration Vals
 export const TEST_TOKEN_LIFETIMES = {
     DEFAULT_EXPIRES_IN: 3599,


### PR DESCRIPTION
Fixes a bug where an error is thrown if an access token is not returned by the server, such as a scenario where login is called with an empty request object (we only expect id_token in the response)