### PR TITLE
[msal-common] Fix ID Token Claims type

### DIFF
--- a/change/@azure-msal-common-2020-08-11-16-45-31-fix-id-token-claims-type.json
+++ b/change/@azure-msal-common-2020-08-11-16-45-31-fix-id-token-claims-type.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Change AuthenticationResult.idTokenClaims type from StringDict to generic Object type to allow for non-string valued ID Token Claims. (#2105)",
+  "comment": "Change AuthenticationResult.idTokenClaims type from StringDict to generic Object type to allow for non-string valued ID Token Claims. Also updates exp claim type in IdTokenClaims type from string to number (#2105)",
   "packageName": "@azure/msal-common",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@azure-msal-common-2020-08-11-16-45-31-fix-id-token-claims-type.json
+++ b/change/@azure-msal-common-2020-08-11-16-45-31-fix-id-token-claims-type.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Change AuthenticationResult.idTokenClaims type from StringDict to generic Object type to allow for non-string valued ID Token Claims. (#2105)",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T23:45:31.158Z"
+}

--- a/change/@azure-msal-common-2020-08-11-16-45-31-fix-id-token-claims-type.json
+++ b/change/@azure-msal-common-2020-08-11-16-45-31-fix-id-token-claims-type.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Change AuthenticationResult.idTokenClaims type from StringDict to generic Object type to allow for non-string valued ID Token Claims. Also updates exp claim type in IdTokenClaims type from string to number (#2105)",
+  "comment": "Update typing of IdTokenClaims (#2105)",
   "packageName": "@azure/msal-common",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch",

--- a/lib/msal-common/src/account/IdTokenClaims.ts
+++ b/lib/msal-common/src/account/IdTokenClaims.ts
@@ -16,7 +16,7 @@ export type IdTokenClaims = {
     preferred_username?: string,
     name?: string,
     nonce?: string,
-    exp?: string,
+    exp?: number,
     home_oid?: string,
     sid?: string,
     cloud_instance_host_name?: string

--- a/lib/msal-common/src/response/AuthenticationResult.ts
+++ b/lib/msal-common/src/response/AuthenticationResult.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { StringDict } from "../utils/MsalTypes";
 import { AccountInfo } from "../account/AccountInfo";
 
 /**
@@ -27,7 +26,7 @@ export type AuthenticationResult = {
     scopes: Array<string>;
     account: AccountInfo;
     idToken: string;
-    idTokenClaims: StringDict;
+    idTokenClaims: Object;
     accessToken: string;
     fromCache: boolean;
     expiresOn: Date;

--- a/lib/msal-common/src/response/AuthenticationResult.ts
+++ b/lib/msal-common/src/response/AuthenticationResult.ts
@@ -26,7 +26,7 @@ export type AuthenticationResult = {
     scopes: Array<string>;
     account: AccountInfo;
     idToken: string;
-    idTokenClaims: Object;
+    idTokenClaims: object;
     accessToken: string;
     fromCache: boolean;
     expiresOn: Date;


### PR DESCRIPTION
This PR:

- Fixes #2084 
- Changes the type for AuthenticationResult.idTokenClaims from StringDict to generic object in order to allow non-string values for ID Token claims