### PR TITLE
fix: AzureAD/microsoft-authentication-library-for-js#2652

### DIFF
--- a/change/@azure-msal-common-2020-11-25-14-41-39-fix-2652.json
+++ b/change/@azure-msal-common-2020-11-25-14-41-39-fix-2652.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: added missing async (AzureAD/microsoft-authentication-library-for-js#2652)",
+  "packageName": "@azure/msal-common",
+  "email": "patrick@ruhkopf.me",
+  "dependentChangeType": "patch",
+  "date": "2020-11-25T19:41:39.934Z"
+}

--- a/lib/msal-common/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-common/src/client/OnBehalfOfClient.ts
@@ -40,7 +40,7 @@ export class OnBehalfOfClient extends BaseClient {
             return await this.executeTokenRequest(request, this.authority);
         }
 
-        const cachedAuthenticationResult = this.getCachedAuthenticationResult(request);
+        const cachedAuthenticationResult = await this.getCachedAuthenticationResult(request);
         if (cachedAuthenticationResult != null) {
             return cachedAuthenticationResult;
         } else {

--- a/lib/msal-common/test/client/OnBehalfOfClient.spec.ts
+++ b/lib/msal-common/test/client/OnBehalfOfClient.spec.ts
@@ -94,7 +94,7 @@ describe("OnBehalfOf unit tests", () => {
 
     it("acquires a token, no token in the cache", async () => {
 
-        sinon.stub(OnBehalfOfClient.prototype, <any>"getCachedAuthenticationResult").returns(null);
+        sinon.stub(OnBehalfOfClient.prototype, <any>"getCachedAuthenticationResult").resolves(null);
         sinon.stub(OnBehalfOfClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
 
         const createTokenRequestBodySpy = sinon.spy(OnBehalfOfClient.prototype, <any>"createTokenRequestBody");


### PR DESCRIPTION
Fixes  https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/2652

`async` was missing and the test mock returned `null` instead of a Promise of `null`.