### PR TITLE
Ensure scrollbars are enabled for browser popups

### DIFF
--- a/change/@azure-msal-browser-ad675bda-ab43-4b3d-935d-1688d2913cca.json
+++ b/change/@azure-msal-browser-ad675bda-ab43-4b3d-935d-1688d2913cca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure scrollbars are enabled for popups in browser",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_handler/PopupHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/PopupHandler.ts
@@ -167,7 +167,7 @@ export class PopupHandler extends InteractionHandler {
         const left = Math.max(0, ((width / 2) - (BrowserConstants.POPUP_WIDTH / 2)) + winLeft);
         const top = Math.max(0, ((height / 2) - (BrowserConstants.POPUP_HEIGHT / 2)) + winTop);
 
-        return window.open(urlNavigate, popupName, "width=" + BrowserConstants.POPUP_WIDTH + ", height=" + BrowserConstants.POPUP_HEIGHT + ", top=" + top + ", left=" + left);
+        return window.open(urlNavigate, popupName, `width=${BrowserConstants.POPUP_WIDTH}, height=${BrowserConstants.POPUP_HEIGHT}, top=${top}, left=${left}, scrollbars=yes`);
     }
 
     /**


### PR DESCRIPTION
This ensures that we are enabling scrollbars for popup interactions. Modern browsers seem to set this by default, but IE11 does not. This change was originally done in v1 in #1426, and we forgot to bring it forward to v2. This is an accessibility consideration, namely.