### PR TITLE
Fix getAccountByUsername for B2C Scenarios

### DIFF
--- a/lib/msal-common/src/account/IdTokenClaims.ts
+++ b/lib/msal-common/src/account/IdTokenClaims.ts
@@ -14,6 +14,7 @@ export type IdTokenClaims = {
     ver?: string,
     upn?: string,
     preferred_username?: string,
+    emails?: string[],
     name?: string,
     nonce?: string,
     exp?: string,

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -150,7 +150,7 @@ export class AccountEntity {
                 ? idToken.claims.oid
                 : idToken.claims.sid;
             account.localAccountId = localAccountId;
-            account.username = idToken.claims.preferred_username;
+            account.username = idToken.claims.preferred_username || (idToken.claims.emails? idToken.claims.emails[0]: "");
             account.name = idToken.claims.name;
         }
 

--- a/lib/msal-common/src/response/AuthenticationResult.ts
+++ b/lib/msal-common/src/response/AuthenticationResult.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { StringDict } from "../utils/MsalTypes";
 import { AccountInfo } from "../account/AccountInfo";
+import { IdTokenClaims } from "../account/IdTokenClaims";
 
 /**
  * Result returned from the authority's token endpoint.
@@ -27,7 +27,7 @@ export class AuthenticationResult {
     scopes: Array<string>;
     account: AccountInfo;
     idToken: string;
-    idTokenClaims: StringDict;
+    idTokenClaims: IdTokenClaims;
     accessToken: string;
     fromCache: boolean;
     expiresOn: Date;

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -11,6 +11,56 @@ import sinon from "sinon";
 import { ClientAuthError, ClientAuthErrorMessage } from "../../../src";
 import { ClientTestUtils } from "../../client/ClientTestUtils";
 
+const cryptoInterface: ICrypto = {
+    createNewGuid(): string {
+        return RANDOM_TEST_GUID;
+    },
+    base64Decode(input: string): string {
+        switch (input) {
+            case TEST_DATA_CLIENT_INFO.TEST_CACHE_RAW_CLIENT_INFO:
+                return TEST_DATA_CLIENT_INFO.TEST_CACHE_DECODED_CLIENT_INFO;
+            default:
+                return input;
+        }
+    },
+    base64Encode(input: string): string {
+        switch (input) {
+            case "uid":
+                return "dWlk";
+            case "utid":
+                return "dXRpZA==";
+            default:
+                return input;
+        }
+    },
+    async generatePkceCodes(): Promise<PkceCodes> {
+        return {
+            challenge: TEST_CONFIG.TEST_CHALLENGE,
+            verifier: TEST_CONFIG.TEST_VERIFIER,
+        };
+    },
+};
+
+const networkInterface: INetworkModule = {
+    sendGetRequestAsync<T>(
+        url: string,
+        options?: NetworkRequestOptions
+    ): T {
+        return null;
+    },
+    sendPostRequestAsync<T>(
+        url: string,
+        options?: NetworkRequestOptions
+    ): T {
+        return null;
+    }
+};
+
+const authority =  AuthorityFactory.createInstance(
+    Constants.DEFAULT_AUTHORITY,
+    networkInterface
+);
+
 describe("AccountEntity.ts Unit Tests", () => {
     beforeEach(() => {
         ClientTestUtils.setCloudDiscoveryMetadataStubs();
@@ -45,56 +95,7 @@ describe("AccountEntity.ts Unit Tests", () => {
         expect(ac.generateType()).to.eql(1003);
     });
 
-    it("create an Account", () => {
-        let cryptoInterface: ICrypto = {
-            createNewGuid(): string {
-                return RANDOM_TEST_GUID;
-            },
-            base64Decode(input: string): string {
-                switch (input) {
-                    case TEST_DATA_CLIENT_INFO.TEST_CACHE_RAW_CLIENT_INFO:
-                        return TEST_DATA_CLIENT_INFO.TEST_CACHE_DECODED_CLIENT_INFO;
-                    default:
-                        return input;
-                }
-            },
-            base64Encode(input: string): string {
-                switch (input) {
-                    case "uid":
-                        return "dWlk";
-                    case "utid":
-                        return "dXRpZA==";
-                    default:
-                        return input;
-                }
-            },
-            async generatePkceCodes(): Promise<PkceCodes> {
-                return {
-                    challenge: TEST_CONFIG.TEST_CHALLENGE,
-                    verifier: TEST_CONFIG.TEST_VERIFIER,
-                };
-            },
-        };
-
-        const networkInterface: INetworkModule = {
-            sendGetRequestAsync<T>(
-                url: string,
-                options?: NetworkRequestOptions
-            ): T {
-                return null;
-            },
-            sendPostRequestAsync<T>(
-                url: string,
-                options?: NetworkRequestOptions
-            ): T {
-                return null;
-            }
-        };
-        const authority =  AuthorityFactory.createInstance(
-            Constants.DEFAULT_AUTHORITY,
-            networkInterface
-		);
-        
+    it("create an Account", () => {        
         // Set up stubs
         const idTokenClaims = {
             "ver": "2.0",
@@ -118,5 +119,59 @@ describe("AccountEntity.ts Unit Tests", () => {
         );
 
         expect(acc.generateAccountKey()).to.eql(`uid.utid-login.windows.net-${idTokenClaims.tid}`);
+        expect(acc.username).to.eq("AbeLi@microsoft.com");
+    });
+
+    it("create an Account with emails claim instead of preferred_username claim", () => {       
+        // Set up stubs
+        const idTokenClaims = {
+            "ver": "2.0",
+            "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
+            "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+            "exp": "1536361411",
+            "name": "Abe Lincoln",
+            "emails": ["AbeLi@microsoft.com"],
+            "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+            "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+            "nonce": "123523",
+        };
+        sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
+		const idToken = new IdToken(TEST_TOKENS.IDTOKEN_V2, cryptoInterface);
+
+        const acc = AccountEntity.createAccount(
+            TEST_DATA_CLIENT_INFO.TEST_CACHE_RAW_CLIENT_INFO,
+            authority,
+            idToken,
+            cryptoInterface
+        );
+
+        expect(acc.generateAccountKey()).to.eql(`uid.utid-login.windows.net-${idTokenClaims.tid}`);
+        expect(acc.username).to.eq("AbeLi@microsoft.com");
+    });
+
+    it("create an Account no preferred_username or emails claim", () => {       
+        // Set up stubs
+        const idTokenClaims = {
+            "ver": "2.0",
+            "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
+            "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+            "exp": "1536361411",
+            "name": "Abe Lincoln",
+            "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+            "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+            "nonce": "123523",
+        };
+        sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
+		const idToken = new IdToken(TEST_TOKENS.IDTOKEN_V2, cryptoInterface);
+
+        const acc = AccountEntity.createAccount(
+            TEST_DATA_CLIENT_INFO.TEST_CACHE_RAW_CLIENT_INFO,
+            authority,
+            idToken,
+            cryptoInterface
+        );
+
+        expect(acc.generateAccountKey()).to.eql(`uid.utid-login.windows.net-${idTokenClaims.tid}`);
+        expect(acc.username).to.eq("");
     });
 });


### PR DESCRIPTION
Addresses #2000 

B2C does not return the `preferred_username` claim on idTokens which causes calls to `getAccountByUsername` to fail. B2C instead provides an `emails` claim that can be enabled on each user_flow. It returns an array of emails associated with the user. This PR provides the first email in this array as a fallback if `preferred_username` is undefined. 

There may be some future optimizations possible if we decide to support multiple emails returned on the `emails` claim.

TODO: 
- [ ] Currently being discussed with B2C team to find out if this is the recommended approach
- [ ] Add docs or FAQ explaining how to enable the claim on your user_flow