### PR TITLE
Add the correct type to `load()` method in IPersistence class

### DIFF
--- a/extensions/msal-node-extensions/src/persistence/FilePersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/FilePersistence.ts
@@ -46,7 +46,7 @@ export class FilePersistence implements IPersistence {
         }
     }
 
-    public async load(): Promise<string> {
+    public async load(): Promise<string | null> {
         try {
             return await fs.readFile(this.getFilePath(), "utf-8");
         } catch (err) {

--- a/extensions/msal-node-extensions/src/persistence/IPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/IPersistence.ts
@@ -7,7 +7,7 @@ import { Logger } from "@azure/msal-common";
 
 export interface IPersistence {
     save(contents: string): Promise<void>;
-    load(): Promise<string>;
+    load(): Promise<string | null>;
     delete(): Promise<boolean>;
     reloadNecessary(lastSync: number): Promise<boolean>;
     getFilePath(): string;


### PR DESCRIPTION
We have a mismatch in the return types for the function `load()` in `FilePersistence.ts` and other implementations of `IPersistence` header. This PR corrects it.