### PR TITLE
Fix msal-react SSR warning server/client mismatch

### DIFF
--- a/change/@azure-msal-react-2020-11-24-11-41-00-react-ssr-fix.json
+++ b/change/@azure-msal-react-2020-11-24-11-41-00-react-ssr-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Server/Client mismatch when using SSR (#2646)",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-24T19:41:00.243Z"
+}

--- a/lib/msal-react/src/MsalProvider.tsx
+++ b/lib/msal-react/src/MsalProvider.tsx
@@ -19,7 +19,7 @@ export type MsalProviderProps = PropsWithChildren<{
 
 export function MsalProvider({instance, children}: MsalProviderProps): React.ReactElement {
     // State hook to store accounts
-    const [accounts, setAccounts] = useState<AccountInfo[]>(instance.getAllAccounts());
+    const [accounts, setAccounts] = useState<AccountInfo[]>([]);
     // State hook to store in progress value
     const [inProgress, setInProgress] = useState<InteractionStatus>(InteractionStatus.Startup);
 

--- a/lib/msal-react/src/hooks/useIsAuthenticated.ts
+++ b/lib/msal-react/src/hooks/useIsAuthenticated.ts
@@ -21,7 +21,7 @@ export function useIsAuthenticated(accountIdentifiers?: AccountIdentifiers): boo
     const { accounts: allAccounts } = useMsal();
     const account = useAccount(accountIdentifiers || {});
 
-    const [hasAuthenticated, setHasAuthenticated] = useState<boolean>(isAuthenticated(allAccounts, account, accountIdentifiers));
+    const [hasAuthenticated, setHasAuthenticated] = useState<boolean>(false);
 
     useEffect(() => {
         setHasAuthenticated(isAuthenticated(allAccounts, account, accountIdentifiers));


### PR DESCRIPTION
Updates state value defaults to static values instead of relying on `msal-browser` APIs.

## Before this change

Server Side Render - State **always** defaults to `accounts: []` and `isAuthenticated: false` because window object is not available
Client Side Render - State can default to any valid value because window object is now available and a user could potentially be signed in

This causes a mismatch between the Server Side Render and the initial Client Side Render

## After this change

All renders default to `[]` and `false`, then `useEffect` hook calls `msal-browser` APIs to get the current value on mount.

This ensures the Server Side Render matches the initial Client Side Render and the Client is still able to get the correct state.