### PR TITLE
[msal-browser] Add negative offset value prevention for popup windows

### DIFF
--- a/lib/msal-browser/src/interaction_handler/PopupHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/PopupHandler.ts
@@ -126,8 +126,8 @@ export class PopupHandler extends InteractionHandler {
              */
             const width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
             const height = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
-            const left = ((width / 2) - (popUpWidth / 2)) + winLeft;
-            const top = ((height / 2) - (popUpHeight / 2)) + winTop;
+            const left = ((width / 2) - (popUpWidth / 2)) + Math.max(0, winLeft);
+            const top = ((height / 2) - (popUpHeight / 2)) + Math.max(0, winTop);
 
             // open the window
             const popupWindow = window.open(urlNavigate, title, "width=" + popUpWidth + ", height=" + popUpHeight + ", top=" + top + ", left=" + left);

--- a/lib/msal-browser/src/interaction_handler/PopupHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/PopupHandler.ts
@@ -126,8 +126,8 @@ export class PopupHandler extends InteractionHandler {
              */
             const width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
             const height = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
-            const left = ((width / 2) - (popUpWidth / 2)) + Math.max(0, winLeft);
-            const top = ((height / 2) - (popUpHeight / 2)) + Math.max(0, winTop);
+            const left = Math.max(0, ((width / 2) - (popUpWidth / 2)) + winLeft);
+            const top = Math.max(0, ((height / 2) - (popUpHeight / 2)) + winTop);
 
             // open the window
             const popupWindow = window.open(urlNavigate, title, "width=" + popUpWidth + ", height=" + popUpHeight + ", top=" + top + ", left=" + left);


### PR DESCRIPTION
This PR prevents PopUp window position offsets from being negative by using `Math.max()` in order to make the top and left offsets 0 if they are negative immediately before they are added to the calculated position.

Fixes #1928 