### PR TITLE
Fix empty query string bug

### DIFF
--- a/change/@azure-msal-common-2020-12-07-13-07-17-fix-empty-query-string.json
+++ b/change/@azure-msal-common-2020-12-07-13-07-17-fix-empty-query-string.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix login loop with empty query string (#2707)",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-07T21:07:17.508Z"
+}

--- a/lib/msal-common/src/url/UrlString.ts
+++ b/lib/msal-common/src/url/UrlString.ts
@@ -40,10 +40,16 @@ export class UrlString {
     static canonicalizeUri(url: string): string {
         if (url) {
             url = url.toLowerCase();
-        }
 
-        if (url && !StringUtils.endsWith(url, "/")) {
-            url += "/";
+            if (StringUtils.endsWith(url, "?")) {
+                url = url.slice(0, -1);
+            } else if (StringUtils.endsWith(url, "?/")) {
+                url = url.slice(0, -2);
+            }
+
+            if (!StringUtils.endsWith(url, "/")) {
+                url += "/";
+            }
         }
 
         return url;

--- a/lib/msal-common/test/url/UrlString.spec.ts
+++ b/lib/msal-common/test/url/UrlString.spec.ts
@@ -68,6 +68,14 @@ describe("UrlString.ts Class Unit Tests", () => {
         expect(UrlString.removeHashFromUrl(fullUrl)).to.eq(baseUrl);
     });
 
+    it("removes empty query string from url provided", () => {
+        const baseUrl = "https://localhost/";
+        const testUrl = baseUrl + "?";
+        const testUrl2 = baseUrl + "?/";
+        expect(UrlString.removeHashFromUrl(testUrl)).to.eq(baseUrl);
+        expect(UrlString.removeHashFromUrl(testUrl2)).to.eq(baseUrl);
+    });
+
     it("replaceTenantPath correctly replaces common with tenant id", () => {
         let urlObj = new UrlString(TEST_URIS.TEST_AUTH_ENDPT);
         const sampleTenantId = "sample-tenant-id";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browser.spec.ts
@@ -90,6 +90,33 @@ describe("Browser tests", function () {
                 await verifyTokenStore(BrowserCache, aadTokenRequest.scopes);
             });
 
+            it("Performs loginRedirect from url with empty query string", async () => {
+                await page.goto(SAMPLE_HOME_URL + "?");
+                const testName = "redirectEmptyQueryString";
+                const screenshot = new Screenshot(`${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`);
+
+                await clickLoginRedirect(screenshot, page);
+                await enterCredentials(page, screenshot, username, accountPwd);
+                await waitForReturnToApp(screenshot, page);
+                // Verify browser cache contains Account, idToken, AccessToken and RefreshToken
+                await verifyTokenStore(BrowserCache, aadTokenRequest.scopes);
+                expect(page.url()).to.be.eq(SAMPLE_HOME_URL);
+            });
+
+            it("Performs loginRedirect from url with test query string", async () => {
+                const testUrl = SAMPLE_HOME_URL + "?test";
+                await page.goto(testUrl);
+                const testName = "redirectEmptyQueryString";
+                const screenshot = new Screenshot(`${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`);
+
+                await clickLoginRedirect(screenshot, page);
+                await enterCredentials(page, screenshot, username, accountPwd);
+                await waitForReturnToApp(screenshot, page);
+                // Verify browser cache contains Account, idToken, AccessToken and RefreshToken
+                await verifyTokenStore(BrowserCache, aadTokenRequest.scopes);
+                expect(page.url()).to.be.eq(testUrl);
+            });
+
             it("Performs loginRedirect with relative redirectUri", async () => {
                 const relativeRedirectUriRequest: RedirectRequest = {
                     ...aadTokenRequest,


### PR DESCRIPTION
When a redirect is initiated from a page with an empty ? in the url it will lead to an infinite loop

`clearHash` will remove the empty ? before comparison of loginRequestUrl to current url so the 2 will never be equal

This PR fixes this by removing the ? from the end of a url before comparison