### PR TITLE
Add internal in-memory storage to BrowserCacheManager

### DIFF
--- a/change/@azure-msal-browser-8173e10f-1d8e-4169-83b5-6febcecf6134.json
+++ b/change/@azure-msal-browser-8173e10f-1d8e-4169-83b5-6febcecf6134.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add internal in-memory storage to BrowserCacheManager (#2765)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -24,6 +24,8 @@ export class BrowserCacheManager extends CacheManager {
     private cacheConfig: CacheOptions;
     // Window storage object (either local or sessionStorage)
     private browserStorage: IWindowStorage;
+    // Internal in-memory storage object used for data used by msal that does not need to persist across page loads
+    private internalStorage: MemoryStorage;
     // Client id of application. Used in cache keys to partition cache correctly in the case of multiple instances of MSAL.
     private logger: Logger;
 
@@ -37,6 +39,7 @@ export class BrowserCacheManager extends CacheManager {
         this.logger = logger;
 
         this.browserStorage = this.setupBrowserStorage(cacheConfig.cacheLocation);
+        this.internalStorage = new MemoryStorage();
 
         // Migrate any cache entries from older versions of MSAL.
         this.migrateCacheEntries();


### PR DESCRIPTION
Adds an internal in-memory storage object to BrowserCacheManager which can be used for data internal to msal that does not need to be stored in local/session storage and does not need to persist across page loads or PCA instances.

Examples: 
- Authority metadata
- Broker responses before being passed down to child