### PR TITLE
[msal-common] Add missing default headers to device code

### DIFF
--- a/change/@azure-msal-common-2020-10-23-08-46-53-set-default-headers.json
+++ b/change/@azure-msal-common-2020-10-23-08-46-53-set-default-headers.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing default headers to device code",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T15:46:53.613Z"
+}

--- a/change/@azure-msal-common-2020-10-23-08-46-53-set-default-headers.json
+++ b/change/@azure-msal-common-2020-10-23-08-46-53-set-default-headers.json
@@ -3,6 +3,6 @@
   "comment": "Add missing default headers to device code",
   "packageName": "@azure/msal-common",
   "email": "sameera.gajjarapu@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-10-23T15:46:53.613Z"
 }

--- a/lib/msal-common/src/client/DeviceCodeClient.ts
+++ b/lib/msal-common/src/client/DeviceCodeClient.ts
@@ -64,7 +64,7 @@ export class DeviceCodeClient extends BaseClient {
      */
     private async getDeviceCode(request: DeviceCodeRequest): Promise<DeviceCodeResponse> {
         const queryString = this.createQueryString(request);
-        const headers = this.createDefaultLibraryHeaders();
+        const headers = this.createDefaultTokenRequestHeaders();
         const thumbprint: RequestThumbprint = {
             clientId: this.config.authOptions.clientId,
             authority: request.authority,
@@ -122,7 +122,7 @@ export class DeviceCodeClient extends BaseClient {
 
         parameterBuilder.addScopes(request.scopes);
         parameterBuilder.addClientId(this.config.authOptions.clientId);
-        
+
         if (!StringUtils.isEmpty(request.claims) || this.config.authOptions.clientCapabilities && this.config.authOptions.clientCapabilities.length > 0) {
             parameterBuilder.addClaims(request.claims, this.config.authOptions.clientCapabilities);
         }


### PR DESCRIPTION
`Content-type` and `Telemetry` headers are missing in `device code flow` as we are not calling the default headers API correctly. Fixing the issue with this PR.

Note: We mock all our network calls in unit tests and hence couldn't catch this in our testing. 

Todo:
Adding these in end-to-end tests is a good idea. Will try to see if the current framework allows this.