### PR TITLE
Move /token headers to POST body

### DIFF
--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -168,6 +168,15 @@ export class AuthorizationCodeClient extends BaseClient {
         // add code: user set, not validated
         parameterBuilder.addAuthorizationCode(request.code);
 
+        // Add library metadata
+        parameterBuilder.addLibraryInfo(this.config.libraryInfo);
+
+        parameterBuilder.addThrottling();
+        
+        if (this.serverTelemetryManager) {
+            parameterBuilder.addServerTelemetry(this.serverTelemetryManager);
+        }
+
         // add code_verifier if passed
         if (request.codeVerifier) {
             parameterBuilder.addCodeVerifier(request.codeVerifier);

--- a/lib/msal-common/src/client/BaseClient.ts
+++ b/lib/msal-common/src/client/BaseClient.ts
@@ -9,7 +9,7 @@ import { NetworkManager, NetworkResponse } from "../network/NetworkManager";
 import { ICrypto } from "../crypto/ICrypto";
 import { Authority } from "../authority/Authority";
 import { Logger } from "../logger/Logger";
-import { AADServerParamKeys, Constants, HeaderNames } from "../utils/Constants";
+import { Constants, HeaderNames } from "../utils/Constants";
 import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
 import { CacheManager } from "../cache/CacheManager";
 import { ServerTelemetryManager } from "../telemetry/server/ServerTelemetryManager";
@@ -75,29 +75,8 @@ export abstract class BaseClient {
      * Creates default headers for requests to token endpoint
      */
     protected createDefaultTokenRequestHeaders(): Record<string, string> {
-        const headers = this.createDefaultLibraryHeaders();
-        headers[HeaderNames.CONTENT_TYPE] = Constants.URL_FORM_CONTENT_TYPE;
-        headers[HeaderNames.X_MS_LIB_CAPABILITY] = HeaderNames.X_MS_LIB_CAPABILITY_VALUE;
-
-        if (this.serverTelemetryManager) {
-            headers[HeaderNames.X_CLIENT_CURR_TELEM] = this.serverTelemetryManager.generateCurrentRequestHeaderValue();
-            headers[HeaderNames.X_CLIENT_LAST_TELEM] = this.serverTelemetryManager.generateLastRequestHeaderValue();
-        }
-
-        return headers;
-    }
-
-    /**
-     * addLibraryData
-     */
-    protected createDefaultLibraryHeaders(): Record<string, string> {
         const headers: Record<string, string> = {};
-
-        // client info headers
-        headers[AADServerParamKeys.X_CLIENT_SKU] = this.config.libraryInfo.sku;
-        headers[AADServerParamKeys.X_CLIENT_VER] = this.config.libraryInfo.version;
-        headers[AADServerParamKeys.X_CLIENT_OS] = this.config.libraryInfo.os;
-        headers[AADServerParamKeys.X_CLIENT_CPU] = this.config.libraryInfo.cpu;
+        headers[HeaderNames.CONTENT_TYPE] = Constants.URL_FORM_CONTENT_TYPE;
 
         return headers;
     }

--- a/lib/msal-common/src/client/ClientCredentialClient.ts
+++ b/lib/msal-common/src/client/ClientCredentialClient.ts
@@ -152,6 +152,14 @@ export class ClientCredentialClient extends BaseClient {
 
         parameterBuilder.addGrantType(GrantType.CLIENT_CREDENTIALS_GRANT);
 
+        parameterBuilder.addLibraryInfo(this.config.libraryInfo);
+
+        parameterBuilder.addThrottling();
+        
+        if (this.serverTelemetryManager) {
+            parameterBuilder.addServerTelemetry(this.serverTelemetryManager);
+        }
+
         const correlationId = request.correlationId || this.config.cryptoInterface.createNewGuid();
         parameterBuilder.addCorrelationId(correlationId);
 

--- a/lib/msal-common/src/client/DeviceCodeClient.ts
+++ b/lib/msal-common/src/client/DeviceCodeClient.ts
@@ -222,6 +222,12 @@ export class DeviceCodeClient extends BaseClient {
         const correlationId = request.correlationId || this.config.cryptoInterface.createNewGuid();
         requestParameters.addCorrelationId(correlationId);
         requestParameters.addClientInfo();
+        requestParameters.addLibraryInfo(this.config.libraryInfo);
+        requestParameters.addThrottling();
+        
+        if (this.serverTelemetryManager) {
+            requestParameters.addServerTelemetry(this.serverTelemetryManager);
+        }
 
         if (!StringUtils.isEmpty(request.claims) || this.config.authOptions.clientCapabilities && this.config.authOptions.clientCapabilities.length > 0) {
             requestParameters.addClaims(request.claims, this.config.authOptions.clientCapabilities);

--- a/lib/msal-common/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-common/src/client/OnBehalfOfClient.ts
@@ -206,6 +206,14 @@ export class OnBehalfOfClient extends BaseClient {
 
         parameterBuilder.addClientInfo();
 
+        parameterBuilder.addLibraryInfo(this.config.libraryInfo);
+
+        parameterBuilder.addThrottling();
+        
+        if (this.serverTelemetryManager) {
+            parameterBuilder.addServerTelemetry(this.serverTelemetryManager);
+        }
+
         const correlationId = request.correlationId || this.config.cryptoInterface.createNewGuid();
         parameterBuilder.addCorrelationId(correlationId);
 

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -154,6 +154,14 @@ export class RefreshTokenClient extends BaseClient {
 
         parameterBuilder.addClientInfo();
 
+        parameterBuilder.addLibraryInfo(this.config.libraryInfo);
+
+        parameterBuilder.addThrottling();
+        
+        if (this.serverTelemetryManager) {
+            parameterBuilder.addServerTelemetry(this.serverTelemetryManager);
+        }
+
         const correlationId = request.correlationId || this.config.cryptoInterface.createNewGuid();
         parameterBuilder.addCorrelationId(correlationId);
 

--- a/lib/msal-common/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-common/src/client/UsernamePasswordClient.ts
@@ -87,6 +87,14 @@ export class UsernamePasswordClient extends BaseClient {
         parameterBuilder.addGrantType(GrantType.RESOURCE_OWNER_PASSWORD_GRANT);
         parameterBuilder.addClientInfo();
 
+        parameterBuilder.addLibraryInfo(this.config.libraryInfo);
+
+        parameterBuilder.addThrottling();
+        
+        if (this.serverTelemetryManager) {
+            parameterBuilder.addServerTelemetry(this.serverTelemetryManager);
+        }
+
         const correlationId = request.correlationId || this.config.cryptoInterface.createNewGuid();
         parameterBuilder.addCorrelationId(correlationId);
 

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -3,13 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { AADServerParamKeys, Constants, ResponseMode, SSOTypes, ClientInfo, AuthenticationScheme, ClaimsRequestKeys, PasswordGrantConstants, OIDC_DEFAULT_SCOPES} from "../utils/Constants";
+import { AADServerParamKeys, Constants, ResponseMode, SSOTypes, ClientInfo, AuthenticationScheme, ClaimsRequestKeys, PasswordGrantConstants, OIDC_DEFAULT_SCOPES, ThrottlingConstants} from "../utils/Constants";
 import { ScopeSet } from "./ScopeSet";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
 import { StringDict } from "../utils/MsalTypes";
 import { RequestValidator } from "./RequestValidator";
 import { LibraryInfo } from "../config/ClientConfiguration";
 import { StringUtils } from "../utils/StringUtils";
+import { ServerTelemetryManager } from "../telemetry/server/ServerTelemetryManager";
 
 export class RequestParameterBuilder {
 
@@ -337,6 +338,22 @@ export class RequestParameterBuilder {
             this.parameters.set(AADServerParamKeys.TOKEN_TYPE, AuthenticationScheme.POP);
             this.parameters.set(AADServerParamKeys.REQ_CNF, encodeURIComponent(cnfString));
         }
+    }
+
+    /**
+     * add server telemetry fields
+     * @param serverTelemetryManager 
+     */
+    addServerTelemetry(serverTelemetryManager: ServerTelemetryManager) {
+        this.parameters.set(AADServerParamKeys.X_CLIENT_CURR_TELEM, serverTelemetryManager.generateCurrentRequestHeaderValue());
+        this.parameters.set(AADServerParamKeys.X_CLIENT_LAST_TELEM, serverTelemetryManager.generateLastRequestHeaderValue());
+    }
+
+    /**
+     * Adds parameter that indicates to the server that throttling is supported
+     */
+    addThrottling() {
+        this.parameters.set(AADServerParamKeys.X_MS_LIB_CAPABILITY, ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE);
     }
 
     /**

--- a/lib/msal-common/src/telemetry/server/ServerTelemetryManager.ts
+++ b/lib/msal-common/src/telemetry/server/ServerTelemetryManager.ts
@@ -65,6 +65,13 @@ export class ServerTelemetryManager {
      */
     cacheFailedRequest(error: AuthError): void {
         const lastRequests = this.getLastRequests();
+        if (lastRequests.errors.length >= SERVER_TELEM_CONSTANTS.MAX_CACHED_ERRORS) {
+            // Remove a cached error to make room, first in first out
+            lastRequests.failedRequests.shift(); // apiId
+            lastRequests.failedRequests.shift(); // correlationId
+            lastRequests.errors.shift();
+        }
+        
         lastRequests.failedRequests.push(this.apiId, this.correlationId);
 
         if (!StringUtils.isEmpty(error.subError)) {
@@ -141,7 +148,7 @@ export class ServerTelemetryManager {
             // Count number of characters that would be added to header, each character is 1 byte. Add 3 at the end to account for separators
             dataSize += apiId.toString().length + correlationId.toString().length + errorCode.length + 3;
 
-            if (dataSize < SERVER_TELEM_CONSTANTS.MAX_HEADER_BYTES) {
+            if (dataSize < SERVER_TELEM_CONSTANTS.MAX_LAST_HEADER_BYTES) {
                 // Adding this entry to the header would still keep header size below the limit
                 maxErrors += 1;
             } else {

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -57,11 +57,7 @@ export const OIDC_SCOPES = [
  */
 export enum HeaderNames {
     CONTENT_TYPE = "Content-Type",
-    X_CLIENT_CURR_TELEM = "x-client-current-telemetry",
-    X_CLIENT_LAST_TELEM = "x-client-last-telemetry",
-    RETRY_AFTER = "Retry-After",
-    X_MS_LIB_CAPABILITY = "x-ms-lib-capability",
-    X_MS_LIB_CAPABILITY_VALUE = "retry-after, h429"
+    RETRY_AFTER = "Retry-After"
 }
 
 /**
@@ -115,6 +111,9 @@ export enum AADServerParamKeys {
     X_CLIENT_VER = "x-client-VER",
     X_CLIENT_OS = "x-client-OS",
     X_CLIENT_CPU = "x-client-CPU",
+    X_CLIENT_CURR_TELEM = "x-client-current-telemetry",
+    X_CLIENT_LAST_TELEM = "x-client-last-telemetry",
+    X_MS_LIB_CAPABILITY = "x-ms-lib-capability",
     POST_LOGOUT_URI = "post_logout_redirect_uri",
     ID_TOKEN_HINT= "id_token_hint",
     DEVICE_CODE = "device_code",
@@ -316,7 +315,9 @@ export const ThrottlingConstants = {
     // Default maximum time to throttle in seconds, overrides what the server sends back
     DEFAULT_MAX_THROTTLE_TIME_SECONDS: 3600,
     // Prefix for storing throttling entries
-    THROTTLING_PREFIX: "throttling"
+    THROTTLING_PREFIX: "throttling",
+    // Value assigned to the x-ms-lib-capability header to indicate to the server the library supports throttling
+    X_MS_LIB_CAPABILITY_VALUE: "retry-after, h429"
 };
 
 export const Errors = {

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -289,7 +289,9 @@ export enum AuthorityMetadataSource {
 
 export const SERVER_TELEM_CONSTANTS = {
     SCHEMA_VERSION: 2,
-    MAX_HEADER_BYTES: 4000, // Max is 4KB, 4000 Bytes provides 96 Byte buffer for separators, schema version, etc. 
+    MAX_CUR_HEADER_BYTES: 80, // ESTS limit is 100B, set to 80 to provide a 20B buffer
+    MAX_LAST_HEADER_BYTES: 330, // ESTS limit is 350B, set to 330 to provide a 20B buffer,
+    MAX_CACHED_ERRORS: 50, // Limit the number of errors that can be stored to prevent uncontrolled size gains
     CACHE_KEY: "server-telemetry",
     CATEGORY_SEPARATOR: "|",
     VALUE_SEPARATOR: ",",


### PR DESCRIPTION
Telemetry and library info headers on the /token endpoint are causing an OPTIONS request which is an unnecessary performance hit. In discussion with the server team we've decided to move these headers to the POST body in order to make /token requests "simple requests" in the context of CORS. We've also made the decision to reduce the maximum size that the telemetry headers can be and how much we cache at any given point.

Do not merge until the server changes have been fully deployed.