### PR TITLE
Prevent UnauthenticatedTemplate from rendering when handleRedirectPromise is in progress

### DIFF
--- a/change/@azure-msal-react-ba499dcd-7a30-4bcc-a96f-2d4c127ba56c.json
+++ b/change/@azure-msal-react-ba499dcd-7a30-4bcc-a96f-2d4c127ba56c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent UnauthenticatedTemplate from rendering children while processing redirect response #3552",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-react/package.json
+++ b/lib/msal-react/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build --tsconfig ./tsconfig.build.json",
-    "build:modules:watch": "tsdx watch --verbose",
+    "build:modules:watch": "tsdx watch --verbose --tsconfig ./tsconfig.build.json",
     "test": "tsdx test .*.spec.*",
     "test:watch": "tsdx test .*.spec.* --watch",
     "test:coverage": "tsdx test .*.spec.* --coverage",

--- a/lib/msal-react/src/components/UnauthenticatedTemplate.tsx
+++ b/lib/msal-react/src/components/UnauthenticatedTemplate.tsx
@@ -27,7 +27,7 @@ export function UnauthenticatedTemplate({ username, homeAccountId, localAccountI
     }, [username, homeAccountId, localAccountId]);
     const isAuthenticated = useIsAuthenticated(accountIdentifier);
 
-    if (!isAuthenticated && context.inProgress !== InteractionStatus.Startup) {
+    if (!isAuthenticated && context.inProgress !== InteractionStatus.Startup && context.inProgress !== InteractionStatus.HandleRedirect) {
         return (
             <React.Fragment>
                 {getChildrenOrFunction(children, context)}


### PR DESCRIPTION
When signing in using redirects applications may flash Unauthenticated content momentarily while the redirect response is being processed. This PR fixes this behavior by preventing `UnauthenticatedTemplate` from rendering children until after `handleRedirectPromise` is finished.

Fixes #3538