### PR TITLE
Await loginRedirect in MSAL Guard to prevent race conditions

### DIFF
--- a/change/@azure-msal-angular-449f8e13-b11b-4dfc-92b3-e3e1542431ea.json
+++ b/change/@azure-msal-angular-449f8e13-b11b-4dfc-92b3-e3e1542431ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Await loginRedirect in MSAL Guard to prevent race conditions",
+  "packageName": "@azure/msal-angular",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/karma.conf.js
+++ b/lib/msal-angular/karma.conf.js
@@ -1,33 +1,38 @@
-// Karma configuration file, see link for more information
-// https://karma-runner.github.io/1.0/config/configuration-file.html
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
 
 module.exports = function (config) {
-  config.set({
-    basePath: '',
-    frameworks: ['jasmine', '@angular-devkit/build-angular'],
-    plugins: [
-      require('karma-jasmine'),
-      require('karma-chrome-launcher'),
-      require('karma-jasmine-html-reporter'),
-      require('karma-coverage-istanbul-reporter'),
-      require('@angular-devkit/build-angular/plugins/karma')
-    ],
-    client: {
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
-    },
-    coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, './coverage'),
-      reports: ['html', 'lcovonly', 'text-summary'],
-      fixWebpackSourcePaths: true
-    },
-    reporters: ['progress', 'kjhtml', 'coverage-istanbul'],
-    port: 9876,
-    colors: true,
-    logLevel: config.LOG_INFO,
-    autoWatch: true,
-    browsers: ['ChromeHeadless'],
-    singleRun: true,
-    restartOnFileChange: true,
-    concurrency: 1
-  });
+    config.set({
+        basePath: "",
+        frameworks: ["jasmine", "@angular-devkit/build-angular"],
+        plugins: [
+            require("karma-jasmine"),
+            require("karma-chrome-launcher"),
+            require("karma-jasmine-html-reporter"),
+            require("karma-coverage-istanbul-reporter"),
+            require("@angular-devkit/build-angular/plugins/karma")
+        ],
+        client: {
+            jasmine: {
+                failSpecWithNoExpectations: true
+            },
+            clearContext: false // leave Jasmine Spec Runner output visible in browser
+        },
+        coverageIstanbulReporter: {
+            dir: require("path").join(__dirname, "./coverage"),
+            reports: ["html", "lcovonly", "text-summary"],
+            fixWebpackSourcePaths: true
+        },
+        reporters: ["progress", "kjhtml", "coverage-istanbul"],
+        port: 9876,
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: true,
+        browsers: ["ChromeHeadless"],
+        singleRun: true,
+        restartOnFileChange: true,
+        concurrency: 1
+    });
 };

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -169,10 +169,11 @@ describe('MsalGuard', () => {
       })
     ));
 
-    const listener = jasmine.createSpy();
-    guard.canActivate(routeMock, routeStateMock).subscribe(listener);
-    expect(listener).toHaveBeenCalledWith(false);
-    done();
+    guard.canActivate(routeMock, routeStateMock)
+        .subscribe(result => {
+            expect(result).toBeFalse;
+            done();
+        });
   });
 
   it("canActivateChild returns true with logged in user", (done) => {

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -171,7 +171,7 @@ describe('MsalGuard', () => {
 
     guard.canActivate(routeMock, routeStateMock)
         .subscribe(result => {
-            expect(result).toBeFalse;
+            expect(result).toBeFalse();
             done();
         });
   });

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -78,11 +78,13 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
 
         this.authService.getLogger().verbose("Guard - logging in by redirect");
         const redirectStartPage = this.getDestinationUrl(url);
-        this.authService.loginRedirect({
+        return this.authService.loginRedirect({
             redirectStartPage,
             ...this.msalGuardConfig.authRequest
-        } as RedirectRequest);
-        return of(false);
+        } as RedirectRequest)
+            .pipe(
+                map(() => false)
+            );
     }
 
     /**


### PR DESCRIPTION
When `false` is returned from an Angular Guard, the default behavior is for the app to be redirect back to the home page. In theory, `loginRedirect` could take longer than expected, causing the app to be redirected to the home page and then redirected to the login screen. This can be problematic if the home page uses a guard, or automatically redirects to a page use the guard. This should help mitigate this race condition by letting the `loginRedirect` operation complete first (which should happen, as that promise is set to take 30 seconds, but the redirect should always happen first, not giving the promise a chance to resolve).