### PR TITLE
Add git submodule for ADAL.js

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deprecated/azure-activedirectory-library-for-js"]
+	path = deprecated/azure-activedirectory-library-for-js
+	url = git@github.com:AzureAD/azure-activedirectory-library-for-js.git


### PR DESCRIPTION
Adds ADAL.js as a [submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). This allows us to pull in the ADAL.js code into this repo, while keeping it separate and maintaining its Git history.

Pros (versus copying files over):
- Simpler
- Maintains history
- Keeps repos separate

Cons:
- More complex
- Requires some additional setup for tooling and CI
- Might not work with lerna / beachball
- Commits will be made in ADAL.js repo, instead of MSAL.js repo