### PR TITLE
Remove experimental folder from lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -25,8 +25,7 @@
     }
   },
   "packages": [
-    "lib/*",
-    "experimental/*"
+    "lib/*"
   ],
   "version": "independent",
   "concurrency": 3


### PR DESCRIPTION
This isn't needed right now, and just slows down `lerna bootstrap`.