### PR TITLE
Fix Telemetry Cache Hit Bug

### DIFF
--- a/change/@azure-msal-common-2020-08-20-11-36-50-Fix-Telem-CacheHit-bug.json
+++ b/change/@azure-msal-common-2020-08-20-11-36-50-Fix-Telem-CacheHit-bug.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix Telemetry cacheHit Bug (#2170)",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.l.norling@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T18:36:50.041Z"
+}

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -75,7 +75,9 @@ export class SilentFlowClient extends BaseClient {
         }
 
         // Return tokens from cache
-        this.config.serverTelemetryManager.incrementCacheHits();
+        if (this.config.serverTelemetryManager) {
+            this.config.serverTelemetryManager.incrementCacheHits();
+        }
         const cachedIdToken = this.readIdTokenFromCache(homeAccountId, environment, cachedAccount.realm);
         const idTokenObj = new IdToken(cachedIdToken.secret, this.config.cryptoInterface);
 

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -187,4 +187,86 @@ describe("SilentFlowClient unit tests", () => {
         expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.REFRESH_TOKEN}=${TEST_TOKENS.REFRESH_TOKEN}`);
         expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.GRANT_TYPE}=${GrantType.REFRESH_TOKEN_GRANT}`);
     });
+
+    it("returns cached token", async () => {
+        const idTokenClaims: IdTokenClaims = {
+            "ver": "2.0",
+            "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+            "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+            "exp": 1536361411,
+            "name": "Abe Lincoln",
+            "preferred_username": "AbeLi@microsoft.com",
+            "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+            "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+            "nonce": "123523",
+        };
+
+        const testAccountEntity: AccountEntity = new AccountEntity();
+        testAccountEntity.homeAccountId = TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID;
+        testAccountEntity.localAccountId = "testId";
+        testAccountEntity.environment = "login.windows.net";
+        testAccountEntity.realm = idTokenClaims.tid;
+        testAccountEntity.username = idTokenClaims.preferred_username;
+        testAccountEntity.authorityType = "MSSTS";
+
+        const testIdToken: IdTokenEntity = new IdTokenEntity();
+        testIdToken.homeAccountId = TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID;
+        testIdToken.clientId = TEST_CONFIG.MSAL_CLIENT_ID;
+        testIdToken.environment = testAccountEntity.environment;
+        testIdToken.realm = idTokenClaims.tid;
+        testIdToken.secret = AUTHENTICATION_RESULT.body.id_token;
+        testIdToken.credentialType = CredentialType.ID_TOKEN;
+
+        const testAccessTokenEntity: AccessTokenEntity = new AccessTokenEntity();
+        testAccessTokenEntity.homeAccountId = TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID;
+        testAccessTokenEntity.clientId = TEST_CONFIG.MSAL_CLIENT_ID;
+        testAccessTokenEntity.environment = testAccountEntity.environment;
+        testAccessTokenEntity.realm = idTokenClaims.tid;
+        testAccessTokenEntity.secret = AUTHENTICATION_RESULT.body.access_token;
+        testAccessTokenEntity.credentialType = CredentialType.ACCESS_TOKEN;
+        testAccessTokenEntity.target = TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]
+
+        const testRefreshTokenEntity: RefreshTokenEntity = new RefreshTokenEntity();
+        testRefreshTokenEntity.homeAccountId = TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID;
+        testRefreshTokenEntity.clientId = TEST_CONFIG.MSAL_CLIENT_ID;
+        testRefreshTokenEntity.environment = testAccountEntity.environment;
+        testRefreshTokenEntity.realm = idTokenClaims.tid;
+        testRefreshTokenEntity.secret = AUTHENTICATION_RESULT.body.refresh_token;
+        testRefreshTokenEntity.credentialType = CredentialType.REFRESH_TOKEN;
+
+        sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
+        sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
+        sinon.stub(CacheManager.prototype, "getAccount").returns(testAccountEntity);
+
+        sinon.stub(SilentFlowClient.prototype, <any>"readIdTokenFromCache").returns(testIdToken);
+        sinon.stub(SilentFlowClient.prototype, <any>"readAccessTokenFromCache").returns(testAccessTokenEntity);
+        sinon.stub(SilentFlowClient.prototype, <any>"readRefreshTokenFromCache").returns(testRefreshTokenEntity);
+        sinon.stub(TimeUtils, <any>"isTokenExpired").returns(false);
+
+        const config = await ClientTestUtils.createTestClientConfiguration();
+        const client = new SilentFlowClient(config);
+        const testAccount: AccountInfo = {
+            homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+            tenantId: idTokenClaims.tid,
+            environment: "login.windows.net",
+            username: idTokenClaims.preferred_username
+        };
+
+        const silentFlowRequest: SilentFlowRequest = {
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            account: testAccount,
+            forceRefresh: false
+        };
+
+        const authResult: AuthenticationResult = await client.acquireToken(silentFlowRequest);
+        const expectedScopes = [TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.uniqueId).to.deep.eq(idTokenClaims.oid);
+        expect(authResult.tenantId).to.deep.eq(idTokenClaims.tid);
+        expect(authResult.scopes).to.deep.eq(expectedScopes);
+        expect(authResult.account).to.deep.eq(testAccount);
+        expect(authResult.idToken).to.deep.eq(testIdToken.secret);
+        expect(authResult.idTokenClaims).to.deep.eq(idTokenClaims);
+        expect(authResult.accessToken).to.deep.eq(testAccessTokenEntity.secret);
+        expect(authResult.state).to.be.empty;
+    });
 });


### PR DESCRIPTION
If ServerTelemetryManager is not instantiated, getting a token from cache in SilentFlowClient would throw an error due to the `incrementCacheHits` call not being gated. This PR fixes that bug and adds a test for getting token from cache