### PR TITLE
AuthCode with Non-PKCE flow clients

### DIFF
--- a/lib/msal-browser/package-lock.json
+++ b/lib/msal-browser/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "@azure/msal-browser",
+    "name": "msal-browser-ext",
     "version": "2.3.0",
     "lockfileVersion": 1,
     "requires": true,
@@ -137,13 +137,6 @@
             "dev": true,
             "requires": {
                 "tslib": "^1.9.3"
-            }
-        },
-        "@azure/msal-common": {
-            "version": "file:../msal-common/azure-msal-common-1.5.0.tgz",
-            "integrity": "sha512-sGuvCph4qVA2oq9ycvgUw68E9kfjysJtp9xqHxdRXKQ9JobpvAGlLedDHqJWtBJHQv077hnGZ93IZTfcb+O7rw==",
-            "requires": {
-                "debug": "^4.1.1"
             }
         },
         "@azure/storage-blob": {
@@ -3836,6 +3829,14 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "msal-common-ext": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/msal-common-ext/-/msal-common-ext-1.5.0.tgz",
+            "integrity": "sha512-0gDMACnXOYQQJJ8oYEehZG7rTHVVqRRxWXrKo7CuV+rkyDA6dPsHQCQmuTZXFImUYLwQg460P6NJch2rkC6JQg==",
+            "requires": {
+                "debug": "^4.1.1"
+            }
         },
         "neo-async": {
             "version": "2.6.1",

--- a/lib/msal-browser/package-lock.json
+++ b/lib/msal-browser/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/msal-browser",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -140,9 +140,8 @@
             }
         },
         "@azure/msal-common": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-1.4.0.tgz",
-            "integrity": "sha512-Z0zZc0nDkym/usNugB0BYDGyX5ymwlRXJJT0xfpE921H8/lHDzBfrO/NVw0lljH3Ex5CVE+PpdAGahQQ4zWzKQ==",
+            "version": "file:../msal-common/azure-msal-common-1.5.0.tgz",
+            "integrity": "sha512-sGuvCph4qVA2oq9ycvgUw68E9kfjysJtp9xqHxdRXKQ9JobpvAGlLedDHqJWtBJHQv077hnGZ93IZTfcb+O7rw==",
             "requires": {
                 "debug": "^4.1.1"
             }

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure/msal-browser",
+  "name": "msal-browser-ext",
   "author": {
     "name": "Microsoft",
     "email": "nugetaad@microsoft.com",
@@ -8,9 +8,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
+    "url": "https://github.com/noant/microsoft-authentication-library-for-js-ext"
   },
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",
@@ -95,6 +95,6 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@azure/msal-common": "C:\\Projects\\msaljs\\lib\\msal-common\\azure-msal-common-1.5.0.tgz"
+    "msal-common-ext": "^1.5.0"
   }
 }

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -95,6 +95,6 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@azure/msal-common": "^1.5.0"
+    "@azure/msal-common": "C:\\Projects\\msaljs\\lib\\msal-common\\azure-msal-common-1.5.0.tgz"
   }
 }

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -31,6 +31,8 @@ export type BrowserAuthOptions = {
     postLogoutRedirectUri?: string;
     navigateToLoginRequestUrl?: boolean;
     clientCapabilities?: Array<string>;
+    nonPkceAuthCodeExchangeEndpoint?: string;    
+    useNonPkceAuthCodeExchangeEndpoint?: boolean,
 };
 
 /**

--- a/lib/msal-common/package.json
+++ b/lib/msal-common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure/msal-common",
+  "name": "msal-common-ext",
   "author": {
     "name": "Microsoft",
     "email": "nugetaad@microsoft.com",
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
+    "url": "https://github.com/noant/microsoft-authentication-library-for-js-ext"
   },
   "version": "1.5.0",
   "description": "Microsoft Authentication Library for js",

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -147,7 +147,7 @@ export class AuthorizationCodeClient extends BaseClient {
      * Generates a map for all the params to be sent to the service
      * @param request
      */
-    private async createTokenRequestBody(request: AuthorizationCodeRequest): Promise<string> {
+    protected async createTokenRequestBody(request: AuthorizationCodeRequest): Promise<string> {
         const parameterBuilder = new RequestParameterBuilder();
 
         parameterBuilder.addClientId(this.config.authOptions.clientId);

--- a/lib/msal-common/src/client/AuthorizationCodeClientNonPkce.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClientNonPkce.ts
@@ -1,0 +1,53 @@
+import { AuthorizationCodeClient } from "./AuthorizationCodeClient";
+import { ClientConfiguration } from "../config/ClientConfiguration";
+import { ResponseHandler } from '../response/ResponseHandler';
+import { ServerAuthorizationTokenResponse } from '../response/ServerAuthorizationTokenResponse';
+import { AuthorizationCodeRequest } from '../request/AuthorizationCodeRequest';
+import { StringUtils } from '../utils/StringUtils';
+import { ClientAuthError } from '../error/ClientAuthError';
+import { AuthenticationResult } from '../response/AuthenticationResult';
+import { NetworkResponse } from '../network/NetworkManager';
+import { RequestThumbprint } from '../network/RequestThumbprint';
+
+export class AuthorizationCodeClientNonPkce extends AuthorizationCodeClient{
+    constructor(configuration: ClientConfiguration) {
+        super(configuration);
+    }
+
+    async acquireToken(request: AuthorizationCodeRequest, cachedNonce?: string, cachedState?: string): Promise<AuthenticationResult> {
+        this.logger.info("in non-PKCE acquireToken call");
+        if (!request || StringUtils.isEmpty(request.code)) {
+            throw ClientAuthError.createTokenRequestCannotBeMadeError();
+        }
+        const response = await this.executeTokenRequestToAuthCodeExchangeServer(request);
+        const responseHandler = new ResponseHandler(
+            this.config.authOptions.clientId,
+            this.cacheManager,
+            this.cryptoUtils,
+            this.logger,
+            this.config.serializableCache,
+            this.config.persistencePlugin
+        );
+
+        // Validate response. This function throws a server error if an error is returned by the server.
+        responseHandler.validateTokenResponse(response.body);
+        return await responseHandler.handleServerTokenResponse(response.body, this.authority, request.resourceRequestMethod, request.resourceRequestUri, cachedNonce, cachedState);
+    }
+
+    /**
+     * Executes POST request to token endpoint
+     * @param authority
+     * @param request
+     */
+    private async executeTokenRequestToAuthCodeExchangeServer(request: AuthorizationCodeRequest): Promise<NetworkResponse<ServerAuthorizationTokenResponse>> {
+        const thumbprint: RequestThumbprint = {
+            clientId: this.config.authOptions.clientId,
+            authority: this.config.authOptions.nonPkceAuthCodeExchangeEndpoint,
+            scopes: request.scopes
+        };
+        
+        const headers: Record<string, string> = this.createDefaultTokenRequestHeaders();
+        const requestBody = await this.createTokenRequestBody(request);
+        return this.executePostToTokenEndpoint(this.config.authOptions.nonPkceAuthCodeExchangeEndpoint, requestBody, headers, thumbprint);
+    }
+}

--- a/lib/msal-common/src/client/BaseClient.ts
+++ b/lib/msal-common/src/client/BaseClient.ts
@@ -115,7 +115,6 @@ export abstract class BaseClient {
             tokenEndpoint, 
             { body: queryString, headers: headers }
         );
-
         if (this.config.serverTelemetryManager && response.status < 500 && response.status !== 429) {
             // Telemetry data successfully logged by server, clear Telemetry cache
             this.config.serverTelemetryManager.clearTelemetryCache();

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -9,7 +9,6 @@ import { RefreshTokenRequest } from "../request/RefreshTokenRequest";
 import { Authority } from "../authority/Authority";
 import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
 import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { ScopeSet } from "../request/ScopeSet";
 import { GrantType, AuthenticationScheme, Errors  } from "../utils/Constants";
 import { ResponseHandler } from "../response/ResponseHandler";
 import { AuthenticationResult } from "../response/AuthenticationResult";
@@ -144,7 +143,7 @@ export class RefreshTokenClient extends BaseClient {
      * Helper function to create the token request body
      * @param request
      */
-    private async createTokenRequestBody(request: RefreshTokenRequest): Promise<string> {
+    protected async createTokenRequestBody(request: RefreshTokenRequest): Promise<string> {
         const parameterBuilder = new RequestParameterBuilder();
 
         parameterBuilder.addClientId(this.config.authOptions.clientId);

--- a/lib/msal-common/src/client/RefreshTokenClientNonPkce.ts
+++ b/lib/msal-common/src/client/RefreshTokenClientNonPkce.ts
@@ -1,0 +1,57 @@
+import { ClientConfiguration } from "../config/ClientConfiguration";
+import { NetworkResponse } from '../network/NetworkManager';
+import { RequestThumbprint } from '../network/RequestThumbprint';
+import { RefreshTokenRequest } from '../request/RefreshTokenRequest';
+import { AuthenticationResult } from '../response/AuthenticationResult';
+import { ResponseHandler } from '../response/ResponseHandler';
+import { ServerAuthorizationTokenResponse } from '../response/ServerAuthorizationTokenResponse';
+import { RefreshTokenClient } from './RefreshTokenClient';
+
+export class RefreshTokenClientNonPkce extends RefreshTokenClient{
+    constructor(configuration: ClientConfiguration) {
+        super(configuration);
+    }
+
+    public async acquireToken(request: RefreshTokenRequest): Promise<AuthenticationResult> {
+        const response = await this.executeTokenRequestToAuthCodeExchangeServer(request);
+
+        const responseHandler = new ResponseHandler(
+            this.config.authOptions.clientId,
+            this.cacheManager,
+            this.cryptoUtils,
+            this.logger,
+            this.config.serializableCache,
+            this.config.persistencePlugin
+        );
+
+        responseHandler.validateTokenResponse(response.body);
+        return responseHandler.handleServerTokenResponse(
+            response.body,
+            this.authority,
+            request.resourceRequestMethod,
+            request.resourceRequestUri,
+            null,
+            null,
+            null,
+            null,
+            true
+        );
+    }
+
+    /**
+     * Executes POST request to token endpoint
+     * @param authority
+     * @param request
+     */
+    private async executeTokenRequestToAuthCodeExchangeServer(request: RefreshTokenRequest): Promise<NetworkResponse<ServerAuthorizationTokenResponse>> {
+        const thumbprint: RequestThumbprint = {
+            clientId: this.config.authOptions.clientId,
+            authority: this.config.authOptions.nonPkceAuthCodeExchangeEndpoint,
+            scopes: request.scopes
+        };
+        
+        const headers: Record<string, string> = this.createDefaultTokenRequestHeaders();
+        const requestBody = await this.createTokenRequestBody(request);
+        return this.executePostToTokenEndpoint(this.config.authOptions.nonPkceAuthCodeExchangeEndpoint, requestBody, headers, thumbprint);
+    }
+}

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -17,6 +17,7 @@ import { ClientConfigurationError } from "../error/ClientConfigurationError";
 import { ResponseHandler } from "../response/ResponseHandler";
 import { CacheRecord } from "../cache/entities/CacheRecord";
 import { Authority } from "../authority/Authority";
+import { RefreshTokenClientNonPkce } from './RefreshTokenClientNonPkce';
 
 export class SilentFlowClient extends BaseClient {
 
@@ -34,8 +35,9 @@ export class SilentFlowClient extends BaseClient {
             return await this.acquireCachedToken(request);
         } catch (e) {
             if (e instanceof ClientAuthError && e.errorCode === ClientAuthErrorMessage.tokenRefreshRequired.code) {
-                const refreshTokenClient = new RefreshTokenClient(this.config);
-                return refreshTokenClient.acquireTokenByRefreshToken(request);
+                if (this.config.authOptions.useNonPkceAuthCodeExchangeEndpoint)                
+                    return new RefreshTokenClientNonPkce(this.config).acquireTokenByRefreshToken(request);
+                return new RefreshTokenClient(this.config).acquireTokenByRefreshToken(request);                
             } else {
                 throw e;
             }

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -60,6 +60,8 @@ export type AuthOptions = {
     knownAuthorities?: Array<string>;
     cloudDiscoveryMetadata?: string;
     clientCapabilities?: Array<string>;
+    nonPkceAuthCodeExchangeEndpoint?: string;
+    useNonPkceAuthCodeExchangeEndpoint?: boolean,
 };
 
 /**

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -1,7 +1,9 @@
 // App Auth Modules and Configuration
 export { AuthorizationCodeClient} from "./client/AuthorizationCodeClient";
+export { AuthorizationCodeClientNonPkce} from "./client/AuthorizationCodeClientNonPkce";
 export { DeviceCodeClient } from "./client/DeviceCodeClient";
 export { RefreshTokenClient } from "./client/RefreshTokenClient";
+export { RefreshTokenClientNonPkce } from "./client/RefreshTokenClientNonPkce";
 export { ClientCredentialClient } from "./client/ClientCredentialClient";
 export { OnBehalfOfClient } from "./client/OnBehalfOfClient";
 export { SilentFlowClient } from "./client/SilentFlowClient";


### PR DESCRIPTION
Hi! We found that msal.js not works with non-pkce auth code flow. It means that I can't use msal.js and Chinese Azure Ad B2C, because now it accepts only implicit flow and auth code flow with client secret. So, to provide client secret we should call token endpoint through our custom endpoint with addiction of client secret. Net Core Web Api example:
```
        [HttpPost]
        [AllowAnonymous]
        public async Task<ObjectResult> ExchangeCn()
        {
            using (var sr = new StreamReader(HttpContext.Request.Body)) 
            {
                var requestBody = sr.ReadToEnd();
                
                if (!requestBody.Contains($"client_id=<clientId>"))
                    throw new HttpRequestException("Invalid client_id parameter");

                var extendedRequestBody = $"{requestBody}&client_secret=<clientSecret>";

                var tokenRequestContent = new StringContent(extendedRequestBody, Encoding.UTF8, "application/x-www-form-urlencoded");

                foreach (var header in HttpContext.Request.Headers.Where(x => x.Key.StartsWith("x-client")))
                    tokenRequestContent.Headers.Add(header.Key, header.Value.ToArray());


                using var client = HttpClientFactory.Create(new HttpClientHandler() { AllowAutoRedirect = true });
                var response = await client.PostAsync("https://<domain>.b2clogin.cn/<tenant>/b2c_1_sign_1_cn/oauth2/v2.0/token", tokenRequestContent);

                return new ObjectResult(await response.Content.ReadAsStringAsync());
            }
        }
```

I added some classes (AuthorizationCodeClientNonPkce, RefreshTokenClientNonPkce) that can be used to access to our custom endpoint instead of the token endpoint. Provider settings example:

```
export const config = {
    auth: {
        clientId: process.env.MSAL_CLIENT_ID,
        authority: SIGN_IN_AUTHORITY,
        redirectUri: window.location.origin,
        postLogoutRedirectUri: window.location.origin,
        navigateToLoginRequestUrl: false,
        nonPkceAuthCodeExchangeEndpoint: 'https://<my_custom_endpoint>/api/v1.2/auth/exchange_cn', <<< custom endpoint parameter
        useNonPkceAuthCodeExchangeEndpoint: true, <<< if true - use custom endpoint to exchange auth code to tokens
        knownAuthorities: ['https://<some_known_authority>']
    },
    cache: {
        cacheLocation: 'localStorage',
        storeAuthStateInCookie: !!window.document.documentMode, // true for IE
    },
    system: {
        loadFrameTimeout: 30000,
        // tokenRenewalOffsetSeconds: 0,
    },
};
```

I have already created my personal npm packages forked from msal-browser and msal-common because this functionality is very important to my organization.
https://www.npmjs.com/package/msal-common-ext
https://www.npmjs.com/package/msal-browser-ext
So in this branch, package.json in msal-browser refers to standard msal-common package and for msal-browser debugging, msal-common link should be changed to currently locally created msal-common package with new classes. In dev branch in my fork msal-browser already uses msal-common-ext package from npm.