### PR TITLE
Prevent MSAL Guard from navigating app to url with code hash

### DIFF
--- a/change/@azure-msal-angular-b0172103-6866-4f25-9d89-4084d829edd3.json
+++ b/change/@azure-msal-angular-b0172103-6866-4f25-9d89-4084d829edd3.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Prevent MSAL Guard from navigating app to url with code hash",
+  "comment": "Prevent MSAL Guard from navigating app to url with code hash #3506",
   "packageName": "@azure/msal-angular",
   "email": "janutter@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-angular-b0172103-6866-4f25-9d89-4084d829edd3.json
+++ b/change/@azure-msal-angular-b0172103-6866-4f25-9d89-4084d829edd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent MSAL Guard from navigating app to url with code hash",
+  "packageName": "@azure/msal-angular",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/docs/v2-docs/known-issues.md
+++ b/lib/msal-angular/docs/v2-docs/known-issues.md
@@ -1,5 +1,8 @@
 # Known issues for MSAL Angular v2
 
+## 2.0.0-beta.4
+* When the MSAL Guard is used on the page used for the redirect URI, the `code=` hash may remain in the url. This is addressed in `2.0.0-beta.5`, expect when the MSAL Guard is used for `canLoad`. To mitigate this issue, applications should not put the MSAL Guard on the page used for the redirect URI.
+
 ## 2.0.0-alpha.3
 * MSAL Guard's `Canload` interface has a return type of `Observable<boolean|UrlTree>`, which is incompatible with the Angular 9 `CanLoad` base type. This is addressed in version `2.0.0-alpha.4`.
 

--- a/lib/msal-angular/docs/v2-docs/known-issues.md
+++ b/lib/msal-angular/docs/v2-docs/known-issues.md
@@ -1,7 +1,7 @@
 # Known issues for MSAL Angular v2
 
 ## 2.0.0-beta.4
-* When the MSAL Guard is used on the page used for the redirect URI, the `code=` hash may remain in the url. This is addressed in `2.0.0-beta.5`, expect when the MSAL Guard is used for `canLoad`. To mitigate this issue, applications should not put the MSAL Guard on the page used for the redirect URI.
+* When the MSAL Guard is used on the page used for the redirect URI, the `code=` hash may remain in the url. This is addressed in `2.0.0-beta.5`, except when the MSAL Guard is used for `canLoad`. To mitigate this issue, applications should not put the MSAL Guard on the page used for the redirect URI.
 
 ## 2.0.0-alpha.3
 * MSAL Guard's `Canload` interface has a return type of `Observable<boolean|UrlTree>`, which is incompatible with the Angular 9 `CanLoad` base type. This is addressed in version `2.0.0-alpha.4`.

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -94,6 +94,30 @@ describe('MsalGuard', () => {
       });
   });
 
+  it("returns false if page contains known successful response", (done) => {
+    spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
+        //@ts-ignore
+        of("test")
+    );
+
+    spyOn(PublicClientApplication.prototype, "getAllAccounts").and.returnValue([{
+        homeAccountId: "test",
+        localAccountId: "test",
+        environment: "test",
+        tenantId: "test",
+        username: "test"
+      }]);
+  
+    guard.canActivate(routeMock, {
+        ...routeStateMock,
+        url: "/#code=test"
+    })
+    .subscribe(result => {
+        expect(result).toBeFalse();
+        done();
+    });
+  });
+
   it("returns true for a logged in user", (done) => {
     spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
       //@ts-ignore

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -135,6 +135,13 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
                     }
 
                     this.authService.getLogger().verbose("Guard - at least 1 account exists, can activate or load");
+
+                    // Prevent navigating the app to /#code=
+                    if (state && state.url.indexOf("#") > -1 && state.url.indexOf("code=") > -1) {
+                        this.authService.getLogger().info("Guard - Hash contains known code response, stopping navigation.");
+                        return of(false);
+                    }
+
                     return of(true);
 
                 }),


### PR DESCRIPTION
When the redirect URI was set to a page with the MSAL Guard, the guard could end up navigating the user to `/#code`, even though it should be cleared from the URL when processing the redirect. This change makes sure the user isn't navigated back to a url with the `#code=` hash response still in the url. 