### PR TITLE
Don't use normalized url in Angular custom nav client

### DIFF
--- a/change/@azure-msal-angular-e7434b36-e43d-4b31-bf57-f8b075fae09c.json
+++ b/change/@azure-msal-angular-e7434b36-e43d-4b31-bf57-f8b075fae09c.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Don't use normalized url in Angular custom nav client",
+  "comment": "Don't use normalized url in Angular custom nav client #3757",
   "packageName": "@azure/msal-angular",
   "email": "janutter@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-angular-e7434b36-e43d-4b31-bf57-f8b075fae09c.json
+++ b/change/@azure-msal-angular-e7434b36-e43d-4b31-bf57-f8b075fae09c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't use normalized url in Angular custom nav client",
+  "packageName": "@azure/msal-angular",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/src/msal.navigation.client.spec.ts
+++ b/lib/msal-angular/src/msal.navigation.client.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { EventType, InteractionStatus, InteractionType, NavigationOptions, PublicClientApplication } from '@azure/msal-browser';
+import { EventType, InteractionStatus, InteractionType, NavigationClient, NavigationOptions, PublicClientApplication } from '@azure/msal-browser';
 import { MsalBroadcastService } from './msal.broadcast.service';
 import { MsalModule, MsalService } from './public-api';
 import { MsalCustomNavigationClient } from './msal.navigation.client';
@@ -44,7 +44,7 @@ describe('MsalCustomNaviationClient', () => {
             expect(navigationClient).toBeTruthy();
         });
 
-        it("NavigateInternal", (done) => {
+        it("NavigateInternal (noHistory false)", (done) => {
             const url = 'http://localhost:4200/profile';
             const normalizedAbsoluteUrl = '/profile';
 
@@ -61,7 +61,19 @@ describe('MsalCustomNaviationClient', () => {
                 done();
             });
         });
+
+        it("NavigateInternal (noHistory true)", (done) => {
+            const url = 'http://localhost:4200/profile';
+
+            const options = {
+                noHistory: true
+            } as NavigationOptions;
+
+            const windowLocationReplaceSpy = spyOn(NavigationClient.prototype, 'navigateInternal');
+            navigationClient.navigateInternal(url, options).then(() => {
+                expect(windowLocationReplaceSpy).toHaveBeenCalledWith(url, options);
+                done();
+            });
+        });
     });
-
-
 });

--- a/lib/msal-angular/src/msal.navigation.client.ts
+++ b/lib/msal-angular/src/msal.navigation.client.ts
@@ -7,7 +7,7 @@ import { NavigationClient, NavigationOptions, UrlString } from "@azure/msal-brow
 import { Router } from "@angular/router";
 import { Location } from "@angular/common";
 import { MsalService } from "./msal.service";
-import { Injectable } from "@angular/core";
+import { Injectable, ɵCompiler_compileModuleSync__POST_R3__ } from "@angular/core";
 
 /**
  * Custom navigation used for Angular client-side navigation.
@@ -26,19 +26,18 @@ export class MsalCustomNavigationClient extends NavigationClient {
     }
 
     async navigateInternal(url:string, options: NavigationOptions): Promise<boolean> {
-        this.authService.getLogger().verbose("MsalCustomNavigationClient called");
-        const urlComponents = new UrlString(url).getUrlComponents();
-
-        // Normalizing newUrl if no query string
-        const newUrl = urlComponents.QueryString ? `${urlComponents.AbsolutePath}?${urlComponents.QueryString}` : this.location.normalize(urlComponents.AbsolutePath);
-
-        // Replaces current state if noHistory flag set to true
-        this.authService.getLogger().verbosePii(`MsalCustomNavigationClient - navigating to newUrl: ${newUrl}`);
-
+        this.authService.getLogger().trace("MsalCustomNavigationClient called");
+        
+        this.authService.getLogger().verbose("MsalCustomNavigationClient - navigating");
+        this.authService.getLogger().verbosePii(`MsalCustomNavigationClient - navigating to url: ${url}`);
+        
         // Prevent hash clearing from causing an issue with Client-side navigation after redirect is handled
         if (options.noHistory) {
-            window.location.replace(newUrl);
+            window.location.replace(url);
         } else {
+            // Normalizing newUrl if no query string
+            const urlComponents = new UrlString(url).getUrlComponents();
+            const newUrl = urlComponents.QueryString ? `${urlComponents.AbsolutePath}?${urlComponents.QueryString}` : this.location.normalize(urlComponents.AbsolutePath);
             this.router.navigateByUrl(newUrl, { replaceUrl: options.noHistory });
         }
         return Promise.resolve(options.noHistory);

--- a/lib/msal-angular/src/msal.navigation.client.ts
+++ b/lib/msal-angular/src/msal.navigation.client.ts
@@ -7,7 +7,7 @@ import { NavigationClient, NavigationOptions, UrlString } from "@azure/msal-brow
 import { Router } from "@angular/router";
 import { Location } from "@angular/common";
 import { MsalService } from "./msal.service";
-import { Injectable, ɵCompiler_compileModuleSync__POST_R3__ } from "@angular/core";
+import { Injectable } from "@angular/core";
 
 /**
  * Custom navigation used for Angular client-side navigation.
@@ -33,7 +33,7 @@ export class MsalCustomNavigationClient extends NavigationClient {
         
         // Prevent hash clearing from causing an issue with Client-side navigation after redirect is handled
         if (options.noHistory) {
-            window.location.replace(url);
+            return super.navigateInternal(url, options);
         } else {
             // Normalizing newUrl if no query string
             const urlComponents = new UrlString(url).getUrlComponents();


### PR DESCRIPTION
Using the normalized url is causing side effects resulting in a broken experience. Given the normalization is there for the Angular router (which isn't being used for navigateToLoginRequestUrl), we can just use the absolute url provided as-is.