### PR TITLE
Expose name field in AccountInfo

### DIFF
--- a/change/@azure-msal-browser-2020-09-14-16-48-24-accountinfo-name.json
+++ b/change/@azure-msal-browser-2020-09-14-16-48-24-accountinfo-name.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add name field to AccountInfo",
+  "packageName": "@azure/msal-browser",
+  "email": "jamckenn@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-14T23:48:18.939Z"
+}

--- a/change/@azure-msal-browser-2020-09-14-16-48-24-accountinfo-name.json
+++ b/change/@azure-msal-browser-2020-09-14-16-48-24-accountinfo-name.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "Add name field to AccountInfo",
+  "type": "none",
+  "comment": "Add name field to AccountInfo (#2288)",
   "packageName": "@azure/msal-browser",
   "email": "jamckenn@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@azure-msal-common-2020-09-14-16-48-24-accountinfo-name.json
+++ b/change/@azure-msal-common-2020-09-14-16-48-24-accountinfo-name.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add name field to AccountInfo",
+  "packageName": "@azure/msal-common",
+  "email": "jamckenn@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-14T23:48:24.691Z"
+}

--- a/change/@azure-msal-common-2020-09-14-16-48-24-accountinfo-name.json
+++ b/change/@azure-msal-common-2020-09-14-16-48-24-accountinfo-name.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add name field to AccountInfo",
+  "comment": "Add name field to AccountInfo (#2288)",
   "packageName": "@azure/msal-common",
   "email": "jamckenn@microsoft.com",
   "dependentChangeType": "patch",

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1508,7 +1508,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         testAccount1.environment = testAccountInfo1.environment;
         testAccount1.realm = testAccountInfo1.tenantId;
         testAccount1.username = testAccountInfo1.username;
-        testAccount1.name = "Abe Lincoln";
+        testAccount1.name = testAccountInfo1.name;
         testAccount1.authorityType = "MSSTS";
         testAccount1.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
 
@@ -1526,7 +1526,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         testAccount2.environment = testAccountInfo2.environment;
         testAccount2.realm = testAccountInfo2.tenantId;
         testAccount2.username = testAccountInfo2.username;
-        testAccount2.name = "Abe Lincoln";
+        testAccount2.name = testAccountInfo2.name;
         testAccount2.authorityType = "MSSTS";
         testAccount2.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
 

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1499,7 +1499,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
             environment: "login.windows.net",
             tenantId: TEST_DATA_CLIENT_INFO.TEST_UTID,
-            username: "example@microsoft.com"
+            username: "example@microsoft.com",
+            name: "Abe Lincoln"
         };
 
         const testAccount1: AccountEntity = new AccountEntity();
@@ -1507,6 +1508,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         testAccount1.environment = testAccountInfo1.environment;
         testAccount1.realm = testAccountInfo1.tenantId;
         testAccount1.username = testAccountInfo1.username;
+        testAccount1.name = "Abe Lincoln";
         testAccount1.authorityType = "MSSTS";
         testAccount1.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
 
@@ -1515,7 +1517,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             homeAccountId: "different-home-account-id",
             environment: "login.windows.net",
             tenantId: TEST_DATA_CLIENT_INFO.TEST_UTID,
-            username: "anotherExample@microsoft.com"
+            username: "anotherExample@microsoft.com",
+            name: "Abe Lincoln"
         };
 
         const testAccount2: AccountEntity = new AccountEntity();
@@ -1523,6 +1526,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         testAccount2.environment = testAccountInfo2.environment;
         testAccount2.realm = testAccountInfo2.tenantId;
         testAccount2.username = testAccountInfo2.username;
+        testAccount2.name = "Abe Lincoln";
         testAccount2.authorityType = "MSSTS";
         testAccount2.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
 

--- a/lib/msal-common/src/account/AccountInfo.ts
+++ b/lib/msal-common/src/account/AccountInfo.ts
@@ -9,10 +9,12 @@
  * - environment            - Entity which issued the token represented by the domain of the issuer (e.g. login.microsoftonline.com)
  * - tenantId               - Full tenant or organizational id that this account belongs to
  * - username               - preferred_username claim of the id_token that represents this account
+ * - name                   - Full name for the account, including given name and family name
  */
 export type AccountInfo = {
     homeAccountId: string;
     environment: string;
     tenantId: string;
     username: string;
+    name?: string;
 };

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -99,7 +99,8 @@ export class AccountEntity {
             homeAccountId: this.homeAccountId,
             environment: this.environment,
             tenantId: this.realm,
-            username: this.username
+            username: this.username,
+            name: this.name
         };
     }
 

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -71,7 +71,8 @@ describe("RefreshTokenClient unit tests", () => {
             homeAccountId: `${TEST_DATA_CLIENT_INFO.TEST_UID}.${TEST_DATA_CLIENT_INFO.TEST_UTID}`,
             tenantId: ID_TOKEN_CLAIMS.tid,
             environment: "login.windows.net",
-            username: ID_TOKEN_CLAIMS.preferred_username
+            username: ID_TOKEN_CLAIMS.preferred_username,
+            name: "Abe Lincoln"
         };
 
         beforeEach(async () => {

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -72,7 +72,7 @@ describe("RefreshTokenClient unit tests", () => {
             tenantId: ID_TOKEN_CLAIMS.tid,
             environment: "login.windows.net",
             username: ID_TOKEN_CLAIMS.preferred_username,
-            name: "Abe Lincoln"
+            name: ID_TOKEN_CLAIMS.name
         };
 
         beforeEach(async () => {

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -25,6 +25,7 @@ testAccountEntity.localAccountId = "testId";
 testAccountEntity.environment = "login.windows.net";
 testAccountEntity.realm = ID_TOKEN_CLAIMS.tid;
 testAccountEntity.username = ID_TOKEN_CLAIMS.preferred_username;
+testAccountEntity.name = "Abe Lincoln";
 testAccountEntity.authorityType = "MSSTS";
 
 const testIdToken: IdTokenEntity = new IdTokenEntity();
@@ -235,7 +236,8 @@ describe("SilentFlowClient unit tests", () => {
             homeAccountId: `${TEST_DATA_CLIENT_INFO.TEST_UID}.${TEST_DATA_CLIENT_INFO.TEST_UTID}`,
             tenantId: ID_TOKEN_CLAIMS.tid,
             environment: "login.windows.net",
-            username: ID_TOKEN_CLAIMS.preferred_username
+            username: ID_TOKEN_CLAIMS.preferred_username,
+            name: "Abe Lincoln"
         };
         
         beforeEach(async () => {

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -25,7 +25,7 @@ testAccountEntity.localAccountId = "testId";
 testAccountEntity.environment = "login.windows.net";
 testAccountEntity.realm = ID_TOKEN_CLAIMS.tid;
 testAccountEntity.username = ID_TOKEN_CLAIMS.preferred_username;
-testAccountEntity.name = "Abe Lincoln";
+testAccountEntity.name = ID_TOKEN_CLAIMS.name;
 testAccountEntity.authorityType = "MSSTS";
 
 const testIdToken: IdTokenEntity = new IdTokenEntity();

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -237,7 +237,7 @@ describe("SilentFlowClient unit tests", () => {
             tenantId: ID_TOKEN_CLAIMS.tid,
             environment: "login.windows.net",
             username: ID_TOKEN_CLAIMS.preferred_username,
-            name: "Abe Lincoln"
+            name: ID_TOKEN_CLAIMS.name
         };
         
         beforeEach(async () => {


### PR DESCRIPTION
Fixes #2147

This adds the  optional `name` field to the `AccountInfo` type, pulling it directly from `AccountEntity`. This exposes it to our users through `getAllAccounts()`