### PR TITLE
Remove console.logs from unit tests

### DIFF
--- a/change/@azure-msal-browser-2020-11-20-16-19-36-remove-console-logs-tests.json
+++ b/change/@azure-msal-browser-2020-11-20-16-19-36-remove-console-logs-tests.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Remove console.log in unit tests (#2629)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-11-21T00:19:23.071Z"
+}

--- a/change/@azure-msal-common-2020-11-20-16-19-36-remove-console-logs-tests.json
+++ b/change/@azure-msal-common-2020-11-20-16-19-36-remove-console-logs-tests.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Remove console.log in unit tests (#2629)",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-11-21T00:19:36.174Z"
+}

--- a/lib/msal-browser/test/config/Configuration.spec.ts
+++ b/lib/msal-browser/test/config/Configuration.spec.ts
@@ -13,11 +13,7 @@ const TEST_OFFSET = 100;
 
 describe("Configuration.ts Class Unit Tests", () => {
 
-    const testLoggerCallback = (level: LogLevel, message: string, containsPii: boolean): void => {
-        if (containsPii) {
-            console.log(`Log level: ${level} Message: ${message}`);
-        }
-    }
+    const testLoggerCallback = (level: LogLevel, message: string, containsPii: boolean): void => {}
 
     it("buildConfiguration assigns default values", () => {
         let emptyConfig: Configuration = buildConfiguration({auth: null});
@@ -94,10 +90,10 @@ describe("Configuration.ts Class Unit Tests", () => {
     });
 
     it("Tests logger", () => {
-        const consoleErrorSpy = sinon.spy(console, "error");
-        const consoleInfoSpy = sinon.spy(console, "info");
-        const consoleDebugSpy = sinon.spy(console, "debug");
-        const consoleWarnSpy = sinon.spy(console, "warn");
+        const consoleErrorSpy = sinon.stub(console, "error");
+        const consoleInfoSpy = sinon.stub(console, "info");
+        const consoleDebugSpy = sinon.stub(console, "debug");
+        const consoleWarnSpy = sinon.stub(console, "warn");
         const message = "log message";
         let emptyConfig: Configuration = buildConfiguration({
             auth: null,

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -122,11 +122,7 @@ describe("InteractionHandler.ts Unit Tests", () => {
                 }
             },
             loggerOptions: {
-                loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {
-                    if (containsPii) {
-                        console.log(`Log level: ${level} Message: ${message}`);
-                    }
-                },
+                loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {},
                 piiLoggingEnabled: true
             }
         };

--- a/lib/msal-browser/test/interaction_handler/PopupHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/PopupHandler.spec.ts
@@ -102,9 +102,7 @@ describe("PopupHandler.ts Unit Tests", () => {
                     level: LogLevel,
                     message: string,
                     containsPii: boolean
-                ): void => {
-                    console.log(`Log level: ${level} Message: ${message}`);
-                },
+                ): void => {},
                 piiLoggingEnabled: true,
             },
         };

--- a/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
@@ -65,11 +65,7 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 level: LogLevel,
                 message: string,
                 containsPii: boolean
-            ): void => {
-                if (containsPii) {
-                    console.log(`Log level: ${level} Message: ${message}`);
-                }
-            },
+            ): void => {},
             piiLoggingEnabled: true,
         };
         const logger = new Logger(loggerConfig);

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -105,9 +105,7 @@ describe("SilentHandler.ts Unit Tests", () => {
                     level: LogLevel,
                     message: string,
                     containsPii: boolean
-                ): void => {
-                    console.log(`Log level: ${level} Message: ${message}`);
-                },
+                ): void => {},
                 piiLoggingEnabled: true,
             },
         };

--- a/lib/msal-common/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-common/test/config/ClientConfiguration.spec.ts
@@ -115,11 +115,7 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
                 }
             },
             loggerOptions: {
-                loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {
-                    if (containsPii) {
-                        console.log(`Log level: ${level} Message: ${message}`);
-                    }
-                },
+                loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {},
                 piiLoggingEnabled: true
             },
             libraryInfo: {


### PR DESCRIPTION
Removes logger messages output to the console when running unit tests