### PR TITLE
[msal-common] Add validation to cache entities

### DIFF
--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -5,7 +5,7 @@
 
 import { AccountCache, AccountFilter, CredentialFilter, CredentialCache } from "./utils/CacheTypes";
 import { CacheRecord } from "./entities/CacheRecord";
-import { CacheSchemaType, CredentialType, Constants, APP_META_DATA } from "../utils/Constants";
+import { CacheSchemaType, CredentialType, Constants, APP_METADATA } from "../utils/Constants";
 import { CredentialEntity } from "./entities/CredentialEntity";
 import { ScopeSet } from "../request/ScopeSet";
 import { AccountEntity } from "./entities/AccountEntity";
@@ -478,7 +478,7 @@ export abstract class CacheManager implements ICacheManager {
 
     /**
      * Returns a valid AccountEntity if key and object contain correct values, null otherwise.
-     * @param key 
+     * @param key
      */
     private getAccountEntity(key: string): AccountEntity | null {
         // don't parse any non-account type cache entities
@@ -507,7 +507,7 @@ export abstract class CacheManager implements ICacheManager {
      * @param key
      */
     private isAppMetadata(key: string): boolean {
-        return key.indexOf(APP_META_DATA) !== -1;
+        return key.indexOf(APP_METADATA) !== -1;
     }
 
     /**

--- a/lib/msal-common/src/cache/entities/AccessTokenEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccessTokenEntity.ts
@@ -9,11 +9,11 @@ import { TimeUtils } from "../../utils/TimeUtils";
 
 /**
  * ACCESS_TOKEN Credential Type
- * 
+ *
  * Key:Value Schema:
- * 
+ *
  * Key Example: uid.utid-login.microsoftonline.com-accesstoken-clientId-contoso.com-user.read
- * 
+ *
  * Value Schema:
  * {
  *      homeAccountId: home account identifier for the auth scheme,
@@ -82,5 +82,23 @@ export class AccessTokenEntity extends CredentialEntity {
         atEntity.target = scopes;
 
         return atEntity;
+    }
+
+    /**
+     * Validates an entity: checks for all expected params
+     * @param entity
+     */
+    static isAccessTokenEntity(entity: object): boolean {
+
+        return (
+            entity.hasOwnProperty("homeAccountId") &&
+            entity.hasOwnProperty("environment") &&
+            entity.hasOwnProperty("credentialType") &&
+            entity.hasOwnProperty("realm") &&
+            entity.hasOwnProperty("clientId") &&
+            entity.hasOwnProperty("secret") &&
+            entity.hasOwnProperty("target") &&
+            entity["credentialType"] === CredentialType.ACCESS_TOKEN
+        );
     }
 }

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -19,11 +19,11 @@ import { ClientAuthError } from "../../error/ClientAuthError";
 
 /**
  * Type that defines required and optional parameters for an Account field (based on universal cache schema implemented by all MSALs).
- * 
+ *
  * Key : Value Schema
- * 
+ *
  * Key: <home_account_id>-<environment>-<realm*>
- * 
+ *
  * Value Schema:
  * {
  *      homeAccountId: home account identifier for the auth scheme,
@@ -35,7 +35,7 @@ import { ClientAuthError } from "../../error/ClientAuthError";
  *      name: Full name for the account, including given name and family name,
  *      clientInfo: Full base64 encoded client info received from ESTS
  *      lastModificationTime: last time this entity was modified in the cache
- *      lastModificationApp: 
+ *      lastModificationApp:
  * }
  */
 export class AccountEntity {
@@ -140,7 +140,7 @@ export class AccountEntity {
         if (StringUtils.isEmpty(env)) {
             throw ClientAuthError.createInvalidCacheEnvironmentError();
         }
-        
+
         account.environment = env;
         account.realm = idToken.claims.tid;
 
@@ -170,7 +170,7 @@ export class AccountEntity {
 
         account.authorityType = CacheAccountType.ADFS_ACCOUNT_TYPE;
         account.homeAccountId = idToken.claims.sub;
-        
+
         const reqEnvironment = authority.canonicalAuthorityUrlComponents.HostNameAndPort;
         const env = TrustedAuthority.getCloudDiscoveryMetadata(reqEnvironment) ? TrustedAuthority.getCloudDiscoveryMetadata(reqEnvironment).preferred_cache : "";
 
@@ -184,5 +184,21 @@ export class AccountEntity {
         // account.name = idToken.claims.uniqueName;
 
         return account;
+    }
+
+    /**
+     * Validates an entity: checks for all expected params
+     * @param entity
+     */
+    static isAccountEntity(entity: object): boolean {
+
+        return (
+            entity.hasOwnProperty("homeAccountId") &&
+            entity.hasOwnProperty("environment") &&
+            entity.hasOwnProperty("realm") &&
+            entity.hasOwnProperty("localAccountId") &&
+            entity.hasOwnProperty("username") &&
+            entity.hasOwnProperty("authorityType")
+        );
     }
 }

--- a/lib/msal-common/src/cache/entities/AppMetadataEntity.ts
+++ b/lib/msal-common/src/cache/entities/AppMetadataEntity.ts
@@ -2,16 +2,16 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { APP_META_DATA, Separators } from "../../utils/Constants";
+import { APP_METADATA, Separators } from "../../utils/Constants";
 
 /**
  * APP_META_DATA Cache
- * 
+ *
  * Key:Value Schema:
- * 
+ *
  * Key: appmetadata-<environment>-<client_id>
- * 
- * Value: 
+ *
+ * Value:
  * {
  *      clientId: client ID of the application
  *      environment: entity that issued the token, represented as a full host
@@ -27,7 +27,19 @@ export class AppMetadataEntity {
      * Generate Account Cache Key as per the schema: <home_account_id>-<environment>-<realm*>
      */
     generateAppMetaDataEntityKey(): string {
-        const appMetaDataKeyArray: Array<string> = [APP_META_DATA, this.environment, this.clientId];
+        const appMetaDataKeyArray: Array<string> = [APP_METADATA, this.environment, this.clientId];
         return appMetaDataKeyArray.join(Separators.CACHE_KEY_SEPARATOR).toLowerCase();
+    }
+
+    /**
+     * Validates an entity: checks for all expected params
+     * @param entity
+     */
+    static isAppMetadataEntity(key: string, entity: object): boolean {
+        return (
+            (key.indexOf(APP_METADATA) !== -1) &&
+            entity.hasOwnProperty("clientId") &&
+            entity.hasOwnProperty("environment")
+        );
     }
 }

--- a/lib/msal-common/src/cache/entities/CredentialEntity.ts
+++ b/lib/msal-common/src/cache/entities/CredentialEntity.ts
@@ -8,11 +8,11 @@ import { ClientAuthError } from "../../error/ClientAuthError";
 
 /**
  * Base type for credentials to be stored in the cache: eg: ACCESS_TOKEN, ID_TOKEN etc
- * 
+ *
  * Key:Value Schema:
- * 
+ *
  * Key: <home_account_id*>-<environment>-<credential_type>-<client_id>-<realm*>-<target*>
- * 
+ *
  * Value Schema:
  * {
  *      homeAccountId: home account identifier for the auth scheme,

--- a/lib/msal-common/src/cache/entities/IdTokenEntity.ts
+++ b/lib/msal-common/src/cache/entities/IdTokenEntity.ts
@@ -8,11 +8,11 @@ import { CredentialType } from "../../utils/Constants";
 
 /**
  * ID_TOKEN Cache
- * 
+ *
  * Key:Value Schema:
- * 
+ *
  * Key Example: uid.utid-login.microsoftonline.com-idtoken-clientId-contoso.com-
- * 
+ *
  * Value Schema:
  * {
  *      homeAccountId: home account identifier for the auth scheme,
@@ -50,5 +50,22 @@ export class IdTokenEntity extends CredentialEntity {
         idTokenEntity.realm = tenantId;
 
         return idTokenEntity;
+    }
+
+    /**
+     * Validates an entity: checks for all expected params
+     * @param entity
+     */
+    static isIdTokenEntity(entity: object): boolean {
+
+        return (
+            entity.hasOwnProperty("homeAccountId") &&
+            entity.hasOwnProperty("environment") &&
+            entity.hasOwnProperty("credentialType") &&
+            entity.hasOwnProperty("realm") &&
+            entity.hasOwnProperty("clientId") &&
+            entity.hasOwnProperty("secret") &&
+            entity["credentialType"] === CredentialType.ID_TOKEN
+        );
     }
 }

--- a/lib/msal-common/src/cache/entities/RefreshTokenEntity.ts
+++ b/lib/msal-common/src/cache/entities/RefreshTokenEntity.ts
@@ -8,11 +8,11 @@ import { CredentialType } from "../../utils/Constants";
 
 /**
  * REFRESH_TOKEN Cache
- * 
+ *
  * Key:Value Schema:
- * 
+ *
  * Key Example: uid.utid-login.microsoftonline.com-refreshtoken-clientId--
- * 
+ *
  * Value:
  * {
  *      homeAccountId: home account identifier for the auth scheme,
@@ -54,5 +54,21 @@ export class RefreshTokenEntity extends CredentialEntity {
             rtEntity.familyId = familyId;
 
         return rtEntity;
+    }
+
+    /**
+     * Validates an entity: checks for all expected params
+     * @param entity
+     */
+    static isRefreshTokenEntity(entity: object): boolean {
+
+        return (
+            entity.hasOwnProperty("homeAccountId") &&
+            entity.hasOwnProperty("environment") &&
+            entity.hasOwnProperty("credentialType") &&
+            entity.hasOwnProperty("clientId") &&
+            entity.hasOwnProperty("secret") &&
+            entity["credentialType"] === CredentialType.REFRESH_TOKEN
+        );
     }
 }

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -245,13 +245,13 @@ export enum CacheType {
     ACCESS_TOKEN = 2001,
     REFRESH_TOKEN = 2002,
     ID_TOKEN = 2003,
-    APP_META_DATA = 3001
+    APP_METADATA = 3001
 };
 
 /**
  * More Cache related constants
  */
-export const APP_META_DATA = "appmetadata";
+export const APP_METADATA = "appmetadata";
 export const ClientInfo = "client_info";
 
 export const SERVER_TELEM_CONSTANTS = {

--- a/lib/msal-common/test/cache/entities/AccessTokenEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccessTokenEntity.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { AccessTokenEntity } from "../../../src/cache/entities/AccessTokenEntity";
-import { mockCache } from "./cacheConstants";
+import { mockCache, mockAccessTokenEntity_1, mockAccessTokenEntity_2, mockRefreshTokenEntity } from "./cacheConstants";
 import { ClientAuthError, ClientAuthErrorMessage } from "../../../src";
 import { CacheType } from "../../../src/utils/Constants";
 
@@ -27,5 +27,14 @@ describe("AccessTokenEntity.ts Unit Tests", () => {
     it("Generate AccessTokenEntity type", () => {
         const at = mockCache.createMockATOne();
         expect(at.generateType()).to.eql(CacheType.ACCESS_TOKEN);
+    });
+
+    it("verify if an object is an access token entity", () => {
+        expect(AccessTokenEntity.isAccessTokenEntity(mockAccessTokenEntity_1)).to.eql(true);
+        expect(AccessTokenEntity.isAccessTokenEntity(mockAccessTokenEntity_2)).to.eql(true);
+    });
+
+    it("verify if an object is not an access token entity", () => {
+        expect(AccessTokenEntity.isAccessTokenEntity(mockRefreshTokenEntity)).to.eql(false);
     });
 });

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { AccountEntity } from "../../../src/cache/entities/AccountEntity";
-import { mockAccountEntity } from "./cacheConstants";
+import { mockAccountEntity, mockIdTokenEntity} from "./cacheConstants";
 import { IdToken } from "../../../src/account/IdToken";
 import { AuthorityFactory } from "../../../src/authority/AuthorityFactory";
 import { Constants } from "../../../src/utils/Constants";
@@ -94,7 +94,7 @@ describe("AccountEntity.ts Unit Tests", () => {
             Constants.DEFAULT_AUTHORITY,
             networkInterface
 		);
-        
+
         // Set up stubs
         const idTokenClaims = {
             "ver": "2.0",
@@ -118,5 +118,13 @@ describe("AccountEntity.ts Unit Tests", () => {
         );
 
         expect(acc.generateAccountKey()).to.eql(`uid.utid-login.windows.net-${idTokenClaims.tid}`);
+    });
+
+    it("verify if an object is an account entity", () => {
+        expect(AccountEntity.isAccountEntity(mockAccountEntity)).to.eql(true);
+    });
+
+    it("verify if an object is not an account entity", () => {
+        expect(AccountEntity.isAccountEntity(mockIdTokenEntity)).to.eql(false);
     });
 });

--- a/lib/msal-common/test/cache/entities/AppMetadataEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AppMetadataEntity.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { AppMetadataEntity } from "../../../src/cache/entities/AppMetadataEntity";
-import { mockAppMetaDataEntity } from "./cacheConstants";
+import { mockAppMetaDataEntity, mockIdTokenEntity } from "./cacheConstants";
+import { IdTokenEntity } from "../../../src";
 
 describe("AppMetadataEntity.ts Unit Tests", () => {
     it("Verify an AppMetadataEntity", () => {
@@ -14,5 +15,19 @@ describe("AppMetadataEntity.ts Unit Tests", () => {
         expect(appM.generateAppMetaDataEntityKey()).to.eql(
             "appmetadata-login.microsoftonline.com-mock_client_id"
         );
+    });
+
+    it("verify if an object is an appMetadata  entity", () => {
+        let appM = new AppMetadataEntity();
+        Object.assign(appM, mockAppMetaDataEntity);
+        const key = appM.generateAppMetaDataEntityKey();
+        expect(AppMetadataEntity.isAppMetadataEntity(key, mockAppMetaDataEntity)).to.eql(true);
+    });
+
+    it("verify if an object is not an appMetadata entity", () => {
+        let idT = new IdTokenEntity();
+        Object.assign(idT, mockIdTokenEntity);
+        const key = idT.generateCredentialKey();
+        expect(AppMetadataEntity.isAppMetadataEntity(key, mockIdTokenEntity)).to.eql(false);
     });
 });

--- a/lib/msal-common/test/cache/entities/IdTokenEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/IdTokenEntity.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { IdTokenEntity } from "../../../src/cache/entities/IdTokenEntity";
-import { mockIdTokenEntity } from "./cacheConstants";
+import { mockIdTokenEntity, mockAccessTokenEntity_1 } from "./cacheConstants";
 import { ClientAuthError, ClientAuthErrorMessage } from "../../../src";
 import { CacheType } from "../../../src/utils/Constants";
 
@@ -28,5 +28,13 @@ describe("IdTokenEntity.ts Unit Tests", () => {
         const idT = new IdTokenEntity();
         Object.assign(idT, mockIdTokenEntity);
         expect(idT.generateType()).to.eql(CacheType.ID_TOKEN);
+    });
+
+    it("verify if an object is an id token entity", () => {
+        expect(IdTokenEntity.isIdTokenEntity(mockIdTokenEntity)).to.eql(true);
+    });
+
+    it("verify if an object is not an id token entity", () => {
+        expect(IdTokenEntity.isIdTokenEntity(mockAccessTokenEntity_1)).to.eql(false);
     });
 });

--- a/lib/msal-common/test/cache/entities/RefreshTokenEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/RefreshTokenEntity.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { RefreshTokenEntity } from "../../../src/cache/entities/RefreshTokenEntity";
-import { mockRefreshTokenEntity, mockRefreshTokenEntityWithFamilyId } from "./cacheConstants";
+import { mockRefreshTokenEntity, mockRefreshTokenEntityWithFamilyId, mockAppMetaDataEntity } from "./cacheConstants";
 import { ClientAuthError, ClientAuthErrorMessage } from "../../../src";
 import { CacheType } from "../../../src/utils/Constants";
 
@@ -36,5 +36,14 @@ describe("RefreshTokenEntity.ts Unit Tests", () => {
         const rt = new RefreshTokenEntity();
         Object.assign(rt, mockRefreshTokenEntity);
         expect(rt.generateType()).to.eql(CacheType.REFRESH_TOKEN);
+    });
+
+    it("verify if an object is a refresh token entity", () => {
+        expect(RefreshTokenEntity.isRefreshTokenEntity(mockRefreshTokenEntity)).to.eql(true);
+        expect(RefreshTokenEntity.isRefreshTokenEntity(mockRefreshTokenEntityWithFamilyId)).to.eql(true);
+    });
+
+    it("verify if an object is not a refresh token entity", () => {
+        expect(RefreshTokenEntity.isRefreshTokenEntity(mockAppMetaDataEntity)).to.eql(false);
     });
 });


### PR DESCRIPTION
Adds validation for a cache entity. 

This is needed as `msal-browser` saves the values in the `storage` as `JSON strings` instead of `objects` and when retrieving the `values`, they need to be assigned as the object instances of the `cache entities`.

**Context:**
This PR is the first of the series of changes being made to optimize and simplify `getItem()` and `setItem()` implementations in `msal-browser` and `msal-node`