### PR TITLE
Prevent markdown file updates from triggering build pipeline

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -9,6 +9,8 @@ on:
       - 'dev'
       - 'master'
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
 

--- a/.github/workflows/msal-browser-e2e.yml
+++ b/.github/workflows/msal-browser-e2e.yml
@@ -13,6 +13,7 @@ on:
       - 'msal-browser/**/*' 
       - 'msal-common/**/*'
       - 'samples/msal-browser-samples/VanillaJSTestApp2.0/**/*'
+      - '!**.md'
 
 jobs:
   run-e2e:

--- a/.github/workflows/msal-core-e2e.yml
+++ b/.github/workflows/msal-core-e2e.yml
@@ -12,6 +12,7 @@ on:
     paths: 
       - 'msal-core/**/*'
       - 'samples/msal-core-samples/VanillaJSTestApp/**/*'
+      - '!**.md'
 
 jobs:
   run-e2e:

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -13,6 +13,7 @@ on:
       - 'msal-node/**/*' 
       - 'msal-common/**/*'
       - 'samples/msal-node-samples/EndToEndTestApp/**/*'
+      - '!**.md'
 
 jobs:
   run-e2e:


### PR DESCRIPTION
No need to run build or tests when PRs only make docs updates. This PR updates the workflows to ignore `.md` files