### PR TITLE
Add action to deploy typedocs

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
 
-      - name: Clean Install
+      - name: Install
         env:
           RUNNING_NODE_CI: 1
         run: npm ci
@@ -26,13 +26,45 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Docs - Generatae
+      - name: Generate
         run: npx lerna run doc:generate
 
-      - name: Docs - Deploy - msal
+      - name: Deploy - msal-core
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./lib/msal-core/ref
           destination_dir: ./ref/msal-core
+          keep_files: true
+
+      - name: Deploy - msal-angular
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./lib/msal-angular/ref
+          destination_dir: ./ref/msal-angular
+          keep_files: true
+
+      - name: Deploy - msal-browser
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./lib/msal-browser/ref
+          destination_dir: ./ref/msal-browser
+          keep_files: true
+
+      - name: Deploy - msal-common
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./lib/msal-common/ref
+          destination_dir: ./ref/msal-common
+          keep_files: true
+
+      - name: Deploy - msal-node
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./lib/msal-node/ref
+          destination_dir: ./ref/msal-node
           keep_files: true

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -15,6 +15,14 @@ jobs:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+
+      - name: Clean Install
+        env:
+          RUNNING_NODE_CI: 1
+        run: npm ci
+
       - name: Build
         run: npx lerna run doc:generate
 

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -1,0 +1,27 @@
+name: Typedoc
+
+on:
+  push:
+    branches:
+      - master  # Set a branch name to trigger deployment
+      - typedoc-action
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Build
+        run: npx lerna run doc:generate
+
+      - name: Deploy - msal
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./lib/msal-core/ref
+          destination_dir: ./ref/msal-core
+          keep_files: true

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -24,9 +24,12 @@ jobs:
         run: npm ci
 
       - name: Build
+        run: npm run build
+
+      - name: Docs - Generatae
         run: npx lerna run doc:generate
 
-      - name: Deploy - msal
+      - name: Docs - Deploy - msal
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/msal-angular/tsconfig.json
+++ b/lib/msal-angular/tsconfig.json
@@ -18,6 +18,7 @@
       "skipLibCheck": true,
       "outDir": "dist",
       "rootDir": "src",
+      "baseUrl": ".",
       "paths": {
         "@angular/*": [
           "./node_modules/@angular/*"

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "beachball:change": "beachball change --branch origin/dev",
     "beachball:bump": "beachball bump --bumpDeps false",
     "beachball:bumpDeps": "beachball bump",
-    "beachball:publish": "beachball publish -n $NODE_AUTH_TOKEN",
-    "typedoc": "lerna run doc:generate"
+    "beachball:publish": "beachball publish -n $NODE_AUTH_TOKEN"
   },
   "dependencies": {
     "@babel/register": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "beachball:change": "beachball change --branch origin/dev",
     "beachball:bump": "beachball bump --bumpDeps false",
     "beachball:bumpDeps": "beachball bump",
-    "beachball:publish": "beachball publish -n $NODE_AUTH_TOKEN"
+    "beachball:publish": "beachball publish -n $NODE_AUTH_TOKEN",
+    "typedoc": "lerna run doc:generate"
   },
   "dependencies": {
     "@babel/register": "^7.7.0",


### PR DESCRIPTION
This action will automatically build and deploy typedocs on pushes to master branch.

You can see it worked here: https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/gh-pages/ref