### PR TITLE
Fix double query string

### DIFF
--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -49,7 +49,8 @@ export class AuthorizationCodeClient extends BaseClient {
      */
     async getAuthCodeUrl(request: CommonAuthorizationUrlRequest): Promise<string> {
         const queryString = this.createAuthCodeUrlQueryString(request);
-        return `${this.authority.authorizationEndpoint}?${queryString}`;
+
+        return UrlString.appendQueryString(this.authority.authorizationEndpoint, queryString);
     }
 
     /**

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -21,6 +21,7 @@ import { ClientConfigurationError } from "../error/ClientConfigurationError";
 import { ClientAuthError, ClientAuthErrorMessage } from "../error/ClientAuthError";
 import { ServerError } from "../error/ServerError";
 import { TimeUtils } from "../utils/TimeUtils";
+import { UrlString } from "../url/UrlString";
 
 /**
  * OAuth2.0 refresh token client
@@ -135,8 +136,7 @@ export class RefreshTokenClient extends BaseClient {
             scopes: request.scopes
         };
 
-        const endpoint = StringUtils.isEmpty(queryParameters) ? authority.tokenEndpoint : `${authority.tokenEndpoint}?${queryParameters}`;
-
+        const endpoint = UrlString.appendQueryString(authority.tokenEndpoint, queryParameters);
         return this.executePostToTokenEndpoint(endpoint, requestBody, headers, thumbprint);
     }
 

--- a/lib/msal-common/src/url/UrlString.ts
+++ b/lib/msal-common/src/url/UrlString.ts
@@ -95,6 +95,23 @@ export class UrlString {
         return this.urlString;
     }
 
+    /**
+     * Given a url and a query string return the url with provided query string appended
+     * @param url 
+     * @param queryString 
+     */
+    static appendQueryString(url: string, queryString: string): string {
+        if (StringUtils.isEmpty(queryString)) {
+            return url;
+        }
+
+        return url.indexOf("?") < 0 ? `${url}?${queryString}` : `${url}&${queryString}`;
+    }
+
+    /**
+     * Returns a url with the hash removed
+     * @param url 
+     */
     static removeHashFromUrl(url: string): string {
         return UrlString.canonicalizeUri(url.split("#")[0]);
     }

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -439,6 +439,42 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(loginRequest);
             expect(loginUrl).to.contain(`${AADServerParamKeys.SCOPE}=${encodeURIComponent(`${testScope1} ${testScope2}`)}`);
         });
+
+        it("Does not append an extra '?' when the authorization endpoint already contains a query string", async () => {
+            // Override with alternate authority openid_config
+            sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves({
+                "token_endpoint": "https://login.windows.net/common/oauth2/v2.0/token?param1=value1",
+                "issuer": "https://login.windows.net/{tenantid}/v2.0",
+                "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+                "authorization_endpoint": "https://login.windows.net/common/oauth2/v2.0/authorize?param1=value1",
+                "end_session_endpoint": "https://login.windows.net/common/oauth2/v2.0/logout?param1=value1",
+            });
+
+            const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            const authCodeUrlRequest: CommonAuthorizationUrlRequest = {
+                authority: TEST_CONFIG.validAuthority,
+                responseMode: ResponseMode.QUERY,
+                redirectUri: TEST_URIS.TEST_REDIRECT_URI_LOCALHOST,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD,
+                correlationId: RANDOM_TEST_GUID,
+                authenticationScheme: AuthenticationScheme.BEARER
+            };
+            const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
+            expect(loginUrl.split("?").length).to.equal(2);
+            expect(loginUrl).to.contain(`param1=value1`);
+            expect(loginUrl).to.contain(ALTERNATE_OPENID_CONFIG_RESPONSE.body.authorization_endpoint.replace("{tenant}", "common"));
+            expect(loginUrl).to.contain(`${AADServerParamKeys.SCOPE}=${Constants.OPENID_SCOPE}%20${Constants.PROFILE_SCOPE}%20${Constants.OFFLINE_ACCESS_SCOPE}`);
+            expect(loginUrl).to.contain(`${AADServerParamKeys.RESPONSE_TYPE}=${Constants.CODE_RESPONSE_TYPE}`);
+            expect(loginUrl).to.contain(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`);
+            expect(loginUrl).to.contain(`${AADServerParamKeys.REDIRECT_URI}=${encodeURIComponent(TEST_URIS.TEST_REDIRECT_URI_LOCALHOST)}`);
+            expect(loginUrl).to.contain(`${AADServerParamKeys.RESPONSE_MODE}=${encodeURIComponent(ResponseMode.QUERY)}`);
+            expect(loginUrl).to.contain(`${AADServerParamKeys.CODE_CHALLENGE}=${encodeURIComponent(TEST_CONFIG.TEST_CHALLENGE)}`);
+            expect(loginUrl).to.contain(`${AADServerParamKeys.CODE_CHALLENGE_METHOD}=${encodeURIComponent(Constants.S256_CODE_CHALLENGE_METHOD)}`);
+        });
     });
 
     describe("handleFragmentResponse()", () => {

--- a/lib/msal-common/test/url/UrlString.spec.ts
+++ b/lib/msal-common/test/url/UrlString.spec.ts
@@ -62,6 +62,14 @@ describe("UrlString.ts Class Unit Tests", () => {
         expect(urlObj2.urlString).to.not.contain("param2=value2");
     });
 
+    it("appendQueryString appends the provided query string", () => {
+        const baseUrl = "https://localhost/";
+        const queryString = "param1=value1&param2=value2";
+        expect(UrlString.appendQueryString(baseUrl, queryString)).to.equal(`${baseUrl}?${queryString}`);
+        expect(UrlString.appendQueryString(`${baseUrl}?param3=value3`, queryString)).to.equal(`${baseUrl}?param3=value3&${queryString}`);
+        expect(UrlString.appendQueryString(baseUrl, "")).to.equal(baseUrl);
+    });
+
     it("removes hash from url provided", () => {
         const baseUrl = "https://localhost/";
         const fullUrl = baseUrl + "#thisIsATestHash";


### PR DESCRIPTION
Some authorities may advertise their endpoints with query strings. Currently if this happens MSAL adds another '?' character when appending its own query parameters because it assumes endpoints do not contain query strings. This PR fixes this behavior.

Fixes #3574