### PR TITLE
Fix dependabot username in workflow checks

### DIFF
--- a/.github/workflows/beachball-check.yml
+++ b/.github/workflows/beachball-check.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   beachball-check:
-    if: github.actor != 'dependabot'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       BEACHBALL: 1

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   label:
     runs-on: ubuntu-latest
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.event.pull_request.head.repo.full_name == github.repository)
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.event.pull_request.head.repo.full_name == github.repository) && (github.actor != 'dependabot[bot]')
     steps:
     - uses: actions/labeler@v3
       with:


### PR DESCRIPTION
Skip beachball and labeler workflows for dependabot PRs as they are expected to fail and not needed. This fixes the username used in the check.