### PR TITLE
Fix hash removal from URL and browser history after interactive request

### DIFF
--- a/change/@azure-msal-angular-31c5cd50-1761-4a5f-9b9d-3c43fd2b822e.json
+++ b/change/@azure-msal-angular-31c5cd50-1761-4a5f-9b9d-3c43fd2b822e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix navigation bug when clearing auth code from hash in msal-angular #3609",
+  "packageName": "@azure/msal-angular",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-9343b33e-75b7-41df-8ad1-d3ea7134bfe3.json
+++ b/change/@azure-msal-browser-9343b33e-75b7-41df-8ad1-d3ea7134bfe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix hash removal from URL and browser history after interactive request",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-9343b33e-75b7-41df-8ad1-d3ea7134bfe3.json
+++ b/change/@azure-msal-browser-9343b33e-75b7-41df-8ad1-d3ea7134bfe3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix hash removal from URL and browser history after interactive request",
+  "comment": "Fix hash removal from URL and browser history after interactive request #3609",
   "packageName": "@azure/msal-browser",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-angular/src/msal.navigation.client.ts
+++ b/lib/msal-angular/src/msal.navigation.client.ts
@@ -34,8 +34,12 @@ export class MsalCustomNavigationClient extends NavigationClient {
 
         // Replaces current state if noHistory flag set to true
         this.authService.getLogger().verbosePii(`MsalCustomNavigationClient - navigating to newUrl: ${newUrl}`);
-        this.router.navigateByUrl(newUrl, { replaceUrl: options.noHistory });
 
-        return Promise.resolve(false);
+        if (options.noHistory) {
+            window.location.replace(newUrl);
+        } else {
+            this.router.navigateByUrl(newUrl, { replaceUrl: options.noHistory });
+        }
+        return Promise.resolve(options.noHistory);
     }
 }

--- a/lib/msal-angular/src/msal.navigation.client.ts
+++ b/lib/msal-angular/src/msal.navigation.client.ts
@@ -35,6 +35,7 @@ export class MsalCustomNavigationClient extends NavigationClient {
         // Replaces current state if noHistory flag set to true
         this.authService.getLogger().verbosePii(`MsalCustomNavigationClient - navigating to newUrl: ${newUrl}`);
 
+        // Prevent hash clearing from causing an issue with Client-side navigation after redirect is handled
         if (options.noHistory) {
             window.location.replace(newUrl);
         } else {

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -210,7 +210,7 @@ export abstract class ClientApplication {
         let state: string;
         try {
             state = this.validateAndExtractStateFromHash(responseHash, InteractionType.Redirect);
-            BrowserUtils.clearHash();
+            BrowserUtils.clearHash(window);
             this.logger.verbose("State extracted from hash");
         } catch (e) {
             this.logger.info(`handleRedirectPromise was unable to extract state due to: ${e}`);

--- a/lib/msal-browser/src/interaction_handler/PopupHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/PopupHandler.ts
@@ -9,6 +9,7 @@ import { BrowserAuthError } from "../error/BrowserAuthError";
 import { BrowserConstants, TemporaryCacheKeys } from "../utils/BrowserConstants";
 import { BrowserCacheManager } from "../cache/BrowserCacheManager";
 import { PopupUtils } from "../utils/PopupUtils";
+import { BrowserUtils } from "../utils/BrowserUtils";
 
 export type PopupParams = InteractionParams & {
     popup?: Window|null;
@@ -56,6 +57,7 @@ export class PopupHandler extends InteractionHandler {
     monitorPopupForHash(popupWindow: Window): Promise<string> {
         return this.popupUtils.monitorPopupForSameOrigin(popupWindow).then(() => {
             const contentHash = popupWindow.location.hash;
+            BrowserUtils.clearHash(popupWindow);
             this.popupUtils.cleanPopup(popupWindow);
 
             if (!contentHash) {

--- a/lib/msal-browser/src/utils/BrowserUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserUtils.ts
@@ -21,7 +21,7 @@ export class BrowserUtils {
      */
     static clearHash(contentWindow: Window): void {
         // Office.js sets history.replaceState to null
-        contentWindow.location.hash = "";
+        contentWindow.location.hash = Constants.EMPTY_STRING;
         if (typeof contentWindow.history.replaceState === "function") {
             // Full removes "#" from url
             contentWindow.history.replaceState(null, Constants.EMPTY_STRING, `${contentWindow.location.pathname}${contentWindow.location.search}`);

--- a/lib/msal-browser/src/utils/BrowserUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserUtils.ts
@@ -19,13 +19,12 @@ export class BrowserUtils {
     /**
      * Clears hash from window url.
      */
-    static clearHash(): void {
+    static clearHash(contentWindow: Window): void {
         // Office.js sets history.replaceState to null
-        if (typeof history.replaceState === "function") {
+        contentWindow.location.hash = "";
+        if (typeof contentWindow.history.replaceState === "function") {
             // Full removes "#" from url
-            history.replaceState(null, Constants.EMPTY_STRING, `${window.location.pathname}${window.location.search}`);
-        } else {
-            window.location.hash = "";
+            contentWindow.history.replaceState(null, Constants.EMPTY_STRING, `${contentWindow.location.pathname}${contentWindow.location.search}`);
         }
     }
 
@@ -35,7 +34,6 @@ export class BrowserUtils {
     static replaceHash(url: string): void {
         const urlParts = url.split("#");
         urlParts.shift(); // Remove part before the hash
-        
         window.location.hash = urlParts.length > 0 ? urlParts.join("#") : "";
     }
 

--- a/lib/msal-browser/test/interaction_handler/PopupHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/PopupHandler.spec.ts
@@ -208,6 +208,9 @@ describe("PopupHandler.ts Unit Tests", () => {
                     href: "http://localhost/#/code=hello",
                     hash: "#code=hello"
                 },
+                history: {
+                    replaceState: () => { return }
+                },
                 close: () => {}
             };
 

--- a/lib/msal-browser/test/utils/BrowserUtils.spec.ts
+++ b/lib/msal-browser/test/utils/BrowserUtils.spec.ts
@@ -23,7 +23,7 @@ describe("BrowserUtils.ts Function Unit Tests", () => {
 
     it("clearHash() clears the window hash", () => {
         window.location.hash = "thisIsAHash";
-        BrowserUtils.clearHash();
+        BrowserUtils.clearHash(window);
         expect(window.location.href.includes("#thisIsAHash")).to.be.false;
     });
 
@@ -33,7 +33,7 @@ describe("BrowserUtils.ts Function Unit Tests", () => {
         history.replaceState = null;
 
         window.location.hash = "thisIsAHash";
-        BrowserUtils.clearHash();
+        BrowserUtils.clearHash(window);
         expect(window.location.href.includes("#thisIsAHash")).to.be.false;
         
         history.replaceState = oldReplaceState;
@@ -42,7 +42,7 @@ describe("BrowserUtils.ts Function Unit Tests", () => {
     it("replaceHash replaces the current window hash with the hash from the provided url", () => {
         window.location.hash = "thisIsAHash";
         const url = "http://localhost/#";
-        const testHash = "replacementHash";
+        const testHash = "#replacementHash";
         BrowserUtils.replaceHash(url + testHash);
         expect(window.location.hash).to.be.eq(testHash);
     });


### PR DESCRIPTION
This PR:

- Refactors `BrowserUtils.clearHash` to accept a window as a parameter and perform hash removal/history replacement on that content window.
- Fixes a bug in which the auth code hash was being left in the browser history