### PR TITLE
Add removeEventCallback API

### DIFF
--- a/change/@azure-msal-browser-2020-10-20-14-41-15-unsubscribe-event.json
+++ b/change/@azure-msal-browser-2020-10-20-14-41-15-unsubscribe-event.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add removeEventCallback API (#2462)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T21:41:15.901Z"
+}

--- a/change/@azure-msal-browser-2020-10-20-14-41-15-unsubscribe-event.json
+++ b/change/@azure-msal-browser-2020-10-20-14-41-15-unsubscribe-event.json
@@ -3,6 +3,6 @@
   "comment": "Add removeEventCallback API (#2462)",
   "packageName": "@azure/msal-browser",
   "email": "thomas.norling@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-10-20T21:41:15.901Z"
 }

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -890,8 +890,8 @@ export abstract class ClientApplication {
     
             this.logger.info(`Emitting event: ${eventType}`);
     
-            this.eventCallbacks.forEach((callback: EventCallbackFunction) => {
-                this.logger.verbose(`Emitting event to callback: ${eventType}`);
+            this.eventCallbacks.forEach((callback: EventCallbackFunction, callbackId: string) => {
+                this.logger.verbose(`Emitting event to callback ${callbackId}: ${eventType}`);
                 callback.apply(null, [message]);
             });
         }
@@ -903,9 +903,9 @@ export abstract class ClientApplication {
      */
     addEventCallback(callback: EventCallbackFunction): string | null {
         if (this.isBrowserEnvironment) {
-            this.logger.verbose("Event callback registered");
             const callbackId = this.browserCrypto.createNewGuid();
             this.eventCallbacks.set(callbackId, callback);
+            this.logger.verbose(`Event callback registered with id: ${callbackId}`);
 
             return callbackId;
         }
@@ -915,6 +915,7 @@ export abstract class ClientApplication {
 
     removeEventCallback(callbackId: string): void {
         this.eventCallbacks.delete(callbackId);
+        this.logger.verbose(`Event callback ${callbackId} removed.`);
     }
 
     // #endregion

--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -13,7 +13,8 @@ export interface IPublicClientApplication {
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
     acquireTokenRedirect(request: RedirectRequest): Promise<void>;
     acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
-    addEventCallback(callback: Function): void;
+    addEventCallback(callback: Function): string | null;
+    removeEventCallback(callbackId: string): void;
     getAccountByHomeId(homeAccountId: string): AccountInfo | null;
     getAccountByUsername(userName: string): AccountInfo | null;
     getAllAccounts(): AccountInfo[];

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1,8 +1,11 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import "mocha";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 import sinon from "sinon";
 import { PublicClientApplication } from "../../src/app/PublicClientApplication";
 import { TEST_CONFIG, TEST_URIS, TEST_HASHES, TEST_TOKENS, TEST_DATA_CLIENT_INFO, TEST_TOKEN_LIFETIMES, RANDOM_TEST_GUID, DEFAULT_OPENID_CONFIG_RESPONSE, testNavUrl, testLogoutUrl, TEST_STATE_VALUES, testNavUrlNoRequest } from "../utils/StringConstants";
@@ -20,6 +23,8 @@ import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 import { EventType } from "../../src/event/EventType";
 import { SilentRequest } from "../../src/request/SilentRequest";
+chai.use(chaiAsPromised);
+const expect = chai.expect;
 
 describe("PublicClientApplication.ts Class Unit Tests", () => {
     const cacheConfig = {
@@ -1806,7 +1811,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         });
     });
 
-    describe("broadcastEvent and addEventCallback tests", () => {
+    describe("Event API tests", () => {
         it("can add an event callback and broadcast to it", (done) => {
             const subscriber = (message) => {
                 expect(message.eventType).to.deep.eq(EventType.LOGIN_START);
@@ -1816,6 +1821,22 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             pca.addEventCallback(subscriber);
             pca.emitEvent(EventType.LOGIN_START, InteractionType.Popup);
+        });
+
+        it("can remove an event callback", (done) => {
+            const subscriber = (message) => {
+                expect(message.eventType).to.deep.eq(EventType.LOGIN_START);
+                expect(message.interactionType).to.deep.eq(InteractionType.Popup);
+            };
+
+            const callbackSpy = sinon.spy(subscriber);
+
+            const callbackId = pca.addEventCallback(callbackSpy);
+            pca.emitEvent(EventType.LOGIN_START, InteractionType.Popup);
+            pca.removeEventCallback(callbackId);
+            pca.emitEvent(EventType.LOGIN_START, InteractionType.Popup);
+            expect(callbackSpy.calledOnce).to.be.true;
+            done();
         });
 
         it("can add multiple callbacks and broadcast to all", (done) => {


### PR DESCRIPTION
- Adds an API to remove an event callback
- Changes `eventCallbacks` array to a Map with a guid key
- `addEventCallback` returns an id
- Fixes login vs acquireToken logic which had the comparison backwards