### PR TITLE
Update angular10-browser-sample readme

### DIFF
--- a/samples/msal-angular-v2-samples/README.md
+++ b/samples/msal-angular-v2-samples/README.md
@@ -1,0 +1,14 @@
+# MSAL Angular v2 Samples
+
+**`@azure/msal-angular@2` is now available for private preview. Please see the [`@azure/msal-angular` README](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/msal-angular-v2/lib/msal-angular) for information on installation and changes.** 
+
+### Current available Angular v2 samples
+* [Angular v9](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/msal-angular-v2/samples/msal-angular-v2-samples/angular9-v2-sample-app)
+* [Angular v10](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/msal-angular-v2/samples/msal-angular-v2-samples/angular10-sample-app)
+* [Angular v11](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/msal-angular-v2/samples/msal-angular-v2-samples/angular11-sample-app)
+
+### Pre-Angular v2 sample
+
+* [Angular 10 Browser Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v2-samples/angular10-browser-sample)
+    * **Note:** This sample was created before `@azure/msal-angular@2` was available to demonstrate how to use `@azure/msal-browser` in an Angular application directly.
+    

--- a/samples/msal-angular-v2-samples/angular10-browser-sample/README.md
+++ b/samples/msal-angular-v2-samples/angular10-browser-sample/README.md
@@ -1,8 +1,10 @@
-# Angular 10 MSAL.js 2.x Sample
+# Angular 10 MSAL-Browser Sample
 
 ## About this sample
 
-This developer sample is used to demonstrate how to use MSAL.js in Angular 10.
+This developer sample was created before `@azure/msal-angular@2` was available to demonstrate how to use `@azure/msal-browser` in an Angular application directly.
+
+**`@azure/msal-angular@2` is now available for private preview. Please see the [`@azure/msal-angular` README](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/msal-angular-v2/lib/msal-angular) for information on installation, changes, and new samples.** 
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 10.0.6.
 
@@ -22,5 +24,4 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 - In the web page, click on the "Login" button. The app will automatically reload if you change any of the source files.
 
 ## Additional notes
-- The default interaction type for the sample is popups. The sample can be configured to use redirects by changing the `interactionType` in `app.module.ts` to `InteractionType.REDIRECT`. Note that there are current issues with using redirects, such as updating state and the asynchronous processing of redirect responses. These issues are being investigated and will be addressed.
-- The sample implements basic versions of Angular service, guard, and interceptors. Broadcast functionality has not been implemented.
+- The default interaction type for the sample is redirects. The sample can be configured to use popups by changing the `interactionType` in `app.module.ts` to `InteractionType.Popup`. 

--- a/samples/msal-angular-v2-samples/angular10-browser-sample/src/app/app.module.ts
+++ b/samples/msal-angular-v2-samples/angular10-browser-sample/src/app/app.module.ts
@@ -32,7 +32,7 @@ function MSALInterceptorConfigFactory(): MsalInterceptorConfig {
   protectedResourceMap.set('https://graph.microsoft.com/v1.0/me', ['user.read']);
 
   return {
-    interactionType: InteractionType.Popup,
+    interactionType: InteractionType.Redirect,
     protectedResourceMap,
   };
 }


### PR DESCRIPTION
This PR:
- Updates the `angular10-browser-sample` with information about `@azure/msal-angular@2`
- Adds a readme file to `msal-angular-v2-samples` folder with links to samples
- Changes default interaction type in sample to use redirects. 

This PR addresses and will close issue #2630 .