### PR TITLE
Replace /organizations with tenant ID in replaceTenantPath

### DIFF
--- a/lib/msal-core/src/utils/Constants.ts
+++ b/lib/msal-core/src/utils/Constants.ts
@@ -113,6 +113,7 @@ export enum SSOTypes {
     ACCOUNT = "account",
     SID = "sid",
     LOGIN_HINT = "login_hint",
+    ORGANIZATIONS = "organizations",
     ID_TOKEN ="id_token",
     ACCOUNT_ID = "accountIdentifier",
     HOMEACCOUNT_ID = "homeAccountIdentifier"

--- a/lib/msal-core/src/utils/UrlUtils.ts
+++ b/lib/msal-core/src/utils/UrlUtils.ts
@@ -115,10 +115,10 @@ export class UrlUtils {
      * @param tenantId The tenant id to replace
      */
     static replaceTenantPath(url: string, tenantId: string): string {
-        url = url.toLowerCase();
-        const urlObject = this.GetUrlComponents(url);
+        const lowerCaseUrl = url.toLowerCase();
+        const urlObject = this.GetUrlComponents(lowerCaseUrl);
         const pathArray = urlObject.PathSegments;
-        if (tenantId && (pathArray.length !== 0 && pathArray[0] === Constants.common)) {
+        if (tenantId && (pathArray.length !== 0 && (pathArray[0] === Constants.common || pathArray[0] === SSOTypes.ORGANIZATIONS))) {
             pathArray[0] = tenantId;
         }
         return this.constructAuthorityUriFromObject(urlObject, pathArray);

--- a/lib/msal-core/test/utils/UrlUtils.spec.ts
+++ b/lib/msal-core/test/utils/UrlUtils.spec.ts
@@ -24,10 +24,16 @@ describe("UrlUtils.ts class", () => {
     const TEST_URL_HASH_SINGLE_CHAR = `${TEST_URL_NO_HASH}${TEST_SUCCESS_HASH_1}`;
     const TEST_URL_HASH_TWO_CHAR = `${TEST_URL_NO_HASH}${TEST_SUCCESS_HASH_2}`;
 
-    it("replaceTenantPath", () => {
-        expect(UrlUtils.replaceTenantPath("http://a.com/common/d?e=f", "1234-5678")).to.eq("http://a.com/1234-5678/d/");
-        expect(UrlUtils.replaceTenantPath("http://a.com/common/", "1234-56778")).to.eq("http://a.com/1234-56778/");
-        expect(UrlUtils.replaceTenantPath("http://a.com/common", "1234-5678")).to.eq("http://a.com/1234-5678/");
+    describe("replaceTenantPath", () => {
+        it("/common", () => {
+            expect(UrlUtils.replaceTenantPath("http://a.com/common/d?e=f", "1234-5678")).to.eq("http://a.com/1234-5678/d/");
+            expect(UrlUtils.replaceTenantPath("http://a.com/common/", "1234-56778")).to.eq("http://a.com/1234-56778/");
+            expect(UrlUtils.replaceTenantPath("http://a.com/common", "1234-5678")).to.eq("http://a.com/1234-5678/");
+        });
+
+        it("/organizations", () => {
+            expect(UrlUtils.replaceTenantPath("http://a.com/organizations", "1234-5678")).to.eq("http://a.com/1234-5678/");
+        });
     });
 
     it("test getHashFromUrl returns hash from url if hash is single character", () => {


### PR DESCRIPTION
Partially reverts changes made in #1299, which stopped replacing `/organizations` with the tenant ID. Also added tests. Addresses #1583 