### PR TITLE
Check useAccount() for undefined accounts[0] value

### DIFF
--- a/lib/msal-react/docs/getting-started.md
+++ b/lib/msal-react/docs/getting-started.md
@@ -196,7 +196,7 @@ import { useMsal, useAccount } from "@azure/msal-react";
 
 export function App() {
     const { instance, accounts, inProgress } = useMsal();
-    const account = useAccount(accounts[0]);
+    const account = useAccount(accounts[0] || {});
     const [apiData, setApiData] = useState(null);
 
     useEffect(() => {


### PR DESCRIPTION
Added `{}` as default value in `useAccount()` because an error is otherwise thrown on first render due to `accounts[0]` being undefined until a successful authentication has been achieved. See #2773 where this issue has been reported.