### PR TITLE
Extend relative uri support to redirectStartPage

### DIFF
--- a/change/@azure-msal-browser-2ca47cd6-90a9-4988-b2c3-d0fbeacecdad.json
+++ b/change/@azure-msal-browser-2ca47cd6-90a9-4988-b2c3-d0fbeacecdad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "redirectStartPage supports relative URIs (#2866)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-2ca47cd6-90a9-4988-b2c3-d0fbeacecdad.json
+++ b/change/@azure-msal-browser-2ca47cd6-90a9-4988-b2c3-d0fbeacecdad.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "redirectStartPage supports relative URIs (#2866)",
   "packageName": "@azure/msal-browser",
   "email": "thomas.norling@microsoft.com",

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -731,7 +731,7 @@ export abstract class ClientApplication {
      * @param requestStartPage 
      */
     protected getRedirectStartPage(requestStartPage?: string): string {
-        const redirectStartPage = requestStartPage || BrowserUtils.getCurrentUri();
+        const redirectStartPage = requestStartPage || window.location.href;
         return UrlString.getAbsoluteUrl(redirectStartPage, BrowserUtils.getCurrentUri());
     }
 

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -323,7 +323,7 @@ export abstract class ClientApplication {
             // Create acquire token url.
             const navigateUrl = await authClient.getAuthCodeUrl(validRequest);
 
-            const redirectStartPage = (request && request.redirectStartPage) || window.location.href;
+            const redirectStartPage = this.getRedirectStartPage(request.redirectStartPage);
 
             // Show the UI once the url has been created. Response will come back in the hash, which will be handled in the handleRedirectCallback function.
             return interactionHandler.initiateAuthRequest(navigateUrl, {
@@ -721,6 +721,15 @@ export abstract class ClientApplication {
     protected getPostLogoutRedirectUri(requestPostLogoutRedirectUri?: string): string {
         const postLogoutRedirectUri = requestPostLogoutRedirectUri || this.config.auth.postLogoutRedirectUri || BrowserUtils.getCurrentUri();
         return UrlString.getAbsoluteUrl(postLogoutRedirectUri, BrowserUtils.getCurrentUri());
+    }
+
+    /**
+     * Use to get the redirectStartPage either from request or use current window
+     * @param requestStartPage 
+     */
+    protected getRedirectStartPage(requestStartPage?: string): string {
+        const redirectStartPage = requestStartPage || BrowserUtils.getCurrentUri();
+        return UrlString.getAbsoluteUrl(redirectStartPage, BrowserUtils.getCurrentUri());
     }
 
     /**

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browser.spec.ts
@@ -134,6 +134,24 @@ describe("Default tests", function () {
                 // Verify browser cache contains Account, idToken, AccessToken and RefreshToken
                 await verifyTokenStore(BrowserCache, aadTokenRequest.scopes);
             });
+
+            it("Performs loginRedirect with relative redirectStartPage", async () => {
+                const relativeRedirectUriRequest: RedirectRequest = {
+                    ...aadTokenRequest,
+                    redirectStartPage: "/"
+                }
+                fs.writeFileSync("./app/customizable-e2e-test/testConfig.json", JSON.stringify({msalConfig: aadMsalConfig, request: relativeRedirectUriRequest}));
+                page.reload();
+
+                const testName = "redirectBaseCase";
+                const screenshot = new Screenshot(`${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`);
+
+                await clickLoginRedirect(screenshot, page);
+                await enterCredentials(page, screenshot, username, accountPwd);
+                await waitForReturnToApp(screenshot, page);
+                // Verify browser cache contains Account, idToken, AccessToken and RefreshToken
+                await verifyTokenStore(BrowserCache, aadTokenRequest.scopes);
+            });
             
             it("Performs loginPopup", async () => {
                 const testName = "popupBaseCase";


### PR DESCRIPTION
This PR adds support for relative uris on `redirectStartPage` using the same API that was used to support this for `redirectUri` and `postLogoutRedirectUri`

Closes #2855