### PR TITLE
AT Proof-Of-Possession #1: Adding req_cnf to the token request

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -64,9 +64,6 @@ export class PublicClientApplication implements IPublicClientApplication {
     // Network interface implementation
     private readonly networkClient: INetworkModule;
 
-    // Response promise
-    private readonly tokenExchangePromise: Promise<AuthenticationResult>;
-
     // Input configuration by developer/user
     private config: Configuration;
 

--- a/lib/msal-browser/src/crypto/BrowserCrypto.ts
+++ b/lib/msal-browser/src/crypto/BrowserCrypto.ts
@@ -112,6 +112,7 @@ export class BrowserCrypto {
      * @param data 
      */
     private async getSubtleCryptoDigest(algorithm: string, data: Uint8Array): Promise<ArrayBuffer> {
+        console.log(algorithm);
         return window.crypto.subtle.digest(algorithm, data);
     }
 

--- a/lib/msal-browser/src/crypto/BrowserCrypto.ts
+++ b/lib/msal-browser/src/crypto/BrowserCrypto.ts
@@ -165,7 +165,6 @@ export class BrowserCrypto {
         return new Promise((resolve: any, reject: any) => {
             const msExportKey = window["msCrypto"].subtle.exportKey(format, key);
             msExportKey.addEventListener("complete", (e: { target: { result: ArrayBuffer; }; }) => {
-                // TODO: Check with Jason for details?
                 const resultBuffer: ArrayBuffer = e.target.result;
 
                 const resultString = BrowserStringUtils.utf8ArrToString(new Uint8Array(resultBuffer))

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -7,7 +7,8 @@ import { GuidGenerator } from "./GuidGenerator";
 import { Base64Encode } from "../encode/Base64Encode";
 import { Base64Decode } from "../encode/Base64Decode";
 import { PkceGenerator } from "./PkceGenerator";
-import { BrowserCrypto } from "./BrowserCrypto";
+import { BrowserCrypto, KeyFormat } from "./BrowserCrypto";
+import { BrowserStringUtils } from "../utils/BrowserStringUtils";
 
 /**
  * This class implements MSAL's crypto interface, which allows it to perform base64 encoding and decoding, generating cryptographically random GUIDs and 
@@ -21,6 +22,10 @@ export class CryptoOps implements ICrypto {
     private b64Decode: Base64Decode;
     private pkceGenerator: PkceGenerator;
 
+    private static POP_KEY_USAGES: Array<KeyUsage> = ["sign", "verify"];
+    private static EXTRACTABLE: boolean = true;
+    private static POP_HASH_LENGTH = 43; // 256 bit digest / 6 bits per char = 43
+
     constructor() {
         // Browser crypto needs to be validated first before any other classes can be set.
         this.browserCrypto = new BrowserCrypto();
@@ -28,6 +33,16 @@ export class CryptoOps implements ICrypto {
         this.b64Decode = new Base64Decode();
         this.guidGenerator = new GuidGenerator(this.browserCrypto);
         this.pkceGenerator = new PkceGenerator(this.browserCrypto);
+    }
+
+    async getPublicKeyThumprint(): Promise<string> {
+        const keyPair = await this.browserCrypto.generateKeyPair(CryptoOps.EXTRACTABLE, CryptoOps.POP_KEY_USAGES);
+        // TODO: Store keypair
+        const publicKeyJwk: JsonWebKey = await this.browserCrypto.exportKey(keyPair.publicKey, KeyFormat.jwk);
+        const publicJwkString: string = BrowserCrypto.getJwkString(publicKeyJwk);
+        const publicJwkBuffer: ArrayBuffer = await this.browserCrypto.sha256Digest(publicJwkString);
+        const publicJwkDigest: string = this.b64Encode.urlEncodeArr(new Uint8Array(publicJwkBuffer));
+        return this.base64Encode(publicJwkDigest).substr(0, CryptoOps.POP_HASH_LENGTH);
     }
 
     /**

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -7,8 +7,7 @@ import { GuidGenerator } from "./GuidGenerator";
 import { Base64Encode } from "../encode/Base64Encode";
 import { Base64Decode } from "../encode/Base64Decode";
 import { PkceGenerator } from "./PkceGenerator";
-import { BrowserCrypto, KeyFormat } from "./BrowserCrypto";
-import { BrowserStringUtils } from "../utils/BrowserStringUtils";
+import { BrowserCrypto } from "./BrowserCrypto";
 
 /**
  * This class implements MSAL's crypto interface, which allows it to perform base64 encoding and decoding, generating cryptographically random GUIDs and 
@@ -35,10 +34,10 @@ export class CryptoOps implements ICrypto {
         this.pkceGenerator = new PkceGenerator(this.browserCrypto);
     }
 
-    async getPublicKeyThumprint(): Promise<string> {
+    async getPublicKeyThumbprint(): Promise<string> {
         const keyPair = await this.browserCrypto.generateKeyPair(CryptoOps.EXTRACTABLE, CryptoOps.POP_KEY_USAGES);
         // TODO: Store keypair
-        const publicKeyJwk: JsonWebKey = await this.browserCrypto.exportKey(keyPair.publicKey, KeyFormat.jwk);
+        const publicKeyJwk: JsonWebKey = await this.browserCrypto.exportJwk(keyPair.publicKey);
         const publicJwkString: string = BrowserCrypto.getJwkString(publicKeyJwk);
         const publicJwkBuffer: ArrayBuffer = await this.browserCrypto.sha256Digest(publicJwkString);
         const publicJwkDigest: string = this.b64Encode.urlEncodeArr(new Uint8Array(publicJwkBuffer));

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -14,6 +14,7 @@ export { SilentRequest } from "./request/SilentRequest";
 
 // Common Object Formats
 export {
+    AuthenticationScheme,
     // Account
     AccountInfo,
     // Request

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1,7 +1,6 @@
-import * as Mocha from "mocha";
+import * as mocha from "mocha";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 import sinon from "sinon";

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -590,7 +590,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 			it("Uses adal token from cache if it is present.", async () => {
 				const idTokenClaims: IdTokenClaims = {
 					"iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
-					"exp": "1536279024",
+					"exp": 1536279024,
 					"name": "abeli",
 					"nonce": "123523",
 					"oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
@@ -637,7 +637,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 			it("Does not use adal token from cache if it is present and SSO params have been given.", async () => {
 				const idTokenClaims: IdTokenClaims = {
 					"iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
-					"exp": "1536279024",
+					"exp": 1536279024,
 					"name": "abeli",
 					"nonce": "123523",
 					"oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
@@ -796,7 +796,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 				const testScope = "testscope";
 				const idTokenClaims: IdTokenClaims = {
 					"iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
-					"exp": "1536279024",
+					"exp": 1536279024,
 					"name": "abeli",
 					"nonce": "123523",
 					"oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
@@ -843,7 +843,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 			it("Does not use adal token from cache if it is present and SSO params have been given.", async () => {
 				const idTokenClaims: IdTokenClaims = {
 					"iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
-					"exp": "1536279024",
+					"exp": 1536279024,
 					"name": "abeli",
 					"nonce": "123523",
 					"oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",

--- a/lib/msal-browser/test/crypto/CryptoOps.spec.ts
+++ b/lib/msal-browser/test/crypto/CryptoOps.spec.ts
@@ -7,7 +7,6 @@ import crypto from "crypto";
 import { PkceCodes } from "@azure/msal-common";
 
 describe("CryptoOps.ts Unit Tests", () => {
-
     let cryptoObj: CryptoOps;
     beforeEach(() => {
         cryptoObj = new CryptoOps();
@@ -91,5 +90,5 @@ describe("CryptoOps.ts Unit Tests", () => {
         expect(generateKeyPairSpy.calledWith(true, ["sign", "verify"]));
         expect(exportJwkSpy.calledWith((await generateKeyPairSpy.returnValues[0]).publicKey));
         expect(regExp.test(pkThumbprint)).to.be.true;
-    });
+    }).timeout(800);
 });

--- a/lib/msal-browser/test/crypto/CryptoOps.spec.ts
+++ b/lib/msal-browser/test/crypto/CryptoOps.spec.ts
@@ -90,5 +90,5 @@ describe("CryptoOps.ts Unit Tests", () => {
         expect(generateKeyPairSpy.calledWith(true, ["sign", "verify"]));
         expect(exportJwkSpy.calledWith((await generateKeyPairSpy.returnValues[0]).publicKey));
         expect(regExp.test(pkThumbprint)).to.be.true;
-    }).timeout(800);
+    }).timeout(2500);
 });

--- a/lib/msal-browser/test/encode/Base64Decode.spec.ts
+++ b/lib/msal-browser/test/encode/Base64Decode.spec.ts
@@ -67,7 +67,7 @@ describe("Base64Decode.ts Unit Tests", () => {
                 "ver": "2.0",
                 "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
                 "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-                "exp": "1536361411",
+                "exp": 1536361411,
                 "name": "Abe Lincoln",
                 "preferred_username": "AbeLi@microsoft.com",
                 "oid": "00000000-0000-0000-66f3-3332eca7ea81",

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { InteractionHandler } from "../../src/interaction_handler/InteractionHandler";
 import { PkceCodes, NetworkRequestOptions, LogLevel, AccountInfo, AuthorityFactory, AuthorizationCodeRequest, AuthenticationResult, CacheManager, AuthorizationCodeClient } from "@azure/msal-common";
 import { Configuration, buildConfiguration } from "../../src/config/Configuration";
-import { TEST_CONFIG, TEST_URIS, TEST_DATA_CLIENT_INFO, TEST_TOKENS, TEST_TOKEN_LIFETIMES, TEST_HASHES } from "../utils/StringConstants";
+import { TEST_CONFIG, TEST_URIS, TEST_DATA_CLIENT_INFO, TEST_TOKENS, TEST_TOKEN_LIFETIMES, TEST_HASHES, TEST_POP_VALUES } from "../utils/StringConstants";
 import { BrowserStorage } from "../../src/cache/BrowserStorage";
 import { BrowserAuthErrorMessage, BrowserAuthError } from "../../src/error/BrowserAuthError";
 import sinon from "sinon";
@@ -108,6 +108,9 @@ describe("InteractionHandler.ts Unit Tests", () => {
                 },
                 generatePkceCodes: async (): Promise<PkceCodes> => {
                     return testPkceCodes;
+                },
+                getPublicKeyThumbprint: async (): Promise<string> => {
+                    return TEST_POP_VALUES.ENCODED_REQ_CNF;
                 }
             },
             storageInterface: new TestStorageInterface(),

--- a/lib/msal-browser/test/interaction_handler/PopupHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/PopupHandler.spec.ts
@@ -6,7 +6,7 @@ import { PkceCodes, NetworkRequestOptions, LogLevel, AuthorityFactory, Authoriza
 import { PopupHandler } from "../../src/interaction_handler/PopupHandler";
 import { BrowserStorage } from "../../src/cache/BrowserStorage";
 import { Configuration, buildConfiguration } from "../../src/config/Configuration";
-import { TEST_CONFIG, TEST_URIS, RANDOM_TEST_GUID } from "../utils/StringConstants";
+import { TEST_CONFIG, TEST_URIS, RANDOM_TEST_GUID, TEST_POP_VALUES } from "../utils/StringConstants";
 import sinon from "sinon";
 import { InteractionHandler } from "../../src/interaction_handler/InteractionHandler";
 import { BrowserAuthErrorMessage, BrowserAuthError } from "../../src/error/BrowserAuthError";
@@ -93,6 +93,9 @@ describe("PopupHandler.ts Unit Tests", () => {
                 generatePkceCodes: async (): Promise<PkceCodes> => {
                     return testPkceCodes;
                 },
+                getPublicKeyThumbprint: async (): Promise<string> => {
+                    return TEST_POP_VALUES.ENCODED_REQ_CNF;
+                }
             },
             storageInterface: new TestStorageInterface(),
             networkInterface: {

--- a/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
@@ -5,7 +5,7 @@ const expect = chai.expect;
 import sinon from "sinon";
 import { Configuration, buildConfiguration } from "../../src/config/Configuration";
 import { PkceCodes, NetworkRequestOptions, LogLevel, AccountInfo, AuthorityFactory, AuthorizationCodeRequest, Constants, AuthenticationResult, CacheSchemaType, CacheManager, AuthorizationCodeClient } from "@azure/msal-common";
-import { TEST_CONFIG, TEST_URIS, TEST_TOKENS, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID, TEST_HASHES, TEST_TOKEN_LIFETIMES } from "../utils/StringConstants";
+import { TEST_CONFIG, TEST_URIS, TEST_TOKENS, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID, TEST_HASHES, TEST_TOKEN_LIFETIMES, TEST_POP_VALUES } from "../utils/StringConstants";
 import { BrowserStorage } from "../../src/cache/BrowserStorage";
 import { RedirectHandler } from "../../src/interaction_handler/RedirectHandler";
 import { InteractionHandler } from "../../src/interaction_handler/InteractionHandler";
@@ -73,6 +73,9 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 generatePkceCodes: async (): Promise<PkceCodes> => {
                     return testPkceCodes;
                 },
+                getPublicKeyThumbprint: async (): Promise<string> => {
+                    return TEST_POP_VALUES.ENCODED_REQ_CNF;
+                }
             },
             storageInterface: browserStorage,
             networkInterface: {

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -7,7 +7,7 @@ import sinon from "sinon";
 import { SilentHandler } from "../../src/interaction_handler/SilentHandler";
 import { BrowserStorage } from "../../src/cache/BrowserStorage";
 import { Configuration, buildConfiguration } from "../../src/config/Configuration";
-import { TEST_CONFIG, testNavUrl, TEST_URIS, RANDOM_TEST_GUID } from "../utils/StringConstants";
+import { TEST_CONFIG, testNavUrl, TEST_URIS, RANDOM_TEST_GUID, TEST_POP_VALUES } from "../utils/StringConstants";
 import { InteractionHandler } from "../../src/interaction_handler/InteractionHandler";
 import { BrowserAuthError, BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
 
@@ -94,6 +94,9 @@ describe("SilentHandler.ts Unit Tests", () => {
                 generatePkceCodes: async (): Promise<PkceCodes> => {
                     return testPkceCodes;
                 },
+                getPublicKeyThumbprint: async (): Promise<string> => {
+                    return TEST_POP_VALUES.ENCODED_REQ_CNF;
+                }
             },
             storageInterface: new TestStorageInterface(),
             networkInterface: {

--- a/lib/msal-browser/test/network/XhrClient.spec.ts
+++ b/lib/msal-browser/test/network/XhrClient.spec.ts
@@ -54,8 +54,7 @@ describe("XhrClient.ts Unit Tests", () => {
 
         it("sends headers with the requests", async () => {
             const targetUri = `${Constants.DEFAULT_AUTHORITY}/`;
-            const reqHeaders = new Map<string, string>();
-            reqHeaders.set("Content-Type", Constants.URL_FORM_CONTENT_TYPE);
+            const reqHeaders: Record<string, string> = { "Content-Type": Constants.URL_FORM_CONTENT_TYPE }
             const requestOptions: NetworkRequestOptions = {
                 body: "thisIsAPostBody",
                 headers: reqHeaders

--- a/lib/msal-browser/test/utils/StringConstants.ts
+++ b/lib/msal-browser/test/utils/StringConstants.ts
@@ -69,6 +69,12 @@ export const TEST_DATA_CLIENT_INFO = {
     TEST_HOME_ACCOUNT_ID: "MTIzLXRlc3QtdWlk.NDU2LXRlc3QtdXRpZA=="
 };
 
+export const TEST_POP_VALUES = {
+    KID: "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+    ENCODED_REQ_CNF: "eyJraWQiOiJOemJMc1hoOHVEQ2NkLTZNTndYRjRXXzdub1dYRlpBZkhreFpzUkdDOVhzIiwieG1zX2tzbCI6InN3In0=",
+    DECODED_REQ_CNF: `{"kid":"NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs","xms_ksl":"sw"}`
+};
+
 export const TEST_STATE_VALUES = {
     USER_STATE: "userState",
     TEST_TIMESTAMP: 1592846482,

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -174,7 +174,7 @@ export class AuthorizationCodeClient extends BaseClient {
         parameterBuilder.addGrantType(GrantType.AUTHORIZATION_CODE_GRANT);
         parameterBuilder.addClientInfo();
 
-        if (request.authenticationType === AuthenticationType.POP) {
+        if (request.authenticationScheme === AuthenticationType.POP) {
             const popTokenGenerator = new PopTokenGenerator(this.cryptoUtils);
             parameterBuilder.addPopToken(await popTokenGenerator.generateCnf());
         }

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -8,7 +8,7 @@ import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { Authority } from "../authority/Authority";
 import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { GrantType, AADServerParamKeys } from "../utils/Constants";
+import { GrantType, AADServerParamKeys, AuthenticationType } from "../utils/Constants";
 import { ClientConfiguration } from "../config/ClientConfiguration";
 import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
 import { NetworkResponse } from "../network/NetworkManager";
@@ -22,6 +22,7 @@ import { ServerAuthorizationCodeResponse } from "../response/ServerAuthorization
 import { AccountEntity } from "../cache/entities/AccountEntity";
 import { EndSessionRequest } from "../request/EndSessionRequest";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
+import { PopTokenGenerator } from "../crypto/PopTokenGenerator";
 
 /**
  * Oauth2.0 Authorization Code client
@@ -131,7 +132,7 @@ export class AuthorizationCodeClient extends BaseClient {
      * @param request
      */
     private async executeTokenRequest(authority: Authority, request: AuthorizationCodeRequest): Promise<NetworkResponse<ServerAuthorizationTokenResponse>> {
-        const requestBody = this.createTokenRequestBody(request);
+        const requestBody = await this.createTokenRequestBody(request);
         const headers: Record<string, string> = this.createDefaultTokenRequestHeaders();
 
         return this.executePostToTokenEndpoint(authority.tokenEndpoint, requestBody, headers);
@@ -141,7 +142,7 @@ export class AuthorizationCodeClient extends BaseClient {
      * Generates a map for all the params to be sent to the service
      * @param request
      */
-    private createTokenRequestBody(request: AuthorizationCodeRequest): string {
+    private async createTokenRequestBody(request: AuthorizationCodeRequest): Promise<string> {
         const parameterBuilder = new RequestParameterBuilder();
 
         parameterBuilder.addClientId(this.config.authOptions.clientId);
@@ -172,6 +173,11 @@ export class AuthorizationCodeClient extends BaseClient {
 
         parameterBuilder.addGrantType(GrantType.AUTHORIZATION_CODE_GRANT);
         parameterBuilder.addClientInfo();
+
+        if (request.authenticationType === AuthenticationType.POP) {
+            const popTokenGenerator = new PopTokenGenerator(this.cryptoUtils);
+            parameterBuilder.addPopToken(await popTokenGenerator.generateCnf());
+        }
 
         const correlationId = request.correlationId || this.config.cryptoInterface.createNewGuid();
         parameterBuilder.addCorrelationId(correlationId);

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -8,7 +8,7 @@ import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { Authority } from "../authority/Authority";
 import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { GrantType, AADServerParamKeys, AuthenticationType } from "../utils/Constants";
+import { GrantType, AADServerParamKeys, AuthenticationScheme } from "../utils/Constants";
 import { ClientConfiguration } from "../config/ClientConfiguration";
 import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
 import { NetworkResponse } from "../network/NetworkManager";
@@ -174,9 +174,10 @@ export class AuthorizationCodeClient extends BaseClient {
         parameterBuilder.addGrantType(GrantType.AUTHORIZATION_CODE_GRANT);
         parameterBuilder.addClientInfo();
 
-        if (request.authenticationScheme === AuthenticationType.POP) {
+        if (request.authenticationScheme === AuthenticationScheme.POP) {
             const popTokenGenerator = new PopTokenGenerator(this.cryptoUtils);
-            parameterBuilder.addPopToken(await popTokenGenerator.generateCnf());
+            const cnfString = await popTokenGenerator.generateCnf();
+            parameterBuilder.addPopToken(cnfString);
         }
 
         const correlationId = request.correlationId || this.config.cryptoInterface.createNewGuid();

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -145,6 +145,10 @@ const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
     async generatePkceCodes(): Promise<PkceCodes> {
         const notImplErr = "Crypto interface - generatePkceCodes() has not been implemented";
         throw AuthError.createUnexpectedError(notImplErr);
+    },
+    async getPublicKeyThumprint(): Promise<string> {
+        const notImplErr = "Crypto interface - getPublicKeyThumprint() has not been implemented";
+        throw AuthError.createUnexpectedError(notImplErr);
     }
 };
 

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -146,8 +146,8 @@ const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
         const notImplErr = "Crypto interface - generatePkceCodes() has not been implemented";
         throw AuthError.createUnexpectedError(notImplErr);
     },
-    async getPublicKeyThumprint(): Promise<string> {
-        const notImplErr = "Crypto interface - getPublicKeyThumprint() has not been implemented";
+    async getPublicKeyThumbprint(): Promise<string> {
+        const notImplErr = "Crypto interface - getPublicKeyThumbprint() has not been implemented";
         throw AuthError.createUnexpectedError(notImplErr);
     }
 };

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -38,5 +38,5 @@ export interface ICrypto {
     /**
      * Generates an JWK RSA S256 Thumbprint
      */
-    generatePoPThumbprint(): Promise<string>;
+    getPublicKeyThumprint(): Promise<string>;
 }

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -38,5 +38,5 @@ export interface ICrypto {
     /**
      * Generates an JWK RSA S256 Thumbprint
      */
-    getPublicKeyThumprint(): Promise<string>;
+    getPublicKeyThumbprint(): Promise<string>;
 }

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -35,4 +35,8 @@ export interface ICrypto {
      * Generate PKCE codes for OAuth. See RFC here: https://tools.ietf.org/html/rfc7636
      */
     generatePkceCodes(): Promise<PkceCodes>;
+    /**
+     * Generates an JWK RSA S256 Thumbprint
+     */
+    generatePoPThumbprint(): Promise<string>;
 }

--- a/lib/msal-common/src/crypto/PopTokenGenerator.ts
+++ b/lib/msal-common/src/crypto/PopTokenGenerator.ts
@@ -1,0 +1,36 @@
+import { ICrypto } from "./ICrypto";
+
+/**
+ * See eSTS docs for more info.
+ * - A kid element, with the value containing an RFC 7638-compliant JWK thumbprint that is base64 encoded.
+ * -  xms_ksl element, representing the storage location of the key's secret component on the client device. One of two values:
+ *      - sw: software storage
+ *      - uhw: hardware storage
+ */
+type ReqCnf = {
+    kid: string;
+    xms_ksl: KeyLocation;
+};
+
+enum KeyLocation {
+    SW = "sw",
+    UHW = "uhw"
+}
+
+export class PopTokenGenerator {
+
+    private cryptoUtils: ICrypto;
+
+    constructor(cryptoUtils: ICrypto) {
+        this.cryptoUtils = cryptoUtils;
+    }
+
+    async generateCnf(): Promise<string> {
+        const reqCnf: ReqCnf = {
+            kid: await this.cryptoUtils.generatePoPThumbprint(),
+            xms_ksl: KeyLocation.SW
+        };
+
+        return this.cryptoUtils.base64Encode(JSON.stringify(reqCnf));
+    }
+}

--- a/lib/msal-common/src/crypto/PopTokenGenerator.ts
+++ b/lib/msal-common/src/crypto/PopTokenGenerator.ts
@@ -26,8 +26,9 @@ export class PopTokenGenerator {
     }
 
     async generateCnf(): Promise<string> {
+        const kidThumbprint = await this.cryptoUtils.getPublicKeyThumbprint();
         const reqCnf: ReqCnf = {
-            kid: await this.cryptoUtils.getPublicKeyThumprint(),
+            kid: kidThumbprint,
             xms_ksl: KeyLocation.SW
         };
 

--- a/lib/msal-common/src/crypto/PopTokenGenerator.ts
+++ b/lib/msal-common/src/crypto/PopTokenGenerator.ts
@@ -27,7 +27,7 @@ export class PopTokenGenerator {
 
     async generateCnf(): Promise<string> {
         const reqCnf: ReqCnf = {
-            kid: await this.cryptoUtils.generatePoPThumbprint(),
+            kid: await this.cryptoUtils.getPublicKeyThumprint(),
             xms_ksl: KeyLocation.SW
         };
 

--- a/lib/msal-common/src/crypto/PopTokenGenerator.ts
+++ b/lib/msal-common/src/crypto/PopTokenGenerator.ts
@@ -31,7 +31,6 @@ export class PopTokenGenerator {
             kid: kidThumbprint,
             xms_ksl: KeyLocation.SW
         };
-
         return this.cryptoUtils.base64Encode(JSON.stringify(reqCnf));
     }
 }

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -51,7 +51,7 @@ export { ServerError } from "./error/ServerError";
 export { ClientAuthError, ClientAuthErrorMessage } from "./error/ClientAuthError";
 export { ClientConfigurationError, ClientConfigurationErrorMessage } from "./error/ClientConfigurationError";
 // Constants and Utils
-export { Constants, PromptValue, PersistentCacheKeys, ResponseMode, CacheSchemaType, CredentialType } from "./utils/Constants";
+export { Constants, PromptValue, PersistentCacheKeys, ResponseMode, CacheSchemaType, CredentialType, AuthenticationScheme } from "./utils/Constants";
 export { StringUtils } from "./utils/StringUtils";
 export { StringDict } from "./utils/MsalTypes";
 export { ProtocolUtils, RequestStateObject, LibraryStateObject } from "./utils/ProtocolUtils";

--- a/lib/msal-common/src/request/AuthorizationCodeRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationCodeRequest.ts
@@ -4,7 +4,7 @@
  */
 
 import { BaseAuthRequest } from "./BaseAuthRequest";
-import { AuthenticationType } from "../utils/Constants";
+import { AuthenticationScheme } from "../utils/Constants";
 
 /**
  * Request object passed by user to acquire a token from the server exchanging a valid authorization code (second leg of OAuth2.0 Authorization Code flow)
@@ -20,5 +20,5 @@ export type AuthorizationCodeRequest = BaseAuthRequest & {
     redirectUri: string;
     code: string;
     codeVerifier?: string;
-    authenticationScheme?: AuthenticationType;
+    authenticationScheme?: AuthenticationScheme;
 };

--- a/lib/msal-common/src/request/AuthorizationCodeRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationCodeRequest.ts
@@ -20,5 +20,5 @@ export type AuthorizationCodeRequest = BaseAuthRequest & {
     redirectUri: string;
     code: string;
     codeVerifier?: string;
-    authenticationType?: AuthenticationType;
+    authenticationScheme?: AuthenticationType;
 };

--- a/lib/msal-common/src/request/AuthorizationCodeRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationCodeRequest.ts
@@ -4,6 +4,7 @@
  */
 
 import { BaseAuthRequest } from "./BaseAuthRequest";
+import { AuthenticationType } from "../utils/Constants";
 
 /**
  * Request object passed by user to acquire a token from the server exchanging a valid authorization code (second leg of OAuth2.0 Authorization Code flow)
@@ -19,4 +20,5 @@ export type AuthorizationCodeRequest = BaseAuthRequest & {
     redirectUri: string;
     code: string;
     codeVerifier?: string;
+    authenticationType?: AuthenticationType;
 };

--- a/lib/msal-common/src/request/AuthorizationCodeRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationCodeRequest.ts
@@ -13,6 +13,7 @@ import { AuthenticationScheme } from "../utils/Constants";
  * - authority:              - URL of the authority, the security token service (STS) from which MSAL will acquire tokens. If authority is set on client application object, this will override that value. Overriding the value will cause for authority validation to happen each time. If the same authority will be used for all request, set on the application object instead of the requests.
  * - correlationId           - Unique GUID set per request to trace a request end-to-end for telemetry purposes.
  * - redirectUri             - The redirect URI of your app, where the authority will redirect to after the user inputs credentials and consents. It must exactly match one of the redirect URIs you registered in the portal.
+ * - authenticationScheme       - The type of token retrieved. Defaults to "Bearer". Can also be type "pop".
  * - code                    - The authorization_code that the user acquired in the first leg of the flow.
  * - codeVerifier            - The same code_verifier that was used to obtain the authorization_code. Required if PKCE was used in the authorization code grant request.For more information, see the PKCE RFC: https://tools.ietf.org/html/rfc7636
  */

--- a/lib/msal-common/src/request/AuthorizationUrlRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationUrlRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ResponseMode, AuthenticationType } from "../utils/Constants";
+import { ResponseMode, AuthenticationScheme } from "../utils/Constants";
 import { StringDict } from "../utils/MsalTypes";
 import { BaseAuthRequest } from "./BaseAuthRequest";
 
@@ -32,7 +32,7 @@ import { BaseAuthRequest } from "./BaseAuthRequest";
  * - nonce                      - A value included in the request that is returned in the id token. A randomly generated unique value is typically used to mitigate replay attacks.
  */
 export type AuthorizationUrlRequest = BaseAuthRequest & {
-    authenticationScheme?: AuthenticationType,
+    authenticationScheme?: AuthenticationScheme,
     redirectUri?: string;
     extraScopesToConsent?: Array<string>;
     responseMode?: ResponseMode;

--- a/lib/msal-common/src/request/AuthorizationUrlRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationUrlRequest.ts
@@ -32,7 +32,7 @@ import { BaseAuthRequest } from "./BaseAuthRequest";
  * - nonce                      - A value included in the request that is returned in the id token. A randomly generated unique value is typically used to mitigate replay attacks.
  */
 export type AuthorizationUrlRequest = BaseAuthRequest & {
-    authenticationType?: AuthenticationType,
+    authenticationScheme?: AuthenticationType,
     redirectUri?: string;
     extraScopesToConsent?: Array<string>;
     responseMode?: ResponseMode;

--- a/lib/msal-common/src/request/AuthorizationUrlRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationUrlRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ResponseMode } from "../utils/Constants";
+import { ResponseMode, AuthenticationType } from "../utils/Constants";
 import { StringDict } from "../utils/MsalTypes";
 import { BaseAuthRequest } from "./BaseAuthRequest";
 
@@ -32,6 +32,7 @@ import { BaseAuthRequest } from "./BaseAuthRequest";
  * - nonce                      - A value included in the request that is returned in the id token. A randomly generated unique value is typically used to mitigate replay attacks.
  */
 export type AuthorizationUrlRequest = BaseAuthRequest & {
+    authenticationType?: AuthenticationType,
     redirectUri?: string;
     extraScopesToConsent?: Array<string>;
     responseMode?: ResponseMode;

--- a/lib/msal-common/src/request/AuthorizationUrlRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationUrlRequest.ts
@@ -10,6 +10,7 @@ import { BaseAuthRequest } from "./BaseAuthRequest";
 /**
  * Request object passed by user to retrieve a Code from the server (first leg of authorization code grant flow)
  * 
+ * - authenticationScheme       - The type of token retrieved. Defaults to "Bearer". Can also be type "pop".
  * - scopes                     - Array of scopes the application is requesting access to.
  * - authority                  - Url of the authority which the application acquires tokens from.
  * - correlationId              - Unique GUID set per request to trace a request end-to-end for telemetry purposes.

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -3,7 +3,7 @@
 * Licensed under the MIT License.
 */
 
-import { AADServerParamKeys, Constants, ResponseMode, SSOTypes, ClientInfo, AuthenticationType } from "../utils/Constants";
+import { AADServerParamKeys, Constants, ResponseMode, SSOTypes, ClientInfo, AuthenticationScheme } from "../utils/Constants";
 import { ScopeSet } from "./ScopeSet";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
 import { StringDict } from "../utils/MsalTypes";
@@ -249,9 +249,9 @@ export class RequestParameterBuilder {
      * add pop_jwk to query params
      * @param cnfString 
      */
-    addPopToken(cnfString: string) {
+    addPopToken(cnfString: string): void {
         if (!StringUtils.isEmpty(cnfString)) {
-            this.parameters.set(AADServerParamKeys.TOKEN_TYPE, AuthenticationType.POP);
+            this.parameters.set(AADServerParamKeys.TOKEN_TYPE, AuthenticationScheme.POP);
             this.parameters.set(AADServerParamKeys.REQ_CNF, encodeURIComponent(cnfString));
         }
     }

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -3,7 +3,7 @@
 * Licensed under the MIT License.
 */
 
-import { AADServerParamKeys, Constants, ResponseMode, SSOTypes, ClientInfo } from "../utils/Constants";
+import { AADServerParamKeys, Constants, ResponseMode, SSOTypes, ClientInfo, AuthenticationType } from "../utils/Constants";
 import { ScopeSet } from "./ScopeSet";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
 import { StringDict } from "../utils/MsalTypes";
@@ -243,6 +243,17 @@ export class RequestParameterBuilder {
         Object.keys(eQparams).forEach((key) => {
             this.parameters.set(key, eQparams[key]);
         });
+    }
+
+    /**
+     * add pop_jwk to query params
+     * @param cnfString 
+     */
+    addPopToken(cnfString: string) {
+        if (!StringUtils.isEmpty(cnfString)) {
+            this.parameters.set(AADServerParamKeys.TOKEN_TYPE, AuthenticationType.POP);
+            this.parameters.set(AADServerParamKeys.REQ_CNF, encodeURIComponent(cnfString));
+        }
     }
 
     /**

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -267,7 +267,7 @@ export const SERVER_TELEM_CONSTANTS = {
 /**
  * Type of the authentication request
  */
-export enum AuthenticationType {
+export enum AuthenticationScheme {
     POP = "pop",
     BEARER = "bearer"
 };

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -269,5 +269,5 @@ export const SERVER_TELEM_CONSTANTS = {
  */
 export enum AuthenticationScheme {
     POP = "pop",
-    BEARER = "bearer"
+    BEARER = "Bearer"
 };

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -102,6 +102,8 @@ export enum AADServerParamKeys {
     CLIENT_SECRET = "client_secret",
     CLIENT_ASSERTION = "client_assertion",
     CLIENT_ASSERTION_TYPE = "client_assertion_type",
+    TOKEN_TYPE = "token_type",
+    REQ_CNF = "req_cnf"
 }
 
 /**
@@ -260,4 +262,12 @@ export const SERVER_TELEM_CONSTANTS = {
     CACHE_KEY: "server-telemetry",
     CATEGORY_SEPARATOR: "|",
     VALUE_SEPARATOR: ","
+};
+
+/**
+ * Type of the authentication request
+ */
+export enum AuthenticationType {
+    POP = "pop",
+    BEARER = "bearer"
 };

--- a/lib/msal-common/test/account/ClientInfo.spec.ts
+++ b/lib/msal-common/test/account/ClientInfo.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { buildClientInfo } from "../../src/account/ClientInfo";
-import { TEST_CONFIG, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID } from "../utils/StringConstants";
+import { TEST_CONFIG, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID, TEST_POP_VALUES } from "../utils/StringConstants";
 import { PkceCodes, ICrypto } from "../../src/crypto/ICrypto";
 import sinon from "sinon";
 import { ClientAuthError, ClientAuthErrorMessage } from "../../src";
@@ -16,6 +16,8 @@ describe("ClientInfo.ts Class Unit Tests", () => {
                 },
                 base64Decode(input: string): string {
                     switch (input) {
+                        case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                            return TEST_POP_VALUES.DECODED_REQ_CNF;
                         case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
                             return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
                         default:
@@ -28,8 +30,8 @@ describe("ClientInfo.ts Class Unit Tests", () => {
                             return "MTIzLXRlc3QtdWlk";
                         case "456-test-uid":
                             return "NDU2LXRlc3QtdWlk";
-                        case "456-test-utid":
-                            return "NDU2LXRlc3QtdXRpZA==";
+                        case TEST_POP_VALUES.DECODED_REQ_CNF:
+                            return TEST_POP_VALUES.ENCODED_REQ_CNF;
                         default:
                             return input;
                     }
@@ -39,6 +41,9 @@ describe("ClientInfo.ts Class Unit Tests", () => {
                         challenge: TEST_CONFIG.TEST_CHALLENGE,
                         verifier: TEST_CONFIG.TEST_VERIFIER
                     }
+                },
+                async getPublicKeyThumbprint(): Promise<string> {
+                    return TEST_POP_VALUES.KID;
                 }
             };
         });

--- a/lib/msal-common/test/account/IdToken.spec.ts
+++ b/lib/msal-common/test/account/IdToken.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { IdToken } from "../../src/account/IdToken";
-import { TEST_CONFIG, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID, TEST_TOKENS, TEST_URIS } from "../utils/StringConstants";
+import { TEST_CONFIG, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID, TEST_TOKENS, TEST_URIS, TEST_POP_VALUES } from "../utils/StringConstants";
 import { PkceCodes, ICrypto } from "../../src/crypto/ICrypto";
 import sinon from "sinon";
 import { ClientAuthErrorMessage, ClientAuthError, StringUtils } from "../../src";
@@ -11,7 +11,7 @@ const idTokenClaims = {
     "ver": "2.0",
     "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
     "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-    "exp": "1536361411",
+    "exp": 1536361411,
     "name": "Abe Lincoln",
     "preferred_username": "AbeLi@microsoft.com",
     "oid": "00000000-0000-0000-66f3-3332eca7ea81",
@@ -31,6 +31,8 @@ describe("IdToken.ts Class Unit Tests", () => {
                 },
                 base64Decode(input: string): string {
                     switch (input) {
+                        case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                            return TEST_POP_VALUES.DECODED_REQ_CNF;
                         case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
                             return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
                         case testTokenPayload:
@@ -45,8 +47,8 @@ describe("IdToken.ts Class Unit Tests", () => {
                             return "MTIzLXRlc3QtdWlk";
                         case "456-test-uid":
                             return "NDU2LXRlc3QtdWlk";
-                        case "456-test-utid":
-                            return "NDU2LXRlc3QtdXRpZA==";
+                        case TEST_POP_VALUES.DECODED_REQ_CNF:
+                            return TEST_POP_VALUES.ENCODED_REQ_CNF;
                         default:
                             return input;
                     }
@@ -56,6 +58,9 @@ describe("IdToken.ts Class Unit Tests", () => {
                         challenge: TEST_CONFIG.TEST_CHALLENGE,
                         verifier: TEST_CONFIG.TEST_VERIFIER
                     }
+                },
+                async getPublicKeyThumbprint(): Promise<string> {
+                    return TEST_POP_VALUES.KID;
                 }
             };
         });

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -12,7 +12,6 @@ import { ClientConfigurationErrorMessage, ClientConfigurationError } from "../..
 import { ClientAuthErrorMessage } from "../../src";
 import { ClientTestUtils } from "../client/ClientTestUtils";
 import { TrustedAuthority } from "../../src/authority/TrustedAuthority";
-import { hostname } from "os";
 
 describe("Authority.ts Class Unit Tests", () => {
     afterEach(() => {

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -6,7 +6,7 @@ import { AuthorityFactory } from "../../../src/authority/AuthorityFactory";
 import { Constants } from "../../../src/utils/Constants";
 import { NetworkRequestOptions, INetworkModule } from "../../../src/network/INetworkModule";
 import { ICrypto, PkceCodes } from "../../../src/crypto/ICrypto";
-import { RANDOM_TEST_GUID, TEST_DATA_CLIENT_INFO, TEST_CONFIG, TEST_TOKENS, TEST_URIS } from "../../utils/StringConstants";
+import { RANDOM_TEST_GUID, TEST_DATA_CLIENT_INFO, TEST_CONFIG, TEST_TOKENS, TEST_URIS, TEST_POP_VALUES } from "../../utils/StringConstants";
 import sinon from "sinon";
 import { ClientAuthError, ClientAuthErrorMessage } from "../../../src";
 import { ClientTestUtils } from "../../client/ClientTestUtils";
@@ -52,6 +52,8 @@ describe("AccountEntity.ts Unit Tests", () => {
             },
             base64Decode(input: string): string {
                 switch (input) {
+                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        return TEST_POP_VALUES.DECODED_REQ_CNF;
                     case TEST_DATA_CLIENT_INFO.TEST_CACHE_RAW_CLIENT_INFO:
                         return TEST_DATA_CLIENT_INFO.TEST_CACHE_DECODED_CLIENT_INFO;
                     default:
@@ -60,6 +62,8 @@ describe("AccountEntity.ts Unit Tests", () => {
             },
             base64Encode(input: string): string {
                 switch (input) {
+                    case TEST_POP_VALUES.DECODED_REQ_CNF:
+                        TEST_POP_VALUES.ENCODED_REQ_CNF;
                     case "uid":
                         return "dWlk";
                     case "utid":
@@ -74,6 +78,9 @@ describe("AccountEntity.ts Unit Tests", () => {
                     verifier: TEST_CONFIG.TEST_VERIFIER,
                 };
             },
+            async getPublicKeyThumbprint(): Promise<string> {
+                return TEST_POP_VALUES.KID;
+            }
         };
 
         const networkInterface: INetworkModule = {
@@ -100,7 +107,7 @@ describe("AccountEntity.ts Unit Tests", () => {
             "ver": "2.0",
             "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
             "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-            "exp": "1536361411",
+            "exp": 1536361411,
             "name": "Abe Lincoln",
             "preferred_username": "AbeLi@microsoft.com",
             "oid": "00000000-0000-0000-66f3-3332eca7ea81",

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -1,7 +1,9 @@
 import * as Mocha from "mocha";
-import { expect } from "chai";
+import * as chai from "chai";
 import sinon from "sinon";
 import chaiAsPromised from "chai-as-promised";
+const expect = chai.expect;
+chai.use(chaiAsPromised);
 import {
     Authority,
     AuthorizationCodeClient,
@@ -25,11 +27,13 @@ import {
     TEST_URIS,
     TEST_DATA_CLIENT_INFO,
     RANDOM_TEST_GUID,
-    TEST_STATE_VALUES
+    TEST_STATE_VALUES,
+    TEST_POP_VALUES,
+    POP_AUTHENTICATION_RESULT
 } from "../utils/StringConstants";
 import { ClientConfiguration } from "../../src/config/ClientConfiguration";
 import { BaseClient } from "../../src/client/BaseClient";
-import { AADServerParamKeys, PromptValue, ResponseMode, SSOTypes } from "../../src/utils/Constants";
+import { AADServerParamKeys, PromptValue, ResponseMode, SSOTypes, AuthenticationScheme } from "../../src/utils/Constants";
 import { ClientTestUtils, MockStorageClass } from "./ClientTestUtils";
 
 describe("AuthorizationCodeClient unit tests", () => {
@@ -199,6 +203,8 @@ describe("AuthorizationCodeClient unit tests", () => {
                 switch (input) {
                     case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
                         return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        return TEST_POP_VALUES.DECODED_REQ_CNF;
                     default:
                         return input;
                 }
@@ -209,6 +215,8 @@ describe("AuthorizationCodeClient unit tests", () => {
                         return "MTIzLXRlc3QtdWlk";
                     case "456-test-utid":
                         return "NDU2LXRlc3QtdXRpZA==";
+                    case TEST_POP_VALUES.DECODED_REQ_CNF:
+                        return TEST_POP_VALUES.ENCODED_REQ_CNF;
                     default:
                         return input;
                 }
@@ -226,6 +234,8 @@ describe("AuthorizationCodeClient unit tests", () => {
                 switch (input) {
                     case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
                         return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        return TEST_POP_VALUES.DECODED_REQ_CNF;
                     default:
                         return input;
                 }
@@ -236,6 +246,8 @@ describe("AuthorizationCodeClient unit tests", () => {
                         return "MTIzLXRlc3QtdWlk";
                     case "456-test-utid":
                         return "NDU2LXRlc3QtdXRpZA==";
+                    case TEST_POP_VALUES.DECODED_REQ_CNF:
+                        return TEST_POP_VALUES.ENCODED_REQ_CNF;
                     default:
                         return input;
                 }
@@ -290,11 +302,14 @@ describe("AuthorizationCodeClient unit tests", () => {
             const createTokenRequestBodySpy = sinon.spy(AuthorizationCodeClient.prototype, <any>"createTokenRequestBody");
 
             const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+
             // Set up required objects and mocked return values
             const testState = `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9${Constants.RESOURCE_DELIM}userState`;
             const decodedLibState = `{ "id": "testid", "ts": 1592846482 }`;
             config.cryptoInterface.base64Decode = (input: string): string => {
                 switch (input) {
+                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        return TEST_POP_VALUES.DECODED_REQ_CNF;
                     case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
                         return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
                     case `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9`:
@@ -306,6 +321,8 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             config.cryptoInterface.base64Encode = (input: string): string => {
                 switch (input) {
+                    case TEST_POP_VALUES.DECODED_REQ_CNF:
+                        return TEST_POP_VALUES.ENCODED_REQ_CNF;
                     case "123-test-uid":
                         return "MTIzLXRlc3QtdWlk";
                     case "456-test-utid":
@@ -321,7 +338,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 "ver": "2.0",
                 "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
                 "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-                "exp": "1536361411",
+                "exp": 1536361411,
                 "name": "Abe Lincoln",
                 "preferred_username": "AbeLi@microsoft.com",
                 "oid": "00000000-0000-0000-66f3-3332eca7ea81",
@@ -343,14 +360,89 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(authenticationResult.accessToken).to.deep.eq(AUTHENTICATION_RESULT.body.access_token);
             expect((Date.now() + (AUTHENTICATION_RESULT.body.expires_in * 1000)) >= authenticationResult.expiresOn.getMilliseconds()).to.be.true;
             expect(createTokenRequestBodySpy.calledWith(authCodeRequest)).to.be.ok;
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.SCOPE}=${TEST_CONFIG.DEFAULT_GRAPH_SCOPE}%20${Constants.OPENID_SCOPE}%20${Constants.PROFILE_SCOPE}%20${Constants.OFFLINE_ACCESS_SCOPE}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.REDIRECT_URI}=${encodeURIComponent(TEST_URIS.TEST_REDIRECT_URI_LOCALHOST)}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.CODE}=${TEST_TOKENS.AUTHORIZATION_CODE}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.GRANT_TYPE}=${Constants.CODE_GRANT_TYPE}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.CODE_VERIFIER}=${TEST_CONFIG.TEST_VERIFIER}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.CLIENT_SECRET}=${TEST_CONFIG.MSAL_CLIENT_SECRET}`);
+        });
 
-            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.SCOPE}=${TEST_CONFIG.DEFAULT_GRAPH_SCOPE}%20${Constants.OPENID_SCOPE}%20${Constants.PROFILE_SCOPE}%20${Constants.OFFLINE_ACCESS_SCOPE}`);
-            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`);
-            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.REDIRECT_URI}=${encodeURIComponent(TEST_URIS.TEST_REDIRECT_URI_LOCALHOST)}`);
-            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CODE}=${TEST_TOKENS.AUTHORIZATION_CODE}`);
-            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.GRANT_TYPE}=${Constants.CODE_GRANT_TYPE}`);
-            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CODE_VERIFIER}=${TEST_CONFIG.TEST_VERIFIER}`);
-            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLIENT_SECRET}=${TEST_CONFIG.MSAL_CLIENT_SECRET}`);
+        it("Sends the required parameters when a pop token is requested", async () => {
+            sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
+            sinon.stub(AuthorizationCodeClient.prototype, <any>"executePostToTokenEndpoint").resolves(POP_AUTHENTICATION_RESULT);
+            const createTokenRequestBodySpy = sinon.spy(AuthorizationCodeClient.prototype, <any>"createTokenRequestBody");
+
+            const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+
+            // Set up required objects and mocked return values
+            const testState = `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9${Constants.RESOURCE_DELIM}userState`;
+            const decodedLibState = `{ "id": "testid", "ts": 1592846482 }`;
+            config.cryptoInterface.base64Decode = (input: string): string => {
+                switch (input) {
+                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        return TEST_POP_VALUES.DECODED_REQ_CNF;
+                    case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
+                        return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    case `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9`:
+                        return decodedLibState;
+                    default:
+                        return input;
+                }
+            };
+
+            config.cryptoInterface.base64Encode = (input: string): string => {
+                switch (input) {
+                    case TEST_POP_VALUES.DECODED_REQ_CNF:
+                        return TEST_POP_VALUES.ENCODED_REQ_CNF;
+                    case "123-test-uid":
+                        return "MTIzLXRlc3QtdWlk";
+                    case "456-test-utid":
+                        return "NDU2LXRlc3QtdXRpZA==";
+                    case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
+                        return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    default:
+                        return input;
+                }
+            };
+            // Set up stubs
+            const idTokenClaims = {
+                "ver": "2.0",
+                "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
+                "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                "exp": 1536361411,
+                "name": "Abe Lincoln",
+                "preferred_username": "AbeLi@microsoft.com",
+                "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+                "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+                "nonce": "123523",
+            };
+            sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
+            const client = new AuthorizationCodeClient(config);
+            const authCodeRequest: AuthorizationCodeRequest = {
+                authenticationScheme: AuthenticationScheme.POP,
+                authority: Constants.DEFAULT_AUTHORITY,
+                scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE, ...TEST_CONFIG.DEFAULT_SCOPES],
+                redirectUri: TEST_URIS.TEST_REDIRECT_URI_LOCALHOST,
+                code: TEST_TOKENS.AUTHORIZATION_CODE,
+                codeVerifier: TEST_CONFIG.TEST_VERIFIER
+            };
+
+            const authenticationResult = await client.acquireToken(authCodeRequest, idTokenClaims.nonce, testState);
+
+            expect(authenticationResult.accessToken).to.deep.eq(POP_AUTHENTICATION_RESULT.body.access_token);
+            expect((Date.now() + (POP_AUTHENTICATION_RESULT.body.expires_in * 1000)) >= authenticationResult.expiresOn.getMilliseconds()).to.be.true;
+            expect(createTokenRequestBodySpy.calledWith(authCodeRequest)).to.be.ok;
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.SCOPE}=${TEST_CONFIG.DEFAULT_GRAPH_SCOPE}%20${Constants.OPENID_SCOPE}%20${Constants.PROFILE_SCOPE}%20${Constants.OFFLINE_ACCESS_SCOPE}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.REDIRECT_URI}=${encodeURIComponent(TEST_URIS.TEST_REDIRECT_URI_LOCALHOST)}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.CODE}=${TEST_TOKENS.AUTHORIZATION_CODE}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.GRANT_TYPE}=${Constants.CODE_GRANT_TYPE}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.CODE_VERIFIER}=${TEST_CONFIG.TEST_VERIFIER}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.CLIENT_SECRET}=${TEST_CONFIG.MSAL_CLIENT_SECRET}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.TOKEN_TYPE}=${AuthenticationScheme.POP}`);
+            await expect(createTokenRequestBodySpy.returnValues[0]).to.eventually.contain(`${AADServerParamKeys.REQ_CNF}=${encodeURIComponent(TEST_POP_VALUES.ENCODED_REQ_CNF)}`);
         });
     });
 

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -1,5 +1,5 @@
 import { ClientConfiguration, Constants, LogLevel, NetworkRequestOptions, PkceCodes, ClientAuthError} from "../../src";
-import { RANDOM_TEST_GUID, TEST_CONFIG } from "../utils/StringConstants";
+import { RANDOM_TEST_GUID, TEST_CONFIG, TEST_POP_VALUES } from "../utils/StringConstants";
 import { AuthorityFactory } from "../../src";
 import { TrustedAuthority } from "../../src/authority/TrustedAuthority";
 import sinon from "sinon";
@@ -81,10 +81,20 @@ export class ClientTestUtils {
                     return RANDOM_TEST_GUID;
                 },
                 base64Decode(input: string): string {
-                    return input;
+                    switch (input) {
+                        case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                            return TEST_POP_VALUES.DECODED_REQ_CNF;
+                        default:
+                            return input;
+                    }
                 },
                 base64Encode(input: string): string {
-                    return input;
+                    switch (input) {
+                        case TEST_POP_VALUES.DECODED_REQ_CNF:
+                            return TEST_POP_VALUES.ENCODED_REQ_CNF;
+                        default:
+                            return input;
+                    }
                 },
                 async generatePkceCodes(): Promise<PkceCodes> {
                     return {
@@ -92,6 +102,9 @@ export class ClientTestUtils {
                         verifier: TEST_CONFIG.TEST_VERIFIER,
                     };
                 },
+                async getPublicKeyThumbprint(): Promise<string> {
+                    return TEST_POP_VALUES.KID;
+                }
             },
             loggerOptions: {
                 loggerCallback: testLoggerCallback,

--- a/lib/msal-common/test/client/DeviceCodeClient.spec.ts
+++ b/lib/msal-common/test/client/DeviceCodeClient.spec.ts
@@ -16,7 +16,8 @@ import {
     DEVICE_CODE_RESPONSE,
     TEST_CONFIG,
     TEST_DATA_CLIENT_INFO,
-    TEST_URIS
+    TEST_URIS,
+    TEST_POP_VALUES
 } from "../utils/StringConstants";
 import { BaseClient } from "../../src/client/BaseClient";
 import { AADServerParamKeys, GrantType } from "../../src/utils/Constants";
@@ -38,6 +39,8 @@ describe("DeviceCodeClient unit tests", async () => {
         const decodedLibState = `{ "id": "testid", "ts": 1592846482 }`;
         config.cryptoInterface.base64Decode = (input: string): string => {
             switch (input) {
+                case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        return TEST_POP_VALUES.DECODED_REQ_CNF;
                 case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
                     return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
                 case `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9`:
@@ -49,6 +52,8 @@ describe("DeviceCodeClient unit tests", async () => {
 
         config.cryptoInterface.base64Encode = (input: string): string => {
             switch (input) {
+                case TEST_POP_VALUES.DECODED_REQ_CNF:
+                    return TEST_POP_VALUES.ENCODED_REQ_CNF;
                 case "123-test-uid":
                     return "MTIzLXRlc3QtdWlk";
                 case "456-test-utid":
@@ -65,7 +70,7 @@ describe("DeviceCodeClient unit tests", async () => {
             ver: "2.0",
             iss: `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
             sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-            exp: "1536361411",
+            exp: 1536361411,
             name: "Abe Lincoln",
             preferred_username: "AbeLi@microsoft.com",
             oid: "00000000-0000-0000-66f3-3332eca7ea81",

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -44,7 +44,7 @@ describe("RefreshTokenClient unit tests", () => {
             "ver": "2.0",
             "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
             "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-            "exp": "1536361411",
+            "exp": 1536361411,
             "name": "Abe Lincoln",
             "preferred_username": "AbeLi@microsoft.com",
             "oid": "00000000-0000-0000-66f3-3332eca7ea81",

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -104,7 +104,7 @@ describe("SilentFlowClient unit tests", () => {
             "ver": "2.0",
             "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
             "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-            "exp": "1536361411",
+            "exp": 1536361411,
             "name": "Abe Lincoln",
             "preferred_username": "AbeLi@microsoft.com",
             "oid": "00000000-0000-0000-66f3-3332eca7ea81",

--- a/lib/msal-common/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-common/test/config/ClientConfiguration.spec.ts
@@ -6,7 +6,7 @@ import { NetworkRequestOptions } from "../../src/network/INetworkModule";
 import { LogLevel } from "../../src/logger/Logger";
 import { Constants } from "../../src";
 import { version } from "../../package.json";
-import {TEST_CONFIG} from "../utils/StringConstants";
+import {TEST_CONFIG, TEST_POP_VALUES} from "../utils/StringConstants";
 import { MockStorageClass } from "../client/ClientTestUtils";
 
 describe("ClientConfiguration.ts Class Unit Tests", () => {
@@ -79,7 +79,7 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
 
     const testKeySet = ["testKey1", "testKey2"];
 
-    it("buildConfiguration correctly assigns new values", () => {
+    it("buildConfiguration correctly assigns new values", async () => {
         const newConfig: ClientConfiguration = buildClientConfiguration({
 			authOptions: {
 				clientId: TEST_CONFIG.MSAL_CLIENT_ID
@@ -96,6 +96,9 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
                 },
                 generatePkceCodes: async (): Promise<PkceCodes> => {
                     return testPkceCodes;
+                },
+                async getPublicKeyThumbprint(): Promise<string> {
+                    return TEST_POP_VALUES.KID;
                 }
             },
             storageInterface: cacheStorageMock,
@@ -130,7 +133,7 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
         expect(newConfig.cryptoInterface.base64Encode).to.be.not.null;
         expect(newConfig.cryptoInterface.base64Encode("testString")).to.be.eq("testEncodedString");
         expect(newConfig.cryptoInterface.generatePkceCodes).to.be.not.null;
-        expect(newConfig.cryptoInterface.generatePkceCodes()).to.eventually.eq(testPkceCodes);
+        await expect(newConfig.cryptoInterface.generatePkceCodes()).to.eventually.eq(testPkceCodes);
         // Storage interface tests
         expect(newConfig.storageInterface).to.be.not.null;
         expect(newConfig.storageInterface.clear).to.be.not.null;
@@ -148,9 +151,9 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
         // Network interface tests
         expect(newConfig.networkInterface).to.be.not.null;
         expect(newConfig.networkInterface.sendGetRequestAsync).to.be.not.null;
-        expect(newConfig.networkInterface.sendGetRequestAsync("", null)).to.eventually.eq(testNetworkResult);
+        await expect(newConfig.networkInterface.sendGetRequestAsync("", null)).to.eventually.eq(testNetworkResult);
         expect(newConfig.networkInterface.sendPostRequestAsync).to.be.not.null;
-        expect(newConfig.networkInterface.sendPostRequestAsync("", null)).to.eventually.eq(testNetworkResult);
+        await expect(newConfig.networkInterface.sendPostRequestAsync("", null)).to.eventually.eq(testNetworkResult);
         // Logger option tests
         expect(newConfig.loggerOptions).to.be.not.null;
         expect(newConfig.loggerOptions.loggerCallback).to.be.not.null;

--- a/lib/msal-common/test/crypto/PopTokenGenerator.spec.ts
+++ b/lib/msal-common/test/crypto/PopTokenGenerator.spec.ts
@@ -1,0 +1,55 @@
+import * as Mocha from "mocha";
+import * as chai from "chai";
+import sinon from "sinon";
+import chaiAsPromised from "chai-as-promised";
+const expect = chai.expect;
+chai.use(chaiAsPromised);
+import { ICrypto, PkceCodes } from "../../src";
+import { RANDOM_TEST_GUID, TEST_POP_VALUES, TEST_DATA_CLIENT_INFO, TEST_CONFIG } from "../utils/StringConstants";
+import { PopTokenGenerator } from "../../src/crypto/PopTokenGenerator";
+
+describe("PopTokenGenerator Unit Tests", () => {
+
+    const cryptoInterface: ICrypto = {
+        createNewGuid(): string {
+            return RANDOM_TEST_GUID;
+        },
+        base64Decode(input: string): string {
+            switch (input) {
+                case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                    return TEST_POP_VALUES.DECODED_REQ_CNF;
+                case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
+                    return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                default:
+                    return input;
+            }
+        },
+        base64Encode(input: string): string {
+            switch (input) {
+                case "123-test-uid":
+                    return "MTIzLXRlc3QtdWlk";
+                case "456-test-uid":
+                    return "NDU2LXRlc3QtdWlk";
+                case TEST_POP_VALUES.DECODED_REQ_CNF:
+                    return TEST_POP_VALUES.ENCODED_REQ_CNF;
+                default:
+                    return input;
+            }
+        },
+        async generatePkceCodes(): Promise<PkceCodes> {
+            return {
+                challenge: TEST_CONFIG.TEST_CHALLENGE,
+                verifier: TEST_CONFIG.TEST_VERIFIER
+            }
+        },
+        async getPublicKeyThumbprint(): Promise<string> {
+            return TEST_POP_VALUES.KID;
+        }
+    };
+
+    it("Generates the req_cnf correctly", async () => {
+        const popTokenGenerator = new PopTokenGenerator(cryptoInterface);
+        const req_cnf = await popTokenGenerator.generateCnf();
+        expect(req_cnf).to.be.eq(TEST_POP_VALUES.ENCODED_REQ_CNF);
+    })
+});

--- a/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
+++ b/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai";
-import {Constants, SSOTypes, PromptValue, AADServerParamKeys, ResponseMode, GrantType} from "../../src/utils/Constants";
+import {Constants, SSOTypes, PromptValue, AADServerParamKeys, ResponseMode, GrantType, AuthenticationScheme} from "../../src/utils/Constants";
 import {
     TEST_CONFIG,
     TEST_URIS,
     TEST_TOKENS,
-    DEVICE_CODE_RESPONSE
+    DEVICE_CODE_RESPONSE,
+    TEST_POP_VALUES
 } from "../utils/StringConstants";
 import { RequestParameterBuilder } from "../../src/request/RequestParameterBuilder";
 import { ScopeSet } from "../../src/request/ScopeSet";
@@ -57,6 +58,26 @@ describe("RequestParameterBuilder unit tests", () => {
         expect(requestQueryString).to.contain(`${AADServerParamKeys.DEVICE_CODE}=${encodeURIComponent(DEVICE_CODE_RESPONSE.deviceCode)}`);
         expect(requestQueryString).to.contain(`${AADServerParamKeys.CODE_VERIFIER}=${encodeURIComponent(TEST_CONFIG.TEST_VERIFIER)}`);
         expect(requestQueryString).to.contain(`${SSOTypes.SID}=${encodeURIComponent(TEST_CONFIG.SID)}`);
+    });
+
+    it("Adds token type and req_cnf correctly for proof-of-possession tokens", () => {
+        const requestParameterBuilder = new RequestParameterBuilder();
+        requestParameterBuilder.addPopToken(TEST_POP_VALUES.ENCODED_REQ_CNF);
+        const requestQueryString = requestParameterBuilder.createQueryString();
+        expect(requestQueryString).to.contain(`${AADServerParamKeys.TOKEN_TYPE}=${AuthenticationScheme.POP}`);
+        expect(requestQueryString).to.contain(`${AADServerParamKeys.REQ_CNF}=${encodeURIComponent(TEST_POP_VALUES.ENCODED_REQ_CNF)}`);
+    });
+
+    it("Does not add token type or req_cnf if req_cnf is undefined or empty", () => {
+        const requestParameterBuilder = new RequestParameterBuilder();
+        requestParameterBuilder.addPopToken("");
+        const requestQueryString = requestParameterBuilder.createQueryString();
+        expect(requestQueryString).to.be.empty;
+        
+        const requestParameterBuilder2 = new RequestParameterBuilder();
+        requestParameterBuilder.addPopToken(undefined);
+        const requestQueryString2 = requestParameterBuilder2.createQueryString();
+        expect(requestQueryString2).to.be.empty;
     });
 
     it("addCodeChallengeParams throws invalidCodeChallengeParamsError if codeChallengeMethod empty", () => {

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { ServerAuthorizationTokenResponse } from "../../src/response/ServerAuthorizationTokenResponse";
 import { ResponseHandler } from "../../src/response/ResponseHandler";
-import { AUTHENTICATION_RESULT, RANDOM_TEST_GUID, TEST_CONFIG, ID_TOKEN_CLAIMS, TEST_DATA_CLIENT_INFO, TEST_STATE_VALUES } from "../utils/StringConstants";
+import { AUTHENTICATION_RESULT, RANDOM_TEST_GUID, TEST_CONFIG, ID_TOKEN_CLAIMS, TEST_DATA_CLIENT_INFO, TEST_STATE_VALUES, TEST_POP_VALUES } from "../utils/StringConstants";
 import { Authority } from "../../src/authority/Authority";
 import { INetworkModule, NetworkRequestOptions } from "../../src/network/INetworkModule";
 import { CacheManager } from "../../src/cache/CacheManager";
@@ -12,7 +12,7 @@ import { IdToken } from "../../src/account/IdToken";
 import { IdTokenClaims } from "../../src/account/IdTokenClaims";
 import { ClientTestUtils } from "../client/ClientTestUtils";
 import { AccountEntity, TrustedAuthority, ClientAuthError, ClientAuthErrorMessage, InteractionRequiredAuthError, ServerError } from "../../src";
-import { ServerAuthorizationCodeResponse } from "../../src/server/ServerAuthorizationCodeResponse";
+import { ServerAuthorizationCodeResponse } from "../../src/response/ServerAuthorizationCodeResponse";
 import { buildClientInfo } from "../../src/account/ClientInfo";
 
 const networkInterface: INetworkModule = {
@@ -30,6 +30,8 @@ const cryptoInterface: ICrypto = {
     },
     base64Decode(input: string): string {
         switch (input) {
+            case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                TEST_POP_VALUES.DECODED_REQ_CNF;
             case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
                 return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
             default:
@@ -37,7 +39,14 @@ const cryptoInterface: ICrypto = {
         }
     },
     base64Encode(input: string): string {
-        return input;
+        switch (input) {
+            case TEST_POP_VALUES.DECODED_REQ_CNF:
+                TEST_POP_VALUES.ENCODED_REQ_CNF;
+            case TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO:
+                return TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO;
+            default:
+                return input;
+        }
     },
     async generatePkceCodes(): Promise<PkceCodes> {
         return {
@@ -45,6 +54,9 @@ const cryptoInterface: ICrypto = {
             verifier: TEST_CONFIG.TEST_VERIFIER,
         };
     },
+    async getPublicKeyThumbprint(): Promise<string> {
+        return TEST_POP_VALUES.KID;
+    }
 }
 
 let store = {};

--- a/lib/msal-common/test/utils/ProtocolUtils.spec.ts
+++ b/lib/msal-common/test/utils/ProtocolUtils.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { ProtocolUtils } from "../../src/utils/ProtocolUtils";
-import { RANDOM_TEST_GUID, TEST_CONFIG } from "./StringConstants";
+import { RANDOM_TEST_GUID, TEST_CONFIG, TEST_POP_VALUES } from "./StringConstants";
 import { ICrypto, PkceCodes } from "../../src/crypto/ICrypto";
 import { Constants } from "../../src/utils/Constants";
 import sinon from "sinon";
@@ -23,6 +23,8 @@ describe("ProtocolUtils.ts Class Unit Tests", () => {
             },
             base64Decode(input: string): string {
                 switch (input) {
+                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        TEST_POP_VALUES.DECODED_REQ_CNF;
                     case encodedLibState:
                         return decodedLibState;
                     default:
@@ -31,6 +33,8 @@ describe("ProtocolUtils.ts Class Unit Tests", () => {
             },
             base64Encode(input: string): string {
                 switch (input) {
+                    case TEST_POP_VALUES.DECODED_REQ_CNF:
+                        TEST_POP_VALUES.ENCODED_REQ_CNF;
                     case `${decodedLibState}`:
                         return encodedLibState;
                     default:
@@ -43,6 +47,9 @@ describe("ProtocolUtils.ts Class Unit Tests", () => {
                     verifier: TEST_CONFIG.TEST_VERIFIER,
                 };
             },
+            async getPublicKeyThumbprint(): Promise<string> {
+                return TEST_POP_VALUES.KID;
+            }
         };
     });
 

--- a/lib/msal-common/test/utils/StringConstants.ts
+++ b/lib/msal-common/test/utils/StringConstants.ts
@@ -27,7 +27,7 @@ export const ID_TOKEN_CLAIMS = {
     iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
     sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
     aud: "6cb04018-a3f5-46a7-b995-940c78f5aef3",
-    exp: "1536361411",
+    exp: 1536361411,
     iat: "1536274711",
     nbf: "1536274711",
     name: "Abe Lincoln",
@@ -119,6 +119,12 @@ export const TEST_CONFIG = {
 };
 
 export const RANDOM_TEST_GUID = "11553a9b-7116-48b1-9d48-f6d4a8ff8371";
+
+export const TEST_POP_VALUES = {
+    KID: "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+    ENCODED_REQ_CNF: "eyJraWQiOiJOemJMc1hoOHVEQ2NkLTZNTndYRjRXXzdub1dYRlpBZkhreFpzUkdDOVhzIiwieG1zX2tzbCI6InN3In0=",
+    DECODED_REQ_CNF: `{"kid":"NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs","xms_ksl":"sw"}`
+};
 
 export const TEST_STATE_VALUES = {
     USER_STATE: "userState",
@@ -226,6 +232,20 @@ export const AUTHENTICATION_RESULT = {
         "expires_in": 3599,
         "ext_expires_in": 3599,
         "access_token": "thisIs.an.accessT0ken",
+        "refresh_token": "thisIsARefreshT0ken",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
+        "client_info": `${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}`
+    }
+};
+
+export const POP_AUTHENTICATION_RESULT = {
+    status: 200,
+    body: {
+        "token_type": "Bearer",
+        "scope": "openid profile User.Read email",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "thisIs.an.POPaccessT0ken",
         "refresh_token": "thisIsARefreshT0ken",
         "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
         "client_info": `${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}`

--- a/lib/msal-node/src/crypto/CryptoProvider.ts
+++ b/lib/msal-node/src/crypto/CryptoProvider.ts
@@ -50,4 +50,8 @@ export class CryptoProvider implements ICrypto {
     generatePkceCodes(): Promise<PkceCodes> {
         return this.pkceGenerator.generatePkceCodes();
     }
+
+    getPublicKeyThumbprint(): Promise<string> {
+        throw new Error("Method not implemented.");
+    }
 }

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/default/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/default/authConfig.js
@@ -35,7 +35,8 @@ const msalConfig = {
 
 // Add here scopes for id token to be used at MS Identity Platform endpoints.
 const loginRequest = {
-    scopes: ["User.Read"]
+    scopes: ["User.Read"],
+    authenticationType: "pop"
 };
 
 // Add here the endpoints for MS Graph API services you would like to use.

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/auth.js
@@ -1,0 +1,88 @@
+// Browser check variables
+// If you support IE, our recommendation is that you sign-in using Redirect APIs
+// If you as a developer are testing using Edge InPrivate mode, please add "isEdge" to the if check
+const ua = window.navigator.userAgent;
+const msie = ua.indexOf("MSIE ");
+const msie11 = ua.indexOf("Trident/");
+const msedge = ua.indexOf("Edge/");
+const isIE = msie > 0 || msie11 > 0;
+const isEdge = msedge > 0;
+
+let signInType;
+let username = "";
+
+// Create the main myMSALObj instance
+// configuration parameters are located at authConfig.js
+const myMSALObj = new msal.PublicClientApplication(msalConfig);
+
+// Redirect: once login is successful and redirects with tokens, call Graph API
+myMSALObj.handleRedirectPromise().then(handleResponse).catch(err => {
+    console.error(err);
+});
+
+function handleResponse(resp) {
+    if (resp !== null) {
+        username = resp.account.username;
+        showWelcomeMessage(resp.account);
+    } else {
+        // need to call getAccount here?
+        const currentAccounts = myMSALObj.getAllAccounts();
+        if (!currentAccounts || currentAccounts.length < 1) {
+            return;
+        } else if (currentAccounts.length > 1) {
+            // Add choose account code here
+        } else if (currentAccounts.length === 1) {
+            username = currentAccounts[0].username;
+            showWelcomeMessage(currentAccounts[0]);
+        }
+    }
+}
+
+async function signIn(method) {
+    signInType = isIE ? "loginRedirect" : method;
+    if (signInType === "loginPopup") {
+        return myMSALObj.loginPopup(loginRequest).then(handleResponse).catch(function (error) {
+            console.log(error);
+        });
+    } else if (signInType === "loginRedirect") {
+        return myMSALObj.loginRedirect(loginRequest)
+    }
+}
+
+function signOut() {
+    const logoutRequest = {
+        account: myMSALObj.getAccountByUsername(username)
+    };
+
+    myMSALObj.logout(logoutRequest);
+}
+
+async function getTokenPopup(request, account) {
+    request.account = account;
+    return await myMSALObj.acquireTokenSilent(request).catch(async (error) => {
+        console.log("silent token acquisition fails.");
+        if (error instanceof msal.InteractionRequiredAuthError) {
+            console.log("acquiring token using popup");
+            return myMSALObj.acquireTokenPopup(request).catch(error => {
+                console.error(error);
+            });
+        } else {
+            console.error(error);
+        }
+    });
+}
+
+// This function can be removed if you do not need to support IE
+async function getTokenRedirect(request, account) {
+    request.account = account;
+    return await myMSALObj.acquireTokenSilent(request).catch(async (error) => {
+        console.log("silent token acquisition fails.");
+        if (error instanceof msal.InteractionRequiredAuthError) {
+            // fallback to interaction when silent call fails
+            console.log("acquiring token using redirect");
+            myMSALObj.acquireTokenRedirect(request);
+        } else {
+            console.error(error);
+        }
+    });
+}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/authConfig.js
@@ -35,7 +35,8 @@ const msalConfig = {
 
 // Add here scopes for id token to be used at MS Identity Platform endpoints.
 const loginRequest = {
-    scopes: ["User.Read"]
+    scopes: ["User.Read"],
+    authenticationScheme: msal.AuthenticationScheme.POP
 };
 
 // Add here the endpoints for MS Graph API services you would like to use.

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/graph.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/graph.js
@@ -1,0 +1,64 @@
+// Helper function to call MS Graph API endpoint 
+// using authorization bearer token scheme
+function callMSGraph(endpoint, accessToken, callback) {
+    const headers = new Headers();
+    const bearer = `Bearer ${accessToken}`;
+
+    headers.append("Authorization", bearer);
+
+    const options = {
+        method: "GET",
+        headers: headers
+    };
+
+    console.log('request made to Graph API at: ' + new Date().toString());
+
+    fetch(endpoint, options)
+        .then(response => response.json())
+        .then(response => callback(response, endpoint))
+        .catch(error => console.log(error));
+}
+
+async function seeProfile() {
+    const currentAcc = myMSALObj.getAccountByUsername(username);
+    if (currentAcc) {
+        const response = await getTokenPopup(loginRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+        profileButton.style.display = 'none';
+    }
+}
+
+async function readMail() {
+    const currentAcc = myMSALObj.getAccountByUsername(username);
+    if (currentAcc) {
+        const response = await getTokenPopup(tokenRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMailEndpoint, response.accessToken, updateUI);
+        mailButton.style.display = 'none';
+    }
+}
+
+async function seeProfileRedirect() {
+    const currentAcc = myMSALObj.getAccountByUsername(username);
+    if (currentAcc) {
+        const response = await getTokenRedirect(loginRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+        profileButton.style.display = 'none';
+    }
+}
+
+async function readMailRedirect() {
+    const currentAcc = myMSALObj.getAccountByUsername(username);
+    if (currentAcc) {
+        const response = await getTokenRedirect(tokenRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMailEndpoint, response.accessToken, updateUI);
+        mailButton.style.display = 'none';
+    }
+}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/index.html
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>Quickstart | MSAL.JS Vanilla JavaScript SPA</title>
+    
+    <script src="../../lib/msal-browser.js"></script>
+    
+    <!-- adding Bootstrap 4 for UI components  -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link rel="SHORTCUT ICON" href="https://c.s-microsoft.com/favicon.ico?v2" type="image/x-icon">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <a class="navbar-brand" href="/">MS Identity Platform</a>
+      <div class="btn-group ml-auto dropleft">
+          <button type="button" id="SignIn" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Sign In
+          </button>
+          <div class="dropdown-menu">
+            <button class="dropdown-item" id="loginPopup" onclick="signIn(this.id)">Sign in using Popup</button>
+            <button class="dropdown-item" id="loginRedirect" onclick="signIn(this.id)">Sign in using Redirect</button>
+          </div>
+      </div>
+    </nav>
+    <br>
+    <h5 class="card-header text-center">Vanilla JavaScript SPA calling MS Graph API with MSAL.JS</h5>
+    <br>
+    <div class="row" style="margin:auto" >
+    <div id="card-div" class="col-md-3" style="display:none">
+    <div class="card text-center">
+      <div class="card-body">
+        <h5 class="card-title" id="WelcomeMessage">Please sign-in to see your profile and read your mails</h5>
+        <div id="profile-div"></div>
+        <br>
+        <br>
+        <button class="btn btn-primary" id="seeProfile" onclick="seeProfile()">See Profile</button>
+        <br>
+        <br>
+        <button class="btn btn-primary" id="readMail" onclick="readMail()">Read Mails</button>
+      </div>
+    </div>
+    </div>
+    <br>
+    <br>
+      <div class="col-md-4">
+        <div class="list-group" id="list-tab" role="tablist">
+        </div>
+      </div>
+      <div class="col-md-5">
+        <div class="tab-content" id="nav-tabContent">
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+
+    <!-- importing bootstrap.js and supporting js libraries -->
+    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>  
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    
+    <!-- importing app scripts | load order is important -->
+    <script type="text/javascript" src="./authConfig.js"></script>
+    <script type="text/javascript" src="./ui.js"></script>  
+    <script type="text/javascript" src="./auth.js"></script>
+    <script type="text/javascript" src="./graph.js"></script>
+  </body>
+</html>

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/test/browser.spec.ts
@@ -1,0 +1,65 @@
+import "mocha";
+import puppeteer from "puppeteer";
+import { expect } from "chai";
+import { Screenshot, createFolder, setupCredentials, getTokens, getAccountFromCache, accessTokenForScopesExists } from "../../../e2eTests/TestUtils"
+
+const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
+const SAMPLE_HOME_URL = 'http://localhost:30662/';
+let username = "";
+let accountPwd = "";
+
+async function enterCredentials(page: puppeteer.Page, screenshot: Screenshot): Promise<void> {
+    await page.waitForNavigation({ waitUntil: "networkidle0"});
+    await page.waitForSelector("#i0116");
+    await screenshot.takeScreenshot(page, `loginPage`);
+    await page.type("#i0116", username);
+    await page.click("#idSIButton9");
+    await page.waitForNavigation({ waitUntil: "networkidle0"});
+    await page.waitForSelector("#i0118");
+    await screenshot.takeScreenshot(page, `pwdInputPage`);
+    await page.type("#i0118", accountPwd);
+    await page.click("#idSIButton9");
+}
+
+async function goBackToSampleHomepage(page: puppeteer.Page, screenshot: Screenshot): Promise<void> {
+    await page.waitForSelector("#i0116");
+    await screenshot.takeScreenshot(page, `loginPage`);
+    await page.click("#idBtn_Back");
+    await page.waitForSelector("#i0116");
+    await screenshot.takeScreenshot(page, `loginPage2`);
+    await page.click("#idBtn_Back");
+}
+
+describe("Browser tests", function () {
+    this.timeout(0);
+    this.retries(1);
+
+    let browser: puppeteer.Browser;
+    before(async () => {
+        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        [username, accountPwd] = await setupCredentials("azureppe");
+        browser = await puppeteer.launch({
+            headless: true,
+            ignoreDefaultArgs: ['--no-sandbox', '–disable-setuid-sandbox']
+        });
+    });
+
+    let context: puppeteer.BrowserContext;
+    let page: puppeteer.Page;
+    beforeEach(async () => {
+        context = await browser.createIncognitoBrowserContext();
+        page = await context.newPage();
+        await page.goto(SAMPLE_HOME_URL);
+    });
+
+    afterEach(async () => {
+        await page.close();
+    });
+
+    after(async () => {
+        await context.close();
+        await browser.close();
+    });
+
+    // TODO: Add tests
+});

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/ui.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/ui.js
@@ -1,0 +1,66 @@
+// Select DOM elements to work with
+const welcomeDiv = document.getElementById("WelcomeMessage");
+const signInButton = document.getElementById("SignIn");
+const cardDiv = document.getElementById("card-div");
+const mailButton = document.getElementById("readMail");
+const profileButton = document.getElementById("seeProfile");
+const profileDiv = document.getElementById("profile-div");
+
+function showWelcomeMessage(account) {
+    // Reconfiguring DOM elements
+    cardDiv.style.display = 'initial';
+    welcomeDiv.innerHTML = `Welcome ${username}`;
+    signInButton.nextElementSibling.style.display = 'none';
+    signInButton.setAttribute("onclick", "signOut();");
+    signInButton.setAttribute('class', "btn btn-success")
+    signInButton.innerHTML = "Sign Out";
+}
+
+function updateUI(data, endpoint) {
+    console.log('Graph API responded at: ' + new Date().toString());
+
+    if (endpoint === graphConfig.graphMeEndpoint) {
+        const title = document.createElement('p');
+        title.innerHTML = "<strong>Title: </strong>" + data.jobTitle;
+        const email = document.createElement('p');
+        email.innerHTML = "<strong>Mail: </strong>" + data.mail;
+        const phone = document.createElement('p');
+        phone.innerHTML = "<strong>Phone: </strong>" + data.businessPhones[0];
+        const address = document.createElement('p');
+        address.innerHTML = "<strong>Location: </strong>" + data.officeLocation;
+        profileDiv.appendChild(title);
+        profileDiv.appendChild(email);
+        profileDiv.appendChild(phone);
+        profileDiv.appendChild(address);
+    } else if (endpoint === graphConfig.graphMailEndpoint) {
+        if (data.value.length < 1) {
+            alert("Your mailbox is empty!")
+        } else {
+            const tabList = document.getElementById("list-tab");
+            const tabContent = document.getElementById("nav-tabContent");
+
+            data.value.map((d, i) => {
+                // Keeping it simple
+                if (i < 10) {
+                    const listItem = document.createElement("a");
+                    listItem.setAttribute("class", "list-group-item list-group-item-action")
+                    listItem.setAttribute("id", "list" + i + "list")
+                    listItem.setAttribute("data-toggle", "list")
+                    listItem.setAttribute("href", "#list" + i)
+                    listItem.setAttribute("role", "tab")
+                    listItem.setAttribute("aria-controls", i)
+                    listItem.innerHTML = d.subject;
+                    tabList.appendChild(listItem)
+
+                    const contentItem = document.createElement("div");
+                    contentItem.setAttribute("class", "tab-pane fade")
+                    contentItem.setAttribute("id", "list" + i)
+                    contentItem.setAttribute("role", "tabpanel")
+                    contentItem.setAttribute("aria-labelledby", "list" + i + "list")
+                    contentItem.innerHTML = "<strong> from: " + d.from.emailAddress.address + "</strong><br><br>" + d.bodyPreview + "...";
+                    tabContent.appendChild(contentItem);
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR is the first for the Proof-of-Possession feature in MSAL.js 2.x. 

This PR adds the following:

- Adding the `req_cnf` parameter to the access token request in the authorization code flow
- Adding authenticationType to the request object
- Generating and exporting keypairs in the browser package