### PR TITLE
Refactor E2E Tests

### DIFF
--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/default/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/default/test/browser.spec.ts
@@ -1,50 +1,21 @@
 import "mocha";
 import puppeteer from "puppeteer";
 import { expect } from "chai";
-import fs from "fs";
-import { LabClient } from "../../../e2eTests/LabClient";
+import { Screenshot, createFolder, setupCredentials, getTokens, getAccountFromCache, accessTokenForScopesExists } from "../../../e2eTests/TestUtils"
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
-let SCREENSHOT_NUM = 0;
 let username = "";
 let accountPwd = "";
 
-function setupScreenshotDir() {
-    if (!fs.existsSync(`${SCREENSHOT_BASE_FOLDER_NAME}`)) {
-        fs.mkdirSync(SCREENSHOT_BASE_FOLDER_NAME);
-    }
-}
-
-async function setupCredentials() {
-    const testCreds = new LabClient();
-    const envResponse = await testCreds.getUserVarsByCloudEnvironment("azureppe");
-    const testEnv = envResponse[0];
-    if (testEnv.upn) {
-        username = testEnv.upn;
-    }
-
-    const testPwdSecret = await testCreds.getSecret(testEnv.labName);
-
-    accountPwd = testPwdSecret.value;
-}
-
-async function takeScreenshot(page: puppeteer.Page, testName: string, screenshotName: string): Promise<void> {
-    const screenshotFolderName = `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
-    if (!fs.existsSync(`${screenshotFolderName}`)) {
-        fs.mkdirSync(screenshotFolderName);
-    }
-    await page.screenshot({ path: `${screenshotFolderName}/${++SCREENSHOT_NUM}_${screenshotName}.png` });
-}
-
-async function enterCredentials(page: puppeteer.Page, testName: string): Promise<void> {
+async function enterCredentials(page: puppeteer.Page, screenshot: Screenshot): Promise<void> {
     await page.waitForNavigation({ waitUntil: "networkidle0"});
     await page.waitForSelector("#i0116");
-    await takeScreenshot(page, testName, `loginPage`);
+    await screenshot.takeScreenshot(page, `loginPage`);
     await page.type("#i0116", username);
     await page.click("#idSIButton9");
     await page.waitForNavigation({ waitUntil: "networkidle0"});
     await page.waitForSelector("#i0118");
-    await takeScreenshot(page, testName, `pwdInputPage`);
+    await screenshot.takeScreenshot(page, `pwdInputPage`);
     await page.type("#i0118", accountPwd);
     await page.click("#idSIButton9");
 }
@@ -55,8 +26,8 @@ describe("Browser tests", function () {
 
     let browser: puppeteer.Browser;
     before(async () => {
-        setupScreenshotDir();
-        setupCredentials();
+        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        [username, accountPwd] = await setupCredentials("azureppe");
         browser = await puppeteer.launch({
             headless: true,
             ignoreDefaultArgs: ['--no-sandbox', '–disable-setuid-sandbox']
@@ -66,7 +37,6 @@ describe("Browser tests", function () {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     beforeEach(async () => {
-        SCREENSHOT_NUM = 0;
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
         await page.goto('http://localhost:30662/');
@@ -81,45 +51,56 @@ describe("Browser tests", function () {
         await browser.close();
     });
 
-    it("Performs loginRedirect", async () => {
+    it.only("Performs loginRedirect", async () => {
         const testName = "redirectBaseCase";
+        const screenshot = new Screenshot(`${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`);
         // Home Page
-        await takeScreenshot(page, testName, `samplePageInit`);
+        await screenshot.takeScreenshot(page, `samplePageInit`);
         // Click Sign In
         await page.click("#SignIn");
-        await takeScreenshot(page, testName, `signInClicked`);
+        await screenshot.takeScreenshot(page, `signInClicked`);
         // Click Sign In With Redirect
         await page.click("#loginRedirect");
         // Enter credentials
-        await enterCredentials(page, testName);
+        await enterCredentials(page, screenshot);
         // Wait for return to page
         await page.waitForNavigation({ waitUntil: "networkidle0"});
-        await takeScreenshot(page, testName, `samplePageLoggedIn`);
-        const sessionStorage = await page.evaluate(() =>  Object.assign({}, window.sessionStorage));
-        expect(Object.keys(sessionStorage).length).to.be.eq(4);
+        await screenshot.takeScreenshot(page, `samplePageLoggedIn`);
+        let tokenStore = await getTokens(page);
+        expect(tokenStore.idTokens).to.be.length(1);
+        expect(tokenStore.accessTokens).to.be.length(1);
+        expect(tokenStore.refreshTokens).to.be.length(1);
+        expect(getAccountFromCache(page, tokenStore.idTokens[0])).to.not.be.null;
+        
+        expect(await accessTokenForScopesExists(page, tokenStore.accessTokens, ["openid", "profile", "user.read"])).to.be.true;
     });
 
     it("Performs loginPopup", async () => {
         const testName = "popupBaseCase";
+        const screenshot = new Screenshot(`${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`);
         // Home Page
-        await takeScreenshot(page, testName, `samplePageInit`);
+        await screenshot.takeScreenshot(page, `samplePageInit`);
         // Click Sign In
         await page.click("#SignIn");
-        await takeScreenshot(page, testName, `signInClicked`);
+        await screenshot.takeScreenshot(page, `signInClicked`);
         // Click Sign In With Popup
         const newPopupWindowPromise = new Promise<puppeteer.Page>(resolve => page.once('popup', resolve));
         await page.click("#loginPopup");
         const popupPage = await newPopupWindowPromise;
         const popupWindowClosed = new Promise<void>(resolve => popupPage.once("close", resolve));
         // Enter credentials
-        await enterCredentials(popupPage, testName);
+        await enterCredentials(popupPage, screenshot);
         // Wait until popup window closes and see that we are logged in
         await popupWindowClosed;
         // Wait for token acquisition
         await page.waitFor(2000);
         expect(popupPage.isClosed()).to.be.true;
-        await takeScreenshot(page, testName, `samplePageLoggedIn`);
-        const sessionStorage = await page.evaluate(() =>  Object.assign({}, window.sessionStorage));
-        expect(Object.keys(sessionStorage).length).to.be.eq(4);
+        await screenshot.takeScreenshot(page, `samplePageLoggedIn`);
+        let tokenStore = await getTokens(page);
+        expect(tokenStore.idTokens).to.be.length(1);
+        expect(tokenStore.accessTokens).to.be.length(1);
+        expect(tokenStore.refreshTokens).to.be.length(1);
+        expect(getAccountFromCache(page, tokenStore.idTokens[0])).to.not.be.null;
+        expect(await accessTokenForScopesExists(page, tokenStore.accessTokens, ["openid", "profile", "user.read"])).to.be.true;
     });
 });

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/default/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/default/test/browser.spec.ts
@@ -51,7 +51,7 @@ describe("Browser tests", function () {
         await browser.close();
     });
 
-    it.only("Performs loginRedirect", async () => {
+    it("Performs loginRedirect", async () => {
         const testName = "redirectBaseCase";
         const screenshot = new Screenshot(`${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`);
         // Home Page

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multipleResources/test/multiple_resources.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multipleResources/test/multiple_resources.spec.ts
@@ -1,50 +1,21 @@
 import "mocha";
 import puppeteer from "puppeteer";
 import { expect } from "chai";
-import fs from "fs";
-import { LabClient } from "../../../e2eTests/LabClient";
+import { Screenshot, createFolder, setupCredentials, getTokens, removeTokens, getAccountFromCache, accessTokenForScopesExists } from "../../../e2eTests/TestUtils"
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
-let SCREENSHOT_NUM = 0;
 let username = "";
 let accountPwd = "";
 
-function setupScreenshotDir() {
-    if (!fs.existsSync(`${SCREENSHOT_BASE_FOLDER_NAME}`)) {
-        fs.mkdirSync(SCREENSHOT_BASE_FOLDER_NAME);
-    }
-}
-
-async function setupCredentials() {
-    const testCreds = new LabClient();
-    const envResponse = await testCreds.getUserVarsByCloudEnvironment("azureppe");
-    const testEnv = envResponse[0];
-    if (testEnv.upn) {
-        username = testEnv.upn;
-    }
-
-    const testPwdSecret = await testCreds.getSecret(testEnv.labName);
-
-    accountPwd = testPwdSecret.value;
-}
-
-async function takeScreenshot(page: puppeteer.Page, testName: string, screenshotName: string): Promise<void> {
-    const screenshotFolderName = `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
-    if (!fs.existsSync(`${screenshotFolderName}`)) {
-        fs.mkdirSync(screenshotFolderName);
-    }
-    await page.screenshot({ path: `${screenshotFolderName}/${++SCREENSHOT_NUM}_${screenshotName}.png` });
-}
-
-async function enterCredentials(page: puppeteer.Page, testName: string): Promise<void> {
+async function enterCredentials(page: puppeteer.Page, screenshot: Screenshot): Promise<void> {
     await page.waitForNavigation({ waitUntil: "networkidle0"});
     await page.waitForSelector("#i0116");
-    await takeScreenshot(page, testName, `loginPage`);
+    await screenshot.takeScreenshot(page, "loginPage");
     await page.type("#i0116", username);
     await page.click("#idSIButton9");
     await page.waitForNavigation({ waitUntil: "networkidle0"});
     await page.waitForSelector("#i0118");
-    await takeScreenshot(page, testName, `pwdInputPage`);
+    await screenshot.takeScreenshot(page, "pwdInputPage");
     await page.type("#i0118", accountPwd);
     await page.click("#idSIButton9");
 }
@@ -55,8 +26,8 @@ describe("Browser tests", function () {
 
     let browser: puppeteer.Browser;
     before(async () => {
-        setupScreenshotDir();
-        setupCredentials();
+        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        [username, accountPwd] = await setupCredentials("azureppe");
         browser = await puppeteer.launch({
             headless: true,
             ignoreDefaultArgs: ['--no-sandbox', '–disable-setuid-sandbox']
@@ -66,7 +37,6 @@ describe("Browser tests", function () {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     beforeEach(async () => {
-        SCREENSHOT_NUM = 0;
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
         await page.goto('http://localhost:30662/');
@@ -82,34 +52,47 @@ describe("Browser tests", function () {
     });
 
     it("Performs loginRedirect and acquires 2 tokens", async () => {
-        const testName = "multipleResources";
+        const screenshot = new Screenshot(`${SCREENSHOT_BASE_FOLDER_NAME}/multipleResources`);
         // Home Page
-        await takeScreenshot(page, testName, `samplePageInit`);
+        await screenshot.takeScreenshot(page, "samplePageInit");
         // Click Sign In
         await page.click("#SignIn");
-        await takeScreenshot(page, testName, `signInClicked`);
+        await screenshot.takeScreenshot(page, "signInClicked");
         // Click Sign In With Redirect
         await page.click("#loginRedirect");
         // Enter credentials
-        await enterCredentials(page, testName);
+        await enterCredentials(page, screenshot);
         // Wait for return to page
         await page.waitForNavigation({ waitUntil: "networkidle0"});
-        await takeScreenshot(page, testName, `samplePageLoggedIn`);
-        let sessionStorage = await page.evaluate(() =>  Object.assign({}, window.sessionStorage));
-        expect(Object.keys(sessionStorage).length).to.be.eq(4);
+        await screenshot.takeScreenshot(page, "samplePageLoggedIn");
+        let tokenStore = await getTokens(page);
+        expect(tokenStore.idTokens).to.be.length(1);
+        expect(tokenStore.accessTokens).to.be.length(1);
+        expect(tokenStore.refreshTokens).to.be.length(1);
+        expect(getAccountFromCache(page, tokenStore.idTokens[0])).to.not.be.null;
 
         // acquire First Access Token
+        await removeTokens(page, tokenStore.accessTokens);
         await page.click("#seeProfile");
         await page.waitFor(2000)
-        await takeScreenshot(page, testName, `seeProfile`);
-        sessionStorage = await page.evaluate(() =>  Object.assign({}, window.sessionStorage));
-        expect(Object.keys(sessionStorage).length).to.be.eq(4);
+        await screenshot.takeScreenshot(page, "seeProfile");
+        tokenStore = await getTokens(page);
+        expect(tokenStore.idTokens).to.be.length(1);
+        expect(tokenStore.accessTokens).to.be.length(1);
+        expect(tokenStore.refreshTokens).to.be.length(1);
+        expect(getAccountFromCache(page, tokenStore.idTokens[0])).to.not.be.null;
+        expect(await accessTokenForScopesExists(page, tokenStore.accessTokens, ["openid", "profile", "user.read"])).to.be.true;
 
         //acquire Second Access Token
         await page.click("#secondToken");
         await page.waitForSelector("#second-resource-div");
-        await takeScreenshot(page, testName, `secondToken`);
-        sessionStorage = await page.evaluate(() =>  Object.assign({}, window.sessionStorage));
-        expect(Object.keys(sessionStorage).length).to.be.eq(5);
+        await screenshot.takeScreenshot(page, "secondToken");
+        tokenStore = await getTokens(page);
+        expect(tokenStore.idTokens).to.be.length(1);
+        expect(tokenStore.accessTokens).to.be.length(2);
+        expect(tokenStore.refreshTokens).to.be.length(1);
+        expect(getAccountFromCache(page, tokenStore.idTokens[0])).to.not.be.null;
+        expect(await accessTokenForScopesExists(page, tokenStore.accessTokens, ["openid", "profile", "user.read"])).to.be.true;
+        expect(await accessTokenForScopesExists(page, tokenStore.accessTokens, ["https://msidlab0.spoppe.com/User.Read"])).to.be.true;
     });
 });

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/e2eTests/LabClient.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/e2eTests/LabClient.ts
@@ -35,10 +35,27 @@ export class LabClient {
         return null;
     }
 
-    async getUserVarsByCloudEnvironment(envName: string): Promise<any> {
+    async getUserVarsByCloudEnvironment(envName: string, usertype?: string, federationprovider?:string): Promise<any> {
         const accessToken = await this.getCurrentToken();
+        let apiParams: Array<string> = [];
 
-        return await this.requestLabApi(`/user?azureenvironment=${envName}`, accessToken);
+
+        if (envName) {
+            apiParams.push(`azureenvironment=${envName}`);
+        }
+        if (usertype) {
+            apiParams.push(`usertype=${usertype}`);
+        }
+        if (federationprovider) {
+            apiParams.push(`federationprovider=${federationprovider}`);
+        }
+
+        if (apiParams.length <= 0) {
+            throw "Must provide at least one param to getUserVarsByCloudEnvironment";
+        }
+        const apiUrl = '/user?' + apiParams.join("&");
+
+        return await this.requestLabApi(apiUrl, accessToken);
     }
 
     async getSecret(secretName: string): Promise<any> {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/e2eTests/TestUtils.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/e2eTests/TestUtils.ts
@@ -1,0 +1,134 @@
+import fs from "fs";
+import puppeteer from "puppeteer";
+import { LabClient } from "./LabClient";
+import { expect } from 'chai';
+
+export class Screenshot {
+    private folderName: string;
+    private screenshotNum: number;
+
+    constructor (foldername: string) {
+        this.folderName = foldername
+        this.screenshotNum = 0;
+        createFolder(this.folderName);
+    }
+
+    async takeScreenshot(page: puppeteer.Page, screenshotName: string): Promise<void> {
+        await page.screenshot({ path: `${this.folderName}/${++this.screenshotNum}_${screenshotName}.png` });
+    }
+}
+
+export function createFolder(foldername: string) {
+    if (!fs.existsSync(foldername)) {
+        fs.mkdirSync(foldername);
+    }
+}
+
+export async function setupCredentials(envName: string, usertype?: string, federationprovider?:string): Promise<[string, string]> {
+    let username = "";
+    let accountPwd = "";
+    const testCreds = new LabClient();
+    const envResponse = await testCreds.getUserVarsByCloudEnvironment(envName, usertype, federationprovider);
+    const testEnv = envResponse[0];
+    if (testEnv.upn) {
+        username = testEnv.upn;
+    }
+
+    const testPwdSecret = await testCreds.getSecret(testEnv.labName);
+
+    accountPwd = testPwdSecret.value;
+
+    return [username, accountPwd];
+}
+
+export type tokenMap = {
+    idTokens: string[],
+    accessTokens: string[],
+    refreshTokens: string[]
+}
+
+export async function getTokens(page: puppeteer.Page): Promise<tokenMap> {
+    const storage = await page.evaluate(() =>  Object.assign({}, window.sessionStorage));
+    let tokenKeys: tokenMap = {
+        idTokens: [],
+        accessTokens: [],
+        refreshTokens: []
+    }
+
+    Object.keys(storage).forEach(async key => {
+        if (key.includes("idtoken") && validateToken(page, storage[key], "IdToken")) {
+            tokenKeys.idTokens.push(key);
+        } else if (key.includes("accesstoken") && validateToken(page, storage[key], "AccessToken")) {
+            tokenKeys.accessTokens.push(key);
+        } else if (key.includes("refreshtoken") && validateToken(page, storage[key], "RefreshToken")) {
+            tokenKeys.refreshTokens.push(key)
+        }
+    });
+
+    return tokenKeys;
+}
+
+export function validateToken(page: puppeteer.Page, rawTokenVal: string, tokenType: String): boolean {
+    const tokenVal = JSON.parse(rawTokenVal);
+    
+    if (
+        !validateStringField(tokenVal.clientId) || 
+        !validateStringField(tokenVal.credentialType) ||
+        !validateStringField(tokenVal.environment) ||
+        !validateStringField(tokenVal.homeAccountId) ||
+        !validateStringField(tokenVal.secret) ||
+        tokenVal.credentialType !== tokenType
+    ) {
+        return false;
+    }
+
+    if (tokenType === "IdToken" && !validateStringField(tokenVal.realm)) {
+            return false;
+    } else if (tokenType === "AccessToken") {
+        if (
+            !validateStringField(tokenVal.cachedAt) ||
+            !validateStringField(tokenVal.expiresOn) ||
+            !validateStringField(tokenVal.extendedExpiresOn) ||
+            !validateStringField(tokenVal.target)
+        ) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function validateStringField(field: any): boolean {
+    return typeof(field) === "string" && field.length > 0;
+}
+
+export async function accessTokenForScopesExists(page: puppeteer.Page, accessTokenKeys: Array<string>, scopes: Array<String>): Promise<boolean> {
+    const storage = await page.evaluate(() =>  Object.assign({}, window.sessionStorage));
+
+    return accessTokenKeys.some((key) => {
+        const tokenVal = JSON.parse(storage[key]);
+        const tokenScopes = tokenVal.target.split(' ');
+        
+        return scopes.every((scope) => {
+            return tokenScopes.includes(scope.toLowerCase());
+        });
+    });
+}
+
+export async function removeTokens(page: puppeteer.Page, tokens: Array<string>) {
+    tokens.forEach(async (key) => {
+        await page.evaluate((key) => window.localStorage.removeItem(key))
+    });
+}
+
+export async function getAccountFromCache(page: puppeteer.Page, idTokenKey: string): Promise<Object|null> {
+    const storage = await page.evaluate(() =>  Object.assign({}, window.sessionStorage));
+    const tokenVal = JSON.parse(storage[idTokenKey]);
+    const accountKey = tokenVal.homeAccountId + "-" + tokenVal.environment + "-" + tokenVal.realm;
+
+    if (Object.keys(storage).includes(accountKey)) {
+        return JSON.parse(storage[accountKey]);
+    }
+
+    return null
+}


### PR DESCRIPTION
- Moves some commonly used functions to separate TestUtils file
- Improves validation of tokens in the cache by inspecting the contents rather than relying on a count
- Extends the account selector for future use cases such as testing B2C or ADFS