### PR TITLE
Discard tokens acquired after current time

### DIFF
--- a/change/@azure-msal-common-a410d7ad-36b1-4d1c-9c44-b02dfa1012d7.json
+++ b/change/@azure-msal-common-a410d7ad-36b1-4d1c-9c44-b02dfa1012d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Discard tokens cached after current time #3786",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -65,6 +65,7 @@ export class SilentFlowClient extends BaseClient {
             !StringUtils.isEmptyObj(request.claims) || 
             !cacheRecord.accessToken || 
             TimeUtils.isTokenExpired(cacheRecord.accessToken.expiresOn, this.config.systemOptions.tokenRenewalOffsetSeconds) ||
+            TimeUtils.wasClockTurnedBack(cacheRecord.accessToken.cachedAt) ||
             (cacheRecord.accessToken.refreshOn && TimeUtils.isTokenExpired(cacheRecord.accessToken.refreshOn, 0))) {
             // Must refresh due to request parameters, or expired or non-existent access_token
             throw ClientAuthError.createRefreshRequiredError();

--- a/lib/msal-common/src/utils/TimeUtils.ts
+++ b/lib/msal-common/src/utils/TimeUtils.ts
@@ -30,6 +30,18 @@ export class TimeUtils {
     }
 
     /**
+     * If the current time is earlier than the time that a token was cached at, we must discard the token
+     * i.e. The system clock was turned back after acquiring the cached token
+     * @param cachedAt 
+     * @param offset 
+     */
+    static wasClockTurnedBack(cachedAt: string): boolean {
+        const cachedAtSec = Number(cachedAt);
+
+        return cachedAtSec > TimeUtils.nowSeconds();
+    }
+
+    /**
      * Waits for t number of milliseconds
      * @param t number
      * @param value T

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -440,6 +440,28 @@ describe("SilentFlowClient unit tests", () => {
             expect(client.acquireCachedToken(silentFlowRequest)).rejects.toMatchObject(ClientAuthError.createRefreshRequiredError());
         });
 
+        it("acquireCachedToken throws refresh requiredError if access token was cached after the current time", async () => {
+            sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+            sinon.stub(AuthToken, "extractTokenClaims").returns(ID_TOKEN_CLAIMS);
+            sinon.stub(CacheManager.prototype, "readAccountFromCache").returns(testAccountEntity);
+            sinon.stub(CacheManager.prototype, "readIdTokenFromCache").returns(testIdToken);
+            sinon.stub(CacheManager.prototype, "readAccessTokenFromCache").returns(testAccessTokenEntity);
+            sinon.stub(CacheManager.prototype, "readRefreshTokenFromCache").returns(testRefreshTokenEntity);
+            const config = await ClientTestUtils.createTestClientConfiguration();
+            const client = new SilentFlowClient(config);
+            sinon.stub(TimeUtils, <any>"wasClockTurnedBack").returns(true);
+
+            const silentFlowRequest: CommonSilentFlowRequest = {
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                account: testAccount,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                forceRefresh: false
+            };
+
+            expect(client.acquireCachedToken(silentFlowRequest)).rejects.toMatchObject(ClientAuthError.createRefreshRequiredError());
+        });
+
         it("acquireCachedToken throws refresh requiredError if no access token is cached", async () => {
             sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
             sinon.stub(AuthToken, "extractTokenClaims").returns(ID_TOKEN_CLAIMS);

--- a/lib/msal-common/test/utils/TimeUtils.spec.ts
+++ b/lib/msal-common/test/utils/TimeUtils.spec.ts
@@ -7,4 +7,14 @@ describe("TimeUtils.ts Class Unit Tests", () => {
         expect(typeof currSeconds).toBe("number");
         expect(currSeconds).toBeLessThanOrEqual(TimeUtils.nowSeconds());
     });
+
+    it("isTokenExpired() returns whether or not a token is expired", () => {
+        expect(TimeUtils.isTokenExpired(TimeUtils.nowSeconds().toString(), 60000)).toBe(true);
+        expect(TimeUtils.isTokenExpired((TimeUtils.nowSeconds() + 60000).toString(), 0)).toBe(false);
+    });
+
+    it("wasClockTurnedBack() returns whether or not the clock was turned back", () => {
+        expect(TimeUtils.wasClockTurnedBack((TimeUtils.nowSeconds() + 6000).toString())).toBe(true);
+        expect(TimeUtils.wasClockTurnedBack((TimeUtils.nowSeconds() - 60000).toString())).toBe(false);
+    });
 });


### PR DESCRIPTION
If a user turns back their system clock after a token is acquired they can potentially prolong the amount of time that MSAL will return a cached token to them even though the token may no longer be valid. This PR fixes this behavior by comparing the token `cachedAt` time to the current time and forcing a refresh if the current time is earlier than the cached at time. This is in accordance with the unified cache schema spec.

Fixes #3206