### PR TITLE
Update slight typo in README

### DIFF
--- a/samples/msal-node-samples/standalone-samples/device-code/readme.md
+++ b/samples/msal-node-samples/standalone-samples/device-code/readme.md
@@ -1,6 +1,6 @@
 # MSAL Node Standalone Sample:  Device Code
 
-The sample applications contained in this directory are independent samples of MSAL Node usage, covering each of the authorization flows that MSAL Node currently supports. To get started with this sample, first follow the general instructions [here](../readme.me).
+The sample applications contained in this directory are independent samples of MSAL Node usage, covering each of the authorization flows that MSAL Node currently supports. To get started with this sample, first follow the general instructions [here](../README.md).
 
 Once MSAL Node is installed, and you have the right files, come here to learn about this scenario.
 


### PR DESCRIPTION
Noticed that a link was broken when following along with the steps.  Verified that the link now links to the right place.

Not sure why there is a whitespace change on line 115? I made this change on the web GUI.