### PR TITLE
Export EventPopup and fix event type casting in msal-angular samples

### DIFF
--- a/change/@azure-msal-angular-8e4f15fb-20b5-442a-97c4-a5bff75e8292.json
+++ b/change/@azure-msal-angular-8e4f15fb-20b5-442a-97c4-a5bff75e8292.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update samples and docs with event payload typecasting #3360",
+  "packageName": "@azure/msal-angular",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-browser-556df87b-50db-4e57-9008-07cbeac3c298.json
+++ b/change/@azure-msal-browser-556df87b-50db-4e57-9008-07cbeac3c298.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export PopupEvent #3360",
+  "packageName": "@azure/msal-browser",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/docs/v2-docs/events.md
+++ b/lib/msal-angular/docs/v2-docs/events.md
@@ -28,7 +28,7 @@ export class AppComponent implements OnInit, OnDestroy {
         filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_SUCCESS), 
         takeUntil(this._destroying$)
       )
-      .subscribe((result) => {
+      .subscribe((result: EventMessage) => {
         // Do something with the result
       });
   }
@@ -40,8 +40,25 @@ export class AppComponent implements OnInit, OnDestroy {
 }
 ```
 
+Note that you may need to cast the `result.payload` as a specific type to prevent compilation errors. The payload type will depend on the event, and can be found in our documentation [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/events.md).
 
-For the full example of using events, please see our sample [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular10-sample-app/src/app/app.component.ts#L29).
+```javascript
+ngOnInit(): void {
+  this.msalBroadcastService.msalSubject$
+    .pipe(
+      filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_SUCCESS),
+    )
+    .subscribe((result: EventMessage) => {
+      // Casting payload as AuthenticationResult to access account
+      const payload = result.payload as AuthenticationResult;
+      this.authService.instance.setActiveAccount(payload.account);
+    });
+}
+```
+
+
+
+For the full example of using events, please see our sample [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/d46c4455243bd51767f669a13fbb717d786c6716/samples/msal-angular-v2-samples/angular11-sample-app/src/app/home/home.component.ts#L17).
 
 ## Table of events
 

--- a/lib/msal-browser/docs/events.md
+++ b/lib/msal-browser/docs/events.md
@@ -15,7 +15,7 @@ export type EventMessage = {
 
 The payload and error in `EventMessage` are defined as follows: 
 ```javascript
-export type EventPayload = PopupRequest | RedirectRequest | SilentRequest | SsoSilentRequest | EndSessionRequest | AuthenticationResult | null;
+export type EventPayload = PopupRequest | RedirectRequest | SilentRequest | SsoSilentRequest | EndSessionRequest | AuthenticationResult | PopupEvent | null;
 
 export type EventError = AuthError | Error | null;
 ```

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -31,7 +31,7 @@ export { EndSessionPopupRequest } from "./request/EndSessionPopupRequest";
 export { AuthorizationUrlRequest } from "./request/AuthorizationUrlRequest";
 
 // Events
-export { EventMessage, EventPayload, EventError, EventCallbackFunction, EventMessageUtils } from "./event/EventMessage";
+export { EventMessage, EventPayload, EventError, EventCallbackFunction, EventMessageUtils, PopupEvent } from "./event/EventMessage";
 export { EventType } from "./event/EventType";
 
 // Common Object Formats

--- a/samples/msal-angular-v2-samples/angular10-sample-app/src/app/home/home.component.ts
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/src/app/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MsalBroadcastService, MsalService } from '@azure/msal-angular';
-import { EventMessage, EventType } from '@azure/msal-browser';
+import { AuthenticationResult, EventMessage, EventType } from '@azure/msal-browser';
 import { filter } from 'rxjs/operators';
 
 @Component({
@@ -20,9 +20,8 @@ export class HomeComponent implements OnInit {
       )
       .subscribe((result: EventMessage) => {
         console.log(result);
-        if (result?.payload?.account) {
-          this.authService.instance.setActiveAccount(result.payload.account);
-        }
+        const payload = result.payload as AuthenticationResult;
+        this.authService.instance.setActiveAccount(payload.account);
       });
 
     this.setLoginDisplay();

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/home/home.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MsalBroadcastService, MsalService } from '@azure/msal-angular';
-import { EventMessage, EventType } from '@azure/msal-browser';
+import { AuthenticationResult, EventMessage, EventType } from '@azure/msal-browser';
 import { filter } from 'rxjs/operators';
 
 @Component({
@@ -21,9 +21,8 @@ export class HomeComponent implements OnInit {
       .subscribe({
         next: (result: EventMessage) => {
           console.log(result);
-          if (result?.payload?.account) {
-            this.authService.instance.setActiveAccount(result.payload.account);
-          }
+          const payload = result.payload as AuthenticationResult;
+          this.authService.instance.setActiveAccount(payload.account);
         },
         error: (error) => console.log(error)
       });

--- a/samples/msal-angular-v2-samples/angular11-sample-app/src/app/home/home.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/src/app/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MsalBroadcastService, MsalService } from '@azure/msal-angular';
-import { EventMessage, EventType } from '@azure/msal-browser';
+import { AuthenticationResult, EventMessage, EventType } from '@azure/msal-browser';
 import { filter } from 'rxjs/operators';
 
 @Component({
@@ -20,9 +20,8 @@ export class HomeComponent implements OnInit {
       )
       .subscribe((result: EventMessage) => {
         console.log(result);
-        if (result?.payload?.account) {
-          this.authService.instance.setActiveAccount(result.payload.account);
-        }
+        const payload = result.payload as AuthenticationResult;
+        this.authService.instance.setActiveAccount(payload.account);
       });
     
     this.setLoginDisplay();


### PR DESCRIPTION
This PR:
- Exports `PopupEvent` from msal-browser
- Updates msal-browser docs to include `PopupEvent`
- Updates msal-angular samples to cast event payload to correct types (fixes CI test failures)
- Updates msal-angular event docs to include casting examples and instructions