### PR TITLE
Fix bug in issue bot

### DIFF
--- a/.github/actions/issue_template_bot/dist/index.js
+++ b/.github/actions/issue_template_bot/dist/index.js
@@ -13382,8 +13382,8 @@ async function run() {
         core.debug(`Issue Payload: ${JSON.stringify(payload)}`);
     }
     catch (e) { }
-    if (!!payload.changes.old_issue) {
-        core.setFailed("This issue was transferred from another repository. Skipping.");
+    if (payload.changes && !!payload.changes.old_issue) {
+        core.info("This issue was transferred from another repository. Skipping.");
         return;
     }
     const issue = payload.issue;

--- a/.github/actions/issue_template_bot/main/index.ts
+++ b/.github/actions/issue_template_bot/main/index.ts
@@ -25,8 +25,8 @@ async function run() {
         core.debug(`Issue Payload: ${JSON.stringify(payload)}`);
     } catch (e) {}
 
-    if (!!payload.changes.old_issue) {
-        core.setFailed("This issue was transferred from another repository. Skipping.");
+    if (payload.changes && !!payload.changes.old_issue) {
+        core.info("This issue was transferred from another repository. Skipping.");
         return;
     }
 


### PR DESCRIPTION
Fixes error thrown when payload doesn't contain `changes` property (this was added last week to prevent parsing issues transferred from another repo)