### PR TITLE
Msal-Browser supports parallel silent requests

### DIFF
--- a/change/@azure-msal-browser-adabc718-b19b-4b98-a5b7-887465c75857.json
+++ b/change/@azure-msal-browser-adabc718-b19b-4b98-a5b7-887465c75857.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Msal-Browser supports parallel silent requests #3837",
+  "packageName": "@azure/msal-browser",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AccountInfo, AuthenticationResult, CommonSilentFlowRequest, RequestThumbprint, ThrottlingUtils } from "@azure/msal-common";
+import { AccountInfo, AuthenticationResult, CommonSilentFlowRequest, RequestThumbprint } from "@azure/msal-common";
 import { Configuration } from "../config/Configuration";
 import { DEFAULT_REQUEST, ApiId, InteractionType } from "../utils/BrowserConstants";
 import { IPublicClientApplication } from "./IPublicClientApplication";
@@ -96,7 +96,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
             scopes: request.scopes,
             homeAccountIdentifier: account.homeAccountId
         };
-        const silentRequestKey = ThrottlingUtils.generateThrottlingStorageKey(thumbprint);
+        const silentRequestKey = JSON.stringify(thumbprint);
         let response = this.activeSilentTokenRequests.get(silentRequestKey);
         if (typeof response === "undefined") {
             this.logger.verbose("acquireTokenSilent called for the first time, storing active request", request.correlationId);

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -95,15 +95,14 @@ export class PublicClientApplication extends ClientApplication implements IPubli
             authority: request.authority || "",
             scopes: request.scopes,
             homeAccountIdentifier: account.homeAccountId
-        }
+        };
         const silentRequestKey = ThrottlingUtils.generateThrottlingStorageKey(thumbprint);
         let response = this.silentRequest.get(silentRequestKey);
         if (typeof response === "undefined") {
             response = this.acquireTokenSilentAsync(request, account).then((result) => {
                 this.silentRequest.delete(silentRequestKey);
                 return result;
-            })
-            .catch((error) => {
+            }).catch((error) => {
                 this.silentRequest.delete(silentRequestKey);
                 throw error;
             });

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -78,7 +78,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
     }
 
     /**
-     * Silently acquire an access token for a given set of scopes. Returnings currently processing promise if parallel requests are made.
+     * Silently acquire an access token for a given set of scopes. Returns currently processing promise if parallel requests are made.
      *
      * @param {@link (SilentRequest:type)}
      * @returns {Promise.<AuthenticationResult>} - a promise that is fulfilled when this function has completed, or rejected if an error was raised. Returns the {@link AuthResponse} object

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthenticationResult, CommonSilentFlowRequest } from "@azure/msal-common";
+import { AccountInfo, AuthenticationResult, CommonSilentFlowRequest, RequestThumbprint, ThrottlingUtils } from "@azure/msal-common";
 import { Configuration } from "../config/Configuration";
 import { DEFAULT_REQUEST, ApiId, InteractionType } from "../utils/BrowserConstants";
 import { IPublicClientApplication } from "./IPublicClientApplication";
@@ -20,6 +20,9 @@ import { version, name } from "../packageMetadata";
  * to obtain JWT tokens as described in the OAuth 2.0 Authorization Code Flow with PKCE specification.
  */
 export class PublicClientApplication extends ClientApplication implements IPublicClientApplication {
+
+    // Redirect Response Object
+    private silentRequest: Map<string, Promise<AuthenticationResult>>;
 
     /**
      * @constructor
@@ -44,6 +47,8 @@ export class PublicClientApplication extends ClientApplication implements IPubli
      */
     constructor(configuration: Configuration) {
         super(configuration);
+
+        this.silentRequest = new Map();
     }
 
     /**
@@ -73,7 +78,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
     }
 
     /**
-     * Silently acquire an access token for a given set of scopes. Will use cached token if available, otherwise will attempt to acquire a new token from the network via refresh token.
+     * Silently acquire an access token for a given set of scopes. Returnings currently processing promise if parallel requests are made.
      *
      * @param {@link (SilentRequest:type)}
      * @returns {Promise.<AuthenticationResult>} - a promise that is fulfilled when this function has completed, or rejected if an error was raised. Returns the {@link AuthResponse} object
@@ -85,6 +90,37 @@ export class PublicClientApplication extends ClientApplication implements IPubli
         if (!account) {
             throw BrowserAuthError.createNoAccountError();
         }
+        const thumbprint: RequestThumbprint = {
+            clientId: this.config.auth.clientId,
+            authority: request.authority || "",
+            scopes: request.scopes,
+            homeAccountIdentifier: account.homeAccountId
+        }
+        const silentRequestKey = ThrottlingUtils.generateThrottlingStorageKey(thumbprint);
+        let response = this.silentRequest.get(silentRequestKey);
+        if (typeof response === "undefined") {
+            response = this.acquireTokenSilentAsync(request, account).then((result) => {
+                this.silentRequest.delete(silentRequestKey);
+                return result;
+            })
+            .catch((error) => {
+                this.silentRequest.delete(silentRequestKey);
+                throw error;
+            });
+            this.silentRequest.set(silentRequestKey, response);
+        } else {
+            this.logger.verbose("acquireTokenSilent has been called previously, returning the result from the first call");
+        }
+        return response;
+    }
+
+    /**
+     * Silently acquire an access token for a given set of scopes. Will use cached token if available, otherwise will attempt to acquire a new token from the network via refresh token.
+     * @param {@link (SilentRequest:type)}
+     * @param {@link (AccountInfo:type)}
+     * @returns {Promise.<AuthenticationResult>} - a promise that is fulfilled when this function has completed, or rejected if an error was raised. Returns the {@link AuthResponse} 
+     */
+    private async acquireTokenSilentAsync(request: SilentRequest, account: AccountInfo): Promise<AuthenticationResult>{
         const silentRequest: CommonSilentFlowRequest = {
             ...request,
             ...this.initializeBaseRequest(request),

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -2244,16 +2244,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(parallelResponse).toHaveLength(3);
         });
 
-        it.only("makes network requests for each distinct request when acquireTokenSilent is called in parallel", async () => {
-            const testServerTokenResponse = {
-                token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,
-                scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
-                expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
-                ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
-                access_token: TEST_TOKENS.ACCESS_TOKEN,
-                refresh_token: TEST_TOKENS.REFRESH_TOKEN,
-                id_token: TEST_TOKENS.IDTOKEN_V2
-            };
+        it("makes network requests for each distinct request when acquireTokenSilent is called in parallel", async () => {
             const testIdTokenClaims: TokenClaims = {
                 "ver": "2.0",
                 "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
@@ -2271,22 +2262,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tenantId: testIdTokenClaims.tid || "",
                 username: testIdTokenClaims.preferred_username || ""
             };
-            const testTokenResponse: AuthenticationResult = {
-                authority: TEST_CONFIG.validAuthority,
-                uniqueId: testIdTokenClaims.oid || "",
-                tenantId: testIdTokenClaims.tid || "",
-                scopes: [...TEST_CONFIG.DEFAULT_SCOPES, "User.Read"],
-                idToken: testServerTokenResponse.id_token,
-                idTokenClaims: testIdTokenClaims,
-                accessToken: testServerTokenResponse.access_token,
-                fromCache: false,
-                expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
-                account: testAccount,
-                tokenType: AuthenticationScheme.BEARER
-            };
             sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
-            const silentATStub = sinon.stub(RefreshTokenClient.prototype, <any>"acquireTokenByRefreshToken").resolves(testTokenResponse);
-            const tokenRequest: CommonSilentFlowRequest = {
+            const silentATStub = sinon.stub(RefreshTokenClient.prototype, <any>"acquireTokenByRefreshToken");
+            const tokenRequest1: CommonSilentFlowRequest = {
                 scopes: ["User.Read"],
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
@@ -2294,24 +2272,70 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 correlationId: TEST_CONFIG.CORRELATION_ID,
                 forceRefresh: false
             };
-            const expectedTokenRequest: CommonSilentFlowRequest = {
-                ...tokenRequest,
+            const expectedTokenRequest1: CommonSilentFlowRequest = {
+                ...tokenRequest1,
                 scopes: ["User.Read"],
                 authority: `${Constants.DEFAULT_AUTHORITY}`,
                 correlationId: RANDOM_TEST_GUID,
                 forceRefresh: false
             };
-            const silentRequest1 = pca.acquireTokenSilent(tokenRequest);
-            const silentRequest2 = pca.acquireTokenSilent(tokenRequest);
-            const silentRequest3 = pca.acquireTokenSilent(tokenRequest);
-            const parallelResponse = await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
+            const tokenRequest2: CommonSilentFlowRequest = {
+                scopes: ["Mail.Read"],
+                account: testAccount,
+                authority: TEST_CONFIG.validAuthority,
+                authenticationScheme: AuthenticationScheme.BEARER,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                forceRefresh: false
+            };
+            const expectedTokenRequest2: CommonSilentFlowRequest = {
+                ...tokenRequest1,
+                scopes: ["Mail.Read"],
+                authority: `${Constants.DEFAULT_AUTHORITY}`,
+                correlationId: RANDOM_TEST_GUID,
+                forceRefresh: false
+            };
+            const silentRequest1 = pca.acquireTokenSilent(tokenRequest1);
+            const silentRequest2 = pca.acquireTokenSilent(tokenRequest1);
+            const silentRequest3 = pca.acquireTokenSilent(tokenRequest2);
+            await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
 
-            expect(silentATStub.calledWith(expectedTokenRequest)).toBeTruthy();
-            expect(silentATStub.callCount).toEqual(1);
-            expect(parallelResponse[0]).toEqual(testTokenResponse);
-            expect(parallelResponse[1]).toEqual(testTokenResponse);
-            expect(parallelResponse[2]).toEqual(testTokenResponse);
-            expect(parallelResponse).toHaveLength(3);
+            expect(silentATStub.calledWith(expectedTokenRequest1)).toBeTruthy();
+            expect(silentATStub.calledWith(expectedTokenRequest2)).toBeTruthy();
+            expect(silentATStub.callCount).toEqual(2);
+        });
+
+        it("throws error that SilentFlowClient.acquireToken() throws when making parallel requests", async () => {
+            const testError = {
+                errorCode: "create_login_url_error",
+                errorMessage: "Error in creating a login url"
+            };
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: "testTenantId",
+                username: "username@contoso.com"
+            };
+            sinon.stub(RefreshTokenClient.prototype, <any>"acquireTokenByRefreshToken").rejects(testError);
+            try {
+                const tokenRequest = {
+                    scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                    account: testAccount
+                };
+                const silentRequest1 = pca.acquireTokenSilent(tokenRequest);
+                const silentRequest2 = pca.acquireTokenSilent(tokenRequest);
+                const silentRequest3 = pca.acquireTokenSilent(tokenRequest);
+                await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
+            } catch (e) {
+                // Test that error was cached for telemetry purposes and then thrown
+                expect(window.sessionStorage).toHaveLength(1);
+                const failures = window.sessionStorage.getItem(`server-telemetry-${TEST_CONFIG.MSAL_CLIENT_ID}`);
+                const failureObj = JSON.parse(failures || "") as ServerTelemetryEntity;
+                expect(failureObj.failedRequests).toHaveLength(2);
+                expect(failureObj.failedRequests[0]).toEqual(ApiId.acquireTokenSilent_silentFlow);
+                expect(failureObj.errors[0]).toEqual(testError.errorCode);
+                expect(e).toEqual(testError);
+            }
         });
     });
 


### PR DESCRIPTION
This adds a `silentRequest` Map to *PublicClientApplication.ts*, and assigns a unique thumbprint to every request made in `acquireTokenSilent`. These thumbprints are used to track requests made, and is designed to gracefully handle multiple concurrent `acquireTokenSilent` calls with the same request. 

This PR addresses #2884.