### PR TITLE
Add getInteractionStatusFromEvent to msal-browser

### DIFF
--- a/lib/msal-angular/src/constants.ts
+++ b/lib/msal-angular/src/constants.ts
@@ -14,13 +14,3 @@ export const MSAL_INTERCEPTOR_CONFIG = new InjectionToken<string>("MSAL_INTERCEP
 export const name = "@azure/msal-angular";
 
 export const version = "2.0.0-alpha.1";
-
-export enum InteractionStatus {
-    Startup = "startup",
-    Login = "login",
-    Logout = "logout",
-    AcquireToken = "acquireToken",
-    SsoSilent = "ssoSilent",
-    HandleRedirect = "handleRedirect",
-    None = "none"
-}

--- a/lib/msal-angular/src/msal.broadcast.service.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.ts
@@ -6,7 +6,7 @@
 import { Inject, Injectable } from "@angular/core";
 import { Observable, Subject } from "rxjs";
 import { MSAL_INSTANCE, InteractionStatus } from "./constants";
-import { EventMessage, EventType, InteractionType, IPublicClientApplication } from "@azure/msal-browser";
+import { EventMessage, EventMessageUtils, IPublicClientApplication } from "@azure/msal-browser";
 
 @Injectable()
 export class MsalBroadcastService {
@@ -24,45 +24,10 @@ export class MsalBroadcastService {
         this.inProgress$ = this._inProgress.asObservable();
         this.msalInstance.addEventCallback((message: EventMessage) => {
             this._msalSubject.next(message);
-            switch (message.eventType) {
-                case EventType.LOGIN_START:
-                    this.msalInstance.getLogger().verbose("BroadcastService - Login called, setting inProgress to 'login'");
-                    this._inProgress.next(InteractionStatus.Login);
-                    break;
-                case EventType.SSO_SILENT_START:
-                    this.msalInstance.getLogger().verbose("BroadcastService - SsoSilent called, setting inProgress to 'ssoSilent'");
-                    this._inProgress.next(InteractionStatus.SsoSilent);
-                    break;
-                case EventType.ACQUIRE_TOKEN_START:
-                    this.msalInstance.getLogger().verbose("BroadcastService - Interactive acquireToken called, setting inProgress to 'acquireToken'");
-                    if (message.interactionType === InteractionType.Redirect || message.interactionType === InteractionType.Popup) {
-                        this._inProgress.next(InteractionStatus.AcquireToken);
-                    }
-                    break;
-                case EventType.HANDLE_REDIRECT_START:
-                    this.msalInstance.getLogger().verbose("BroadcastService - HandleRedirectPromise called, setting inProgress to 'handleRedirect'");
-                    this._inProgress.next(InteractionStatus.HandleRedirect);
-                    break;
-                case EventType.LOGOUT_START:
-                    this.msalInstance.getLogger().verbose("BroadcastService - Logout called, setting inProgress to 'logout'");
-                    this._inProgress.next(InteractionStatus.Logout);
-                    break;
-                case EventType.LOGIN_SUCCESS:
-                case EventType.SSO_SILENT_SUCCESS:
-                case EventType.HANDLE_REDIRECT_END:
-                case EventType.LOGIN_FAILURE:
-                case EventType.SSO_SILENT_FAILURE:
-                case EventType.LOGOUT_FAILURE:
-                    this.msalInstance.getLogger().verbose("BroadcastService - Interactive request finished, setting inProgress to 'none'");
-                    this._inProgress.next(InteractionStatus.None);
-                    break;
-                case EventType.ACQUIRE_TOKEN_SUCCESS:
-                case EventType.ACQUIRE_TOKEN_FAILURE:
-                    this.msalInstance.getLogger().verbose("BroadcastService - Interactive acquireToken request finished, setting inProgress to 'none'");
-                    if (message.interactionType === InteractionType.Redirect || message.interactionType === InteractionType.Popup) {
-                        this._inProgress.next(InteractionStatus.None);
-                    }
-                    break;
+            const status = EventMessageUtils.getInteractionStatusFromEvent(message);
+            if (status !== null) {
+                this.msalInstance.getLogger().verbose(`BroadcastService - setting inProgress to ${status}`);
+                this._inProgress.next(status);
             }
         });
     }

--- a/lib/msal-angular/src/msal.broadcast.service.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.ts
@@ -5,8 +5,8 @@
 
 import { Inject, Injectable } from "@angular/core";
 import { Observable, Subject } from "rxjs";
-import { MSAL_INSTANCE, InteractionStatus } from "./constants";
-import { EventMessage, EventMessageUtils, IPublicClientApplication } from "@azure/msal-browser";
+import { MSAL_INSTANCE } from "./constants";
+import { EventMessage, EventMessageUtils, IPublicClientApplication, InteractionStatus } from "@azure/msal-browser";
 
 @Injectable()
 export class MsalBroadcastService {

--- a/lib/msal-angular/src/msal.broadcast.service.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.ts
@@ -26,7 +26,7 @@ export class MsalBroadcastService {
             this._msalSubject.next(message);
             const status = EventMessageUtils.getInteractionStatusFromEvent(message);
             if (status !== null) {
-                this.msalInstance.getLogger().verbose(`BroadcastService - setting inProgress to ${status}`);
+                this.msalInstance.getLogger().verbose(`BroadcastService - ${message.interactionType} results in setting inProgress to ${status}`);
                 this._inProgress.next(status);
             }
         });

--- a/lib/msal-angular/src/public-api.ts
+++ b/lib/msal-angular/src/public-api.ts
@@ -9,6 +9,6 @@ export { MsalGuard } from "./msal.guard";
 export { MsalGuardConfiguration } from "./msal.guard.config";
 export { MsalInterceptor } from "./msal.interceptor";
 export { MsalInterceptorConfiguration } from "./msal.interceptor.config";
-export { MSAL_INSTANCE, MSAL_GUARD_CONFIG, MSAL_INTERCEPTOR_CONFIG, InteractionStatus } from "./constants";
+export { MSAL_INSTANCE, MSAL_GUARD_CONFIG, MSAL_INTERCEPTOR_CONFIG } from "./constants";
 export { MsalBroadcastService } from "./msal.broadcast.service";
 export { MsalModule } from "./msal.module";

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -25,7 +25,7 @@ export type EventCallbackFunction = (message: EventMessage) => void;
 export class EventMessageUtils {
 
     /**
-     * Sets interaction status from event message
+     * Gets interaction status from event message
      * @param message 
      */
     static getInteractionStatusFromEvent(message: EventMessage): InteractionStatus|null {

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -5,7 +5,7 @@
 
 import { AuthenticationResult, AuthError, EndSessionRequest } from "@azure/msal-common";
 import { EventType } from "./EventType";
-import { InteractionType } from "../utils/BrowserConstants";
+import { InteractionStatus, InteractionType } from "../utils/BrowserConstants";
 import { PopupRequest, RedirectRequest, SilentRequest, SsoSilentRequest } from "..";
 
 export type EventMessage = {
@@ -21,3 +21,44 @@ export type EventPayload = PopupRequest | RedirectRequest | SilentRequest | SsoS
 export type EventError = AuthError | Error | null;
 
 export type EventCallbackFunction = (message: EventMessage) => void;
+
+export class EventMessageUtils {
+
+    /**
+     * Sets interaction status from event message
+     * @param message 
+     */
+    static getInteractionStatusFromEvent(message: EventMessage): InteractionStatus|null {
+        switch (message.eventType) {
+            case EventType.LOGIN_START:
+                return InteractionStatus.Login;
+            case EventType.SSO_SILENT_START:
+                return InteractionStatus.SsoSilent;
+            case EventType.ACQUIRE_TOKEN_START:
+                if (message.interactionType === InteractionType.Redirect || message.interactionType === InteractionType.Popup) {
+                    return InteractionStatus.AcquireToken;
+                }
+                break;
+            case EventType.HANDLE_REDIRECT_START:
+                return InteractionStatus.HandleRedirect;
+            case EventType.LOGOUT_START:
+                return InteractionStatus.Logout;
+            case EventType.LOGIN_SUCCESS:
+            case EventType.SSO_SILENT_SUCCESS:
+            case EventType.HANDLE_REDIRECT_END:
+            case EventType.LOGIN_FAILURE:
+            case EventType.SSO_SILENT_FAILURE:
+            case EventType.LOGOUT_FAILURE:
+                return InteractionStatus.None;
+            case EventType.ACQUIRE_TOKEN_SUCCESS:
+            case EventType.ACQUIRE_TOKEN_FAILURE:
+                if (message.interactionType === InteractionType.Redirect || message.interactionType === InteractionType.Popup) {
+                    return InteractionStatus.None;
+                }
+                break;
+            default:
+                break;
+        }
+        return null;
+    }
+}

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -5,7 +5,7 @@
 
 export { PublicClientApplication } from "./app/PublicClientApplication";
 export { Configuration } from "./config/Configuration";
-export { InteractionType, BrowserCacheLocation } from "./utils/BrowserConstants";
+export { InteractionType, InteractionStatus, BrowserCacheLocation } from "./utils/BrowserConstants";
 export { BrowserUtils } from "./utils/BrowserUtils";
 
 // Browser Errors
@@ -22,7 +22,7 @@ export { EndSessionRequest } from "./request/EndSessionRequest";
 export { AuthorizationUrlRequest } from "./request/AuthorizationUrlRequest";
 
 // Events
-export { EventMessage, EventPayload, EventError, EventCallbackFunction } from "./event/EventMessage";
+export { EventMessage, EventPayload, EventError, EventCallbackFunction, EventMessageUtils } from "./event/EventMessage";
 export { EventType } from "./event/EventType";
 
 // Common Object Formats

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -82,15 +82,23 @@ export enum InteractionType {
 }
 
 /**
- * Type of interaction in progress
+ * Types of interaction currently in progress.
+ * Used in events in wrapper libraries to invoke functions when certain interaction is in progress or all interactions are complete.
  */
 export enum InteractionStatus {
+    // Initial status before interaction occurs
     Startup = "startup",
+    // Status set when all login calls occuring
     Login = "login",
+    // Status set when logout call occuring
     Logout = "logout",
+    // Status set for acquireToken calls
     AcquireToken = "acquireToken",
+    // Status set for ssoSilent calls
     SsoSilent = "ssoSilent",
+    // Status set when handleRedirect in progress
     HandleRedirect = "handleRedirect",
+    // Status set when interaction is complete
     None = "none"
 }
 

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -81,6 +81,19 @@ export enum InteractionType {
     Silent = "silent"
 }
 
+/**
+ * Type of interaction in progress
+ */
+export enum InteractionStatus {
+    Startup = "startup",
+    Login = "login",
+    Logout = "logout",
+    AcquireToken = "acquireToken",
+    SsoSilent = "ssoSilent",
+    HandleRedirect = "handleRedirect",
+    None = "none"
+}
+
 export const DEFAULT_REQUEST: RedirectRequest|PopupRequest = {
     scopes: [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE]
 };

--- a/lib/msal-browser/test/event/EventMessage.spec.ts
+++ b/lib/msal-browser/test/event/EventMessage.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { expect } from "chai";
+import { InteractionStatus, InteractionType } from "../../src";
+import { EventMessage, EventMessageUtils } from "../../src/event/EventMessage";
+import { EventType } from "../../src/event/EventType";
+
+describe("EventMessage.ts Unit Tests", () => {
+
+    describe("getInteractionStatusFromEvent()", () => {
+        let TEST_EVENT_MESSAGE: EventMessage = {
+            eventType: EventType.LOGIN_START,
+            interactionType: InteractionType.Popup,
+            payload: null,
+            error: null,
+            timestamp: 0
+        }
+
+        it("returns status Login with event type LOGIN_START", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.LOGIN_START;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(InteractionStatus.Login);
+        });
+
+        it("returns status SsoSilent with event type SSO_SILENT_START", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.SSO_SILENT_START;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(InteractionStatus.SsoSilent);
+        });
+
+        it("returns status AcquireToken with event type ACQUIRE_TOKEN_START and interaction type Popup", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.ACQUIRE_TOKEN_START;
+            TEST_EVENT_MESSAGE.interactionType = InteractionType.Popup;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(InteractionStatus.AcquireToken);
+        });
+
+        it("returns null with event type ACQUIRE_TOKEN_START and an interaction type that is not Popup or Redirect", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.ACQUIRE_TOKEN_START;
+            TEST_EVENT_MESSAGE.interactionType = InteractionType.Silent;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(null);
+        });
+
+        it("returns status HandleRedirect with event type HANDLE_REDIRECT_START", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.HANDLE_REDIRECT_START;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(InteractionStatus.HandleRedirect);
+        });
+
+        it("returns status Logout with event type LOGOUT_START", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.LOGOUT_START;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(InteractionStatus.Logout);
+        });
+
+        it("returns status None with event type LOGIN_SUCCESS", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.LOGIN_SUCCESS;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(InteractionStatus.None);
+        });
+
+        it("returns status None with event type ACQUIRE_TOKEN_SUCCESS and interaction type redirect", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.ACQUIRE_TOKEN_SUCCESS;
+            TEST_EVENT_MESSAGE.interactionType = InteractionType.Redirect;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(InteractionStatus.None);
+        });
+
+        it("returns null with event type ACQUIRE_TOKEN_FAILURE and an interaction type that is not popup or redirect", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.ACQUIRE_TOKEN_FAILURE;
+            TEST_EVENT_MESSAGE.interactionType = InteractionType.Silent;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(null);
+        });
+
+        it("returns null with event type not in switch statement", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.ACQUIRE_TOKEN_NETWORK_START;
+
+            const result = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE);
+            expect(result).to.equal(null);
+        });
+    });
+});

--- a/lib/msal-react/src/MsalContext.ts
+++ b/lib/msal-react/src/MsalContext.ts
@@ -4,8 +4,7 @@
  */
 
 import * as React from "react";
-import { IPublicClientApplication, stubbedPublicClientApplication, Logger } from "@azure/msal-browser";
-import { InteractionStatus } from "./utils/Constants";
+import { IPublicClientApplication, stubbedPublicClientApplication, Logger, InteractionStatus } from "@azure/msal-browser";
 import { AccountIdentifiers } from "./types/AccountIdentifiers";
 
 export interface IMsalContext {

--- a/lib/msal-react/src/MsalProvider.tsx
+++ b/lib/msal-react/src/MsalProvider.tsx
@@ -68,7 +68,7 @@ export function MsalProvider({instance, children}: MsalProviderProps): React.Rea
         const callbackId = instance.addEventCallback((message: EventMessage) => {
             const status = EventMessageUtils.getInteractionStatusFromEvent(message);
             if (status !== null) {
-                logger.info(`MsalProvider - setting inProgress to ${status}`);
+                logger.info(`MsalProvider - ${message.interactionType} results in setting inProgress to ${status}`);
                 setInProgress(status);
             }
         });

--- a/lib/msal-react/src/MsalProvider.tsx
+++ b/lib/msal-react/src/MsalProvider.tsx
@@ -7,12 +7,13 @@ import React, { useState, useEffect, PropsWithChildren, useMemo } from "react";
 import {
     IPublicClientApplication,
     EventType,
-    EventMessage, 
-    InteractionType,
+    EventMessage,
+    EventMessageUtils,
+    InteractionStatus,
     Logger
 } from "@azure/msal-browser";
 import { MsalContext, IMsalContext } from "./MsalContext";
-import { Constants, InteractionStatus } from "./utils/Constants";
+import { Constants } from "./utils/Constants";
 import { accountArraysAreEqual } from "./utils/utilities";
 import { AccountIdentifiers } from "./types/AccountIdentifiers";
 
@@ -65,45 +66,10 @@ export function MsalProvider({instance, children}: MsalProviderProps): React.Rea
 
     useEffect(() => {
         const callbackId = instance.addEventCallback((message: EventMessage) => {
-            switch (message.eventType) {
-                case EventType.LOGIN_START:
-                    logger.info("MsalProvider - Login called, setting inProgress to 'login'");
-                    setInProgress(InteractionStatus.Login);
-                    break;
-                case EventType.SSO_SILENT_START:
-                    logger.info("MsalProvider - SsoSilent called, setting inProgress to 'ssoSilent'");
-                    setInProgress(InteractionStatus.SsoSilent);
-                    break;
-                case EventType.ACQUIRE_TOKEN_START:
-                    if (message.interactionType === InteractionType.Redirect || message.interactionType === InteractionType.Popup) {
-                        logger.info("MsalProvider - Interactive acquireToken called, setting inProgress to 'acquireToken'");
-                        setInProgress(InteractionStatus.AcquireToken);
-                    }
-                    break;
-                case EventType.HANDLE_REDIRECT_START:
-                    logger.info("MsalProvider - HandleRedirectPromise called, setting inProgress to 'handleRedirect'");
-                    setInProgress(InteractionStatus.HandleRedirect);
-                    break;
-                case EventType.LOGOUT_START:
-                    logger.info("MsalProvider - Logout called, setting inProgress to 'logout'");
-                    setInProgress(InteractionStatus.Logout);
-                    break;
-                case EventType.LOGIN_SUCCESS:
-                case EventType.SSO_SILENT_SUCCESS:
-                case EventType.HANDLE_REDIRECT_END:
-                case EventType.LOGIN_FAILURE:
-                case EventType.SSO_SILENT_FAILURE:
-                case EventType.LOGOUT_FAILURE:
-                    logger.info("MsalProvider - Interactive request finished, setting inProgress to 'none'");
-                    setInProgress(InteractionStatus.None);
-                    break;
-                case EventType.ACQUIRE_TOKEN_SUCCESS:
-                case EventType.ACQUIRE_TOKEN_FAILURE:
-                    if (message.interactionType === InteractionType.Redirect || message.interactionType === InteractionType.Popup) {
-                        logger.info("MsalProvider - Interactive acquireToken request finished, setting inProgress to 'none'");
-                        setInProgress(InteractionStatus.None);
-                    }
-                    break;
+            const status = EventMessageUtils.getInteractionStatusFromEvent(message);
+            if (status !== null) {
+                logger.info(`MsalProvider - setting inProgress to ${status}`);
+                setInProgress(status);
             }
         });
         logger.verbose(`MsalProvider - Registered event callback with id: ${callbackId}`);

--- a/lib/msal-react/src/components/MsalAuthenticationTemplate.tsx
+++ b/lib/msal-react/src/components/MsalAuthenticationTemplate.tsx
@@ -9,8 +9,7 @@ import { getChildrenOrFunction } from "../utils/utilities";
 import { useMsal } from "../hooks/useMsal";
 import { MsalAuthenticationResult, useMsalAuthentication } from "../hooks/useMsalAuthentication";
 import { useIsAuthenticated } from "../hooks/useIsAuthenticated";
-import { InteractionType, PopupRequest, RedirectRequest, SsoSilentRequest } from "@azure/msal-browser";
-import { InteractionStatus } from "../utils/Constants";
+import { InteractionType, PopupRequest, RedirectRequest, SsoSilentRequest, InteractionStatus } from "@azure/msal-browser";
 import { IMsalContext } from "../MsalContext";
 
 export type MsalAuthenticationProps = PropsWithChildren<AccountIdentifiers & {

--- a/lib/msal-react/src/hooks/useAccount.ts
+++ b/lib/msal-react/src/hooks/useAccount.ts
@@ -4,10 +4,9 @@
  */
 
 import { useState, useEffect } from "react";
-import { AccountInfo, IPublicClientApplication } from "@azure/msal-browser";
+import { AccountInfo, IPublicClientApplication, InteractionStatus } from "@azure/msal-browser";
 import { useMsal } from "./useMsal";
 import { AccountIdentifiers } from "../types/AccountIdentifiers";
-import { InteractionStatus } from "../utils/Constants";
 
 function getAccount(instance: IPublicClientApplication, accountIdentifiers: AccountIdentifiers): AccountInfo | null {
     const allAccounts = instance.getAllAccounts();

--- a/lib/msal-react/src/hooks/useIsAuthenticated.ts
+++ b/lib/msal-react/src/hooks/useIsAuthenticated.ts
@@ -7,8 +7,7 @@ import { useState, useEffect } from "react";
 import { useMsal } from "./useMsal";
 import { AccountIdentifiers } from "../types/AccountIdentifiers";
 import { useAccount } from "./useAccount";
-import { AccountInfo } from "@azure/msal-browser";
-import { InteractionStatus } from "../utils/Constants";
+import { AccountInfo, InteractionStatus } from "@azure/msal-browser";
 
 function isAuthenticated(allAccounts: AccountIdentifiers[], account: AccountInfo | null, matchAccount?: AccountIdentifiers): boolean {
     if(matchAccount && (matchAccount.username || matchAccount.homeAccountId || matchAccount.localAccountId)) {

--- a/lib/msal-react/src/hooks/useMsalAuthentication.ts
+++ b/lib/msal-react/src/hooks/useMsalAuthentication.ts
@@ -4,11 +4,10 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { PopupRequest, RedirectRequest, SsoSilentRequest, InteractionType, AuthenticationResult, AuthError, EventMessage, EventType } from "@azure/msal-browser";
+import { PopupRequest, RedirectRequest, SsoSilentRequest, InteractionType, AuthenticationResult, AuthError, EventMessage, EventType, InteractionStatus } from "@azure/msal-browser";
 import { useIsAuthenticated } from "./useIsAuthenticated";
 import { AccountIdentifiers } from "../types/AccountIdentifiers";
 import { useMsal } from "./useMsal";
-import { InteractionStatus } from "../utils/Constants";
 
 export type MsalAuthenticationResult = {
     login: Function; 

--- a/lib/msal-react/src/index.ts
+++ b/lib/msal-react/src/index.ts
@@ -26,4 +26,4 @@ export { useAccount } from "./hooks/useAccount";
 export { useIsAuthenticated } from "./hooks/useIsAuthenticated";
 export { useMsalAuthentication } from "./hooks/useMsalAuthentication";
 
-export { InteractionStatus } from "./utils/Constants";
+export { InteractionStatus } from "@azure/msal-browser";

--- a/lib/msal-react/src/utils/Constants.ts
+++ b/lib/msal-react/src/utils/Constants.ts
@@ -7,13 +7,3 @@ export const Constants = {
     SKU: "@azure/msal-react",
     VERSION: "1.0.0-alpha.3"
 };
-
-export enum InteractionStatus {
-    Startup = "startup",
-    Login = "login",
-    Logout = "logout",
-    AcquireToken = "acquireToken",
-    SsoSilent = "ssoSilent",
-    HandleRedirect = "handleRedirect",
-    None = "none"
-}

--- a/lib/msal-react/test/MsalProvider.spec.tsx
+++ b/lib/msal-react/test/MsalProvider.spec.tsx
@@ -7,10 +7,9 @@
 import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { AccountInfo, Configuration, EventCallbackFunction, EventMessage, EventType, InteractionType, PublicClientApplication } from "@azure/msal-browser";
+import { AccountInfo, Configuration, EventCallbackFunction, EventMessage, EventType, InteractionType, InteractionStatus, PublicClientApplication } from "@azure/msal-browser";
 import { testAccount, TEST_CONFIG } from "./TestConstants";
 import { IMsalContext, MsalConsumer, MsalProvider } from "../src/index";
-import { InteractionStatus } from "../src/utils/Constants";
 
 describe("withMsal tests", () => {
     let pca: PublicClientApplication;


### PR DESCRIPTION
This PR:
- Adds `getInteractionStatusFromEvent` to msal-browser
- Updates msal-react and msal-angular to use `getInteractionStatusFromEvent`
- Adds unit tests

This PR will merge into `angular-b2c-sample-change` #2885 before merging to dev.