### PR TITLE
Update msal-angular preinstall script to force npm-force-resolutions version

### DIFF
--- a/change/@azure-msal-angular-7c84ff5a-7773-4dde-a551-3665adb6e468.json
+++ b/change/@azure-msal-angular-7c84ff5a-7773-4dde-a551-3665adb6e468.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Update msal-angular preinstall script to force npm-force-resolutions version (#3074)",
   "packageName": "@azure/msal-angular",
   "email": "joarroyo@microsoft.com",

--- a/change/@azure-msal-angular-7c84ff5a-7773-4dde-a551-3665adb6e468.json
+++ b/change/@azure-msal-angular-7c84ff5a-7773-4dde-a551-3665adb6e468.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update msal-angular preinstall script to force npm-force-resolutions version (#3074)",
+  "packageName": "@azure/msal-angular",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "npm run lint -- -- --fix",
     "e2e": "ng e2e",
     "prepack": "npm run build:all",
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "npx npm-force-resolutions@0.0.3",
     "prepublishOnly": "echo Use npm run deploy && exit 1"
   },
   "main": "./dist/bundles/azure-msal-angular.umd.js",


### PR DESCRIPTION
Msal-Angular has a preinstall script that runs `npm-force-resolutions` to force npm to install certain versions of dependencies. A recent update to the `npm-force-resolutions` package is causing this preinstall script to fail, so this PR forces the version of `npm-force-resolutions` to 0.0.3.