### PR TITLE
Fix OIDC Scopes Caching Issue

### DIFF
--- a/change/@azure-msal-common-ba830074-164e-4e0f-8188-9d5d3f44c276.json
+++ b/change/@azure-msal-common-ba830074-164e-4e0f-8188-9d5d3f44c276.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix OIDC Scopes Caching Issue (#3065)",
+  "packageName": "@azure/msal-common",
+  "email": "prkanher@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -805,6 +805,8 @@ export abstract class CacheManager implements ICacheManager {
 
         if (!requestTargetScopeSet.containsOnlyOIDCScopes()) {
             requestTargetScopeSet.removeOIDCScopes(); // ignore OIDC scopes
+        } else {
+            requestTargetScopeSet.removeScope(Constants.OFFLINE_ACCESS_SCOPE);
         }
         return entityScopeSet.containsScopeSet(requestTargetScopeSet);
     }

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -80,8 +80,7 @@ export class RefreshTokenClient extends BaseClient {
         if (isFOCI) {
             try {
                 return this.acquireTokenWithCachedRefreshToken(request, true);
-            }
-            catch (e) {
+            } catch (e) {
                 const noFamilyRTInCache = e instanceof ClientAuthError && e.errorCode === ClientAuthErrorMessage.noTokensFoundError.code;
                 const clientMismatchErrorWithFamilyRT = e instanceof ServerError && e.errorCode === Errors.INVALID_GRANT_ERROR && e.subError === Errors.CLIENT_MISMATCH_ERROR;
 

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -55,7 +55,6 @@ export class SilentFlowClient extends BaseClient {
         if (!request.account) {
             throw ClientAuthError.createNoAccountInSilentRequestError();
         }
-
         const requestScopes = new ScopeSet(request.scopes || []);
         const environment = request.authority || this.authority.getPreferredCache();
         const cacheRecord = this.cacheManager.readCacheRecord(request.account, this.config.authOptions.clientId, requestScopes, environment);

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -21,7 +21,7 @@ import { SilentFlowClient } from "../../src/client/SilentFlowClient";
 import { RefreshTokenClient } from "../../src/client/RefreshTokenClient";
 import { AuthenticationResult } from "../../src/response/AuthenticationResult";
 import { AccountInfo } from "../../src/account/AccountInfo";
-import { SilentFlowRequest, AccountEntity, IdTokenEntity, AccessTokenEntity, RefreshTokenEntity, CacheManager, ClientConfigurationErrorMessage, ClientAuthErrorMessage, TimeUtils, ClientConfiguration, RefreshTokenRequest, ServerTelemetryManager, TokenClaims } from "../../src";
+import { CommonSilentFlowRequest, AccountEntity, IdTokenEntity, AccessTokenEntity, RefreshTokenEntity, CacheManager, ClientConfigurationErrorMessage, ClientAuthErrorMessage, TimeUtils, ClientConfiguration, RefreshTokenRequest, ServerTelemetryManager, TokenClaims } from "../../src";
 import { AuthToken } from "../../src/account/AuthToken";
 
 const testAccountEntity: AccountEntity = new AccountEntity();
@@ -88,20 +88,20 @@ describe("SilentFlowClient unit tests", () => {
             const config = await ClientTestUtils.createTestClientConfiguration();
             const client = new SilentFlowClient(config);
             await expect(client.acquireToken({
-                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
                 account: null,
                 authority: TEST_CONFIG.validAuthority,
                 correlationId: TEST_CONFIG.CORRELATION_ID,
                 forceRefresh: false
             })).to.be.rejectedWith(ClientAuthErrorMessage.NoAccountInSilentRequest.desc);
             await expect(client.acquireCachedToken({
-                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
                 account: null,
                 authority: TEST_CONFIG.validAuthority,
                 correlationId: TEST_CONFIG.CORRELATION_ID,
                 forceRefresh: false
             })).to.be.rejectedWith(ClientAuthErrorMessage.NoAccountInSilentRequest.desc);
-        });
+        }); 
 
         it("Throws error if request object is null or undefined", async () => {
             sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
@@ -127,7 +127,7 @@ describe("SilentFlowClient unit tests", () => {
         });
 
         it("Throws error if scopes are empty in request object", async () => {
-            const tokenRequest: SilentFlowRequest = {
+            const tokenRequest: CommonSilentFlowRequest = {
                 scopes: [],
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -151,7 +151,7 @@ describe("SilentFlowClient unit tests", () => {
             testAccountEntity.authorityType = "MSSTS";
             sinon.stub(MockStorageClass.prototype, "getAccount").returns(testAccountEntity);
             sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
-            const tokenRequest: SilentFlowRequest = {
+            const tokenRequest: CommonSilentFlowRequest = {
                 scopes: [testScope2],
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -175,7 +175,7 @@ describe("SilentFlowClient unit tests", () => {
             const client = new SilentFlowClient(config);
             sinon.stub(TimeUtils, <any>"isTokenExpired").returns(false);
 
-            const silentFlowRequest: SilentFlowRequest = {
+            const silentFlowRequest: CommonSilentFlowRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -197,7 +197,7 @@ describe("SilentFlowClient unit tests", () => {
             const client = new SilentFlowClient(config);
             sinon.stub(TimeUtils, <any>"isTokenExpired").returns(false);
 
-            const silentFlowRequest: SilentFlowRequest = {
+            const silentFlowRequest: CommonSilentFlowRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -220,7 +220,7 @@ describe("SilentFlowClient unit tests", () => {
             const client = new SilentFlowClient(config);
             sinon.stub(TimeUtils, <any>"isTokenExpired").returns(true);
 
-            const silentFlowRequest: SilentFlowRequest = {
+            const silentFlowRequest: CommonSilentFlowRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -242,8 +242,8 @@ describe("SilentFlowClient unit tests", () => {
             const client = new SilentFlowClient(config);
             sinon.stub(TimeUtils, <any>"isTokenExpired").returns(false);
 
-            const silentFlowRequest: SilentFlowRequest = {
-                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            const silentFlowRequest: CommonSilentFlowRequest = {
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
                 correlationId: TEST_CONFIG.CORRELATION_ID,
@@ -286,7 +286,7 @@ describe("SilentFlowClient unit tests", () => {
         });
 
         it("acquireToken returns token from cache", async () => {
-            const silentFlowRequest: SilentFlowRequest = {
+            const silentFlowRequest: CommonSilentFlowRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -311,7 +311,7 @@ describe("SilentFlowClient unit tests", () => {
         });
 
         it("acquireToken calls refreshToken if refresh is required", async () => {
-            const silentFlowRequest: SilentFlowRequest = {
+            const silentFlowRequest: CommonSilentFlowRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -343,7 +343,7 @@ describe("SilentFlowClient unit tests", () => {
             const telemetryCacheHitSpy = sinon.stub(ServerTelemetryManager.prototype, "incrementCacheHits").returns(1);
             sinon.stub(TimeUtils, <any>"isTokenExpired").returns(false);
 
-            const silentFlowRequest: SilentFlowRequest = {
+            const silentFlowRequest: CommonSilentFlowRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -368,7 +368,7 @@ describe("SilentFlowClient unit tests", () => {
             const client = new SilentFlowClient(config);
             sinon.stub(TimeUtils, "isTokenExpired").returns(true);
 
-            const silentFlowRequest: SilentFlowRequest = {
+            const silentFlowRequest: CommonSilentFlowRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,


### PR DESCRIPTION
Fixes #3045.

`acquireTokenSilent()` was seeing cache misses due to `offline_access` scope not being present, this PR fixes the issue (adds on to previous PR #2969)