### PR TITLE
Update workflows to cancel in-progress runs

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -33,6 +33,11 @@ jobs:
             - msal-react
   
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-angular-e2e.yml
+++ b/.github/workflows/msal-angular-e2e.yml
@@ -32,6 +32,11 @@ jobs:
           - 'angular11-sample-app'
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-browser-e2e.yml
+++ b/.github/workflows/msal-browser-e2e.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-core-e2e.yml
+++ b/.github/workflows/msal-core-e2e.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-react-e2e.yml
+++ b/.github/workflows/msal-react-e2e.yml
@@ -30,6 +30,11 @@ jobs:
           - 'nextjs-sample'
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+        
     - uses: actions/checkout@v2
 
     - name: Use Node.js


### PR DESCRIPTION
Adds a step to CI and E2E workflows to cancel in-progress and queued workflow runs on the same branch. This will help speed things up when you make several back to back pushes to a PR, ensuring that previous workflow runs aren't holding up the most recent push due to concurrency limits.