### PR TITLE
Fix double query string for logout

### DIFF
--- a/change/@azure-msal-common-118d673d-d0d8-4e24-bc0e-9033e4b16b69.json
+++ b/change/@azure-msal-common-118d673d-d0d8-4e24-bc0e-9033e4b16b69.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix double query string for logout endpoint #3814",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -133,7 +133,7 @@ export class AuthorizationCodeClient extends BaseClient {
         const queryString = this.createLogoutUrlQueryString(logoutRequest);
 
         // Construct logout URI.
-        return StringUtils.isEmpty(queryString) ? this.authority.endSessionEndpoint : `${this.authority.endSessionEndpoint}?${queryString}`;
+        return UrlString.appendQueryString(this.authority.endSessionEndpoint, queryString);
     }
 
     /**


### PR DESCRIPTION
PR #3620 fixed an issue where the '?' symbol would be appended to the url a second time if the a`.well-known/openid-configuration` endpoint returned endpoints that already contained a query string. That PR did not address the end session endpoint. This PR fixes the issue for logout.

cc. @nilact