### PR TITLE
[msal-common] Enable "-strict" in tsconfig for msal-common

### DIFF
--- a/lib/msal-common/src/cache/entities/CacheRecord.ts
+++ b/lib/msal-common/src/cache/entities/CacheRecord.ts
@@ -10,11 +10,11 @@ import { AccountEntity } from "./AccountEntity";
 import { AppMetadataEntity } from "./AppMetadataEntity";
 
 export class CacheRecord {
-    account: AccountEntity;
-    idToken: IdTokenEntity;
-    accessToken: AccessTokenEntity;
-    refreshToken: RefreshTokenEntity;
-    appMetadata: AppMetadataEntity;
+    account?: AccountEntity;
+    idToken?: IdTokenEntity;
+    accessToken?: AccessTokenEntity;
+    refreshToken?: RefreshTokenEntity;
+    appMetadata?: AppMetadataEntity;
 
     constructor(accountEntity?: AccountEntity, idTokenEntity?: IdTokenEntity, accessTokenEntity?: AccessTokenEntity, refreshTokenEntity?: RefreshTokenEntity, appMetadataEntity?: AppMetadataEntity) {
         this.account = accountEntity;

--- a/lib/msal-common/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-common/src/client/OnBehalfOfClient.ts
@@ -42,14 +42,14 @@ export class OnBehalfOfClient extends BaseClient {
         }
 
         const cachedAuthenticationResult = this.getCachedAuthenticationResult(request);
-        if (cachedAuthenticationResult != null) {
+        if (cachedAuthenticationResult !== null) {
             return cachedAuthenticationResult;
         } else {
             return await this.executeTokenRequest(request, this.authority);
         }
     }
 
-    private async getCachedAuthenticationResult(request: OnBehalfOfRequest): Promise<AuthenticationResult> {
+    private async getCachedAuthenticationResult(request: OnBehalfOfRequest): Promise<AuthenticationResult | null> {
         const cachedAccessToken = this.readAccessTokenFromCache(request);
         if (!cachedAccessToken ||
             TimeUtils.isTokenExpired(cachedAccessToken.expiresOn, this.config.systemOptions.tokenRenewalOffsetSeconds)) {
@@ -77,9 +77,9 @@ export class OnBehalfOfClient extends BaseClient {
                 account: cachedAccount,
                 accessToken: cachedAccessToken,
                 idToken: cachedIdToken,
-                refreshToken: null,
-                appMetadata: null,
-            }, idTokenObject, true);
+                refreshToken: undefined,
+                appMetadata: undefined,
+            }, true, idTokenObject);
     }
 
     private readAccessTokenFromCache(request: OnBehalfOfRequest): AccessTokenEntity {

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -61,7 +61,7 @@ export class SilentFlowClient extends BaseClient {
         const environment = request.authority || Authority.generateEnvironmentFromAuthority(this.authority);
         const cacheRecord = this.cacheManager.readCacheRecord(request.account, this.config.authOptions.clientId, requestScopes, environment);
 
-        if (this.isRefreshRequired(request, cacheRecord.accessToken)) {
+        if (!cacheRecord.accessToken || this.isRefreshRequired(request, cacheRecord.accessToken)) {
             throw ClientAuthError.createRefreshRequiredError();
         } else {
             if (this.config.serverTelemetryManager) {
@@ -80,9 +80,9 @@ export class SilentFlowClient extends BaseClient {
         return await ResponseHandler.generateAuthenticationResult(
             this.cryptoUtils,
             cacheRecord,
-            idTokenObj, 
             true,
-            null,
+            idTokenObj,
+            undefined,
             resourceRequestMethod,
             resourceRequestUri
         );

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -24,23 +24,26 @@ const DEFAULT_TOKEN_RENEWAL_OFFSET_SEC = 300;
  *
  * This object allows you to configure important elements of MSAL functionality:
  * - authOptions                - Authentication for application
+ * - storageInterface           - Storage implementation
+ * - networkInterface           - Network implementation
  * - cryptoInterface            - Implementation of crypto functions
  * - libraryInfo                - Library metadata
- * - loggerOptions              - Logging for application
- * - networkInterface           - Network implementation
- * - storageInterface           - Storage implementation
  * - systemOptions              - Additional library options
+ * - loggerOptions              - Logging for application
  * - clientCredentials          - Credentials options for confidential clients
+ * - serverTelemetryManager     - Adds the server telemetry options for every request
+ * - persistencePlugin          - Interface for Cache plugin implemented for persistence in extensions / User app to implement it otherwise
+ * - serializableCache          - Serializes persistent cache if enabled
  */
 export type ClientConfiguration = {
     authOptions: AuthOptions,
-    systemOptions?: SystemOptions,
+    storageInterface: CacheManager,
+    networkInterface: INetworkModule,
+    cryptoInterface: ICrypto,
+    libraryInfo: LibraryInfo
+    systemOptions: SystemOptions,
     loggerOptions?: LoggerOptions,
-    storageInterface?: CacheManager,
-    networkInterface?: INetworkModule,
-    cryptoInterface?: ICrypto,
     clientCredentials?: ClientCredentials,
-    libraryInfo?: LibraryInfo
     serverTelemetryManager?: ServerTelemetryManager,
     persistencePlugin?: ICachePlugin,
     serializableCache?: ISerializableTokenCache
@@ -71,7 +74,7 @@ export type AuthOptions = {
  * - tokenRenewalOffsetSeconds    - Sets the window of offset needed to renew the token before expiry
  */
 export type SystemOptions = {
-    tokenRenewalOffsetSeconds?: number;
+    tokenRenewalOffsetSeconds: number;
 };
 
 /**
@@ -196,7 +199,7 @@ export function buildClientConfiguration(
         cryptoInterface: cryptoImplementation,
         clientCredentials: clientCredentials,
         libraryInfo: libraryInfo,
-        serverTelemetryManager: serverTelemetryManager, 
+        serverTelemetryManager: serverTelemetryManager,
         persistencePlugin: persistencePlugin,
         serializableCache: serializableCache
     } : ClientConfiguration): ClientConfiguration {

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -80,6 +80,10 @@ export const ClientConfigurationErrorMessage = {
     untrustedAuthority: {
         code: "untrusted_authority",
         desc: "The provided authority is not a trusted authority. Please include this authority in the knownAuthorities config parameter."
+    },
+    resourceRequestParametersRequired: {
+        code: "resourceRequest_parameters_required",
+        desc: "resourceRequestMethod and resourceRequestUri are required"
     }
 };
 
@@ -251,5 +255,13 @@ export class ClientConfigurationError extends ClientAuthError {
     static createUntrustedAuthorityError(): ClientConfigurationError {
         return new ClientConfigurationError(ClientConfigurationErrorMessage.untrustedAuthority.code,
             ClientConfigurationErrorMessage.untrustedAuthority.desc);
+    }
+
+    /**
+     * Throws error when resourceRequestMethod or resourceRequestUri is missing
+     */
+    static createResourceRequestParametersRequiredError(): ClientConfigurationError {
+        return new ClientConfigurationError(ClientConfigurationErrorMessage.resourceRequestParametersRequired.code,
+            ClientConfigurationErrorMessage.resourceRequestParametersRequired.desc);
     }
 }

--- a/lib/msal-common/src/request/BaseAuthRequest.ts
+++ b/lib/msal-common/src/request/BaseAuthRequest.ts
@@ -9,8 +9,8 @@
  * - claims                  - A stringified claims request which will be added to all /authorize and /token calls
  * - authority               - URL of the authority, the security token service (STS) from which MSAL will acquire tokens. Defaults to https://login.microsoftonline.com/common. If using the same authority for all request, authority should set on client application object and not request, to avoid resolving authority endpoints multiple times.
  * - correlationId           - Unique GUID set per request to trace a request end-to-end for telemetry purposes.
- * - resourceRequestMethod      - HTTP Request type used to request data from the resource (i.e. "GET", "POST", etc.).  Used for proof-of-possession flows.
- * - resourceRequestUri         - URI that token will be used for. Used for proof-of-possession flows.
+ * - resourceRequestMethod   - HTTP Request type used to request data from the resource (i.e. "GET", "POST", etc.).  Used for proof-of-possession flows.
+ * - resourceRequestUri      - URI that token will be used for. Used for proof-of-possession flows.
  */
 export type BaseAuthRequest = {
     scopes: Array<string>;

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -85,7 +85,7 @@ export class RequestParameterBuilder {
 
     /**
      * add sid
-     * @param sid 
+     * @param sid
      */
     addSid(sid: string): void {
         this.parameters.set(SSOTypes.SID, encodeURIComponent(sid));
@@ -95,7 +95,7 @@ export class RequestParameterBuilder {
      * add claims
      * @param claims
      */
-    addClaims(claims: string, clientCapabilities: Array<string>): void {
+    addClaims(claims?: string, clientCapabilities?: Array<string>): void {
         const mergedClaims = this.addClientCapabilitiesToClaims(claims, clientCapabilities);
         RequestValidator.validateClaims(mergedClaims);
         this.parameters.set(AADServerParamKeys.CLAIMS, encodeURIComponent(mergedClaims));
@@ -222,7 +222,7 @@ export class RequestParameterBuilder {
     addClientAssertionType(clientAssertionType: string): void {
         this.parameters.set(AADServerParamKeys.CLIENT_ASSERTION_TYPE, encodeURIComponent(clientAssertionType));
     }
-    
+
     /**
      * add OBO assertion for confidential client flows
      * @param clientAssertion
@@ -230,7 +230,7 @@ export class RequestParameterBuilder {
     addOboAssertion(oboAssertion: string): void {
         this.parameters.set(AADServerParamKeys.OBO_ASSERTION, encodeURIComponent(oboAssertion));
     }
-    
+
     /**
      * add grant type
      * @param grantType
@@ -266,7 +266,7 @@ export class RequestParameterBuilder {
         });
     }
 
-    addClientCapabilitiesToClaims(claims: string, clientCapabilities: Array<string>): string {
+    addClientCapabilitiesToClaims(claims?: string, clientCapabilities?: Array<string>): string {
         let mergedClaims: object;
 
         // Parse provided claims into JSON object or initialize empty object
@@ -297,7 +297,7 @@ export class RequestParameterBuilder {
 
     /**
      * add pop_jwk to query params
-     * @param cnfString 
+     * @param cnfString
      */
     addPopToken(cnfString: string): void {
         if (!StringUtils.isEmpty(cnfString)) {

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -152,7 +152,7 @@ export class ResponseHandler {
             /*
              * When saving a refreshed tokens to the cache, it is expected that the account that was used is present in the cache.
              * If not present, we should return null, as it's the case that another application called removeAccount in between
-             * the calls to getAllAccounts and acquireTokenSilent. We should not overwrite that removal. 
+             * the calls to getAllAccounts and acquireTokenSilent. We should not overwrite that removal.
              */
             if (handlingRefreshTokenResponse && cacheRecord.account) {
                 const key = cacheRecord.account.generateAccountKey();
@@ -169,7 +169,7 @@ export class ResponseHandler {
                 await this.persistencePlugin.afterCacheAccess(cacheContext);
             }
         }
-        return ResponseHandler.generateAuthenticationResult(this.cryptoObj, cacheRecord, idTokenObj, false, requestStateObj, resourceRequestMethod, resourceRequestUri);
+        return ResponseHandler.generateAuthenticationResult(this.cryptoObj, cacheRecord, false, idTokenObj, requestStateObj, resourceRequestMethod, resourceRequestUri);
     }
 
     /**
@@ -294,7 +294,7 @@ export class ResponseHandler {
      * @param fromTokenCache
      * @param stateString
      */
-    static async generateAuthenticationResult(cryptoObj: ICrypto, cacheRecord: CacheRecord, idTokenObj: AuthToken, fromTokenCache: boolean, requestState?: RequestStateObject, resourceRequestMethod?: string, resourceRequestUri?: string): Promise<AuthenticationResult> {
+    static async generateAuthenticationResult(cryptoObj: ICrypto, cacheRecord: CacheRecord, fromTokenCache: boolean, idTokenObj?: AuthToken, requestState?: RequestStateObject, resourceRequestMethod?: string, resourceRequestUri?: string): Promise<AuthenticationResult> {
         let accessToken: string = "";
         let responseScopes: Array<string> = [];
         let expiresOn: Date = null;

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -35,7 +35,8 @@ export const Constants = {
     S256_CODE_CHALLENGE_METHOD: "S256",
     URL_FORM_CONTENT_TYPE: "application/x-www-form-urlencoded;charset=utf-8",
     AUTHORIZATION_PENDING: "authorization_pending",
-    NOT_DEFINED: "not_defined"
+    NOT_DEFINED: "not_defined",
+    EMPTY_STRING: ""
 };
 
 /**
@@ -264,7 +265,7 @@ export const THE_FAMILY_ID = "1";
 
 export const SERVER_TELEM_CONSTANTS = {
     SCHEMA_VERSION: 2,
-    MAX_HEADER_BYTES: 4000, // Max is 4KB, 4000 Bytes provides 96 Byte buffer for separators, schema version, etc. 
+    MAX_HEADER_BYTES: 4000, // Max is 4KB, 4000 Bytes provides 96 Byte buffer for separators, schema version, etc.
     CACHE_KEY: "server-telemetry",
     CATEGORY_SEPARATOR: "|",
     VALUE_SEPARATOR: ",",

--- a/lib/msal-common/src/utils/StringUtils.ts
+++ b/lib/msal-common/src/utils/StringUtils.ts
@@ -38,7 +38,7 @@ export class StringUtils {
      *
      * @param str
      */
-    static isEmpty(str: string): boolean {
+    static isEmpty(str?: string): boolean {
         return (typeof str === "undefined" || !str || 0 === str.length);
     }
 

--- a/lib/msal-common/tsconfig.json
+++ b/lib/msal-common/tsconfig.json
@@ -13,7 +13,17 @@
         "allowUnusedLabels": false,
         "noImplicitReturns": true,
         "esModuleInterop": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "strictPropertyInitialization": false,
+        "strict": true,
+        // "noImplicitAny": true,
+        "alwaysStrict": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
Enabling the below flags in `.tsconfig` for `msal-common`:

```javascript

        "strictNullChecks": true,
        "strictFunctionTypes": true,
        "strictPropertyInitialization": false,
        "strict": true,
        "alwaysStrict": true,
        "noImplicitThis": true,
        "noUnusedLocals": true,
        "noUnusedParameters": true,
        "noFallthroughCasesInSwitch": true,
```