### PR TITLE
Throw untrusted authority error if discovery endpoint returns an error in the body

### DIFF
--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -512,7 +512,8 @@ export abstract class ClientApplication {
             } else {
                 this.emitEvent(EventType.LOGIN_FAILURE, InteractionType.Popup, null, e);
             }
-
+            
+            popup?.close(); // Close the synchronous popup if an error is thrown before the window unload event is registered
             serverTelemetryManager.cacheFailedRequest(e);
             this.browserStorage.cleanRequestByState(validRequest.state);
             throw e;
@@ -809,6 +810,7 @@ export abstract class ClientApplication {
             }
 
         } catch (e) {
+            popup?.close(); // Close the synchronous popup if an error is thrown before the window unload event is registered
             this.browserStorage.removeItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.INTERACTION_STATUS_KEY));
             this.emitEvent(EventType.LOGOUT_FAILURE, InteractionType.Popup, null, e);
             serverTelemetryManager.cacheFailedRequest(e);

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -366,6 +366,10 @@ export class Authority {
         try {
             const response = await this.networkInterface.sendGetRequestAsync<CloudInstanceDiscoveryResponse>(instanceDiscoveryEndpoint);
             const metadata = isCloudInstanceDiscoveryResponse(response.body) ? response.body.metadata : [];
+            if (metadata.length === 0) {
+                // If no metadata is returned, authority is untrusted
+                return null;
+            }
             match = Authority.getCloudDiscoveryMetadataFromNetworkResponse(metadata, this.hostnameAndPort);
         } catch(e) {
             return null;

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -589,6 +589,30 @@ describe("Authority.ts Class Unit Tests", () => {
                 });
             });
 
+            it("throws untrustedAuthority error if host is not part of knownAuthorities, cloudDiscoveryMetadata and instance discovery network call doesn't return metadata", (done) => {
+                const authorityOptions: AuthorityOptions = {
+                    protocolMode: ProtocolMode.AAD,
+                    knownAuthorities: [],
+                    cloudDiscoveryMetadata: "",
+                    authorityMetadata: ""
+                };
+                networkInterface.sendGetRequestAsync = (url: string, options?: NetworkRequestOptions): any => {
+                    return {
+                        body: { 
+                            error: "This endpoint does not exist"
+                        }
+                    };
+                };
+                authority = new Authority(Constants.DEFAULT_AUTHORITY, networkInterface, mockStorage, authorityOptions);
+    
+                authority.resolveEndpointsAsync().catch(e => {
+                    expect(e).to.be.instanceOf(ClientConfigurationError);
+                    expect(e.errorMessage).to.equal(ClientConfigurationErrorMessage.untrustedAuthority.desc);
+                    expect(e.errorCode).to.equal(ClientConfigurationErrorMessage.untrustedAuthority.code);
+                    done();
+                });
+            });
+
             it("getPreferredCache throws error if discovery is not complete", () => {
                 expect(() => authority.getPreferredCache()).to.throw(ClientAuthErrorMessage.endpointResolutionError.desc);
             });


### PR DESCRIPTION
We currently throw an untrusted authority error when the instance discovery network call throws but there are scenarios where the network call itself succeeds but the service returns an error in the response body. For example: 

```javascript
{
"error":"invalid_instance",
"error_description":"AADSTS50049: Unknown or invalid instance.",
"error_codes":[50049],
"timestamp":"2021-05-03 16:57:22Z",
"trace_id":"f3c55048-42c4-45f1-8ba8-21e9b5a81a00",
"correlation_id":"1986d9ef-bdb8-4d21-9a3c-dab247de1347",
"error_uri":"https://login.microsoftonline.com/error?code=50049"
}
```

This scenario is not currently covered in the library. This PR patches the instance discovery logic to throw if a valid response is not received.