### PR TITLE
Remove debug package dependency from msal-common

### DIFF
--- a/change/@azure-msal-angular-2020-09-09-18-53-39-users-hegi-remove-debug-dependency.json
+++ b/change/@azure-msal-angular-2020-09-09-18-53-39-users-hegi-remove-debug-dependency.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary debug dependency from msal-common",
+  "packageName": "@azure/msal-angular",
+  "email": "hegi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T01:53:25.335Z"
+}

--- a/change/@azure-msal-browser-2020-09-09-18-53-39-users-hegi-remove-debug-dependency.json
+++ b/change/@azure-msal-browser-2020-09-09-18-53-39-users-hegi-remove-debug-dependency.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary debug dependency from msal-common",
+  "packageName": "@azure/msal-browser",
+  "email": "hegi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T01:53:29.375Z"
+}

--- a/change/@azure-msal-common-2020-09-09-18-53-39-users-hegi-remove-debug-dependency.json
+++ b/change/@azure-msal-common-2020-09-09-18-53-39-users-hegi-remove-debug-dependency.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary debug dependency from msal-common",
+  "packageName": "@azure/msal-common",
+  "email": "hegi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T01:53:33.562Z"
+}

--- a/change/@azure-msal-node-2020-09-09-18-53-39-users-hegi-remove-debug-dependency.json
+++ b/change/@azure-msal-node-2020-09-09-18-53-39-users-hegi-remove-debug-dependency.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unnecessary debug dependency from msal-common",
+  "packageName": "@azure/msal-node",
+  "email": "hegi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T01:53:39.233Z"
+}

--- a/experimental/msal-electron-proof-of-concept/package-lock.json
+++ b/experimental/msal-electron-proof-of-concept/package-lock.json
@@ -269,7 +269,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
             "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "brace-expansion": {
             "version": "1.1.11",

--- a/lib/msal-angular/package-lock.json
+++ b/lib/msal-angular/package-lock.json
@@ -6353,15 +6353,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "msal": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.0.tgz",
-      "integrity": "sha512-NTxMFQh6t5g2QWMlvZTWTxL1bmcqiCv0cs2lxTHhUbWEuxWCfvaVRZfjxN8i+T0VltVVGaVIdML8QEoBnlbaSw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",

--- a/lib/msal-browser/package-lock.json
+++ b/lib/msal-browser/package-lock.json
@@ -139,14 +139,6 @@
                 "tslib": "^1.9.3"
             }
         },
-        "@azure/msal-common": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-1.2.0.tgz",
-            "integrity": "sha512-5MjxcUoalIxGo29MBHCdwMo6HCsCBt25HDkg+Du7x6nG7Y3NAUb9jM8oibLTth9iIRDaWYVvLfxnpXTKwBGs+A==",
-            "requires": {
-                "debug": "^4.1.1"
-            }
-        },
         "@azure/storage-blob": {
             "version": "12.2.0-preview.1",
             "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.2.0-preview.1.tgz",
@@ -2211,6 +2203,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -3836,7 +3829,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "neo-async": {
             "version": "2.6.1",

--- a/lib/msal-common/package-lock.json
+++ b/lib/msal-common/package-lock.json
@@ -1082,12 +1082,6 @@
                 "@types/chai": "*"
             }
         },
-        "@types/debug": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
-            "dev": true
-        },
         "@types/estree": {
             "version": "0.0.44",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
@@ -1737,6 +1731,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -3005,7 +3000,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "neo-async": {
             "version": "2.6.1",

--- a/lib/msal-common/package.json
+++ b/lib/msal-common/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",
@@ -67,7 +67,6 @@
     "@rollup/plugin-json": "^4.0.0",
     "@types/chai": "^4.2.5",
     "@types/chai-as-promised": "^7.1.2",
-    "@types/debug": "^4.1.5",
     "@types/mocha": "^5.2.7",
     "@types/sinon": "^7.5.0",
     "babel-plugin-istanbul": "^5.2.0",
@@ -90,6 +89,5 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "debug": "^4.1.1"
   }
 }

--- a/lib/msal-node/package-lock.json
+++ b/lib/msal-node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/msal-node",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4729,7 +4729,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4750,12 +4751,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4770,17 +4773,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4897,7 +4903,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4909,6 +4916,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4923,6 +4931,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4930,12 +4939,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4954,6 +4965,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -5015,7 +5027,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -5043,7 +5056,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5055,6 +5069,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5132,7 +5147,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5168,6 +5184,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5187,6 +5204,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5230,12 +5248,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/samples/msal-angular-samples/MSALAngularDemoApp/package-lock.json
+++ b/samples/msal-angular-samples/MSALAngularDemoApp/package-lock.json
@@ -211,15 +211,6 @@
 				"tslib": "^1.7.1"
 			}
 		},
-		"@azure/msal-angular": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@azure/msal-angular/-/msal-angular-1.1.1.tgz",
-			"integrity": "sha512-qVl8zQdGEzgHzfJgmZAi3/7HxTuvdwrXXPIzc0gUQB4+zgPQF6p1v1IjUiWWSdXy4M1O67FDy0GdFtL1RCjigA==",
-			"requires": {
-				"minimatch": "^3.0.4",
-				"path": "^0.12.7"
-			}
-		},
 		"@ngtools/json-schema": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ngtools/json-schema/-/json-schema-1.2.0.tgz",
@@ -597,13 +588,15 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
 			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"atob": {
 			"version": "2.1.2",
@@ -636,7 +629,8 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -762,7 +756,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -953,6 +948,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1215,7 +1211,8 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"center-align": {
 			"version": "0.1.3",
@@ -1425,6 +1422,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -1480,7 +1478,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -1697,6 +1696,7 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
 			"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"which": "^1.2.9"
@@ -2226,7 +2226,8 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"emojis-list": {
 			"version": "2.1.0",
@@ -2597,7 +2598,8 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -2817,7 +2819,8 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"form-data": {
 			"version": "2.1.4",
@@ -3480,6 +3483,7 @@
 			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
 			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"globule": "^1.0.0"
 			}
@@ -4336,7 +4340,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
 			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"indent-string": {
 			"version": "2.1.0",
@@ -4631,7 +4636,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -4676,7 +4682,8 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"istanbul-instrumenter-loader": {
 			"version": "3.0.1",
@@ -4809,7 +4816,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"json3": {
 			"version": "3.3.3",
@@ -4844,6 +4852,7 @@
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -5265,6 +5274,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -5381,7 +5391,8 @@
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
 			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -5460,6 +5471,7 @@
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
 			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"fstream": "^1.0.0",
 				"glob": "^7.0.3",
@@ -5668,6 +5680,7 @@
 			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
 			"integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
@@ -5693,6 +5706,7 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
 					"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -5704,37 +5718,43 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
 					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"camelcase": {
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -5748,6 +5768,7 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
 					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"string-width": "^3.1.0",
 						"strip-ansi": "^5.2.0",
@@ -5759,6 +5780,7 @@
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^4.1.0"
 							}
@@ -5769,13 +5791,15 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -5785,6 +5809,7 @@
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"asynckit": "^0.4.0",
 						"combined-stream": "^1.0.6",
@@ -5795,19 +5820,22 @@
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"har-schema": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
 					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"har-validator": {
 					"version": "5.1.5",
 					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
 					"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ajv": "^6.12.3",
 						"har-schema": "^2.0.0"
@@ -5818,6 +5846,7 @@
 					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
 						"jsprim": "^1.2.2",
@@ -5828,19 +5857,22 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -5850,13 +5882,15 @@
 					"version": "0.9.0",
 					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"p-limit": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -5866,6 +5900,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -5874,25 +5909,29 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"performance-now": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"qs": {
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"request": {
 					"version": "2.88.2",
 					"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 					"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"aws-sign2": "~0.7.0",
 						"aws4": "^1.8.0",
@@ -5920,13 +5959,15 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"sass-graph": {
 					"version": "2.2.5",
 					"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
 					"integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"glob": "^7.0.0",
 						"lodash": "^4.0.0",
@@ -5939,6 +5980,7 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -5950,6 +5992,7 @@
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^4.1.0"
 							}
@@ -5960,13 +6003,15 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"tough-cookie": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
@@ -5976,13 +6021,15 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"wrap-ansi": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
 					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-styles": "^3.2.0",
 						"string-width": "^3.0.0",
@@ -5994,6 +6041,7 @@
 							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"color-convert": "^1.9.0"
 							}
@@ -6003,6 +6051,7 @@
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^4.1.0"
 							}
@@ -6014,6 +6063,7 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
 					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"cliui": "^5.0.0",
 						"find-up": "^3.0.0",
@@ -6032,6 +6082,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
 					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
@@ -6090,6 +6141,7 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -6409,30 +6461,6 @@
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
 			"dev": true
 		},
-		"path": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-			"integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-			"requires": {
-				"process": "^0.11.1",
-				"util": "^0.10.3"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-				},
-				"util": {
-					"version": "0.10.4",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-					"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-					"requires": {
-						"inherits": "2.0.3"
-					}
-				}
-			}
-		},
 		"path-browserify": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
@@ -6682,7 +6710,8 @@
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
@@ -6732,7 +6761,8 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
 			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -7577,6 +7607,7 @@
 			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
 			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"js-base64": "^2.1.8",
 				"source-map": "^0.4.2"
@@ -8144,6 +8175,7 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -8206,6 +8238,7 @@
 			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
 			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
 			}
@@ -8595,6 +8628,7 @@
 			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
 			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"glob": "^7.1.2"
 			}
@@ -8721,6 +8755,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}

--- a/samples/msal-angular-v2-samples/angular10-browser-sample/package-lock.json
+++ b/samples/msal-angular-v2-samples/angular10-browser-sample/package-lock.json
@@ -456,22 +456,6 @@
         "tslib": "^2.0.0"
       }
     },
-    "@azure/msal-browser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.0.2.tgz",
-      "integrity": "sha512-BUxxiikWxkXLaHaHXQiG9EJQtAzGj2TcXy4Bh5RlP+kWVQxHFkPpo3x4U/jzAFoyVadriVK20IWygvsfQdRp5A==",
-      "requires": {
-        "@azure/msal-common": "^1.1.1"
-      }
-    },
-    "@azure/msal-common": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-1.1.1.tgz",
-      "integrity": "sha512-qZ8DeuG9VFeyoYiVX7nAXZJhxrRsQrOk1KLJ9/xFQchXbM26BvbpROyiWGO5vBkyGyDt0AlOOKdwYQQNkdz/bQ==",
-      "requires": {
-        "debug": "^4.1.1"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -3989,6 +3973,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -7699,7 +7684,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/samples/msal-angularjs-samples/MsalAngularjsDemoApp/package-lock.json
+++ b/samples/msal-angularjs-samples/MsalAngularjsDemoApp/package-lock.json
@@ -4,14 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@azure/msal-angularjs": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@azure/msal-angularjs/-/msal-angularjs-0.1.1.tgz",
-			"integrity": "sha512-K+z/8Fwif8IQnZaM+1IMLG6NS0grCBLTN+8wZlpzkeLrMVyVgba8ZQ6sLFW3UjJdgEkv/p7FUbcy7blTc8LopA==",
-			"requires": {
-				"msal": "0.2.1"
-			}
-		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -3370,14 +3362,6 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
-		"msal": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/msal/-/msal-0.2.1.tgz",
-			"integrity": "sha512-oDWPtWTB+tmtVUOawNJS1pGKhtvy2IUrZQFGfpx53bgJvHV+AbF3718AvyRHuJZBt1egS0m4Aqk129nKAe7CUw==",
-			"requires": {
-				"tslib": "1.7.1"
-			}
-		},
 		"multicast-dns": {
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -4912,11 +4896,6 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
-		},
-		"tslib": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
-			"integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
 		},
 		"tty-browserify": {
 			"version": "0.0.0",

--- a/samples/msal-browser-samples/TypescriptTestApp2.0/package-lock.json
+++ b/samples/msal-browser-samples/TypescriptTestApp2.0/package-lock.json
@@ -3831,7 +3831,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "object-assign": {
       "version": "4.1.1",

--- a/samples/msal-core-samples/ModuleSample/package-lock.json
+++ b/samples/msal-core-samples/ModuleSample/package-lock.json
@@ -2553,15 +2553,6 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
-		"msal": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/msal/-/msal-0.1.3.tgz",
-			"integrity": "sha1-bqEKEFFg6mNGxrlM0Lsj1zGGeI0=",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.7.1"
-			}
-		},
 		"nan": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",

--- a/samples/msal-node-extensions/package-lock.json
+++ b/samples/msal-node-extensions/package-lock.json
@@ -27,32 +27,6 @@
 				}
 			}
 		},
-		"@azure/msal-node": {
-			"version": "1.0.0-alpha.4",
-			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.0.0-alpha.4.tgz",
-			"integrity": "sha512-Tbo+lxiesPsGbid13IfGf3V910QWMG0jmJ9xHPaNXpBa/mFSbluBwV1fJavHzieCL20S5W0rGE/SHtdJYw2DfA==",
-			"requires": {
-				"@azure/msal-common": "^1.1.0",
-				"axios": "^0.19.2",
-				"debug": "^4.1.1",
-				"jsonwebtoken": "^8.5.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
-			}
-		},
 		"@azure/msal-node-extensions": {
 			"version": "1.0.0-alpha.2",
 			"resolved": "https://registry.npmjs.org/@azure/msal-node-extensions/-/msal-node-extensions-1.0.0-alpha.2.tgz",
@@ -96,14 +70,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
-		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-			"requires": {
-				"follow-redirects": "1.5.10"
-			}
 		},
 		"base64-js": {
 			"version": "1.3.1",
@@ -170,11 +136,6 @@
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4"
 			}
-		},
-		"buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"bytes": {
 			"version": "3.1.0",
@@ -265,14 +226,6 @@
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
-		"ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -360,24 +313,6 @@
 				"parseurl": "~1.3.3",
 				"statuses": "~1.5.0",
 				"unpipe": "~1.0.0"
-			}
-		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
 			}
 		},
 		"forwarded": {
@@ -473,49 +408,6 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
-		"jsonwebtoken": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-			"requires": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^5.6.0"
-			},
-			"dependencies": {
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
-			}
-		},
-		"jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"requires": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"requires": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"keytar": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/keytar/-/keytar-6.0.1.tgz",
@@ -524,41 +416,6 @@
 				"node-addon-api": "^3.0.0",
 				"prebuild-install": "5.3.4"
 			}
-		},
-		"lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-		},
-		"lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-		},
-		"lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-		},
-		"lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-		},
-		"lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-		},
-		"lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"media-typer": {
 			"version": "0.3.0",

--- a/samples/msal-node-samples/auth-code/package-lock.json
+++ b/samples/msal-node-samples/auth-code/package-lock.json
@@ -4,54 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@azure/msal-common": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-1.0.0.tgz",
-			"integrity": "sha512-l/+1Z9kQWLAlMwJ/c3MGhy4ujtEAK/3CMUaUXHvjUIsQknLFRb9+b3id5YSuToPfAvdUkAQGDZiQXosv1I+eLA==",
-			"requires": {
-				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
-			}
-		},
-		"@azure/msal-node": {
-			"version": "1.0.0-alpha.3",
-			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.0.0-alpha.3.tgz",
-			"integrity": "sha512-DVV0VqCscFxjLjg5+DH0RXzToEdtUx7syl/C35ePuBDVeSHQ/mmD3v0yacTg7MN4biU1qYnv/xDunLLi5pWCVA==",
-			"requires": {
-				"@azure/msal-common": "^1.0.0",
-				"axios": "^0.19.2",
-				"debug": "^4.1.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
-			}
-		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -65,14 +17,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
-		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-			"requires": {
-				"follow-redirects": "1.5.10"
-			}
 		},
 		"body-parser": {
 			"version": "1.19.0",
@@ -206,24 +150,6 @@
 				"parseurl": "~1.3.3",
 				"statuses": "~1.5.0",
 				"unpipe": "~1.0.0"
-			}
-		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
 			}
 		},
 		"forwarded": {

--- a/samples/msal-react-native-android-poc-sample/package-lock.json
+++ b/samples/msal-react-native-android-poc-sample/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@azuread/msal-react-native-android-poc": {
-      "version": "1.0.5",
-      "resolved": "https://npm.pkg.github.com/download/@azuread/msal-react-native-android-poc/1.0.5/2371465063222b69a30ba96bff16be198d2afced929e47bdaeb1f776d73cebfe",
-      "integrity": "sha512-wuNoAtraB01Pvm2inOvybwVl7GEbeRrcGPFPCBDuxlvK+TI/NcGac77EYuj2prqJaS1xRFIe5udh9Aoj7Xcxvw=="
-    },
     "@babel/code-frame": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",


### PR DESCRIPTION
It looks like the package `debug` is not used in `msal-common`. Removing it allows us to avoid tracking `ms` and `debug` as external dependencies.