### PR TITLE
Workflows use native concurrency check

### DIFF
--- a/.github/workflows/beachball-check.yml
+++ b/.github/workflows/beachball-check.yml
@@ -8,6 +8,10 @@ on:
     branches:  
       - dev
 
+concurrency:
+  group: beachball-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   beachball-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -14,6 +14,10 @@ on:
       - '!**.md'
       - '.github/workflows/build-steps.yml'
 
+concurrency:
+  group: ci-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
 
   build-test:
@@ -33,11 +37,6 @@ jobs:
             - msal-react
   
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,6 +9,10 @@ name: Labeler
 on: 
 - pull_request
 
+concurrency:
+  group: labeler-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/msal-angular-e2e.yml
+++ b/.github/workflows/msal-angular-e2e.yml
@@ -18,6 +18,10 @@ on:
       - '!**.md'
       - '.github/workflows/msal-angular-e2e.yml'
 
+concurrency:
+  group: angular-e2e-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
@@ -34,11 +38,6 @@ jobs:
           - 'angular12-sample-app'
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
-        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-browser-e2e.yml
+++ b/.github/workflows/msal-browser-e2e.yml
@@ -16,17 +16,16 @@ on:
       - 'samples/e2eTestUtils/**/*'
       - '!**.md'
 
+concurrency:
+  group: browser-e2e-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     runs-on: ubuntu-latest
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
-        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-core-e2e.yml
+++ b/.github/workflows/msal-core-e2e.yml
@@ -14,6 +14,10 @@ on:
       - 'samples/msal-core-samples/VanillaJSTestApp/**/*'
       - '!**.md'
 
+concurrency:
+  group: core-e2e-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
@@ -21,11 +25,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
-        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -17,6 +17,10 @@ on:
       - '!**.md'
       - '.github/workflows/msal-node-e2e.yml'
 
+concurrency:
+  group: node-e2e-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
@@ -29,11 +33,6 @@ jobs:
     name: Node ${{ matrix.node }}
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
-        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/msal-react-e2e.yml
+++ b/.github/workflows/msal-react-e2e.yml
@@ -18,6 +18,10 @@ on:
       - '!**.md'
       - '.github/workflows/msal-react-e2e.yml'
 
+concurrency:
+  group: react-e2e-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
@@ -31,11 +35,6 @@ jobs:
           - 'nextjs-sample'
 
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
-        
     - uses: actions/checkout@v2
 
     - name: Use Node.js

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -19,6 +19,10 @@ on:
       - 'npm-audit'
       - 'fix-node-extension-audit'
 
+concurrency:
+  group: audit-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   audit-root:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github Actions recently added a native check for concurrent workflows running on the same PR and cancel any in progress workflow.

This PR replaces the existing 3rd party check with Githubs check which runs when the workflow is _queued_ instead of when it actually _starts_.