### PR TITLE
[msal-browser] update browser export

### DIFF
--- a/change/@azure-msal-browser-2020-12-03-14-11-51-update-browser-exports.json
+++ b/change/@azure-msal-browser-2020-12-03-14-11-51-update-browser-exports.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "update browser export (#2693)",
+  "packageName": "@azure/msal-browser",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-12-03T22:11:51.378Z"
+}

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -44,5 +44,6 @@ export {
     // Protocol Mode
     ProtocolMode,
     // Utils
+    StringUtils,
     UrlString
 } from "@azure/msal-common";


### PR DESCRIPTION
This PR updates msal-browser's exports, as required by changes made to msal-angular-v2 on PR #2683, in order for it to be available at the next release. 

