### PR TITLE
Use history API to clear hash to remove # sign

### DIFF
--- a/change/@azure-msal-browser-2020-10-16-15-05-51-core-remove-hash-history.json
+++ b/change/@azure-msal-browser-2020-10-16-15-05-51-core-remove-hash-history.json
@@ -3,6 +3,6 @@
   "comment": "Use history API to clear hash for msal-browser",
   "packageName": "@azure/msal-browser",
   "email": "janutter@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-10-16T22:05:51.520Z"
 }

--- a/change/@azure-msal-browser-2020-10-16-15-05-51-core-remove-hash-history.json
+++ b/change/@azure-msal-browser-2020-10-16-15-05-51-core-remove-hash-history.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use history API to clear hash for msal-browser",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T22:05:51.520Z"
+}

--- a/change/msal-2020-10-15-15-29-10-core-remove-hash-history.json
+++ b/change/msal-2020-10-15-15-29-10-core-remove-hash-history.json
@@ -3,6 +3,6 @@
   "comment": "Use history API to clear hash to remove # sign",
   "packageName": "msal",
   "email": "janutter@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-10-15T22:29:10.803Z"
 }

--- a/change/msal-2020-10-15-15-29-10-core-remove-hash-history.json
+++ b/change/msal-2020-10-15-15-29-10-core-remove-hash-history.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use history API to clear hash to remove # sign",
+  "packageName": "msal",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-15T22:29:10.803Z"
+}

--- a/lib/msal-browser/src/utils/BrowserUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserUtils.ts
@@ -31,7 +31,12 @@ export class BrowserUtils {
      * Clears hash from window url.
      */
     static clearHash(): void {
-        window.location.hash = "";
+        if ("replaceState" in history) {
+            // Full removes "#" from url
+            history.replaceState(null, null, `${window.location.pathname}${window.location.search}`);
+        } else {
+            window.location.hash = "";
+        }
     }
 
     /**

--- a/lib/msal-browser/test/utils/BrowserUtils.spec.ts
+++ b/lib/msal-browser/test/utils/BrowserUtils.spec.ts
@@ -60,7 +60,7 @@ describe("BrowserUtils.ts Function Unit Tests", () => {
     it("clearHash() clears the window hash", () => {
         window.location.hash = "thisIsAHash";
         BrowserUtils.clearHash();
-        expect(window.location.hash).to.be.empty;
+        expect(window.location.href.includes("#thisIsAHash")).to.be.false;
     });
 
     it("replaceHash replaces the current window hash with the hash from the provided url", () => {

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -1233,7 +1233,7 @@ export class UserAgentApplication {
         this.logger.verbose("HandleRedirectAuthenticationResponse has been called");
 
         // clear hash from window
-        window.location.hash = "";
+        WindowUtils.clearUrlFragment();
         this.logger.verbose("Window.location.hash cleared");
 
         // if (window.parent !== window), by using self, window.parent becomes equal to window in getResponseState method specifically

--- a/lib/msal-core/src/utils/WindowUtils.ts
+++ b/lib/msal-core/src/utils/WindowUtils.ts
@@ -332,4 +332,16 @@ export class WindowUtils {
             cacheStorage.resetTempCacheItems(state);
         }
     }
+
+    /**
+     * Removes url fragment from browser url
+     */
+    static clearUrlFragment() {
+        if ("replaceState" in history) {
+            // Full removes "#" from url
+            history.replaceState(null, null, `${window.location.pathname}${window.location.search}`);
+        } else {
+            window.location.hash = "";
+        }
+    }
 }

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -1992,26 +1992,25 @@ describe("UserAgentApplication.ts Class", function () {
             const loginStartPage = loginUrl + userQueryString;
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
-            window.location.href = loginStartPage;
+            window.location.href = `${loginStartPage}${successHash}`;
             window.location.search = userQueryString;
+            window.location.hash = successHash;
+            window.location.pathname = "/test/";
 
             sinon.stub(window, "parent").returns(window);
-            sinon.stub(window.location, "href").returns(loginStartPage + successHash);
-            sinon.stub(window.history, "replaceState").callsFake((data, title, url) => {
-                window.location.hash = "";
+            sinon.stub(window.location, "assign").callsFake(() => {});
+            
+            sinon.stub(history, "replaceState").callsFake((data, title, url) => {
+                window.location.href = `http://localhost:8081${url}`;
             });
+            sinon.stub(UrlUtils, "urlContainsHash").returns(true);
 
-            window.location.hash = successHash;
             cacheStorage.setItem(AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.LOGIN_REQUEST, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`), loginStartPage);
             cacheStorage.setItem(AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.STATE_LOGIN, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`), `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`);
             cacheStorage.setItem(AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.NONCE_IDTOKEN, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`), TEST_NONCE);
 
-            expect(window.location.href).to.equal(loginStartPage);
-            expect(window.location.hash).to.equal(successHash);
-            expect(window.location.search).to.equal(userQueryString);
             msal = new UserAgentApplication(config);
             expect(window.location.href).to.equal(loginStartPage);
-            expect(window.location.hash).to.equal("");
             expect(window.location.search).to.equal(userQueryString);
             expect(cacheStorage.getItem(PersistentCacheKeys.IDTOKEN)).to.equal(TEST_TOKENS.IDTOKEN_V2);
         });
@@ -2344,6 +2343,7 @@ describe("UserAgentApplication.ts Class", function () {
                     postLogoutRedirectUri: TEST_URIS.TEST_LOGOUT_URI
                 }
             };
+            window.location.hash = "";
             msal = new UserAgentApplication(config);
             setAuthInstanceStubs();
             setTestCacheItems();

--- a/lib/msal-core/test/UserAgentApplication.spec.ts
+++ b/lib/msal-core/test/UserAgentApplication.spec.ts
@@ -153,7 +153,7 @@ describe("UserAgentApplication.ts Class", function () {
             clientId: "0813e1d1-ad72-46a9-8665-399bba48c201",
             scopes: undefined,
             homeAccountIdentifier: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID
-        }
+        };
 
         idToken = {
             accessToken: null,
@@ -285,10 +285,10 @@ describe("UserAgentApplication.ts Class", function () {
                 assign: function (url) {
                     try {
                         expect(url).to.include("&state");
-                        let hash = UrlUtils.getHashFromUrl(url);
-                        let state = UrlUtils.deserializeHash(hash).state;
-                        let decodedState = CryptoUtils.base64Decode(state);
-                        let stateObj = JSON.parse(decodedState);
+                        const hash = UrlUtils.getHashFromUrl(url);
+                        const state = UrlUtils.deserializeHash(hash).state;
+                        const decodedState = CryptoUtils.base64Decode(state);
+                        const stateObj = JSON.parse(decodedState);
 
                         expect(stateObj).to.include.keys("id");
                         expect(stateObj).to.include.keys("ts");
@@ -647,7 +647,7 @@ describe("UserAgentApplication.ts Class", function () {
                     done();
                     return false;
                 }
-            })
+            });
         });
 
         it("acquireTokenRedirect does not navigate if onRedirectNavigate is implemented and returns false", done => {
@@ -676,7 +676,7 @@ describe("UserAgentApplication.ts Class", function () {
                     done();
                     return false;
                 }
-            })
+            });
         });
 
         it("navigates if onRedirectNavigate returns null", done => {
@@ -701,7 +701,7 @@ describe("UserAgentApplication.ts Class", function () {
                 onRedirectNavigate: url => {
                     expect(url).to.be.not.null;
                 }
-            })
+            });
         });
 
         it("navigates if onRedirectNavigate returns true", done => {
@@ -726,9 +726,9 @@ describe("UserAgentApplication.ts Class", function () {
                 onRedirectNavigate: url => {
                     expect(url).to.be.not.null;
 
-                    return true
+                    return true;
                 }
-            })
+            });
         });
 
         it("calls error callback on loginRedirect if interaction is true", function (done) {
@@ -762,7 +762,6 @@ describe("UserAgentApplication.ts Class", function () {
             msal.handleRedirectCallback(checkErrorFromLibrary);
             msal.acquireTokenRedirect({scopes: [ "user.read" ]});
         });
-
 
         it("throws error on loginRedirect if interaction is true", function (done) {
             cacheStorage.setItem(TemporaryCacheKeys.INTERACTION_STATUS, Constants.inProgress);
@@ -830,7 +829,7 @@ describe("UserAgentApplication.ts Class", function () {
                 assign: function (url) {
                     try {
                         const state = UrlUtils.deserializeHash(url).state;
-                        const accountKey = AuthCache.generateAcquireTokenAccountKey(account.homeAccountIdentifier, state)
+                        const accountKey = AuthCache.generateAcquireTokenAccountKey(account.homeAccountIdentifier, state);
 
                         expect(cacheStorage.getItem(accountKey)).equals(JSON.stringify(account));
                         done();
@@ -1044,14 +1043,14 @@ describe("UserAgentApplication.ts Class", function () {
         it("Hash is not processed in popup case" , function () {
             const oldWindowOpener = window.opener;
             window.opener = "different_window";
-            const TEST_LIBRARY_STATE_POPUP = RequestUtils.generateLibraryState(Constants.interactionTypePopup)
+            const TEST_LIBRARY_STATE_POPUP = RequestUtils.generateLibraryState(Constants.interactionTypePopup);
 
             cacheStorage.setItem(AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.STATE_LOGIN, `${TEST_LIBRARY_STATE_POPUP}|${TEST_USER_STATE_NUM}`), `${TEST_LIBRARY_STATE_POPUP}|${TEST_USER_STATE_NUM}`);
             cacheStorage.setItem(AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.NONCE_IDTOKEN, `${TEST_LIBRARY_STATE_POPUP}|${TEST_USER_STATE_NUM}`), TEST_NONCE);
             window.location.hash = testHashesForState(TEST_LIBRARY_STATE_POPUP).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
-            let hashBeforeProcessing = window.location.hash;
-            let callbackExecuted = false
+            const hashBeforeProcessing = window.location.hash;
+            let callbackExecuted = false;
             msal = new UserAgentApplication(config);
 
             const checkResponseFromServer = function(error: AuthError, response: AuthResponse) {
@@ -1508,7 +1507,7 @@ describe("UserAgentApplication.ts Class", function () {
                 afterEach(() => {
                     cacheStorage.clear();
                     sinon.reset();
-                })
+                });
 
                 it("should return null if there is no cached access token", (done) => {
                     const renewTokenSpy = sinon.spy(msal, <any>"renewToken");
@@ -1590,7 +1589,6 @@ describe("UserAgentApplication.ts Class", function () {
                         done();
                     }).catch(done);
                 });
-
 
                 it("should return access token with id token if there are valid matching access token and id token in the cache", (done) => {
                     cacheStorage.setItem(JSON.stringify(accessTokenKey), JSON.stringify(accessTokenValue));
@@ -1878,7 +1876,7 @@ describe("UserAgentApplication.ts Class", function () {
 
         it("tests navigation to loginRequestUrl after first redirect", function(done) {
             config.auth.navigateToLoginRequestUrl = true;
-            const loginStartPage = "http://localhost:8081/test/"
+            const loginStartPage = "http://localhost:8081/test/";
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
             window.location = {
@@ -1906,8 +1904,8 @@ describe("UserAgentApplication.ts Class", function () {
 
         it("tests navigation to loginRequestUrl after first redirect", function(done) {
             config.auth.navigateToLoginRequestUrl = true;
-            const baseStartUrl = "http://localhost:8081/test/"
-            const loginStartPage = baseStartUrl + "#testHash"
+            const baseStartUrl = "http://localhost:8081/test/";
+            const loginStartPage = baseStartUrl + "#testHash";
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
             window.location = {
@@ -1935,8 +1933,8 @@ describe("UserAgentApplication.ts Class", function () {
 
         it("tests navigation to loginRequestUrl inc. user querystring after first redirect", function(done) {
             config.auth.navigateToLoginRequestUrl = true;
-            const baseStartUrl = "http://localhost:8081/test/"
-            const loginStartPage = baseStartUrl + "?testKey=testVal"
+            const baseStartUrl = "http://localhost:8081/test/";
+            const loginStartPage = baseStartUrl + "?testKey=testVal";
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
             window.location = {
@@ -1964,15 +1962,15 @@ describe("UserAgentApplication.ts Class", function () {
 
         it("tests user hash is added back to url on final page and token response is cached", function() {
             config.auth.navigateToLoginRequestUrl = true;
-            const loginUrl = "http://localhost:8081/test/"
-            const userHash = "#testHash"
-            const loginStartPage = loginUrl + userHash
+            const loginUrl = "http://localhost:8081/test/";
+            const userHash = "#testHash";
+            const loginStartPage = loginUrl + userHash;
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
             window.location.href = loginUrl;
 
             sinon.stub(window, "parent").returns(window);
-            sinon.stub(window.location, "href").returns(loginStartPage + successHash)
+            sinon.stub(window.location, "href").returns(loginStartPage + successHash);
 
             window.location.hash = successHash;
             cacheStorage.setItem(AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.LOGIN_REQUEST, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`), loginStartPage);
@@ -1989,8 +1987,8 @@ describe("UserAgentApplication.ts Class", function () {
 
         it("tests user query string present on final page url and token response is cached", function() {
             config.auth.navigateToLoginRequestUrl = true;
-            const loginUrl = "http://localhost:8081/test/"
-            const userQueryString = "?testKey=testVal"
+            const loginUrl = "http://localhost:8081/test/";
+            const userQueryString = "?testKey=testVal";
             const loginStartPage = loginUrl + userQueryString;
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
@@ -1998,7 +1996,10 @@ describe("UserAgentApplication.ts Class", function () {
             window.location.search = userQueryString;
 
             sinon.stub(window, "parent").returns(window);
-            sinon.stub(window.location, "href").returns(loginStartPage + successHash)
+            sinon.stub(window.location, "href").returns(loginStartPage + successHash);
+            sinon.stub(window.history, "replaceState").callsFake((data, title, url) => {
+                window.location.hash = "";
+            });
 
             window.location.hash = successHash;
             cacheStorage.setItem(AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.LOGIN_REQUEST, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`), loginStartPage);
@@ -2017,9 +2018,9 @@ describe("UserAgentApplication.ts Class", function () {
 
         it("tests user hash is added back to url and query string exists on final page url and token response is cached", function() {
             config.auth.navigateToLoginRequestUrl = true;
-            const loginUrl = "http://localhost:8081/test/"
-            const userQueryString = "?testKey=testVal"
-            const userHash = "#testHash"
+            const loginUrl = "http://localhost:8081/test/";
+            const userQueryString = "?testKey=testVal";
+            const userHash = "#testHash";
             const loginStartPage = loginUrl + userQueryString + userHash;
             const successHash = testHashesForState(TEST_LIBRARY_STATE).TEST_SUCCESS_ID_TOKEN_HASH + TEST_USER_STATE_NUM;
 
@@ -2027,7 +2028,7 @@ describe("UserAgentApplication.ts Class", function () {
             window.location.search = userQueryString;
 
             sinon.stub(window, "parent").returns(window);
-            sinon.stub(window.location, "href").returns(loginStartPage + successHash)
+            sinon.stub(window.location, "href").returns(loginStartPage + successHash);
 
             window.location.hash = successHash;
             cacheStorage.setItem(AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.LOGIN_REQUEST, `${TEST_LIBRARY_STATE}|${TEST_USER_STATE_NUM}`), loginStartPage);
@@ -2555,7 +2556,7 @@ describe("UserAgentApplication.ts Class", function () {
                 account: account
             };
 
-            const TEST_LIBRARY_STATE_POPUP = RequestUtils.generateLibraryState(Constants.interactionTypePopup)
+            const TEST_LIBRARY_STATE_POPUP = RequestUtils.generateLibraryState(Constants.interactionTypePopup);
 
             window = {
                 ...oldWindow,
@@ -2566,11 +2567,11 @@ describe("UserAgentApplication.ts Class", function () {
                 },
                 open: function (url?, target?, features?, replace?): Window {
                     const state = UrlUtils.deserializeHash(url).state;
-                    const accountKey = AuthCache.generateAcquireTokenAccountKey(account.homeAccountIdentifier, state)
+                    const accountKey = AuthCache.generateAcquireTokenAccountKey(account.homeAccountIdentifier, state);
     
                     expect(cacheStorage.getItem(accountKey)).equals(JSON.stringify(account));
                     done();
-                    return window
+                    return window;
                 },
                 close: function(): void {},
                 focus: null
@@ -2579,7 +2580,7 @@ describe("UserAgentApplication.ts Class", function () {
             const acquireTokenPromise = msal.acquireTokenPopup(tokenRequest);
             expect(acquireTokenPromise instanceof Promise).to.be.true;
 
-            acquireTokenPromise.catch(error => {console.log(error)});
+            acquireTokenPromise.catch(error => {console.log(error);});
         });
 
     });
@@ -2632,21 +2633,21 @@ describe("UserAgentApplication.ts Class", function () {
             try {
                 msal.acquireTokenSilent(null);
             } catch(e) {
-                () => {expect(e).to.be.instanceOf(ClientConfigurationError);}
-            };
+                () => {expect(e).to.be.instanceOf(ClientConfigurationError);};
+            }
         });
 
         it("throws an error if configured with a null request", () => {
             try {
                 msal.acquireTokenPopup(null);
             } catch(e) {
-                () => {expect(e).to.be.instanceOf(ClientConfigurationError);}
-            };
+                () => {expect(e).to.be.instanceOf(ClientConfigurationError);};
+            }
         });
     });
 
-    describe('Logger', () => {
-        it('getLogger and setLogger', done => {
+    describe("Logger", () => {
+        it("getLogger and setLogger", done => {
             const config: Configuration = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -2659,7 +2660,7 @@ describe("UserAgentApplication.ts Class", function () {
             const correlationId = CryptoUtils.createNewGuid();
 
             const logger = new Logger((level, message, containsPii) => {
-                expect(message).to.contain('Message');
+                expect(message).to.contain("Message");
                 expect(message).to.contain(correlationId);
                 expect(message).to.contain(LogLevel.Info);
 
@@ -2676,7 +2677,7 @@ describe("UserAgentApplication.ts Class", function () {
 
             expect(msal.getLogger()).to.equal(logger);
 
-            msal.getLogger().info('Message');
+            msal.getLogger().info("Message");
         });
     });
 
@@ -2760,7 +2761,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -2775,7 +2776,7 @@ describe("UserAgentApplication.ts Class", function () {
 
             describe("loginPopup", () => {
                 const oldWindow = window;
-                const TEST_LIBRARY_STATE_POPUP = RequestUtils.generateLibraryState(Constants.interactionTypePopup)
+                const TEST_LIBRARY_STATE_POPUP = RequestUtils.generateLibraryState(Constants.interactionTypePopup);
 
                 beforeEach(function() {
                     cacheStorage = new AuthCache(TEST_CONFIG.MSAL_CLIENT_ID, "sessionStorage", true);
@@ -2815,7 +2816,7 @@ describe("UserAgentApplication.ts Class", function () {
                     const loginPopupPromise = msal.loginPopup({});
                     loginPopupPromise.catch(error => {
                         expect(navigateUrl).to.include(idTokenType);
-                        expect(navigateUrl).to.not.include(tokenType)
+                        expect(navigateUrl).to.not.include(tokenType);
                         expect(navigateUrl).to.not.include(idTokenTokenType);
                         done();
                     });
@@ -2852,7 +2853,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -2871,7 +2872,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -2890,7 +2891,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -2909,7 +2910,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -2928,7 +2929,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -2947,7 +2948,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -2957,7 +2958,7 @@ describe("UserAgentApplication.ts Class", function () {
                     };
                     
                     sinon.stub(msal, "getAccount").returns(account);
-                    msal.acquireTokenRedirect({ scopes: ['S1', Constants.openidScope], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1", Constants.openidScope], account});
                 });
 
                 it("should set response_type to id_token token when a resource scope is included along with profile", (done) => {
@@ -2966,7 +2967,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -2976,7 +2977,7 @@ describe("UserAgentApplication.ts Class", function () {
                     };
                     
                     sinon.stub(msal, "getAccount").returns(account);
-                    msal.acquireTokenRedirect({ scopes: ['S1', Constants.profileScope], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1", Constants.profileScope], account});
                 });
 
                 it("should set response_type to id_token token when a resource scope is included along with both OIDC scopes", (done) => {
@@ -2985,7 +2986,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -2996,7 +2997,7 @@ describe("UserAgentApplication.ts Class", function () {
 
                     const oidcScopes = [Constants.openidScope, Constants.profileScope];                        
                     sinon.stub(msal, "getAccount").returns(account);
-                    msal.acquireTokenRedirect({ scopes: ['S1', ...oidcScopes], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1", ...oidcScopes], account});
                 });
 
                 it("should treat clientId as a resource scope when included with OIDC scopes and therefore set response_type to id_token token", (done) => {
@@ -3005,7 +3006,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3025,7 +3026,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(tokenType);
-                                expect(url).to.not.include(idTokenTokenType)
+                                expect(url).to.not.include(idTokenTokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3036,7 +3037,7 @@ describe("UserAgentApplication.ts Class", function () {
 
                     const oidcScopes = [Constants.openidScope, Constants.profileScope];                        
                     sinon.stub(msal, "getAccount").returns(account);
-                    msal.acquireTokenRedirect({ scopes: ['S1'], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1"], account});
                 });
 
                 it("should set response_type to token when multiple resource scopes are included", (done) => {
@@ -3045,7 +3046,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(tokenType);
-                                expect(url).to.not.include(idTokenTokenType)
+                                expect(url).to.not.include(idTokenTokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3056,7 +3057,7 @@ describe("UserAgentApplication.ts Class", function () {
 
                     const oidcScopes = [Constants.openidScope, Constants.profileScope];                        
                     sinon.stub(msal, "getAccount").returns(account);
-                    msal.acquireTokenRedirect({ scopes: ['S1', 'S2'], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1", "S2"], account});
                 });
                 it("should treat clientId as a resource scope when included with resource scopes and therefore set response_type to token", (done) => {
                     window.location = {
@@ -3064,7 +3065,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(tokenType);
-                                expect(url).to.not.include(idTokenTokenType)
+                                expect(url).to.not.include(idTokenTokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3075,7 +3076,7 @@ describe("UserAgentApplication.ts Class", function () {
 
                     const oidcScopes = [Constants.openidScope, Constants.profileScope];                        
                     sinon.stub(msal, "getAccount").returns(account);
-                    msal.acquireTokenRedirect({ scopes: [TEST_CONFIG.MSAL_CLIENT_ID, 'S1'], account});
+                    msal.acquireTokenRedirect({ scopes: [TEST_CONFIG.MSAL_CLIENT_ID, "S1"], account});
                 });
             }); 
 
@@ -3107,7 +3108,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -3125,7 +3126,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -3143,7 +3144,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -3161,7 +3162,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenTokenType);
                                 done();
                             } catch (e) {
@@ -3179,7 +3180,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3188,7 +3189,7 @@ describe("UserAgentApplication.ts Class", function () {
                         }
                     };
                     
-                    msal.acquireTokenRedirect({ scopes: ['S1', Constants.openidScope], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1", Constants.openidScope], account});
                 });
 
                 it("should set response_type to id_token token when a resource scope is included along with profile", (done) => {
@@ -3197,7 +3198,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3206,7 +3207,7 @@ describe("UserAgentApplication.ts Class", function () {
                         }
                     };
                     
-                    msal.acquireTokenRedirect({ scopes: ['S1', Constants.profileScope], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1", Constants.profileScope], account});
                 });
 
                 it("should set response_type to id_token token when a resource scope is included along with both OIDC scopes", (done) => {
@@ -3215,7 +3216,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3225,7 +3226,7 @@ describe("UserAgentApplication.ts Class", function () {
                     };
 
                     const oidcScopes = [Constants.openidScope, Constants.profileScope];                        
-                    msal.acquireTokenRedirect({ scopes: ['S1', ...oidcScopes], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1", ...oidcScopes], account});
                 });
 
                 it("should treat clientId as a resource scope when included with OIDC scopes and therefore set response_type to id_token token", (done) => {
@@ -3234,7 +3235,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.include(idTokenTokenType);
-                                expect(url).to.not.include(tokenType)
+                                expect(url).to.not.include(tokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3263,7 +3264,7 @@ describe("UserAgentApplication.ts Class", function () {
                     };
 
                     const oidcScopes = [Constants.openidScope, Constants.profileScope];                        
-                    msal.acquireTokenRedirect({ scopes: ['S1'], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1"], account});
                 });
 
                 it("should set response_type to id_token token when multiple resource scopes are included because login is required", (done) => {
@@ -3282,7 +3283,7 @@ describe("UserAgentApplication.ts Class", function () {
                     };
 
                     const oidcScopes = [Constants.openidScope, Constants.profileScope];                        
-                    msal.acquireTokenRedirect({ scopes: ['S1', 'S2'], account});
+                    msal.acquireTokenRedirect({ scopes: ["S1", "S2"], account});
                 });
                 it("should treat clientId as a resource scope when included with resource scopes and therefore set response_type to id_token token because login is required", (done) => {
                     window.location = {
@@ -3290,7 +3291,7 @@ describe("UserAgentApplication.ts Class", function () {
                         assign: function (url) {
                             try {
                                 expect(url).to.not.include(tokenType);
-                                expect(url).to.include(idTokenTokenType)
+                                expect(url).to.include(idTokenTokenType);
                                 expect(url).to.not.include(idTokenType);
                                 done();
                             } catch (e) {
@@ -3300,7 +3301,7 @@ describe("UserAgentApplication.ts Class", function () {
                     };
 
                     const oidcScopes = [Constants.openidScope, Constants.profileScope];                        
-                    msal.acquireTokenRedirect({ scopes: [TEST_CONFIG.MSAL_CLIENT_ID, 'S1'], account});
+                    msal.acquireTokenRedirect({ scopes: [TEST_CONFIG.MSAL_CLIENT_ID, "S1"], account});
                 });
             }); 
         });

--- a/samples/msal-core-samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
+++ b/samples/msal-core-samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
@@ -174,7 +174,7 @@ describe("Browser tests", function () {
         await takeScreenshot(page, testName, "samplePageGotToken");
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
-        expect(page.url()).to.be.eq(customQueryPage + "#"); // Redirect will leave empty hash on the url
+        expect(page.url()).to.be.eq(customQueryPage); // Redirect will leave empty hash on the url
     });
 
     it("Performs loginPopup then acquireTokenPopup", async () => {

--- a/samples/msal-core-samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
+++ b/samples/msal-core-samples/VanillaJSTestApp/app/get_access_token_interactively/test/browser.spec.ts
@@ -174,7 +174,7 @@ describe("Browser tests", function () {
         await takeScreenshot(page, testName, "samplePageGotToken");
         localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(6);
-        expect(page.url()).to.be.eq(customQueryPage); // Redirect will leave empty hash on the url
+        expect(page.url()).to.be.eq(customQueryPage);
     });
 
     it("Performs loginPopup then acquireTokenPopup", async () => {


### PR DESCRIPTION
There are scenarios where an application uses server-side and client-side routing, and do not want the empty hash left over, as it will trigger client-side routing, which is not desired. Falling back to old method in case `replaceState` is not supported.