### PR TITLE
Msal node export errors

### DIFF
--- a/change/@azure-msal-node-2020-10-14-14-29-17-msal-node-export-errors.json
+++ b/change/@azure-msal-node-2020-10-14-14-29-17-msal-node-export-errors.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Export error types for msal-node",
+  "packageName": "@azure/msal-node",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-14T21:29:17.513Z"
+}

--- a/change/@azure-msal-node-2020-10-14-14-29-17-msal-node-export-errors.json
+++ b/change/@azure-msal-node-2020-10-14-14-29-17-msal-node-export-errors.json
@@ -3,6 +3,6 @@
   "comment": "Export error types for msal-node",
   "packageName": "@azure/msal-node",
   "email": "sameera.gajjarapu@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-10-14T21:29:17.513Z"
 }

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -22,6 +22,12 @@ export {
     // Error
     AuthError,
     AuthErrorMessage,
+    InteractionRequiredAuthError,
+    ServerError,
+    ClientAuthError,
+    ClientAuthErrorMessage,
+    ClientConfigurationError,
+    ClientConfigurationErrorMessage,
     // Network Interface
     INetworkModule,
     NetworkRequestOptions,


### PR DESCRIPTION
This PR adds 'error' types in msal-node export types for users to discern between different error types and to be able to use `instanceOf` to classify their errors.