### PR TITLE
Fix stub errors not throwing properly

### DIFF
--- a/change/@azure-msal-browser-04c92788-a1e3-4dac-ba88-85c8f9be715d.json
+++ b/change/@azure-msal-browser-04c92788-a1e3-4dac-ba88-85c8f9be715d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix PCA stub errors (#2963)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/docs/errors.md
+++ b/lib/msal-browser/docs/errors.md
@@ -1,6 +1,71 @@
 # Errors
-1. [I get this error "Access to fetch at [url] has been blocked by CORS policy"](#I-get-this-error-Access-to-fetch-at-[url]-has-been-blocked-by-CORS-policy")
 
-## I get this error "Access to fetch at [url] has been blocked by CORS policy"
+***
+
+**[BrowserConfigurationAuthErrors](#Browserconfigurationautherrors)**
+
+1. [stubbed_public_client_application_called](#stubbed_public_client_application_called)
+
+**[Other](#other)**
+
+1. [Access to fetch at [url] has been blocked by CORS policy](#Access-to-fetch-at-[url]-has-been-blocked-by-CORS-policy)
+
+***
+
+## BrowserConfigurationAuthErrors
+
+### stubbed_public_client_application_called
+
+**Error Message**: Stub instance of Public Client Application was called. If using msal-react, please ensure context is not used without a provider.
+
+When using `msal-react` this error is thrown when you try to use an msal component or hook without an `MsalProvider` higher up in the component tree. All `msal-react` hooks and components make use of the [React Context API](https://reactjs.org/docs/context.html) and require a provider.
+
+❌ The following example will throw this error because the `useMsal` hook is used outside the context of `MsalProvider`:
+
+```javascript
+import { useMsal, MsalProvider } from "@azure/msal-react";
+import { PublicClientApplication } from "@azure/msal-browser";
+
+const pca = new PublicClientApplication(config);
+
+function App() {
+    const { accounts } = useMsal();
+
+    return (
+        <MsalProvider instance={pca}>
+            <YourAppComponent>
+        </ MsalProvider>
+    )
+}
+```
+
+✔️ To resolve the error you should refactor the code above so that the `useMsal` hook is called in a component underneath `MsalProvider`:
+
+```javascript
+import { useMsal, MsalProvider } from "@azure/msal-react";
+import { PublicClientApplication } from "@azure/msal-browser";
+
+const pca = new PublicClientApplication(config);
+
+function ExampleComponent () {
+    const { accounts } = useMsal();
+
+    return <YourAppComponent />;
+};
+
+function App() {
+    return (
+        <MsalProvider instance={pca}>
+            <ExampleComponent />
+        </ MsalProvider>
+    )
+}
+```
+
+## Other
+
+Errors not thrown by msal, such as server errors
+
+### Access to fetch at [url] has been blocked by CORS policy
 
 This error occurs with MSAL.js v2.x and is due to improper configuration during **App Registration** on **Azure Portal**. In particular, you should not have both `Web` and `Single-page application` added as a platform under the **Authentication** blade in your App Registration.

--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -36,13 +36,13 @@ export interface IPublicClientApplication {
 
 export const stubbedPublicClientApplication: IPublicClientApplication = {
     acquireTokenPopup: () => {
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError);
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
     },
     acquireTokenRedirect: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError);	
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
     },	
     acquireTokenSilent: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError);	
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
     },	
     getAllAccounts: () => {
         return [];	
@@ -57,19 +57,19 @@ export const stubbedPublicClientApplication: IPublicClientApplication = {
         return null;
     },
     handleRedirectPromise: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError);	
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
     },	
     loginPopup: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError);	
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
     },	
     loginRedirect: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError);	
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
     },	
     logout: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError);	
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
     },	
     ssoSilent: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError);	
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
     },
     addEventCallback: () => {
         return null;

--- a/lib/msal-browser/src/error/BrowserConfigurationAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserConfigurationAuthError.ts
@@ -33,7 +33,7 @@ export const BrowserConfigurationAuthErrorMessage = {
     },
     stubPcaInstanceCalled: {
         code: "stubbed_public_client_application_called",
-        desc: "Stub instance of Public Client Application was called. If using msal-react, please ensure context is not used without a provider."
+        desc: "Stub instance of Public Client Application was called. If using msal-react, please ensure context is not used without a provider. For more visit: aka.ms/msalBrowserErrors"
     },
     inMemRedirectUnavailable: {
         code: "in_mem_redirect_unavailable",

--- a/lib/msal-browser/src/error/BrowserConfigurationAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserConfigurationAuthError.ts
@@ -33,7 +33,7 @@ export const BrowserConfigurationAuthErrorMessage = {
     },
     stubPcaInstanceCalled: {
         code: "stubbed_public_client_application_called",
-        desc: "Stub instance of Public Client Application was called. If using msal-react, please ensure context is not used without a provider. For more visit: aka.ms/msalBrowserErrors"
+        desc: "Stub instance of Public Client Application was called. If using msal-react, please ensure context is not used without a provider. For more visit: aka.ms/msaljs/browser-errors"
     },
     inMemRedirectUnavailable: {
         code: "in_mem_redirect_unavailable",

--- a/lib/msal-browser/test/app/IPublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/IPublicClientApplication.spec.ts
@@ -12,11 +12,10 @@ import { BrowserConfigurationAuthErrorMessage } from "../../src/error/BrowserCon
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe.only("IPublicClientApplication.ts Class Unit Tests", () => {
+describe("IPublicClientApplication.ts Class Unit Tests", () => {
     describe("stubbedPublicClientApplication tests", () => {
         it("acquireTokenPopup throws", (done) => {
             stubbedPublicClientApplication.acquireTokenPopup({scopes: ["openid"]}).catch(e => {
-                console.log(e);
                 expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
                 expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
                 done();

--- a/lib/msal-browser/test/app/IPublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/IPublicClientApplication.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import "mocha";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { stubbedPublicClientApplication } from "../../src/app/IPublicClientApplication";
+import { BrowserConfigurationAuthErrorMessage } from "../../src/error/BrowserConfigurationAuthError";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe.only("IPublicClientApplication.ts Class Unit Tests", () => {
+    describe("stubbedPublicClientApplication tests", () => {
+        it("acquireTokenPopup throws", (done) => {
+            stubbedPublicClientApplication.acquireTokenPopup({scopes: ["openid"]}).catch(e => {
+                console.log(e);
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+                done();
+            });
+        });
+
+        it("acquireTokenRedirect throws", (done) => {
+            stubbedPublicClientApplication.acquireTokenRedirect({scopes: ["openid"]}).catch(e => {
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+                done();
+            });
+        });
+
+        it("acquireTokenSilent throws", (done) => {
+            stubbedPublicClientApplication.acquireTokenSilent({scopes: ["openid"]}).catch(e => {
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+                done();
+            });
+        });
+        it("handleRedirectPromise throws", (done) => {
+            stubbedPublicClientApplication.handleRedirectPromise().catch(e => {
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+                done();
+            });
+        });
+
+        it("loginPopup throws", (done) => {
+            stubbedPublicClientApplication.loginPopup().catch(e => {
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+                done();
+            });
+        });
+
+        it("loginRedirect throws", (done) => {
+            stubbedPublicClientApplication.loginRedirect().catch(e => {
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+                done();
+            });
+        });
+
+        it("logout throws", (done) => {
+            stubbedPublicClientApplication.logout().catch(e => {
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+                done();
+            });
+        });
+
+        it("ssoSilent throws", (done) => {
+            stubbedPublicClientApplication.ssoSilent({}).catch(e => {
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+                done();
+            });
+        });
+
+        it("getLogger throws", () => {
+            try {
+                stubbedPublicClientApplication.getLogger();
+            } catch (e) {
+                expect(e.errorCode).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.code);
+                expect(e.errorMessage).to.eq(BrowserConfigurationAuthErrorMessage.stubPcaInstanceCalled.desc);
+            };
+        });
+    });
+});

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1021,7 +1021,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             });
 
             it("passes onRedirectNavigate callback", (done) => {
-                const expectedUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=0813e1d1-ad72-46a9-8665-399bba48c201&scope=user.read%20openid%20profile&redirect_uri=https%3A%2F%2Flocalhost%3A8081%2Findex.html&client-request-id=11553a9b-7116-48b1-9d48-f6d4a8ff8371&response_mode=fragment&response_type=code&x-client-SKU=msal.js.browser&x-client-VER=2.10.0&x-client-OS=&x-client-CPU=&client_info=1&code_challenge=JsjesZmxJwehdhNY9kvyr0QOeSMEvryY_EHZo3BKrqg&code_challenge_method=S256&nonce=11553a9b-7116-48b1-9d48-f6d4a8ff8371&state=eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsIm1ldGEiOnsiaW50ZXJhY3Rpb25UeXBlIjoicmVkaXJlY3QifX0%3D%7CuserState`;
+                const expectedUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=0813e1d1-ad72-46a9-8665-399bba48c201&scope=user.read%20openid%20profile&redirect_uri=https%3A%2F%2Flocalhost%3A8081%2Findex.html&client-request-id=11553a9b-7116-48b1-9d48-f6d4a8ff8371&response_mode=fragment&response_type=code&x-client-SKU=msal.js.browser&x-client-VER=${pkg.version}&x-client-OS=&x-client-CPU=&client_info=1&code_challenge=JsjesZmxJwehdhNY9kvyr0QOeSMEvryY_EHZo3BKrqg&code_challenge_method=S256&nonce=11553a9b-7116-48b1-9d48-f6d4a8ff8371&state=eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsIm1ldGEiOnsiaW50ZXJhY3Rpb25UeXBlIjoicmVkaXJlY3QifX0%3D%7CuserState`;
 
                 const onRedirectNavigate = (url) => {
                     expect(url).to.equal(expectedUrl)


### PR DESCRIPTION
`PublicClientApplication` stub errors were throwing the constructor rather than the error message. This PR fixes this and also:

- Adds tests
- Adds explanation to the errors doc
- Adds aka.ms vanity link to the errors doc in the error message (open to other suggestions for the link name)