### PR TITLE
Skip E2E tests when triggered by dependabot

### DIFF
--- a/.github/workflows/msal-angular-e2e.yml
+++ b/.github/workflows/msal-angular-e2e.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/msal-browser-e2e.yml
+++ b/.github/workflows/msal-browser-e2e.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/msal-core-e2e.yml
+++ b/.github/workflows/msal-core-e2e.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/msal-react-e2e.yml
+++ b/.github/workflows/msal-react-e2e.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Dependabot does not have access to repository secrets and cannot successfully run the E2E tests. This PR skips E2E tests when triggered by dependabot so the PR can be merged. E2E tests can still be run on dependabot PRs by manually re-running the jobs if needed.