### PR TITLE
[msal-node]: Modify on-behalf-of client token filter

### DIFF
--- a/change/@azure-msal-common-23d8d974-2351-4a1d-b44a-8dc361d0a0c8.json
+++ b/change/@azure-msal-common-23d8d974-2351-4a1d-b44a-8dc361d0a0c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: modify the access token filter #3375",
+  "packageName": "@azure/msal-common",
+  "email": "samuelkamau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-common/src/client/OnBehalfOfClient.ts
@@ -57,7 +57,7 @@ export class OnBehalfOfClient extends BaseClient {
      * @param request
      */
     private async getCachedAuthenticationResult(request: CommonOnBehalfOfRequest): Promise<AuthenticationResult | null> {
-        const cachedAccessToken = this.readAccessTokenFromCache(request);
+        const cachedAccessToken = this.readAccessTokenFromCache();
         if (!cachedAccessToken ||
             TimeUtils.isTokenExpired(cachedAccessToken.expiresOn, this.config.systemOptions.tokenRenewalOffsetSeconds)) {
             return null;
@@ -99,14 +99,13 @@ export class OnBehalfOfClient extends BaseClient {
      * read access token from cache TODO: CacheManager API should be used here
      * @param request
      */
-    private readAccessTokenFromCache(request: CommonOnBehalfOfRequest): AccessTokenEntity | null {
+    private readAccessTokenFromCache(): AccessTokenEntity | null {
         const accessTokenFilter: CredentialFilter = {
             environment: this.authority.canonicalAuthorityUrlComponents.HostNameAndPort,
             credentialType: CredentialType.ACCESS_TOKEN,
             clientId: this.config.authOptions.clientId,
             realm: this.authority.tenant,
             target: this.scopeSet.printScopesLowerCase(),
-            oboAssertion: request.oboAssertion
         };
 
         const credentialCache: CredentialCache = this.cacheManager.getCredentialsFilteredBy(accessTokenFilter);


### PR DESCRIPTION
Modify the on behalf of client access token filter to not include the oboAssertion as part of the cache filter

Fixes the issue #3375 