### PR TITLE
[msal-browser] Add exports to index.ts

### DIFF
--- a/change/@azure-msal-browser-2020-12-02-09-16-10-browser-new-exports.json
+++ b/change/@azure-msal-browser-2020-12-02-09-16-10-browser-new-exports.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "Add exports to index.ts (#2680)",
   "packageName": "@azure/msal-browser",
   "email": "joarroyo@microsoft.com",

--- a/change/@azure-msal-browser-2020-12-02-09-16-10-browser-new-exports.json
+++ b/change/@azure-msal-browser-2020-12-02-09-16-10-browser-new-exports.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add exports to index.ts (#2680)",
+  "packageName": "@azure/msal-browser",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-12-02T17:16:10.131Z"
+}

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -6,6 +6,7 @@
 export { PublicClientApplication } from "./app/PublicClientApplication";
 export { Configuration } from "./config/Configuration";
 export { InteractionType, BrowserCacheLocation } from "./utils/BrowserConstants";
+export { BrowserUtils } from "./utils/BrowserUtils";
 
 // Browser Errors
 export { BrowserAuthError, BrowserAuthErrorMessage } from "./error/BrowserAuthError";
@@ -41,5 +42,7 @@ export {
     Logger,
     LogLevel,
     // Protocol Mode
-    ProtocolMode
+    ProtocolMode,
+    // Utils
+    UrlString
 } from "@azure/msal-common";


### PR DESCRIPTION
This PR matches the changes being done in #2677, adding additional exports to msal-browser `index.ts`, to be used in the msal-angular-v2 guard. 