### PR TITLE
Fix inline links in React hooks documentation page

### DIFF
--- a/lib/msal-react/docs/hooks.md
+++ b/lib/msal-react/docs/hooks.md
@@ -1,9 +1,9 @@
 # Hooks
 
-1. [`useAccount`](#useaccount)
-1. [`useIsAuthenticated`](#useisauthenticated)
-1. [`useMsal`](#usemsal)
-1. [`useMsalAuthentication`](#usemsalauthentication)
+1. [`useAccount`](#useaccount-hook)
+1. [`useIsAuthenticated`](#useisauthenticated-hook)
+1. [`useMsal`](#usemsal-hook)
+1. [`useMsalAuthentication`](#usemsalauthentication-hook)
 
 ## `useAccount` hook
 


### PR DESCRIPTION
This PR fixes the invalid links at the start of the MSAL React hooks documentation page. All index links needed `-hook` appended to them in order to link with the headers on the page.