### PR TITLE
Add redirectUri parameter to chromium extension sample

### DIFF
--- a/samples/msal-browser-samples/ChromiumExtensionSample/README.md
+++ b/samples/msal-browser-samples/ChromiumExtensionSample/README.md
@@ -105,7 +105,7 @@ async function acquireToken(request) {
 }
 
 // Login
-const loginUrl = await getLoginUrl();
+const loginUrl = await getLoginUrl({redirectUri: redirectUri});
 const loginResult = await launchWebAuthFlow(loginUrl);
 
 // Acquire token

--- a/samples/msal-browser-samples/ChromiumExtensionSample/auth.js
+++ b/samples/msal-browser-samples/ChromiumExtensionSample/auth.js
@@ -34,7 +34,8 @@ getSignedInUser()
             signInHintButton.innerHTML = `Sign In (w/ ${user.email})`;
             signInHintButton.addEventListener("click", async () => {
                 const url = await getLoginUrl({
-                    loginHint: user.email
+                    loginHint: user.email,
+                    redirectUri: redirectUri
                 });
 
                 const result = await launchWebAuthFlow(url);


### PR DESCRIPTION
See #3059, the chromium sample fails to login because the redirect uri used to obtain the auth code doesn't match the one used late ,in the token call, this PR modifies the sample and the readme to explicitly pass the right redirect uri.