### PR TITLE
ClientAssertion.parseCertificate - handle newlines

### DIFF
--- a/change/@azure-msal-node-e1216fab-db96-4b5e-b319-17f3bcffa13b.json
+++ b/change/@azure-msal-node-e1216fab-db96-4b5e-b319-17f3bcffa13b.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "ClientAssertion.parseCertificate - allow newlines in cert",
+  "comment": "ClientAssertion.parseCertificate - allow newlines in cert (#2721).",
   "packageName": "@azure/msal-node",
   "email": "email not defined",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-node-e1216fab-db96-4b5e-b319-17f3bcffa13b.json
+++ b/change/@azure-msal-node-e1216fab-db96-4b5e-b319-17f3bcffa13b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ClientAssertion.parseCertificate - allow newlines in cert",
+  "packageName": "@azure/msal-node",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/client/ClientAssertion.ts
+++ b/lib/msal-node/src/client/ClientAssertion.ts
@@ -108,7 +108,7 @@ export class ClientAssertion {
          * "." means any string character, "+" means match 1 or more times, and "?" means the shortest match.
          * The "g" at the end of the regex means search the string globally, and the "m" means search across multiple lines.
          */
-        const regexToFindCerts = /-----BEGIN CERTIFICATE-----\n(.+?)\n-----END CERTIFICATE-----/gm;
+        const regexToFindCerts = /-----BEGIN CERTIFICATE-----\n(.+?)\n-----END CERTIFICATE-----/gms;
         const certs: string[] = [];
 
         let matches;

--- a/lib/msal-node/src/client/ClientAssertion.ts
+++ b/lib/msal-node/src/client/ClientAssertion.ts
@@ -106,15 +106,15 @@ export class ClientAssertion {
          * We want to look for the contents between the BEGIN and END certificate strings, without the associated newlines.
          * The information in parens "(.+?)" is the capture group to represent the cert we want isolated.
          * "." means any string character, "+" means match 1 or more times, and "?" means the shortest match.
-         * The "g" at the end of the regex means search the string globally, and the "m" means search across multiple lines.
+         * The "g" at the end of the regex means search the string globally, and the "s" enables the "." to match newlines.
          */
-        const regexToFindCerts = /-----BEGIN CERTIFICATE-----\n(.+?)\n-----END CERTIFICATE-----/gms;
+        const regexToFindCerts = /-----BEGIN CERTIFICATE-----\n(.+?)\n-----END CERTIFICATE-----/gs;
         const certs: string[] = [];
 
         let matches;
         while ((matches = regexToFindCerts.exec(publicCertificate)) !== null) {
             // matches[1] represents the first parens capture group in the regex.
-            certs.push(matches[1]);
+            certs.push(matches[1].replace(/\n/, ""));
         }
         
         return certs;

--- a/lib/msal-node/test/client/ClientAssertion.spec.ts
+++ b/lib/msal-node/test/client/ClientAssertion.spec.ts
@@ -55,7 +55,7 @@ describe('Client assertion test', () => {
             "header": {
                 [JwtConstants.ALGORITHM]: JwtConstants.RSA_256,
                 [JwtConstants.X5T]: EncodingUtils.base64EncodeUrl(TEST_CONSTANTS.THUMBPRINT, "hex"),
-                [JwtConstants.X5C]: ["test1", "test2"]
+                [JwtConstants.X5C]: ["line1line2", "line3line4"]
             }
         }
 
@@ -72,7 +72,7 @@ describe('Client assertion test', () => {
     });
 
     test('parseCertificate finds all valid certs in a chain', () => {
-        const parsedCert = ["test1", "test2"];
+        const parsedCert = ["line1line2", "line3line4"];
         expect(ClientAssertion.parseCertificate(TEST_CONSTANTS.PUBLIC_CERTIFICATE)).toEqual(parsedCert);
     })
 

--- a/lib/msal-node/test/utils/TestConstants.ts
+++ b/lib/msal-node/test/utils/TestConstants.ts
@@ -25,11 +25,13 @@ export const TEST_CONSTANTS = {
     PRIVATE_KEY: "PRIVATE_KEY",
     PUBLIC_CERTIFICATE: 
 `-----BEGIN CERTIFICATE-----
-test1
+line1
+line2
 -----END CERTIFICATE-----
 
 -----BEGIN CERTIFICATE-----
-test2
+line3
+line4
 -----END CERTIFICATE-----
     `,
 };


### PR DESCRIPTION
It is common for certs exported from pfx to contain newlines. For example, OpenSSL exports certs in the format:
```
-----BEGIN CERTIFICATE-----
MIIFSDCCBDCg........................................
IqNDl5bnkmR0........................................
eUd4y23epjUW........................................
BnozMiiGCHuG........................................
jGqq8qpdA6wT........................................
...
-----END CERTIFICATE-----
```

The regex in `ClientAssertion.parseCertificate` was unable to parse such certs due to the `.` term's default behavior of not matching newlines (even when the multiline flag is present). This is fixed by the addition of the s (dotall) flag.

Fixes https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/2720
