### PR TITLE
Release @azure/msal-angular@1.1.1

### DIFF
--- a/lib/msal-angular/.beachballrc
+++ b/lib/msal-angular/.beachballrc
@@ -1,0 +1,3 @@
+{
+    "shouldPublish": false
+}

--- a/lib/msal-angular/package-lock.json
+++ b/lib/msal-angular/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/msal-angular",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": [
     "implicit",
     "angular",


### PR DESCRIPTION
MSAL Angular has a custom publish command, so 1.1.0 wasn't publish correctly. Disabling beachball on it for now, and manually publishing.