### PR TITLE
Increase device code tests timeout

### DIFF
--- a/samples/msal-node-samples/device-code/test/device-code-aad.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-aad.spec.ts
@@ -33,7 +33,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 const config = require("../config/AAD.json");
 
 describe('Device Code AAD PPE Tests', () => {
-    jest.setTimeout(20000);
+    jest.setTimeout(25000);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
@@ -32,7 +32,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 const config = require("../config/ADFS.json");
 
 describe('Device Code ADFS PPE Tests', () => {
-    jest.setTimeout(20000);
+    jest.setTimeout(25000);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;


### PR DESCRIPTION
This PR adds 5 seconds to the jest timeout for device code tests that are currently timing out intermittently