### PR TITLE
Update B2C docs with ClientId workaround

### DIFF
--- a/change/@azure-msal-browser-d3c10e55-3c44-480c-9389-d20067eed81e.json
+++ b/change/@azure-msal-browser-d3c10e55-3c44-480c-9389-d20067eed81e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Doc Updates #3287",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-browser/docs/working-with-b2c.md
+++ b/lib/msal-browser/docs/working-with-b2c.md
@@ -67,9 +67,7 @@ A user's B2C authentication cannot be used to authorize to AAD protected apps, o
 
 ### OpenID Connect Permissions
 
-The exception to the rule above comes from a special set of scopes known as **OpenID Connect** (OIDC) permissions, which includes `openid` and `profile`. Another special permission is the `offline_access`, which gives your app access to a resources on behalf of the user for an extended time (using a **Refresh Token**). MSAL.js will supply `openid`, and `profile` by default during `loginPopup()` and `loginRedirect()` requests.
-
-> :information_source: At the moment, `offline_access` must be added to scopes when requesting a token from B2C endpoint. If you're reasonably certain that the token is valid and available in the cache then you may omit `offline_access` in an `acquireTokenSilent()` call in order to retrieve the **Access Token** from the cache. However, when the token must be renewed you must make sure to include `offline_access`.
+The exception to the rule above comes from a special set of scopes known as **OpenID Connect** (OIDC) permissions, which includes `openid` and `profile`. Another special permission is the `offline_access`, which gives your app access to a resources on behalf of the user for an extended time (using a **Refresh Token**). MSAL.js will supply `openid`, `profile` and `offline_access` by default during `loginPopup()` and `loginRedirect()` requests.
 
 ### AAD Authentication against a B2C Tenant
 
@@ -98,6 +96,30 @@ During application registration, you are prompted to select an **audience**. The
 | #1               | Accounts in this organizational directory only (single tenant)    | AAD Authentication  |
 | #2               | Accounts in any organizational directory (multi-tenant).          | AAD Authentication  |
 | #3               | Accounts in any organizational directory or any identity provider | B2C Authentication  |
+
+### Acquiring an access token for your own API
+
+There are 2 ways to acquire an access token for your own API: 
+
+1. Request your clientId as a scope:
+
+```javascript
+msal.loginRedirect({
+    scopes: ["client_Id"]
+});
+```
+
+Read more [here](https://docs.microsoft.com/en-us/azure/active-directory-b2c/authorization-code-flow#2-get-an-access-token)
+
+Note: Currently there is a known issue where the B2C service responds with the scope "/" which prevents MSAL caching from working properly when requesting clientId as a scope. Currently option 2 is the recommended approach to ensure caching works. Track issue [#2451](#2451) for a resolution to this issue.
+
+2. Expose your own custom scope on your app registration and request this scope:
+
+```javascript
+msal.loginRedirect({
+    scopes: ["api://clientId/customScope.Read"]
+});
+```
 
 ### B2C and Sign-out Experience
 


### PR DESCRIPTION
Updates working with B2C doc to remove outdated information and adds note about known issue with passing clientId as scope