### PR TITLE
[msal-node-extensions] Add the verification of persistence

### DIFF
--- a/extensions/msal-node-extensions/src/error/PersistenceError.ts
+++ b/extensions/msal-node-extensions/src/error/PersistenceError.ts
@@ -58,4 +58,14 @@ export class PersistenceError extends Error {
     static createCrossPlatformLockError(errorMessage: string): PersistenceError {
         return new PersistenceError("CrossPlatformLockError", errorMessage);
     }
+
+    /**
+     * Throw cache persistence error
+     * 
+     * @param errorMessage string
+     * @returns PersistenceError
+     */
+    static createCachePersistenceError(errorMessage: string): PersistenceError {
+        return new PersistenceError("CachePersistenceError", errorMessage);
+    }
 }

--- a/extensions/msal-node-extensions/src/persistence/BasePersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/BasePersistence.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { PersistenceError } from "../error/PersistenceError";
+import { Constants } from "../utils/Constants";
+import { IPersistence } from "./IPersistence";
+
+export abstract class BasePersistence {
+    public abstract createForPersistenceValidation(): Promise<IPersistence>; 
+
+    public async verifyPersistence(): Promise<boolean> {
+        // We are using a different location for the test to avoid overriding the functional cache
+        const persistenceValidator = await this.createForPersistenceValidation();
+
+        try {
+            persistenceValidator.save(Constants.PERSISTENCE_TEST_DATA);
+
+            const retrievedDummyData = await persistenceValidator.load();
+
+            if (!retrievedDummyData) {
+                throw PersistenceError.createCachePersistenceError(
+                    "Persistence check failed. Data was written but it could not be read. " +
+                    "Possible cause: on Linux, LibSecret is installed but D-Bus isn't running because it cannot be started over SSH."
+                );
+            }
+
+            if (retrievedDummyData !== Constants.PERSISTENCE_TEST_DATA) {
+                throw PersistenceError.createCachePersistenceError(
+                    `Persistence check failed. Data written ${Constants.PERSISTENCE_TEST_DATA} is different from data read ${retrievedDummyData}`
+                );
+            }
+         } catch(e) {
+            throw PersistenceError.createCachePersistenceError(`Verifing persistence failed with the error: ${e}`)
+        } finally {
+            persistenceValidator.delete();
+            return true;
+        }
+    }
+
+}

--- a/extensions/msal-node-extensions/src/persistence/FilePersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/FilePersistence.ts
@@ -9,6 +9,7 @@ import { IPersistence } from "./IPersistence";
 import { Constants } from "../utils/Constants";
 import { PersistenceError } from "../error/PersistenceError";
 import { Logger, LoggerOptions, LogLevel } from "@azure/msal-common";
+import { BasePersistence } from "./BasePersistence";
 
 /**
  * Reads and writes data to file specified by file location. File contents are not
@@ -17,7 +18,7 @@ import { Logger, LoggerOptions, LogLevel } from "@azure/msal-common";
  * If file or directory has not been created, it FilePersistence.create() will create
  * file and any directories in the path recursively.
  */
-export class FilePersistence implements IPersistence {
+export class FilePersistence extends BasePersistence implements IPersistence {
 
     private filePath: string;
     private logger: Logger;
@@ -86,6 +87,11 @@ export class FilePersistence implements IPersistence {
 
     public getLogger(): Logger {
         return this.logger;
+    }
+
+    public createForPersistenceValidation(): Promise<FilePersistence> {
+        const testCacheFileLocation = `${dirname(this.filePath)}/test.cache`;
+        return FilePersistence.create(testCacheFileLocation);
     }
 
     private static createDefaultLoggerOptions(): LoggerOptions {

--- a/extensions/msal-node-extensions/src/persistence/FilePersistenceWithDataProtection.ts
+++ b/extensions/msal-node-extensions/src/persistence/FilePersistenceWithDataProtection.ts
@@ -9,6 +9,8 @@ import { PersistenceError } from "../error/PersistenceError";
 import { Dpapi } from "../dpapi-addon/Dpapi";
 import { DataProtectionScope } from "./DataProtectionScope";
 import { Logger, LoggerOptions } from "@azure/msal-common";
+import { dirname } from "path";
+import { BasePersistence } from "./BasePersistence";
 
 /**
  * Uses CryptProtectData and CryptUnprotectData on Windows to encrypt and decrypt file contents.
@@ -16,13 +18,14 @@ import { Logger, LoggerOptions } from "@azure/msal-common";
  * scope: Scope of the data protection. Either local user or the current machine
  * optionalEntropy: Password or other additional entropy used to encrypt the data
  */
-export class FilePersistenceWithDataProtection implements IPersistence {
+export class FilePersistenceWithDataProtection extends BasePersistence implements IPersistence {
 
     private filePersistence: FilePersistence;
     private scope: DataProtectionScope;
     private optionalEntropy: Uint8Array;
 
     private constructor(scope: DataProtectionScope, optionalEntropy?: string) {
+        super();
         this.scope = scope;
         this.optionalEntropy = optionalEntropy ? Buffer.from(optionalEntropy, "utf-8") : null;
     }
@@ -80,5 +83,10 @@ export class FilePersistenceWithDataProtection implements IPersistence {
 
     public getLogger(): Logger {
         return this.filePersistence.getLogger();
+    }
+
+    public createForPersistenceValidation(): Promise<FilePersistenceWithDataProtection> {
+        const testCacheFileLocation = `${dirname(this.filePersistence.getFilePath())}/test.cache`;
+        return FilePersistenceWithDataProtection.create(testCacheFileLocation, DataProtectionScope.CurrentUser);
     }
 }

--- a/extensions/msal-node-extensions/src/persistence/IPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/IPersistence.ts
@@ -11,5 +11,7 @@ export interface IPersistence {
     delete(): Promise<boolean>;
     reloadNecessary(lastSync: number): Promise<boolean>;
     getFilePath(): string;
-    getLogger(): Logger
+    getLogger(): Logger;
+    verifyPersistence(): Promise<boolean>;
+    createForPersistenceValidation(): Promise<IPersistence>;
 }

--- a/extensions/msal-node-extensions/src/persistence/KeychainPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/KeychainPersistence.ts
@@ -8,6 +8,8 @@ import { FilePersistence } from "./FilePersistence";
 import { IPersistence } from "./IPersistence";
 import { PersistenceError } from "../error/PersistenceError";
 import { Logger, LoggerOptions } from "@azure/msal-common";
+import { dirname } from "path";
+import { BasePersistence } from "./BasePersistence";
 
 /**
  * Uses reads and writes passwords to macOS keychain
@@ -15,13 +17,14 @@ import { Logger, LoggerOptions } from "@azure/msal-common";
  * serviceName: Identifier used as key for whatever value is stored
  * accountName: Account under which password should be stored
  */
-export class KeychainPersistence implements IPersistence {
+export class KeychainPersistence extends BasePersistence implements IPersistence {
 
     protected readonly serviceName;
     protected readonly accountName;
     private filePersistence: FilePersistence;
 
     private constructor(serviceName: string, accountName: string) {
+        super();
         this.serviceName = serviceName;
         this.accountName = accountName;
     }
@@ -74,5 +77,10 @@ export class KeychainPersistence implements IPersistence {
 
     public getLogger(): Logger {
         return this.filePersistence.getLogger();
+    }
+   
+    public createForPersistenceValidation(): Promise<KeychainPersistence> {
+        const testCacheFileLocation = `${dirname(this.filePersistence.getFilePath())}/test.cache`;
+        return KeychainPersistence.create(testCacheFileLocation, "persistenceValidationServiceName", "persistencValidationAccountName");
     }
 }

--- a/extensions/msal-node-extensions/src/persistence/LibSecretPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/LibSecretPersistence.ts
@@ -8,6 +8,8 @@ import { FilePersistence } from "./FilePersistence";
 import { IPersistence } from "./IPersistence";
 import { PersistenceError } from "../error/PersistenceError";
 import { Logger, LoggerOptions } from "@azure/msal-common";
+import { dirname } from "path";
+import { BasePersistence } from "./BasePersistence";
 
 /**
  * Uses reads and writes passwords to Secret Service API/libsecret. Requires libsecret
@@ -16,13 +18,14 @@ import { Logger, LoggerOptions } from "@azure/msal-common";
  * serviceName: Identifier used as key for whatever value is stored
  * accountName: Account under which password should be stored
  */
-export class LibSecretPersistence implements IPersistence {
+export class LibSecretPersistence extends BasePersistence implements IPersistence {
 
     protected readonly serviceName;
     protected readonly accountName;
     private filePersistence: FilePersistence;
 
     private constructor(serviceName: string, accountName: string) {
+        super();
         this.serviceName = serviceName;
         this.accountName = accountName;
     }
@@ -75,5 +78,10 @@ export class LibSecretPersistence implements IPersistence {
 
     public getLogger(): Logger {
         return this.filePersistence.getLogger();
+    }
+      
+    public createForPersistenceValidation(): Promise<LibSecretPersistence> {
+        const testCacheFileLocation = `${dirname(this.filePersistence.getFilePath())}/test.cache`;
+        return LibSecretPersistence.create(testCacheFileLocation, "persistenceValidationServiceName", "persistencValidationAccountName");
     }
 }

--- a/extensions/msal-node-extensions/src/utils/Constants.ts
+++ b/extensions/msal-node-extensions/src/utils/Constants.ts
@@ -27,4 +27,9 @@ export const Constants = {
      * Default service name for using MSAL Keytar
      */
     DEFAULT_SERVICE_NAME: "msal-node-extensions",
+
+    /**
+     * Test data used to verify underlying persistence mechanism
+     */
+    PERSISTENCE_TEST_DATA: "Dummy data to verify underlying persistence mechanism"
 };

--- a/extensions/samples/msal-node-extensions/index.js
+++ b/extensions/samples/msal-node-extensions/index.js
@@ -18,11 +18,16 @@ createPersistence().then((filePersistence) => {
         auth: {
             clientId: "99cab759-2aab-420b-91d8-5e3d8d4f063b",
             authority: "https://login.microsoftonline.com/90b8faa8-cc95-460e-a618-ee770bee1759",
-        },
-        cache: {
-            cachePlugin: new extensions.PersistenceCachePlugin(filePersistence)
-        },
+        }
     };
+
+    if (filePersistence.verifyPersistence()) {
+        console.log("Persistence verified...");
+        publicClientConfig.cache = {
+            cachePlugin: new extensions.PersistenceCachePlugin(filePersistence)
+        }
+    }
+
     const pca = new msal.PublicClientApplication(publicClientConfig);
 
     // Create Express App and Routes


### PR DESCRIPTION
Add the verifyPersistence method to each persistence implementation to enable our users to verify that the underlying persistence mechanisms are available for their environment.
