### PR TITLE
handleRedirect fixes

### DIFF
--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -65,9 +65,6 @@ export class RedirectHandler extends InteractionHandler {
         this.authCodeRequest = this.browserStorage.getCachedRequest(requestState, browserCrypto);
         this.authCodeRequest.code = authCode;
 
-        // Hash was processed successfully - remove from cache
-        this.browserStorage.removeItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.URL_HASH));
-
         // Acquire token with retrieved code.
         const tokenResponse = await this.authModule.acquireToken(this.authCodeRequest, cachedNonce, requestState);
 

--- a/lib/msal-browser/src/utils/BrowserUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserUtils.ts
@@ -60,6 +60,12 @@ export class BrowserUtils {
         return window.location.href.split("?")[0].split("#")[0];
     }
 
+    static getHomepage(): string {
+        const currentUrl = new UrlString(window.location.href);
+        const urlComponents = currentUrl.getUrlComponents();
+        return urlComponents.Protocol + "//" + urlComponents.HostNameAndPort + "/";
+    }
+
     /**
      * Returns best compatible network client object. 
      */

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -74,7 +74,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH;
             sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
                 expect(noHistory).to.be.true;
-                expect(urlNavigate).to.be.eq("/");
+                expect(urlNavigate).to.be.eq("https://localhost:8081/");
+                expect(window.sessionStorage.getItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`)).to.be.eq("https://localhost:8081/");
                 done();
             });
             pca.handleRedirectPromise();
@@ -86,7 +87,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`, "null");
             sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
                 expect(noHistory).to.be.true;
-                expect(urlNavigate).to.be.eq("/");
+                expect(urlNavigate).to.be.eq("https://localhost:8081/");
+                expect(window.sessionStorage.getItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`)).to.be.eq("https://localhost:8081/");
                 done();
             });
             pca.handleRedirectPromise();

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -131,6 +131,17 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca.handleRedirectPromise();
         });
 
+        it("processes hash if navigateToLoginRequestUri is true and loginRequestUrl contains trailing slash", (done) => {
+            const loginRequestUrl = window.location.href.endsWith('/') ? window.location.href.slice(0, -1) : window.location.href + "/";
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH;
+            window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`, loginRequestUrl);
+            sinon.stub(PublicClientApplication.prototype, <any>"handleHash").callsFake((responseHash) => {
+                expect(responseHash).to.be.eq(TEST_HASHES.TEST_SUCCESS_CODE_HASH);
+                done();
+            });
+            pca.handleRedirectPromise();
+        });
+
         it("clears hash if navigateToLoginRequestUri is false and loginRequestUrl contains custom hash", (done) => {
             pca = new PublicClientApplication({
                 auth: {

--- a/lib/msal-common/src/url/UrlString.ts
+++ b/lib/msal-common/src/url/UrlString.ts
@@ -23,7 +23,7 @@ export class UrlString {
     constructor(url: string) {
         this._urlString = url;
         if (!StringUtils.isEmpty(this._urlString) && StringUtils.isEmpty(this.getHash())) {
-            this._urlString = this.canonicalizeUri(url);
+            this._urlString = UrlString.canonicalizeUri(url);
         } else if (StringUtils.isEmpty(this._urlString)) {
             // Throws error if url is empty
             throw ClientConfigurationError.createUrlEmptyError();
@@ -34,7 +34,7 @@ export class UrlString {
      * Ensure urls are lower case and end with a / character.
      * @param url 
      */
-    private canonicalizeUri(url: string): string {
+    static canonicalizeUri(url: string): string {
         if (url) {
             url = url.toLowerCase();
         }
@@ -87,7 +87,7 @@ export class UrlString {
     }
 
     static removeHashFromUrl(url: string): string {
-        return url.split("#")[0];
+        return UrlString.canonicalizeUri(url.split("#")[0]);
     }
 
     /**


### PR DESCRIPTION
Builds on #2045, refactors and fixes the following bugs in the redirect flow:

- #2055 State mismatch error when calling `handleRedirectPromise` multiple times
- `currentUrl` and `loginRequestUrl` being evaluated as not equal if one has a trailing slash and the other does not
- When `loginRequestUrl` is not in the cache, msal redirects to the homepage but would not process the hash