### PR TITLE
Encode control characters in cookies set by MSAL.js v1

### DIFF
--- a/change/msal-ba6e8b60-d254-4653-ae66-605a883bebac.json
+++ b/change/msal-ba6e8b60-d254-4653-ae66-605a883bebac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Encode control characters in cookies set by MSAL.js v1",
+  "packageName": "msal",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/msal-ba6e8b60-d254-4653-ae66-605a883bebac.json
+++ b/change/msal-ba6e8b60-d254-4653-ae66-605a883bebac.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Encode control characters in cookies set by MSAL.js v1",
+  "comment": "Encode control characters in cookies set by MSAL.js v1 #3469",
   "packageName": "msal",
   "email": "janutter@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-core/src/cache/BrowserStorage.ts
+++ b/lib/msal-core/src/cache/BrowserStorage.ts
@@ -73,7 +73,7 @@ export class BrowserStorage {// Singleton
      * @param expires
      */
     setItemCookie(cName: string, cValue: string, expires?: number): void {
-        let cookieStr = cName + "=" + cValue + ";path=/;";
+        let cookieStr = encodeURIComponent(cName) + "=" + encodeURIComponent(cValue) + ";path=/;";
         if (expires) {
             const expireTime = this.getCookieExpirationTime(expires);
             cookieStr += "expires=" + expireTime + ";";
@@ -87,7 +87,7 @@ export class BrowserStorage {// Singleton
      * @param cName
      */
     getItemCookie(cName: string): string {
-        const name = cName + "=";
+        const name = encodeURIComponent(cName) + "=";
         const ca = document.cookie.split(";");
         for (let i = 0; i < ca.length; i++) {
             let c = ca[i];
@@ -95,7 +95,7 @@ export class BrowserStorage {// Singleton
                 c = c.substring(1);
             }
             if (c.indexOf(name) === 0) {
-                return c.substring(name.length, c.length);
+                return decodeURIComponent(c.substring(name.length, c.length));
             }
         }
         return "";

--- a/lib/msal-core/test/Storage.localStorage.spec.ts
+++ b/lib/msal-core/test/Storage.localStorage.spec.ts
@@ -162,6 +162,17 @@ describe("CacheStorage.ts Class - Local Storage", function () {
             cacheStorage.clearItemCookie(`${AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.NONCE_IDTOKEN, TEST_STATE)}`);
         });
 
+        it("setItemCookie and getItemCookie properly escape control characters", () => {
+            const cookieName = "cookie|name|\r|";
+            const cookieValue = "cookie|value|\n|";
+            cacheStorage.setItemCookie(cookieName, cookieValue);
+            let storedCookieValue = cacheStorage.getItemCookie(cookieName);
+            expect(document.cookie).to.include(escape(cookieName));
+            expect(document.cookie).to.include(escape(cookieValue));
+            expect(storedCookieValue).to.equal(cookieValue);
+            cacheStorage.clearItemCookie(cookieName);
+        });
+
         it("tests getCookieExpirationTime", function () {
             // 86400000 ms = 1 day
             let nextDayUTC = new Date(Date.now() + 86400000);

--- a/lib/msal-core/test/Storage.localStorage.spec.ts
+++ b/lib/msal-core/test/Storage.localStorage.spec.ts
@@ -149,7 +149,7 @@ describe("CacheStorage.ts Class - Local Storage", function () {
         it("tests setItemCookie works", function () {
             let idTokenNonceString = "idTokenNonce";
             cacheStorage.setItemCookie(`${AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.NONCE_IDTOKEN, TEST_STATE)}`, idTokenNonceString);
-            expect(document.cookie).to.include(`${AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.NONCE_IDTOKEN, TEST_STATE)}`);
+            expect(document.cookie).to.include(encodeURIComponent(`${AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.NONCE_IDTOKEN, TEST_STATE)}`));
             expect(document.cookie).to.include(idTokenNonceString);
             cacheStorage.clearItemCookie(`${AuthCache.generateTemporaryCacheKey(TemporaryCacheKeys.NONCE_IDTOKEN, TEST_STATE)}`);
         });
@@ -167,8 +167,8 @@ describe("CacheStorage.ts Class - Local Storage", function () {
             const cookieValue = "cookie|value|\n|";
             cacheStorage.setItemCookie(cookieName, cookieValue);
             let storedCookieValue = cacheStorage.getItemCookie(cookieName);
-            expect(document.cookie).to.include(escape(cookieName));
-            expect(document.cookie).to.include(escape(cookieValue));
+            expect(document.cookie).to.include(encodeURIComponent(cookieName));
+            expect(document.cookie).to.include(encodeURIComponent(cookieValue));
             expect(storedCookieValue).to.equal(cookieValue);
             cacheStorage.clearItemCookie(cookieName);
         });

--- a/lib/msal-core/test/Storage.sessionStorage.spec.ts
+++ b/lib/msal-core/test/Storage.sessionStorage.spec.ts
@@ -149,7 +149,7 @@ describe("CacheStorage.ts Class - Session Storage", function () {
         it("tests setItemCookie works", function () {
             let idTokenNonceString = "idTokenNonce";
             cacheStorage.setItemCookie(`${TemporaryCacheKeys.NONCE_IDTOKEN}|RANDOM_GUID`, idTokenNonceString);
-            expect(document.cookie).to.include(`${TemporaryCacheKeys.NONCE_IDTOKEN}|RANDOM_GUID`);
+            expect(document.cookie).to.include(encodeURIComponent(`${TemporaryCacheKeys.NONCE_IDTOKEN}|RANDOM_GUID`));
             expect(document.cookie).to.include(idTokenNonceString);
             cacheStorage.clearItemCookie(`${TemporaryCacheKeys.NONCE_IDTOKEN}|RANDOM_GUID`);
         });


### PR DESCRIPTION
Ensures cookie names and values are encoded to prevent control characters from being sent to servers.

Should match v2 implementation: https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/789428d8fd6fc6c69656e9f0802a874fa09d1d07/lib/msal-browser/src/cache/BrowserCacheManager.ts#L500-L531