### PR TITLE
Update imports for Angular v2 B2C sample

### DIFF
--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Inject, OnDestroy } from '@angular/core';
 import { MsalService, MsalBroadcastService, MSAL_GUARD_CONFIG, MsalGuardConfiguration } from '@azure/msal-angular';
-import { EventMessage, EventType, InteractionType, PopupRequest, RedirectRequest } from '@azure/msal-browser';
-import { AuthenticationResult, AuthError } from '@azure/msal-common'
+import { EventMessage, EventType, InteractionType, PopupRequest, RedirectRequest, AuthenticationResult, AuthError } from '@azure/msal-browser';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { b2cPolicies } from './b2c-config';
@@ -90,7 +89,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.msalGuardConfig
     if (this.msalGuardConfig.interactionType === InteractionType.Popup) {
       if (this.msalGuardConfig.authRequest) {
-        this.authService.loginPopup({...this.msalGuardConfig.authRequest, ...userFlowRequest})
+        this.authService.loginPopup({...this.msalGuardConfig.authRequest, ...userFlowRequest} as PopupRequest)
           .subscribe(() => this.checkAccount());
       } else {
         this.authService.loginPopup(userFlowRequest)
@@ -98,7 +97,7 @@ export class AppComponent implements OnInit, OnDestroy {
       }
     } else {
       if (this.msalGuardConfig.authRequest){
-        this.authService.loginRedirect({...this.msalGuardConfig.authRequest, ...userFlowRequest});
+        this.authService.loginRedirect({...this.msalGuardConfig.authRequest, ...userFlowRequest} as RedirectRequest);
       } else {
         this.authService.loginRedirect(userFlowRequest);
       }


### PR DESCRIPTION
This PR addresses a comment made on [this commit](https://github.com/AzureAD/microsoft-authentication-library-for-js/commit/f149f86c9a42997d620019c1d1a3da2d1d172f6c) about imports in the Angular v2 B2C sample, and updates the imports accordingly. It also changes a type-casting warning in the same file.