### PR TITLE
Look for temp cache items in local storage as fallback

### DIFF
--- a/change/@azure-msal-browser-332c1b46-7af3-4c8e-a6d8-d34fc6f729fa.json
+++ b/change/@azure-msal-browser-332c1b46-7af3-4c8e-a6d8-d34fc6f729fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Look for temp cache items in local storage as fallback",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-332c1b46-7af3-4c8e-a6d8-d34fc6f729fa.json
+++ b/change/@azure-msal-browser-332c1b46-7af3-4c8e-a6d8-d34fc6f729fa.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Look for temp cache items in local storage as fallback",
+  "comment": "Look for temp cache items in local storage as fallback #3509",
   "packageName": "@azure/msal-browser",
   "email": "janutter@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -420,6 +420,14 @@ export class BrowserCacheManager extends CacheManager {
 
         const value = this.temporaryCacheStorage.getItem(key);
         if (!value) {
+            // If temp cache item not found in session/memory, check local storage for items set by old versions
+            if (this.cacheConfig.cacheLocation === BrowserCacheLocation.LocalStorage) {
+                const item = this.browserStorage.getItem(key);
+                if (item) {
+                    this.logger.verbose("BrowserCacheManager.getTemporaryCache: Temporary cache item found in local storage");
+                    return item;
+                }
+            }
             return null;
         }
         return value;

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -137,6 +137,15 @@ describe("BrowserCacheManager tests", () => {
             expect(window.sessionStorage.getItem(msalCacheKey2)).to.be.eq(cacheVal);
         });
 
+        it("getTemporaryCache falls back to local storage if not found in session/memory storage", () => {
+            const testTempItemKey = "test-temp-item-key";
+            const testTempItemValue = "test-temp-item-value";
+            window.localStorage.setItem(testTempItemKey, testTempItemValue);
+            cacheConfig.cacheLocation = BrowserCacheLocation.LocalStorage;
+            browserLocalStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig, browserCrypto, logger);
+            expect(browserLocalStorage.getTemporaryCache(testTempItemKey)).equals(testTempItemValue);
+        })
+
         it("setItem", () => {
             window.sessionStorage.setItem(msalCacheKey, cacheVal);
             window.localStorage.setItem(msalCacheKey2, cacheVal);


### PR DESCRIPTION
Since 2.10, temp cache items have been stored in session storage or in memory, instead of local storage (if configured). This can result in unexpected cache misses when upgrading between versions. This change will look in local storage if temp cache items aren't found in session/memory storage.