### PR TITLE
Network Interface is exported for custom http calls in AzureSDK

### DIFF
--- a/change/@azure-msal-common-2020-09-23-11-49-08-public-network-interface.json
+++ b/change/@azure-msal-common-2020-09-23-11-49-08-public-network-interface.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Remove null in function return types to be compatible with ICacheManager.ts",
+  "comment": "Remove null in function return types to be compatible with ICacheManager.ts (#2335)",
   "packageName": "@azure/msal-common",
   "email": "sameera.gajjarapu@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@azure-msal-common-2020-09-23-11-49-08-public-network-interface.json
+++ b/change/@azure-msal-common-2020-09-23-11-49-08-public-network-interface.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove null in function return types to be compatible with ICacheManager.ts",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T18:48:44.045Z"
+}

--- a/change/@azure-msal-node-2020-09-23-11-49-08-public-network-interface.json
+++ b/change/@azure-msal-node-2020-09-23-11-49-08-public-network-interface.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Make network interface public",
+  "comment": "Make network interface public (#2335)",
   "packageName": "@azure/msal-node",
   "email": "sameera.gajjarapu@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@azure-msal-node-2020-09-23-11-49-08-public-network-interface.json
+++ b/change/@azure-msal-node-2020-09-23-11-49-08-public-network-interface.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Make network interface public",
+  "packageName": "@azure/msal-node",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T18:49:08.577Z"
+}

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -151,7 +151,7 @@ export abstract class CacheManager implements ICacheManager {
      * retrieve an account entity given the cache key
      * @param key
      */
-    getAccount(key: string): AccountEntity {
+    getAccount(key: string): AccountEntity | null {
         // don't parse any non-account type cache entities
         if (CredentialEntity.getCredentialType(key) !== Constants.NOT_DEFINED || this.isAppMetadata(key)) {
             return null;
@@ -177,7 +177,7 @@ export abstract class CacheManager implements ICacheManager {
      * retrieve a credential - accessToken, idToken or refreshToken; given the cache key
      * @param key
      */
-    getCredential(key: string): CredentialEntity {
+    getCredential(key: string): CredentialEntity | null {
         return this.getItem(key, CacheSchemaType.CREDENTIAL) as CredentialEntity;
     }
 
@@ -185,7 +185,7 @@ export abstract class CacheManager implements ICacheManager {
      * retrieve an appmetadata entity given the cache key
      * @param key
      */
-    getAppMetadata(key: string): AppMetadataEntity {
+    getAppMetadata(key: string): AppMetadataEntity | null {
         return this.getItem(key, CacheSchemaType.APP_METADATA) as AppMetadataEntity;
     }
 

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -151,7 +151,7 @@ export abstract class CacheManager implements ICacheManager {
      * retrieve an account entity given the cache key
      * @param key
      */
-    getAccount(key: string): AccountEntity | null {
+    getAccount(key: string): AccountEntity {
         // don't parse any non-account type cache entities
         if (CredentialEntity.getCredentialType(key) !== Constants.NOT_DEFINED || this.isAppMetadata(key)) {
             return null;
@@ -177,7 +177,7 @@ export abstract class CacheManager implements ICacheManager {
      * retrieve a credential - accessToken, idToken or refreshToken; given the cache key
      * @param key
      */
-    getCredential(key: string): CredentialEntity | null {
+    getCredential(key: string): CredentialEntity {
         return this.getItem(key, CacheSchemaType.CREDENTIAL) as CredentialEntity;
     }
 

--- a/lib/msal-common/src/cache/interface/ICacheManager.ts
+++ b/lib/msal-common/src/cache/interface/ICacheManager.ts
@@ -32,19 +32,19 @@ export interface ICacheManager {
      * Given account key retrieve an account
      * @param key
      */
-    getAccount(key: string): AccountEntity;
+    getAccount(key: string): AccountEntity | null;
 
     /**
      * retrieve a credential - accessToken, idToken or refreshToken; given the cache key
      * @param key
      */
-    getCredential(key: string): CredentialEntity;
+    getCredential(key: string): CredentialEntity | null;
 
     /**
     * retrieve appMetadata, given the cache key
     * @param key
     */
-    getAppMetadata(key: string): AppMetadataEntity;
+    getAppMetadata(key: string): AppMetadataEntity | null;
 
     /**
      * retrieve accounts matching all provided filters; if no filter is set, get all accounts

--- a/lib/msal-common/src/cache/interface/ICacheManager.ts
+++ b/lib/msal-common/src/cache/interface/ICacheManager.ts
@@ -41,9 +41,9 @@ export interface ICacheManager {
     getCredential(key: string): CredentialEntity | null;
 
     /**
-    * retrieve appMetadata, given the cache key
-    * @param key
-    */
+     * retrieve appMetadata, given the cache key
+     * @param key
+     */
     getAppMetadata(key: string): AppMetadataEntity | null;
 
     /**

--- a/lib/msal-common/src/cache/interface/ICacheManager.ts
+++ b/lib/msal-common/src/cache/interface/ICacheManager.ts
@@ -13,6 +13,7 @@ import {
 import { CacheRecord } from "../entities/CacheRecord";
 import { AccountEntity } from "../entities/AccountEntity";
 import { AccountInfo } from "../../account/AccountInfo";
+import { AppMetadataEntity } from "../entities/AppMetadataEntity";
 
 export interface ICacheManager {
 
@@ -38,6 +39,12 @@ export interface ICacheManager {
      * @param key
      */
     getCredential(key: string): CredentialEntity;
+
+    /**
+    * retrieve appMetadata, given the cache key
+    * @param key
+    */
+    getAppMetadata(key: string): AppMetadataEntity;
 
     /**
      * retrieve accounts matching all provided filters; if no filter is set, get all accounts

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -23,7 +23,10 @@ export {
     // Error
     AuthError,
     AuthErrorMessage,
+    // Network Interface
     INetworkModule,
+    NetworkRequestOptions,
+    NetworkResponse,
     // Logger
     LogLevel,
 } from "@azure/msal-common";


### PR DESCRIPTION
AzureSDK has a requirement to customize their network calls and `msal-common` already has an interface which facilitates it. This PR exports the needed interfaces in `msal-node` to limit the package dependency.