### PR TITLE
Add extraQueryParameters to acquireTokenSilent in msal-browser

### DIFF
--- a/change/@azure-msal-browser-2020-10-13-16-54-21-browser-extraQueryParameters-silent.json
+++ b/change/@azure-msal-browser-2020-10-13-16-54-21-browser-extraQueryParameters-silent.json
@@ -3,6 +3,6 @@
   "comment": "Add extraQueryParameters to acquireTokenSilent in msal-browser",
   "packageName": "@azure/msal-browser",
   "email": "janutter@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-10-13T23:54:21.055Z"
 }

--- a/change/@azure-msal-browser-2020-10-13-16-54-21-browser-extraQueryParameters-silent.json
+++ b/change/@azure-msal-browser-2020-10-13-16-54-21-browser-extraQueryParameters-silent.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add extraQueryParameters to acquireTokenSilent in msal-browser",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-13T23:54:21.055Z"
+}

--- a/lib/msal-browser/src/request/SilentRequest.ts
+++ b/lib/msal-browser/src/request/SilentRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SilentFlowRequest } from "@azure/msal-common";
+import { SilentFlowRequest, StringDict } from "@azure/msal-common";
 
 /**
  * SilentRequest: Request object passed by user to retrieve tokens from the
@@ -15,8 +15,10 @@ import { SilentFlowRequest } from "@azure/msal-common";
  * - correlationId          - Unique GUID set per request to trace a request end-to-end for telemetry purposes.
  * - account                - Account entity to lookup the credentials.
  * - forceRefresh           - Forces silent requests to make network calls if true.
+ * - extraQueryParameters   - String to string map of custom query parameters. Only used when renewing the refresh token.
  * - redirectUri            - The redirect URI where authentication responses can be received by your application. It must exactly match one of the redirect URIs registered in the Azure portal. Only used for cases where refresh token is expired.
  */
 export type SilentRequest = SilentFlowRequest & {
     redirectUri?: string;
+    extraQueryParameters?: StringDict;
 };

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -18,6 +18,7 @@ import { SilentHandler } from "../../src/interaction_handler/SilentHandler";
 import { BrowserStorage } from "../../src/cache/BrowserStorage";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
+import { SilentRequest } from "../../src/request/SilentRequest";
 
 describe("PublicClientApplication.ts Class Unit Tests", () => {
     const cacheConfig = {
@@ -1647,9 +1648,12 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             });
             sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
             sinon.stub(ProtocolUtils, "setRequestState").returns(TEST_STATE_VALUES.TEST_STATE);
-            const silentFlowRequest: SilentFlowRequest = {
+            const silentFlowRequest: SilentRequest = {
                 scopes: ["User.Read"],
-                account: testAccount
+                account: testAccount,
+                extraQueryParameters: {
+                    queryKey: "queryValue"
+                }
             };
             const expectedRequest: AuthorizationUrlRequest = {
                 ...silentFlowRequest,


### PR DESCRIPTION
`acquireTokenSilent` does not take in `extraQueryParameters`. This prevents applications from potentially passing query parameters to the authorize endpoint when the refresh token needs to be renewed.