### PR TITLE
Remove telemetryoptions from msal-common

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -542,8 +542,7 @@ export class PublicClientApplication implements IPublicClientApplication {
                 cloudDiscoveryMetadata: this.config.auth.cloudDiscoveryMetadata
             },
             systemOptions: {
-                tokenRenewalOffsetSeconds: this.config.system.tokenRenewalOffsetSeconds,
-                telemetry: this.config.system.telemetry
+                tokenRenewalOffsetSeconds: this.config.system.tokenRenewalOffsetSeconds
             },
             loggerOptions: {
                 loggerCallback: this.config.system.loggerOptions.loggerCallback,

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -39,7 +39,6 @@ export type CacheOptions = {
  * - loadFrameTimeout             - maximum time the library should wait for a frame to load
  * - windowHashTimeout            - sets the wait time for hidden iFrame navigation
  * - tokenRenewalOffsetSeconds    - sets the window of offset needed to renew the token before expiry
- * - telemetry                    - Telemetry options for library network requests
  */
 export type BrowserSystemOptions = SystemOptions & {
     loggerOptions?: LoggerOptions;
@@ -55,7 +54,7 @@ export type BrowserSystemOptions = SystemOptions & {
  * This object allows you to configure important elements of MSAL functionality:
  * - auth: this is where you configure auth elements like clientID, authority used for authenticating against the Microsoft Identity Platform
  * - cache: this is where you configure cache location and whether to store cache in cookies
- * - system: this is where you can configure the network client, logger, token renewal offset, and telemetry
+ * - system: this is where you can configure the network client, logger, token renewal offset
  */
 export type Configuration = {
     auth?: BrowserAuthOptions,

--- a/lib/msal-browser/test/config/Configuration.spec.ts
+++ b/lib/msal-browser/test/config/Configuration.spec.ts
@@ -47,7 +47,6 @@ describe("Configuration.ts Class Unit Tests", () => {
         expect(emptyConfig.system.windowHashTimeout).to.be.not.null.and.not.undefined;
         expect(emptyConfig.system.windowHashTimeout).to.be.eq(DEFAULT_POPUP_TIMEOUT_MS);
         expect(emptyConfig.system.tokenRenewalOffsetSeconds).to.be.eq(300);
-        expect(emptyConfig.system.telemetry).to.be.null;
     });
 
     it("Tests logger", () => {
@@ -94,8 +93,6 @@ describe("Configuration.ts Class Unit Tests", () => {
         expect(consoleWarnSpy.calledOnce).to.be.true;
     });
 
-    const testAppName = "MSAL.js App";
-    const testAppVersion = "v1.0.0";
     let testProtectedResourceMap = new Map<string, Array<string>>();
     testProtectedResourceMap.set("testResource1", ["resourceUri1"]);
     it("buildConfiguration correctly assigns new values", () => {
@@ -117,10 +114,6 @@ describe("Configuration.ts Class Unit Tests", () => {
                 loggerOptions: {
                     loggerCallback: testLoggerCallback,
                     piiLoggingEnabled: true
-                },
-                telemetry: {
-                    applicationName: testAppName,
-                    applicationVersion: testAppVersion
                 }
             }
         });
@@ -143,9 +136,6 @@ describe("Configuration.ts Class Unit Tests", () => {
         expect(newConfig.system.windowHashTimeout).to.be.eq(TEST_POPUP_TIMEOUT_MS);
         expect(newConfig.system.tokenRenewalOffsetSeconds).to.be.not.null;
         expect(newConfig.system.tokenRenewalOffsetSeconds).to.be.eq(TEST_OFFSET);
-        expect(newConfig.system.telemetry).to.be.not.null;
-        expect(newConfig.system.telemetry.applicationName).to.be.eq(testAppName);
-        expect(newConfig.system.telemetry.applicationVersion).to.be.eq(testAppVersion);
         expect(newConfig.system.loggerOptions).to.be.not.null;
         expect(newConfig.system.loggerOptions.loggerCallback).to.be.not.null;
         expect(newConfig.system.loggerOptions.piiLoggingEnabled).to.be.true;

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -94,8 +94,7 @@ describe("InteractionHandler.ts Unit Tests", () => {
 				authority: authorityInstance,
 			},
             systemOptions: {
-                tokenRenewalOffsetSeconds: configObj.system.tokenRenewalOffsetSeconds,
-                telemetry: configObj.system.telemetry
+                tokenRenewalOffsetSeconds: configObj.system.tokenRenewalOffsetSeconds
             },
             cryptoInterface: {
                 createNewGuid: (): string => {

--- a/lib/msal-browser/test/interaction_handler/PopupHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/PopupHandler.spec.ts
@@ -78,8 +78,7 @@ describe("PopupHandler.ts Unit Tests", () => {
 			},
             systemOptions: {
                 tokenRenewalOffsetSeconds:
-                    configObj.system.tokenRenewalOffsetSeconds,
-                telemetry: configObj.system.telemetry,
+                    configObj.system.tokenRenewalOffsetSeconds
             },
             cryptoInterface: {
                 createNewGuid: (): string => {

--- a/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
@@ -59,7 +59,6 @@ describe("RedirectHandler.ts Unit Tests", () => {
             systemOptions: {
                 tokenRenewalOffsetSeconds:
                     configObj.system.tokenRenewalOffsetSeconds,
-                telemetry: configObj.system.telemetry,
             },
             cryptoInterface: {
                 createNewGuid: (): string => {

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -79,8 +79,7 @@ describe("SilentHandler.ts Unit Tests", () => {
 			},
             systemOptions: {
                 tokenRenewalOffsetSeconds:
-                    configObj.system.tokenRenewalOffsetSeconds,
-                telemetry: configObj.system.telemetry,
+                    configObj.system.tokenRenewalOffsetSeconds
             },
             cryptoInterface: {
                 createNewGuid: (): string => {

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -53,26 +53,12 @@ export type AuthOptions = {
 };
 
 /**
- * Use this to configure the telemetry options in the Configuration object
- *
- * - applicationName              - Name of the consuming apps application
- * - applicationVersion           - Version of the consuming application
- */
-export type TelemetryOptions = {
-    applicationName: string;
-    applicationVersion: string;
-    // TODO, add onlyAddFailureTelemetry option
-};
-
-/**
- * Use this to configure token renewal and telemetry info in the Configuration object
+ * Use this to configure token renewal info in the Configuration object
  *
  * - tokenRenewalOffsetSeconds    - Sets the window of offset needed to renew the token before expiry
- * - telemetry                    - Telemetry options for library network requests
  */
 export type SystemOptions = {
     tokenRenewalOffsetSeconds?: number;
-    telemetry?: TelemetryOptions;
 };
 
 /**
@@ -106,8 +92,7 @@ const DEFAULT_AUTH_OPTIONS: AuthOptions = {
 };
 
 export const DEFAULT_SYSTEM_OPTIONS: SystemOptions = {
-    tokenRenewalOffsetSeconds: DEFAULT_TOKEN_RENEWAL_OFFSET_SEC,
-    telemetry: null
+    tokenRenewalOffsetSeconds: DEFAULT_TOKEN_RENEWAL_OFFSET_SEC
 };
 
 const DEFAULT_LOGGER_IMPLEMENTATION: LoggerOptions = {

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -3,7 +3,7 @@ export { AuthorizationCodeClient} from "./client/AuthorizationCodeClient";
 export { DeviceCodeClient } from "./client/DeviceCodeClient";
 export { RefreshTokenClient } from "./client/RefreshTokenClient";
 export { SilentFlowClient } from "./client/SilentFlowClient";
-export { AuthOptions, SystemOptions, LoggerOptions, TelemetryOptions, DEFAULT_SYSTEM_OPTIONS } from "./config/ClientConfiguration";
+export { AuthOptions, SystemOptions, LoggerOptions, DEFAULT_SYSTEM_OPTIONS } from "./config/ClientConfiguration";
 export { ClientConfiguration } from "./config/ClientConfiguration";
 // Account
 export { AccountInfo } from "./account/AccountInfo";


### PR DESCRIPTION
Removing TelemetryOptions, as we will rebuild client telemetry for v2 and add back post-GA.