### PR TITLE
[msal-angular] Update guard with version detection for canLoad

### DIFF
--- a/change/@azure-msal-angular-0de29d0d-210a-4af4-81b3-bf865c46e95d.json
+++ b/change/@azure-msal-angular-0de29d0d-210a-4af4-81b3-bf865c46e95d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add version detection to msal guard for canLoad interface (#2948)",
+  "packageName": "@azure/msal-angular",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -5,7 +5,7 @@
 
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, CanActivateChild, CanLoad, UrlTree, Router } from "@angular/router";
 import { MsalService } from "./msal.service";
-import { Injectable, Inject } from "@angular/core";
+import { Injectable, Inject, VERSION } from "@angular/core";
 import { Location } from "@angular/common";
 import { InteractionType, BrowserConfigurationAuthError, BrowserUtils, UrlString, PopupRequest, RedirectRequest, AuthenticationResult } from "@azure/msal-browser";
 import { MsalGuardConfiguration } from "./msal.guard.config";
@@ -120,7 +120,7 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
                 }),
                 catchError(() => {
                     this.authService.getLogger().verbose("Guard - error while logging in, unable to activate");
-                    if (this.loginFailedRoute) {
+                    if (this.loginFailedRoute && parseInt(VERSION.major, 10) > 9) {
                         this.authService.getLogger().verbose("Guard - loginFailedRoute set, redirecting");
                         return of(this.loginFailedRoute);
                     }
@@ -139,8 +139,9 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
         return this.activateHelper(state);
     }
 
-    canLoad(): Observable<boolean|UrlTree> {
+    canLoad(): Observable<boolean> {
         this.authService.getLogger().verbose("Guard - canLoad");
+        //@ts-ignore
         return this.activateHelper();
     }
 

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -120,7 +120,10 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
                 }),
                 catchError(() => {
                     this.authService.getLogger().verbose("Guard - error while logging in, unable to activate");
-                    // 
+                    /**
+                     * If a loginFailedRoute is set, checks to see if Angular 10+ is used and state is passed in before returning route
+                     * Apps using Angular 9 will receive of(false) in canLoad interface, as it does not support UrlTree return types
+                     */
                     if (this.loginFailedRoute && parseInt(VERSION.major, 10) > 9 && state) {
                         this.authService.getLogger().verbose("Guard - loginFailedRoute set, redirecting");
                         return of(this.loginFailedRoute);

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -145,7 +145,7 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
 
     canLoad(): Observable<boolean> {
         this.authService.getLogger().verbose("Guard - canLoad");
-        //@ts-ignore
+        // @ts-ignore
         return this.activateHelper();
     }
 

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -120,7 +120,8 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
                 }),
                 catchError(() => {
                     this.authService.getLogger().verbose("Guard - error while logging in, unable to activate");
-                    if (this.loginFailedRoute && parseInt(VERSION.major, 10) > 9) {
+                    // 
+                    if (this.loginFailedRoute && parseInt(VERSION.major, 10) > 9 && state) {
                         this.authService.getLogger().verbose("Guard - loginFailedRoute set, redirecting");
                         return of(this.loginFailedRoute);
                     }


### PR DESCRIPTION
This PR updates the MSAL Guard to check the version of Angular used by applications to determine whether to return a `loginFailedRoute` or boolean in the `canLoad` interface. 

This PR addresses issue #2923.