### PR TITLE
Expand msal-angular B2C sample README

### DIFF
--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/README.md
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/README.md
@@ -45,3 +45,9 @@ Implementing B2C user-flows is a matter of initiating authorization requests aga
 ## Additional notes
 
 - The default interaction type for the sample is redirect. The sample can be configured to use popups by changing the `interactionType` in `app.module.ts` to `InteractionType.Popup`.
+
+- If you would like to protect all the routes in your application so that upon hitting your home page, users are automatically prompted for login, follow the [steps outlined in FAQ](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/FAQ.md#how-do-i-log-users-in-when-they-hit-the-application)
+
+## Common errors
+
+- If your app is running into redirect loops when trying to acquire a token for a resource such as your web API, make sure you have granted **admin consent** to the permissions/scopes required for that resource on App registration portal. See [MSAL Angular v2 Errors](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/v2-docs/errors.md) for other common errors.

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/README.md
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/README.md
@@ -46,8 +46,8 @@ Implementing B2C user-flows is a matter of initiating authorization requests aga
 
 - The default interaction type for the sample is redirect. The sample can be configured to use popups by changing the `interactionType` in `app.module.ts` to `InteractionType.Popup`.
 
-- If you would like to protect all the routes in your application so that upon hitting your home page, users are automatically prompted for login, follow the [steps outlined in FAQ](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/FAQ.md#how-do-i-log-users-in-when-they-hit-the-application)
+- If you would like to protect all the routes in your application so that upon hitting any page, users are automatically prompted for login, follow the [steps outlined in FAQ](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/FAQ.md#how-do-i-log-users-in-when-they-hit-the-application)
 
 ## Common errors
 
-- If your app is running into redirect loops when trying to acquire a token for a resource such as your web API, make sure you have granted **admin consent** to the permissions/scopes required for that resource on App registration portal. See [MSAL Angular v2 Errors](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/v2-docs/errors.md) for other common errors.
+- If your app is running into redirect loops when trying to acquire a token for a resource such as your web API, make sure you have granted **admin consent** to the permissions/scopes required for that resource on App registration portal. See [Using redirects in MSAL Angular v2](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/v2-docs/redirects.md) for more on redirect experience. See [MSAL Angular v2 Errors](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/v2-docs/errors.md) for other common errors.

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app-routing.module.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app-routing.module.ts
@@ -1,8 +1,10 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-import { ProfileComponent } from './profile/profile.component';
-import { HomeComponent } from './home/home.component';
 import { MsalGuard } from '@azure/msal-angular';
+
+import { ProfileComponent } from './profile/profile.component';
+import { FailedComponent } from './failed/failed.component';
+import { HomeComponent } from './home/home.component';
 
 const routes: Routes = [
   {
@@ -30,7 +32,11 @@ const routes: Routes = [
   {
     path: '',
     component: HomeComponent
-  }
+  },
+  {
+    path: 'login-failed',
+    component: FailedComponent
+  },
 ];
 
 const isIframe = window !== window.parent && !window.opener;

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.component.ts
@@ -63,6 +63,15 @@ export class AppComponent implements OnInit, OnDestroy {
 
         return result;
       });
+
+      this.msalBroadcastService.msalSubject$
+      .pipe(
+        filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_FAILURE || msg.eventType === EventType.ACQUIRE_TOKEN_FAILURE),
+        takeUntil(this._destroying$)
+      )
+      .subscribe((result: EventMessage) => {
+        // Add your auth error handling logic here
+      });
   }
 
   setLoginDisplay() {

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.module.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HomeComponent } from './home/home.component';
 import { ProfileComponent } from './profile/profile.component';
+import { FailedComponent } from './failed/failed.component';
 
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { IPublicClientApplication, PublicClientApplication, InteractionType, BrowserCacheLocation, LogLevel } from '@azure/msal-browser';
@@ -62,6 +63,7 @@ export function MSALGuardConfigFactory(): MsalGuardConfiguration {
     authRequest: {
       scopes: [...apiConfig.scopes],
     },
+    loginFailedRoute: 'login-failed'
   };
 }
 
@@ -69,7 +71,8 @@ export function MSALGuardConfigFactory(): MsalGuardConfiguration {
   declarations: [
     AppComponent,
     HomeComponent,
-    ProfileComponent
+    ProfileComponent,
+    FailedComponent
   ],
   imports: [
     BrowserModule,

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/failed/failed.component.html
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/failed/failed.component.html
@@ -1,0 +1,2 @@
+<p>Login failed. Please try again.</p>
+<a mat-button [routerLink]="['']">Go back</a>

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/failed/failed.component.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/failed/failed.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FailedComponent } from './failed.component';
+
+describe('FailedComponent', () => {
+  let component: FailedComponent;
+  let fixture: ComponentFixture<FailedComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FailedComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FailedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/failed/failed.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/failed/failed.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-failed',
+  templateUrl: './failed.component.html',
+  styleUrls: ['./failed.component.css']
+})
+export class FailedComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/home/home.component.html
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/home/home.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="!loginDisplay">
     <p class="welcome">Welcome to the MSAL.js v2 Angular Quickstart!</p>
-    <p>This sample demonstrates how to configure MSAL Angular to login, logout, protect a route, and acquire an access token for a protected resource such as the Microsoft Graph.</p>
-    <p>Please sign-in to see your profile information.</p>
+    <p>This sample demonstrates how to configure MSAL Angular to login, logout, protect a route, and acquire an access token for a protected resource such as a B2C protected web API.</p>
+    <p>Please sign-in to acquire a token and make an API call.</p>
 </div>
 
 <div *ngIf="loginDisplay">

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/home/home.component.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/src/app/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MsalBroadcastService, MsalService } from '@azure/msal-angular';
-import { AuthenticationResult, EventMessage, EventType } from '@azure/msal-browser';
+import { AuthenticationResult, EventMessage, EventType, InteractionStatus } from '@azure/msal-browser';
 import { filter } from 'rxjs/operators';
 
 @Component({
@@ -18,17 +18,19 @@ export class HomeComponent implements OnInit {
       .pipe(
         filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_SUCCESS),
       )
-      .subscribe({
-        next: (result: EventMessage) => {
-          console.log(result);
-          const payload = result.payload as AuthenticationResult;
-          this.authService.instance.setActiveAccount(payload.account);
-        },
-        error: (error) => console.log(error)
+      .subscribe((result: EventMessage) => {
+        console.log(result);
+        const payload = result.payload as AuthenticationResult;
+        this.authService.instance.setActiveAccount(payload.account);
       });
 
-    this.setLoginDisplay();
-
+    this.msalBroadcastService.inProgress$
+      .pipe(
+        filter((status: InteractionStatus) => status === InteractionStatus.None)
+      )
+      .subscribe(() => {
+        this.setLoginDisplay();
+      })
   }
 
   setLoginDisplay() {

--- a/samples/msal-angular-v2-samples/angular11-b2c-sample/test/test.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-b2c-sample/test/test.spec.ts
@@ -26,7 +26,7 @@ describe('/ (Home Page)', () => {
 
     it('should load without error', async () => {
         const text = await page.evaluate(() => document.body.textContent);
-        expect(text).toContain('Microsoft');
+        expect(text).toContain('MSAL');
     });
   }
 );


### PR DESCRIPTION
This PR
- expands the sample README in response to issue #3722 and #3730 (possibly).
- adds a `loginFailedRoute` for MsalGuard
- adds subscription to login / token acquisiton failure events