### PR TITLE
Properly handle MSAL guard on redirect uri for hash and path routing

### DIFF
--- a/change/@azure-msal-angular-85214804-df42-45d1-8491-8485605eef32.json
+++ b/change/@azure-msal-angular-85214804-df42-45d1-8491-8485605eef32.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Properly handle MSAL guard on redirect uri for hash and path routing",
+  "packageName": "@azure/msal-angular",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/.gitignore
+++ b/lib/msal-angular/.gitignore
@@ -47,3 +47,5 @@ Thumbs.db
 
 # Typedocs
 ref/
+
+__ivy_ngcc__

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -26,7 +26,7 @@ function MSALInstanceFactory(): IPublicClientApplication {
     system: {
         loggerOptions: {
             loggerCallback: (level, message) => {
-                console.log(message)
+                // console.log(message)
             },
             logLevel: LogLevel.Verbose,
             piiLoggingEnabled: true

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -1,16 +1,17 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { Router, UrlTree } from '@angular/router';
+import { UrlTree } from '@angular/router';
+import { Location } from "@angular/common";
 import { BrowserSystemOptions, BrowserUtils, InteractionType, IPublicClientApplication, LogLevel, PublicClientApplication, UrlString } from '@azure/msal-browser';
 import { of } from 'rxjs';
 import { MsalGuardConfiguration } from './msal.guard.config';
 import { MsalModule, MsalGuard, MsalService, MsalBroadcastService } from './public-api';
+import { RouterTestingModule } from '@angular/router/testing';
 
 let guard: MsalGuard;
 let authService: MsalService;
 let routeMock: any = { snapshot: {} };
 let routeStateMock: any = { snapshot: {}, url: '/' };
-let routerMock = { navigate: jasmine.createSpy('navigate') };
 let testInteractionType: InteractionType;
 let testLoginFailedRoute: string;
 let testConfiguration: Partial<MsalGuardConfiguration>;
@@ -21,6 +22,15 @@ function MSALInstanceFactory(): IPublicClientApplication {
     auth: {
       clientId: '6226576d-37e9-49eb-b201-ec1eeb0029b6',
       redirectUri: 'http://localhost:4200'
+    },
+    system: {
+        loggerOptions: {
+            loggerCallback: (level, message) => {
+                console.log(message)
+            },
+            logLevel: LogLevel.Verbose,
+            piiLoggingEnabled: true
+        }
     }
   });
 }
@@ -34,7 +44,7 @@ function MSALGuardConfigFactory(): MsalGuardConfiguration {
   }
 }
 
-function initializeMsal() {
+function initializeMsal(providers: any[] = []) {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
     imports: [
@@ -42,13 +52,14 @@ function initializeMsal() {
         MSALInstanceFactory(),
         MSALGuardConfigFactory(),
         { interactionType: InteractionType.Popup, protectedResourceMap: new Map() }),
-      HttpClientTestingModule
+      HttpClientTestingModule,
+      RouterTestingModule.withRoutes([])
     ],
     providers: [
       MsalGuard,
-      { provide: Router, useValue: routerMock },
       MsalService,
-      MsalBroadcastService
+      MsalBroadcastService,
+      ...providers
     ]
   });
 
@@ -94,7 +105,16 @@ describe('MsalGuard', () => {
       });
   });
 
-  it("returns false if page contains known successful response", (done) => {
+  it("returns false if page contains known successful response (path routing)", (done) => {
+    initializeMsal([
+        {
+            provide: Location,
+            useValue: {
+                path: jasmine.createSpy("path").and.callFake((hash: boolean) => hash ? "/path#code=": "/path")
+            }
+        }
+    ])
+
     spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
         //@ts-ignore
         of("test")
@@ -108,14 +128,41 @@ describe('MsalGuard', () => {
         username: "test"
       }]);
   
-    guard.canActivate(routeMock, {
-        ...routeStateMock,
-        url: "/#code=test"
-    })
-    .subscribe(result => {
-        expect(result).toBeFalse();
-        done();
-    });
+    guard.canActivate(routeMock, routeStateMock)
+        .subscribe((result: UrlTree) => {
+            expect(result.toString()).toEqual('/path');
+            done();
+        });
+  });
+
+  it("returns false if page contains known successful response (hash routing)", (done) => {
+    initializeMsal([
+        {
+            provide: Location,
+            useValue: {
+                path: jasmine.createSpy("path").and.callFake((hash: boolean) => hash ? "/code=": "/")
+            }
+        }
+    ])
+
+    spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
+        //@ts-ignore
+        of("test")
+    );
+
+    spyOn(PublicClientApplication.prototype, "getAllAccounts").and.returnValue([{
+        homeAccountId: "test",
+        localAccountId: "test",
+        environment: "test",
+        tenantId: "test",
+        username: "test"
+      }]);
+  
+    guard.canActivate(routeMock, routeStateMock)
+        .subscribe((result: UrlTree) => {
+            expect(result.toString()).toEqual('/');
+            done();
+        });
   });
 
   it("returns true for a logged in user", (done) => {

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -122,6 +122,9 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
             this.loginFailedRoute = this.parseUrl(this.msalGuardConfig.loginFailedRoute);
         }
 
+        // Capture current path before it gets changed by handleRedirectObservable
+        const currentPath = this.location.path(true);
+
         return this.authService.handleRedirectObservable()
             .pipe(
                 concatMap(() => {
@@ -136,17 +139,25 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
 
                     this.authService.getLogger().verbose("Guard - at least 1 account exists, can activate or load");
 
-                    // Prevent navigating the app to /#code=
-                    if (state && state.url.indexOf("#") > -1 && state.url.indexOf("code=") > -1) {
+                    // Prevent navigating the app to /#code= or /code=
+                    if (state && currentPath.indexOf("code=")> -1) {
                         this.authService.getLogger().info("Guard - Hash contains known code response, stopping navigation.");
-                        return of(false);
+                        
+                        // Path routing (navigate to current path without hash)
+                        if (currentPath.indexOf("#") > -1) {
+                            return of(this.parseUrl(this.location.path()));
+                        }
+                        
+                        // Hash routing (navigate to root path)
+                        return of(this.parseUrl(""));
                     }
 
                     return of(true);
 
                 }),
-                catchError(() => {
-                    this.authService.getLogger().verbose("Guard - error while logging in, unable to activate");
+                catchError((error: Error) => {
+                    this.authService.getLogger().error("Guard - error while logging in, unable to activate");
+                    this.authService.getLogger().errorPii(`Guard - error: ${error.message}`);
                     /**
                      * If a loginFailedRoute is set, checks to see if Angular 10+ is used and state is passed in before returning route
                      * Apps using Angular 9 will receive of(false) in canLoad interface, as it does not support UrlTree return types

--- a/samples/msal-angular-v2-samples/angular10-sample-app/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/src/app/app.component.ts
@@ -31,6 +31,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.isIframe = window !== window.parent && !window.opener;
+    this.setLoginDisplay();
 
     this.msalBroadcastService.inProgress$
       .pipe(

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
@@ -30,7 +30,8 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.isIframe = window !== window.parent && !window.opener;
-
+    this.setLoginDisplay();
+    
     this.msalBroadcastService.inProgress$
     .pipe(
       filter((status: InteractionStatus) => status === InteractionStatus.None),

--- a/samples/msal-angular-v2-samples/angular11-sample-app/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/src/app/app.component.ts
@@ -23,7 +23,8 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.isIframe = window !== window.parent && !window.opener; // Remove this line to use Angular Universal
-
+    this.setLoginDisplay();
+    
     this.msalBroadcastService.inProgress$
       .pipe(
         filter((status: InteractionStatus) => status === InteractionStatus.None),

--- a/samples/msal-angular-v2-samples/angular12-sample-app/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular12-sample-app/src/app/app.component.ts
@@ -23,7 +23,8 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.isIframe = window !== window.parent && !window.opener; // Remove this line to use Angular Universal
-
+    this.setLoginDisplay();
+    
     this.msalBroadcastService.inProgress$
       .pipe(
         filter((status: InteractionStatus) => status === InteractionStatus.None),


### PR DESCRIPTION
In #3506, this scenario was only handled for path routing. Furthermore, return `false` in the guard is not the correct behavior. Instead, it should return a url tree to the page without the hash response.