### PR TITLE
Fix back button behavior

### DIFF
--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -327,7 +327,8 @@ export class WindowUtils {
         // if redirect request is set and there is no hash
         if(redirectCache && !UrlUtils.urlContainsHash(window.location.hash)) {
             const splitCache = redirectCache.split(Constants.resourceDelimiter);
-            const state = splitCache.length > 1 ? splitCache[splitCache.length-1]: null;
+            splitCache.shift();
+            const state = splitCache.length > 0 ? splitCache.join(Constants.resourceDelimiter): null;
             cacheStorage.resetTempCacheItems(state);
         }
     }

--- a/samples/msal-core-samples/VanillaJSTestApp/e2eTests/testRunner.ts
+++ b/samples/msal-core-samples/VanillaJSTestApp/e2eTests/testRunner.ts
@@ -15,7 +15,7 @@ const APP_DIR = PARENT_DIR + `/app`;
 
 // Get all sample folders
 const sampleFolders = fs.readdirSync(APP_DIR, { withFileTypes: true }).filter(function(file) {
-    return file.isDirectory() && file.name !== `sample_template`;
+    return file.isDirectory() && file.name !== `sample_template` && fs.existsSync(`${APP_DIR}/${file.name}/test`);
 }).map(function(file) {
     return file.name;
 });


### PR DESCRIPTION
Fixes #2071

When a user provides their own `state` as part of the request, `checkIfBackButtonIsPressed` throws a state mismatch because it splits the cached request `"redirect"|libraryState|userState` on the delimiter and takes the last value. This results in `libraryState|userState` being compared to just `userState`. This PR fixes the behavior by dropping the first value after splitting and then rejoining the remaining values with the delimiter.