### PR TITLE
[msal-angular] Update docs and samples

### DIFF
--- a/change/@azure-msal-angular-798c02ae-d006-4c63-980b-0d5d9fe50148.json
+++ b/change/@azure-msal-angular-798c02ae-d006-4c63-980b-0d5d9fe50148.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update docs and samples (#2764)",
+  "packageName": "@azure/msal-angular",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-browser-fd4bda27-4447-4533-857c-ef1a34dc9cb0.json
+++ b/change/@azure-msal-browser-fd4bda27-4447-4533-857c-ef1a34dc9cb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update event docs in msal-browser (#2764)",
+  "packageName": "@azure/msal-browser",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-browser/docs/events.md
+++ b/lib/msal-browser/docs/events.md
@@ -13,6 +13,13 @@ export type EventMessage = {
 };
 ```
 
+The payload and error in `EventMessage` are defined as follows: 
+```javascript
+export type EventPayload = PopupRequest | RedirectRequest | SilentRequest | SsoSilentRequest | EndSessionRequest | AuthenticationResult | null;
+
+export type EventError = AuthError | Error | null;
+```
+
 ## How events are emitted in msal-browser
 Msal-browser has a protected function `emitEvent`, and emits events in major APIs. For the list of currently emitted events, see the table below.
 
@@ -40,6 +47,22 @@ Adding an event callback will return an id. This id can be used to remove the ca
 
 ```javascript
 msalInstance.removeEventCallback(callbackId);
+```
+
+### Handling errors
+Due to the way `EventError` is defined, handling errors emitted with an event may require validating that the error is of the correct type before accessing specific properties on the emitted error. The error can be cast to `AuthError` or checked that it is an instance of `AuthError`. 
+
+Here is an example of consuming an emitted event and casting the error:
+
+```javascript
+const callbackId = msalInstance.addEventCallback((message: EventMessage) => {
+    // Update UI or interact with EventMessage here
+    if (message.eventType === EventType.LOGIN_FAILURE) {
+        if (message.error instanceof AuthError) {
+            // Do something with the error
+        }
+     }
+});
 ```
 
 ## Table of events

--- a/samples/msal-angular-v2-samples/angular10-browser-sample/src/app/msal/msal.service.ts
+++ b/samples/msal-angular-v2-samples/angular10-browser-sample/src/app/msal/msal.service.ts
@@ -29,7 +29,7 @@ export class MsalService implements IMsalService {
         }
     }
 
-    acquireTokenPopup(request: AuthorizationUrlRequest): Observable<AuthenticationResult> {
+    acquireTokenPopup(request: PopupRequest): Observable<AuthenticationResult> {
         return from(this.instance.acquireTokenPopup(request));
     }
     acquireTokenRedirect(request: RedirectRequest): Observable<void> {
@@ -47,7 +47,7 @@ export class MsalService implements IMsalService {
     handleRedirectObservable(): Observable<AuthenticationResult> {
         return from(this.instance.handleRedirectPromise(this.redirectHash));
     }
-    loginPopup(request?: AuthorizationUrlRequest): Observable<AuthenticationResult> {
+    loginPopup(request?: PopupRequest): Observable<AuthenticationResult> {
         return from(this.instance.loginPopup(request));
     }
     loginRedirect(request?: RedirectRequest): Observable<void> {
@@ -56,7 +56,7 @@ export class MsalService implements IMsalService {
     logout(logoutRequest?: EndSessionRequest): Observable<void> {
         return from(this.instance.logout(logoutRequest));
     }
-    ssoSilent(request: AuthorizationUrlRequest): Observable<AuthenticationResult> {
+    ssoSilent(request: SilentRequest): Observable<AuthenticationResult> {
         return from(this.instance.ssoSilent(request));
     }
 

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Inject, OnDestroy } from '@angular/core';
 import { MsalService, MsalBroadcastService, MSAL_GUARD_CONFIG, MsalGuardConfiguration } from '@azure/msal-angular';
 import { EventMessage, EventPayload, EventType, InteractionType } from '@azure/msal-browser';
-import { AuthenticationResult, BaseAuthRequest } from '@azure/msal-common'
+import { AuthenticationResult, AuthError, BaseAuthRequest } from '@azure/msal-common'
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { b2cPolicies } from './b2c-config';
@@ -39,7 +39,7 @@ export class AppComponent implements OnInit, OnDestroy {
         filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_SUCCESS || msg.eventType === EventType.ACQUIRE_TOKEN_SUCCESS),
         takeUntil(this._destroying$)
       )
-      .subscribe((result) => {
+      .subscribe((result: EventMessage) => {
       
         let payload: IdTokenClaims = <AuthenticationResult>result.payload;
 
@@ -64,8 +64,8 @@ export class AppComponent implements OnInit, OnDestroy {
         filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_FAILURE || msg.eventType === EventType.ACQUIRE_TOKEN_FAILURE),
         takeUntil(this._destroying$)
       )
-      .subscribe((result) => {
-        if (result.error) {
+      .subscribe((result: EventMessage) => {
+        if (result.error instanceof AuthError) {
           // Check for forgot password error
           // Learn more about AAD error codes at https://docs.microsoft.com/azure/active-directory/develop/reference-aadsts-error-codes
           if (result.error.message.includes('AADB2C90118')) {


### PR DESCRIPTION
This PR: 
- Updates the msal-angular v2 docs with information on how to handle EventError, in response to issue #2761
- Updates the `angular11-b2c-sample` with type checking 
- Updates `angular10-browser-sample` with correct request parameters from `@azure/msal-browser@2.8`, in response to issue #2763