### PR TITLE
acquireTokenSilent calls ssoSilent

### DIFF
--- a/change/@azure-msal-browser-2020-09-10-15-56-58-add-loginHint-to-iframed-acquireTokenSilent.json
+++ b/change/@azure-msal-browser-2020-09-10-15-56-58-add-loginHint-to-iframed-acquireTokenSilent.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "acquireTokenSilent calls ssoSilent (#2264)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T22:56:23.876Z"
+}

--- a/change/@azure-msal-common-2020-09-10-15-56-58-add-loginHint-to-iframed-acquireTokenSilent.json
+++ b/change/@azure-msal-common-2020-09-10-15-56-58-add-loginHint-to-iframed-acquireTokenSilent.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move refreshToken API to RefreshTokenClient (#2264)",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T22:56:58.175Z"
+}

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -5,7 +5,7 @@
 
 import { CryptoOps } from "../crypto/CryptoOps";
 import { BrowserStorage } from "../cache/BrowserStorage";
-import { Authority, TrustedAuthority, StringUtils, CacheSchemaType, UrlString, ServerAuthorizationCodeResponse, AuthorizationCodeRequest, AuthorizationUrlRequest, AuthorizationCodeClient, PromptValue, SilentFlowRequest, ServerError, InteractionRequiredAuthError, EndSessionRequest, AccountInfo, AuthorityFactory, ServerTelemetryManager, SilentFlowClient, ClientConfiguration, BaseAuthRequest, ServerTelemetryRequest, PersistentCacheKeys, IdToken, ProtocolUtils, ResponseMode, Constants, INetworkModule, AuthenticationResult, Logger, ThrottlingUtils } from "@azure/msal-common";
+import { Authority, TrustedAuthority, StringUtils, CacheSchemaType, UrlString, ServerAuthorizationCodeResponse, AuthorizationCodeRequest, AuthorizationUrlRequest, AuthorizationCodeClient, PromptValue, SilentFlowRequest, ServerError, InteractionRequiredAuthError, EndSessionRequest, AccountInfo, AuthorityFactory, ServerTelemetryManager, SilentFlowClient, ClientConfiguration, BaseAuthRequest, ServerTelemetryRequest, PersistentCacheKeys, IdToken, ProtocolUtils, ResponseMode, Constants, INetworkModule, AuthenticationResult, Logger, ThrottlingUtils, RefreshTokenClient } from "@azure/msal-common";
 import { buildConfiguration, Configuration } from "../config/Configuration";
 import { TemporaryCacheKeys, InteractionType, ApiId, BrowserConstants, DEFAULT_REQUEST } from "../utils/BrowserConstants";
 import { BrowserUtils } from "../utils/BrowserUtils";
@@ -328,7 +328,7 @@ export abstract class ClientApplication {
         BrowserUtils.blockReloadInHiddenIframes();
 
         // Check that we have some SSO data
-        if (StringUtils.isEmpty(request.loginHint) && StringUtils.isEmpty(request.sid)) {
+        if (StringUtils.isEmpty(request.loginHint) && StringUtils.isEmpty(request.sid) && (!request.account || StringUtils.isEmpty(request.account.username))) {
             throw BrowserAuthError.createSilentSSOInsufficientInfoError();
         }
 
@@ -378,50 +378,25 @@ export abstract class ClientApplication {
      * @returns {Promise.<AuthenticationResult>} - a promise that is fulfilled when this function has completed, or rejected if an error was raised. Returns the {@link AuthResponse} object
      *
      */
-    async acquireTokenSilent(request: SilentRequest): Promise<AuthenticationResult> {
+    protected async acquireTokenByRefreshToken(request: SilentRequest): Promise<AuthenticationResult> {
         // block the reload if it occurred inside a hidden iframe
         BrowserUtils.blockReloadInHiddenIframes();
         const silentRequest: SilentFlowRequest = {
             ...request,
             ...this.initializeBaseRequest(request)
         };
-        let serverTelemetryManager = this.initializeServerTelemetryManager(ApiId.acquireTokenSilent_silentFlow, silentRequest.correlationId);
+        const serverTelemetryManager = this.initializeServerTelemetryManager(ApiId.acquireTokenSilent_silentFlow, silentRequest.correlationId);
         try {
-            const silentAuthClient = await this.createSilentFlowClient(serverTelemetryManager, silentRequest.authority);
+            const refreshTokenClient = await this.createRefreshTokenClient(serverTelemetryManager, silentRequest.authority);
             // Send request to renew token. Auth module will throw errors if token cannot be renewed.
-            return await silentAuthClient.acquireToken(silentRequest);
+            return await refreshTokenClient.acquireTokenByRefreshToken(silentRequest);
         } catch (e) {
             serverTelemetryManager.cacheFailedRequest(e);
             const isServerError = e instanceof ServerError;
             const isInteractionRequiredError = e instanceof InteractionRequiredAuthError;
             const isInvalidGrantError = (e.errorCode === BrowserConstants.INVALID_GRANT_ERROR);
             if (isServerError && isInvalidGrantError && !isInteractionRequiredError) {
-                const silentAuthUrlRequest: AuthorizationUrlRequest = this.initializeAuthorizationRequest({
-                    ...silentRequest,
-                    redirectUri: request.redirectUri,
-                    prompt: PromptValue.NONE
-                }, InteractionType.SILENT);
-                serverTelemetryManager = this.initializeServerTelemetryManager(ApiId.acquireTokenSilent_authCode, silentAuthUrlRequest.correlationId);
-
-                try {
-                    // Create auth code request and generate PKCE params
-                    const authCodeRequest: AuthorizationCodeRequest = await this.initializeAuthorizationCodeRequest(silentAuthUrlRequest);
-
-                    // Initialize the client
-                    const authClient: AuthorizationCodeClient = await this.createAuthCodeClient(serverTelemetryManager, silentAuthUrlRequest.authority);
-
-                    // Create authorize request url
-                    const navigateUrl = await authClient.getAuthCodeUrl(silentAuthUrlRequest);
-
-                    // Get scopeString for iframe ID
-                    const scopeString = silentAuthUrlRequest.scopes ? silentAuthUrlRequest.scopes.join(" ") : "";
-
-                    return await this.silentTokenHelper(navigateUrl, authCodeRequest, authClient, scopeString);
-                } catch (e) {
-                    serverTelemetryManager.cacheFailedRequest(e);
-                    this.browserStorage.cleanRequest();
-                    throw e;
-                }
+                return await this.ssoSilent(request);
             }
 
             throw e;
@@ -566,6 +541,16 @@ export abstract class ClientApplication {
         // Create auth module.
         const clientConfig = await this.getClientConfiguration(serverTelemetryManager, authorityUrl);
         return new SilentFlowClient(clientConfig);
+    }
+
+    /**
+     * Creates a Refresh Client with the given authority, or the default authority.
+     * @param authorityUrl 
+     */
+    protected async createRefreshTokenClient(serverTelemetryManager: ServerTelemetryManager, authorityUrl?: string): Promise<RefreshTokenClient> {
+        // Create auth module.
+        const clientConfig = await this.getClientConfiguration(serverTelemetryManager, authorityUrl);
+        return new RefreshTokenClient(clientConfig);
     }
 
     /**

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -2,13 +2,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { AuthenticationResult } from "@azure/msal-common";
+import { AuthenticationResult, SilentFlowRequest } from "@azure/msal-common";
 import { Configuration } from "../config/Configuration";
-import { DEFAULT_REQUEST } from "../utils/BrowserConstants";
+import { DEFAULT_REQUEST, ApiId } from "../utils/BrowserConstants";
 import { IPublicClientApplication } from "./IPublicClientApplication";
 import { RedirectRequest } from "../request/RedirectRequest";
 import { PopupRequest } from "../request/PopupRequest";
 import { ClientApplication } from "./ClientApplication";
+import { SilentRequest } from "../request/SilentRequest";
 
 /**
  * The PublicClientApplication class is the object exposed by the library to perform authentication and authorization functions in Single Page Applications
@@ -63,5 +64,20 @@ export class PublicClientApplication extends ClientApplication implements IPubli
      */
     loginPopup(request?: PopupRequest): Promise<AuthenticationResult> {
         return this.acquireTokenPopup(request || DEFAULT_REQUEST);
+    }
+
+    async acquireTokenSilent(request: SilentRequest): Promise<AuthenticationResult> {
+        const silentRequest: SilentFlowRequest = {
+            ...request,
+            ...this.initializeBaseRequest(request)
+        };
+        try {
+            // Telemetry manager only used to increment cacheHits here
+            const serverTelemetryManager = this.initializeServerTelemetryManager(ApiId.acquireTokenSilent_silentFlow, silentRequest.correlationId);
+            const silentAuthClient = await this.createSilentFlowClient(serverTelemetryManager, silentRequest.authority);
+            return silentAuthClient.acquireCachedToken(silentRequest);
+        } catch (e) {
+            return this.acquireTokenByRefreshToken(request);
+        }
     }
 }

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -7,7 +7,7 @@ const expect = chai.expect;
 import sinon from "sinon";
 import { PublicClientApplication } from "../../src/app/PublicClientApplication";
 import { TEST_CONFIG, TEST_URIS, TEST_HASHES, TEST_TOKENS, TEST_DATA_CLIENT_INFO, TEST_TOKEN_LIFETIMES, RANDOM_TEST_GUID, DEFAULT_OPENID_CONFIG_RESPONSE, testNavUrl, testLogoutUrl, TEST_STATE_VALUES, testNavUrlNoRequest } from "../utils/StringConstants";
-import { ServerError, Constants, AccountInfo, IdTokenClaims, PromptValue, AuthenticationResult, AuthorizationCodeRequest, AuthorizationUrlRequest, IdToken, PersistentCacheKeys, SilentFlowRequest, CacheSchemaType, TimeUtils, AuthorizationCodeClient, ResponseMode, SilentFlowClient, TrustedAuthority, EndSessionRequest, CloudDiscoveryMetadata, AccountEntity, ProtocolUtils, ServerTelemetryCacheValue } from "@azure/msal-common";
+import { ServerError, Constants, AccountInfo, IdTokenClaims, PromptValue, AuthenticationResult, AuthorizationCodeRequest, AuthorizationUrlRequest, IdToken, PersistentCacheKeys, SilentFlowRequest, CacheSchemaType, TimeUtils, AuthorizationCodeClient, ResponseMode, SilentFlowClient, TrustedAuthority, EndSessionRequest, CloudDiscoveryMetadata, AccountEntity, ProtocolUtils, ServerTelemetryCacheValue, RefreshTokenClient } from "@azure/msal-common";
 import { BrowserUtils } from "../../src/utils/BrowserUtils";
 import { BrowserConstants, TemporaryCacheKeys, ApiId } from "../../src/utils/BrowserConstants";
 import { Base64Encode } from "../../src/encode/Base64Encode";
@@ -149,7 +149,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
         it("processes hash if navigateToLoginRequestUri is true and loginRequestUrl contains trailing slash", (done) => {
             sinon.stub(pca, <any>"interactionInProgress").returns(true);
-            const loginRequestUrl = window.location.href.endsWith('/') ? window.location.href.slice(0, -1) : window.location.href + "/";
+            const loginRequestUrl = window.location.href.endsWith("/") ? window.location.href.slice(0, -1) : window.location.href + "/";
             window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH;
             window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`, loginRequestUrl);
             sinon.stub(PublicClientApplication.prototype, <any>"handleHash").callsFake((responseHash) => {
@@ -279,10 +279,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.URL_HASH}`, TEST_HASHES.TEST_ERROR_HASH);
                 window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${BrowserConstants.INTERACTION_STATUS_KEY}`, BrowserConstants.INTERACTION_IN_PROGRESS_VALUE);
                 
-				pca = new PublicClientApplication({
-					auth: {
-						clientId: TEST_CONFIG.MSAL_CLIENT_ID
-					}
+                pca = new PublicClientApplication({
+                    auth: {
+                        clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                    }
                 });
 
                 pca.handleRedirectPromise().catch((err) => {
@@ -465,7 +465,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             it("loginRedirect throws an error if interaction is currently in progress", async () => {
                 window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${BrowserConstants.INTERACTION_STATUS_KEY}`, BrowserConstants.INTERACTION_IN_PROGRESS_VALUE);
                 await expect(pca.loginRedirect(null)).to.be.rejectedWith(BrowserAuthErrorMessage.interactionInProgress.desc);
-				await expect(pca.loginRedirect(null)).to.be.rejectedWith(BrowserAuthError);
+                await expect(pca.loginRedirect(null)).to.be.rejectedWith(BrowserAuthError);
             });
 
             it("Uses default request if no request provided", (done) => {
@@ -484,15 +484,15 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(navigateUrl).to.be.eq(testNavUrl);
                     done();
                     return window;
-				});
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+                });
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				const loginRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
+                const loginRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
                     scopes: ["user.read"],
                     state: TEST_STATE_VALUES.USER_STATE
                 };
@@ -505,89 +505,89 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(navigateUrl.startsWith(testNavUrlNoRequest)).to.be.true;
                     done();
                     return window;
-				});
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+                });
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
 
                 pca.loginRedirect(null);
             });
 
-			it("Updates cache entries correctly", async () => {
-				const emptyRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [],
+            it("Updates cache entries correctly", async () => {
+                const emptyRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [],
                     state: TEST_STATE_VALUES.USER_STATE
                 };
 
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
                 });
 
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
-					expect(noHistory).to.be.undefined;
-					expect(urlNavigate).to.be.not.empty;
+                sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
+                    expect(noHistory).to.be.undefined;
+                    expect(urlNavigate).to.be.not.empty;
                 });
 
-				const browserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				await pca.loginRedirect(emptyRequest);
-				expect(browserStorage.getItem(browserStorage.generateCacheKey(TemporaryCacheKeys.REQUEST_STATE), CacheSchemaType.TEMPORARY)).to.be.deep.eq(TEST_STATE_VALUES.TEST_STATE);
-				expect(browserStorage.getItem(browserStorage.generateCacheKey(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_STATE_VALUES.TEST_STATE}`), CacheSchemaType.TEMPORARY)).to.be.eq(RANDOM_TEST_GUID);
-				expect(browserStorage.getItem(browserStorage.generateCacheKey(`${TemporaryCacheKeys.AUTHORITY}|${TEST_STATE_VALUES.TEST_STATE}`), CacheSchemaType.TEMPORARY)).to.be.eq(`${Constants.DEFAULT_AUTHORITY}`);
-			});
+                const browserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                await pca.loginRedirect(emptyRequest);
+                expect(browserStorage.getItem(browserStorage.generateCacheKey(TemporaryCacheKeys.REQUEST_STATE), CacheSchemaType.TEMPORARY)).to.be.deep.eq(TEST_STATE_VALUES.TEST_STATE);
+                expect(browserStorage.getItem(browserStorage.generateCacheKey(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_STATE_VALUES.TEST_STATE}`), CacheSchemaType.TEMPORARY)).to.be.eq(RANDOM_TEST_GUID);
+                expect(browserStorage.getItem(browserStorage.generateCacheKey(`${TemporaryCacheKeys.AUTHORITY}|${TEST_STATE_VALUES.TEST_STATE}`), CacheSchemaType.TEMPORARY)).to.be.eq(`${Constants.DEFAULT_AUTHORITY}`);
+            });
 
-			it("Caches token request correctly", async () => {
-				const tokenRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [],
+            it("Caches token request correctly", async () => {
+                const tokenRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [],
                     correlationId: RANDOM_TEST_GUID,
                     state: TEST_STATE_VALUES.USER_STATE
                 };
 
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
                 });
 
-				sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
+                sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
-					expect(noHistory).to.be.undefined;
-					expect(urlNavigate).to.be.not.empty;
+                sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
+                    expect(noHistory).to.be.undefined;
+                    expect(urlNavigate).to.be.not.empty;
                 });
 
-				const browserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				const browserCrypto = new CryptoOps();
+                const browserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                const browserCrypto = new CryptoOps();
                 await pca.loginRedirect(tokenRequest);
-				const cachedRequest: AuthorizationCodeRequest = JSON.parse(browserCrypto.base64Decode(browserStorage.getItem(browserStorage.generateCacheKey(TemporaryCacheKeys.REQUEST_PARAMS), CacheSchemaType.TEMPORARY) as string));
-				expect(cachedRequest.scopes).to.be.deep.eq(TEST_CONFIG.DEFAULT_SCOPES);
-				expect(cachedRequest.codeVerifier).to.be.deep.eq(TEST_CONFIG.TEST_VERIFIER);
-				expect(cachedRequest.authority).to.be.deep.eq(`${Constants.DEFAULT_AUTHORITY}`);
-				expect(cachedRequest.correlationId).to.be.deep.eq(RANDOM_TEST_GUID);
-			});
+                const cachedRequest: AuthorizationCodeRequest = JSON.parse(browserCrypto.base64Decode(browserStorage.getItem(browserStorage.generateCacheKey(TemporaryCacheKeys.REQUEST_PARAMS), CacheSchemaType.TEMPORARY) as string));
+                expect(cachedRequest.scopes).to.be.deep.eq(TEST_CONFIG.DEFAULT_SCOPES);
+                expect(cachedRequest.codeVerifier).to.be.deep.eq(TEST_CONFIG.TEST_VERIFIER);
+                expect(cachedRequest.authority).to.be.deep.eq(`${Constants.DEFAULT_AUTHORITY}`);
+                expect(cachedRequest.correlationId).to.be.deep.eq(RANDOM_TEST_GUID);
+            });
 
-			it("Cleans cache before error is thrown", async () => {
-				const emptyRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [],
+            it("Cleans cache before error is thrown", async () => {
+                const emptyRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [],
                     state: TEST_STATE_VALUES.USER_STATE
-				};
-				const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+                };
+                const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
 				
-				const testError = {
+                const testError = {
                     errorCode: "create_login_url_error",
                     errorMessage: "Error in creating a login url"
-                }
+                };
                 sinon.stub(AuthorizationCodeClient.prototype, "getAuthCodeUrl").throws(testError);
                 try {
                     await pca.loginRedirect(emptyRequest);
@@ -601,101 +601,101 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(failureObj.errors[0]).to.eq(testError.errorCode);
                     expect(e).to.be.eq(testError);
                 }
-			});
+            });
 
-			it("Uses adal token from cache if it is present.", async () => {
-				const idTokenClaims: IdTokenClaims = {
-					"iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
-					"exp": "1536279024",
-					"name": "abeli",
-					"nonce": "123523",
-					"oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
-					"sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
-					"tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
-					"ver": "1.0",
-					"upn": "AbeLincoln@contoso.com"
-				};
-				sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
-				const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				browserStorage.setItem(PersistentCacheKeys.ADAL_ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, CacheSchemaType.TEMPORARY);
-				const loginUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+            it("Uses adal token from cache if it is present.", async () => {
+                const idTokenClaims: IdTokenClaims = {
+                    "iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
+                    "exp": "1536279024",
+                    "name": "abeli",
+                    "nonce": "123523",
+                    "oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
+                    "sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
+                    "tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
+                    "ver": "1.0",
+                    "upn": "AbeLincoln@contoso.com"
+                };
+                sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
+                const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                browserStorage.setItem(PersistentCacheKeys.ADAL_ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, CacheSchemaType.TEMPORARY);
+                const loginUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
-					expect(noHistory).to.be.undefined;
-					expect(urlNavigate).to.be.not.empty;
-				});
-				const emptyRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [],
+                sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
+                    expect(noHistory).to.be.undefined;
+                    expect(urlNavigate).to.be.not.empty;
+                });
+                const emptyRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [],
                     state: TEST_STATE_VALUES.USER_STATE
-				};
-				await pca.loginRedirect(emptyRequest);
-				const validatedRequest: AuthorizationUrlRequest = {
+                };
+                await pca.loginRedirect(emptyRequest);
+                const validatedRequest: AuthorizationUrlRequest = {
                     ...emptyRequest,
                     scopes: TEST_CONFIG.DEFAULT_SCOPES,
-					loginHint: idTokenClaims.upn,
-					state: TEST_STATE_VALUES.TEST_STATE,
+                    loginHint: idTokenClaims.upn,
+                    state: TEST_STATE_VALUES.TEST_STATE,
                     correlationId: RANDOM_TEST_GUID,
                     nonce: RANDOM_TEST_GUID,
                     authority: `${Constants.DEFAULT_AUTHORITY}`,
                     responseMode: ResponseMode.FRAGMENT,
-					codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
-					codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+                    codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                    codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
                 };
-				expect(loginUrlSpy.calledWith(validatedRequest)).to.be.true;
-			});
+                expect(loginUrlSpy.calledWith(validatedRequest)).to.be.true;
+            });
 	
-			it("Does not use adal token from cache if it is present and SSO params have been given.", async () => {
-				const idTokenClaims: IdTokenClaims = {
-					"iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
-					"exp": "1536279024",
-					"name": "abeli",
-					"nonce": "123523",
-					"oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
-					"sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
-					"tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
-					"ver": "1.0",
-					"upn": "AbeLincoln@contoso.com"
-				};
-				sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
-				const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				browserStorage.setItem(PersistentCacheKeys.ADAL_ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, CacheSchemaType.TEMPORARY);
-				const loginUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+            it("Does not use adal token from cache if it is present and SSO params have been given.", async () => {
+                const idTokenClaims: IdTokenClaims = {
+                    "iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
+                    "exp": "1536279024",
+                    "name": "abeli",
+                    "nonce": "123523",
+                    "oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
+                    "sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
+                    "tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
+                    "ver": "1.0",
+                    "upn": "AbeLincoln@contoso.com"
+                };
+                sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
+                const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                browserStorage.setItem(PersistentCacheKeys.ADAL_ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, CacheSchemaType.TEMPORARY);
+                const loginUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
-					expect(noHistory).to.be.undefined;
-					expect(urlNavigate).to.be.not.empty;
-				});
-				const loginRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [],
-					loginHint: "AbeLi@microsoft.com",
+                sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
+                    expect(noHistory).to.be.undefined;
+                    expect(urlNavigate).to.be.not.empty;
+                });
+                const loginRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [],
+                    loginHint: "AbeLi@microsoft.com",
                     state: TEST_STATE_VALUES.USER_STATE
-				};
-				await pca.loginRedirect(loginRequest);
-				const validatedRequest: AuthorizationUrlRequest = {
+                };
+                await pca.loginRedirect(loginRequest);
+                const validatedRequest: AuthorizationUrlRequest = {
                     ...loginRequest,
                     scopes: TEST_CONFIG.DEFAULT_SCOPES,
-					state: TEST_STATE_VALUES.TEST_STATE,
-					correlationId: RANDOM_TEST_GUID,
-					authority: `${Constants.DEFAULT_AUTHORITY}`,
-					nonce: RANDOM_TEST_GUID,
+                    state: TEST_STATE_VALUES.TEST_STATE,
+                    correlationId: RANDOM_TEST_GUID,
+                    authority: `${Constants.DEFAULT_AUTHORITY}`,
+                    nonce: RANDOM_TEST_GUID,
                     responseMode: ResponseMode.FRAGMENT,
-					codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
-					codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
-				};
-				expect(loginUrlSpy.calledWith(validatedRequest)).to.be.true;
-			});
+                    codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                    codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+                };
+                expect(loginUrlSpy.calledWith(validatedRequest)).to.be.true;
+            });
         });
 
         describe("acquireTokenRedirect", () => {
@@ -711,88 +711,88 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(navigateUrl).to.be.eq(testNavUrl);
                     done();
                     return window;
-				});
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+                });
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				const loginRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: ["user.read", "openid", "profile"],
+                const loginRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: ["user.read", "openid", "profile"],
                     state: TEST_STATE_VALUES.USER_STATE
-				};
+                };
                 pca.acquireTokenRedirect(loginRequest);
             });
 
-			it("Updates cache entries correctly", async () => {
-				const testScope = "testscope";
-				const emptyRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [testScope],
+            it("Updates cache entries correctly", async () => {
+                const testScope = "testscope";
+                const emptyRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [testScope],
                     state: TEST_STATE_VALUES.USER_STATE
-				};
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+                };
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
-					expect(noHistory).to.be.undefined;
-					expect(urlNavigate).to.be.not.empty;
-				});
-				const browserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				await pca.loginRedirect(emptyRequest);
-				expect(browserStorage.getItem(browserStorage.generateCacheKey(TemporaryCacheKeys.REQUEST_STATE), CacheSchemaType.TEMPORARY)).to.be.deep.eq(TEST_STATE_VALUES.TEST_STATE);
-				expect(browserStorage.getItem(browserStorage.generateCacheKey(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_STATE_VALUES.TEST_STATE}`), CacheSchemaType.TEMPORARY)).to.be.eq(RANDOM_TEST_GUID);
-				expect(browserStorage.getItem(browserStorage.generateCacheKey(`${TemporaryCacheKeys.AUTHORITY}|${TEST_STATE_VALUES.TEST_STATE}`), CacheSchemaType.TEMPORARY)).to.be.eq(`${Constants.DEFAULT_AUTHORITY}`);
-			});
+                sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
+                    expect(noHistory).to.be.undefined;
+                    expect(urlNavigate).to.be.not.empty;
+                });
+                const browserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                await pca.loginRedirect(emptyRequest);
+                expect(browserStorage.getItem(browserStorage.generateCacheKey(TemporaryCacheKeys.REQUEST_STATE), CacheSchemaType.TEMPORARY)).to.be.deep.eq(TEST_STATE_VALUES.TEST_STATE);
+                expect(browserStorage.getItem(browserStorage.generateCacheKey(`${TemporaryCacheKeys.NONCE_IDTOKEN}|${TEST_STATE_VALUES.TEST_STATE}`), CacheSchemaType.TEMPORARY)).to.be.eq(RANDOM_TEST_GUID);
+                expect(browserStorage.getItem(browserStorage.generateCacheKey(`${TemporaryCacheKeys.AUTHORITY}|${TEST_STATE_VALUES.TEST_STATE}`), CacheSchemaType.TEMPORARY)).to.be.eq(`${Constants.DEFAULT_AUTHORITY}`);
+            });
 	
-			it("Caches token request correctly", async () => {
-				const testScope = "testscope";
-				const tokenRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [testScope],
-					correlationId: RANDOM_TEST_GUID,
+            it("Caches token request correctly", async () => {
+                const testScope = "testscope";
+                const tokenRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [testScope],
+                    correlationId: RANDOM_TEST_GUID,
                     state: TEST_STATE_VALUES.USER_STATE
-				};
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
-				sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
-				sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
-					expect(noHistory).to.be.undefined;
-					expect(urlNavigate).to.be.not.empty;
-				});
-				const browserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				const browserCrypto = new CryptoOps();
-				await pca.acquireTokenRedirect(tokenRequest);
-				const cachedRequest: AuthorizationCodeRequest = JSON.parse(browserCrypto.base64Decode(browserStorage.getItem(browserStorage.generateCacheKey(TemporaryCacheKeys.REQUEST_PARAMS), CacheSchemaType.TEMPORARY) as string));
-				expect(cachedRequest.scopes).to.be.deep.eq([testScope, ...TEST_CONFIG.DEFAULT_SCOPES]);
-				expect(cachedRequest.codeVerifier).to.be.deep.eq(TEST_CONFIG.TEST_VERIFIER);
-				expect(cachedRequest.authority).to.be.deep.eq(`${Constants.DEFAULT_AUTHORITY}`);
-				expect(cachedRequest.correlationId).to.be.deep.eq(RANDOM_TEST_GUID);
-			});
+                };
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
+                sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
+                sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
+                    expect(noHistory).to.be.undefined;
+                    expect(urlNavigate).to.be.not.empty;
+                });
+                const browserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                const browserCrypto = new CryptoOps();
+                await pca.acquireTokenRedirect(tokenRequest);
+                const cachedRequest: AuthorizationCodeRequest = JSON.parse(browserCrypto.base64Decode(browserStorage.getItem(browserStorage.generateCacheKey(TemporaryCacheKeys.REQUEST_PARAMS), CacheSchemaType.TEMPORARY) as string));
+                expect(cachedRequest.scopes).to.be.deep.eq([testScope, ...TEST_CONFIG.DEFAULT_SCOPES]);
+                expect(cachedRequest.codeVerifier).to.be.deep.eq(TEST_CONFIG.TEST_VERIFIER);
+                expect(cachedRequest.authority).to.be.deep.eq(`${Constants.DEFAULT_AUTHORITY}`);
+                expect(cachedRequest.correlationId).to.be.deep.eq(RANDOM_TEST_GUID);
+            });
 
-			it("Cleans cache before error is thrown", async () => {
-				const testScope = "testscope";
-				const emptyRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [testScope]
-				};
-				const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
+            it("Cleans cache before error is thrown", async () => {
+                const testScope = "testscope";
+                const emptyRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [testScope]
+                };
+                const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
                 });
                 
-				const testError = {
+                const testError = {
                     errorCode: "create_login_url_error",
                     errorMessage: "Error in creating a login url"
-                }
+                };
                 sinon.stub(AuthorizationCodeClient.prototype, "getAuthCodeUrl").throws(testError);
                 try {
                     await pca.acquireTokenRedirect(emptyRequest);
@@ -806,103 +806,103 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(failureObj.errors[0]).to.eq(testError.errorCode);
                     expect(e).to.be.eq(testError);
                 }
-			});
+            });
 
-			it("Uses adal token from cache if it is present.", async () => {
-				const testScope = "testscope";
-				const idTokenClaims: IdTokenClaims = {
-					"iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
-					"exp": "1536279024",
-					"name": "abeli",
-					"nonce": "123523",
-					"oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
-					"sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
-					"tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
-					"ver": "1.0",
-					"upn": "AbeLincoln@contoso.com"
-				};
-				sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
-				const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				browserStorage.setItem(PersistentCacheKeys.ADAL_ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, CacheSchemaType.TEMPORARY);
-				const acquireTokenUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+            it("Uses adal token from cache if it is present.", async () => {
+                const testScope = "testscope";
+                const idTokenClaims: IdTokenClaims = {
+                    "iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
+                    "exp": "1536279024",
+                    "name": "abeli",
+                    "nonce": "123523",
+                    "oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
+                    "sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
+                    "tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
+                    "ver": "1.0",
+                    "upn": "AbeLincoln@contoso.com"
+                };
+                sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
+                const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                browserStorage.setItem(PersistentCacheKeys.ADAL_ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, CacheSchemaType.TEMPORARY);
+                const acquireTokenUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
-					expect(noHistory).to.be.undefined;
-					expect(urlNavigate).to.be.not.empty;
-				});
-				const emptyRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
+                sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
+                    expect(noHistory).to.be.undefined;
+                    expect(urlNavigate).to.be.not.empty;
+                });
+                const emptyRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
                     scopes: [testScope],
                     state: TEST_STATE_VALUES.USER_STATE
-				};
-				await pca.acquireTokenRedirect(emptyRequest);
-				const validatedRequest: AuthorizationUrlRequest = {
+                };
+                await pca.acquireTokenRedirect(emptyRequest);
+                const validatedRequest: AuthorizationUrlRequest = {
                     ...emptyRequest,
                     scopes: [...emptyRequest.scopes, ...TEST_CONFIG.DEFAULT_SCOPES],
-					loginHint: idTokenClaims.upn,
-					state: TEST_STATE_VALUES.TEST_STATE,
-					correlationId: RANDOM_TEST_GUID,
-					authority: `${Constants.DEFAULT_AUTHORITY}`,
-					nonce: RANDOM_TEST_GUID,
+                    loginHint: idTokenClaims.upn,
+                    state: TEST_STATE_VALUES.TEST_STATE,
+                    correlationId: RANDOM_TEST_GUID,
+                    authority: `${Constants.DEFAULT_AUTHORITY}`,
+                    nonce: RANDOM_TEST_GUID,
                     responseMode: ResponseMode.FRAGMENT,
-					codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
-					codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+                    codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                    codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
                 };
-				expect(acquireTokenUrlSpy.calledWith(validatedRequest)).to.be.true;
-			});
+                expect(acquireTokenUrlSpy.calledWith(validatedRequest)).to.be.true;
+            });
 	
-			it("Does not use adal token from cache if it is present and SSO params have been given.", async () => {
-				const idTokenClaims: IdTokenClaims = {
-					"iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
-					"exp": "1536279024",
-					"name": "abeli",
-					"nonce": "123523",
-					"oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
-					"sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
-					"tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
-					"ver": "1.0",
-					"upn": "AbeLincoln@contoso.com"
-				};
-				sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
-				const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
-				browserStorage.setItem(PersistentCacheKeys.ADAL_ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, CacheSchemaType.TEMPORARY);
-				const acquireTokenUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
+            it("Does not use adal token from cache if it is present and SSO params have been given.", async () => {
+                const idTokenClaims: IdTokenClaims = {
+                    "iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
+                    "exp": "1536279024",
+                    "name": "abeli",
+                    "nonce": "123523",
+                    "oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
+                    "sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
+                    "tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
+                    "ver": "1.0",
+                    "upn": "AbeLincoln@contoso.com"
+                };
+                sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
+                const browserStorage: BrowserStorage = new BrowserStorage(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig);
+                browserStorage.setItem(PersistentCacheKeys.ADAL_ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, CacheSchemaType.TEMPORARY);
+                const acquireTokenUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
                 sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 sinon.stub(TimeUtils, "nowSeconds").returns(TEST_STATE_VALUES.TEST_TIMESTAMP);
-				sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
-					expect(noHistory).to.be.undefined;
-					expect(urlNavigate).to.be.not.empty;
-				});
-				const testScope = "testscope";
-				const loginRequest: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: [testScope],
-					loginHint: "AbeLi@microsoft.com",
+                sinon.stub(BrowserUtils, "navigateWindow").callsFake((urlNavigate: string, noHistory?: boolean) => {
+                    expect(noHistory).to.be.undefined;
+                    expect(urlNavigate).to.be.not.empty;
+                });
+                const testScope = "testscope";
+                const loginRequest: AuthorizationUrlRequest = {
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: [testScope],
+                    loginHint: "AbeLi@microsoft.com",
                     state: TEST_STATE_VALUES.USER_STATE
-				};
-				await pca.acquireTokenRedirect(loginRequest);
-				const validatedRequest: AuthorizationUrlRequest = {
+                };
+                await pca.acquireTokenRedirect(loginRequest);
+                const validatedRequest: AuthorizationUrlRequest = {
                     ...loginRequest,
                     scopes: [...loginRequest.scopes, ...TEST_CONFIG.DEFAULT_SCOPES],
-					state: TEST_STATE_VALUES.TEST_STATE,
-					correlationId: RANDOM_TEST_GUID,
-					authority: `${Constants.DEFAULT_AUTHORITY}`,
-					nonce: RANDOM_TEST_GUID,
+                    state: TEST_STATE_VALUES.TEST_STATE,
+                    correlationId: RANDOM_TEST_GUID,
+                    authority: `${Constants.DEFAULT_AUTHORITY}`,
+                    nonce: RANDOM_TEST_GUID,
                     responseMode: ResponseMode.FRAGMENT,
-					codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
-					codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
-				};
-				expect(acquireTokenUrlSpy.calledWith(validatedRequest)).to.be.true;
-			});
+                    codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                    codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+                };
+                expect(acquireTokenUrlSpy.calledWith(validatedRequest)).to.be.true;
+            });
         });
     });
 
@@ -991,14 +991,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 const testError = {
                     errorCode: "create_login_url_error",
                     errorMessage: "Error in creating a login url"
-                }
+                };
                 sinon.stub(AuthorizationCodeClient.prototype, "getAuthCodeUrl").resolves(testNavUrl);
-				sinon.stub(PopupHandler.prototype, "initiateAuthRequest").throws(testError);
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
-				sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
+                sinon.stub(PopupHandler.prototype, "initiateAuthRequest").throws(testError);
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
+                sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 try {
                     const tokenResp = await pca.loginPopup(null);
                 } catch (e) {
@@ -1039,9 +1039,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             it("opens popup window before network request by default", async () => {
                 const request: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: ["scope"],
-					loginHint: "AbeLi@microsoft.com",
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: ["scope"],
+                    loginHint: "AbeLi@microsoft.com",
                     state: TEST_STATE_VALUES.USER_STATE
                 };
 
@@ -1074,9 +1074,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 });
 
                 const request: AuthorizationUrlRequest = {
-					redirectUri: TEST_URIS.TEST_REDIR_URI,
-					scopes: ["scope"],
-					loginHint: "AbeLi@microsoft.com",
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    scopes: ["scope"],
+                    loginHint: "AbeLi@microsoft.com",
                     state: TEST_STATE_VALUES.USER_STATE
                 };
 
@@ -1153,14 +1153,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 const testError = {
                     errorCode: "create_login_url_error",
                     errorMessage: "Error in creating a login url"
-                }
+                };
                 sinon.stub(AuthorizationCodeClient.prototype, "getAuthCodeUrl").resolves(testNavUrl);
-				sinon.stub(PopupHandler.prototype, "initiateAuthRequest").throws(testError);
-				sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-					challenge: TEST_CONFIG.TEST_CHALLENGE,
-					verifier: TEST_CONFIG.TEST_VERIFIER
-				});
-				sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
+                sinon.stub(PopupHandler.prototype, "initiateAuthRequest").throws(testError);
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
+                sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
                 try {
                     const tokenResp = await pca.acquireTokenPopup({
                         redirectUri: TEST_URIS.TEST_REDIR_URI,
@@ -1355,7 +1355,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 account: testAccount
             };
             sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
-            const silentATStub = sinon.stub(SilentFlowClient.prototype, "acquireToken").resolves(testTokenResponse);
+            const silentATStub = sinon.stub(RefreshTokenClient.prototype, <any>"acquireTokenByRefreshToken").resolves(testTokenResponse);
             const tokenRequest: SilentFlowRequest = {
                 scopes: ["scope1"],
                 account: testAccount
@@ -1377,14 +1377,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const testError = {
                 errorCode: "create_login_url_error",
                 errorMessage: "Error in creating a login url"
-            }
+            };
             const testAccount: AccountInfo = {
                 homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
                 environment: "login.windows.net",
                 tenantId: "testTenantId",
                 username: "username@contoso.com"
             };
-            sinon.stub(SilentFlowClient.prototype, "acquireToken").throws(testError);
+            sinon.stub(RefreshTokenClient.prototype, <any>"acquireTokenByRefreshToken").throws(testError);
             try {
                 const tokenResp = await pca.acquireTokenSilent({
                     scopes: TEST_CONFIG.DEFAULT_SCOPES,
@@ -1404,7 +1404,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
         it("Falls back to silent handler if thrown error is a refresh token expired error", async () => {
             const invalidGrantError: ServerError = new ServerError("invalid_grant", "AADSTS700081: The refresh token has expired due to maximum lifetime. The token was issued on xxxxxxx and the maximum allowed lifetime for this application is 1.00:00:00.\r\nTrace ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx\r\nCorrelation ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx\r\nTimestamp: 2020-0x-0x XX:XX:XXZ");
-            sinon.stub(SilentFlowClient.prototype, "acquireToken").rejects(invalidGrantError);
+            sinon.stub(RefreshTokenClient.prototype, <any>"acquireTokenByRefreshToken").rejects(invalidGrantError);
             const testServerTokenResponse = {
                 token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,
                 scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
@@ -1442,11 +1442,11 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 account: testAccount
             };
             const createAcqTokenStub = sinon.stub(AuthorizationCodeClient.prototype, "getAuthCodeUrl").resolves(testNavUrl);
-			const silentTokenHelperStub = sinon.stub(pca, <any>"silentTokenHelper").resolves(testTokenResponse);
-			sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-				challenge: TEST_CONFIG.TEST_CHALLENGE,
-				verifier: TEST_CONFIG.TEST_VERIFIER
-			});
+            const silentTokenHelperStub = sinon.stub(pca, <any>"silentTokenHelper").resolves(testTokenResponse);
+            sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                challenge: TEST_CONFIG.TEST_CHALLENGE,
+                verifier: TEST_CONFIG.TEST_VERIFIER
+            });
             sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
             sinon.stub(ProtocolUtils, "setRequestState").returns(RANDOM_TEST_GUID);
             const silentFlowRequest: SilentFlowRequest = {
@@ -1460,7 +1460,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 correlationId: RANDOM_TEST_GUID,
                 prompt: "none",
                 redirectUri: TEST_URIS.TEST_REDIR_URI,
-				state: RANDOM_TEST_GUID,
+                state: RANDOM_TEST_GUID,
                 nonce: RANDOM_TEST_GUID,
                 responseMode: ResponseMode.FRAGMENT,
                 codeChallenge: TEST_CONFIG.TEST_CHALLENGE,

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -231,16 +231,17 @@ export class AuthorizationCodeClient extends BaseClient {
             parameterBuilder.addPrompt(request.prompt);
         }
 
-        if (request.loginHint) {
-            parameterBuilder.addLoginHint(request.loginHint);
-        }
-
         if (request.domainHint) {
             parameterBuilder.addDomainHint(request.domainHint);
         }
 
+        // Add sid or loginHint with preference for sid -> loginHint -> username of AccountInfo object
         if (request.sid) {
             parameterBuilder.addSid(request.sid);
+        } else if (request.loginHint) {
+            parameterBuilder.addLoginHint(request.loginHint);
+        } else if (request.account && request.account.username) {
+            parameterBuilder.addLoginHint(request.account.username);
         }
 
         if (request.nonce) {

--- a/lib/msal-common/src/request/AuthorizationUrlRequest.ts
+++ b/lib/msal-common/src/request/AuthorizationUrlRequest.ts
@@ -6,6 +6,7 @@
 import { ResponseMode } from "../utils/Constants";
 import { StringDict } from "../utils/MsalTypes";
 import { BaseAuthRequest } from "./BaseAuthRequest";
+import { AccountInfo } from "../account/AccountInfo";
 
 /**
  * Request object passed by user to retrieve a Code from the server (first leg of authorization code grant flow)
@@ -25,6 +26,7 @@ import { BaseAuthRequest } from "./BaseAuthRequest";
  *          none:  will ensure that the user isn't presented with any interactive prompt. if request can't be completed via single-sign on, the endpoint will return an interaction_required error
  *          consent: will the trigger the OAuth consent dialog after the user signs in, asking the user to grant permissions to the app
  *          select_account: will interrupt single sign-=on providing account selection experience listing all the accounts in session or any remembered accounts or an option to choose to use a different account
+ * - account                    - AccountInfo obtained from a getAccount API. Will be used in certain scenarios to generate login_hint if both loginHint and sid params are not provided.
  * - loginHint                  - Can be used to pre-fill the username/email address field of the sign-in page for the user, if you know the username/email address ahead of time. Often apps use this parameter during re-authentication, having already extracted the username from a previous sign-in using the preferred_username claim.
  * - sid                        - Session ID, unique identifier for the session. Available as an optional claim on ID tokens.
  * - domainHint                 - Provides a hint about the tenant or domain that the user should use to sign in. The value of the domain hint is a registered domain for the tenant.
@@ -39,6 +41,7 @@ export type AuthorizationUrlRequest = BaseAuthRequest & {
     codeChallengeMethod?: string;
     state?: string;
     prompt?: string;
+    account?: AccountInfo;
     loginHint?: string;
     domainHint?: string;
     sid?: string;

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -25,7 +25,8 @@ import {
     TEST_URIS,
     TEST_DATA_CLIENT_INFO,
     RANDOM_TEST_GUID,
-    TEST_STATE_VALUES
+    TEST_STATE_VALUES,
+    TEST_ACCOUNT_INFO
 } from "../utils/StringConstants";
 import { ClientConfiguration } from "../../src/config/ClientConfiguration";
 import { BaseClient } from "../../src/client/BaseClient";
@@ -76,7 +77,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(loginUrl).to.contain(`${AADServerParamKeys.REDIRECT_URI}=${encodeURIComponent(TEST_URIS.TEST_REDIRECT_URI_LOCALHOST)}`);
             expect(loginUrl).to.contain(`${AADServerParamKeys.RESPONSE_MODE}=${encodeURIComponent(ResponseMode.QUERY)}`);
             expect(loginUrl).to.contain(`${AADServerParamKeys.CODE_CHALLENGE}=${encodeURIComponent(TEST_CONFIG.TEST_CHALLENGE)}`);
-			expect(loginUrl).to.contain(`${AADServerParamKeys.CODE_CHALLENGE_METHOD}=${encodeURIComponent(Constants.S256_CODE_CHALLENGE_METHOD)}`);
+            expect(loginUrl).to.contain(`${AADServerParamKeys.CODE_CHALLENGE_METHOD}=${encodeURIComponent(Constants.S256_CODE_CHALLENGE_METHOD)}`);
         });
 
         it("Creates an authorization url passing in optional parameters", async () => {
@@ -98,8 +99,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 loginHint: TEST_CONFIG.LOGIN_HINT,
                 domainHint: TEST_CONFIG.DOMAIN_HINT,
                 claims: TEST_CONFIG.CLAIMS,
-                nonce: TEST_CONFIG.NONCE,
-                sid: TEST_CONFIG.SID
+                nonce: TEST_CONFIG.NONCE
             };
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(loginUrl).to.contain(TEST_CONFIG.alternateValidAuthority);
@@ -116,7 +116,59 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(loginUrl).to.contain(`${SSOTypes.LOGIN_HINT}=${encodeURIComponent(TEST_CONFIG.LOGIN_HINT)}`);
             expect(loginUrl).to.contain(`${SSOTypes.DOMAIN_HINT}=${encodeURIComponent(TEST_CONFIG.DOMAIN_HINT)}`);
             expect(loginUrl).to.contain(`${AADServerParamKeys.CLAIMS}=${encodeURIComponent(TEST_CONFIG.CLAIMS)}`);
+        });
+
+        it("Prefers sid over loginHint if both provided", async () => {
+            // Override with alternate authority openid_config
+            sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(ALTERNATE_OPENID_CONFIG_RESPONSE);
+
+            const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            const authCodeUrlRequest: AuthorizationUrlRequest = {
+                redirectUri: TEST_URIS.TEST_REDIRECT_URI_LOCALHOST,
+                scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE, ...TEST_CONFIG.DEFAULT_SCOPES],
+                loginHint: TEST_CONFIG.LOGIN_HINT,
+                sid: TEST_CONFIG.SID
+            };
+            const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
+            expect(loginUrl).to.not.contain(`${SSOTypes.LOGIN_HINT}=`);
             expect(loginUrl).to.contain(`${SSOTypes.SID}=${encodeURIComponent(TEST_CONFIG.SID)}`);
+        });
+
+        it("Prefers loginHint over Account if both provided", async () => {
+            // Override with alternate authority openid_config
+            sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(ALTERNATE_OPENID_CONFIG_RESPONSE);
+
+            const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            const authCodeUrlRequest: AuthorizationUrlRequest = {
+                redirectUri: TEST_URIS.TEST_REDIRECT_URI_LOCALHOST,
+                scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE, ...TEST_CONFIG.DEFAULT_SCOPES],
+                loginHint: TEST_CONFIG.LOGIN_HINT,
+                account: TEST_ACCOUNT_INFO
+            };
+            const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
+            expect(loginUrl).to.contain(`${SSOTypes.LOGIN_HINT}=${encodeURIComponent(TEST_CONFIG.LOGIN_HINT)}`);
+            expect(loginUrl).to.not.contain(`${SSOTypes.SID}=`);
+        });
+
+        it("Sets login_hint to Account.username if login_hint and sid are not provided", async () => {
+            // Override with alternate authority openid_config
+            sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(ALTERNATE_OPENID_CONFIG_RESPONSE);
+
+            const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            const authCodeUrlRequest: AuthorizationUrlRequest = {
+                redirectUri: TEST_URIS.TEST_REDIRECT_URI_LOCALHOST,
+                scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE, ...TEST_CONFIG.DEFAULT_SCOPES],
+                account: TEST_ACCOUNT_INFO
+            };
+            const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
+            expect(loginUrl).to.contain(`${SSOTypes.LOGIN_HINT}=${encodeURIComponent(TEST_ACCOUNT_INFO.username)}`);
+            expect(loginUrl).to.not.contain(`${SSOTypes.SID}=`);
         });
 
         it("Creates a login URL with scopes from given token request", async () => {
@@ -129,10 +181,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             const testScope1 = "testscope1";
             const testScope2 = "testscope2";
             const loginRequest: AuthorizationUrlRequest = {
-				redirectUri: TEST_URIS.TEST_REDIR_URI,
-				scopes: [testScope1, testScope2],
-				codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
-				codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+                redirectUri: TEST_URIS.TEST_REDIR_URI,
+                scopes: [testScope1, testScope2],
+                codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
             };
 
             const loginUrl = await client.getAuthCodeUrl(loginRequest);
@@ -145,11 +197,11 @@ describe("AuthorizationCodeClient unit tests", () => {
             const client = new AuthorizationCodeClient(config);
 
             const loginRequest: AuthorizationUrlRequest = {
-				redirectUri: TEST_URIS.TEST_REDIR_URI,
+                redirectUri: TEST_URIS.TEST_REDIR_URI,
                 scopes: TEST_CONFIG.DEFAULT_SCOPES,
-				authority: `${TEST_URIS.ALTERNATE_INSTANCE}/common`,
-				codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
-				codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+                authority: `${TEST_URIS.ALTERNATE_INSTANCE}/common`,
+                codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
             };
             const loginUrl = await client.getAuthCodeUrl(loginRequest);
             expect(loginUrl).to.contain(TEST_URIS.ALTERNATE_INSTANCE);
@@ -166,11 +218,11 @@ describe("AuthorizationCodeClient unit tests", () => {
             const client = new AuthorizationCodeClient(config);
 
             const emptyRequest: AuthorizationUrlRequest = {
-				redirectUri: TEST_URIS.TEST_REDIR_URI,
-				scopes: null,
-				codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
-				codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
-			};
+                redirectUri: TEST_URIS.TEST_REDIR_URI,
+                scopes: null,
+                codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+            };
             await expect(client.getAuthCodeUrl(emptyRequest)).to.be.rejectedWith(ClientConfigurationErrorMessage.emptyScopesError.desc);
         });
 
@@ -180,11 +232,11 @@ describe("AuthorizationCodeClient unit tests", () => {
             const client = new AuthorizationCodeClient(config);
 
             const emptyRequest: AuthorizationUrlRequest = {
-				redirectUri: TEST_URIS.TEST_REDIR_URI,
-				scopes: [],
-				codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
-				codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
-			};
+                redirectUri: TEST_URIS.TEST_REDIR_URI,
+                scopes: [],
+                codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+            };
             await expect(client.getAuthCodeUrl(emptyRequest)).to.be.rejectedWith(ClientConfigurationErrorMessage.emptyScopesError.desc);
         });
     });
@@ -215,7 +267,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
             const client: AuthorizationCodeClient = new AuthorizationCodeClient(config);
             const code = client.handleFragmentResponse(testSuccessHash, TEST_STATE_VALUES.ENCODED_LIB_STATE);
-            expect(code).to.be.eq(`thisIsATestCode`);
+            expect(code).to.be.eq("thisIsATestCode");
         });
 
         it("returns valid server code response when state is encoded twice", async () => {
@@ -242,7 +294,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
             const client: AuthorizationCodeClient = new AuthorizationCodeClient(config);
             const code = client.handleFragmentResponse(testSuccessHash, TEST_STATE_VALUES.ENCODED_LIB_STATE);
-            expect(code).to.be.eq(`thisIsATestCode`);
+            expect(code).to.be.eq("thisIsATestCode");
         });
 
         it("throws server error when error is in hash", async () => {
@@ -292,12 +344,12 @@ describe("AuthorizationCodeClient unit tests", () => {
             const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
             // Set up required objects and mocked return values
             const testState = `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9${Constants.RESOURCE_DELIM}userState`;
-            const decodedLibState = `{ "id": "testid", "ts": 1592846482 }`;
+            const decodedLibState = "{ \"id\": \"testid\", \"ts\": 1592846482 }";
             config.cryptoInterface.base64Decode = (input: string): string => {
                 switch (input) {
                     case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
                         return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
-                    case `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9`:
+                    case "eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9":
                         return decodedLibState;
                     default:
                         return input;
@@ -373,7 +425,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             const logoutUri = client.getLogoutUri({account: null});
 
             expect(removeAccountSpy.calledOnce).to.be.true;
-            expect(logoutUri).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace(`{tenant}`, "common"));
+            expect(logoutUri).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace("{tenant}", "common"));
         });
 
         it("Returns a uri and clears the cache of relevant account info", async () => {
@@ -391,7 +443,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             const logoutUri = client.getLogoutUri({account: testAccount});
 
             expect(removeAccountSpy.calledWith(AccountEntity.generateAccountCacheKey(testAccount))).to.be.true;
-            expect(logoutUri).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace(`{tenant}`, "common"));
+            expect(logoutUri).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace("{tenant}", "common"));
         });
 
         it("Returns a uri with given postLogoutUri and correlationId", async () => {
@@ -413,7 +465,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             });
 
             expect(removeAccountSpy.calledWith(AccountEntity.generateAccountCacheKey(testAccount))).to.be.true;
-            const testLogoutUriWithParams = `${DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace(`{tenant}`, "common")}?${AADServerParamKeys.POST_LOGOUT_URI}=${encodeURIComponent(TEST_URIS.TEST_LOGOUT_URI)}&${AADServerParamKeys.CLIENT_REQUEST_ID}=${encodeURIComponent(RANDOM_TEST_GUID)}`;
+            const testLogoutUriWithParams = `${DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace("{tenant}", "common")}?${AADServerParamKeys.POST_LOGOUT_URI}=${encodeURIComponent(TEST_URIS.TEST_LOGOUT_URI)}&${AADServerParamKeys.CLIENT_REQUEST_ID}=${encodeURIComponent(RANDOM_TEST_GUID)}`;
             expect(logoutUri).to.be.eq(testLogoutUriWithParams);
         });
     });

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -6,17 +6,41 @@ import {
     TEST_CONFIG,
     TEST_TOKENS,
     TEST_DATA_CLIENT_INFO,
-    TEST_URIS,
+    ID_TOKEN_CLAIMS,
 } from "../utils/StringConstants";
 import {BaseClient} from "../../src/client/BaseClient";
-import {AADServerParamKeys, GrantType, Constants} from "../../src/utils/Constants";
+import {AADServerParamKeys, GrantType, Constants, CredentialType} from "../../src/utils/Constants";
 import {ClientTestUtils} from "./ClientTestUtils";
 import { Authority } from "../../src/authority/Authority";
 import { RefreshTokenClient } from "../../src/client/RefreshTokenClient";
 import { IdTokenClaims } from "../../src/account/IdTokenClaims";
 import { IdToken } from "../../src/account/IdToken";
 import { RefreshTokenRequest } from "../../src/request/RefreshTokenRequest";
-import { AccountInfo, AuthenticationResult } from "../../src";
+import { AccountEntity } from "../../src/cache/entities/AccountEntity";
+import { RefreshTokenEntity } from "../../src/cache/entities/RefreshTokenEntity";
+import { AuthenticationResult } from "../../src/response/AuthenticationResult";
+import { AccountInfo } from "../../src/account/AccountInfo";
+import { CacheManager } from "../../src/cache/CacheManager";
+import { ClientConfiguration } from "../../src/config/ClientConfiguration";
+import { SilentFlowRequest } from "../../src/request/SilentFlowRequest";
+import { ClientAuthErrorMessage } from "../../src/error/ClientAuthError";
+import { ClientConfigurationErrorMessage } from "../../src/error/ClientConfigurationError";
+
+const testAccountEntity: AccountEntity = new AccountEntity();
+testAccountEntity.homeAccountId = `${TEST_DATA_CLIENT_INFO.TEST_UID}.${TEST_DATA_CLIENT_INFO.TEST_UTID}`;
+testAccountEntity.localAccountId = "testId";
+testAccountEntity.environment = "login.windows.net";
+testAccountEntity.realm = ID_TOKEN_CLAIMS.tid;
+testAccountEntity.username = ID_TOKEN_CLAIMS.preferred_username;
+testAccountEntity.authorityType = "MSSTS";
+
+const testRefreshTokenEntity: RefreshTokenEntity = new RefreshTokenEntity();
+testRefreshTokenEntity.homeAccountId = `${TEST_DATA_CLIENT_INFO.TEST_UID}.${TEST_DATA_CLIENT_INFO.TEST_UTID}`;
+testRefreshTokenEntity.clientId = TEST_CONFIG.MSAL_CLIENT_ID;
+testRefreshTokenEntity.environment = testAccountEntity.environment;
+testRefreshTokenEntity.realm = ID_TOKEN_CLAIMS.tid;
+testRefreshTokenEntity.secret = AUTHENTICATION_RESULT.body.refresh_token;
+testRefreshTokenEntity.credentialType = CredentialType.REFRESH_TOKEN;
 
 describe("RefreshTokenClient unit tests", () => {
     beforeEach(() => {
@@ -39,57 +63,99 @@ describe("RefreshTokenClient unit tests", () => {
         });
     });
 
-    it("acquires a token", async () => {
-        const idTokenClaims: IdTokenClaims = {
-            "ver": "2.0",
-            "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
-            "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-            "exp": 1536361411,
-            "name": "Abe Lincoln",
-            "preferred_username": "AbeLi@microsoft.com",
-            "oid": "00000000-0000-0000-66f3-3332eca7ea81",
-            "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
-            "nonce": "123523",
-        };
-        sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
-        AUTHENTICATION_RESULT.body.client_info = TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
-        sinon.stub(RefreshTokenClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT);
-        sinon.stub(IdToken, "extractIdToken").returns(idTokenClaims);
-        
-        const createTokenRequestBodySpy = sinon.spy(RefreshTokenClient.prototype, <any>"createTokenRequestBody");
+    describe("acquireToken APIs", () => {
+        let config: ClientConfiguration;
+        let client: RefreshTokenClient;
 
-        const config = await ClientTestUtils.createTestClientConfiguration();
-        const client = new RefreshTokenClient(config);
-        const refreshTokenRequest: RefreshTokenRequest = {
-            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
-            refreshToken: TEST_TOKENS.REFRESH_TOKEN,
-            claims: TEST_CONFIG.CLAIMS
-        };
-
-        const authResult: AuthenticationResult = await client.acquireToken(refreshTokenRequest);
         const testAccount: AccountInfo = {
             homeAccountId: `${TEST_DATA_CLIENT_INFO.TEST_UID}.${TEST_DATA_CLIENT_INFO.TEST_UTID}`,
-            tenantId: idTokenClaims.tid,
+            tenantId: ID_TOKEN_CLAIMS.tid,
             environment: "login.windows.net",
-            username: idTokenClaims.preferred_username
+            username: ID_TOKEN_CLAIMS.preferred_username
         };
-        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0], "email"];
-        expect(authResult.uniqueId).to.deep.eq(idTokenClaims.oid);
-        expect(authResult.tenantId).to.deep.eq(idTokenClaims.tid);
-        expect(authResult.scopes).to.deep.eq(expectedScopes);
-        expect(authResult.account).to.deep.eq(testAccount);
-        expect(authResult.idToken).to.deep.eq(AUTHENTICATION_RESULT.body.id_token);
-        expect(authResult.idTokenClaims).to.deep.eq(idTokenClaims);
-        expect(authResult.accessToken).to.deep.eq(AUTHENTICATION_RESULT.body.access_token);
-        expect(authResult.state).to.be.empty;
 
-        expect(createTokenRequestBodySpy.calledWith(refreshTokenRequest)).to.be.true;
+        beforeEach(async () => {
+            sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
+            AUTHENTICATION_RESULT.body.client_info = TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+            sinon.stub(RefreshTokenClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT);
+            sinon.stub(IdToken, "extractIdToken").returns(ID_TOKEN_CLAIMS);
+            sinon.stub(CacheManager.prototype, "getAccount").returns(testAccountEntity);
+            sinon.stub(CacheManager.prototype, "getRefreshTokenEntity").returns(testRefreshTokenEntity);
 
-        expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]}`);
-        expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`);
-        expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.REFRESH_TOKEN}=${TEST_TOKENS.REFRESH_TOKEN}`);
-        expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.GRANT_TYPE}=${GrantType.REFRESH_TOKEN_GRANT}`);
-        expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLIENT_SECRET}=${TEST_CONFIG.MSAL_CLIENT_SECRET}`);
-        expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLAIMS}=${encodeURIComponent(TEST_CONFIG.CLAIMS)}`);
+            config = await ClientTestUtils.createTestClientConfiguration();
+            client = new RefreshTokenClient(config);
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it("acquires a token", async () => {          
+            const createTokenRequestBodySpy = sinon.spy(RefreshTokenClient.prototype, <any>"createTokenRequestBody");
+    
+            const config = await ClientTestUtils.createTestClientConfiguration();
+            const client = new RefreshTokenClient(config);
+            const refreshTokenRequest: RefreshTokenRequest = {
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
+                claims: TEST_CONFIG.CLAIMS
+            };
+    
+            const authResult: AuthenticationResult = await client.acquireToken(refreshTokenRequest);
+            const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0], "email"];
+            expect(authResult.uniqueId).to.deep.eq(ID_TOKEN_CLAIMS.oid);
+            expect(authResult.tenantId).to.deep.eq(ID_TOKEN_CLAIMS.tid);
+            expect(authResult.scopes).to.deep.eq(expectedScopes);
+            expect(authResult.account).to.deep.eq(testAccount);
+            expect(authResult.idToken).to.deep.eq(AUTHENTICATION_RESULT.body.id_token);
+            expect(authResult.idTokenClaims).to.deep.eq(ID_TOKEN_CLAIMS);
+            expect(authResult.accessToken).to.deep.eq(AUTHENTICATION_RESULT.body.access_token);
+            expect(authResult.state).to.be.empty;
+    
+            expect(createTokenRequestBodySpy.calledWith(refreshTokenRequest)).to.be.true;
+    
+            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]}`);
+            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`);
+            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.REFRESH_TOKEN}=${TEST_TOKENS.REFRESH_TOKEN}`);
+            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.GRANT_TYPE}=${GrantType.REFRESH_TOKEN_GRANT}`);
+            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLIENT_SECRET}=${TEST_CONFIG.MSAL_CLIENT_SECRET}`);
+            expect(createTokenRequestBodySpy.returnValues[0]).to.contain(`${AADServerParamKeys.CLAIMS}=${encodeURIComponent(TEST_CONFIG.CLAIMS)}`);
+        });
+
+        it("acquireTokenByRefreshToken refreshes a token", async () => {
+            const silentFlowRequest: SilentFlowRequest = {
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                account: testAccount
+            };
+
+            const expectedRefreshRequest: RefreshTokenRequest = {
+                ...silentFlowRequest,
+                refreshToken: testRefreshTokenEntity.secret
+            };
+            const refreshTokenClientSpy = sinon.stub(RefreshTokenClient.prototype, "acquireToken");
+
+            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            expect(refreshTokenClientSpy.calledWith(expectedRefreshRequest)).to.be.true;
+        });
+    });
+
+    describe("Error cases", () => {
+        it("Throws error if account is not included in request object", async () => {
+            sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
+            const config = await ClientTestUtils.createTestClientConfiguration();
+            const client = new RefreshTokenClient(config);
+            await expect(client.acquireTokenByRefreshToken({
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                account: null
+            })).to.be.rejectedWith(ClientAuthErrorMessage.NoAccountInSilentRequest.desc);
+        });
+
+        it("Throws error if request object is null or undefined", async () => {
+            sinon.stub(Authority.prototype, <any>"discoverEndpoints").resolves(DEFAULT_OPENID_CONFIG_RESPONSE);
+            const config = await ClientTestUtils.createTestClientConfiguration();
+            const client = new RefreshTokenClient(config);
+            await expect(client.acquireTokenByRefreshToken(null)).to.be.rejectedWith(ClientConfigurationErrorMessage.tokenRequestEmptyError.desc);
+            await expect(client.acquireTokenByRefreshToken(undefined)).to.be.rejectedWith(ClientConfigurationErrorMessage.tokenRequestEmptyError.desc);
+        });
     });
 });

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -88,10 +88,6 @@ describe("SilentFlowClient unit tests", () => {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: null
             })).to.be.rejectedWith(ClientAuthErrorMessage.NoAccountInSilentRequest.desc);
-            await expect(client.refreshToken({
-                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
-                account: null
-            })).to.be.rejectedWith(ClientAuthErrorMessage.NoAccountInSilentRequest.desc);
             expect(() => client.acquireCachedToken({
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: null
@@ -104,8 +100,6 @@ describe("SilentFlowClient unit tests", () => {
             const client = new SilentFlowClient(config);
             await expect(client.acquireToken(null)).to.be.rejectedWith(ClientConfigurationErrorMessage.tokenRequestEmptyError.desc);
             await expect(client.acquireToken(undefined)).to.be.rejectedWith(ClientConfigurationErrorMessage.tokenRequestEmptyError.desc);
-            await expect(client.refreshToken(null)).to.be.rejectedWith(ClientConfigurationErrorMessage.tokenRequestEmptyError.desc);
-            await expect(client.refreshToken(undefined)).to.be.rejectedWith(ClientConfigurationErrorMessage.tokenRequestEmptyError.desc);
             expect(() => client.acquireCachedToken(null)).to.throw(ClientConfigurationErrorMessage.tokenRequestEmptyError.desc);
             expect(() => client.acquireCachedToken(undefined)).to.throw(ClientConfigurationErrorMessage.tokenRequestEmptyError.desc);
         });
@@ -301,22 +295,6 @@ describe("SilentFlowClient unit tests", () => {
             
             await client.acquireToken(silentFlowRequest);
             expect(refreshTokenClientSpy.called).to.be.true;
-            expect(refreshTokenClientSpy.calledWith(expectedRefreshRequest)).to.be.true;
-        });
-        
-        it("refreshToken refreshes a token", async () => {            
-            const silentFlowRequest: SilentFlowRequest = {
-                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
-                account: testAccount
-            };
-
-            const expectedRefreshRequest: RefreshTokenRequest = {
-                ...silentFlowRequest,
-                refreshToken: testRefreshTokenEntity.secret
-            };
-            const refreshTokenClientSpy = sinon.stub(RefreshTokenClient.prototype, "acquireToken");
-
-            await client.refreshToken(silentFlowRequest);
             expect(refreshTokenClientSpy.calledWith(expectedRefreshRequest)).to.be.true;
         });
     

--- a/lib/msal-common/test/utils/StringConstants.ts
+++ b/lib/msal-common/test/utils/StringConstants.ts
@@ -3,13 +3,15 @@
  */
 
 import { Constants } from "../../src/utils/Constants";
-import { RequestThumbprint, ThrottlingEntity } from "../../src";
+import { RequestThumbprint, ThrottlingEntity, AccountInfo } from "../../src";
 import { NetworkRequestOptions } from "../../src/network/INetworkModule";
 
 // Test Tokens
 export const TEST_TOKENS = {
-    // idTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
-    // accessTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
+    /*
+     * idTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
+     * accessTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
+     */
     IDTOKEN_V1: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjdfWnVmMXR2a3dMeFlhSFMzcTZsVWpVWUlHdyIsImtpZCI6IjdfWnVmMXR2a3dMeFlhSFMzcTZsVWpVWUlHdyJ9.eyJhdWQiOiJiMTRhNzUwNS05NmU5LTQ5MjctOTFlOC0wNjAxZDBmYzljYWEiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9mYTE1ZDY5Mi1lOWM3LTQ0NjAtYTc0My0yOWYyOTU2ZmQ0MjkvIiwiaWF0IjoxNTM2Mjc1MTI0LCJuYmYiOjE1MzYyNzUxMjQsImV4cCI6MTUzNjI3OTAyNCwiYWlvIjoiQVhRQWkvOElBQUFBcXhzdUIrUjREMnJGUXFPRVRPNFlkWGJMRDlrWjh4ZlhhZGVBTTBRMk5rTlQ1aXpmZzN1d2JXU1hodVNTajZVVDVoeTJENldxQXBCNWpLQTZaZ1o5ay9TVTI3dVY5Y2V0WGZMT3RwTnR0Z2s1RGNCdGsrTExzdHovSmcrZ1lSbXY5YlVVNFhscGhUYzZDODZKbWoxRkN3PT0iLCJhbXIiOlsicnNhIl0sImVtYWlsIjoiYWJlbGlAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiTGluY29sbiIsImdpdmVuX25hbWUiOiJBYmUiLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaXBhZGRyIjoiMTMxLjEwNy4yMjIuMjIiLCJuYW1lIjoiYWJlbGkiLCJub25jZSI6IjEyMzUyMyIsIm9pZCI6IjA1ODMzYjZiLWFhMWQtNDJkNC05ZWMwLTFiMmJiOTE5NDQzOCIsInJoIjoiSSIsInN1YiI6IjVfSjlyU3NzOC1qdnRfSWN1NnVlUk5MOHhYYjhMRjRGc2dfS29vQzJSSlEiLCJ0aWQiOiJmYTE1ZDY5Mi1lOWM3LTQ0NjAtYTc0My0yOWYyOTU2ZmQ0MjkiLCJ1bmlxdWVfbmFtZSI6IkFiZUxpQG1pY3Jvc29mdC5jb20iLCJ1dGkiOiJMeGVfNDZHcVRrT3BHU2ZUbG40RUFBIiwidmVyIjoiMS4wIn0=.UJQrCA6qn2bXq57qzGX_-D3HcPHqBMOKDPx4su1yKRLNErVD8xkxJLNLVRdASHqEcpyDctbdHccu6DPpkq5f0ibcaQFhejQNcABidJCTz0Bb2AbdUCTqAzdt9pdgQvMBnVH1xk3SCM6d4BbT4BkLLj10ZLasX7vRknaSjE_C5DI7Fg4WrZPwOhII1dB0HEZ_qpNaYXEiy-o94UJ94zCr07GgrqMsfYQqFR7kn-mn68AjvLcgwSfZvyR_yIK75S_K37vC3QryQ7cNoafDe9upql_6pB2ybMVlgWPs_DmbJ8g0om-sPlwyn74Cc1tW3ze-Xptw_2uVdPgWyqfuWAfq6Q",
     IDTOKEN_V2: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
     IDTOKEN_V2_NEWCLAIM: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.ewogICJ2ZXIiOiAiMi4wIiwKICAiaXNzIjogImh0dHBzOi8vbG9naW4ubWljcm9zb2Z0b25saW5lLmNvbS85MTg4MDQwZC02YzY3LTRjNWItYjExMi0zNmEzMDRiNjZkYWQvdjIuMCIsCiAgInN1YiI6ICJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwKICAiYXVkIjogIjZjYjA0MDE4LWEzZjUtNDZhNy1iOTk1LTk0MGM3OGY1YWVmMyIsCiAgImV4cCI6IDE1MzYzNjE0MTEsCiAgImlhdCI6IDE1MzYyNzQ3MTEsCiAgIm5iZiI6IDE1MzYyNzQ3MTEsCiAgIm5hbWUiOiAiQWJlIExpbmNvbG4iLAogICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiQWJlTGlAbWljcm9zb2Z0LmNvbSIsCiAgIm9pZCI6ICIwMDAwMDAwMC0wMDAwLTAwMDAtNjZmMy0zMzMyZWNhN2VhODEiLAogICJlbWFpbCI6ICJBYmVMaUBtaWNyb3NvZnQuY29tIiwKICAidGlkIjogIjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsCiAgIm5vbmNlIjogIjEyMzUyMyIsCiAgImFpbyI6ICJEZjJVVlhMMWl4IWxNQ1dNU09KQmNGYXR6Y0dmdkZHaGpLdjhxNWcweDczMmRSNU1CNUJpc3ZHUU83WVdCeWpkOGlRRExxIWVHYklEYWt5cDVtbk9yY2RxSGVZU25sdGVwUW1ScDZBSVo4alkiCn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
@@ -38,7 +40,7 @@ export const ID_TOKEN_CLAIMS = {
     tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
     nonce: "123523",
     aio: "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY"
-}
+};
 
 // Test Expiration Vals
 export const TEST_TOKEN_LIFETIMES = {
@@ -51,13 +53,13 @@ export const TEST_TOKEN_LIFETIMES = {
 export const TEST_DATA_CLIENT_INFO = {
     TEST_UID: "123-test-uid",
     TEST_UTID: "456-test-utid",
-    TEST_DECODED_CLIENT_INFO: `{"uid":"123-test-uid","utid":"456-test-utid"}`,
-    TEST_INVALID_JSON_CLIENT_INFO: `{"uid":"123-test-uid""utid":"456-test-utid"}`,
+    TEST_DECODED_CLIENT_INFO: "{\"uid\":\"123-test-uid\",\"utid\":\"456-test-utid\"}",
+    TEST_INVALID_JSON_CLIENT_INFO: "{\"uid\":\"123-test-uid\"\"utid\":\"456-test-utid\"}",
     TEST_RAW_CLIENT_INFO: "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9",
     TEST_CLIENT_INFO_B64ENCODED: "eyJ1aWQiOiIxMjM0NSIsInV0aWQiOiI2Nzg5MCJ9",
     TEST_HOME_ACCOUNT_ID: "MTIzLXRlc3QtdWlk.NDU2LXRlc3QtdXRpZA==",
     TEST_CACHE_RAW_CLIENT_INFO: "eyJ1aWQiOiJ1aWQiLCAidXRpZCI6InV0aWQifQ==",
-    TEST_CACHE_DECODED_CLIENT_INFO: `{"uid":"uid", "utid":"utid"}`
+    TEST_CACHE_DECODED_CLIENT_INFO: "{\"uid\":\"uid\", \"utid\":\"utid\"}"
 };
 
 // Test Hashes
@@ -112,7 +114,7 @@ export const TEST_CONFIG = {
     DOMAIN_HINT: "test.com",
     SID: "session-id",
     CORRELATION_ID: "7821e1d3-ad52-42t9-8666-399gea483401",
-    CLAIMS: '{"access_token":{"example_claim":{"values":["example_value"]}}}',
+    CLAIMS: "{\"access_token\":{\"example_claim\":{\"values\":[\"example_value\"]}}}",
     TEST_SKU: "test.sku",
     TEST_VERSION: "1.1.0",
     TEST_OS: "win32",
@@ -122,12 +124,18 @@ export const TEST_CONFIG = {
 
 export const RANDOM_TEST_GUID = "11553a9b-7116-48b1-9d48-f6d4a8ff8371";
 
+export const TEST_ACCOUNT_INFO: AccountInfo = {
+    homeAccountId: `${TEST_DATA_CLIENT_INFO.TEST_UID}.${TEST_DATA_CLIENT_INFO.TEST_UTID}`,
+    tenantId: ID_TOKEN_CLAIMS.tid,
+    environment: "login.windows.net",
+    username: ID_TOKEN_CLAIMS.preferred_username
+};
 export const TEST_STATE_VALUES = {
     USER_STATE: "userState",
     TEST_TIMESTAMP: 1592846482,
     DECODED_LIB_STATE: `{"id":"${RANDOM_TEST_GUID}","ts":1592846482}`,
-    ENCODED_LIB_STATE: `eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ==`,
-    URI_ENCODED_LIB_STATE: `eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ%3D%3D`,
+    ENCODED_LIB_STATE: "eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ==",
+    URI_ENCODED_LIB_STATE: "eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ%3D%3D",
     TEST_STATE: `eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ==${Constants.RESOURCE_DELIM}userState`
 };
 
@@ -279,16 +287,16 @@ export const DEVICE_CODE_EXPIRED_RESPONSE = {
 
 export const AUTHORIZATION_PENDING_RESPONSE = {
     body: {
-        error: 'authorization_pending',
-        error_description: 'AADSTS70016: OAuth 2.0 device flow error. Authorization is pending. Continue polling.' +
-            'Trace ID: 01707a0c-640b-4049-8cbb-ee2304dc0700' +
-            'Correlation ID: 78b0fdfc-dd0e-4dfb-b13a-d316333783f6' +
-            'Timestamp: 2020-03-26 22:54:14Z',
+        error: "authorization_pending",
+        error_description: "AADSTS70016: OAuth 2.0 device flow error. Authorization is pending. Continue polling." +
+            "Trace ID: 01707a0c-640b-4049-8cbb-ee2304dc0700" +
+            "Correlation ID: 78b0fdfc-dd0e-4dfb-b13a-d316333783f6" +
+            "Timestamp: 2020-03-26 22:54:14Z",
         error_codes: [70016],
-        timestamp: '2020-03-26 22:54:14Z',
-        trace_id: '01707a0c-640b-4049-8cbb-ee2304dc0700',
-        correlation_id: '78b0fdfc-dd0e-4dfb-b13a-d316333783f6',
-        error_uri: 'https://login.microsoftonline.com/error?code=70016'
+        timestamp: "2020-03-26 22:54:14Z",
+        trace_id: "01707a0c-640b-4049-8cbb-ee2304dc0700",
+        correlation_id: "78b0fdfc-dd0e-4dfb-b13a-d316333783f6",
+        error_uri: "https://login.microsoftonline.com/error?code=70016"
     }
 };
 
@@ -299,7 +307,7 @@ export const DEFAULT_NETWORK_IMPLEMENTATION = {
     sendPostRequestAsync: async (url: string, options?: NetworkRequestOptions): Promise<any> => {
         return { test: "test" };
     }
-}
+};
 
 export const THUMBPRINT: RequestThumbprint = {
     clientId: TEST_CONFIG.MSAL_CLIENT_ID,


### PR DESCRIPTION
- Move `acquireTokenByRefreshToken` to `RefreshTokenClient`
- `acquireTokenSilent` uses:
  1. `acquireCachedToken` on `SilentFlowClient`
  2. `acquireTokenByRefreshToken` on `RefreshTokenClient`
  3. `ssoSilent` if refresh token is expired
- `account` is added as optional parameter on `AuthorizationUrlRequest` to accommodate the lack of `loginHint` and `sid` on the `SilentFlowRequest` object.
- Auth Code Url parameter builder prefers `sid` over `loginHint` and will generate `login_hint` from `account.username` if neither are provided.