### PR TITLE
Ensure indexeddb is cleared on logout

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,7 @@
         "no-multiple-empty-lines": [2, { "max": 1 }],
         "no-var": 2,
         "no-console": 2,
+        "no-debugger": 2,
         "prefer-const": 2,
         "quotes": [2, "double"],
         "spaced-comment": 2,

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -666,9 +666,20 @@ export abstract class ClientApplication {
 
         try {
             this.emitEvent(EventType.LOGOUT_START, InteractionType.Redirect, logoutRequest);
+            
+            // create logout string and navigate user window to logout.
             const authClient = await this.createAuthCodeClient(serverTelemetryManager, logoutRequest && logoutRequest.authority);
-            // create logout string and navigate user window to logout. Auth module will clear cache.
             const logoutUri: string = authClient.getLogoutUri(validLogoutRequest);
+
+            // Clear caches
+            if (validLogoutRequest.account) {
+                // Clear given account.
+                this.browserStorage.removeAccount(AccountEntity.generateAccountCacheKey(validLogoutRequest.account));
+            } else {
+                // Clear all accounts and tokens
+                await this.browserStorage.clear();
+            }
+
             this.emitEvent(EventType.LOGOUT_SUCCESS, InteractionType.Redirect, validLogoutRequest);
 
             if (!validLogoutRequest.account || AccountEntity.accountInfoIsEqual(validLogoutRequest.account, this.getActiveAccount())) {

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -11,6 +11,7 @@ import { BrowserStorage } from "./BrowserStorage";
 import { MemoryStorage } from "./MemoryStorage";
 import { IWindowStorage } from "./IWindowStorage";
 import { BrowserProtocolUtils } from "../utils/BrowserProtocolUtils";
+import { CryptoOps } from "../crypto/CryptoOps";
 
 /**
  * This class implements the cache storage interface for MSAL through browser local or session storage.
@@ -480,7 +481,7 @@ export class BrowserCacheManager extends CacheManager {
     /**
      * Clears all cache entries created by MSAL (except tokens).
      */
-    clear(): void {
+    async clear(): Promise<void> {
         this.removeAllAccounts();
         this.removeAppMetadata();
         this.getKeys().forEach((cacheKey: string) => {
@@ -490,7 +491,9 @@ export class BrowserCacheManager extends CacheManager {
             }
         });
 
+        debugger;
         this.internalStorage.clear();
+        await (this.cryptoImpl as CryptoOps).clearCache();
     }
 
     /**

--- a/lib/msal-browser/src/cache/DatabaseStorage.ts
+++ b/lib/msal-browser/src/cache/DatabaseStorage.ts
@@ -110,4 +110,28 @@ export class DatabaseStorage<T>{
             dbPut.addEventListener("error", e => reject(e));
         });
     }
+
+    /**
+     * Remove all records from the database
+     */
+    async clear(): Promise<void> {
+        if (!this.dbOpen) {
+            await this.open();
+        }
+
+        return new Promise<void>((resolve: any, reject: any) => {
+            if (!this.db) {
+                return reject(BrowserAuthError.createDatabaseNotOpenError());
+            }
+
+            const transaction = this.db.transaction([this.tableName], "readwrite");
+            const objectStore = transaction.objectStore(this.tableName);
+
+            const dbClear = objectStore.clear();
+            dbClear.addEventListener("success", () => {
+                resolve();
+            });
+            dbClear.addEventListener("error", e => reject(e));
+        });
+    }
 }

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -153,4 +153,11 @@ export class CryptoOps implements ICrypto {
 
         return `${tokenString}.${encodedSignature}`;
     }
+
+    /**
+     * Clears crypto cache storage (IndexedDB)
+     */
+    async clearCache() {
+        return this.cache.clear();
+    }
 }

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -159,7 +159,7 @@ export abstract class CacheManager implements ICacheManager {
     /**
      * Function which clears cache.
      */
-    abstract clear(): void;
+    abstract clear(): Promise<void>;
 
     /**
      * Returns all accounts in cache
@@ -949,7 +949,7 @@ export class DefaultStorageClass extends CacheManager {
         const notImplErr = "Storage interface - getKeys() has not been implemented for the cacheStorage interface.";
         throw AuthError.createUnexpectedError(notImplErr);
     }
-    clear(): void {
+    clear(): Promise<void> {
         const notImplErr = "Storage interface - clear() has not been implemented for the cacheStorage interface.";
         throw AuthError.createUnexpectedError(notImplErr);
     }

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -18,7 +18,6 @@ import { StringUtils } from "../utils/StringUtils";
 import { ClientAuthError } from "../error/ClientAuthError";
 import { UrlString } from "../url/UrlString";
 import { ServerAuthorizationCodeResponse } from "../response/ServerAuthorizationCodeResponse";
-import { AccountEntity } from "../cache/entities/AccountEntity";
 import { CommonEndSessionRequest } from "../request/CommonEndSessionRequest";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
 import { PopTokenGenerator } from "../crypto/PopTokenGenerator";
@@ -116,14 +115,6 @@ export class AuthorizationCodeClient extends BaseClient {
         // Throw error if logoutRequest is null/undefined
         if (!logoutRequest) {
             throw ClientConfigurationError.createEmptyLogoutRequestError();
-        }
-
-        if (logoutRequest.account) {
-            // Clear given account.
-            this.cacheManager.removeAccount(AccountEntity.generateAccountCacheKey(logoutRequest.account));
-        } else {
-            // Clear all accounts and tokens
-            this.cacheManager.clear();
         }
 
         const queryString = this.createLogoutUrlQueryString(logoutRequest);

--- a/lib/msal-common/test/cache/MockCache.ts
+++ b/lib/msal-common/test/cache/MockCache.ts
@@ -23,8 +23,8 @@ export class MockCache {
     }
 
     // clear the cache
-    clearCache(): void {
-        this.cacheManager.clear();
+    async clearCache(): Promise<void> {
+        await this.cacheManager.clear();
     }
 
     // create account entries in the cache

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -114,7 +114,7 @@ export class MockStorageClass extends CacheManager {
     getAuthorityMetadataKeys(): string[] {
         return this.getKeys();
     }
-    clear(): void {
+    async clear(): Promise<void> {
         this.store = {};
     }
 }

--- a/lib/msal-node/src/cache/NodeStorage.ts
+++ b/lib/msal-node/src/cache/NodeStorage.ts
@@ -399,7 +399,7 @@ export class NodeStorage extends CacheManager {
     /**
      * Clears all cache entries created by MSAL (except tokens).
      */
-    clear(): void {
+    async clear(): Promise<void> {
         this.logger.verbose("Clearing cache entries created by MSAL");
 
         // read inMemoryCache


### PR DESCRIPTION
Today, anything stored in IndexedDB is not cleared on logout. This PR makes the following changes:

- Adds `clear` operation to `DatabaseStorage` class.
- Makes `clearCache` operation asynchronous to handle async `DatabaseStorage.clear` function
- Moves cache clearing into logout function, instead of `getLogoutUri` (since `getLogoutUri` is other synchronous).