### PR TITLE
Update MSAL Angular peer depedencies for Angular core libraries, pass generic to ModuleWithProviders

### DIFF
--- a/change/@azure-msal-angular-2020-11-10-12-09-45-angular-v1-peer-dep.json
+++ b/change/@azure-msal-angular-2020-11-10-12-09-45-angular-v1-peer-dep.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Pass generic to ModuleWithProviders for MsalModule v1",
+  "packageName": "@azure/msal-angular",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-10T20:09:45.661Z"
+}

--- a/change/@azure-msal-angular-2020-11-10-12-09-45-angular-v1-peer-dep.json
+++ b/change/@azure-msal-angular-2020-11-10-12-09-45-angular-v1-peer-dep.json
@@ -1,8 +1,8 @@
 {
   "type": "patch",
-  "comment": "Pass generic to ModuleWithProviders for MsalModule v1",
+  "comment": "Pass generic to ModuleWithProviders for MsalModule v1, set supported Angular versions to 6-9 (#2577)",
   "packageName": "@azure/msal-angular",
   "email": "janutter@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-11-10T20:09:45.661Z"
 }

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -33,8 +33,8 @@
     ]
   },
   "peerDependencies": {
-    "@angular/common": ">= 6.0.0",
-    "@angular/core": ">= 6.0.0",
+    "@angular/common": "6 - 9",
+    "@angular/core": "6 - 9",
     "msal": "^1.4.3",
     "rxjs": "^6.0.0"
   },

--- a/lib/msal-angular/src/msal.module.ts
+++ b/lib/msal-angular/src/msal.module.ts
@@ -23,7 +23,7 @@ export class MsalModule {
     static forRoot(
         config: Configuration,
         angularConfig: MsalAngularConfiguration = defaultMsalAngularConfiguration
-    ): ModuleWithProviders {
+    ): ModuleWithProviders<MsalModule> {
         return {
             ngModule: MsalModule,
             providers: [


### PR DESCRIPTION
Given we will not be able to properly support Angular 10 in MSAL Angular v1 due to Typescript versions incompat, formalize peer dependencies for MSAL Angular v1.