### PR TITLE
Update Issue bot labeler

### DIFF
--- a/.github/issue_template_bot.json
+++ b/.github/issue_template_bot.json
@@ -3,13 +3,13 @@
         "Library": {
             "labels": {
                 "msal@1.x": {
-                    "searchStrings": ["msal@1.x"]
+                    "searchStrings": ["msal@1."]
                 },
                 "msal-angular": {
-                    "searchStrings": ["msal-angular@0.x", "msal-angular@1.x", "msal-angular@2.x"]
+                    "searchStrings": ["msal-angular@0.", "msal-angular@1.", "msal-angular@2."]
                 },
                 "msal-angularjs": {
-                    "searchStrings": ["msal-angularjs@1.x"]
+                    "searchStrings": ["msal-angularjs@1."]
                 },
                 "msal-browser": {
                     "searchStrings": ["msal-browser"]

--- a/.github/issue_template_bot.json
+++ b/.github/issue_template_bot.json
@@ -6,10 +6,10 @@
                     "searchStrings": ["msal@1."]
                 },
                 "msal-angular": {
-                    "searchStrings": ["msal-angular@0.", "msal-angular@1.", "msal-angular@2."]
+                    "searchStrings": ["msal-angular@"]
                 },
                 "msal-angularjs": {
-                    "searchStrings": ["msal-angularjs@1."]
+                    "searchStrings": ["msal-angularjs@"]
                 },
                 "msal-browser": {
                     "searchStrings": ["msal-browser"]


### PR DESCRIPTION
The `.x` in some of the label search strings is causing the bot to miss labeling issues that specify a specific version e.g. `msal@1.4.4`

Searching for just the package name should allow for better pattern matching