### PR TITLE
Remove B2C empty access token workaround

### DIFF
--- a/change/@azure-msal-browser-c4954852-5365-4234-bd2f-74bd57bbc04a.json
+++ b/change/@azure-msal-browser-c4954852-5365-4234-bd2f-74bd57bbc04a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Documentation Updates #3499",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-browser/FAQ.md
+++ b/lib/msal-browser/FAQ.md
@@ -253,45 +253,6 @@ You can read more about this behavior [here](https://docs.microsoft.com/azure/ac
 
 MSAL.js will only process tokens which it originally requested. If your flow requires that you send a user a link they can use to sign up, you will need to ensure that the link points to your app, not the B2C service directly. An example flow can be seen in the [working with B2C](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/working-with-b2c.md) doc.
 
-## Why is there no access token returned from `acquireTokenSilent`?
-
-Azure AD B2C currently requires refresh tokens to be redeemed with the same scopes that were requested when the refresh token is first obtained. If your application requires different behavior, workarounds include: 
-
-#### If your application only needs to support 1 set of scopes: 
-
-Please ensure that these scopes are requested as part of the `loginPopup`,`loginRedirect` or `ssoSilent` call made prior to calling `acquireTokenSilent`. This ensures the refresh token is issued for the scopes you need.
-
-#### If your application needs to support more than 1 set of scopes:
-
-Include the first set of scopes in `loginPopup`, `loginRedirect` or `ssoSilent` then make another call to `acquireTokenRedirect`, `acquireTokenPopup` or `ssoSilent` containing your 2nd set of scopes. Until the access tokens expire, `acquireTokenSilent` will return either token from the cache. Once an access token is expired, one of the interactive APIs will need to be called again. This is an example of how you can handle this scenario:
-
-```javascript
-// Initial acquisition of scopes 1 and 2
-await msal.loginPopup({scopes: ["scope1"]});
-const account = msal.getAllAccounts()[0];
-await msal.ssoSilent({
-    scopes: ["scope2"],
-    loginHint: account.username
-});
-
-// Subsequent token acquisition with fallback
-msal.acquireTokenSilent({
-    scopes: ["scope1"],
-    account: account
-}).then((response) => {
-    if (!response.accessToken) {
-        return msal.ssoSilent({
-            scopes: ["scope1"],
-            loginHint: account.username
-        });
-    } else {
-        return response;
-    }
-});
-```
-
-:warning: `ssoSilent` will not work in browsers that disable 3rd party cookies, such as Safari. If you need to support these browsers, call `acquireTokenRedirect` or `acquireTokenPopup`
-
 ## What should I do if I believe my issue is with the B2C service itself rather than with the library
 
 In that case, please file a support ticket with the B2C team by following the instructions here: [B2C support options](https://docs.microsoft.com/azure/active-directory-b2c/support-options).

--- a/lib/msal-browser/docs/working-with-b2c.md
+++ b/lib/msal-browser/docs/working-with-b2c.md
@@ -111,8 +111,6 @@ msal.loginRedirect({
 
 Read more [here](https://docs.microsoft.com/en-us/azure/active-directory-b2c/authorization-code-flow#2-get-an-access-token)
 
-Note: Currently there is a known issue where the B2C service responds with the scope "/" which prevents MSAL caching from working properly when requesting clientId as a scope. Currently option 2 is the recommended approach to ensure caching works. Track issue [#2451](#2451) for a resolution to this issue.
-
 2. Expose your own custom scope on your app registration and request this scope:
 
 ```javascript


### PR DESCRIPTION
The empty access token bug on the B2C service has been fixed. This PR removes the workaround from our docs as it's no longer relevant.