### PR TITLE
Switch to Codecov for test coverage reporting

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -19,22 +19,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pre-check:
+    runs-on: ubuntu-latest
+    outputs: 
+      # Expose matched filters as job 'packages' output variable
+      packages: ${{ steps.filter.outputs.changes }}
+
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          # &common and &browser are YAML anchors
+          # *common and *browser references previously defined anchor
+          # browser/node filter will match any path under common as well as their own
+          # angular/react filter will match any path under common and browser as well as their own
+          filters: |
+            core:
+              - 'lib/msal-core/**/**.!(md)'
+              - '.github/workflows/build-steps.yml'
+            common: &common
+              - 'lib/msal-common/**/**.!(md)'
+              - '.github/workflows/build-steps.yml'
+            browser: &browser
+              - *common
+              - 'lib/msal-browser/**/**.!(md)'
+            node:
+              - *common
+              - 'lib/msal-node/**/**.!(md)'
+            angular:
+              - *browser
+              - 'lib/msal-angular/**/**.!(md)'
+            react:
+              - *browser
+              - 'lib/msal-react/**/**.!(md)'
 
   build-test:
+    needs: pre-check
     runs-on: ubuntu-latest
-    env: 
-      NOT_FROM_FORK: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
 
     strategy:
         fail-fast: false
         matrix:
-          library:
-            - msal-core
-            - msal-common
-            - msal-browser
-            - msal-node
-            - msal-angular
-            - msal-react
+          # Parse JSON array containing names of all filters matching any of changed files
+          # e.g. ['package1', 'package2'] if both package folders contains changes
+          library: ${{ fromJSON(needs.pre-check.outputs.packages) }}
   
     steps:
     - uses: actions/checkout@v2
@@ -48,35 +76,20 @@ jobs:
       run: npm ci
 
     - name: Build packages
-      working-directory: lib/${{ matrix.library }}
+      working-directory: lib/msal-${{ matrix.library }}
       run: npm run build:all
 
     - name: Lint
-      working-directory: lib/${{ matrix.library }}
+      working-directory: lib/msal-${{ matrix.library }}
       run: npm run lint
 
     - name: Unit Tests with coverage
-      working-directory: lib/${{ matrix.library }}
+      working-directory: lib/msal-${{ matrix.library }}
       run: npm run test:coverage
 
-    - name: Coveralls
-      if: success() && ${{ env.NOT_FROM_FORK == 'true' }}
-      uses: coverallsapp/github-action@master
+    - name: Upload Test Coverage to CodeCov
+      if: success()
+      uses: codecov/codecov-action@v1
       with:
-        github-token: ${{ secrets.github_token }}
-        flag-name: ${{ matrix.library }}
-        base-path: lib/${{ matrix.library }}
-        path-to-lcov: lib/${{ matrix.library }}/coverage/lcov.info
-        parallel: true
-
-  Coveralls:
-    needs: build-test
-    runs-on: ubuntu-latest
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
-
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.github_token }}
-        parallel-finished: true
+        files: lib/msal-${{matrix.library}}/coverage/lcov.info
+        flags: msal-${{ matrix.library }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+comment:
+  layout: "flags, files"
+  behavior: default
+  require_changes: false  
+  require_base: no
+  require_head: no
+  show_carryforward_flags: true
+
+flag_management:
+  default_rules:
+    carryforward: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -4368,19 +4368,6 @@
         "parse-json": "^4.0.0"
       }
     },
-    "coveralls": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
-      "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
-        "request": "^2.88.0"
-      }
-    },
     "cp-file": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
@@ -7832,12 +7819,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true
-    },
     "lerna": {
       "version": "3.22.1",
       "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.22.1.tgz",
@@ -7974,12 +7955,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-      "dev": true
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "loose-envify": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@typescript-eslint/parser": "^4.0.1",
     "babel-plugin-istanbul": "^5.2.0",
     "beachball": "^1.45.0",
-    "coveralls": "3.0.9",
     "dotenv": "^8.2.0",
     "eslint": "^7.8.1",
     "eslint-plugin-header": "^3.1.0",


### PR DESCRIPTION
Switches code coverage reporting to [Codecov](https://docs.codecov.io/docs). This allows us to upload code coverage results per library and will "carry forward" results for libraries that were unaffected by the PR. This also allows each library's README to display its own code coverage badge instead of the total for all our libraries (will update later)

PR comment will look something like this, showing each library's total coverage and the coverage changes for the specific files touched by the PR. (This comment is configurable if we want more or less information)

![image](https://user-images.githubusercontent.com/5307810/119196762-8f015c80-ba3b-11eb-87d9-175e92b3987c.png)

Also updates the CI workflow to only build and test libraries that were actually affected by the PR (e.g. changes to msal-common runs CI for common, browser, node, react and angular but changes to msal-core only runs CI for msal-core)

Coverage step can also be run on PRs from forks, unlike Coveralls