### PR TITLE
AT Proof-Of-Possession #3: Browser Implementation of token signing and key storage

### DIFF
--- a/lib/msal-browser/src/cache/DatabaseStorage.ts
+++ b/lib/msal-browser/src/cache/DatabaseStorage.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+interface IDBOpenDBRequestEvent extends Event {
+    target: IDBOpenDBRequest & EventTarget;
+}
+
+interface IDBOpenOnUpgradeNeededEvent extends IDBVersionChangeEvent {
+    target: IDBOpenDBRequest & EventTarget;
+}
+
+interface IDBRequestEvent extends Event {
+    target: IDBRequest & EventTarget;
+}
+
+/**
+ * Storage wrapper for IndexedDB storage in browsers: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
+ */
+export class DatabaseStorage<T>{
+    private _db : IDBDatabase;
+    private _dbName: string;
+    private _tableName: string;
+    private _version: number;
+
+    constructor(dbName: string, tableName: string, version: number) {
+        this._dbName = dbName;
+        this._tableName = tableName;
+        this._version = version;
+    }
+
+    /**
+     * Opens IndexedDB instance.
+     */
+    async open(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            // TODO: Add timeouts?
+            const openDB = window.indexedDB.open(this._dbName, this._version);
+            openDB.addEventListener("upgradeneeded", (e: IDBOpenOnUpgradeNeededEvent) => {
+                e.target.result.createObjectStore(this._tableName);
+            });
+            openDB.addEventListener("success", (e: IDBOpenDBRequestEvent) => {
+                this._db = e.target.result;
+                resolve();
+            });
+
+            openDB.addEventListener("error", error => reject(error));
+        });
+    }
+
+    /**
+     * Retrieves item from IndexedDB instance.
+     * @param key 
+     */
+    async get(key: string): Promise<T> {
+        return new Promise((resolve, reject) => {
+            // TODO: Add timeouts?
+            const transaction = this._db.transaction([this._tableName], "readonly");
+
+            const objectStore = transaction.objectStore(this._tableName);
+            const dbGet = objectStore.get(key);
+            dbGet.addEventListener("success", (e: IDBRequestEvent) => resolve(e.target.result));
+            dbGet.addEventListener("error", e => reject(e));
+        });
+    }
+
+    /**
+     * Adds item to IndexedDB under given key
+     * @param key 
+     * @param payload 
+     */
+    async put(key: string, payload: T): Promise<T> {
+        return new Promise((resolve: any, reject: any) => {
+            // TODO: Add timeouts?
+            const transaction = this._db.transaction([this._tableName], "readwrite");
+            const objectStore = transaction.objectStore(this._tableName);
+
+            const dbPut = objectStore.put(payload, key);
+            dbPut.addEventListener("success", (e: IDBRequestEvent) => resolve(e.target.result));
+            dbPut.addEventListener("error", e => reject(e));
+        });
+    }
+}

--- a/lib/msal-browser/src/cache/DatabaseStorage.ts
+++ b/lib/msal-browser/src/cache/DatabaseStorage.ts
@@ -19,15 +19,15 @@ interface IDBRequestEvent extends Event {
  * Storage wrapper for IndexedDB storage in browsers: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
  */
 export class DatabaseStorage<T>{
-    private _db : IDBDatabase;
-    private _dbName: string;
-    private _tableName: string;
-    private _version: number;
+    private db : IDBDatabase;
+    private dbName: string;
+    private tableName: string;
+    private version: number;
 
     constructor(dbName: string, tableName: string, version: number) {
-        this._dbName = dbName;
-        this._tableName = tableName;
-        this._version = version;
+        this.dbName = dbName;
+        this.tableName = tableName;
+        this.version = version;
     }
 
     /**
@@ -36,12 +36,12 @@ export class DatabaseStorage<T>{
     async open(): Promise<void> {
         return new Promise((resolve, reject) => {
             // TODO: Add timeouts?
-            const openDB = window.indexedDB.open(this._dbName, this._version);
+            const openDB = window.indexedDB.open(this.dbName, this.version);
             openDB.addEventListener("upgradeneeded", (e: IDBOpenOnUpgradeNeededEvent) => {
-                e.target.result.createObjectStore(this._tableName);
+                e.target.result.createObjectStore(this.tableName);
             });
             openDB.addEventListener("success", (e: IDBOpenDBRequestEvent) => {
-                this._db = e.target.result;
+                this.db = e.target.result;
                 resolve();
             });
 
@@ -54,11 +54,11 @@ export class DatabaseStorage<T>{
      * @param key 
      */
     async get(key: string): Promise<T> {
-        return new Promise((resolve, reject) => {
+        return new Promise<T>((resolve, reject) => {
             // TODO: Add timeouts?
-            const transaction = this._db.transaction([this._tableName], "readonly");
+            const transaction = this.db.transaction([this.tableName], "readonly");
 
-            const objectStore = transaction.objectStore(this._tableName);
+            const objectStore = transaction.objectStore(this.tableName);
             const dbGet = objectStore.get(key);
             dbGet.addEventListener("success", (e: IDBRequestEvent) => resolve(e.target.result));
             dbGet.addEventListener("error", e => reject(e));
@@ -71,10 +71,10 @@ export class DatabaseStorage<T>{
      * @param payload 
      */
     async put(key: string, payload: T): Promise<T> {
-        return new Promise((resolve: any, reject: any) => {
+        return new Promise<T>((resolve: any, reject: any) => {
             // TODO: Add timeouts?
-            const transaction = this._db.transaction([this._tableName], "readwrite");
-            const objectStore = transaction.objectStore(this._tableName);
+            const transaction = this.db.transaction([this.tableName], "readwrite");
+            const objectStore = transaction.objectStore(this.tableName);
 
             const dbPut = objectStore.put(payload, key);
             dbPut.addEventListener("success", (e: IDBRequestEvent) => resolve(e.target.result));

--- a/lib/msal-browser/src/crypto/BrowserCrypto.ts
+++ b/lib/msal-browser/src/crypto/BrowserCrypto.ts
@@ -9,7 +9,7 @@ import { KEY_FORMAT_JWK } from "../utils/BrowserConstants";
 /**
  * See here for more info on RsaHashedKeyGenParams: https://developer.mozilla.org/en-US/docs/Web/API/RsaHashedKeyGenParams
  */
- // RSA KeyGen Algorithm
+// RSA KeyGen Algorithm
 const PKCS1_V15_KEYGEN_ALG = "RSASSA-PKCS1-v1_5";
 // SHA-256 hashing algorithm
 const S256_HASH_ALG = "SHA-256";

--- a/lib/msal-browser/src/crypto/BrowserCrypto.ts
+++ b/lib/msal-browser/src/crypto/BrowserCrypto.ts
@@ -49,7 +49,6 @@ export class BrowserCrypto {
             modulusLength: keygenConfigModulusLength,
             publicExponent: keygenConfigPublicExponent
         };
-        console.log(this._keygenAlgorithmOptions);
     }
 
     /**
@@ -94,6 +93,33 @@ export class BrowserCrypto {
      */
     async exportKey(key: CryptoKey, format: KeyFormat): Promise<JsonWebKey> {
         return this.hasIECrypto() ? this.msCryptoExportKey(key, format) : window.crypto.subtle.exportKey(format, key);
+    }
+
+    /**
+     * Imports key as given KeyFormat, can set extractable and usages.
+     * @param key 
+     * @param format 
+     * @param extractable 
+     * @param usages 
+     */
+    async importKey(key: JsonWebKey, format: KeyFormat, extractable: boolean, usages: Array<KeyUsage>): Promise<CryptoKey> {
+        const keyString = BrowserCrypto.getJwkString(key);
+        const keyBuffer = BrowserStringUtils.stringToArrayBuffer(keyString);
+
+        return this.hasIECrypto() ? 
+            this.msCryptoImportKey(keyBuffer, format, extractable, usages) 
+            : window.crypto.subtle.importKey(format, key, this._keygenAlgorithmOptions, extractable, usages);
+    }
+
+    /**
+     * Signs given data with given key
+     * @param key 
+     * @param data 
+     */
+    async sign(key: CryptoKey, data: ArrayBuffer): Promise<ArrayBuffer> {
+        return this.hasIECrypto() ?
+            this.msCryptoSign(key, data)
+            : window.crypto.subtle.sign(this._keygenAlgorithmOptions, key, data);
     }
 
     /**
@@ -143,6 +169,11 @@ export class BrowserCrypto {
         });
     }
 
+    /**
+     * IE Helper function for generating a keypair
+     * @param extractable 
+     * @param usages 
+     */
     private async msCryptoGenerateKey(extractable: boolean, usages: Array<KeyUsage>): Promise<CryptoKeyPair> {
         return new Promise((resolve: any, reject: any) => {
             const msGenerateKey = window["msCrypto"].subtle.generateKey(this._keygenAlgorithmOptions, extractable, usages);
@@ -157,7 +188,7 @@ export class BrowserCrypto {
     }
 
     /**
-     * IE Helper function for exporting keys
+     * IE Helper function for exportKey
      * @param key 
      * @param format 
      */
@@ -182,6 +213,44 @@ export class BrowserCrypto {
             });
 
             msExportKey.addEventListener("error", (error: any) => {
+                reject(error);
+            });
+        });
+    }
+
+    /**
+     * IE Helper function for importKey
+     * @param key 
+     * @param format 
+     * @param extractable 
+     * @param usages 
+     */
+    private async msCryptoImportKey(keyBuffer: ArrayBuffer, format: KeyFormat, extractable: boolean, usages: Array<KeyUsage>): Promise<CryptoKey> {
+        return new Promise((resolve: any, reject: any) => {
+            const msImportKey = window["msCrypto"].subtle.importKey(format, keyBuffer, this._keygenAlgorithmOptions, extractable, usages);
+            msImportKey.addEventListener("complete", (e: { target: { result: CryptoKey | PromiseLike<CryptoKey>; }; }) => {
+                resolve(e.target.result);
+            });
+
+            msImportKey.addEventListener("error", (error: any) => {
+                reject(error);
+            });
+        });
+    }
+
+    /**
+     * IE Helper function for sign JWT
+     * @param key 
+     * @param data 
+     */
+    private async msCryptoSign(key: CryptoKey, data: ArrayBuffer): Promise<ArrayBuffer> {
+        return new Promise((resolve: any, reject: any) => {
+            const msSign = window["msCrypto"].subtle.sign(this._keygenAlgorithmOptions, key, data);
+            msSign.addEventListener("complete", (e: { target: { result: ArrayBuffer | PromiseLike<ArrayBuffer>; }; }) => {
+                resolve(e.target.result);
+            });
+
+            msSign.addEventListener("error", (error: any) => {
                 reject(error);
             });
         });

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -12,7 +12,7 @@ import { DatabaseStorage } from "../cache/DatabaseStorage";
 import { BrowserStringUtils } from "../utils/BrowserStringUtils";
 import { KEY_FORMAT_JWK } from "../utils/BrowserConstants";
 
-type CachedKeyPair = {
+export type CachedKeyPair = {
     publicKey: CryptoKey,
     privateKey: CryptoKey,
     requestMethod: string,

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -2,13 +2,21 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ICrypto, PkceCodes } from "@azure/msal-common";
+import { ICrypto, PkceCodes, SignedHttpRequest } from "@azure/msal-common";
 import { GuidGenerator } from "./GuidGenerator";
 import { Base64Encode } from "../encode/Base64Encode";
 import { Base64Decode } from "../encode/Base64Decode";
 import { PkceGenerator } from "./PkceGenerator";
 import { BrowserCrypto, KeyFormat } from "./BrowserCrypto";
+import { DatabaseStorage } from "../cache/DatabaseStorage";
 import { BrowserStringUtils } from "../utils/BrowserStringUtils";
+
+type CachedKeyPair = {
+    publicKey: CryptoKey,
+    privateKey: CryptoKey,
+    requestMethod: string,
+    requestUri: string
+};
 
 /**
  * This class implements MSAL's crypto interface, which allows it to perform base64 encoding and decoding, generating cryptographically random GUIDs and 
@@ -26,6 +34,11 @@ export class CryptoOps implements ICrypto {
     private static EXTRACTABLE: boolean = true;
     private static POP_HASH_LENGTH = 43; // 256 bit digest / 6 bits per char = 43
 
+    private static DB_VERSION = 1;
+    private static DB_NAME = "msal.db";
+    private static TABLE_NAME =`${CryptoOps.DB_NAME}.keys`;
+    private _cache: DatabaseStorage<CachedKeyPair>;
+
     constructor() {
         // Browser crypto needs to be validated first before any other classes can be set.
         this.browserCrypto = new BrowserCrypto();
@@ -33,16 +46,8 @@ export class CryptoOps implements ICrypto {
         this.b64Decode = new Base64Decode();
         this.guidGenerator = new GuidGenerator(this.browserCrypto);
         this.pkceGenerator = new PkceGenerator(this.browserCrypto);
-    }
-
-    async getPublicKeyThumprint(): Promise<string> {
-        const keyPair = await this.browserCrypto.generateKeyPair(CryptoOps.EXTRACTABLE, CryptoOps.POP_KEY_USAGES);
-        // TODO: Store keypair
-        const publicKeyJwk: JsonWebKey = await this.browserCrypto.exportKey(keyPair.publicKey, KeyFormat.jwk);
-        const publicJwkString: string = BrowserCrypto.getJwkString(publicKeyJwk);
-        const publicJwkBuffer: ArrayBuffer = await this.browserCrypto.sha256Digest(publicJwkString);
-        const publicJwkDigest: string = this.b64Encode.urlEncodeArr(new Uint8Array(publicJwkBuffer));
-        return this.base64Encode(publicJwkDigest).substr(0, CryptoOps.POP_HASH_LENGTH);
+        this._cache = new DatabaseStorage(CryptoOps.DB_NAME, CryptoOps.TABLE_NAME, CryptoOps.DB_VERSION);
+        this._cache.open();
     }
 
     /**
@@ -74,5 +79,54 @@ export class CryptoOps implements ICrypto {
      */
     async generatePkceCodes(): Promise<PkceCodes> {
         return this.pkceGenerator.generateCodes();
+    }
+
+    /**
+     * Generates a keypair, stores it and returns a thumbprint
+     * @param resourceRequestMethod 
+     * @param resourceRequestUri 
+     */
+    async getPublicKeyThumprint(resourceRequestMethod: string, resourceRequestUri: string): Promise<string> {
+        const keyPair = await this.browserCrypto.generateKeyPair(CryptoOps.EXTRACTABLE, CryptoOps.POP_KEY_USAGES);
+        const publicKeyJwk: JsonWebKey = await this.browserCrypto.exportKey(keyPair.publicKey, KeyFormat.jwk);
+        const privateKeyJwk: JsonWebKey = await this.browserCrypto.exportKey(keyPair.privateKey, KeyFormat.jwk);
+        const publicJwkString: string = BrowserCrypto.getJwkString(publicKeyJwk);
+        const publicJwkBuffer: ArrayBuffer = await this.browserCrypto.sha256Digest(publicJwkString);
+        const publicJwkDigest: string = this.b64Encode.urlEncodeArr(new Uint8Array(publicJwkBuffer));
+        const unextractablePrivateKey: CryptoKey = await this.browserCrypto.importKey(privateKeyJwk, KeyFormat.jwk, false, ["sign"]);
+        const publicKeyHash = this.base64Encode(publicJwkDigest).substr(0, CryptoOps.POP_HASH_LENGTH);
+        this._cache.put(publicKeyHash, {
+            privateKey: unextractablePrivateKey,
+            publicKey: keyPair.publicKey,
+            requestMethod: resourceRequestMethod,
+            requestUri: resourceRequestUri
+        });
+        return publicKeyHash;
+    }
+
+    /**
+     * Signs the given object as a jwt payload with private key retrieved by given kid.
+     * @param payload 
+     * @param kid 
+     */
+    async signJwt(payload: SignedHttpRequest, kid: string): Promise<string> {
+        const cachedKeyPair: CachedKeyPair = await this._cache.get(kid);
+        const publicKeyJwk = await this.browserCrypto.exportKey(cachedKeyPair.publicKey, KeyFormat.jwk);
+        const publicKeyJwkString = BrowserCrypto.getJwkString(publicKeyJwk);
+
+        const header = {
+            alg: publicKeyJwk.alg,
+            type: KeyFormat.jwk,
+            jwk: JSON.parse(publicKeyJwkString)
+        };
+
+        const encodedHeader = this.b64Encode.urlEncode(JSON.stringify(header));
+        const encodedPayload = this.b64Encode.urlEncode(JSON.stringify(payload));
+        const tokenString = `${encodedHeader}.${encodedPayload}`;
+        const tokenBuffer = BrowserStringUtils.stringToArrayBuffer(tokenString);
+        const signatureBuffer = await this.browserCrypto.sign(cachedKeyPair.privateKey, tokenBuffer);
+        const encodedSignature = this.b64Encode.urlEncode(BrowserStringUtils.utf8ArrToString(new Uint8Array(signatureBuffer)));
+
+        return `${tokenString}.${encodedSignature}`;
     }
 }

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -38,7 +38,7 @@ export class CryptoOps implements ICrypto {
     private static DB_VERSION = 1;
     private static DB_NAME = "msal.db";
     private static TABLE_NAME =`${CryptoOps.DB_NAME}.keys`;
-    private _cache: DatabaseStorage<CachedKeyPair>;
+    private cache: DatabaseStorage<CachedKeyPair>;
 
     constructor() {
         // Browser crypto needs to be validated first before any other classes can be set.
@@ -47,8 +47,8 @@ export class CryptoOps implements ICrypto {
         this.b64Decode = new Base64Decode();
         this.guidGenerator = new GuidGenerator(this.browserCrypto);
         this.pkceGenerator = new PkceGenerator(this.browserCrypto);
-        this._cache = new DatabaseStorage(CryptoOps.DB_NAME, CryptoOps.TABLE_NAME, CryptoOps.DB_VERSION);
-        this._cache.open();
+        this.cache = new DatabaseStorage(CryptoOps.DB_NAME, CryptoOps.TABLE_NAME, CryptoOps.DB_VERSION);
+        this.cache.open();
     }
 
     /**
@@ -96,7 +96,7 @@ export class CryptoOps implements ICrypto {
         const publicJwkDigest: string = this.b64Encode.urlEncodeArr(new Uint8Array(publicJwkBuffer));
         const unextractablePrivateKey: CryptoKey = await this.browserCrypto.importJwk(privateKeyJwk, false, ["sign"]);
         const publicKeyHash = this.base64Encode(publicJwkDigest).substr(0, CryptoOps.POP_HASH_LENGTH);
-        this._cache.put(publicKeyHash, {
+        this.cache.put(publicKeyHash, {
             privateKey: unextractablePrivateKey,
             publicKey: keyPair.publicKey,
             requestMethod: resourceRequestMethod,
@@ -111,7 +111,7 @@ export class CryptoOps implements ICrypto {
      * @param kid 
      */
     async signJwt(payload: SignedHttpRequest, kid: string): Promise<string> {
-        const cachedKeyPair: CachedKeyPair = await this._cache.get(kid);
+        const cachedKeyPair: CachedKeyPair = await this.cache.get(kid);
         const publicKeyJwk = await this.browserCrypto.exportJwk(cachedKeyPair.publicKey);
         const publicKeyJwkString = BrowserCrypto.getJwkString(publicKeyJwk);
 

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -80,3 +80,6 @@ export enum InteractionType {
 export const DEFAULT_REQUEST: AuthorizationUrlRequest = {
     scopes: [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE]
 };
+
+// JWK Key Format string (Type MUST be defined for window crypto APIs)
+export const KEY_FORMAT_JWK = "jwk";

--- a/lib/msal-browser/src/utils/BrowserStringUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserStringUtils.ts
@@ -69,6 +69,19 @@ export class BrowserStringUtils {
     }
 
     /**
+     * Converst string to ArrayBuffer
+     * @param dataString 
+     */
+    static stringToArrayBuffer(dataString: string): ArrayBuffer {
+        const data = new ArrayBuffer(dataString.length);
+        const dataView = new Uint8Array(data);
+        for (let i: number = 0; i < dataString.length; i++) {
+            dataView[i] = dataString.charCodeAt(i);
+        }
+        return data;
+    }
+
+    /**
      * Converts Uint8Array to a string
      * @param aBytes 
      */

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -17,12 +17,15 @@ import { PopupHandler } from "../../src/interaction_handler/PopupHandler";
 import { SilentHandler } from "../../src/interaction_handler/SilentHandler";
 import { BrowserStorage } from "../../src/cache/BrowserStorage";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
+import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 
 describe("PublicClientApplication.ts Class Unit Tests", () => {
     const cacheConfig = {
         cacheLocation: BrowserConstants.CACHE_LOCATION_SESSION,
         storeAuthStateInCookie: false
     };
+
+    let dbStorage = {};
 
     let pca: PublicClientApplication;
     beforeEach(() => {
@@ -34,7 +37,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         };
         sinon.stub(TrustedAuthority, "getTrustedHostList").returns(stubbedCloudDiscoveryMetadata.aliases);
         sinon.stub(TrustedAuthority, "getCloudDiscoveryMetadata").returns(stubbedCloudDiscoveryMetadata);
-
+        sinon.stub(DatabaseStorage.prototype, "open").callsFake(async (): Promise<void> => {
+            dbStorage = {};
+        });
         pca = new PublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID

--- a/lib/msal-browser/test/crypto/CryptoOps.spec.ts
+++ b/lib/msal-browser/test/crypto/CryptoOps.spec.ts
@@ -1,14 +1,24 @@
 import { expect } from "chai";
 import sinon from "sinon";
-import { CryptoOps } from "../../src/crypto/CryptoOps";
+import { CryptoOps, CachedKeyPair } from "../../src/crypto/CryptoOps";
 import { GuidGenerator } from "../../src/crypto/GuidGenerator";
 import { BrowserCrypto } from "../../src/crypto/BrowserCrypto";
 import crypto from "crypto";
 import { PkceCodes } from "@azure/msal-common";
+import { TEST_URIS } from "../utils/StringConstants";
+import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 
 describe("CryptoOps.ts Unit Tests", () => {
     let cryptoObj: CryptoOps;
+    let dbStorage = {};
     beforeEach(() => {
+        sinon.stub(DatabaseStorage.prototype, "open").callsFake(async (): Promise<void> => {
+            dbStorage = {};
+        });
+
+        sinon.stub(DatabaseStorage.prototype, "put").callsFake(async (key: string, payload: CachedKeyPair): Promise<void> => {
+            dbStorage[key] = payload;
+        });
         cryptoObj = new CryptoOps();
     });
 
@@ -82,7 +92,7 @@ describe("CryptoOps.ts Unit Tests", () => {
         });
         const generateKeyPairSpy = sinon.spy(BrowserCrypto.prototype, "generateKeyPair");
         const exportJwkSpy = sinon.spy(BrowserCrypto.prototype, "exportJwk");
-        const pkThumbprint = await cryptoObj.getPublicKeyThumbprint();
+        const pkThumbprint = await cryptoObj.getPublicKeyThumbprint("POST", TEST_URIS.TEST_AUTH_ENDPT_WITH_PARAMS);
         /**
          * Contains alphanumeric, dash '-', underscore '_', plus '+', or slash '/' with length of 43.
          */

--- a/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
@@ -13,6 +13,7 @@ import { BrowserAuthErrorMessage, BrowserAuthError } from "../../src/error/Brows
 import { BrowserUtils } from "../../src/utils/BrowserUtils";
 import { BrowserConstants, TemporaryCacheKeys } from "../../src/utils/BrowserConstants";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
+import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 
 const testPkceCodes = {
     challenge: "TestChallenge",
@@ -150,7 +151,11 @@ describe("RedirectHandler.ts Unit Tests", () => {
 				codeVerifier: TEST_CONFIG.TEST_VERIFIER,
 				authority: `${Constants.DEFAULT_AUTHORITY}/`,
 				correlationId: RANDOM_TEST_GUID
-			};
+            };
+            let dbStorage = {};
+            sinon.stub(DatabaseStorage.prototype, "open").callsFake(async (): Promise<void> => {
+                dbStorage = {};
+            });
 			const browserCrypto = new CryptoOps();
             sinon.stub(BrowserUtils, "isInIframe").returns(true);
             expect(() => redirectHandler.initiateAuthRequest(TEST_URIS.TEST_ALTERNATE_REDIR_URI, testTokenReq, "", browserCrypto)).to.throw(BrowserAuthErrorMessage.redirectInIframeError.desc);
@@ -158,6 +163,10 @@ describe("RedirectHandler.ts Unit Tests", () => {
         });
 
         it("navigates browser window to given window location", () => {
+            let dbStorage = {};
+            sinon.stub(DatabaseStorage.prototype, "open").callsFake(async (): Promise<void> => {
+                dbStorage = {};
+            });
 			const testTokenReq: AuthorizationCodeRequest = {
 				redirectUri: `${TEST_URIS.DEFAULT_INSTANCE}/`,
 				code: "thisIsATestCode",
@@ -216,7 +225,11 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 tenantId: idTokenClaims.tid,
                 uniqueId: idTokenClaims.oid,
                 tokenType: AuthenticationScheme.BEARER
-			};
+            };
+            let dbStorage = {};
+            sinon.stub(DatabaseStorage.prototype, "open").callsFake(async (): Promise<void> => {
+                dbStorage = {};
+            });
 			const browserCrypto = new CryptoOps();
 			const testAuthCodeRequest: AuthorizationCodeRequest = {
 				redirectUri: TEST_URIS.TEST_REDIR_URI,

--- a/lib/msal-browser/test/utils/BrowserProtocolUtils.spec.ts
+++ b/lib/msal-browser/test/utils/BrowserProtocolUtils.spec.ts
@@ -1,10 +1,10 @@
 import { expect } from "chai";
+import sinon from "sinon";
 import { BrowserProtocolUtils, BrowserStateObject } from "../../src/utils/BrowserProtocolUtils";
 import { InteractionType } from "../../src/utils/BrowserConstants";
-import { ICrypto, PkceCodes, ProtocolUtils } from "@azure/msal-common";
-import { RANDOM_TEST_GUID, TEST_CONFIG, TEST_STATE_VALUES } from "./StringConstants";
-import { BrowserCrypto } from "../../src/crypto/BrowserCrypto";
+import { ProtocolUtils } from "@azure/msal-common";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
+import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 
 describe("BrowserProtocolUtils.ts Unit Tests", () => {
 
@@ -12,8 +12,16 @@ describe("BrowserProtocolUtils.ts Unit Tests", () => {
     const browserPopupRequestState: BrowserStateObject = { interactionType: InteractionType.POPUP };
 
     let cryptoInterface: CryptoOps;
+    let dbStorage = {};
     beforeEach(() => {
+        sinon.stub(DatabaseStorage.prototype, "open").callsFake(async (): Promise<void> => {
+            dbStorage = {};
+        });
         cryptoInterface = new CryptoOps();
+    });
+
+    afterEach(() => {
+        sinon.restore(); 
     });
 
     it("extractBrowserRequestState() returns an null if given interaction type is null or empty", () => {

--- a/lib/msal-browser/test/utils/StringConstants.ts
+++ b/lib/msal-browser/test/utils/StringConstants.ts
@@ -14,7 +14,8 @@ export const TEST_URIS = {
     TEST_REDIR_URI: "https://localhost:8081/index.html",
     TEST_ALTERNATE_REDIR_URI: "https://localhost:8081/index2.html",
     TEST_LOGOUT_URI: "https://localhost:8081/logout.html",
-    TEST_AUTH_ENDPT: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    TEST_AUTH_ENDPT: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    TEST_AUTH_ENDPT_WITH_PARAMS: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?param1=value1&param2=value2",
 };
 
 // Test MSAL config params


### PR DESCRIPTION
This PR is a follow up to PR #2153, and includes the `msal-browser` implementation of the token signing and key storage APIs introduced in the previous code.

Specifically, this PR includes the following:

- Browser implementation of key storage using IndexedDB
- Browser implementation of jwt token signing
