### PR TITLE
Issue-2887 useAccount import missing from quickstart documentation

### DIFF
--- a/change/@azure-msal-react-992bfddf-7f4e-4ec3-8641-0b02cd157268.json
+++ b/change/@azure-msal-react-992bfddf-7f4e-4ec3-8641-0b02cd157268.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Issue-2887 fix missing import in quickstart",
+  "packageName": "@azure/msal-react",
+  "email": "simon.j.duff@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-react/docs/getting-started.md
+++ b/lib/msal-react/docs/getting-started.md
@@ -192,7 +192,7 @@ We recommend that your app calls the `acquireTokenSilent` API on your `PublicCli
 
 ```javascript
 import React, { useState, useEffect } from "react"
-import { useMsal } from "@azure/msal-react";
+import { useMsal, useAccount } from "@azure/msal-react";
 
 export function App() {
     const { instance, accounts, inProgress } = useMsal();


### PR DESCRIPTION
Resolves #2887 

The example code does not include a `useAccount` import that is later relied upon.

This PR adds the `useAccount` import from `@azure/msal-react` which results the error.