### PR TITLE
Persist active account

### DIFF
--- a/change/@azure-msal-angular-8e7484b0-bc9b-4de5-9ba7-d4f732bb2fd2.json
+++ b/change/@azure-msal-angular-8e7484b0-bc9b-4de5-9ba7-d4f732bb2fd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove note from FAQ about active accounts not persisting",
+  "packageName": "@azure/msal-angular",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-browser-8cc95449-37c9-4ba3-854e-bb6408f15e71.json
+++ b/change/@azure-msal-browser-8cc95449-37c9-4ba3-854e-bb6408f15e71.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Persist active account #3755",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-35ceb610-cd9e-4aca-b133-5a3303c612ed.json
+++ b/change/@azure-msal-common-35ceb610-cd9e-4aca-b133-5a3303c612ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add constant for active account cache key #3755",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/docs/FAQ.md
+++ b/lib/msal-angular/docs/FAQ.md
@@ -97,6 +97,8 @@ We recommend setting the active account:
 - After any action that may change the account, especially if your app uses multiple accounts. See [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app/src/app/home/home.component.ts#L23) for an example of setting the account after a successful login.
 - On initial page load. Wait until all interactions are complete (by subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None`), check if there is an active account, and if there is none, set the active account. This could be the first account retrieved by `getAllAccounts()`, or other account selection logic required by your app. See [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app) for an example of checking and setting the active account on page load.
 
+**Note:** Prior to `@azure/msal-browser@2.15.0` active account did not persist across page loads. If you are using `@azure/msal-browser@2.14.2` or earlier we recommend that you set the active account for each page load. In version 2.15.0 and above the active account will be cached in the cache location specified in your MSAL config and retrieved each time `getActiveAccount` is called.
+
 Our [Angular 11](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app) sample demonstrates basic usage. Your app may require more complicated logic to choose accounts.
 
 ### How do I log users in when they hit the application?

--- a/lib/msal-angular/docs/FAQ.md
+++ b/lib/msal-angular/docs/FAQ.md
@@ -97,8 +97,6 @@ We recommend setting the active account:
 - After any action that may change the account, especially if your app uses multiple accounts. See [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app/src/app/home/home.component.ts#L23) for an example of setting the account after a successful login.
 - On initial page load. Wait until all interactions are complete (by subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None`), check if there is an active account, and if there is none, set the active account. This could be the first account retrieved by `getAllAccounts()`, or other account selection logic required by your app. See [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app) for an example of checking and setting the active account on page load.
 
-**Note:** Currently, active accounts are for each page load and do not persist. While this is an enhancement we are looking to make, we recommend that you set the active account for each page load.
-
 Our [Angular 11](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app) sample demonstrates basic usage. Your app may require more complicated logic to choose accounts.
 
 ### How do I log users in when they hit the application?

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -51,9 +51,6 @@ export abstract class ClientApplication {
     // Flag to indicate if in browser environment
     protected isBrowserEnvironment: boolean;
 
-    // Sets the account to use if no account info is given
-    private activeLocalAccountId: string | null;
-
     // Set the SKU and Version for wrapper library if applicable
     private wrapperSKU: string | undefined;
     private wrapperVer: string | undefined;
@@ -94,8 +91,6 @@ export abstract class ClientApplication {
         this.isBrowserEnvironment = typeof window !== "undefined";
         // Set the configuration.
         this.config = buildConfiguration(configuration, this.isBrowserEnvironment);
-
-        this.activeLocalAccountId = null;
 
         // Array of events
         this.eventCallbacks = new Map();
@@ -923,25 +918,14 @@ export abstract class ClientApplication {
      * @param account
      */
     setActiveAccount(account: AccountInfo | null): void {
-        if (account) {
-            this.logger.verbose("setActiveAccount: Active account set");
-            this.activeLocalAccountId = account.localAccountId;
-        } else {
-            this.logger.verbose("setActiveAccount: No account passed, active account not set");
-            this.activeLocalAccountId = null;
-        }
+        this.browserStorage.setActiveAccount(account);
     }
 
     /**
      * Gets the currently active account
      */
     getActiveAccount(): AccountInfo | null {
-        if (!this.activeLocalAccountId) {
-            this.logger.verbose("getActiveAccount: No active account");
-            return null;
-        }
-
-        return this.getAccountByLocalId(this.activeLocalAccountId);
+        return this.browserStorage.getActiveAccount();
     }
 
     // #endregion

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -383,7 +383,10 @@ export class BrowserCacheManager extends CacheManager {
     getActiveAccount(): AccountInfo | null {
         const activeAccountIdKey = this.generateCacheKey(PersistentCacheKeys.ACTIVE_ACCOUNT);
         const activeAccountId = this.browserStorage.getItem(activeAccountIdKey);
-        return this.getAccountInfoByFilter({localAccountId: activeAccountId || ""})[0] || null;
+        if (!activeAccountId) {
+            return null;
+        }
+        return this.getAccountInfoByFilter({localAccountId: activeAccountId})[0] || null;
     }
 
     /**

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -381,7 +381,7 @@ export class BrowserCacheManager extends CacheManager {
      * Gets the active account
      */
     getActiveAccount(): AccountInfo | null {
-        const activeAccountIdKey = this.generateCacheKey("active-account");
+        const activeAccountIdKey = this.generateCacheKey(PersistentCacheKeys.ACTIVE_ACCOUNT);
         const activeAccountId = this.browserStorage.getItem(activeAccountIdKey);
         return this.getAccountInfoByFilter({localAccountId: activeAccountId || ""})[0] || null;
     }
@@ -391,7 +391,7 @@ export class BrowserCacheManager extends CacheManager {
      * @param account 
      */
     setActiveAccount(account: AccountInfo | null): void {
-        const activeAccountIdKey = this.generateCacheKey("active-account");
+        const activeAccountIdKey = this.generateCacheKey(PersistentCacheKeys.ACTIVE_ACCOUNT);
         if (account) {
             this.logger.verbose("setActiveAccount: Active account set");
             this.browserStorage.setItem(activeAccountIdKey, account.localAccountId);

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Constants, PersistentCacheKeys, StringUtils, CommonAuthorizationCodeRequest, ICrypto, AccountEntity, IdTokenEntity, AccessTokenEntity, RefreshTokenEntity, AppMetadataEntity, CacheManager, ServerTelemetryEntity, ThrottlingEntity, ProtocolUtils, Logger, AuthorityMetadataEntity, DEFAULT_CRYPTO_IMPLEMENTATION } from "@azure/msal-common";
+import { Constants, PersistentCacheKeys, StringUtils, CommonAuthorizationCodeRequest, ICrypto, AccountEntity, IdTokenEntity, AccessTokenEntity, RefreshTokenEntity, AppMetadataEntity, CacheManager, ServerTelemetryEntity, ThrottlingEntity, ProtocolUtils, Logger, AuthorityMetadataEntity, DEFAULT_CRYPTO_IMPLEMENTATION, AccountInfo } from "@azure/msal-common";
 import { CacheOptions } from "../config/Configuration";
 import { BrowserAuthError } from "../error/BrowserAuthError";
 import { BrowserCacheLocation, InteractionType, TemporaryCacheKeys } from "../utils/BrowserConstants";
@@ -375,6 +375,61 @@ export class BrowserCacheManager extends CacheManager {
     setAuthorityMetadata(key: string, entity: AuthorityMetadataEntity): void {
         this.logger.trace("BrowserCacheManager.setAuthorityMetadata called");
         this.internalStorage.setItem(key, JSON.stringify(entity));
+    }
+
+    /**
+     * Gets the active account
+     */
+    getActiveAccount(): AccountInfo | null {
+        const activeAccountIdKey = this.generateCacheKey("active-account");
+        const activeAccountId = this.browserStorage.getItem(activeAccountIdKey);
+        return this.getAccountInfoByFilter({localAccountId: activeAccountId || ""})[0] || null;
+    }
+
+    /**
+     * Sets the active account's localAccountId in cache
+     * @param account 
+     */
+    setActiveAccount(account: AccountInfo | null): void {
+        const activeAccountIdKey = this.generateCacheKey("active-account");
+        if (account) {
+            this.logger.verbose("setActiveAccount: Active account set");
+            this.browserStorage.setItem(activeAccountIdKey, account?.localAccountId);
+        } else {
+            this.logger.verbose("setActiveAccount: No account passed, active account not set");
+            this.browserStorage.removeItem(activeAccountIdKey);
+        }
+    }
+
+    /**
+     * Gets a list of accounts that match all of the filters provided
+     * @param account 
+     */
+    getAccountInfoByFilter(accountFilter: Partial<Omit<AccountInfo, "idTokenClaims"|"name">>): AccountInfo[] {
+        const allAccounts = this.getAllAccounts();
+        return allAccounts.filter((accountObj) => {
+            if (accountFilter.username && accountFilter.username.toLowerCase() !== accountObj.username.toLowerCase()) {
+                return false;
+            }
+
+            if (accountFilter.homeAccountId && accountFilter.homeAccountId !== accountObj.homeAccountId) {
+                return false;
+            }
+
+            if (accountFilter.localAccountId && accountFilter.localAccountId !== accountObj.localAccountId) {
+                return false;
+            }
+
+            if (accountFilter.tenantId && accountFilter.tenantId !== accountObj.tenantId) {
+                return false;
+            }
+
+            if (accountFilter.environment && accountFilter.environment !== accountObj.environment) {
+                return false;
+            }
+            
+            return true;
+        });
     }
 
     /**

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -394,7 +394,7 @@ export class BrowserCacheManager extends CacheManager {
         const activeAccountIdKey = this.generateCacheKey("active-account");
         if (account) {
             this.logger.verbose("setActiveAccount: Active account set");
-            this.browserStorage.setItem(activeAccountIdKey, account?.localAccountId);
+            this.browserStorage.setItem(activeAccountIdKey, account.localAccountId);
         } else {
             this.logger.verbose("setActiveAccount: No account passed, active account not set");
             this.browserStorage.removeItem(activeAccountIdKey);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -68,7 +68,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
     describe("Constructor tests", () => {
 
         it("passes null check", (done) => {
-            expect(pca).not.toBeNull;
+            expect(pca).not.toBe(null);
             expect(pca instanceof PublicClientApplication).toBeTruthy();
             done();
         });
@@ -78,7 +78,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 sinon.stub(pca, <any>"interactionInProgress").returns(false);
                 window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
                 window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`, TEST_URIS.TEST_ALTERNATE_REDIR_URI);
-                expect(await pca.handleRedirectPromise()).toBeNull;
+                expect(await pca.handleRedirectPromise()).toBe(null);
             }
         );
 
@@ -424,7 +424,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     const tokenResponse1 = await promise1;
                     const tokenResponse2 = await promise2;
                     const tokenResponse3 = await pca.handleRedirectPromise("testHash");
-                    expect(tokenResponse3).toBeNull();
+                    expect(tokenResponse3).toBe(null);
                     const tokenResponse4 = await pca.handleRedirectPromise();
 
                     if (!tokenResponse1 || !tokenResponse2) {
@@ -689,7 +689,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
                     const tokenResponse = await pca.handleRedirectPromise();
                     if (!tokenResponse) {
-                        expect(tokenResponse).not.toBeNull();
+                        expect(tokenResponse).not.toBe(null);
                         throw new Error("Token Response is null!"); // Throw to resolve Typescript complaints below
                     }
                     expect(callbackCalled).toBeTruthy();
@@ -2550,13 +2550,13 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
         it("getAccountByUsername returns null if account doesn't exist", () => {
             const account = pca.getAccountByUsername("this-email-doesnt-exist@microsoft.com");
-            expect(account).toBeNull;
+            expect(account).toBe(null);
         });
 
         it("getAccountByUsername returns null if passed username is null", () => {
             // @ts-ignore
             const account = pca.getAccountByUsername(null);
-            expect(account).toBeNull;
+            expect(account).toBe(null);
         });
 
         it("getAccountByHomeId returns account specified", () => {
@@ -2566,13 +2566,13 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
         it("getAccountByHomeId returns null if passed id doesn't exist", () => {
             const account = pca.getAccountByHomeId("this-id-doesnt-exist");
-            expect(account).toBeNull;
+            expect(account).toBe(null);
         });
 
         it("getAccountByHomeId returns null if passed id is null", () => {
             // @ts-ignore
             const account = pca.getAccountByHomeId(null);
-            expect(account).toBeNull;
+            expect(account).toBe(null);
         });
     });
 
@@ -2609,23 +2609,21 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
         it("active account is initialized as null", () => {
             // Public client should initialze with active account set to null.
-            expect(pca.getActiveAccount()).toBeNull;
+            expect(pca.getActiveAccount()).toBe(null);
         });
 
         it("setActiveAccount() sets the active account local id value correctly", () => {
-                expect(pca.getActiveAccount()).toBeNull;
+                expect(pca.getActiveAccount()).toBe(null);
                 pca.setActiveAccount(testAccountInfo1);
                 expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
-            }
-        );
+        });
 
-        it("getActiveAccount looks up the current account values and returns them()", () => {
+        it("getActiveAccount looks up the current account values and returns them", () => {
                 pca.setActiveAccount(testAccountInfo1);
                 const activeAccount1 = pca.getActiveAccount();
                 expect(activeAccount1).toEqual(testAccountInfo1);
                 
                 const newName = "Ben Franklin";
-                window.sessionStorage.clear();
                 testAccountInfo1.name = newName;
                 testAccount1.name = newName;
                 const cacheKey = AccountEntity.generateAccountCacheKey(testAccountInfo1);
@@ -2633,8 +2631,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
                 const activeAccount2 = pca.getActiveAccount();
                 expect(activeAccount2).toEqual(testAccountInfo1);
-            }
-        );
+        });
 
         describe("activeAccount logout", () => {
             const testAccountInfo2: AccountInfo = {
@@ -2664,7 +2661,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             it("Clears active account on logoutRedirect with no account", async () => {
                 expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
                 await pca.logoutRedirect();
-                expect(pca.getActiveAccount()).toBeNull;
+                expect(pca.getActiveAccount()).toBe(null);
             });
     
             it("Clears active account on logoutRedirect when the given account info matches", async () => {
@@ -2672,7 +2669,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     await pca.logoutRedirect({
                         account: testAccountInfo1
                     });
-                    expect(pca.getActiveAccount()).toBeNull;
+                    expect(pca.getActiveAccount()).toBe(null);
                 }
             );
 
@@ -2688,7 +2685,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             it("Clears active account on logoutPopup with no account", async () => {
                 expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
                 await pca.logoutPopup();
-                expect(pca.getActiveAccount()).toBeNull;
+                expect(pca.getActiveAccount()).toBe(null);
             });
     
             it("Clears active account on logoutPopup when the given account info matches", async () => {
@@ -2696,7 +2693,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     await pca.logoutPopup({
                         account: testAccountInfo1
                     });
-                    expect(pca.getActiveAccount()).toBeNull;
+                    expect(pca.getActiveAccount()).toBe(null);
                 }
             );
 

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -2513,18 +2513,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(pca.getActiveAccount()).toBeNull;
         });
 
-        it(
-            "setActiveAccount() sets the active account local id value correctly",
-            () => {
-                expect((pca as any).activeLocalAccountId).toBeNull;
+        it("setActiveAccount() sets the active account local id value correctly", () => {
+                expect(pca.getActiveAccount()).toBeNull;
                 pca.setActiveAccount(testAccountInfo1);
-                expect((pca as any).activeLocalAccountId).toEqual(testAccountInfo1.localAccountId);
+                expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
             }
         );
 
-        it(
-            "getActiveAccount looks up the current account values and returns them()",
-            () => {
+        it("getActiveAccount looks up the current account values and returns them()", () => {
                 pca.setActiveAccount(testAccountInfo1);
                 const activeAccount1 = pca.getActiveAccount();
                 expect(activeAccount1).toEqual(testAccountInfo1);
@@ -2567,15 +2563,13 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             });
 
             it("Clears active account on logoutRedirect with no account", async () => {
-                expect((pca as any).activeLocalAccountId).toEqual(testAccountInfo1.localAccountId);
+                expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
                 await pca.logoutRedirect();
                 expect(pca.getActiveAccount()).toBeNull;
             });
     
-            it(
-                "Clears active account on logoutRedirect when the given account info matches",
-                async () => {
-                    expect((pca as any).activeLocalAccountId).toEqual(testAccountInfo1.localAccountId);
+            it("Clears active account on logoutRedirect when the given account info matches", async () => {
+                    expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
                     await pca.logoutRedirect({
                         account: testAccountInfo1
                     });
@@ -2583,10 +2577,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 }
             );
 
-            it(
-                "Does not clear active account on logoutRedirect if given account object does not match",
-                async () => {
-                    expect((pca as any).activeLocalAccountId).toEqual(testAccountInfo1.localAccountId);
+            it("Does not clear active account on logoutRedirect if given account object does not match", async () => {
+                    expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
                     await pca.logoutRedirect({
                         account: testAccountInfo2
                     });
@@ -2595,15 +2587,13 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             );
 
             it("Clears active account on logoutPopup with no account", async () => {
-                expect((pca as any).activeLocalAccountId).toEqual(testAccountInfo1.localAccountId);
+                expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
                 await pca.logoutPopup();
                 expect(pca.getActiveAccount()).toBeNull;
             });
     
-            it(
-                "Clears active account on logoutPopup when the given account info matches",
-                async () => {
-                    expect((pca as any).activeLocalAccountId).toEqual(testAccountInfo1.localAccountId);
+            it("Clears active account on logoutPopup when the given account info matches", async () => {
+                    expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
                     await pca.logoutPopup({
                         account: testAccountInfo1
                     });
@@ -2611,10 +2601,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 }
             );
 
-            it(
-                "Does not clear active account on logoutPopup if given account object does not match",
-                async () => {
-                    expect((pca as any).activeLocalAccountId).toEqual(testAccountInfo1.localAccountId);
+            it("Does not clear active account on logoutPopup if given account object does not match", async () => {
+                    expect(pca.getActiveAccount()).toEqual(testAccountInfo1);
                     await pca.logoutPopup({
                         account: testAccountInfo2
                     });

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -7,7 +7,7 @@ import sinon from "sinon";
 import { BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
 import { TEST_CONFIG, TEST_TOKENS, TEST_DATA_CLIENT_INFO, RANDOM_TEST_GUID, TEST_URIS, TEST_STATE_VALUES, DEFAULT_OPENID_CONFIG_RESPONSE } from "../utils/StringConstants";
 import { CacheOptions } from "../../src/config/Configuration";
-import { Constants, PersistentCacheKeys, CommonAuthorizationCodeRequest as AuthorizationCodeRequest, ProtocolUtils, Logger, LogLevel, AuthenticationScheme, AuthorityMetadataEntity, AccountEntity, Authority, StubbedNetworkModule, CacheManager, IdToken, IdTokenEntity, AccessTokenEntity, RefreshTokenEntity, AppMetadataEntity, ServerTelemetryEntity, ThrottlingEntity, CredentialType, ProtocolMode } from "@azure/msal-common";
+import { Constants, PersistentCacheKeys, CommonAuthorizationCodeRequest as AuthorizationCodeRequest, ProtocolUtils, Logger, LogLevel, AuthenticationScheme, AuthorityMetadataEntity, AccountEntity, Authority, StubbedNetworkModule, IdToken, IdTokenEntity, AccessTokenEntity, RefreshTokenEntity, AppMetadataEntity, ServerTelemetryEntity, ThrottlingEntity, CredentialType, ProtocolMode, AccountInfo } from "@azure/msal-common";
 import { BrowserCacheLocation, InteractionType, TemporaryCacheKeys } from "../../src/utils/BrowserConstants";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
@@ -1052,6 +1052,132 @@ describe("BrowserCacheManager tests", () => {
             browserStorage.setTemporaryCache(`${TemporaryCacheKeys.REQUEST_STATE}.${RANDOM_TEST_GUID}`, state, true);
             browserStorage.cleanRequestByInteractionType(InteractionType.Redirect);
             expect(browserStorage.getKeys()).toHaveLength(0);
+        });
+
+        describe("getAccountInfoByFilter", () => {
+            cacheConfig = {
+                cacheLocation: BrowserCacheLocation.SessionStorage,
+                storeAuthStateInCookie: false,
+                secureCookies: false
+            };
+            logger = new Logger({
+                loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {},
+                piiLoggingEnabled: true
+            });
+            const browserStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig, browserCrypto, logger);
+
+            const accountEntity1 = {
+                homeAccountId: "test-home-accountId-1",
+                localAccountId: "test-local-accountId-1",
+                username: "user-1@example.com",
+                environment: "test-environment-1",
+                realm: "test-tenantId-1",
+                name: "name-1",
+                idTokenClaims: {},
+                authorityType: "AAD"
+            }
+
+            const accountEntity2 = {
+                homeAccountId: "test-home-accountId-2",
+                localAccountId: "test-local-accountId-2",
+                username: "user-2@example.com",
+                environment: "test-environment-2",
+                realm: "test-tenantId-2",
+                name: "name-2",
+                idTokenClaims: {},
+                authorityType: "AAD"
+            }
+
+            const account1: AccountInfo = {
+                homeAccountId: accountEntity1.homeAccountId,
+                localAccountId: accountEntity1.localAccountId,
+                username: accountEntity1.username,
+                environment: accountEntity1.environment,
+                tenantId: accountEntity1.realm,
+                name: accountEntity1.name,
+                idTokenClaims: accountEntity1.idTokenClaims
+            };
+
+            const account2: AccountInfo = {
+                homeAccountId: accountEntity2.homeAccountId,
+                localAccountId: accountEntity2.localAccountId,
+                username: accountEntity2.username,
+                environment: accountEntity2.environment,
+                tenantId: accountEntity2.realm,
+                name: accountEntity2.name,
+                idTokenClaims: accountEntity2.idTokenClaims
+            };
+            const cacheKey1 = AccountEntity.generateAccountCacheKey(account1);
+            const cacheKey2 = AccountEntity.generateAccountCacheKey(account2);
+
+            beforeEach(() => {
+                browserStorage.setItem(cacheKey1, JSON.stringify(accountEntity1));
+                browserStorage.setItem(cacheKey2, JSON.stringify(accountEntity2));
+            });
+
+            afterEach(() => {
+                browserStorage.clear();
+            });
+
+            it("Matches accounts by username", () => {
+                expect(browserStorage.getAllAccounts()).toHaveLength(2);
+                const account1Filter = {username: account1.username};
+                const account2Filter = {username: account2.username};
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toContainEqual(account1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toContainEqual(account2);
+            });
+
+            it("Matches accounts by homeAccountId", () => {
+                expect(browserStorage.getAllAccounts()).toHaveLength(2);
+                const account1Filter = {homeAccountId: account1.homeAccountId};
+                const account2Filter = {homeAccountId: account2.homeAccountId};
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toContainEqual(account1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toContainEqual(account2);
+            });
+
+            it("Matches accounts by localAccountId", () => {
+                expect(browserStorage.getAllAccounts()).toHaveLength(2);
+                const account1Filter = {localAccountId: account1.localAccountId};
+                const account2Filter = {localAccountId: account2.localAccountId};
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toContainEqual(account1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toContainEqual(account2);
+            });
+
+            it("Matches accounts by tenantId", () => {
+                expect(browserStorage.getAllAccounts()).toHaveLength(2);
+                const account1Filter = {tenantId: account1.tenantId};
+                const account2Filter = {tenantId: account2.tenantId};
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toContainEqual(account1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toContainEqual(account2);
+            });
+
+            it("Matches accounts by environment", () => {
+                expect(browserStorage.getAllAccounts()).toHaveLength(2);
+                const account1Filter = {environment: account1.environment};
+                const account2Filter = {environment: account2.environment};
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toContainEqual(account1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toContainEqual(account2);
+            });
+
+            it("Matches accounts by all filters", () => {
+                expect(browserStorage.getAllAccounts()).toHaveLength(2);
+                const account1Filter = account1;
+                const account2Filter = account2;
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account1Filter)).toContainEqual(account1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toHaveLength(1);
+                expect(browserStorage.getAccountInfoByFilter(account2Filter)).toContainEqual(account2);
+            });
         });
     });
 });

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -74,7 +74,8 @@ export enum PersistentCacheKeys {
     CLIENT_INFO = "client.info",
     ADAL_ID_TOKEN = "adal.idtoken",
     ERROR = "error",
-    ERROR_DESC = "error.description"
+    ERROR_DESC = "error.description",
+    ACTIVE_ACCOUNT = "active-account"
 }
 
 /**

--- a/samples/msal-angular-v2-samples/angular10-sample-app/src/app/app.component.ts
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/src/app/app.component.ts
@@ -40,11 +40,26 @@ export class AppComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         this.setLoginDisplay();
+        this.checkAndSetActiveAccount();
       })
   }
 
   setLoginDisplay() {
     this.loginDisplay = this.authService.instance.getAllAccounts().length > 0;
+  }
+
+  checkAndSetActiveAccount(){
+    /**
+     * If no active account set but there are accounts signed in, sets first account to active account
+     * To use active account set here, subscribe to inProgress$ first in your component
+     * Note: Basic usage demonstrated. Your app may require more complicated account selection logic
+     */
+    let activeAccount = this.authService.instance.getActiveAccount();
+
+    if (!activeAccount && this.authService.instance.getAllAccounts().length > 0) {
+      let accounts = this.authService.instance.getAllAccounts();
+      this.authService.instance.setActiveAccount(accounts[0]);
+    }
   }
 
   loginRedirect() {

--- a/samples/msal-angular-v2-samples/angular10-sample-app/test/home.spec.ts
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/test/home.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(4);
+    expect(Object.keys(storage).length).toBe(5);
 }
 
 describe('/ (Home Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Home Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
         await page.goto(`http://localhost:${port}`);
     });

--- a/samples/msal-angular-v2-samples/angular10-sample-app/test/profile.spec.ts
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/test/profile.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
 }
 
 describe('/ (Profile Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Profile Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
     });
 

--- a/samples/msal-angular-v2-samples/angular11-sample-app/test/detail.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/test/detail.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
 }
 
 describe('/ (Detail Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Detail Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
         await page.goto(`http://localhost:${port}`);
     });

--- a/samples/msal-angular-v2-samples/angular11-sample-app/test/home.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/test/home.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(4);
+    expect(Object.keys(storage).length).toBe(5);
 }
 
 describe('/ (Home Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Home Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
         await page.goto(`http://localhost:${port}`);
     });

--- a/samples/msal-angular-v2-samples/angular11-sample-app/test/lazy.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/test/lazy.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(4);
+    expect(Object.keys(storage).length).toBe(5);
 }
 
 describe('/ (Lazy Loading Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Lazy Loading Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
         await page.goto(`http://localhost:${port}`);
     });

--- a/samples/msal-angular-v2-samples/angular11-sample-app/test/profile.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/test/profile.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
 }
 
 describe('/ (Profile Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Profile Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
     });
 

--- a/samples/msal-angular-v2-samples/angular12-sample-app/test/home.spec.ts
+++ b/samples/msal-angular-v2-samples/angular12-sample-app/test/home.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(4);
+    expect(Object.keys(storage).length).toBe(5);
 }
 
 describe('/ (Home Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Home Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
         await page.goto(`http://localhost:${port}`);
     });

--- a/samples/msal-angular-v2-samples/angular12-sample-app/test/profile.spec.ts
+++ b/samples/msal-angular-v2-samples/angular12-sample-app/test/profile.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
 }
 
 describe('/ (Profile Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Profile Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
     });
 

--- a/samples/msal-angular-v2-samples/angular9-v2-sample-app/test/home.spec.ts
+++ b/samples/msal-angular-v2-samples/angular9-v2-sample-app/test/home.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(4);
+    expect(Object.keys(storage).length).toBe(5);
 }
 
 describe('/ (Home Page)', () => {
@@ -47,6 +47,7 @@ describe('/ (Home Page)', () => {
     beforeEach(async () => {
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        page.setDefaultTimeout(5000);
         BrowserCache = new BrowserCacheUtils(page, "localStorage");
         await page.goto(`http://localhost:${port}`);
     });

--- a/samples/msal-react-samples/nextjs-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/nextjs-sample/test/home.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(4);
+    expect(Object.keys(storage).length).toBe(5);
 }
 
 describe('/ (Home Page)', () => {

--- a/samples/msal-react-samples/nextjs-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/nextjs-sample/test/profile.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
     const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry["cacheHits"]).toBe(1);

--- a/samples/msal-react-samples/react-router-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/home.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(4);
+    expect(Object.keys(storage).length).toBe(5);
 }
 
 describe('/ (Home Page)', () => {

--- a/samples/msal-react-samples/react-router-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profile.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
     const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry["cacheHits"]).toBe(1);

--- a/samples/msal-react-samples/react-router-sample/test/profileRawContext.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profileRawContext.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
     const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry["cacheHits"]).toBe(1);

--- a/samples/msal-react-samples/react-router-sample/test/profileWithMsal.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profileWithMsal.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
     const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry["cacheHits"]).toBe(1);

--- a/samples/msal-react-samples/typescript-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/typescript-sample/test/home.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(4);
+    expect(Object.keys(storage).length).toBe(5);
 }
 
 describe('/ (Home Page)', () => {

--- a/samples/msal-react-samples/typescript-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/typescript-sample/test/profile.spec.ts
@@ -15,7 +15,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.getAccountFromCache(tokenStore.idTokens[0])).not.toBeNull();
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
-    expect(Object.keys(storage).length).toBe(5);
+    expect(Object.keys(storage).length).toBe(6);
     const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry!.cacheHits).toBe(1);


### PR DESCRIPTION
Updates `getActiveAccount` and `setActiveAccount` APIs to use window storage to persist across page loads.