### PR TITLE
Update msal-react ssoSilent example

### DIFF
--- a/change/@azure-msal-react-2020-11-24-09-32-04-react-ssosilent-example.json
+++ b/change/@azure-msal-react-2020-11-24-09-32-04-react-ssosilent-example.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update msal-react ssoSilent example",
+  "packageName": "@azure/msal-react",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-11-24T17:32:04.155Z"
+}

--- a/lib/msal-react/docs/hooks.md
+++ b/lib/msal-react/docs/hooks.md
@@ -194,26 +194,32 @@ Note: Passing the "Silent" interaction type will call `ssoSilent` which attempts
 If you use silent you should catch any errors and attempt an interactive login as a fallback.
 
 ```javascript
-import React from 'react';
-import { useMsalAuthentication } from "@azure/msal-react";
+import React, { useEffect } from 'react';
+import './App.css';
 
-export function App() {
+import { AuthenticatedTemplate, UnauthenticatedTemplate, useMsal, useMsalAuthentication } from "@azure/msal-react";
+import { InteractionType } from '@azure/msal-browser';
+
+function App() {
     const request = {
-        loginHint: "example_username",
+        loginHint: "name@example.com",
         scopes: ["User.Read"]
     }
-    const [login, response, error] = useMsalAuthentication("silent", request);
+    const { login, result, error } = useMsalAuthentication(InteractionType.Silent, request);
+
     useEffect(() => {
         if (error) {
-            login("popup", request);
+            login(InteractionType.Popup, request);
         }
     }, [error]);
+
+    const msal = useMsal();
 
     return (
         <React.Fragment>
             <p>Anyone can see this paragraph.</p>
             <AuthenticatedTemplate>
-                <p>At least one account is signed in!</p>
+                <p>Signed in as: {msal.accounts[0]?.username}</p>
             </AuthenticatedTemplate>
             <UnauthenticatedTemplate>
                 <p>No users are signed in!</p>
@@ -221,6 +227,8 @@ export function App() {
         </React.Fragment>
     );
 }
+
+export default App;
 ```
 
 ### Specific user example

--- a/lib/msal-react/docs/hooks.md
+++ b/lib/msal-react/docs/hooks.md
@@ -195,7 +195,6 @@ If you use silent you should catch any errors and attempt an interactive login a
 
 ```javascript
 import React, { useEffect } from 'react';
-import './App.css';
 
 import { AuthenticatedTemplate, UnauthenticatedTemplate, useMsal, useMsalAuthentication } from "@azure/msal-react";
 import { InteractionType } from '@azure/msal-browser';
@@ -213,13 +212,13 @@ function App() {
         }
     }, [error]);
 
-    const msal = useMsal();
+    const { accounts } = useMsal();
 
     return (
         <React.Fragment>
             <p>Anyone can see this paragraph.</p>
             <AuthenticatedTemplate>
-                <p>Signed in as: {msal.accounts[0]?.username}</p>
+                <p>Signed in as: {accounts[0]?.username}</p>
             </AuthenticatedTemplate>
             <UnauthenticatedTemplate>
                 <p>No users are signed in!</p>


### PR DESCRIPTION
Fix example to show useMsalAuthentication returns an object instead of an array, using the `InteractionType` enum, and how to display the logged in user.