### PR TITLE
Fix broken link in initialize-public-client-application.md

### DIFF
--- a/lib/msal-node/docs/initialize-public-client-application.md
+++ b/lib/msal-node/docs/initialize-public-client-application.md
@@ -12,7 +12,7 @@ In this document:
 
 ## Initializing the PublicClientApplication object
 
-In order to use MSAL Node, you need to instantiate a [PublicClientApplication](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.publicclientapplication.html) object. We support and strongly recommend the use of [PKCE](https://tools.ietf.org/html/rfc7636#section-6.2) (Proof Key for Code Exchange) for any PublicClientApplication. The usage pattern is demonstrated in the [PKCE Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-node-samples/standalone-samples/auth-code-pkce).
+In order to use MSAL Node, you need to instantiate a [PublicClientApplication](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.publicclientapplication.html) object. We support and strongly recommend the use of [PKCE](https://tools.ietf.org/html/rfc7636#section-6.2) (Proof Key for Code Exchange) for any PublicClientApplication. The usage pattern is demonstrated in the [PKCE Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-node-samples/auth-code-pkce).
 
 ```javascript
 import * as msal from "@azure/msal-node";


### PR DESCRIPTION
Click on the 'PKCE sample' link on [initialize-public-client-application.md](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/initialize-public-client-application.md) page returns a 404 status code. I found the correct link on [README.md](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/README.md) page https://github.com/AzureAD/microsoft-authentication-library-for-js/search?q=auth-code-pkce