### PR TITLE
Update msal-angular service redirect hash handling

### DIFF
--- a/change/@azure-msal-angular-34d95922-3876-421c-89f0-0b025bfb762b.json
+++ b/change/@azure-msal-angular-34d95922-3876-421c-89f0-0b025bfb762b.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Update MSAL Service handleRedirectObservable hash handling (#3243)",
+  "comment": "Update MSAL Service handleRedirectObservable hash handling #3243",
   "packageName": "@azure/msal-angular",
   "email": "joarroyo@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-angular-34d95922-3876-421c-89f0-0b025bfb762b.json
+++ b/change/@azure-msal-angular-34d95922-3876-421c-89f0-0b025bfb762b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update MSAL Service handleRedirectObservable hash handling (#3243)",
+  "packageName": "@azure/msal-angular",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/src/msal.service.spec.ts
+++ b/lib/msal-angular/src/msal.service.spec.ts
@@ -272,7 +272,7 @@ describe('MsalService', () => {
     });
   });
 
-  describe("handleRedirectObservable", () => {
+  fdescribe("handleRedirectObservable", () => {
     it("success", (done) => {
       const sampleAccessToken = {
         accessToken: "123abc"
@@ -309,6 +309,28 @@ describe('MsalService', () => {
             expect(PublicClientApplication.prototype.handleRedirectPromise).toHaveBeenCalled();
             done();
           }
+        });
+    });
+
+    it("called with hash", (done) => {
+      const sampleAccessToken = {
+        accessToken: "123abc"
+      };
+
+      const hash = '#/test';
+
+      spyOn(PublicClientApplication.prototype, "handleRedirectPromise").and.returnValue((
+        new Promise((resolve) => {
+          //@ts-ignore
+          resolve(sampleAccessToken);
+        })
+      ));
+
+      authService.handleRedirectObservable(hash)
+        .subscribe((response: AuthenticationResult) => {
+          expect(response.accessToken).toBe(sampleAccessToken.accessToken);
+          expect(PublicClientApplication.prototype.handleRedirectPromise).toHaveBeenCalledWith(hash);
+          done();
         });
     });
 

--- a/lib/msal-angular/src/msal.service.spec.ts
+++ b/lib/msal-angular/src/msal.service.spec.ts
@@ -272,7 +272,7 @@ describe('MsalService', () => {
     });
   });
 
-  fdescribe("handleRedirectObservable", () => {
+  describe("handleRedirectObservable", () => {
     it("success", (done) => {
       const sampleAccessToken = {
         accessToken: "123abc"

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -47,8 +47,7 @@ export class MsalService implements IMsalService {
         return from(this.instance.acquireTokenSilent(silentRequest));
     }
     handleRedirectObservable(hash?: string): Observable<AuthenticationResult> {
-        const handleRedirect = from(this.instance.handleRedirectPromise(hash || this.redirectHash));
-        return handleRedirect;
+        return from(this.instance.handleRedirectPromise(hash || this.redirectHash));
     }
     loginPopup(request?: PopupRequest): Observable<AuthenticationResult> {
         return from(this.instance.loginPopup(request));

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -46,9 +46,8 @@ export class MsalService implements IMsalService {
     acquireTokenSilent(silentRequest: SilentRequest): Observable<AuthenticationResult> {
         return from(this.instance.acquireTokenSilent(silentRequest));
     }
-    handleRedirectObservable(): Observable<AuthenticationResult> {
-        const handleRedirect = from(this.instance.handleRedirectPromise(this.redirectHash));
-        this.redirectHash = "";
+    handleRedirectObservable(hash?: string): Observable<AuthenticationResult> {
+        const handleRedirect = from(this.instance.handleRedirectPromise(hash || this.redirectHash));
         return handleRedirect;
     }
     loginPopup(request?: PopupRequest): Observable<AuthenticationResult> {


### PR DESCRIPTION
This PR updates `handleRedirectObservable` in the MsalService. The previous code was clearing the `redirectHash` and was causing problems with caching when `handleRedirectObservable` is called multiple times. This change also allows an optional hash to be passed in to `handleRedirectObservable` if necessary.