### PR TITLE
Fix node tests

### DIFF
--- a/samples/msal-node-samples/auth-code/test/auth-code-aad.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-aad.spec.ts
@@ -11,8 +11,7 @@ import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
 import { AppTypes, AzureEnvironments } from "../../../e2eTestUtils/Constants";
 import { 
-    enterCredentials, 
-    enterCredentialsWithConsent, 
+    enterCredentials,
     SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation
  } from "../../testUtils";
@@ -123,7 +122,7 @@ describe("Auth Code AAD PPE Tests", () => {
 
         it("Performs acquire token with prompt = 'consent'", async () => {
             await page.goto(`${homeRoute}/?prompt=consent`);
-            await enterCredentialsWithConsent(page, screenshot, username, accountPwd);
+            await enterCredentials(page, screenshot, username, accountPwd);
 
             const cachedTokens = await NodeCacheTestUtils.waitForTokens(TEST_CACHE_LOCATION, 2000);
             expect(cachedTokens.accessTokens.length).toBe(1);

--- a/samples/msal-node-samples/testUtils.ts
+++ b/samples/msal-node-samples/testUtils.ts
@@ -31,6 +31,10 @@ export async function enterCredentials(page: Page, screenshot: Screenshot, usern
         page.waitForNavigation({ waitUntil: "networkidle0" })
     ]);
 
+    if (page.url().startsWith(SAMPLE_HOME_URL)) {
+        return;
+    }
+
     try {
         await page.waitForSelector('#idSIButton9', {timeout: 1000});
         await screenshot.takeScreenshot(page, "kmsiPage");
@@ -54,11 +58,6 @@ export async function approveRemoteConnect(page: Page, screenshot: Screenshot): 
     } catch (e) {
         return;
     }
-}
-
-export async function enterCredentialsWithConsent(page: Page, screenshot: Screenshot, username: string, accountPwd: string): Promise<void> {
-    await this.enterCredentials(page, screenshot, username, accountPwd);
-    await this.approveConsent(page, screenshot);
 }
 
 export async function enterCredentialsADFSWithConsent(page: Page, screenshot: Screenshot, username: string, accountPwd: string): Promise<void> {

--- a/samples/msal-node-samples/testUtils.ts
+++ b/samples/msal-node-samples/testUtils.ts
@@ -18,16 +18,21 @@ export async function enterCredentials(page: Page, screenshot: Screenshot, usern
     await screenshot.takeScreenshot(page, "loginPage");
     await page.type("#i0116", username);
     await screenshot.takeScreenshot(page, "loginPageUsernameFilled")
-    await page.click("#idSIButton9");
+    await Promise.all([
+        page.click("#idSIButton9"),
+        page.waitForNavigation({ waitUntil: "networkidle0" })
+    ]);
     await page.waitForSelector("#idA_PWD_ForgotPassword");
-    await page.waitForSelector("#idSIButton9");
     await screenshot.takeScreenshot(page, "pwdInputPage");
     await page.type("#i0118", accountPwd);
     await screenshot.takeScreenshot(page, "loginPagePasswordFilled")
-    await page.click("#idSIButton9");
+    await Promise.all([
+        page.click("#idSIButton9"),
+        page.waitForNavigation({ waitUntil: "networkidle0" })
+    ]);
 
     try {
-        await page.waitForSelector('#KmsiCheckboxField', {timeout: 1000});
+        await page.waitForSelector('#idSIButton9', {timeout: 1000});
         await screenshot.takeScreenshot(page, "kmsiPage");
         await Promise.all([
             page.click("#idSIButton9"),


### PR DESCRIPTION
The "Keep me signed in" page seems to have changed and a selector we were previously waiting for is no longer present. This PR addresses this by changing the selector we wait for.