### PR TITLE
[msal-core] Fix invalid state issue by removing second layer of URL decoding

### DIFF
--- a/lib/msal-core/src/utils/CryptoUtils.ts
+++ b/lib/msal-core/src/utils/CryptoUtils.ts
@@ -153,7 +153,7 @@ export class CryptoUtils {
         let match: Array<string>; // Regex for replacing addition symbol with a space
         const pl = /\+/g;
         const search = /([^&=]+)=([^&]*)/g;
-        const decode = (s: string) => decodeURIComponent(s.replace(pl, " ")); // Some values (e.g. state) may need to be decoded twice
+        const decode = (s: string) => decodeURIComponent(s.replace(pl, " "));
         const obj: {} = {};
         match = search.exec(query);
         while (match) {

--- a/lib/msal-core/src/utils/CryptoUtils.ts
+++ b/lib/msal-core/src/utils/CryptoUtils.ts
@@ -153,7 +153,7 @@ export class CryptoUtils {
         let match: Array<string>; // Regex for replacing addition symbol with a space
         const pl = /\+/g;
         const search = /([^&=]+)=([^&]*)/g;
-        const decode = (s: string) => decodeURIComponent(decodeURIComponent(s.replace(pl, " "))); // Some values (e.g. state) may need to be decoded twice
+        const decode = (s: string) => decodeURIComponent(s.replace(pl, " ")); // Some values (e.g. state) may need to be decoded twice
         const obj: {} = {};
         match = search.exec(query);
         while (match) {

--- a/lib/msal-core/test/utils/UrlUtils.spec.ts
+++ b/lib/msal-core/test/utils/UrlUtils.spec.ts
@@ -118,16 +118,24 @@ describe("UrlUtils.ts class", () => {
     });
 
     describe("deserializeHash", () => {
-        it("properly decodes a twice encoded value", () => {
-            // This string is double encoded
-            // "%257C" = | encoded twice
-            const hash = "#state=eyJpZCI6IjJkZWQwNGU5LWYzZGYtNGU0Ny04YzRlLWY0MDMyMTU3YmJlOCIsInRzIjoxNTg1OTMyNzg5LCJtZXRob2QiOiJzaWxlbnRJbnRlcmFjdGlvbiJ9%257Chello";
+        it("properly decodes an encoded value", () => {
+            // This string once encoded
+            const hash = "#state=eyJpZCI6IjJkZWQwNGU5LWYzZGYtNGU0Ny04YzRlLWY0MDMyMTU3YmJlOCIsInRzIjoxNTg1OTMyNzg5LCJtZXRob2QiOiJzaWxlbnRJbnRlcmFjdGlvbiJ9%7Chello";
 
             const { state } = UrlUtils.deserializeHash(hash);
 
             const stateParts = state.split(Constants.resourceDelimiter);
             expect(stateParts[0]).to.equal("eyJpZCI6IjJkZWQwNGU5LWYzZGYtNGU0Ny04YzRlLWY0MDMyMTU3YmJlOCIsInRzIjoxNTg1OTMyNzg5LCJtZXRob2QiOiJzaWxlbnRJbnRlcmFjdGlvbiJ9");
             expect(stateParts[1]).to.equal("hello");
+        });
+
+        it("properly decodes a twice encoded value", () => {
+            // This string is twice encoded
+            const hash = "#state=eyJpZCI6IjJkZWQwNGU5LWYzZGYtNGU0Ny04YzRlLWY0MDMyMTU3YmJlOCIsInRzIjoxNTg1OTMyNzg5LCJtZXRob2QiOiJzaWxlbnRJbnRlcmFjdGlvbiJ9%257Chello";
+
+            const { state } = UrlUtils.deserializeHash(hash);
+
+            expect(state).to.equal("eyJpZCI6IjJkZWQwNGU5LWYzZGYtNGU0Ny04YzRlLWY0MDMyMTU3YmJlOCIsInRzIjoxNTg1OTMyNzg5LCJtZXRob2QiOiJzaWxlbnRJbnRlcmFjdGlvbiJ9%7Chello");
         });
     })
 


### PR DESCRIPTION
This PR:
- Removes wrapping call to decodeURIComponent in CryptoUtils.deserialize to avoid over-decoding user state
- Adds unit test to deserialize hash to make sure state values are only decoded once.
- Fixes #2088
