### PR TITLE
Add self-service sign-up entry to msal-angular and msal-react FAQs

### DIFF
--- a/change/@azure-msal-angular-2021-08-05-12-45-29-prompt-create-docs.json
+++ b/change/@azure-msal-angular-2021-08-05-12-45-29-prompt-create-docs.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update docs with self-service sign up FAQ #3934",
+  "packageName": "@azure/msal-angular",
+  "email": "joliuac@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2021-08-05T19:45:08.030Z"
+}

--- a/change/@azure-msal-browser-2021-08-05-12-45-29-prompt-create-docs.json
+++ b/change/@azure-msal-browser-2021-08-05-12-45-29-prompt-create-docs.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update FAQ #3934",
+  "packageName": "@azure/msal-browser",
+  "email": "joliuac@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2021-08-05T19:45:17.105Z"
+}

--- a/change/@azure-msal-react-2021-08-05-12-45-29-prompt-create-docs.json
+++ b/change/@azure-msal-react-2021-08-05-12-45-29-prompt-create-docs.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update docs with self-service sign-up FAQ #3934",
+  "packageName": "@azure/msal-react",
+  "email": "joliuac@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2021-08-05T19:45:29.360Z"
+}

--- a/lib/msal-angular/docs/FAQ.md
+++ b/lib/msal-angular/docs/FAQ.md
@@ -15,13 +15,17 @@
 1. [How do I add tokens to API calls?](#how-do-i-add-tokens-to-api-calls)
 1. [How do I use my app with path/hash location strategy?](#how-do-i-use-my-app-with-pathhash-location-strategy)
 
+**[Authentication](#authentication)**
+
+1. [How do I log users in when they hit the application?](#how-do-i-log-users-in-when-they-hit-the-application)
+1. [Why is my app looping when logging in with redirect?](#why-is-my-app-looping-when-logging-in-with-redirect)
+1. [How do I implement self-service sign-up?](#how-do-i-implement-self-service-sign-up)
+
 **[Usage](#usage)**
 
 1. [How do I secure routes?](#how-do-i-secure-routes)
 1. [How do I get accounts?](#how-do-i-get-accounts)
 1. [How do I get and set active accounts?](#how-do-i-get-and-set-active-accounts)
-1. [How do I log users in when they hit the application?](#how-do-i-log-users-in-when-they-hit-the-application)
-1. [Why is my app looping when logging in with redirect?](#why-is-my-app-looping-when-logging-in-with-redirect)
 
 **[Errors](#errors)**
 
@@ -74,32 +78,7 @@ Please note that the `MsalInterceptor` is optional. You may wish to explicitly a
 
 See [below](#how-do-i-log-users-in-when-they-hit-the-application) for additional considerations for each strategy if you are wanting to log users in on page load.
 
-## Usage
-
-### How do I secure routes?
-
-Please see our [MsalGuard doc](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/v2-docs/msal-guard.md) for more information about securing routes with the `MsalGuard`.
-
-### How do I get accounts?
-
-The `@azure/msal-browser` instance used by `@azure/msal-angular` exposes multiple methods for getting account information. We recommend using `getAllAccounts()` to get all accounts, and `getAccountByHomeId()` and `getAccountByLocalId()` to get specific accounts. Note that while `getAccountByUsername()` is available, it should be a secondary choice, as it may be less reliable and is for convenience only. See the [`@azure/msal-browser` docs](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_browser.publicclientapplication.html) for more details on account methods.
-
-We recommend subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None` before retrieving account information. This ensures that all interactions have completed before getting account information. See [our sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular10-sample-app/src/app/app.component.ts#L27) for an example of this use.
-
-### How do I get and set active accounts?
-
-The `msal-browser` instance exposes `getActiveAccount()` and `setActiveAccount()` for active accounts. 
-
-We recommend subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None` before retrieving account information with `getActiveAccount()`. This ensures that all interactions have completed before getting account information. 
-
-We recommend setting the active account:
-
-- After any action that may change the account, especially if your app uses multiple accounts. See [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app/src/app/home/home.component.ts#L23) for an example of setting the account after a successful login.
-- On initial page load. Wait until all interactions are complete (by subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None`), check if there is an active account, and if there is none, set the active account. This could be the first account retrieved by `getAllAccounts()`, or other account selection logic required by your app. See [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app) for an example of checking and setting the active account on page load.
-
-**Note:** Prior to `@azure/msal-browser@2.15.0` active account did not persist across page loads. If you are using `@azure/msal-browser@2.14.2` or earlier we recommend that you set the active account for each page load. In version 2.15.0 and above the active account will be cached in the cache location specified in your MSAL config and retrieved each time `getActiveAccount` is called.
-
-Our [Angular 11](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app) sample demonstrates basic usage. Your app may require more complicated logic to choose accounts.
+## Authentication
 
 ### How do I log users in when they hit the application?
 
@@ -131,6 +110,36 @@ See our [Angular 11 sample](https://github.com/AzureAD/microsoft-authentication-
 One of the common reasons your app may be looping while logging in with redirects is due to improper usage of the `loginRedirect()` API. We recommend that you do not call `loginRedirect()` in the `ngOnInit` in the `app.component.ts`, as this will attempt to log in with every page load, often before any redirect has finished processing. 
 
 Redirects **must** be handled either with the `MsalRedirectComponent` or with calling `handleRedirectObservable()`. See our docs on redirects [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-angular/docs/v2-docs/redirects.md) for more information. Additionally, any interaction or account validation should be done after  subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None`. Please see our [sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/30b5ff95e2ff2cc827d98118004d92968bb67b3f/samples/msal-angular-v2-samples/angular11-sample-app/src/app/app.component.ts#L27) for an example. 
+
+## How do I implement self-service sign-up?
+MSAL Angular supports self-service sign-up in the auth code flow. Please see our docs [here](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#popuprequest) for supported prompt values in the request and their expected outcomes, and [here](http://aka.ms/s3u) for an overview of self-service sign-up and configuration changes that need to be made to your Azure tenant. Please note that that self-service sign-up is not available in B2C and test environments.
+
+## Usage
+
+### How do I secure routes?
+
+Please see our [MsalGuard doc](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/v2-docs/msal-guard.md) for more information about securing routes with the `MsalGuard`.
+
+### How do I get accounts?
+
+The `@azure/msal-browser` instance used by `@azure/msal-angular` exposes multiple methods for getting account information. We recommend using `getAllAccounts()` to get all accounts, and `getAccountByHomeId()` and `getAccountByLocalId()` to get specific accounts. Note that while `getAccountByUsername()` is available, it should be a secondary choice, as it may be less reliable and is for convenience only. See the [`@azure/msal-browser` docs](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_browser.publicclientapplication.html) for more details on account methods.
+
+We recommend subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None` before retrieving account information. This ensures that all interactions have completed before getting account information. See [our sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular10-sample-app/src/app/app.component.ts#L27) for an example of this use.
+
+### How do I get and set active accounts?
+
+The `msal-browser` instance exposes `getActiveAccount()` and `setActiveAccount()` for active accounts. 
+
+We recommend subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None` before retrieving account information with `getActiveAccount()`. This ensures that all interactions have completed before getting account information. 
+
+We recommend setting the active account:
+
+- After any action that may change the account, especially if your app uses multiple accounts. See [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app/src/app/home/home.component.ts#L23) for an example of setting the account after a successful login.
+- On initial page load. Wait until all interactions are complete (by subscribing to the `inProgress$` observable and filtering for `InteractionStatus.None`), check if there is an active account, and if there is none, set the active account. This could be the first account retrieved by `getAllAccounts()`, or other account selection logic required by your app. See [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app) for an example of checking and setting the active account on page load.
+
+**Note:** Prior to `@azure/msal-browser@2.15.0` active account did not persist across page loads. If you are using `@azure/msal-browser@2.14.2` or earlier we recommend that you set the active account for each page load. In version 2.15.0 and above the active account will be cached in the cache location specified in your MSAL config and retrieved each time `getActiveAccount` is called.
+
+Our [Angular 11](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v2-samples/angular11-sample-app) sample demonstrates basic usage. Your app may require more complicated logic to choose accounts.
 
 ## Errors
 

--- a/lib/msal-browser/FAQ.md
+++ b/lib/msal-browser/FAQ.md
@@ -16,6 +16,7 @@
 1. [I don't understand the redirect flow. How does the handleRedirectPromise function work?](#i-dont-understand-the-redirect-flow-how-does-the-handleredirectpromise-function-work)
 1. [How can I support authentication with personal Microsoft accounts only?](#how-can-i-support-authentication-with-personal-microsoft-accounts-only)
 1. [How do I get an authorization code from the library?](#how-do-i-get-an-authorization-code-from-the-library)
+1. [How do I implement self-service sign-up?](#how-do-i-implement-self-service-sign-up)
 
 **[Single-Sign-On](#Single-Sign-On)**
 

--- a/lib/msal-react/FAQ.md
+++ b/lib/msal-react/FAQ.md
@@ -13,6 +13,7 @@
 
 1. [How do I handle the redirect flow in a react app?](#how-do-i-handle-the-redirect-flow-in-a-react-app)
 1. [What can I do outside of @azure/msal-react context?](#what-can-i-do-outside-of-azuremsal-react-context)
+1. [How do I implement self-service sign-up?](#how-do-i-implement-self-service-sign-up)
 
 **[B2C](#B2C)**
 
@@ -94,6 +95,9 @@ This means the following APIs are off-limits outside the context of `MsalProvide
 - `acquireTokenRedirect`
 
 **Note:** If you do choose to use any other `@azure/msal-browser` API outside of the react context you should still use the same `PublicClientApplication` instance you pass into `MsalProvider`.
+
+## How do I implement self-service sign-up?
+MSAL React supports self-service sign-up in the auth code flow. Please see our docs [here](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#popuprequest) for supported prompt values in the request and their expected outcomes, and [here](http://aka.ms/s3u) for an overview of self-service sign-up and configuration changes that need to be made to your Azure tenant. Please note that that self-service sign-up is not available in B2C and test environments.
 
 ## B2C
 


### PR DESCRIPTION
This PR confirms that `prompt=create` passed in the request will trigger the self-service sign-up experience when using msal-angular and msal-react. No further changes needed, docs updated. See #3773 for more details. 