### PR TITLE
Restore string to cacheLocation type

### DIFF
--- a/change/@azure-msal-browser-2020-10-29-16-03-05-msal-browser-cache-location-string.json
+++ b/change/@azure-msal-browser-2020-10-29-16-03-05-msal-browser-cache-location-string.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Restore string to cacheLocation type",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-29T23:03:05.675Z"
+}

--- a/change/@azure-msal-browser-2020-10-29-16-03-05-msal-browser-cache-location-string.json
+++ b/change/@azure-msal-browser-2020-10-29-16-03-05-msal-browser-cache-location-string.json
@@ -1,8 +1,8 @@
 {
   "type": "patch",
-  "comment": "Restore string to cacheLocation type",
+  "comment": "Restore string to cacheLocation type (#2523)",
   "packageName": "@azure/msal-browser",
   "email": "janutter@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-10-29T23:03:05.675Z"
 }

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -49,7 +49,7 @@ export class BrowserCacheManager extends CacheManager {
      * Returns a window storage class implementing the IWindowStorage interface that corresponds to the configured cacheLocation.
      * @param cacheLocation 
      */
-    private setupBrowserStorage(cacheLocation: BrowserCacheLocation): IWindowStorage {
+    private setupBrowserStorage(cacheLocation: BrowserCacheLocation | string): IWindowStorage {
         switch (cacheLocation) {
             case BrowserCacheLocation.LocalStorage:
             case BrowserCacheLocation.SessionStorage:

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -44,7 +44,7 @@ export type BrowserAuthOptions = {
  * - storeAuthStateInCookie   - If set, MSAL store's the auth request state required for validation of the auth flows in the browser cookies. By default this flag is set to false.
  */
 export type CacheOptions = {
-    cacheLocation?: BrowserCacheLocation;
+    cacheLocation?: BrowserCacheLocation | string;
     storeAuthStateInCookie?: boolean;
 };
 

--- a/samples/msal-browser-samples/TypescriptTestApp2.0/package-lock.json
+++ b/samples/msal-browser-samples/TypescriptTestApp2.0/package-lock.json
@@ -4,6 +4,37 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/msal-browser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.5.0.tgz",
+      "integrity": "sha512-BqUI/k7/7j5R2yySozetNk3adl6BgO8BVcixtCCR1HWN9SrgFQAHQ3yWUNroVrYJooU61bRZCfC7DqLtsrUzCw==",
+      "requires": {
+        "@azure/msal-common": "^1.6.3"
+      }
+    },
+    "@azure/msal-common": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-1.6.3.tgz",
+      "integrity": "sha512-sZQ8gXavWEX7q0aHS8wNdcDWpbVnfLU4mMcX2E9JRHjn7nKACSEmiYNog2y/8vu7cMMV5RWWttF/oFQmeiIgyg==",
+      "requires": {
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "@babel/cli": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.10.4.tgz",


### PR DESCRIPTION
Unfortunately, using the value of a value in an enum is not good enough for typescript, so we need to restore `string` as a possible type. The `BrowserCacheManager` will [handle a string literal value correctly](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/src/cache/BrowserCacheManager.ts#L52-L66) at runtime.