### PR TITLE
[msal-common] Add clone to Logger

### DIFF
--- a/change/@azure-msal-common-2020-11-30-15-46-35-common-logger-clone.json
+++ b/change/@azure-msal-common-2020-11-30-15-46-35-common-logger-clone.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add clone to Logger (#2670)",
+  "packageName": "@azure/msal-common",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-30T23:46:35.130Z"
+}

--- a/lib/msal-common/src/logger/Logger.ts
+++ b/lib/msal-common/src/logger/Logger.ts
@@ -68,6 +68,13 @@ export class Logger {
     }
 
     /**
+     * Create new Logger with existing configurations.
+     */
+    public clone(packageName: string, packageVersion: string): Logger {
+        return new Logger({loggerCallback: this.localCallback, piiLoggingEnabled: this.piiLoggingEnabled, logLevel: this.level}, packageName, packageVersion);
+    }
+
+    /**
      * Log message with required options.
      */
     private logMessage(logMessage: string, options: LoggerMessageOptions): void {

--- a/lib/msal-common/test/logger/Logger.spec.ts
+++ b/lib/msal-common/test/logger/Logger.spec.ts
@@ -30,6 +30,24 @@ describe("Logger.ts Class Unit Tests", () => {
         });
     });
 
+    describe("clone() tests", () => {
+
+        it("Creates a new logger with logger configurations of existing logger", () => {
+            const logger = new Logger(loggerOptions);
+            const loggerClone = logger.clone("msal-common", "1.0.0");
+            expect(loggerClone.isPiiLoggingEnabled()).to.equal(logger.isPiiLoggingEnabled());
+        });
+
+        it("Creates a new logger with package name and package version", () => {
+            const logger = new Logger(loggerOptions);
+            const loggerClone = logger.clone("msal-common", "2.0.0");
+            loggerClone.info("Message");
+            expect(logStore[LogLevel.Info]).to.include("msal-common");
+            expect(logStore[LogLevel.Info]).to.include("2.0.0");
+            expect(logStore[LogLevel.Info]).to.include("msal-common@2.0.0");
+        });
+    });
+
     describe("executeCallback() tests", () => {
 
         it("Executes a callback if assigned", () => {


### PR DESCRIPTION
This PR adds a `clone` function to the `Logger.ts`. This function will be used by wrapper libraries (such as `msal-angular`) to add a new Logger to log wrapper library-specific logs, while using the same logger configurations set up for `msal-browser`. This PR also adds unit tests. 

Note: This function has also been duplicated on the `msal-angular-v2` branch.