### PR TITLE
Invoke interaction if MSAL Interceptor returns null access token

### DIFF
--- a/change/@azure-msal-angular-f0faf086-e53d-459c-bf10-c0a51c839224.json
+++ b/change/@azure-msal-angular-f0faf086-e53d-459c-bf10-c0a51c839224.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Invoke interaction if MSAL Interceptor resolves with null access token, mitigates B2C service not supporting RTs for multiple resources",
+  "packageName": "@azure/msal-angular",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/src/msal.interceptor.spec.ts
+++ b/lib/msal-angular/src/msal.interceptor.spec.ts
@@ -131,6 +131,37 @@ describe('MsalInterceptor', () => {
     }, 200);
   });
 
+  it("attaches authorization header with access token via interaction if acquireTokenSilent returns null access token", done => {
+    spyOn(PublicClientApplication.prototype, "acquireTokenSilent").and.returnValue((
+      new Promise((resolve) => {
+        //@ts-ignore
+        resolve({
+          accessToken: null
+        });
+      })
+    ));
+
+    spyOn(PublicClientApplication.prototype, "acquireTokenPopup").and.returnValue((
+      new Promise((resolve) => {
+        //@ts-ignore
+        resolve({
+          accessToken: "access-token"
+        });
+      })
+    ));
+
+    spyOn(PublicClientApplication.prototype, "getActiveAccount").and.returnValue(sampleAccountInfo);
+
+    httpClient.get("https://graph.microsoft.com/v1.0/me").subscribe();
+    setTimeout(() => {
+      const request = httpMock.expectOne("https://graph.microsoft.com/v1.0/me");
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toEqual("Bearer access-token");
+      httpMock.verify();
+      done();
+    }, 200);
+  });
+
   it("attaches authorization header with access token for protected resource with wildcard", done => {
     spyOn(PublicClientApplication.prototype, "acquireTokenSilent").and.returnValue((
       new Promise((resolve) => {

--- a/lib/msal-angular/src/msal.interceptor.ts
+++ b/lib/msal-angular/src/msal.interceptor.ts
@@ -74,7 +74,12 @@ export class MsalInterceptor implements HttpInterceptor {
             );
     }
 
-    private acquireTokenInteractively(scopes: string[]) {
+    /**
+     * Invoke interaction for the given set of scopes
+     * @param scopes Array of scopes for the request
+     * @returns Result from the interactive request
+     */
+    private acquireTokenInteractively(scopes: string[]): Observable<AuthenticationResult> {
         if (this.msalInterceptorConfig.interactionType === InteractionType.Popup) {
             this.authService.getLogger().verbose("Interceptor - error acquiring token silently, acquiring by popup");
             return this.authService.acquireTokenPopup({...this.msalInterceptorConfig.authRequest, scopes});
@@ -85,6 +90,11 @@ export class MsalInterceptor implements HttpInterceptor {
         return EMPTY;
     }
 
+    /**
+     * Looks up the scopes for the given endpoint from the protectedResourceMap
+     * @param endpoint Url of the request
+     * @returns Array of scopes, or null if not found
+     */
     private getScopesForEndpoint(endpoint: string): Array<string>|null {
         this.authService.getLogger().verbose("Interceptor - getting scopes for endpoint");
         const protectedResourcesArray = Array.from(this.msalInterceptorConfig.protectedResourceMap.keys());

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.module.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.module.ts
@@ -12,7 +12,7 @@ import { HomeComponent } from './home/home.component';
 import { ProfileComponent } from './profile/profile.component';
 
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
-import { IPublicClientApplication, PublicClientApplication, InteractionType, BrowserCacheLocation } from '@azure/msal-browser';
+import { IPublicClientApplication, PublicClientApplication, InteractionType, BrowserCacheLocation, LogLevel } from '@azure/msal-browser';
 import { MsalGuard, MsalInterceptor, MsalBroadcastService, MsalInterceptorConfiguration, MsalModule, MsalService, MSAL_GUARD_CONFIG, MSAL_INSTANCE, MSAL_INTERCEPTOR_CONFIG, MsalGuardConfiguration } from '@azure/msal-angular';
 
 import { b2cPolicies, apiConfig } from './b2c-config';
@@ -32,6 +32,15 @@ export function MSALInstanceFactory(): IPublicClientApplication {
       cacheLocation: BrowserCacheLocation.LocalStorage,
       storeAuthStateInCookie: isIE, // set to true for IE 11
     },
+    system: {
+        loggerOptions: {
+            piiLoggingEnabled: true,
+            loggerCallback: (level, message) => {
+                console.log(message);
+            },
+            logLevel: LogLevel.Verbose
+        }
+    }
   });
 }
 


### PR DESCRIPTION
There is a known issue with the B2C service where it is only capable of issuing RTs that work for one resource, and calling the token endpoint with a mismatched RT/AT resource combo results in teh service returning a successful response with a null access token. To mitigate, the interceptor will invoke interaction, which will acquire a new RT for the relevant resource.