### PR TITLE
Add angular-eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,15 +14,31 @@
         "react"
     ],
     "extends": [
+        "plugin:@angular-eslint/base",
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:react/recommended",
         "plugin:react-hooks/recommended",
         "plugin:security/recommended",
-        "plugin:import/typescript",
-        "plugin:@angular-eslint/base"
+        "plugin:import/typescript"
     ],
     "rules": {
+        "@angular-eslint/component-class-suffix": 2,
+        "@angular-eslint/contextual-lifecycle": 2,
+        "@angular-eslint/directive-class-suffix": 2,
+        "@angular-eslint/no-attribute-decorator": 1,
+        "@angular-eslint/no-conflicting-lifecycle": 2,
+        "@angular-eslint/no-empty-lifecycle-method": 2,
+        "@angular-eslint/no-host-metadata-property": 2,
+        "@angular-eslint/no-input-rename": 2,
+        "@angular-eslint/no-inputs-metadata-property": 2,
+        "@angular-eslint/no-output-native": 2,
+        "@angular-eslint/no-output-on-prefix": 2,
+        "@angular-eslint/no-output-rename": 2,
+        "@angular-eslint/no-outputs-metadata-property": 2,
+        "@angular-eslint/no-pipe-impure": 1,
+        "@angular-eslint/use-lifecycle-interface": 1,
+        "@angular-eslint/use-pipe-transform-interface": 2,
         "@typescript-eslint/array-type": 0,
         "@typescript-eslint/ban-ts-comment": 1,
         "@typescript-eslint/ban-types": 0,
@@ -69,23 +85,7 @@
         "react/no-string-refs": 2,
         "react/prefer-stateless-function": 2,
         "react/self-closing-comp": 2,
-        "react/sort-comp": 2,
-        "@angular-eslint/component-class-suffix": 2,
-        "@angular-eslint/contextual-lifecycle": 2,
-        "@angular-eslint/directive-class-suffix": 2,
-        "@angular-eslint/no-attribute-decorator": 1,
-        "@angular-eslint/no-conflicting-lifecycle": 2,
-        "@angular-eslint/no-empty-lifecycle-method": 2,
-        "@angular-eslint/no-host-metadata-property": 2,
-        "@angular-eslint/no-input-rename": 2,
-        "@angular-eslint/no-inputs-metadata-property": 2,
-        "@angular-eslint/no-output-native": 2,
-        "@angular-eslint/no-output-on-prefix": 2,
-        "@angular-eslint/no-output-rename": 2,
-        "@angular-eslint/no-outputs-metadata-property": 2,
-        "@angular-eslint/no-pipe-impure": 1,
-        "@angular-eslint/use-lifecycle-interface": 1,
-        "@angular-eslint/use-pipe-transform-interface": 2
+        "react/sort-comp": 2
     },
     "settings": {
         "react": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,8 @@
         "plugin:react/recommended",
         "plugin:react-hooks/recommended",
         "plugin:security/recommended",
-        "plugin:import/typescript"
+        "plugin:import/typescript",
+        "plugin:@angular-eslint/base"
     ],
     "rules": {
         "@typescript-eslint/array-type": 0,
@@ -68,7 +69,23 @@
         "react/no-string-refs": 2,
         "react/prefer-stateless-function": 2,
         "react/self-closing-comp": 2,
-        "react/sort-comp": 2
+        "react/sort-comp": 2,
+        "@angular-eslint/component-class-suffix": 2,
+        "@angular-eslint/contextual-lifecycle": 2,
+        "@angular-eslint/directive-class-suffix": 2,
+        "@angular-eslint/no-attribute-decorator": 1,
+        "@angular-eslint/no-conflicting-lifecycle": 2,
+        "@angular-eslint/no-empty-lifecycle-method": 2,
+        "@angular-eslint/no-host-metadata-property": 2,
+        "@angular-eslint/no-input-rename": 2,
+        "@angular-eslint/no-inputs-metadata-property": 2,
+        "@angular-eslint/no-output-native": 2,
+        "@angular-eslint/no-output-on-prefix": 2,
+        "@angular-eslint/no-output-rename": 2,
+        "@angular-eslint/no-outputs-metadata-property": 2,
+        "@angular-eslint/no-pipe-impure": 1,
+        "@angular-eslint/use-lifecycle-interface": 1,
+        "@angular-eslint/use-pipe-transform-interface": 2
     },
     "settings": {
         "react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,208 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@angular-eslint/eslint-plugin": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-2.0.2.tgz",
+      "integrity": "sha512-/hJNXUjPEXwsmXeWneAW7X3Jg+JwsMavQ8eQ4UevcaKx4Ozthh09n6oyegqc82Y48Adcce7KyalGCKmWY19piA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "4.16.1"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+          "dev": true
+        },
+        "@typescript-eslint/experimental-utils": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.16.1.tgz",
+          "integrity": "sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/scope-manager": "4.16.1",
+            "@typescript-eslint/types": "4.16.1",
+            "@typescript-eslint/typescript-estree": "4.16.1",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.16.1.tgz",
+          "integrity": "sha512-6IlZv9JaurqV0jkEg923cV49aAn8V6+1H1DRfhRcvZUrptQ+UtSKHb5kwTayzOYTJJ/RsYZdcvhOEKiBLyc0Cw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.16.1",
+            "@typescript-eslint/visitor-keys": "4.16.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.16.1.tgz",
+          "integrity": "sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.16.1.tgz",
+          "integrity": "sha512-m8I/DKHa8YbeHt31T+UGd/l8Kwr0XCTCZL3H4HMvvLCT7HU9V7yYdinTOv1gf/zfqNeDcCgaFH2BMsS8x6NvJg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.16.1",
+            "@typescript-eslint/visitor-keys": "4.16.1",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.16.1.tgz",
+          "integrity": "sha512-s/aIP1XcMkEqCNcPQtl60ogUYjSM8FU2mq1O7y5cFf3Xcob1z1iXWNB6cC43Op+NGRTFgGolri6s8z/efA9i1w==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.16.1",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "@angular/compiler": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-11.2.8.tgz",
+      "integrity": "sha512-m2BXvXfp286BZY7tvRLqszXTfs7szb41HhmEmuAIjfDIDSIk79pUAYB3A3RrgOTin9aeNVW397apyICNrvG8zA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "devDependencies": {
     "@angular-eslint/eslint-plugin": "^2.0.2",
+    "@angular/compiler": "^11.2.8",
     "@babel/core": "^7.7.2",
     "@babel/plugin-proposal-class-properties": "^7.7.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "microsoft-authentication-libraries-for-js",
   "private": true,
   "devDependencies": {
+    "@angular-eslint/eslint-plugin": "^2.0.2",
     "@babel/core": "^7.7.2",
     "@babel/plugin-proposal-class-properties": "^7.7.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",


### PR DESCRIPTION
This PR adds Angular-specific lint rules to MSAL to lint msal-angular.

See [angular-eslint](https://github.com/angular-eslint/angular-eslint) for more details. [Base](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/configs/base.json) and [recommended rules](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/configs/recommended.json) added.