### PR TITLE
[B2C] replace legacy password-reset flow

### DIFF
--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/README.md
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/README.md
@@ -38,7 +38,9 @@ Open `.src/app/b2c-config.ts` in an editor:
 
 ### How to handle B2C user-flows
 
-Implementing B2C user-flows is a matter of initiating authorization requests against the corresponding authorities. Some user-flows are slightly more complex. For example, to initiate the **forgotPassword**, the user first needs to click on the **forgot my password** link on the Azure sign-in screen, which causes B2C service to respond with an error. We then catch this error, and trigger another sign-in, this time against the `https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_reset` authority (see `.src/app/app-component.ts`).
+Implementing B2C user-flows is a matter of initiating authorization requests against the corresponding authorities. This sample demonstrates [sign-up/sign-in](https://docs.microsoft.com/azure/active-directory-b2c/add-sign-up-and-sign-in-policy?pivots=b2c-user-flow) (with [self-service password reset](https://docs.microsoft.com/azure/active-directory-b2c/add-password-reset-policy?pivots=b2c-user-flow#self-service-password-reset-recommended)) and [edit-profile](https://docs.microsoft.com/azure/active-directory-b2c/add-profile-editing-policy?pivots=b2c-user-flow) user-flows.
+
+> For implementing legacy [password-reset](https://docs.microsoft.com/azure/active-directory-b2c/add-password-reset-policy?pivots=b2c-user-flow#password-reset-policy-legacy) user-flow, which is slightly more complex, see the code sample: [Angular SPA using MSAL-Angular v1 on Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-angular-spa).
 
 ## Additional notes
 

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
@@ -5,9 +5,9 @@ import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { b2cPolicies } from './b2c-config';
 
-interface IdTokenClaims extends AuthenticationResult {
+interface Payload extends AuthenticationResult {
   idTokenClaims: {
-    acr?: string
+    tfp?: string
   }
 }
 
@@ -46,44 +46,20 @@ export class AppComponent implements OnInit, OnDestroy {
         takeUntil(this._destroying$)
       )
       .subscribe((result: EventMessage) => {
-      
-        let payload: IdTokenClaims = <AuthenticationResult>result.payload;
 
-        // We need to reject id tokens that were not issued with the default sign-in policy.
-        // "acr" claim in the token tells us what policy is used (NOTE: for new policies (v2.0), use "tfp" instead of "acr")
-        // To learn more about b2c tokens, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
+        let payload: Payload = <AuthenticationResult>result.payload;
 
-        if (payload.idTokenClaims?.acr === b2cPolicies.names.forgotPassword) {
-          window.alert('Password has been reset successfully. \nPlease sign-in with your new password.');
-          return this.authService.logout();
-        } else if (payload.idTokenClaims['acr'] === b2cPolicies.names.editProfile) {
+        /**
+         * For the purpose of setting an active account for UI update, we want to consider only the auth response resulting
+         * from SUSI flow. "tfp" claim in the id token tells us the policy (NOTE: legacy policies may use "acr" instead of "tfp").
+         * To learn more about B2C tokens, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
+         */
+        if (payload.idTokenClaims['tfp'] === b2cPolicies.names.editProfile) {
           window.alert('Profile has been updated successfully. \nPlease sign-in again.');
-          return this.authService.logout();
+          return this.logout();
         }
 
         return result;
-      });
-
-      this.msalBroadcastService.msalSubject$
-      .pipe(
-        filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_FAILURE || msg.eventType === EventType.ACQUIRE_TOKEN_FAILURE),
-        takeUntil(this._destroying$)
-      )
-      .subscribe((result: EventMessage) => {
-        if (result.error instanceof AuthError) {
-          // Check for forgot password error
-          // Learn more about AAD error codes at https://docs.microsoft.com/azure/active-directory/develop/reference-aadsts-error-codes
-          if (result.error.message.includes('AADB2C90118')) {
-            
-            // login request with reset authority
-            let resetPasswordFlowRequest = {
-              scopes: ["openid"],
-              authority: b2cPolicies.authorities.forgotPassword.authority,
-            };
-
-            this.login(resetPasswordFlowRequest);
-          }
-        }
       });
   }
 

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/b2c-config.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/b2c-config.ts
@@ -1,34 +1,30 @@
 
 /**
- * Enter here the user flows and custom policies for your B2C application,
- * To learn more about user flows, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/user-flow-overview
- * To learn more about custom policies, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/custom-policy-overview
+ * Enter here the user flows and custom policies for your B2C application
+ * To learn more about user flows, visit: https://docs.microsoft.com/en-us/azure/active-directory-b2c/user-flow-overview
+ * To learn more about custom policies, visit: https://docs.microsoft.com/en-us/azure/active-directory-b2c/custom-policy-overview
  */
 export const b2cPolicies = {
     names: {
-        signUpSignIn: "b2c_1_susi",
-        forgotPassword: "b2c_1_reset",
-        editProfile: "b2c_1_edit_profile"
+        signUpSignIn: "B2C_1_susi_reset_v2",
+        editProfile: "B2C_1_edit_profile_v2"
     },
     authorities: {
         signUpSignIn: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
-        },
-        forgotPassword: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_reset",
+            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_susi_reset_v2",
         },
         editProfile: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_edit_profile"
+            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_edit_profile_v2"
         }
     },
     authorityDomain: "fabrikamb2c.b2clogin.com"
-};
+}
 
 /**
- * Enter here the coordinates of your Web API and scopes for access token request
+ * Enter here the coordinates of your web API and scopes for access token request
  * The current application coordinates were pre-registered in a B2C tenant.
  */
-export const apiConfig: {scopes: string[]; uri: string} = {
+export const apiConfig: { scopes: string[]; uri: string } = {
     scopes: ['https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read'],
     uri: 'https://fabrikamb2chello.azurewebsites.net/hello'
 };

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/profile/profile.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/profile/profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { apiConfig } from '../b2c-config';
 

--- a/samples/msal-node-samples/b2c-auth-code-pkce/index.js
+++ b/samples/msal-node-samples/b2c-auth-code-pkce/index.js
@@ -54,7 +54,6 @@ const SCOPES = {
 const APP_STATES = {
     login: "login",
     call_api: "call_api",
-    password_reset: "password_reset",
 }
 
 /** 
@@ -129,10 +128,10 @@ const getAuthCode = (authority, scopes, state, res) => {
         app.locals.pkceCodes.verifier = verifier;
         app.locals.pkceCodes.challenge = challenge;
 
-        // Add PKCE code challenge and challenge method to authCodeUrl request objectgit st
+        // Add PKCE code challenge and challenge method to authCodeUrl request object
         authCodeRequest.codeChallenge = app.locals.pkceCodes.challenge;
         authCodeRequest.codeChallengeMethod = app.locals.pkceCodes.challengeMethod;
-        // Get url to sign user in and consent to scopes needed for applicatio
+        // Get url to sign user in and consent to scopes needed for application
         pca.getAuthCodeUrl(authCodeRequest).then((response) => {
             res.redirect(response);
         }).catch((error) => console.log(JSON.stringify(error)));
@@ -148,19 +147,8 @@ app.get("/", (req, res) => {
 
 // Initiates auth code grant for login
 app.get("/login", (req, res) => {
-    if (authCodeRequest.state === APP_STATES.password_reset) {
-        // if coming for password reset, set the authority to password reset
-        getAuthCode(policies.authorities.resetPassword.authority, SCOPES.oidc, APP_STATES.password_reset, res);
-    } else {
-        // else, login as usual
-        getAuthCode(policies.authorities.signUpSignIn.authority, SCOPES.oidc, APP_STATES.login, res);
-    }
+    getAuthCode(policies.authorities.signUpSignIn.authority, SCOPES.oidc, APP_STATES.login, res);
 })
-
-// Initiates auth code grant for edit_profile user flow
-app.get("/profile", (req, res) => {
-    getAuthCode(policies.authorities.editProfile.authority, SCOPES.oidc, APP_STATES.login, res);
-});
 
 // Initiates auth code grant for web API call
 app.get("/api", async (req, res) => {
@@ -192,19 +180,6 @@ app.get("/redirect", (req, res) => {
                 const templateParams = { showLoginButton: false, username: response.account.username, profile: false };
                 res.render("api", templateParams);
             }).catch((error) => {
-                if (req.query.error) {
-
-                    /**
-                     * When the user selects "forgot my password" on the sign-in page, B2C service will throw an error.
-                     * We are to catch this error and redirect the user to login again with the resetPassword authority.
-                     * For more information, visit: https://docs.microsoft.com/azure/active-directory-b2c/user-flow-overview#linking-user-flows
-                     */
-                    if (JSON.stringify(req.query.error_description).includes("AADB2C90118")) {
-                        authCodeRequest.authority = policies.authorities.resetPassword;
-                        authCodeRequest.state = APP_STATES.password_reset;
-                        return res.redirect('/login');
-                    }
-                }
                 res.status(500).send(error);
             });
 
@@ -233,11 +208,6 @@ app.get("/redirect", (req, res) => {
                 res.status(500).send(error);
             });
 
-    } else if (req.query.state === APP_STATES.password_reset) {
-
-        // once the password is reset, redirect the user to login again with the new password
-        authCodeRequest.state = APP_STATES.login;
-        res.redirect('/login');
     } else {
         res.status(500).send("Unknown");
     }

--- a/samples/msal-node-samples/b2c-auth-code-pkce/package.json
+++ b/samples/msal-node-samples/b2c-auth-code-pkce/package.json
@@ -10,7 +10,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "@azure/msal-node": "^1.0.1",
+    "@azure/msal-node": "^1.0.3",
     "axios": "^0.19.2",
     "express": "^4.17.1",
     "express-handlebars": "^4.0.4"

--- a/samples/msal-node-samples/b2c-auth-code-pkce/policies.js
+++ b/samples/msal-node-samples/b2c-auth-code-pkce/policies.js
@@ -4,21 +4,10 @@
  * To learn more about custom policies, visit: https://docs.microsoft.com/en-us/azure/active-directory-b2c/custom-policy-overview
  */
 const b2cPolicies = {
-    names: {
-        signUpSignIn: "B2C_1_susi",
-        resetPassword: "B2C_1_reset",
-        editProfile: "B2C_1_edit_profile"
-    },
     authorities: {
         signUpSignIn: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_susi",
+            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_susi_reset_v2",
         },
-        resetPassword: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_reset",
-        },
-        editProfile: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_edit_profile"
-        }
     },
     authorityDomain: "fabrikamb2c.b2clogin.com"
 }

--- a/samples/msal-node-samples/b2c-auth-code-pkce/views/layouts/main.hbs
+++ b/samples/msal-node-samples/b2c-auth-code-pkce/views/layouts/main.hbs
@@ -18,12 +18,6 @@
                 Sign-in
             </a>
         </div>
-        {{else}}
-        <div class="ml-auto">
-            <a type="button" id="EditProfile" class="btn btn-warning" href="/profile" aria-haspopup="true" aria-expanded="false">
-                Edit Profile
-            </a>
-        </div>
         {{/if}}
     </nav>
     <br>

--- a/samples/msal-node-samples/b2c-auth-code/README.md
+++ b/samples/msal-node-samples/b2c-auth-code/README.md
@@ -10,7 +10,7 @@ This sample demonstrates a [confidential client application](https://docs.micros
 
 1. using [OIDC Connect protocol](https://docs.microsoft.com/azure/active-directory-b2c/openid-connect) to implement standard B2C [user-flows](https://docs.microsoft.com/azure/active-directory-b2c/user-flow-overview) to:
 
-- sign-in/sign-up a user
+- sign-up/sign-in a user
 - reset/recover a user password
 - edit a user profile
 
@@ -68,7 +68,7 @@ const confidentialClientConfig = {
 };
 ```
 
-Implementing B2C user-flows is a matter of initiating token requests against the corresponding authorities. Some user-flows are slightly more complex. For example, to initiate the **password-reset**, the user first needs to click on the **forgot my password** link on the Azure sign-in screen, which causes B2C service to respond with an error. We then catch this error, and trigger another sign-in, this time against the "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_reset" authority.
+Implementing B2C user-flows is a matter of initiating token requests against the corresponding authorities. Some user-flows are slightly more complex. For example, to initiate the **password-reset**, the user first needs to click on the **forgot my password** link on the Azure sign-in screen, which causes B2C service to respond with an error. We then catch this error, and trigger another sign-in, this time against the `https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_reset` authority.
 
 In order to keep track of these *flows*, we create some global objects and manipulate these in the rest of the application.
 

--- a/samples/msal-node-samples/b2c-auth-code/index.js
+++ b/samples/msal-node-samples/b2c-auth-code/index.js
@@ -18,7 +18,7 @@ const confidentialClientConfig = {
     auth: {
         clientId: "e6e1bea3-d98f-4850-ba28-e80ed613cc72", 
         authority: policies.authorities.signUpSignIn.authority, 
-        clientSecret: "wr7Q9R~Gg1Qb9l.3s4Dg8jp7Z6.9M~42K0",
+        clientSecret: "m3V5M1-6EpB2Y0.~2C.huNninwm3RI4~EG",
         knownAuthorities: [policies.authorityDomain], 
         redirectUri: "http://localhost:3000/redirect",
     },

--- a/samples/msal-node-samples/b2c-auth-code/package.json
+++ b/samples/msal-node-samples/b2c-auth-code/package.json
@@ -10,7 +10,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "@azure/msal-node": "^1.0.1",
+    "@azure/msal-node": "^1.0.3",
     "axios": "^0.19.2",
     "express": "^4.17.1",
     "express-handlebars": "^4.0.4"

--- a/samples/msal-node-samples/b2c-silent-flow/README.md
+++ b/samples/msal-node-samples/b2c-silent-flow/README.md
@@ -10,9 +10,7 @@ This sample demonstrates a [public client application](https://docs.microsoft.co
 
 1. using [OIDC Connect protocol](https://docs.microsoft.com/azure/active-directory-b2c/openid-connect) to implement standard B2C [user-flows](https://docs.microsoft.com/azure/active-directory-b2c/user-flow-overview) to:
 
-- sign-in/sign-up a user
-- reset/recover a user password
-- edit a user profile
+- sign-up/sign-in a user (with password reset/recovery)
 
 2. using [authorization code grant](https://docs.microsoft.com/azure/active-directory-b2c/authorization-code-flow) to acquire an [Access Token](https://docs.microsoft.com/azure/active-directory-b2c/tokens-overview) to call a [protected web API](https://docs.microsoft.com/azure/active-directory-b2c/add-web-api-application?tabs=app-reg-ga) (also on Azure AD B2C)
 
@@ -34,12 +32,6 @@ const b2cPolicies = {
         signUpSignIn: {
             authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_susi",
         },
-        resetPassword: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_reset",
-        },
-        editProfile: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_edit_profile"
-        }
     },
     authorityDomain: "fabrikamb2c.b2clogin.com"
 }
@@ -81,7 +73,7 @@ const PKCE_CODES = {
 };
 ```
 
-Implementing B2C user-flows is a matter of initiating token requests against the corresponding authorities. Some user-flows are slightly more complex. For example, to initiate the **password-reset**, the user first needs to click on the **forgot my password** link on the Azure sign-in screen, which causes B2C service to respond with an error. We then catch this error, and trigger another sign-in, this time against the "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_reset" authority.
+Implementing B2C user-flows is a matter of initiating authorization requests against the corresponding authorities. This sample demonstrates the [sign-up/sign-in](https://docs.microsoft.com/azure/active-directory-b2c/add-sign-up-and-sign-in-policy?pivots=b2c-user-flow) user-flow with [self-service password reset](https://docs.microsoft.com/azure/active-directory-b2c/add-password-reset-policy?pivots=b2c-user-flow#self-service-password-reset-recommended).
 
 In order to keep track of these *flows*, we create some global objects and manipulate these in the rest of the application.
 
@@ -91,7 +83,6 @@ In order to keep track of these *flows*, we create some global objects and manip
 const APP_STATES = {
     SIGN_IN: "sign_in",
     CALL_API: "call_api",
-    PASSWORD_RESET: "password_reset",
 }
 
 const authCodeRequest = {
@@ -118,13 +109,7 @@ Setup an Express route for initiating the sign-in flow:
 
 ```javascript
 app.get("/signin", (req, res) => {
-    if (authCodeRequest.state === APP_STATES.PASSWORD_RESET) {
-        // if coming for password reset, set the authority to password reset
-        getAuthCode(policies.authorities.resetPassword.authority, SCOPES.oidc, APP_STATES.PASSWORD_RESET, res);
-    } else {
-        // else, login as usual with the default authority
-        getAuthCode(policies.authorities.signUpSignIn.authority, SCOPES.oidc, APP_STATES.SIGN_IN, res);
-    }
+    getAuthCode(policies.authorities.signUpSignIn.authority, SCOPES.oidc, APP_STATES.SIGN_IN, res);
 })
 ```
 
@@ -175,19 +160,6 @@ app.get("/redirect", (req, res) => {
                 const templateParams = { showLoginButton: false, username: response.account.username, profile: false };
                 res.render("api", templateParams);
             }).catch((error) => {
-                if (req.query.error) {
-
-                    /**
-                     * When the user selects "forgot my password" on the sign-in page, B2C service will throw an error.
-                     * We are to catch this error and redirect the user to login again with the resetPassword authority.
-                     * For more information, visit: https://docs.microsoft.com/azure/active-directory-b2c/user-flow-overview#linking-user-flows
-                     */
-                    if (JSON.stringify(req.query.error_description).includes("AADB2C90118")) {
-                        authCodeRequest.authority = policies.authorities.resetPassword;
-                        authCodeRequest.state = APP_STATES.PASSWORD_RESET;
-                        return res.redirect('/login');
-                    }
-                }
                 res.status(500).send(error);
             });
 
@@ -215,11 +187,6 @@ app.get("/redirect", (req, res) => {
                 res.status(500).send(error);
             });
 
-    } else if (req.query.state === APP_STATES.PASSWORD_RESET) {
-
-        // once the password is reset, redirect the user to login again with the new password
-        authCodeRequest.state = APP_STATES.SIGN_IN;
-        res.redirect('/login');
     } else {
         res.status(500).send("Unknown");
     }

--- a/samples/msal-node-samples/b2c-silent-flow/package.json
+++ b/samples/msal-node-samples/b2c-silent-flow/package.json
@@ -10,7 +10,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "@azure/msal-node": "^1.0.1",
+    "@azure/msal-node": "^1.0.3",
     "axios": "^0.19.2",
     "express": "^4.17.1",
     "express-handlebars": "^4.0.4"

--- a/samples/msal-node-samples/b2c-silent-flow/policies.js
+++ b/samples/msal-node-samples/b2c-silent-flow/policies.js
@@ -4,21 +4,10 @@
  * To learn more about custom policies, visit: https://docs.microsoft.com/en-us/azure/active-directory-b2c/custom-policy-overview
  */
 const b2cPolicies = {
-    names: {
-        signUpSignIn: "B2C_1_susi",
-        resetPassword: "B2C_1_reset",
-        editProfile: "B2C_1_edit_profile"
-    },
     authorities: {
         signUpSignIn: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_susi",
+            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_susi_reset_v2",
         },
-        resetPassword: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_reset",
-        },
-        editProfile: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_edit_profile"
-        }
     },
     authorityDomain: "fabrikamb2c.b2clogin.com"
 }

--- a/samples/msal-node-samples/b2c-silent-flow/views/layouts/main.hbs
+++ b/samples/msal-node-samples/b2c-silent-flow/views/layouts/main.hbs
@@ -18,12 +18,6 @@
                 Sign-in
             </a>
         </div>
-        {{else}}
-        <div class="ml-auto">
-            <a type="button" id="EditProfile" class="btn btn-warning" href="/profile" aria-haspopup="true" aria-expanded="false">
-                Edit Profile
-            </a>
-        </div>
         {{/if}}
     </nav>
     <br>

--- a/samples/msal-react-samples/b2c-sample/README.md
+++ b/samples/msal-react-samples/b2c-sample/README.md
@@ -5,6 +5,10 @@
 This developer sample is used to run basic B2C use cases for the MSAL library. You can also alter the configuration in `./src/authConfig.js` to execute other behaviors.
 This sample was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+### How to handle B2C user-flows
+
+Implementing B2C user-flows is a matter of initiating authorization requests against the corresponding authorities. This sample demonstrates the [sign-up/sign-in](https://docs.microsoft.com/azure/active-directory-b2c/add-sign-up-and-sign-in-policy?pivots=b2c-user-flow) user-flow with [self-service password reset](https://docs.microsoft.com/azure/active-directory-b2c/add-password-reset-policy?pivots=b2c-user-flow#self-service-password-reset-recommended).
+
 ## Notable files and what they demonstrate
 
 1. `./src/App.js` - Shows implementation of `MsalProvider`, all children will have access to `@azure/msal-react` context, hooks and components. Also shows how to handle password reset.

--- a/samples/msal-react-samples/b2c-sample/src/App.js
+++ b/samples/msal-react-samples/b2c-sample/src/App.js
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 // Material-UI imports
 import { ThemeProvider } from '@material-ui/core/styles';
@@ -6,14 +5,12 @@ import Grid from "@material-ui/core/Grid";
 import { theme } from "./styles/theme";
 
 // MSAL imports
-import { MsalProvider, useMsal } from "@azure/msal-react";
-import { EventType, InteractionType } from "@azure/msal-browser";
+import { MsalProvider } from "@azure/msal-react";
 
 // Sample app imports
 import { PageLayout } from "./ui-components/PageLayout";
 import { Home } from "./pages/Home";
 import { Protected } from "./pages/Protected";
-import { forgotPasswordRequest } from "./authConfig.js";
 
 function App({ pca }) {
 
@@ -33,36 +30,6 @@ function App({ pca }) {
 }
 
 function Pages() {
-	const { instance } = useMsal();
-	useEffect(() => {
-		const callbackId = instance.addEventCallback((event) => {
-			if (event.eventType === EventType.LOGIN_FAILURE) {
-				if (event.error && event.error.errorMessage.indexOf("AADB2C90118") > -1) {
-					if (event.interactionType === InteractionType.Redirect) {
-						instance.loginRedirect(forgotPasswordRequest);
-					} else if (event.interactionType === InteractionType.Popup) {
-						instance.loginPopup(forgotPasswordRequest).catch(e => {
-							return;
-						});
-					}
-				}
-			} else if (event.eventType === EventType.LOGIN_SUCCESS) {
-				if (event.payload.idTokenClaims["acr"] === "b2c_1_reset") {
-					// Tokens returned from password reset policy cannot be used for sign-in policy, must log out then sign back in
-					instance.logout({
-						account: event.payload.account
-					});
-				}
-			}
-		});
-
-		return () => {
-			if (callbackId) {
-				instance.removeEventCallback(callbackId);
-			}
-		};
-	}, [instance]);
-
 	return (
 		<Switch>
 			<Route path="/protected">

--- a/samples/msal-react-samples/b2c-sample/src/authConfig.js
+++ b/samples/msal-react-samples/b2c-sample/src/authConfig.js
@@ -2,19 +2,14 @@
 export const msalConfig = {
     auth: {
         clientId: "9067c884-9fa6-414f-9aa4-a565b1cb46be",
-        authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
+        authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi_reset_v2",
         knownAuthorities: ["fabrikamb2c.b2clogin.com"],
         redirectUri: "http://localhost:4200",
         postLogoutRedirectUri: "http://localhost:4200"
     }
 };
 
-// Add here scopes for id token to be used at MS Identity Platform endpoints.
+// Scopes you add here will be prompted for consent during login
 export const loginRequest = {
     scopes: ["https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read"]
 };
-
-export const forgotPasswordRequest = {
-    authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_reset"
-}
-


### PR DESCRIPTION
This PR removes the B2C standalone password-reset user-flow in favor of the new sign-up/sign-in user-flow with [self-service password reset](https://docs.microsoft.com/en-us/azure/active-directory-b2c/add-password-reset-policy?pivots=b2c-user-flow#self-service-password-reset-recommended). Affected B2C samples have a notice on this in README.

* **msal-angular-v2/angular11-b2c-sample**
* **msal-react/b2c-sample**
* **msal-node/b2c-auth-code-pkce** (removed both profile-edit and standalone password-reset to simplify)
* **msal-node/b2c-silent-flow** (removed both profile-edit and standalone password-reset to simplify)
* **msal-node/b2c-auth-code** (left as it is to demonstrate how to handle standalone password reset flow)

p.s. **DO NOT MERGE** -issue #3530 is affecting B2C samples. Will update dependencies once a fix is out.