### PR TITLE
Rename TokenCache.cacheHasChanged to TokenCache.hasChanged

### DIFF
--- a/change/@azure-msal-node-2020-09-22-13-40-22-msal-node-token-cache.json
+++ b/change/@azure-msal-node-2020-09-22-13-40-22-msal-node-token-cache.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Rename TokenCache.cacheHasChanged to TokenCache.hasChanged",
+  "packageName": "@azure/msal-node",
+  "email": "sagonzal@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-22T20:40:22.007Z"
+}

--- a/lib/msal-node/src/cache/TokenCache.ts
+++ b/lib/msal-node/src/cache/TokenCache.ts
@@ -24,13 +24,13 @@ const defaultSerializedCache: JsonCache = {
 export class TokenCache {
 
     private storage: Storage;
-    private hasChanged: boolean;
+    private _hasChanged: boolean;
     private cacheSnapshot: string;
     private readonly persistence: ICachePlugin;
     private logger: Logger;
 
     constructor(storage: Storage, logger: Logger, cachePlugin?: ICachePlugin) {
-        this.hasChanged = false;
+        this._hasChanged = false;
         this.storage = storage;
         this.storage.registerChangeEmitter(this.handleChangeEvent.bind(this));
         if (cachePlugin) {
@@ -40,10 +40,10 @@ export class TokenCache {
     }
 
     /**
-     * Set to true if cache state has changed since last time serialized() or writeToPersistence was called
+     * Set to true if cache state has changed since last time serialized() or writeToPersistence() was called
      */
-    cacheHasChanged(): boolean {
-        return this.hasChanged;
+    hasChanged(): boolean {
+        return this._hasChanged;
     }
 
     /**
@@ -65,7 +65,7 @@ export class TokenCache {
         } else {
             this.logger.verbose("No cache snapshot to merge");
         }
-        this.hasChanged = false;
+        this._hasChanged = false;
 
         return JSON.stringify(finalState);
     }
@@ -110,7 +110,7 @@ export class TokenCache {
             };
 
             await this.persistence.writeToStorage(getMergedState);
-            this.hasChanged = false;
+            this._hasChanged = false;
         } else {
             throw ClientAuthError.createCachePluginError();
         }
@@ -166,7 +166,7 @@ export class TokenCache {
      * Called when the cache has changed state.
      */
     private handleChangeEvent() {
-        this.hasChanged = true;
+        this._hasChanged = true;
     }
 
     /**

--- a/lib/msal-node/src/cache/TokenCache.ts
+++ b/lib/msal-node/src/cache/TokenCache.ts
@@ -24,13 +24,13 @@ const defaultSerializedCache: JsonCache = {
 export class TokenCache {
 
     private storage: Storage;
-    private _hasChanged: boolean;
+    private cacheHasChanged: boolean;
     private cacheSnapshot: string;
     private readonly persistence: ICachePlugin;
     private logger: Logger;
 
     constructor(storage: Storage, logger: Logger, cachePlugin?: ICachePlugin) {
-        this._hasChanged = false;
+        this.cacheHasChanged = false;
         this.storage = storage;
         this.storage.registerChangeEmitter(this.handleChangeEvent.bind(this));
         if (cachePlugin) {
@@ -42,8 +42,8 @@ export class TokenCache {
     /**
      * Set to true if cache state has changed since last time serialize or writeToPersistence was called
      */
-    hasChanged(): boolean {
-        return this._hasChanged;
+    get hasChanged(): boolean {
+        return this.cacheHasChanged;
     }
 
     /**
@@ -65,7 +65,7 @@ export class TokenCache {
         } else {
             this.logger.verbose("No cache snapshot to merge");
         }
-        this._hasChanged = false;
+        this.cacheHasChanged = false;
 
         return JSON.stringify(finalState);
     }
@@ -110,7 +110,7 @@ export class TokenCache {
             };
 
             await this.persistence.writeToStorage(getMergedState);
-            this._hasChanged = false;
+            this.cacheHasChanged = false;
         } else {
             throw ClientAuthError.createCachePluginError();
         }
@@ -166,7 +166,7 @@ export class TokenCache {
      * Called when the cache has changed state.
      */
     private handleChangeEvent() {
-        this._hasChanged = true;
+        this.cacheHasChanged = true;
     }
 
     /**

--- a/lib/msal-node/src/cache/TokenCache.ts
+++ b/lib/msal-node/src/cache/TokenCache.ts
@@ -42,7 +42,7 @@ export class TokenCache {
     /**
      * Set to true if cache state has changed since last time serialize or writeToPersistence was called
      */
-    get hasChanged(): boolean {
+    hasChanged(): boolean {
         return this.cacheHasChanged;
     }
 

--- a/lib/msal-node/src/cache/TokenCache.ts
+++ b/lib/msal-node/src/cache/TokenCache.ts
@@ -40,7 +40,7 @@ export class TokenCache {
     }
 
     /**
-     * Set to true if cache state has changed since last time serialized() or writeToPersistence() was called
+     * Set to true if cache state has changed since last time serialize or writeToPersistence was called
      */
     hasChanged(): boolean {
         return this._hasChanged;

--- a/lib/msal-node/test/cache/TokenCache.spec.ts
+++ b/lib/msal-node/test/cache/TokenCache.spec.ts
@@ -27,7 +27,7 @@ describe("TokenCache tests", () => {
         let storage: Storage = new Storage(logger);
         const tokenCache = new TokenCache(storage, logger);
         expect(tokenCache).toBeInstanceOf(TokenCache);
-        expect(tokenCache.cacheHasChanged()).toEqual(false);
+        expect(tokenCache.hasChanged()).toEqual(false);
         expect(tokenCache.getAllAccounts()).toEqual([]);
     });
 
@@ -37,11 +37,11 @@ describe("TokenCache tests", () => {
         const tokenCache = new TokenCache(storage, logger);
 
         tokenCache.deserialize(JSON.stringify(cache));
-        expect(tokenCache.cacheHasChanged()).toEqual(true);
+        expect(tokenCache.hasChanged()).toEqual(true);
 
         const tokenCacheAfterSerialization = tokenCache.serialize();
         expect(JSON.parse(tokenCacheAfterSerialization)).toEqual(cache);
-        expect(tokenCache.cacheHasChanged()).toEqual(false);
+        expect(tokenCache.hasChanged()).toEqual(false);
     });
 
     it("TokenCache serialize/deserialize, does not remove unrecognized entities", () => {
@@ -52,11 +52,11 @@ describe("TokenCache tests", () => {
         const tokenCache = new TokenCache(storage, logger);
 
         tokenCache.deserialize(JSON.stringify(cache));
-        expect(tokenCache.cacheHasChanged()).toEqual(true);
+        expect(tokenCache.hasChanged()).toEqual(true);
 
         const tokenCacheAfterSerialization = tokenCache.serialize();
         expect(JSON.parse(tokenCacheAfterSerialization)).toEqual(cache);
-        expect(tokenCache.cacheHasChanged()).toEqual(false);
+        expect(tokenCache.hasChanged()).toEqual(false);
     });
 
     it("TokenCache.mergeRemovals removes entities from the cache, but does not remove other entities", () => {
@@ -68,10 +68,10 @@ describe("TokenCache tests", () => {
 
         tokenCache.deserialize(JSON.stringify(cache));
         tokenCache.removeAccount(tokenCache.getAllAccounts()[0]);
-        expect(tokenCache.cacheHasChanged()).toEqual(true);
+        expect(tokenCache.hasChanged()).toEqual(true);
 
         const tokenCacheAfterSerialization = JSON.parse(tokenCache.serialize());
-        expect(tokenCache.cacheHasChanged()).toEqual(false);
+        expect(tokenCache.hasChanged()).toEqual(false);
         expect(tokenCacheAfterSerialization.Account).toEqual({});
         expect(tokenCacheAfterSerialization.RefreshToken).toEqual({});
         expect(tokenCacheAfterSerialization.AccessToken).toEqual({});
@@ -108,11 +108,11 @@ describe("TokenCache tests", () => {
         const tokenCache = new TokenCache(storage, logger, cachePlugin);
 
         await tokenCache.readFromPersistence()
-        expect(tokenCache.cacheHasChanged()).toBe(true);
+        expect(tokenCache.hasChanged()).toBe(true);
         expect(tokenCache.getAllAccounts().length).toBe(1);
 
         await tokenCache.writeToPersistence();
-        expect(tokenCache.cacheHasChanged()).toBe(false);
+        expect(tokenCache.hasChanged()).toBe(false);
         expect(require('./cache-test-files/temp-cache.json')).toEqual(require('./cache-test-files/cache-unrecognized-entities.json'));
 
         // try and clean up


### PR DESCRIPTION
Node `TokenCache` used to be `CacheManager`. At that point, `CacheManager.cacheHasChanged` made sense. Now that it's been updated to `TokenCache`, `TokenCache.cacheHasChanged` is a bit redundant. Proposing to update this to `TokenCache.hasChanged`