### PR TITLE
Fix ServerTelemetry maxErrorsToSend bug

### DIFF
--- a/change/@azure-msal-common-2020-10-26-10-27-03-fix-telemetry-bug.json
+++ b/change/@azure-msal-common-2020-10-26-10-27-03-fix-telemetry-bug.json
@@ -3,6 +3,6 @@
   "comment": "Fix ServerTelemetry maxErrorToSend bug (#2491)",
   "packageName": "@azure/msal-common",
   "email": "thomas.norling@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-10-26T17:27:03.375Z"
 }

--- a/change/@azure-msal-common-2020-10-26-10-27-03-fix-telemetry-bug.json
+++ b/change/@azure-msal-common-2020-10-26-10-27-03-fix-telemetry-bug.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix ServerTelemetry maxErrorToSend bug (#2491)",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-26T17:27:03.375Z"
+}

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -35,7 +35,8 @@ export const Constants = {
     S256_CODE_CHALLENGE_METHOD: "S256",
     URL_FORM_CONTENT_TYPE: "application/x-www-form-urlencoded;charset=utf-8",
     AUTHORIZATION_PENDING: "authorization_pending",
-    NOT_DEFINED: "not_defined"
+    NOT_DEFINED: "not_defined",
+    EMPTY_STRING: ""
 };
 
 /**
@@ -269,7 +270,8 @@ export const SERVER_TELEM_CONSTANTS = {
     CATEGORY_SEPARATOR: "|",
     VALUE_SEPARATOR: ",",
     OVERFLOW_TRUE: "1",
-    OVERFLOW_FALSE: "0"
+    OVERFLOW_FALSE: "0",
+    UNKNOWN_ERROR: "unknown_error"
 };
 
 /**


### PR DESCRIPTION
If an error is thrown that is not type `AuthError` (i.e. doesn't have the `errorCode` property) the ServerTelemetryManager will save this error in the cache as `null`. A recent update surfaced this problem when trying to access the length property of `null` and thus throwing an error.

This PR addresses this bug by putting additional fallbacks in place to ensure we always store a string in the cache and a value is type string before we attempt to get the `length`

Fixes #2476, #2474