### PR TITLE
[msal-common] Bound RT #1 - Bound RT Support OIDC Configuration

### DIFF
--- a/lib/msal-common/src/authority/OpenIdConfigResponse.ts
+++ b/lib/msal-common/src/authority/OpenIdConfigResponse.ts
@@ -11,6 +11,7 @@ export type OpenIdConfigResponse = {
     token_endpoint: string;
     end_session_endpoint: string;
     issuer: string;
+    boundrt_supported?: boolean;
 };
 
 export function isOpenIdConfigResponse(response: object): boolean {

--- a/lib/msal-common/src/cache/entities/AuthorityMetadataEntity.ts
+++ b/lib/msal-common/src/cache/entities/AuthorityMetadataEntity.ts
@@ -19,6 +19,7 @@ export class AuthorityMetadataEntity {
     aliasesFromNetwork: boolean;
     endpointsFromNetwork: boolean;
     expiresAt: number;
+    boundrt_supported?: boolean;
 
     constructor() {
         this.expiresAt = TimeUtils.nowSeconds() + AUTHORITY_METADATA_CONSTANTS.REFRESH_TIME_SECONDS;
@@ -47,6 +48,7 @@ export class AuthorityMetadataEntity {
         this.end_session_endpoint = metadata.end_session_endpoint;
         this.issuer = metadata.issuer;
         this.endpointsFromNetwork = fromNetwork;
+        this.boundrt_supported = metadata.boundrt_supported;
     }
 
     /**

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -132,13 +132,18 @@ describe("Authority.ts Class Unit Tests", () => {
                 expect(authority.selfSignedJwtAudience).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer.replace("{tenant}", "common"));
             });
 
-            it("Throws error if endpoint discovery is incomplete for authorizationEndpoint, tokenEndpoint, endSessionEndpoint and selfSignedJwtAudience", () => {
+            it("Returns boundrt_supported of tenantDiscoveryResponse", () => {
+                expect(authority.supportsBoundRefreshTokens).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
+            })
+
+            it("Throws error if endpoint discovery is incomplete for authorizationEndpoint, tokenEndpoint, endSessionEndpoint, selfSignedJwtAudience and boundRtSupported", () => {
                 authority = new Authority(Constants.DEFAULT_AUTHORITY, networkInterface, mockStorage, authorityOptions);
                 expect(() => authority.authorizationEndpoint).to.throw(ClientAuthErrorMessage.endpointResolutionError.desc);
                 expect(() => authority.tokenEndpoint).to.throw(ClientAuthErrorMessage.endpointResolutionError.desc);
                 expect(() => authority.endSessionEndpoint).to.throw(ClientAuthErrorMessage.endpointResolutionError.desc);
                 expect(() => authority.deviceCodeEndpoint).to.throw(ClientAuthErrorMessage.endpointResolutionError.desc);
                 expect(() => authority.selfSignedJwtAudience).to.throw(ClientAuthErrorMessage.endpointResolutionError.desc);
+                expect(() => authority.supportsBoundRefreshTokens).to.throw(ClientAuthErrorMessage.endpointResolutionError.desc);
             });
         });
     });
@@ -186,6 +191,7 @@ describe("Authority.ts Class Unit Tests", () => {
                 expect(authority.deviceCodeEndpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint.replace("/token", "/devicecode"));
                 expect(authority.endSessionEndpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace("{tenant}", "common"));
                 expect(authority.selfSignedJwtAudience).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer.replace("{tenant}", "common"));
+                expect(authority.supportsBoundRefreshTokens).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
 
                 // Test that the metadata is cached
                 const key = `authority-metadata-${TEST_CONFIG.MSAL_CLIENT_ID}-${Constants.DEFAULT_AUTHORITY_HOST}`;
@@ -198,6 +204,7 @@ describe("Authority.ts Class Unit Tests", () => {
                     expect(cachedAuthorityMetadata.end_session_endpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint);
                     expect(cachedAuthorityMetadata.issuer).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer);
                     expect(cachedAuthorityMetadata.endpointsFromNetwork).to.be.false;
+                    expect(cachedAuthorityMetadata.boundrt_supported).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
                 }
             });
 
@@ -232,6 +239,7 @@ describe("Authority.ts Class Unit Tests", () => {
                 expect(authority.deviceCodeEndpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint.replace("/token", "/devicecode"));
                 expect(authority.endSessionEndpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace("{tenant}", "common"));
                 expect(authority.selfSignedJwtAudience).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer.replace("{tenant}", "common"));
+                expect(authority.supportsBoundRefreshTokens).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
 
                 // Test that the metadata is cached
                 const cachedAuthorityMetadata = mockStorage.getAuthorityMetadata(key);
@@ -243,6 +251,7 @@ describe("Authority.ts Class Unit Tests", () => {
                     expect(cachedAuthorityMetadata.end_session_endpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint);
                     expect(cachedAuthorityMetadata.issuer).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer);
                     expect(cachedAuthorityMetadata.endpointsFromNetwork).to.be.true;
+                    expect(cachedAuthorityMetadata.boundrt_supported).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
                 }
             });
 
@@ -267,6 +276,7 @@ describe("Authority.ts Class Unit Tests", () => {
                 expect(authority.deviceCodeEndpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint.replace("/token", "/devicecode"));
                 expect(authority.endSessionEndpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace("{tenant}", "common"));
                 expect(authority.selfSignedJwtAudience).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer.replace("{tenant}", "common"));
+                expect(authority.supportsBoundRefreshTokens).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
 
                 // Test that the metadata is cached
                 const cachedAuthorityMetadata = mockStorage.getAuthorityMetadata(key);
@@ -278,6 +288,7 @@ describe("Authority.ts Class Unit Tests", () => {
                     expect(cachedAuthorityMetadata.end_session_endpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint);
                     expect(cachedAuthorityMetadata.issuer).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer);
                     expect(cachedAuthorityMetadata.endpointsFromNetwork).to.be.true;
+                    expect(cachedAuthorityMetadata.boundrt_supported).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
                 }
             });
 
@@ -294,6 +305,7 @@ describe("Authority.ts Class Unit Tests", () => {
                 expect(authority.deviceCodeEndpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint.replace("/token", "/devicecode"));
                 expect(authority.endSessionEndpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint.replace("{tenant}", "common"));
                 expect(authority.selfSignedJwtAudience).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer.replace("{tenant}", "common"));
+                expect(authority.supportsBoundRefreshTokens).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
 
                 // Test that the metadata is cached
                 const key = `authority-metadata-${TEST_CONFIG.MSAL_CLIENT_ID}-${Constants.DEFAULT_AUTHORITY_HOST}`;
@@ -305,6 +317,7 @@ describe("Authority.ts Class Unit Tests", () => {
                     expect(cachedAuthorityMetadata.token_endpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint);
                     expect(cachedAuthorityMetadata.end_session_endpoint).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint);
                     expect(cachedAuthorityMetadata.issuer).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer);
+                    expect(cachedAuthorityMetadata.boundrt_supported).to.be.eq(DEFAULT_OPENID_CONFIG_RESPONSE.body.boundrt_supported);
                     expect(cachedAuthorityMetadata.endpointsFromNetwork).to.be.true;
                 }
             });

--- a/lib/msal-common/test/utils/StringConstants.ts
+++ b/lib/msal-common/test/utils/StringConstants.ts
@@ -220,7 +220,8 @@ export const DEFAULT_OPENID_CONFIG_RESPONSE = {
         "cloud_instance_name": "microsoftonline.com",
         "cloud_graph_host_name": "graph.windows.net",
         "msgraph_host": "graph.microsoft.com",
-        "rbac_url": "https://pas.windows.net"
+        "rbac_url": "https://pas.windows.net",
+        "boundrt_supported": true
     }
 };
 

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
@@ -116,7 +116,7 @@ describe("LocalStorage Tests", function () {
             await popupPage.close();
             await popupWindowClosed;
             // Wait for processing
-            await page.waitFor(500);
+            await page.waitFor(1000);
             // Wait until popup window closes
             const storage = await BrowserCache.getWindowStorage();
             expect(Object.keys(storage).length).to.be.eq(1); // Telemetry


### PR DESCRIPTION

[UPDATE: This approach has been abandoned.

This PR:
- Adds library info SKU and version headers to the `./well-known/openid-configuration` request
- Adds optional `boundrt_supported` flag to `OpenIdConfigurationResponse`
- Adds optional `boundrt_supported` property to cached `AuthorityMetadataEntity`
- Adds `supportsBoundRefreshTokens` property to `Authority` class
- Adds test coverage for the changes above