### PR TITLE
Update docs to clarify RT lifetime

### DIFF
--- a/change/@azure-msal-browser-37bc3bd2-2a8d-42ff-8b42-82a2ac1ab5f0.json
+++ b/change/@azure-msal-browser-37bc3bd2-2a8d-42ff-8b42-82a2ac1ab5f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Docs update",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-browser/docs/token-lifetimes.md
+++ b/lib/msal-browser/docs/token-lifetimes.md
@@ -18,7 +18,7 @@ Access tokens in the browser have a default recommended expiration of 1 hour. Af
 
 ### Refresh tokens
 
-Refresh tokens given to Single-Page Applications are limited-time refresh tokens (usually 24 hours from the time of retrieval). This is a non-adjustable lifetime. Whenever a refresh token is used to renew an access token, a new refresh token is fetched with the renewed access token. Once a refresh token has expired, a new authorization code flow must be initiated to retrieve an authorization code and trade it for a new set of tokens. (TODO: Add docs for RT here)
+Refresh tokens given to Single-Page Applications are limited-time refresh tokens (usually 24 hours from the time of retrieval). This is a non-adjustable, non-sliding window, lifetime. Whenever a refresh token is used to renew an access token, a new refresh token is fetched with the renewed access token. This new refresh token will have a lifetime equal to the remaining lifetime of the original refresh token. Once a refresh token has expired, a new authorization code flow must be initiated to retrieve an authorization code and trade it for a new set of tokens.
 
 ## Token Renewal
 

--- a/lib/msal-browser/docs/token-lifetimes.md
+++ b/lib/msal-browser/docs/token-lifetimes.md
@@ -20,6 +20,8 @@ Access tokens in the browser have a default recommended expiration of 1 hour. Af
 
 Refresh tokens given to Single-Page Applications are limited-time refresh tokens (usually 24 hours from the time of retrieval). This is a non-adjustable, non-sliding window, lifetime. Whenever a refresh token is used to renew an access token, a new refresh token is fetched with the renewed access token. This new refresh token will have a lifetime equal to the remaining lifetime of the original refresh token. Once a refresh token has expired, a new authorization code flow must be initiated to retrieve an authorization code and trade it for a new set of tokens.
 
+Note: When a new refresh token is obtained, msal.js replaces the cached refresh token with the new refresh token, however the old refresh token is not invalidated by the server and may still be used to obtain access tokens until its expiration.
+
 ## Token Renewal
 
 The `PublicClientApplication` object exposes an API called `acquireTokenSilent` which is meant to retrieve non-expired token silently. It does this in a few steps:


### PR DESCRIPTION
Received some feedback that the wording in the docs around refresh token renewal was confusing. Making this more explicit.