### PR TITLE
Fix Redirect Error Callback

### DIFF
--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -322,9 +322,12 @@ export class UserAgentApplication {
             if (this.errorReceivedCallback) {
                 this.logger.verbose("Two callbacks were provided to handleRedirectCallback, calling error callback");
                 this.errorReceivedCallback(authErr, response.accountState);
-            } else {
+            } else if (this.authResponseCallback) {
                 this.logger.verbose("One callback was provided to handleRedirectCallback, calling authResponseCallback with error");
                 this.authResponseCallback(authErr, response);
+            } else {
+                this.logger.verbose("handleRedirectCallback has not been called and no callbacks are registered, throwing error");
+                throw authErr;
             }
         } else if (interactionType === Constants.interactionTypePopup) {
             this.logger.verbose("Interaction type is popup, rejecting");

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -763,7 +763,7 @@ describe("UserAgentApplication.ts Class", function () {
             }
         });
 
-        it("throws error on loginRedirect if interaction is true", function (done) {
+        it("throws error on acquireTokenRedirect if interaction is true", function (done) {
             cacheStorage.setItem(TemporaryCacheKeys.INTERACTION_STATUS, Constants.inProgress);
             window.location = oldWindowLocation;
             try {

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -716,7 +716,7 @@ describe("UserAgentApplication.ts Class", function () {
             })
         });
 
-        it("exits login function with error if interaction is true", function (done) {
+        it("calls error callback on loginRedirect if interaction is true", function (done) {
             cacheStorage.setItem(TemporaryCacheKeys.INTERACTION_STATUS, Constants.inProgress);
             window.location = oldWindowLocation;
             const checkErrorFromLibrary = function (authErr: AuthError) {
@@ -730,6 +730,51 @@ describe("UserAgentApplication.ts Class", function () {
             };
             msal.handleRedirectCallback(checkErrorFromLibrary);
             msal.loginRedirect();
+        });
+
+        it("calls error callback on acquireTokenRedirect if interaction is true", function (done) {
+            cacheStorage.setItem(TemporaryCacheKeys.INTERACTION_STATUS, Constants.inProgress);
+            window.location = oldWindowLocation;
+            const checkErrorFromLibrary = function (authErr: AuthError) {
+                expect(authErr instanceof ClientAuthError).to.be.true;
+                expect(authErr.errorCode).to.equal(ClientAuthErrorMessage.acquireTokenProgressError.code);
+                expect(authErr.errorMessage).to.equal(ClientAuthErrorMessage.acquireTokenProgressError.desc);
+                expect(authErr.message).to.equal(ClientAuthErrorMessage.acquireTokenProgressError.desc);
+                expect(authErr.name).to.equal("ClientAuthError");
+                expect(authErr.stack).to.include("UserAgentApplication.spec.ts");
+                done();
+            };
+            msal.handleRedirectCallback(checkErrorFromLibrary);
+            msal.acquireTokenRedirect({scopes: [ "user.read" ]});
+        });
+
+
+        it("throws error on loginRedirect if interaction is true", function (done) {
+            cacheStorage.setItem(TemporaryCacheKeys.INTERACTION_STATUS, Constants.inProgress);
+            window.location = oldWindowLocation;
+            try {
+                msal.loginRedirect();
+            } catch(authErr) {
+                expect(authErr instanceof ClientAuthError).to.be.true;
+                expect(authErr.errorCode).to.equal(ClientAuthErrorMessage.loginProgressError.code);
+                expect(authErr.errorMessage).to.equal(ClientAuthErrorMessage.loginProgressError.desc);
+                expect(authErr.message).to.equal(ClientAuthErrorMessage.loginProgressError.desc);
+                done();
+            }
+        });
+
+        it("throws error on loginRedirect if interaction is true", function (done) {
+            cacheStorage.setItem(TemporaryCacheKeys.INTERACTION_STATUS, Constants.inProgress);
+            window.location = oldWindowLocation;
+            try {
+                msal.acquireTokenRedirect({scopes: [ "user.read" ]});
+            } catch(authErr) {
+                expect(authErr instanceof ClientAuthError).to.be.true;
+                expect(authErr.errorCode).to.equal(ClientAuthErrorMessage.acquireTokenProgressError.code);
+                expect(authErr.errorMessage).to.equal(ClientAuthErrorMessage.acquireTokenProgressError.desc);
+                expect(authErr.message).to.equal(ClientAuthErrorMessage.acquireTokenProgressError.desc);
+                done();
+            }
         });
 
         it("exits login function with error if invalid prompt parameter is passed", function (done) {


### PR DESCRIPTION
Fixes a bug where an error is thrown stating that `this.authResponseCallback` is not a function. This can happen in redirect scenarios when `handleRedirectCallback` has not been implemented and an error occurs before redirecting away from the app. For example: when throwing an Interaction in Progress error

Addresses #1877 and a question about this raised in #1674