### PR TITLE
Fix edge case causing acquireTokenSilent to hang in v1

### DIFF
--- a/change/msal-0d7e07a9-7fe1-468c-8e34-3954a85747cb.json
+++ b/change/msal-0d7e07a9-7fe1-468c-8e34-3954a85747cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug causing acquireTokenSilent to hang and never return #3867",
+  "packageName": "msal",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-core/src/UserAgentApplication.ts
+++ b/lib/msal-core/src/UserAgentApplication.ts
@@ -217,10 +217,18 @@ export class UserAgentApplication {
         this.cacheStorage = new AuthCache(this.clientId, this.config.cache.cacheLocation, this.inCookie);
 
         // Initialize window handling code
-        window.activeRenewals = {};
-        window.renewStates = [];
-        window.callbackMappedToRenewStates = { };
-        window.promiseMappedToRenewStates = { };
+        if (!window.activeRenewals) {
+            window.activeRenewals = {};
+        }
+        if (!window.renewStates) {
+            window.renewStates = [];
+        }
+        if (!window.callbackMappedToRenewStates) {
+            window.callbackMappedToRenewStates = {};
+        }
+        if (!window.promiseMappedToRenewStates) {
+            window.promiseMappedToRenewStates = {};
+        }
         window.msal = this;
 
         const urlHash = window.location.hash;
@@ -1000,7 +1008,7 @@ export class UserAgentApplication {
         if (!window.callbackMappedToRenewStates[expectedState]) {
             window.callbackMappedToRenewStates[expectedState] = (response: AuthResponse, error: AuthError) => {
                 // reset active renewals
-                window.activeRenewals[requestSignature] = null;
+                delete window.activeRenewals[requestSignature];
 
                 // for all promiseMappedtoRenewStates for a given 'state' - call the reject/resolve with error/token respectively
                 for (let i = 0; i < window.promiseMappedToRenewStates[expectedState].length; ++i) {
@@ -1019,8 +1027,8 @@ export class UserAgentApplication {
                 }
 
                 // reset
-                window.promiseMappedToRenewStates[expectedState] = null;
-                window.callbackMappedToRenewStates[expectedState] = null;
+                delete window.promiseMappedToRenewStates[expectedState];
+                delete window.callbackMappedToRenewStates[expectedState];
             };
         }
     }


### PR DESCRIPTION
Msal.js v1 uses the global window object to store callbacks and promises, which return the response/error back to the developer. There exists an edge case today that can cause `acquireTokenSilent` to hang and never return anything if another instance of `UserAgentApplication` is instantiated **while** another `acquireTokenSilent` call is in progress. This is due to the fact that the UAA constructor clears the global window objects used to track in progress requests, resulting in the in-progress request losing the reference to the promise it needs to resolve.

This PR addresses this unique scenario by checking if the objects are already defined on the window before instantiating them. It also updates the cleanup logic to delete stale keys rather than just setting the value to `null`.