### PR TITLE
Fix msal-browser tests causing build to fail intermittently

### DIFF
--- a/change/@azure-msal-browser-2020-08-25-16-59-10-fix-unit-tests.json
+++ b/change/@azure-msal-browser-2020-08-25-16-59-10-fix-unit-tests.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix Unit Tests (#2191)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-25T23:59:10.865Z"
+}

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1036,8 +1036,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
                 const popupSpy = sinon.stub(PopupHandler, "openSizedPopup");
                 
-                await pca.acquireTokenPopup(request);
-                expect(popupSpy.calledWith()).to.be.true;
+                try {
+                    await pca.acquireTokenPopup(request);
+                } catch(e) {}
+                expect(popupSpy.getCall(0).args).to.be.length(0);
             });
 
             it("opens popups asynchronously if configured", async () => {
@@ -1064,8 +1066,15 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
                 const popupSpy = sinon.stub(PopupHandler, "openSizedPopup");
                 
-                await pca.acquireTokenPopup(request);
-                expect(popupSpy.calledWith()).to.be.false;
+                try {
+                    await pca.acquireTokenPopup(request);
+                } catch(e) {}
+                expect(popupSpy.calledOnce).to.be.true;
+                expect(popupSpy.getCall(0).args).to.be.length(1);
+                expect(popupSpy.getCall(0).args[0].startsWith(TEST_URIS.TEST_AUTH_ENDPT)).to.be.true;
+                expect(popupSpy.getCall(0).args[0]).to.include(`client_id=${encodeURIComponent(TEST_CONFIG.MSAL_CLIENT_ID)}`);
+                expect(popupSpy.getCall(0).args[0]).to.include(`redirect_uri=${encodeURIComponent(request.redirectUri)}`);
+                expect(popupSpy.getCall(0).args[0]).to.include(`login_hint=${encodeURIComponent(request.loginHint)}`);
             });
 
             it("resolves the response successfully", async () => {

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1021,7 +1021,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 })).rejectedWith(BrowserAuthError);
             });
 
-            it("opens popup window before network request by default", () => {
+            it("opens popup window before network request by default", async () => {
                 const request: AuthorizationUrlRequest = {
 					redirectUri: TEST_URIS.TEST_REDIR_URI,
 					scopes: ["scope"],
@@ -1036,11 +1036,11 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
                 const popupSpy = sinon.stub(PopupHandler, "openSizedPopup");
                 
-                pca.acquireTokenPopup(request);
+                await pca.acquireTokenPopup(request);
                 expect(popupSpy.calledWith()).to.be.true;
             });
 
-            it("opens popups asynchronously if configured", () => {
+            it("opens popups asynchronously if configured", async () => {
                 pca = new PublicClientApplication({
                     auth: {
                         clientId: TEST_CONFIG.MSAL_CLIENT_ID
@@ -1064,7 +1064,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
                 const popupSpy = sinon.stub(PopupHandler, "openSizedPopup");
                 
-                pca.acquireTokenPopup(request);
+                await pca.acquireTokenPopup(request);
                 expect(popupSpy.calledWith()).to.be.false;
             });
 


### PR DESCRIPTION
Not awaiting resolution of `acquireTokenPopup` was causing overlap in tests, meaning sometimes the telemetry cache entry for failed requests had multiple values when it only expected one.