### PR TITLE
Update 'passport' from ^0.3.2 to ^0.4.1 for passport-azure-ad

### DIFF
--- a/maintenance/passport-azure-ad/package-lock.json
+++ b/maintenance/passport-azure-ad/package-lock.json
@@ -2269,9 +2269,9 @@
       "dev": true
     },
     "passport": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
-      "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"

--- a/maintenance/passport-azure-ad/package.json
+++ b/maintenance/passport-azure-ad/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.11.2",
     "node-jose": "^2.0.0",
     "oauth": "0.9.15",
-    "passport": "^0.3.2",
+    "passport": "^0.4.1",
     "request": "^2.72.0",
     "valid-url": "^1.0.6"
   },


### PR DESCRIPTION
This PR updates the version for the `passport` package from `^0.3.2` to `^0.4.1` inside the `passport-azure-ad` package in order to fix certain bugs.