### PR TITLE
Propagate request scopes to response handler

### DIFF
--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -77,7 +77,7 @@ export class AuthorizationCodeClient extends BaseClient {
 
         // Validate response. This function throws a server error if an error is returned by the server.
         responseHandler.validateTokenResponse(response.body);
-        return await responseHandler.handleServerTokenResponse(response.body, this.authority, reqTimestamp, request.resourceRequestMethod, request.resourceRequestUri, authCodePayload);
+        return await responseHandler.handleServerTokenResponse(response.body, this.authority, reqTimestamp, request.resourceRequestMethod, request.resourceRequestUri, authCodePayload, request.scopes);
     }
 
     /**
@@ -308,7 +308,7 @@ export class AuthorizationCodeClient extends BaseClient {
 
     /**
      * Helper to get sid from account. Returns null if idTokenClaims are not present or sid is not present.
-     * @param account 
+     * @param account
      */
     private extractAccountSid(account: AccountInfo): string | null {
         if (account.idTokenClaims) {


### PR DESCRIPTION
My OAuth provider doesn't always return `scopes` in the token response. When scopes are returned MSAL errors. When troubleshooting the errors I noticed the below comment in ResponseHandler.ts.
``` typescript
// If scopes not returned in server response, use request scopes
const responseScopes = serverTokenResponse.scope ? ScopeSet.fromString(serverTokenResponse.scope) : new ScopeSet(requestScopes || []);
```
My change propagates the request scopes so they can be used when the response doesn't include them.