### PR TITLE
[msal-angular] Add redirectUri check to guard

### DIFF
--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { InteractionType, IPublicClientApplication, PublicClientApplication } from '@azure/msal-browser';
+import { BrowserUtils, InteractionType, IPublicClientApplication, PublicClientApplication, UrlString } from '@azure/msal-browser';
 import { of } from 'rxjs';
 import { MsalGuardConfiguration } from './msal.guard.config';
 import { MsalModule, MsalGuard, MsalService, MsalBroadcastService } from './public-api';
@@ -59,6 +59,16 @@ describe('MsalGuard', () => {
 
   it("is created", () => {
     expect(guard).toBeTruthy();
+  });
+
+  it("returns false if page with MSAL Guard is set as redirectUri", (done) => {
+    spyOn(UrlString, "hashContainsKnownProperties").and.returnValue(true);
+    spyOn(BrowserUtils, "isInIframe").and.returnValue(true);
+
+    const listener = jasmine.createSpy();
+    guard.canActivate(routeMock, routeStateMock).subscribe(listener);
+    expect(listener).toHaveBeenCalledWith(false);
+    done();
   });
 
   it("returns true for a logged in user", (done) => {

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -79,6 +79,7 @@ export class MsalGuard implements CanActivate {
         /*
          * If a page with MSAL Guard is set as the redirect for acquireTokenSilent,
          * short-circuit to prevent redirecting or popups.
+         * TODO: Update to allow running in iframe once allowRedirectInIframe is implemented
          */
         if (UrlString.hashContainsKnownProperties(window.location.hash) && BrowserUtils.isInIframe()) {
             this.authService.getLogger().warning("Guard - redirectUri set to page with MSAL Guard. It is recommended to not set redirectUri to a page that requires authentication.");

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -7,7 +7,7 @@ import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from "@angul
 import { MsalService } from "./msal.service";
 import { Injectable, Inject } from "@angular/core";
 import { Location } from "@angular/common";
-import { InteractionType, BrowserConfigurationAuthError } from "@azure/msal-browser";
+import { InteractionType, BrowserConfigurationAuthError, BrowserUtils, UrlString } from "@azure/msal-browser";
 import { MsalGuardConfiguration } from "./msal.guard.config";
 import { MSAL_GUARD_CONFIG } from "./constants";
 import { concatMap, catchError, map } from "rxjs/operators";
@@ -75,6 +75,15 @@ export class MsalGuard implements CanActivate {
             throw new BrowserConfigurationAuthError("invalid_interaction_type", "Invalid interaction type provided to MSAL Guard. InteractionType.Popup or InteractionType.Redirect must be provided in the MsalGuardConfiguration");
         }
         this.authService.getLogger().verbose("MSAL Guard activated");
+
+        /*
+         * If a page with MSAL Guard is set as the redirect for acquireTokenSilent,
+         * short-circuit to prevent redirecting or popups.
+         */
+        if (UrlString.hashContainsKnownProperties(window.location.hash) && BrowserUtils.isInIframe()) {
+            this.authService.getLogger().warning("Guard - redirectUri set to page with MSAL Guard. It is recommended to not set redirectUri to a page that requires authentication.");
+            return of(false);
+        }
 
         return this.authService.handleRedirectObservable()
             .pipe(

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -6,6 +6,7 @@
 export { PublicClientApplication } from "./app/PublicClientApplication";
 export { Configuration } from "./config/Configuration";
 export { InteractionType, BrowserCacheLocation } from "./utils/BrowserConstants";
+export { BrowserUtils } from "./utils/BrowserUtils";
 
 // Browser Errors
 export { BrowserAuthError, BrowserAuthErrorMessage } from "./error/BrowserAuthError";
@@ -42,5 +43,7 @@ export {
     Logger,
     LogLevel,
     // Protocol Mode
-    ProtocolMode
+    ProtocolMode,
+    // Utils
+    UrlString
 } from "@azure/msal-common";


### PR DESCRIPTION
This PR updates the guard to check if redirectUri is set to a page with MSAL guard and logs a warning. 
Also updates exports from msal-browser.

Changes being made to msal-browser are duplicated on the `dev` branch in #2680 