### PR TITLE
Fix initial state values in react hooks

### DIFF
--- a/change/@azure-msal-react-bd81c4ec-0359-4caf-ac48-3b6cc98fc388.json
+++ b/change/@azure-msal-react-bd81c4ec-0359-4caf-ac48-3b6cc98fc388.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix initial state values (#2865)",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-react/src/hooks/useAccount.ts
+++ b/lib/msal-react/src/hooks/useAccount.ts
@@ -7,6 +7,7 @@ import { useState, useEffect } from "react";
 import { AccountInfo, IPublicClientApplication } from "@azure/msal-browser";
 import { useMsal } from "./useMsal";
 import { AccountIdentifiers } from "../types/AccountIdentifiers";
+import { InteractionStatus } from "../utils/Constants";
 
 function getAccount(instance: IPublicClientApplication, accountIdentifiers: AccountIdentifiers): AccountInfo | null {
     const allAccounts = instance.getAllAccounts();
@@ -34,7 +35,8 @@ function getAccount(instance: IPublicClientApplication, accountIdentifiers: Acco
 export function useAccount(accountIdentifiers: AccountIdentifiers): AccountInfo | null {
     const { instance, inProgress } = useMsal();
 
-    const [account, setAccount] = useState<AccountInfo|null>(null);
+    const initialStateValue = inProgress === InteractionStatus.Startup ? null : getAccount(instance, accountIdentifiers);
+    const [account, setAccount] = useState<AccountInfo|null>(initialStateValue);
 
     useEffect(() => {
         setAccount(getAccount(instance, accountIdentifiers));

--- a/lib/msal-react/src/hooks/useIsAuthenticated.ts
+++ b/lib/msal-react/src/hooks/useIsAuthenticated.ts
@@ -8,6 +8,7 @@ import { useMsal } from "./useMsal";
 import { AccountIdentifiers } from "../types/AccountIdentifiers";
 import { useAccount } from "./useAccount";
 import { AccountInfo } from "@azure/msal-browser";
+import { InteractionStatus } from "../utils/Constants";
 
 function isAuthenticated(allAccounts: AccountIdentifiers[], account: AccountInfo | null, matchAccount?: AccountIdentifiers): boolean {
     if(matchAccount && (matchAccount.username || matchAccount.homeAccountId || matchAccount.localAccountId)) {
@@ -18,10 +19,11 @@ function isAuthenticated(allAccounts: AccountIdentifiers[], account: AccountInfo
 }
 
 export function useIsAuthenticated(matchAccount?: AccountIdentifiers): boolean {
-    const { accounts: allAccounts } = useMsal();
+    const { accounts: allAccounts, inProgress } = useMsal();
     const account = useAccount(matchAccount || {});
 
-    const [hasAuthenticated, setHasAuthenticated] = useState<boolean>(false);
+    const initialStateValue = inProgress === InteractionStatus.Startup ? false : isAuthenticated(allAccounts, account, matchAccount);
+    const [hasAuthenticated, setHasAuthenticated] = useState<boolean>(initialStateValue);
 
     useEffect(() => {
         setHasAuthenticated(isAuthenticated(allAccounts, account, matchAccount));

--- a/lib/msal-react/src/index.ts
+++ b/lib/msal-react/src/index.ts
@@ -26,3 +26,4 @@ export { useAccount } from "./hooks/useAccount";
 export { useIsAuthenticated } from "./hooks/useIsAuthenticated";
 export { useMsalAuthentication } from "./hooks/useMsalAuthentication";
 
+export { InteractionStatus } from "./utils/Constants";

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { testAccount, testResult, TEST_CONFIG } from "../TestConstants";
-import { MsalProvider, MsalAuthenticationTemplate, MsalAuthenticationResult, IMsalContext } from "../../src/index";
+import { MsalProvider, MsalAuthenticationTemplate, MsalAuthenticationResult, IMsalContext, useMsal } from "../../src/index";
 import { PublicClientApplication, Configuration, InteractionType, EventType, AccountInfo, EventCallbackFunction, EventMessage, PopupRequest, AuthError } from "@azure/msal-browser";
 
 describe("MsalAuthenticationTemplate tests", () => {
@@ -324,6 +324,36 @@ describe("MsalAuthenticationTemplate tests", () => {
         expect(await screen.findByText("Error Occurred: login_failed")).toBeInTheDocument();
         expect(screen.queryByText("A user is authenticated!")).not.toBeInTheDocument();
         expect(loginRedirectSpy).toHaveBeenCalledTimes(0);
+    });
+
+    test("If user is signed in and MsalAuthenticationTemplate is rendered after MsalProvider, child renders and login is not called", async () => {
+        const loginRedirectSpy = jest.spyOn(pca, "loginRedirect");
+        accounts = [testAccount];
+
+        const TestComponent = () => {
+            const {inProgress} = useMsal();
+
+            if (inProgress === "none") {
+                return (
+                    <MsalAuthenticationTemplate interactionType={InteractionType.Redirect}>
+                        <span> A user is authenticated!</span>
+                    </MsalAuthenticationTemplate>
+                );
+            } else {
+                return null;
+            }
+        };
+
+        render(
+            <MsalProvider instance={pca}>
+                <p>This text will always display.</p>
+                <TestComponent />
+            </MsalProvider>
+        );
+
+        expect(screen.queryByText("This text will always display.")).toBeInTheDocument();
+        expect(await screen.findByText("A user is authenticated!")).toBeInTheDocument();
+        expect(loginRedirectSpy).not.toHaveBeenCalled();
     });
 
     test("Renders provided error component when an error occurs", async () => {

--- a/samples/msal-react-samples/react-router-sample/src/pages/Home.jsx
+++ b/samples/msal-react-samples/react-router-sample/src/pages/Home.jsx
@@ -1,12 +1,13 @@
 import { AuthenticatedTemplate, UnauthenticatedTemplate } from "@azure/msal-react";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
+import { Link as RouterLink } from "react-router-dom";
 
 export function Home() {
   return (
       <>
           <AuthenticatedTemplate>
-              <Button variant="contained" color="primary" href="/profile">Request Profile Information</Button>
+              <Button component={RouterLink} to="/profile" variant="contained" color="primary">Request Profile Information</Button>
           </AuthenticatedTemplate>
 
           <UnauthenticatedTemplate>

--- a/samples/msal-react-samples/react-router-sample/src/ui-components/NavBar.jsx
+++ b/samples/msal-react-samples/react-router-sample/src/ui-components/NavBar.jsx
@@ -5,6 +5,7 @@ import Typography from "@material-ui/core/Typography";
 import WelcomeName from "./WelcomeName";
 import SignInSignOutButton from "./SignInSignOutButton";
 import useStyles from "../styles/useStyles";
+import { Link as RouterLink } from "react-router-dom";
 
 const NavBar = () => {
     const classes = useStyles();
@@ -14,7 +15,7 @@ const NavBar = () => {
             <AppBar position="static">
             <Toolbar>
                 <Typography className={classes.title}>
-                    <Link href="/" color="inherit" variant="h6">MS Identity Platform</Link>
+                    <Link component={RouterLink} to="/" color="inherit" variant="h6">MS Identity Platform</Link>
                 </Typography>
                 <WelcomeName />
                 <SignInSignOutButton />


### PR DESCRIPTION
We recently changed the initial state values inside the `msal-react` hooks to be static values in order to support SSR. This broke scenarios where the hook is rendered **after** the initial render of `MsalProvider` such as is the case when using `react-router-dom` or other router libraries.

To mitigate this problem this PR changes the initial state values to be a static value only if the `inProgress` value is `"startup"`. This will continue to support SSR since the `inProgress` value will always be `"startup"` when rendered on the server.

Also updates the React Router sample to use the router links that surfaced this problem.

Fixes #2846