### PR TITLE
Fix loginRedirect Angular 10 Sample Code

### DIFF
--- a/samples/msal-angular-v2-samples/angular10-browser-sample/src/app/msal/msal.guard.ts
+++ b/samples/msal-angular-v2-samples/angular10-browser-sample/src/app/msal/msal.guard.ts
@@ -49,9 +49,9 @@ export class MsalGuard implements CanActivate {
 
         const redirectStartPage = this.getDestinationUrl(url);
         this.authService.loginRedirect({
-            ...this.msalGuardConfig.authRequest,
             redirectStartPage,
             scopes: [],
+            ...this.msalGuardConfig.authRequest,
         });
         return of(false);
     }


### PR DESCRIPTION
The current msal.guard in the Angular 10 sample code does not use the scopes passed into the MsalGuardConfig during redirect login since it overwrites the given scopes with an empty array.

This updates the sample msal.guard to make sure all the values from the MsalGuardConfig are respected.