### PR TITLE
[msal-common] Device Code Timeout documentation and sample update

### DIFF
--- a/change/@azure-msal-common-164c2c31-d950-4d43-9601-a63101917787.json
+++ b/change/@azure-msal-common-164c2c31-d950-4d43-9601-a63101917787.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarify Device Code Timeout units (#3031)",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/request/CommonDeviceCodeRequest.ts
+++ b/lib/msal-common/src/request/CommonDeviceCodeRequest.ts
@@ -15,7 +15,7 @@ import { BaseAuthRequest } from "./BaseAuthRequest";
  * - cancel                     - Boolean to cancel polling of device code endpoint. While the user authenticates on a separate device, MSAL polls the the token endpoint of security token service for the interval specified in the device code response (usually 15 minutes). To stop polling and cancel the request, set cancel=true.
  * - resourceRequestMethod      - HTTP Request type used to request data from the resource (i.e. "GET", "POST", etc.).  Used for proof-of-possession flows.
  * - resourceRequestUri         - URI that token will be used for. Used for proof-of-possession flows.
- * - timeout                    - Period in which the user explicitly configures for the polling of the device code endpoint. At the end of this period; assuming the device code has not expired yet; the device code polling is stopped and the request cancelled. The device code expiration window will always take precedence over this set period.
+ * - timeout                    - Timeout period in seconds which the user explicitly configures for the polling of the device code endpoint. At the end of this period; assuming the device code has not expired yet; the device code polling is stopped and the request cancelled. The device code expiration window will always take precedence over this set period.
  */
 export type CommonDeviceCodeRequest = BaseAuthRequest &  {
     deviceCodeCallback: (response: DeviceCodeResponse) => void;

--- a/samples/msal-node-samples/standalone-samples/device-code/index.js
+++ b/samples/msal-node-samples/standalone-samples/device-code/index.js
@@ -17,7 +17,7 @@ const pca = new msal.PublicClientApplication(msalConfig);
 const deviceCodeRequest = {
     deviceCodeCallback: (response) => (console.log(response.message)),
     scopes: ["user.read"],
-    timeout: 5,
+    timeout: 20,
 };
 
 pca.acquireTokenByDeviceCode(deviceCodeRequest).then((response) => {


### PR DESCRIPTION
This PR:

- Calls out the unit for the `timeout` configuration option in `CommonDeviceCodeRequest` type as seconds
- Increases the `device-code` sample default timeout from 5 to 20 seconds
- Addresses #3016 and #3017