### PR TITLE
Fix temp cache cleanup when using localStorage

### DIFF
--- a/change/@azure-msal-browser-68164171-9fe4-48ad-a670-53fd594999f9.json
+++ b/change/@azure-msal-browser-68164171-9fe4-48ad-a670-53fd594999f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix temp cache cleanup when using localStorage (#2935)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -162,6 +162,7 @@ export abstract class ClientApplication {
         const responseHash = this.getRedirectResponseHash(hash || window.location.hash);
         if (!responseHash) {
             // Not a recognized server response hash or hash not associated with a redirect request
+            this.logger.info("handleRedirectPromise did not detect a response hash as a result of a redirect. Cleaning temporary cache.");
             this.browserStorage.cleanRequestByInteractionType(InteractionType.Redirect);
             return null;
         }

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -677,27 +677,38 @@ export class BrowserCacheManager extends CacheManager {
         this.removeItem(this.generateCacheKey(TemporaryCacheKeys.INTERACTION_STATUS_KEY));
     }
 
+    /**
+     * Removes temporary cache for the provided state
+     * @param stateString 
+     */
     cleanRequestByState(stateString: string): void {
         // Interaction is completed - remove interaction status.
         if (stateString) {
             const stateKey = this.generateStateKey(stateString);
-            const cachedState = this.getItem(stateKey);
+            const cachedState = this.temporaryCacheStorage.getItem(stateKey);
+            this.logger.info(`BrowserCacheManager.cleanRequestByState: Removing temporary cache items for state: ${cachedState}`);
             this.resetRequestCache(cachedState || "");
         }
     }
 
+    /**
+     * Looks in temporary cache for any state values with the provided interactionType and removes all temporary cache items for that state
+     * Used in scenarios where temp cache needs to be cleaned but state is not known, such as clicking browser back button.
+     * @param interactionType 
+     */
     cleanRequestByInteractionType(interactionType: InteractionType): void {
         this.getKeys().forEach((key) => {
             if (key.indexOf(TemporaryCacheKeys.REQUEST_STATE) === -1) {
                 return;
             }
 
-            const value = this.browserStorage.getItem(key);
+            const value = this.temporaryCacheStorage.getItem(key);
             if (!value) {
                 return;
             }
             const parsedState = BrowserProtocolUtils.extractBrowserRequestState(this.cryptoImpl, value);
             if (parsedState && parsedState.interactionType === interactionType) {
+                this.logger.info(`BrowserCacheManager.cleanRequestByInteractionType: Removing temporary cache items for state: ${value}`);
                 this.resetRequestCache(value);
             }
         });

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
@@ -93,8 +93,13 @@ describe("LocalStorage Tests", function () {
             // Navigate back to home page
             await page.goto(SAMPLE_HOME_URL);
             await page.waitFor(500);
-            const storage = await BrowserCache.getWindowStorage();
-            expect(Object.keys(storage).length).to.be.eq(0);
+
+            // Temporary Cache always uses sessionStorage
+            const sessionBrowserStorage = new BrowserCacheUtils(page, "sessionStorage");
+            const sessionStorage = await sessionBrowserStorage.getWindowStorage();
+            const localStorage = await BrowserCache.getWindowStorage();
+            expect(Object.keys(localStorage).length).to.be.eq(0);
+            expect(Object.keys(sessionStorage).length).to.be.eq(0);
         });
         
         it("Performs loginPopup", async () => {
@@ -113,13 +118,18 @@ describe("LocalStorage Tests", function () {
             const testName = "popupCloseWindow";
             const screenshot = new Screenshot(`${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`);
             const [popupPage, popupWindowClosed] = await clickLoginPopup(screenshot, page);
+            await popupPage.waitForNavigation({waitUntil: 'networkidle0'});
             await popupPage.close();
+            // Wait until popup window closes
             await popupWindowClosed;
             // Wait for processing
-            await page.waitFor(500);
-            // Wait until popup window closes
-            const storage = await BrowserCache.getWindowStorage();
-            expect(Object.keys(storage).length).to.be.eq(1); // Telemetry
+            await page.waitFor(200);
+            // Temporary Cache always uses sessionStorage
+            const sessionBrowserStorage = new BrowserCacheUtils(page, "sessionStorage");
+            const sessionStorage = await sessionBrowserStorage.getWindowStorage();
+            const localStorage = await BrowserCache.getWindowStorage();
+            expect(Object.keys(localStorage).length).to.be.eq(1); // Telemetry
+            expect(Object.keys(sessionStorage).length).to.be.eq(0);
         });
     });
 });


### PR DESCRIPTION
In version 2.10.0 we made a change to store temporary cache items in `sessionStorage` regardless of what storage option was configured for tokens. When making this update we missed 2 functions which clear temporary storage in cases of failure, such as closing an open popup or clicking the browser back button during a redirect. This caused a regression when using `localStorage` potentially resulting in `interaction_in_progress` errors.

This PR updates 2 temporary cache clear functions to clear `sessionStorage` and updates the E2E tests that didn't catch this bug.