### PR TITLE
Fix infinite reload on code route in angular

### DIFF
--- a/change/@azure-msal-angular-2b3afef7-5cf3-4ebc-9156-3f18fa1cbbca.json
+++ b/change/@azure-msal-angular-2b3afef7-5cf3-4ebc-9156-3f18fa1cbbca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix infinite reload on route protected by MsalGuard when '#code=' appears in the url #3995",
+  "packageName": "@azure/msal-angular",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -73,6 +73,7 @@ describe('MsalGuard', () => {
     testLoginFailedRoute = undefined;
     testConfiguration = { };
     browserSystemOptions = { };
+    routeStateMock = { snapshot: {}, url: '/' };
     initializeMsal();
   });
 

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -115,6 +115,8 @@ describe('MsalGuard', () => {
         }
     ])
 
+    routeStateMock = { snapshot: {}, url: '/path#code=' };
+
     spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
         //@ts-ignore
         of("test")
@@ -144,6 +146,8 @@ describe('MsalGuard', () => {
             }
         }
     ])
+
+    routeStateMock = { snapshot: {}, url: '/code=' };
 
     spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
         //@ts-ignore

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -145,7 +145,7 @@ export class MsalGuard implements CanActivate, CanActivateChild, CanLoad {
                     this.authService.getLogger().verbose("Guard - at least 1 account exists, can activate or load");
 
                     // Prevent navigating the app to /#code= or /code=
-                    if (state && currentPath.indexOf("code=")> -1) {
+                    if (state && state.url.indexOf("code=") > -1) {
                         this.authService.getLogger().info("Guard - Hash contains known code response, stopping navigation.");
                         
                         // Path routing (navigate to current path without hash)


### PR DESCRIPTION
When using `msal-angular` if you navigate to a route that is protected by the MsalGuard and `code=` appears in the url it can result in an infinite reload loop. The MsalGuard is invoked before the route is actually changed and currently the logic checks the **current** path rather than the **desired** path for `code=`. This results in an attempted navigation to the current route without the `code=` where the Guard is invoked again with no change to the **current** url resulting in a loop. This PR fixes this behavior by making the code logic check the **destination** path for `code=` instead of current. 

Fixes #3928