### PR TITLE
[msal-node-extensions] verifyPersistence should not finally return true

### DIFF
--- a/extensions/msal-node-extensions/src/persistence/BasePersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/BasePersistence.ts
@@ -15,7 +15,7 @@ export abstract class BasePersistence {
         const persistenceValidator = await this.createForPersistenceValidation();
 
         try {
-            persistenceValidator.save(Constants.PERSISTENCE_TEST_DATA);
+            await persistenceValidator.save(Constants.PERSISTENCE_TEST_DATA);
 
             const retrievedDummyData = await persistenceValidator.load();
 

--- a/extensions/msal-node-extensions/src/persistence/BasePersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/BasePersistence.ts
@@ -31,11 +31,10 @@ export abstract class BasePersistence {
                     `Persistence check failed. Data written ${Constants.PERSISTENCE_TEST_DATA} is different from data read ${retrievedDummyData}`
                 );
             }
-         } catch(e) {
-            throw PersistenceError.createCachePersistenceError(`Verifing persistence failed with the error: ${e}`)
-        } finally {
-            persistenceValidator.delete();
+            await persistenceValidator.delete();
             return true;
+        } catch (e) {
+            throw PersistenceError.createCachePersistenceError(`Verifing persistence failed with the error: ${e}`);
         }
     }
 


### PR DESCRIPTION
Doing finally and returning true takes predominance over throwing the error, so the error doesn’t bubble up properly.

verifyPersistence() should return true only if no error was encountered.