### PR TITLE
Address security and linting for passport-azure-ad

### DIFF
--- a/maintenance/passport-azure-ad/.eslintrc
+++ b/maintenance/passport-azure-ad/.eslintrc
@@ -1,3 +1,34 @@
 {
-  "extends": "oniyi"
+  "root": true,
+  "env": {
+      "browser": true,
+      "node": true,
+      "commonjs": true
+  },
+  "plugins": [
+      "header",
+      "security"
+  ],
+  "extends": [
+      "eslint:recommended",
+      "plugin:security/recommended"
+  ],
+  "parserOptions": {
+      "ecmaVersion": 12
+  },
+  "rules": {
+      "eol-last": 2,
+      "eqeqeq": 2,
+      "header/header": [2, "block", [ "", " * Copyright (c) Microsoft Corporation. All rights reserved.", " * Licensed under the MIT License.", " " ], 2],
+      "multiline-comment-style": [2, "starred-block" ],
+      "no-console": 2,
+      "no-multiple-empty-lines": [2, { "max": 1 }],
+      "no-param-reassign": 2,
+      "no-var": 2,
+      "prefer-const": 2,
+      "quotes": [2, "double"],
+      "security/detect-non-literal-fs-filename": 0,
+      "security/detect-object-injection": 0,
+      "spaced-comment": 2
+  }
 }

--- a/maintenance/passport-azure-ad/lib/aadutils.js
+++ b/maintenance/passport-azure-ad/lib/aadutils.js
@@ -1,36 +1,19 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the "Software"), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
-'use strict';
 
-const base64url = require('base64url');
-const crypto = require('crypto');
-const util = require('util');
+"use strict";
 
-exports.getLibraryProduct = () => { return 'passport-azure-ad' };
+const base64url = require("base64url");
+const crypto = require("crypto");
+const util = require("util");
+
+exports.getLibraryProduct = () => { return "passport-azure-ad" };
 exports.getLibraryVersionParameterName = () => { return "x-client-Ver" };
-exports.getLibraryProductParameterName = () => { return 'x-client-SKU' };
+exports.getLibraryProductParameterName = () => { return "x-client-SKU" };
 exports.getLibraryVersion = () => {
-  return '4.0.0';
+  return "4.0.0";
 };
 
 exports.getElement = (parentElement, elementName) => {
@@ -64,9 +47,9 @@ exports.getFirstElement = (parentElement, elementName) => {
  */
 exports.originalURL = (req) => {
   const headers = req.headers;
-  const protocol = (req.connection.encrypted || req.headers['x-forwarded-proto'] === 'https') ? 'https' : 'http';
+  const protocol = (req.connection.encrypted || req.headers["x-forwarded-proto"] === "https") ? "https" : "http";
   const host = headers.host;
-  const path = req.url || '';
+  const path = req.url || "";
   return `${protocol}://${host}${path}`;
 };
 
@@ -104,13 +87,13 @@ exports.merge = (a, b) => {
  */
 
 exports.uid = (len) => {
-  var bytes = crypto.randomBytes(Math.ceil(len * 3 / 4));
+  const bytes = crypto.randomBytes(Math.ceil(len * 3 / 4));
   return base64url.encode(bytes).slice(0,len);
 };
 
 function prepadSigned(hexStr) {
   const msb = hexStr[0];
-  if (msb < '0' || msb > '7') {
+  if (msb < "0" || msb > "7") {
     return `00${hexStr}`;
   }
   return hexStr;
@@ -124,9 +107,11 @@ function toHex(number) {
   return nstr;
 }
 
-// encode ASN.1 DER length field
-// if <=127, short form
-// if >=128, long form
+/*
+ * encode ASN.1 DER length field
+ * if <=127, short form
+ * if >=128, long form
+ */
 function encodeLengthHex(n) {
   if (n <= 127) {
     return toHex(n);
@@ -138,11 +123,11 @@ function encodeLengthHex(n) {
 
 // http://stackoverflow.com/questions/18835132/xml-to-pem-in-node-js
 exports.rsaPublicKeyPem = (modulusB64, exponentB64) => {
-  const modulus = new Buffer(modulusB64, 'base64');
-  const exponent = new Buffer(exponentB64, 'base64');
+  const modulus = new Buffer(modulusB64, "base64"); // eslint-disable-line security/detect-new-buffer -- Legacy code, Buffer needed
+  const exponent = new Buffer(exponentB64, "base64"); // eslint-disable-line security/detect-new-buffer -- Legacy code, Buffer needed
 
-  const modulusHex = prepadSigned(modulus.toString('hex'));
-  const exponentHex = prepadSigned(exponent.toString('hex'));
+  const modulusHex = prepadSigned(modulus.toString("hex"));
+  const exponentHex = prepadSigned(exponent.toString("hex"));
 
   const modlen = modulusHex.length / 2;
   const explen = exponentHex.length / 2;
@@ -156,46 +141,50 @@ exports.rsaPublicKeyPem = (modulusB64, exponentB64) => {
           encodedExplen.length / 2 + 2
         )}02${encodedModlen}${modulusHex}02${encodedExplen}${exponentHex}`;
 
-  const derB64 = new Buffer(encodedPubkey, 'hex').toString('base64');
+  const derB64 = new Buffer(encodedPubkey, "hex").toString("base64"); // eslint-disable-line security/detect-new-buffer -- Legacy code, Buffer needed
 
-  const pem = `-----BEGIN RSA PUBLIC KEY-----\n${derB64.match(/.{1,64}/g).join('\n')}\n-----END RSA PUBLIC KEY-----\n`;
+  const pem = `-----BEGIN RSA PUBLIC KEY-----\n${derB64.match(/.{1,64}/g).join("\n")}\n-----END RSA PUBLIC KEY-----\n`;
 
   return pem;
 };
 
-// used for c_hash and at_hash validation
-// case (1): content = access_token, hashProvided = at_hash
-// case (2): content = code, hashProvided = c_hash
+/*
+ * used for c_hash and at_hash validation
+ * case (1): content = access_token, hashProvided = at_hash
+ * case (2): content = code, hashProvided = c_hash
+ */
 exports.checkHashValueRS256 = (content, hashProvided) => {
   if (!content)
     return false;
 
   // step 1. hash the content
-  var digest = crypto.createHash('sha256').update(content, 'ascii').digest();
+  const digest = crypto.createHash("sha256").update(content, "ascii").digest();
 
   // step2. take the first half of the digest, and save it in a buffer
-  var buffer = new Buffer(digest.length/2);
-  for (var i = 0; i < buffer.length; i++)
+  const buffer = new Buffer(digest.length/2); // eslint-disable-line security/detect-new-buffer -- Legacy code, Buffer needed
+  for (let i = 0; i < buffer.length; i++)
     buffer[i] = digest[i];
 
   // step 3. base64url encode the buffer to get the hash
-  var hashComputed = base64url(buffer);
+  const hashComputed = base64url(buffer);
 
   return (hashProvided === hashComputed);
 };
 
-// This function is used for handling the tuples containing nonce/state/policy/timeStamp in session
-// remove the additional tuples from array starting from the oldest ones
-// remove expired tuples in array
+/*
+ * This function is used for handling the tuples containing nonce/state/policy/timeStamp in session
+ * remove the additional tuples from array starting from the oldest ones
+ * remove expired tuples in array
+ */
 exports.processArray = function(array, maxAmount, maxAge) {
   // remove the additional tuples, start from the oldest ones
   if (array.length > maxAmount)
     array.splice(0, array.length - maxAmount);
 
   // count the number of those already expired
-  var count = 0;
-  for (var i = 0; i < array.length; i++) {
-    var tuple = array[i];
+  let count = 0;
+  for (let i = 0; i < array.length; i++) {
+    const tuple = array[i];
     if (tuple.timeStamp + maxAge * 1000 <= Date.now())
       count++;
     else
@@ -207,17 +196,19 @@ exports.processArray = function(array, maxAmount, maxAge) {
     array.splice(0, count);
 };
 
-// This function is used to find the tuple matching the given state, remove the tuple
-// from the array and return the tuple
-// @array        - array of {state: x, nonce: x, policy: x, timeStamp: x} tuples
-// @state        - the tuple which matches the given state
+/*
+ * This function is used to find the tuple matching the given state, remove the tuple
+ * from the array and return the tuple
+ * @array        - array of {state: x, nonce: x, policy: x, timeStamp: x} tuples
+ * @state        - the tuple which matches the given state
+ */
 exports.findAndDeleteTupleByState = (array, state) => {
   if (!array)
     return null;
 
-  for (var i = 0; i < array.length; i++) {
-    var tuple = array[i];
-    if (tuple['state'] === state) {
+  for (let i = 0; i < array.length; i++) {
+    const tuple = array[i];
+    if (tuple["state"] === state) {
       // remove the tuple from the array
       array.splice(i, 1);
       return tuple;
@@ -232,18 +223,18 @@ exports.copyObjectFields = (source, dest, fields) => {
   if (!source || !dest || !fields || !Array.isArray(fields))
     return;
 
-  for (var i = 0; i < fields.length; i++)
+  for (let i = 0; i < fields.length; i++)
     dest[fields[i]] = source[fields[i]];
 };
 
 exports.getErrorMessage = (err) => {
-  if (typeof err === 'string')
+  if (typeof err === "string")
     return err;
   if (err instanceof Error)
     return err.message;
 
   // if not string or Error, we try to stringify it
-  var str;
+  let str;
   try {
     str = JSON.stringify(err);
   } catch (ex) {
@@ -253,66 +244,80 @@ exports.getErrorMessage = (err) => {
 };
 
 exports.concatUrl = (url, rest) => {
-  if (typeof rest === 'string' || rest instanceof String) {
-    rest = [rest];
+  let validRest;
+  if (typeof rest === "string" || rest instanceof String) {
+    validRest = [rest];
+  } else {
+    validRest = rest;
   }
 
   if (!url) {
-    return `?${rest.join('&')}`;
+    return `?${validRest.join("&")}`;
   }
 
-  var hasParam = url.indexOf('?') !== -1;
-  return rest ? url.concat(hasParam ? '&' : '?').concat(rest.join('&')) : url;
+  const hasParam = url.indexOf("?") !== -1;
+  return validRest ? url.concat(hasParam ? "&" : "?").concat(validRest.join("&")) : url;
 };
 
-
-// This is a list maintained by the AAD server team, will need to keep an eye on this
-// as things change.  Not ideal, but it is what it is
-// in general, a change like this (adding a new cookie attribute)
-// should be backward compatible as RFC 6265 specifies that browsers should
-// ignore unknown cookie attributes. However, for the specific case of the
-// SameSite attribute, some browsers incorrectly implemented the attribute or
-//  implemented an earlier draft which had contradictory behavior.
-// For these browsers which attempted to support SameSite,
-// but have bugs in their support, we want to omit the SameSite=None attribute.
-// See Chromium official guidance here:  https://www.chromium.org/updates/same-site/incompatible-clients
+/*
+ * This is a list maintained by the AAD server team, will need to keep an eye on this
+ * as things change.  Not ideal, but it is what it is
+ * in general, a change like this (adding a new cookie attribute)
+ * should be backward compatible as RFC 6265 specifies that browsers should
+ * ignore unknown cookie attributes. However, for the specific case of the
+ * SameSite attribute, some browsers incorrectly implemented the attribute or
+ *  implemented an earlier draft which had contradictory behavior.
+ * For these browsers which attempted to support SameSite,
+ * but have bugs in their support, we want to omit the SameSite=None attribute.
+ * See Chromium official guidance here:  https://www.chromium.org/updates/same-site/incompatible-clients
+ */
 exports.sameSiteNotAllowed = userAgent => {
-  // Cover all iOS based browsers here. This includes:
-  // - Safari on iOS 12 for iPhone, iPod Touch, iPad
-  // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
-  // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
-  // All of which are broken by SameSite=None, because they use the iOS networking stack
+  /*
+   * Cover all iOS based browsers here. This includes:
+   * - Safari on iOS 12 for iPhone, iPod Touch, iPad
+   * - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+   * - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+   * All of which are broken by SameSite=None, because they use the iOS networking stack
+   */
   if (userAgent.includes("CPU iPhone OS 12") || userAgent.includes("iPad; CPU OS 12")) {
     return true;
   }
 
-  // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
-  // - Safari on Mac OS X
-  // - Internal browser on Mac OS X
-  // This does not include:
-  // - Chrome on Mac OS X
-  // - Chromium on Mac OS X
-  // Because they do not use the Mac OS networking stack.
+  /*
+   * Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+   * - Safari on Mac OS X
+   * - Internal browser on Mac OS X
+   * This does not include:
+   * - Chrome on Mac OS X
+   * - Chromium on Mac OS X
+   * Because they do not use the Mac OS networking stack.
+   */
   if (userAgent.includes("Macintosh; Intel Mac OS X 10_14") && !userAgent.includes("Chrome/") && !userAgent.includes("Chromium")) {
     return true;
   }
 
-  // Cover Chrome 50-69, because some versions are broken by SameSite=None, and none in this range require it.
-  // Note: this covers some pre-Chromium Edge versions, but pre-Chromim Edge does not require SameSite=None, so this is fine.
-  // Note: this regex applies to Windows, Mac OS X, and Linux, deliberately.
+  /*
+   * Cover Chrome 50-69, because some versions are broken by SameSite=None, and none in this range require it.
+   * Note: this covers some pre-Chromium Edge versions, but pre-Chromim Edge does not require SameSite=None, so this is fine.
+   * Note: this regex applies to Windows, Mac OS X, and Linux, deliberately.
+   */
   if (userAgent.includes("Chrome/5") || userAgent.includes("Chrome/6")) {
     return true;
   }
 
-  // Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
-  // that don't specify their Chrome version as lacking support for SameSite=None.
+  /*
+   * Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
+   * that don't specify their Chrome version as lacking support for SameSite=None.
+   */
   if (userAgent.includes("UnrealEngine") && !userAgent.includes("Chrome")) {
     return true;
   }
 
-  // UCBrowser < 12.13.2 ignores Set-Cookie headers with SameSite=None.
-  // NB: this rule isn't complete - you need regex to make a complete rule.
-  // See: https://www.chromium.org/updates/same-site/incompatible-clients
+  /*
+   * UCBrowser < 12.13.2 ignores Set-Cookie headers with SameSite=None.
+   * NB: this rule isn't complete - you need regex to make a complete rule.
+   * See: https://www.chromium.org/updates/same-site/incompatible-clients
+   */
   if (userAgent.includes("UCBrowser/12") || userAgent.includes("UCBrowser/11")) {
     return true;
   }

--- a/maintenance/passport-azure-ad/lib/aadutils.js
+++ b/maintenance/passport-azure-ad/lib/aadutils.js
@@ -260,13 +260,12 @@ exports.concatUrl = (url, rest) => {
 };
 
 /*
- * This is a list maintained by the AAD server team, will need to keep an eye on this
- * as things change.  Not ideal, but it is what it is
- * in general, a change like this (adding a new cookie attribute)
+ * This is a list maintained by the AAD server team.
+ * In general, a change like this (adding a new cookie attribute)
  * should be backward compatible as RFC 6265 specifies that browsers should
  * ignore unknown cookie attributes. However, for the specific case of the
  * SameSite attribute, some browsers incorrectly implemented the attribute or
- *  implemented an earlier draft which had contradictory behavior.
+ * implemented an earlier draft which had contradictory behavior.
  * For these browsers which attempted to support SameSite,
  * but have bugs in their support, we want to omit the SameSite=None attribute.
  * See Chromium official guidance here:  https://www.chromium.org/updates/same-site/incompatible-clients

--- a/maintenance/passport-azure-ad/lib/aadutils.js
+++ b/maintenance/passport-azure-ad/lib/aadutils.js
@@ -13,7 +13,7 @@ exports.getLibraryProduct = () => { return "passport-azure-ad" };
 exports.getLibraryVersionParameterName = () => { return "x-client-Ver" };
 exports.getLibraryProductParameterName = () => { return "x-client-SKU" };
 exports.getLibraryVersion = () => {
-  return "4.0.0";
+  return "4.3.0";
 };
 
 exports.getElement = (parentElement, elementName) => {

--- a/maintenance/passport-azure-ad/lib/bearerstrategy.js
+++ b/maintenance/passport-azure-ad/lib/bearerstrategy.js
@@ -1,44 +1,27 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the 'Software'), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
-'use strict';
+
+"use strict";
 
 /* eslint no-underscore-dangle: 0 */
 
-const async = require('async');
-const cacheManager = require('cache-manager');
-const jws = require('jws');
-const passport = require('passport');
-const util = require('util');
+const async = require("async");
+const cacheManager = require("cache-manager");
+const jws = require("jws");
+const passport = require("passport");
+const util = require("util");
 
-const aadutils = require('./aadutils');
-const CONSTANTS = require('./constants');
-const jwt = require('./jsonWebToken');
-const Metadata = require('./metadata').Metadata;
-const Log = require('./logging').getLogger;
-const UrlValidator = require('valid-url');
+const aadutils = require("./aadutils");
+const CONSTANTS = require("./constants");
+const jwt = require("./jsonWebToken");
+const Metadata = require("./metadata").Metadata;
+const Log = require("./logging").getLogger;
+const UrlValidator = require("valid-url");
 
-const log = new Log('AzureAD: Bearer Strategy');
-const memoryCache = cacheManager.caching({ store: 'memory', max: 3600, ttl: 1800 /* seconds */ });
+const log = new Log("AzureAD: Bearer Strategy");
+const memoryCache = cacheManager.caching({ store: "memory", max: 3600, ttl: 1800 /* seconds */ });
 const ttl = 1800; // 30 minutes cache
 
 /**
@@ -180,23 +163,25 @@ const ttl = 1800; // 30 minutes cache
  */
 function Strategy(options, verifyFn) {
   passport.Strategy.call(this);
-  this.name = 'oauth-bearer'; // Me, a name I call myself.
+  this.name = "oauth-bearer"; // Me, a name I call myself.
 
   if (!options)
-    throw new Error('In BearerStrategy constructor: options is required');
-  if (!verifyFn || typeof verifyFn !== 'function')
-    throw new Error('In BearerStrategy constructor: verifyFn is required and it must be a function');
+    throw new Error("In BearerStrategy constructor: options is required");
+  if (!verifyFn || typeof verifyFn !== "function")
+    throw new Error("In BearerStrategy constructor: verifyFn is required and it must be a function");
 
   this._verify = verifyFn;
   this._options = options;
 
-  //---------------------------------------------------------------------------
-  // Set up the default values
-  //---------------------------------------------------------------------------
+  /*
+   * ---------------------------------------------------------------------------
+   *  Set up the default values
+   * ---------------------------------------------------------------------------
+   */
 
   // clock skew. Must be a postive integer
-  if (options.clockSkew && (typeof options.clockSkew !== 'number' || options.clockSkew <= 0 || options.clockSkew % 1 !== 0))
-    throw new Error('clockSkew must be a positive integer');
+  if (options.clockSkew && (typeof options.clockSkew !== "number" || options.clockSkew <= 0 || options.clockSkew % 1 !== 0))
+    throw new Error("clockSkew must be a positive integer");
   if (!options.clockSkew)
     options.clockSkew = CONSTANTS.CLOCK_SKEW;
 
@@ -212,72 +197,80 @@ function Strategy(options, verifyFn) {
   if (options.allowMultiAudiencesInToken !== true)
     options.allowMultiAudiencesInToken = false;
 
-  // if options.audience is a string or an array of string, then we use it;
-  // otherwise we use the clientID
-  if (options.audience && typeof options.audience === 'string')
+  /*
+   * if options.audience is a string or an array of string, then we use it;
+   * otherwise we use the clientID
+   */
+  if (options.audience && typeof options.audience === "string")
     options.audience = [options.audience];
   else if (!options.audience || !Array.isArray(options.audience) || options.length === 0)
-    options.audience = [options.clientID, 'spn:' + options.clientID];
+    options.audience = [options.clientID, "spn:" + options.clientID];
 
   // default value of isB2C is false
   if (options.isB2C !== true)
     options.isB2C = false;
 
   // turn issuer into an array
-  if (options.issuer === '')
+  if (options.issuer === "")
     options.issuer = null;
   if (options.issuer && Array.isArray(options.issuer) && options.issuer.length === 0)
     options.issuer = null; 
   if (options.issuer && !Array.isArray(options.issuer))
     options.issuer = [options.issuer];
 
-  //---------------------------------------------------------------------------
-  // validate the things in options
-  //---------------------------------------------------------------------------
+  /*
+   * ---------------------------------------------------------------------------
+   *  validate the things in options
+   * ---------------------------------------------------------------------------
+   */
 
   // clientID should not be empty
-  if (!options.clientID || options.clientID === '')
-    throw new Error('In BearerStrategy constructor: clientID cannot be empty');
+  if (!options.clientID || options.clientID === "")
+    throw new Error("In BearerStrategy constructor: clientID cannot be empty");
 
   // identityMetadata must be https url
   if (!options.identityMetadata || !UrlValidator.isHttpsUri(options.identityMetadata))
-    throw new Error('In BearerStrategy constructor: identityMetadata must be provided and must be a https url');
+    throw new Error("In BearerStrategy constructor: identityMetadata must be provided and must be a https url");
 
   // if scope is provided, it must be an array
   if (options.scope && (!Array.isArray(options.scope) || options.scope.length === 0))
-    throw new Error('In BearerStrategy constructor: scope must be a non-empty array');
+    throw new Error("In BearerStrategy constructor: scope must be a non-empty array");
 
-  //---------------------------------------------------------------------------
-  // treatment of common endpoint and issuer
-  //---------------------------------------------------------------------------
+  /*
+   * ---------------------------------------------------------------------------
+   *  treatment of common endpoint and issuer
+   * ---------------------------------------------------------------------------
+   */
 
   // check if we are using the common endpoint
-  options._isCommonEndpoint = (options.identityMetadata.indexOf('/common/') != -1);
+  options._isCommonEndpoint = (options.identityMetadata.indexOf("/common/") !== -1);
 
   // give a warning if user is not validating issuer
   if (!options.validateIssuer)
-    log.warn(`Production environments should always validate the issuer.`);
+    log.warn("Production environments should always validate the issuer.");
 
-  //---------------------------------------------------------------------------
-  // B2C. 
-  // (1) policy must be provided and must have the valid prefix
-  // (2) common endpoint is not supported
-  //---------------------------------------------------------------------------
+  /*
+   * ---------------------------------------------------------------------------
+   *  B2C. 
+   *  (1) policy must be provided and must have the valid prefix
+   *  (2) common endpoint is not supported
+   * ---------------------------------------------------------------------------
+   */
 
   // for B2C, 
   if (options.isB2C) {
     if (!options.policyName || !CONSTANTS.POLICY_REGEX.test(options.policyName))
-      throw new Error('In BearerStrategy constructor: invalid policy for B2C');
+      throw new Error("In BearerStrategy constructor: invalid policy for B2C");
   }
 
   // if logging level specified, switch to it.
-  if (options.loggingLevel) { log.levels('console', options.loggingLevel); }
+  if (options.loggingLevel) { log.levels("console", options.loggingLevel); }
 
-  if (options.loggingNoPII != false) 
+  if (options.loggingNoPII !== false) 
     options.loggingNoPII = true;
 
   if (options.loggingNoPII)
-    log.info('In BearerStrategy constructor: strategy created');
+    log.info("In BearerStrategy constructor: strategy created");
   else
     log.info(`In BearerStrategy constructor: created strategy with options ${JSON.stringify(options)}`);
 }
@@ -296,52 +289,54 @@ Strategy.prototype.jwtVerify = function jwtVerifyFunc(req, token, metadata, opti
   
   let PEMkey = null;
 
-  if (decoded == null) {
-    return done(null, false, 'In Strategy.prototype.jwtVerify: Invalid JWT token.');
+  if (decoded === null) {
+    return done(null, false, "In Strategy.prototype.jwtVerify: Invalid JWT token.");
   }
 
   if (self._options.loggingNoPII)
-    log.info('In Strategy.prototype.jwtVerify: token is decoded');
+    log.info("In Strategy.prototype.jwtVerify: token is decoded");
   else
-    log.info('In Strategy.prototype.jwtVerify: token decoded:  ', decoded);
+    log.info("In Strategy.prototype.jwtVerify: token decoded:  ", decoded);
 
-  // When we generate the PEMkey, there are two different types of token signatures
-  // we have to validate here. One provides x5t and the other a kid. We need to call 
-  // the right one.
+  /*
+   * When we generate the PEMkey, there are two different types of token signatures
+   * we have to validate here. One provides x5t and the other a kid. We need to call 
+   * the right one.
+   */
   try {
     if (decoded.header.x5t) {
       PEMkey = metadata.generateOidcPEM(decoded.header.x5t);
     } else if (decoded.header.kid) {
       PEMkey = metadata.generateOidcPEM(decoded.header.kid);
     } else {
-      return self.failWithLog('In Strategy.prototype.jwtVerify: We did not receive a token we know how to validate');
+      return self.failWithLog("In Strategy.prototype.jwtVerify: We did not receive a token we know how to validate");
     }
   } catch (error) {
-      return self.failWithLog('In Strategy.prototype.jwtVerify: We did not receive a token we know how to validate');
+      return self.failWithLog("In Strategy.prototype.jwtVerify: We did not receive a token we know how to validate");
   }
 
   if (self._options.loggingNoPII)
-    log.info('PEMkey generated');
+    log.info("PEMkey generated");
   else
-    log.info('PEMkey generated: ' + PEMkey);
+    log.info("PEMkey generated: " + PEMkey);
 
   jwt.verify(token, PEMkey, optionsToValidate, (err, verifiedToken) => {
     if (err) {
       if (err.message && !self._options.loggingNoPII)
         return self.failWithLog(err.message);
       else
-        return self.failWithLog('In Strategy.prototype.jwtVerify: cannot verify token');
+        return self.failWithLog("In Strategy.prototype.jwtVerify: cannot verify token");
     }
 
     // scope validation
     if (optionsToValidate.scope) {
       if (!verifiedToken.scp)
-        return self.failWithLog('In Strategy.prototype.jwtVerify: scope is not found in token');
+        return self.failWithLog("In Strategy.prototype.jwtVerify: scope is not found in token");
 
       // split scope by blanks and remove empty elements in the array
-      var scopesInToken = verifiedToken.scp.split(/[ ]+/).filter(Boolean);
-      var hasValidScopeInToken = false;
-      for (var i = 0; i < scopesInToken.length; i++) {
+      const scopesInToken = verifiedToken.scp.split(/[ ]+/).filter(Boolean);
+      let hasValidScopeInToken = false;
+      for (let i = 0; i < scopesInToken.length; i++) {
         if (optionsToValidate.scope.indexOf(scopesInToken[i]) !== -1) {
           hasValidScopeInToken = true;
           break;
@@ -350,22 +345,22 @@ Strategy.prototype.jwtVerify = function jwtVerifyFunc(req, token, metadata, opti
       
       if (!hasValidScopeInToken) {
         if (self._options.loggingNoPII)
-          return self.failWithLog('In Strategy.prototype.jwtVerify: none of the scopes in token is accepted');
+          return self.failWithLog("In Strategy.prototype.jwtVerify: none of the scopes in token is accepted");
         else
           return self.failWithLog(`In Strategy.prototype.jwtVerify: none of the scopes '${verifiedToken.scp}' in token is accepted`);
       }      
     }
 
     if (self._options.loggingNoPII)
-      log.info('In Strategy.prototype.jwtVerify: token is verified');
+      log.info("In Strategy.prototype.jwtVerify: token is verified");
     else
-      log.info('In Strategy.prototype.jwtVerify: VerifiedToken: ', verifiedToken);
+      log.info("In Strategy.prototype.jwtVerify: VerifiedToken: ", verifiedToken);
     
     if (self._options.passReqToCallback) {
-      log.info('In Strategy.prototype.jwtVerify: We did pass Req back to Callback');
+      log.info("In Strategy.prototype.jwtVerify: We did pass Req back to Callback");
       return self._verify(req, verifiedToken, done);
     } else {
-      log.info('In Strategy.prototype.jwtVerify: We did not pass Req back to Callback');
+      log.info("In Strategy.prototype.jwtVerify: We did not pass Req back to Callback");
       return self._verify(verifiedToken, done);
     }
   });
@@ -377,11 +372,12 @@ Strategy.prototype.jwtVerify = function jwtVerifyFunc(req, token, metadata, opti
  */
 Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
   const self = this;
-  var params = {};
-  var optionsToValidate = {};
-  var tenantIdOrName = options && options.tenantIdOrName;
+  const params = {};
+  const optionsToValidate = {};
+  let tenantIdOrName = options && options.tenantIdOrName;
 
-  /* Some introduction to async.waterfall (from the following link):
+  /*
+   * Some introduction to async.waterfall (from the following link):
    * http://stackoverflow.com/questions/28908180/what-is-a-simple-implementation-of-async-waterfall
    *
    *   Runs the tasks array of functions in series, each passing their results 
@@ -421,7 +417,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
       // if we are not using the common endpoint, but we have tenantIdOrName, just ignore it
       if (!self._options._isCommonEndpoint && tenantIdOrName) {
         if (self._options.loggingNoPII)
-          log.info('identityMetadata is tenant-specific, so we ignore the provided tenantIdOrName');
+          log.info("identityMetadata is tenant-specific, so we ignore the provided tenantIdOrName");
         else
           log.info(`identityMetadata is tenant-specific, so we ignore the tenantIdOrName '${tenantIdOrName}'`);
         tenantIdOrName = null;
@@ -429,23 +425,25 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
 
       // if we are using common endpoint and we are given the tenantIdOrName, let's replace it
       if (self._options._isCommonEndpoint && tenantIdOrName) {
-        params.metadataURL = params.metadataURL.replace('/common/', `/${tenantIdOrName}/`);
+        params.metadataURL = params.metadataURL.replace("/common/", `/${tenantIdOrName}/`);
         if (self._options.loggingNoPII)
-          log.info(`We are replacing 'common' with the provided tenantIdOrName`);
+          log.info("We are replacing 'common' with the provided tenantIdOrName");
         else
           log.info(`we are replacing 'common' with the tenantIdOrName ${tenantIdOrName}`);
       }
 
-      // if we are using the common endpoint and we want to validate issuer, then user has to 
-      // provide issuer in config, or provide tenant id or name using tenantIdOrName option in
-      // passport.authenticate. Otherwise we won't know the issuer.
+      /*
+       * if we are using the common endpoint and we want to validate issuer, then user has to 
+       * provide issuer in config, or provide tenant id or name using tenantIdOrName option in
+       * passport.authenticate. Otherwise we won't know the issuer.
+       */
       if (self._options._isCommonEndpoint && self._options.validateIssuer &&
         (!self._options.issuer && !tenantIdOrName))
-        return next(new Error('In passport.authenticate: issuer or tenantIdOrName must be provided in order to validate issuer on common endpoint'));
+        return next(new Error("In passport.authenticate: issuer or tenantIdOrName must be provided in order to validate issuer on common endpoint"));
 
       // for B2C, if we are using common endpoint, we must have tenantIdOrName provided
       if (self._options.isB2C && self._options._isCommonEndpoint && !tenantIdOrName)
-        return next(new Error('In passport.authenticate: we are using common endpoint for B2C but tenantIdOrName is not provided'));
+        return next(new Error("In passport.authenticate: we are using common endpoint for B2C but tenantIdOrName is not provided"));
 
       if (self._options.isB2C)
         params.metadataURL = aadutils.concatUrl(params.metadataURL, `p=${self._options.policyName}`);
@@ -467,7 +465,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
     (metadata, next) => {
       params.metadata = metadata;
       if (self._options.loggingNoPII)
-        log.info('In Strategy.prototype.authenticate: received metadata');
+        log.info("In Strategy.prototype.authenticate: received metadata");
       else
         log.info(`In Strategy.prototype.authenticate: received metadata: ${JSON.stringify(metadata)}`);
 
@@ -497,73 +495,75 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
       optionsToValidate.isAccessToken = true;
 
       if (self._options.loggingNoPII)
-        log.info(`In Strategy.prototype.authenticate: we will validate the options`);
+        log.info("In Strategy.prototype.authenticate: we will validate the options");
       else
         log.info(`In Strategy.prototype.authenticate: we will validate the following options: ${JSON.stringify(optionsToValidate)}`);
 
       return next();
     }, 
 
-    // extract the access token from the request, after getting the token, it 
-    // will call `jwtVerify` to verify the token. If token is verified, `jwtVerify`
-    // will provide the token payload to self._verify function. self._verify is
-    // provided by the developer, it's up to the developer to decide if the token
-    // payload is considered authenticated. If authenticated, self._verify will
-    // provide `user` object (developer's decision of its content) to `verified` 
-    // function here, and the `verified` function does the final work of stuffing
-    // the `user` obejct into req.user, so the following middleware can use it.
-    // This is basically how bearerStrategy works.
-    (next) => {
-      var token;
+    /*
+     * extract the access token from the request, after getting the token, it 
+     * will call `jwtVerify` to verify the token. If token is verified, `jwtVerify`
+     * will provide the token payload to self._verify function. self._verify is
+     * provided by the developer, it's up to the developer to decide if the token
+     * payload is considered authenticated. If authenticated, self._verify will
+     * provide `user` object (developer's decision of its content) to `verified` 
+     * function here, and the `verified` function does the final work of stuffing
+     * the `user` obejct into req.user, so the following middleware can use it.
+     * This is basically how bearerStrategy works.
+     */
+    () => {
+      let token;
 
       // token could be in header or body. query is not supported.
 
       if (req.query && req.query.access_token)
-        return self.failWithLog('In Strategy.prototype.authenticate: access_token should be passed in request header or body. query is unsupported');
+        return self.failWithLog("In Strategy.prototype.authenticate: access_token should be passed in request header or body. query is unsupported");
 
       if (req.headers && req.headers.authorization) {
-        var auth_components = req.headers.authorization.split(' ');
-        if (auth_components.length == 2 &&auth_components[0].toLowerCase() === 'bearer') {
+        const auth_components = req.headers.authorization.split(" ");
+        if (auth_components.length === 2 && auth_components[0].toLowerCase() === "bearer") {
             token = auth_components[1];
-            if (token !== '') {
+            if (token !== "") { // eslint-disable-line security/detect-possible-timing-attacks -- Timing for comparison to empty string should be the same every time
               if (self._options.loggingNoPII)
-                log.info('In Strategy.prototype.authenticate: access_token is received from request header');
+                log.info("In Strategy.prototype.authenticate: access_token is received from request header");
               else
                 log.info(`In Strategy.prototype.authenticate: received access_token from request header: ${token}`);
             }              
             else
-              return self.failWithLog('In Strategy.prototype.authenticate: missing access_token in the header');
+              return self.failWithLog("In Strategy.prototype.authenticate: missing access_token in the header");
         }
       }
 
       if (req.body && req.body.access_token) {
         if (token) 
-          return self.failWithLog('In Strategy.prototype.authenticate: access_token cannot be passed in both request header and body');
+          return self.failWithLog("In Strategy.prototype.authenticate: access_token cannot be passed in both request header and body");
         token = req.body.access_token;
         if (token) {
           if (self._options.loggingNoPII)
-            log.info('In Strategy.prototype.authenticate: access_token is received from request body');
+            log.info("In Strategy.prototype.authenticate: access_token is received from request body");
           else
             log.info(`In Strategy.prototype.authenticate: received access_token from request body: ${token}`);
         }          
       }
 
       if (!token)
-        return self.failWithLog('token is not found'); 
+        return self.failWithLog("token is not found"); 
 
       function verified(err, user, info) {
         if (err)
           return self.error(err);
 
         if (!user) {
-          var err_message = 'error: invalid_token';
-          if (info && typeof info == 'string')
-            err_message += ', error description: ' + info;
+          let err_message = "error: invalid_token";
+          if (info && typeof info === "string")
+            err_message += ", error description: " + info;
           else if (info)
-            err_message += ', error description: ' + JSON.stringify(info);
+            err_message += ", error description: " + JSON.stringify(info);
 
           if (self._options.loggingNoPII)
-            return self.failWithLog('error: invalid_token');
+            return self.failWithLog("error: invalid_token");
           else
             return self.failWithLog(err_message);
         }
@@ -585,7 +585,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
 
 Strategy.prototype.loadMetadata = function(params, next) {
   const self = this;
-  var metadata = new Metadata(params.metadataURL, 'oidc', self._options);
+  const metadata = new Metadata(params.metadataURL, "oidc", self._options);
 
   // fetch metadata
   return memoryCache.wrap(params.cacheKey, (cacheCallback) => {

--- a/maintenance/passport-azure-ad/lib/bearerstrategy.js
+++ b/maintenance/passport-azure-ad/lib/bearerstrategy.js
@@ -49,7 +49,6 @@ const ttl = 1800; // 30 minutes cache
  * can be used by later middleware for access control.  This is typically used
  * to pass any scope associated with the token.
  * 
- *
  * Options:
  *
  *   - `identityMetadata`   (1) Required
@@ -163,7 +162,7 @@ const ttl = 1800; // 30 minutes cache
  */
 function Strategy(options, verifyFn) {
   passport.Strategy.call(this);
-  this.name = "oauth-bearer"; // Me, a name I call myself.
+  this.name = "oauth-bearer";
 
   if (!options)
     throw new Error("In BearerStrategy constructor: options is required");
@@ -174,9 +173,7 @@ function Strategy(options, verifyFn) {
   this._options = options;
 
   /*
-   * ---------------------------------------------------------------------------
    *  Set up the default values
-   * ---------------------------------------------------------------------------
    */
 
   // clock skew. Must be a postive integer
@@ -219,9 +216,7 @@ function Strategy(options, verifyFn) {
     options.issuer = [options.issuer];
 
   /*
-   * ---------------------------------------------------------------------------
    *  validate the things in options
-   * ---------------------------------------------------------------------------
    */
 
   // clientID should not be empty
@@ -237,9 +232,7 @@ function Strategy(options, verifyFn) {
     throw new Error("In BearerStrategy constructor: scope must be a non-empty array");
 
   /*
-   * ---------------------------------------------------------------------------
    *  treatment of common endpoint and issuer
-   * ---------------------------------------------------------------------------
    */
 
   // check if we are using the common endpoint
@@ -250,11 +243,9 @@ function Strategy(options, verifyFn) {
     log.warn("Production environments should always validate the issuer.");
 
   /*
-   * ---------------------------------------------------------------------------
    *  B2C. 
    *  (1) policy must be provided and must have the valid prefix
    *  (2) common endpoint is not supported
-   * ---------------------------------------------------------------------------
    */
 
   // for B2C, 
@@ -380,7 +371,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
    * Some introduction to async.waterfall (from the following link):
    * http://stackoverflow.com/questions/28908180/what-is-a-simple-implementation-of-async-waterfall
    *
-   *   Runs the tasks array of functions in series, each passing their results 
+   * Runs the tasks array of functions in series, each passing their results 
    * to the next in the array. However, if any of the tasks pass an error to 
    * their own callback, the next function is not executed, and the main callback
    * is immediately called with the error.
@@ -513,7 +504,7 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
      * the `user` obejct into req.user, so the following middleware can use it.
      * This is basically how bearerStrategy works.
      */
-    () => {
+    (next) => { // eslint-disable-line no-unused-vars -- Next used in async.waterfall
       let token;
 
       // token could be in header or body. query is not supported.

--- a/maintenance/passport-azure-ad/lib/constants.js
+++ b/maintenance/passport-azure-ad/lib/constants.js
@@ -1,37 +1,19 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the 'Software'), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
 
-'use strict';
+"use strict";
 
 // constants that are not strategy specific
 
-var CONSTANTS = {};
+const CONSTANTS = {};
 
 CONSTANTS.POLICY_REGEX = /^b2c_1a?_[0-9a-z._-]+$/i;    // policy is case insensitive
 
 CONSTANTS.CLOCK_SKEW = 300; // 5 minutes
 
 CONSTANTS.CLIENT_ASSERTION_JWT_LIFETIME = 600; // 10 minutes
-CONSTANTS.CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+CONSTANTS.CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
 module.exports = CONSTANTS;

--- a/maintenance/passport-azure-ad/lib/cookieContentHandler.js
+++ b/maintenance/passport-azure-ad/lib/cookieContentHandler.js
@@ -1,31 +1,13 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the "Software"), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
 
-'use restrict';
+"use restrict";
 
-var crypto = require('crypto');
-var createBuffer = require('./jwe').createBuffer;
-var sameSiteNotAllowed = require('./aadutils').sameSiteNotAllowed;
+const crypto = require("crypto");
+const createBuffer = require("./jwe").createBuffer;
+const sameSiteNotAllowed = require("./aadutils").sameSiteNotAllowed;
 
 /*
  * the handler for state/nonce/policy
@@ -36,24 +18,24 @@ var sameSiteNotAllowed = require('./aadutils').sameSiteNotAllowed;
  * @domain            - sets the cookie's domain
  */
 function CookieContentHandler(maxAmount, maxAge, cookieEncryptionKeys, domain, cookieSameSite) {
-  if (!maxAge || (typeof maxAge !== 'number' || maxAge <= 0))
-    throw new Error('CookieContentHandler: maxAge must be a positive number');
+  if (!maxAge || (typeof maxAge !== "number" || maxAge <= 0))
+    throw new Error("CookieContentHandler: maxAge must be a positive number");
   this.maxAge = maxAge;  // seconds
 
-  if (!maxAmount || (typeof maxAmount !== 'number' || maxAmount <= 0 || maxAmount % 1 !== 0))
-    throw new Error('CookieContentHandler: maxAmount must be a positive integer');
+  if (!maxAmount || (typeof maxAmount !== "number" || maxAmount <= 0 || maxAmount % 1 !== 0))
+    throw new Error("CookieContentHandler: maxAmount must be a positive integer");
   this.maxAmount = maxAmount;
 
   if (!cookieEncryptionKeys || !Array.isArray(cookieEncryptionKeys) || cookieEncryptionKeys.length === 0)
-    throw new Error('CookieContentHandler: cookieEncryptionKeys must be a non-emptry array');
+    throw new Error("CookieContentHandler: cookieEncryptionKeys must be a non-emptry array");
 
-  if (typeof cookieSameSite !== 'boolean') {
-    throw new Error('CookieContentHandler: cookieSameSite must be a boolean');
+  if (typeof cookieSameSite !== "boolean") {
+    throw new Error("CookieContentHandler: cookieSameSite must be a boolean");
   }
   this.cookieSameSite = cookieSameSite
 
-  for (var i = 0; i < cookieEncryptionKeys.length; i++) {
-    var item = cookieEncryptionKeys[i];
+  for (let i = 0; i < cookieEncryptionKeys.length; i++) {
+    const item = cookieEncryptionKeys[i];
     if (!item.key || !item.iv)
       throw new Error(`CookieContentHandler: array item ${i+1} in cookieEncryptionKeys must have the form { key: , iv: }`);
     if (item.key.length !== 32)
@@ -69,24 +51,24 @@ function CookieContentHandler(maxAmount, maxAge, cookieEncryptionKeys, domain, c
 
 CookieContentHandler.prototype.findAndDeleteTupleByState = function(req, res, stateToFind) {
   if (!req.cookies)
-    throw new Error('Cookie is not found in request. Did you forget to use cookie parsing middleware such as cookie-parser?');
+    throw new Error("Cookie is not found in request. Did you forget to use cookie parsing middleware such as cookie-parser?");
 
-  var cookieEncryptionKeys = this.cookieEncryptionKeys;
+  const cookieEncryptionKeys = this.cookieEncryptionKeys;
 
-  var tuple = null;
+  let tuple = null;
 
   // try every key and every cookie
-  for (var i = 0; i < cookieEncryptionKeys.length; i++) {
-    var item = cookieEncryptionKeys[i];
-    var key = createBuffer(item.key);
-    var iv = createBuffer(item.iv);
+  for (let i = 0; i < cookieEncryptionKeys.length; i++) {
+    const item = cookieEncryptionKeys[i];
+    const key = createBuffer(item.key);
+    const iv = createBuffer(item.iv);
 
-    for (var cookie in req.cookies) {
-      if (req.cookies.hasOwnProperty(cookie) && cookie.startsWith('passport-aad.')) {
-        var encrypted = cookie.substring(13);
+    for (const cookie in req.cookies) {
+      if (Object.prototype.hasOwnProperty.call(req.cookies, cookie) && cookie.startsWith("passport-aad.")) {
+        const encrypted = cookie.substring(13);
 
         try {
-          var decrypted = decryptCookie(encrypted, key, iv);
+          const decrypted = decryptCookie(encrypted, key, iv);
           tuple = JSON.parse(decrypted);
         } catch (ex) {
           continue;
@@ -104,11 +86,11 @@ CookieContentHandler.prototype.findAndDeleteTupleByState = function(req, res, st
 };
 
 CookieContentHandler.prototype.add = function(req, res, tupleToAdd) {
-  var cookies = [];
+  const cookies = [];
 
   // collect the related cookies
-  for (var cookie in req.cookies) {
-    if (req.cookies.hasOwnProperty(cookie) && cookie.startsWith('passport-aad.'))
+  for (const cookie in req.cookies) {
+    if (Object.prototype.hasOwnProperty.call(req.cookies, cookie) && cookie.startsWith("passport-aad."))
       cookies.push(cookie);
   }
 
@@ -116,9 +98,9 @@ CookieContentHandler.prototype.add = function(req, res, tupleToAdd) {
   if (cookies.length > this.maxAmount - 1) {
     cookies.sort();
 
-    var numberToRemove = cookies.length - (this.maxAmount - 1);
+    const numberToRemove = cookies.length - (this.maxAmount - 1);
 
-    for (var i = 0; i < numberToRemove; i++) {
+    for (let i = 0; i < numberToRemove; i++) {
       res.clearCookie(cookies[0]);
       cookies.shift();
     }
@@ -126,50 +108,50 @@ CookieContentHandler.prototype.add = function(req, res, tupleToAdd) {
 
   // add the new cookie
 
-  var tupleString = JSON.stringify(tupleToAdd);
+  const tupleString = JSON.stringify(tupleToAdd);
 
-  var item = this.cookieEncryptionKeys[0];
-  var key = createBuffer(item.key);
-  var iv = createBuffer(item.iv);
+  const item = this.cookieEncryptionKeys[0];
+  const key = createBuffer(item.key);
+  const iv = createBuffer(item.iv);
 
-  var encrypted = encryptCookie(tupleString, key, iv);
+  const encrypted = encryptCookie(tupleString, key, iv);
 
-  let options = { maxAge: this.maxAge * 1000, httpOnly: true }
+  const options = { maxAge: this.maxAge * 1000, httpOnly: true }
   if (this.domain) {
     options.domain = this.domain;
   }
 
-  if (this.cookieSameSite && !sameSiteNotAllowed(req.get('User-Agent'))) {
-    options.sameSite = 'none';
+  if (this.cookieSameSite && !sameSiteNotAllowed(req.get("User-Agent"))) {
+    options.sameSite = "none";
     options.secure = true;
   }
 
-  res.cookie('passport-aad.' + Date.now() + '.' + encrypted, 0, options);
+  res.cookie("passport-aad." + Date.now() + "." + encrypted, 0, options);
 };
 
-var encryptCookie = function(content, key, iv) {
-  var cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+const encryptCookie = function(content, key, iv) {
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
 
-  var encrypted = cipher.update(content, 'utf8', 'hex');
-  encrypted += cipher.final('hex');
-  var authTag = cipher.getAuthTag().toString('hex');
+  let encrypted = cipher.update(content, "utf8", "hex");
+  encrypted += cipher.final("hex");
+  const authTag = cipher.getAuthTag().toString("hex");
 
-  return encrypted + '.' + authTag;
+  return encrypted + "." + authTag;
 };
 
-var decryptCookie = function(encrypted, key, iv) {
-  var parts = encrypted.split('.');
+const decryptCookie = function(encrypted, key, iv) {
+  const parts = encrypted.split(".");
   if (parts.length !== 3)
-    throw new Error('invalid cookie');
+    throw new Error("invalid cookie");
 
   // the first part is timestamp, ignore it
-  var content = createBuffer(parts[1], 'hex');
-  var authTag = createBuffer(parts[2], 'hex');
+  const content = createBuffer(parts[1], "hex");
+  const authTag = createBuffer(parts[2], "hex");
 
-  var decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
   decipher.setAuthTag(authTag);
-  var decrypted = decipher.update(content, 'hex', 'utf8');
-  decrypted +=  decipher.final('utf8');
+  let decrypted = decipher.update(content, "hex", "utf8");
+  decrypted +=  decipher.final("utf8");
 
   return decrypted;
 };

--- a/maintenance/passport-azure-ad/lib/errors/badrequesterror.js
+++ b/maintenance/passport-azure-ad/lib/errors/badrequesterror.js
@@ -1,4 +1,9 @@
-'use strict';
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+"use strict";
 
 /**
  * `BadRequestError` error.
@@ -8,7 +13,7 @@
 function BadRequestError(message) {
   Error.call(this);
   Error.captureStackTrace(this, BadRequestError);
-  this.name = 'BadRequestError';
+  this.name = "BadRequestError";
   this.message = message || null;
 }
 

--- a/maintenance/passport-azure-ad/lib/errors/internaloautherror.js
+++ b/maintenance/passport-azure-ad/lib/errors/internaloautherror.js
@@ -1,4 +1,9 @@
-'use strict';
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+"use strict";
 
 /**
  * `InternalOAuthError` error.
@@ -12,7 +17,7 @@
 function InternalOAuthError(message, err) {
   Error.call(this);
   Error.captureStackTrace(this, InternalOAuthError);
-  this.name = 'InternalOAuthError';
+  this.name = "InternalOAuthError";
   this.message = message;
   this.oauthError = err;
 }

--- a/maintenance/passport-azure-ad/lib/errors/internalopeniderror.js
+++ b/maintenance/passport-azure-ad/lib/errors/internalopeniderror.js
@@ -1,4 +1,9 @@
-'use strict';
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+"use strict";
 
 /**
  * `InternalOpenIDError` error.
@@ -12,7 +17,7 @@
 function InternalOpenIDError(message, err) {
   Error.call(this);
   Error.captureStackTrace(this, InternalOpenIDError);
-  this.name = 'InternalOpenIDError';
+  this.name = "InternalOpenIDError";
   this.message = message;
   this.openidError = err;
 }

--- a/maintenance/passport-azure-ad/lib/index.js
+++ b/maintenance/passport-azure-ad/lib/index.js
@@ -1,30 +1,12 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the 'Software'), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
 
-'use strict';
+"use strict";
 
 /**
  * Export BearerStrategy and OIDCStrategy.
  */
-module.exports.BearerStrategy = require('./bearerstrategy');
-module.exports.OIDCStrategy = require('./oidcstrategy');
+module.exports.BearerStrategy = require("./bearerstrategy");
+module.exports.OIDCStrategy = require("./oidcstrategy");

--- a/maintenance/passport-azure-ad/lib/jsonWebToken.js
+++ b/maintenance/passport-azure-ad/lib/jsonWebToken.js
@@ -37,9 +37,7 @@ const hasCommonElem = (array1, array2) => {
 exports.verify = function(jwtString, PEMKey, options, callback) {
 
   /**
-   ********************************************************************
    * Checking parameters
-   *******************************************************************
    */
 
   /*
@@ -81,9 +79,7 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
     return done(new Error("options.algorithms must be an array containing at least one algorithm"));
 
   /**
-   ********************************************************************
    * Checking jwtString structure, getting header, payload and signature
-   *******************************************************************
    */
 
   // split jwtString, make sure we have three parts and we have signature
@@ -118,9 +114,7 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
     return done(new Error("missing signature in the token"));
 
   /**
-   ********************************************************************
    * validate algorithm and signature
-   *******************************************************************
    */
 
   // header.alg should be one of the algorithms provided in options.algorithms
@@ -138,9 +132,7 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
   }
 
   /**
-   ********************************************************************
    * validate payload content
-   *******************************************************************
    */
 
   /*
@@ -220,9 +212,7 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
   }
 
   /**
-   ********************************************************************
    * return the payload content
-   *******************************************************************
    */
 
   return done(null, payload);

--- a/maintenance/passport-azure-ad/lib/jsonWebToken.js
+++ b/maintenance/passport-azure-ad/lib/jsonWebToken.js
@@ -1,42 +1,25 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the 'Software'), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
 
-'use restrict';
+"use restrict";
 
-const aadutils = require('./aadutils');
-const CONSTANTS = require('./constants');
-const jws = require('jws');
+const aadutils = require("./aadutils");
+const CONSTANTS = require("./constants");
+const jws = require("jws");
 
 // check if two arrays have common elements
-var hasCommonElem = (array1, array2) => {
-  for (var i = 0; i < array1.length; i++) {
+const hasCommonElem = (array1, array2) => {
+  for (let i = 0; i < array1.length; i++) {
     if (array2.indexOf(array1[i]) !== -1)
       return true;
   }
   return false;
 };
 
-/* Verify the token and return the payload
+/*
+ * Verify the token and return the payload
  *
  * @jwtString
  * @PEMKey
@@ -53,176 +36,200 @@ var hasCommonElem = (array1, array2) => {
  */
 exports.verify = function(jwtString, PEMKey, options, callback) {
 
-  /*********************************************************************
+  /**
+   ********************************************************************
    * Checking parameters
-   ********************************************************************/
+   *******************************************************************
+   */
 
-  // check the existence of callback function and options, if we don't have them, that means we have
-  // less than 4 parameters passed. This is a server (code) error, we should throw.
+  /*
+   * check the existence of callback function and options, if we don't have them, that means we have
+   * less than 4 parameters passed. This is a server (code) error, we should throw.
+   */
   if (!callback)
-    throw new Error('callback must be provided in jsonWebToken.verify');
-  if (typeof callback !== 'function')
-    throw new Error('callback in jsonWebToken.verify must be a function');
+    throw new Error("callback must be provided in jsonWebToken.verify");
+  if (typeof callback !== "function")
+    throw new Error("callback in jsonWebToken.verify must be a function");
   if (!options)
-    throw new Error('options must be provided in jsonWebToken.verify');
+    throw new Error("options must be provided in jsonWebToken.verify");
 
-  // check jwtString and PEMKey are provided. Since jwtString and PEMKey are generated, this is
-  // a non-server error, we shouldn't throw, we just give the error back and let authentication fail.
-  if (!jwtString || jwtString === '')
-    return done(new Error('jwtString must be provided in jsonWebToken.verify'));
-  if (!PEMKey || PEMKey === '')
-    return done(new Error('PEMKey must be provided in jsonWebToken.verify'));
+  /*
+   * check jwtString and PEMKey are provided. Since jwtString and PEMKey are generated, this is
+   * a non-server error, we shouldn't throw, we just give the error back and let authentication fail.
+   */
+  if (!jwtString || jwtString === "")
+    return done(new Error("jwtString must be provided in jsonWebToken.verify"));
+  if (!PEMKey || PEMKey === "")
+    return done(new Error("PEMKey must be provided in jsonWebToken.verify"));
 
   // asynchronous wrapper for callback
-  var done = function() {
-    var args = Array.prototype.slice.call(arguments, 0);
+  const done = function() {
+    const args = Array.prototype.slice.call(arguments, 0);
     return process.nextTick(function() {
       callback.apply(null, args);
     });
   };
 
   // make sure we have the required fields in options
-  if (!(options.audience && (typeof options.audience === 'string' || 
+  if (!(options.audience && (typeof options.audience === "string" || 
     (Array.isArray(options.audience) && options.audience.length > 0))))
-    return done(new Error('invalid options.audience value is provided in jsonWebToken.verify'));
+    return done(new Error("invalid options.audience value is provided in jsonWebToken.verify"));
   if (!options.algorithms)
-    return done(new Error('options.algorithms is missing in jsonWebToken.verify'));
-  if (!Array.isArray(options.algorithms) || options.algorithms.length == 0 ||
-    (options.algorithms.length === 1 && options.algorithms[0] === 'none'))
-    return done(new Error('options.algorithms must be an array containing at least one algorithm'));
+    return done(new Error("options.algorithms is missing in jsonWebToken.verify"));
+  if (!Array.isArray(options.algorithms) || options.algorithms.length === 0 ||
+    (options.algorithms.length === 1 && options.algorithms[0] === "none"))
+    return done(new Error("options.algorithms must be an array containing at least one algorithm"));
 
-  /*********************************************************************
+  /**
+   ********************************************************************
    * Checking jwtString structure, getting header, payload and signature
-   ********************************************************************/
+   *******************************************************************
+   */
 
   // split jwtString, make sure we have three parts and we have signature
-  var parts = jwtString.split('.');
+  const parts = jwtString.split(".");
   if (parts.length !== 3)
-    return done(new Error('jwtString is malformed'));
-  if (parts[2] === '')
-    return done(new Error('signature is missing in jwtString'));
+    return done(new Error("jwtString is malformed"));
+  if (parts[2] === "")
+    return done(new Error("signature is missing in jwtString"));
   
   // decode jwsString
-  var decodedToken;
+  let decodedToken;
   try {
     decodedToken = jws.decode(jwtString);
   } catch(err) {
-    return done(new Error('failed to decode the token'));
+    return done(new Error("failed to decode the token"));
   }
 
   if (!decodedToken) {
-    return done(new Error('invalid token'));
+    return done(new Error("invalid token"));
   }
 
   // get header, payload and signature
-  var header = decodedToken.header;
-  var payload = decodedToken.payload;
-  var signature = decodedToken.signature;
+  const header = decodedToken.header;
+  const payload = decodedToken.payload;
+  const signature = decodedToken.signature;
 
   if (!header)
-    return done(new Error('missing header in the token'));
+    return done(new Error("missing header in the token"));
   if (!payload)
-    return done(new Error('missing payload in the token'));
+    return done(new Error("missing payload in the token"));
   if (!signature)
-    return done(new Error('missing signature in the token'));
+    return done(new Error("missing signature in the token"));
 
-  /*********************************************************************
+  /**
+   ********************************************************************
    * validate algorithm and signature
-   ********************************************************************/
+   *******************************************************************
+   */
 
   // header.alg should be one of the algorithms provided in options.algorithms
-  if (typeof header.alg !== 'string' || header.alg === '' || header.alg === 'none' ||
-    options.algorithms.indexOf(header.alg) == -1) {
-    return done(new Error('invalid algorithm'));
+  if (typeof header.alg !== "string" || header.alg === "" || header.alg === "none" ||
+    options.algorithms.indexOf(header.alg) === -1) {
+    return done(new Error("invalid algorithm"));
   }
 
   try {
-    var valid = jws.verify(jwtString, header.alg, PEMKey);
+    const valid = jws.verify(jwtString, header.alg, PEMKey);
     if (!valid)
-      return done(new Error('invalid signature'));
+      return done(new Error("invalid signature"));
   } catch (e) {
     return done(e);
   }
 
-  /*********************************************************************
+  /**
+   ********************************************************************
    * validate payload content
-   ********************************************************************/
+   *******************************************************************
+   */
 
-  // (1) issuer
-  //   - check the existence and the format of payload.iss
-  //   - validate if options.issuer is set
-  if (typeof payload.iss !== 'string' || payload.iss === '')
-    return done(new Error('invalid iss value in payload'));
+  /*
+   * (1) issuer
+   *   - check the existence and the format of payload.iss
+   *   - validate if options.issuer is set
+   */
+  if (typeof payload.iss !== "string" || payload.iss === "")
+    return done(new Error("invalid iss value in payload"));
   if (options.validateIssuer !== false) {
-    if (!options.issuer || options.issuer === '' || (Array.isArray(options.issuer) && options.issuer.length === 0))
-      return done(new Error('options.issuer is missing'));
-    var valid = false;
+    if (!options.issuer || options.issuer === "" || (Array.isArray(options.issuer) && options.issuer.length === 0))
+      return done(new Error("options.issuer is missing"));
+    let valid = false;
     if (Array.isArray(options.issuer))
       valid = (options.issuer.indexOf(payload.iss) !== -1);
     else
       valid = (options.issuer === payload.iss);
     if (!valid)
-      return done(new Error('jwt issuer is invalid'));
+      return done(new Error("jwt issuer is invalid"));
   }
 
-  // (2) subject (id_token only. We don't check subject for access_token)
-  //   - check the existence and the format of payload.sub
-  //   - validate if options.subject is set
+  /*
+   * (2) subject (id_token only. We don't check subject for access_token)
+   *   - check the existence and the format of payload.sub
+   *   - validate if options.subject is set
+   */
   if (options.isAccessToken !== true) {
-    if (typeof payload.sub !== 'string' || payload.sub === '')
-      return done(new Error('invalid sub value in payload'));
+    if (typeof payload.sub !== "string" || payload.sub === "")
+      return done(new Error("invalid sub value in payload"));
     if (options.subject && options.subject !== payload.sub)
-        return done(new Error('jwt subject is invalid. expected'));
+        return done(new Error("jwt subject is invalid. expected"));
   }
 
-  // (3) audience
-  //   - always validate
-  //   - allow payload.aud to be an array of audience
-  //   - options.audience must be a string
-  //   - if there are multiple audiences, then azp claim must exist and must equal client_id
-  if (typeof options.audience === 'string')
-    options.audience = [options.audience, 'spn:' + options.audience];
+  /*
+   * (3) audience
+   *   - always validate
+   *   - allow payload.aud to be an array of audience
+   *   - options.audience must be a string
+   *   - if there are multiple audiences, then azp claim must exist and must equal client_id
+   */
+  if (typeof options.audience === "string")
+    options.audience = [options.audience, "spn:" + options.audience];
   if (options.allowMultiAudiencesInToken === false && Array.isArray(payload.aud) && payload.aud.length > 1)
-    return done(new Error('mulitple audience in token is not allowed'));
-  var payload_audience = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+    return done(new Error("mulitple audience in token is not allowed"));
+  const payload_audience = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
   if (!hasCommonElem(options.audience, payload_audience))
-    return done(new Error('jwt audience is invalid'));
+    return done(new Error("jwt audience is invalid"));
   if (payload_audience.length > 1) {
-    if (typeof payload.azp !== 'string' || payload.azp !== options.clientID)
-      return done(new Error('jwt azp is invalid'));
+    if (typeof payload.azp !== "string" || payload.azp !== options.clientID)
+      return done(new Error("jwt azp is invalid"));
   }
 
-
-  // (4) expiration
-  //   - check the existence and the format of payload.exp
-  //   - validate unless options.ignoreExpiration is set true
-  if (typeof payload.exp !== 'number')
-    return done(new Error('invalid exp value in payload'));
+  /*
+   * (4) expiration
+   *   - check the existence and the format of payload.exp
+   *   - validate unless options.ignoreExpiration is set true
+   */
+  if (typeof payload.exp !== "number")
+    return done(new Error("invalid exp value in payload"));
   if (!options.ignoreExpiration) {
     if (Math.floor(Date.now() / 1000) >= payload.exp + options.clockSkew) {
-      return done(new Error('jwt is expired'));
+      return done(new Error("jwt is expired"));
     }
   }
 
-  // (5) nbf
-  //   - check if it exists
+  /*
+   * (5) nbf
+   *   - check if it exists
+   */
   if (payload.nbf) {
-    if (typeof payload.nbf !== 'number')
-      return done(new Error('nbf value in payload is not a number'));
+    if (typeof payload.nbf !== "number")
+      return done(new Error("nbf value in payload is not a number"));
     if (payload.nbf >= payload.exp)
-      return done(new Error('nbf value in payload is not before the exp value'));
+      return done(new Error("nbf value in payload is not before the exp value"));
     if (payload.nbf >= Math.floor(Date.now() / 1000) + options.clockSkew)
-      return done(new Error('jwt is not active'));
+      return done(new Error("jwt is not active"));
   }
 
-  /*********************************************************************
+  /**
+   ********************************************************************
    * return the payload content
-   ********************************************************************/
+   *******************************************************************
+   */
 
   return done(null, payload);
 };
 
-/* Generate client assertion
+/*
+ * Generate client assertion
  *
  * @params {String} clientID
  * @params {String} token_endpoint
@@ -231,8 +238,8 @@ exports.verify = function(jwtString, PEMKey, options, callback) {
  * @params {Function} callback
  */
 exports.generateClientAssertion = function(clientID, token_endpoint, privatePEMKey, thumbprint, callback) { 
-  var header = { 'x5t': thumbprint, 'alg': 'RS256', 'typ': 'JWT' };
-  var payload = {
+  const header = { "x5t": thumbprint, "alg": "RS256", "typ": "JWT" };
+  const payload = {
     sub: clientID,
     iss: clientID,
     jti: Date.now() + aadutils.uid(16),
@@ -241,8 +248,8 @@ exports.generateClientAssertion = function(clientID, token_endpoint, privatePEMK
     aud: token_endpoint,
   };
 
-  var clientAssertion;
-  var exception = null;
+  let clientAssertion;
+  let exception = null;
 
   try {
     clientAssertion = jws.sign({

--- a/maintenance/passport-azure-ad/lib/jwe.js
+++ b/maintenance/passport-azure-ad/lib/jwe.js
@@ -1,39 +1,21 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the "Software"), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
- 
- /* eslint-disable no-new */
 
-'use strict';
+"use strict";
 
-var crypto = require('crypto');
-var constants = require('constants');
-const base64url = require('base64url');
+const crypto = require("crypto");
+const constants = require("constants");
+const base64url = require("base64url");
 
-var jose = require('node-jose');
+const jose = require("node-jose");
 
-/******************************************************************************
+/**
+ *****************************************************************************
  * utility functions
- *****************************************************************************/
+ ****************************************************************************
+ */
 
 /**
  * Create a buffer depends on the version of node
@@ -42,22 +24,22 @@ var jose = require('node-jose');
  * @param{String}  encoding: ignored if data is a buffer
  * @return{Buffer} 
  */
-var createBuffer = (data, encoding) => {
-  if (!Buffer.isBuffer(data) && typeof data !== 'string' && typeof data !== 'number')
-    throw new Error('in createBuffer, data must be a buffer, string or number');
+const createBuffer = (data, encoding) => {
+  if (!Buffer.isBuffer(data) && typeof data !== "string" && typeof data !== "number")
+    throw new Error("in createBuffer, data must be a buffer, string or number");
 
-  if (process.version >= 'v6') {
-    if (typeof data === 'string')
+  if (process.version >= "v6") {
+    if (typeof data === "string")
       return Buffer.from(data, encoding);
-    else if (typeof data === 'number')
+    else if (typeof data === "number")
       return Buffer.alloc(data);
     else
       return Buffer.from(data);
   } else {
-    if (typeof data === 'string')
-      return new Buffer(data, encoding);
+    if (typeof data === "string")
+      return new Buffer(data, encoding); // eslint-disable-line security/detect-new-buffer -- Legacy code, Buffer needed
     else
-      return new Buffer(data);
+      return new Buffer(data); // eslint-disable-line security/detect-new-buffer -- Legacy code, Buffer needed
   } 
 };
 
@@ -68,22 +50,24 @@ var createBuffer = (data, encoding) => {
  * @param{Buffer}  b: second number
  * @return{Buffer}  a^b
  */
-var xor = (a, b) => {
-  var c1, c2;
+const xor = (a, b) => {
+  let c1, c2;
   if (a.length > b.length) {
     c1 = a; c2 = b;
   } else {
     c2 = a; c1 = b;
   }
-  var c = createBuffer(c1);
-  for (var i = 1; i <= c2.length; i++)
+  const c = createBuffer(c1);
+  for (let i = 1; i <= c2.length; i++)
     c[c1.length-i] = c[c1.length-i] ^ c2[c2.length-i];
   return c;
 };
 
-/******************************************************************************
+/**
+ *****************************************************************************
  * AES key unwrap algorithms
- *****************************************************************************/
+ ****************************************************************************
+ */
 
 /**
  * Unwrap wrapped_cek using AES with kek
@@ -93,50 +77,56 @@ var xor = (a, b) => {
  * @param{Buffer}  kek: key encryption key
  * @return{Buffer}  cek, the unwrapped key
  */
-var AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
+const AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
 
-  /****************************************************************************
+  /**
+   ***************************************************************************
    * Inputs: CipherText, (n+1) 64-bit values {C0, C1, ..., Cn}, and 
    *         Key, K (the KEK)
    * Outputs: Plaintext, n 64-bit values {P0, P1, K, Pn}
-   ***************************************************************************/
-  var C = wrapped_cek;
-  var n = C.length/8-1;
-  var K = kek;
+   **************************************************************************
+   */
+  const C = wrapped_cek;
+  const n = C.length/8-1;
+  const K = kek;
 
-  /****************************************************************************
+  /**
+   ***************************************************************************
    * 1) Initialize variables
    *    Set A = C[0]
    *    For i = 1 to b
    *      R[i] = C[i]
-   ***************************************************************************/
-  var A = C.slice(0,8);
-  var R = [createBuffer(1)];
-  for (var i = 1; i <= n; i++)
+   **************************************************************************
+   */
+  let A = C.slice(0,8);
+  const R = [createBuffer(1)];
+  for (let i = 1; i <= n; i++)
     R.push(C.slice(8*i, 8*i+8));
 
-  /****************************************************************************
+  /**
+   ***************************************************************************
    * 2) compute intermediate values
    *    For j = 5 to 0
    *      For i = n to 1
    *        B = AES-1(K, (A^t) | R[i]) where t = n*j+i
    *        A = MSB(64, B)
    *        R[i] = LSB(64, B)
-   ***************************************************************************/
-  for(var j=5; j >= 0; j--) {
-    for(var i=n; i >= 1; i--) {
+   **************************************************************************
+   */
+  for(let j=5; j >= 0; j--) {
+    for(let i=n; i >= 1; i--) {
       // turn t = n*j+i into buffer
-      var str = (n*j+i).toString(16);
+      let str = (n*j+i).toString(16);
       if (str.length %2 !== 0)
-        str = '0' + str;
-      var t = createBuffer(str, 'hex');
+        str = "0" + str;
+      const t = createBuffer(str, "hex");
 
       // B = AES-1(K, (A^t) | R[i])
-      var aes = crypto.createDecipheriv(algorithm, K, '');
+      const aes = crypto.createDecipheriv(algorithm, K, "");
       aes.setAutoPadding(false);
-      var B = aes.update(Buffer.concat([xor(A, t), R[i]]), null, 'hex');
-      B += aes.final('hex');
-      B = createBuffer(B, 'hex');
+      let B = aes.update(Buffer.concat([xor(A, t), R[i]]), null, "hex");
+      B += aes.final("hex");
+      B = createBuffer(B, "hex");
 
       // A = MSB(64, B)
       A = B.slice(0, 8);
@@ -146,7 +136,8 @@ var AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
     }
   }
 
-  /****************************************************************************
+  /**
+   ***************************************************************************
    * 3) Output results.
    *    If A is an appropriate initial value
    *    Then
@@ -154,23 +145,26 @@ var AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
    *        P[i] = R[i]
    *    Else
    *      Return an error
-   ***************************************************************************/
+   **************************************************************************
+   */
   
   // check A
-  if (A.toString('hex').toUpperCase() === 'A6A6A6A6A6A6A6A6') {
-    var result = R[1];
-    for (var i = 2; i <= n; i++)
+  if (A.toString("hex").toUpperCase() === "A6A6A6A6A6A6A6A6") {
+    let result = R[1];
+    for (let i = 2; i <= n; i++)
       result = Buffer.concat([result, R[i]]);
     
     return result;
   } else {
-    throw new Error('aes decryption failed: invalid key');
+    throw new Error("aes decryption failed: invalid key");
   }
 };
 
-/******************************************************************************
+/**
+ *****************************************************************************
  * AES-CBC-HMAC-SHA2 decryption
- *****************************************************************************/
+ ****************************************************************************
+ */
 
 /**
  * decrypt ciperText using aes-cbc-hmac-sha2 algorithm
@@ -183,24 +177,26 @@ var AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
  * @param{Buffer}  authTag: authentication tag
  * @return{Buffer}  decrypted content
  */
-var decrypt_AES_CBC_HMAC_SHA2 = (algorithm, key, cipherText, iv, aad, authTag) => {
-  // algorithm information
-  // note ENC_KEY_LEN = MAC_KEY_LEN = T_LEN = len
-  var algInfo = {
-    'aes-128-cbc-hmac-sha-256': {
-        'cipher_algo': 'aes-128-cbc', 
-        'hash_algo': 'sha256', 
-        'len': 16
+const decrypt_AES_CBC_HMAC_SHA2 = (algorithm, key, cipherText, iv, aad, authTag) => {
+  /*
+   * algorithm information
+   * note ENC_KEY_LEN = MAC_KEY_LEN = T_LEN = len
+   */
+  const algInfo = {
+    "aes-128-cbc-hmac-sha-256": {
+        "cipher_algo": "aes-128-cbc", 
+        "hash_algo": "sha256", 
+        "len": 16
       },
-    'aes-192-cbc-hmac-sha-384': {
-        'cipher_algo': 'aes-192-cbc', 
-        'hash_algo': 'sha384', 
-        'len': 24
+    "aes-192-cbc-hmac-sha-384": {
+        "cipher_algo": "aes-192-cbc", 
+        "hash_algo": "sha384", 
+        "len": 24
       },
-    'aes-256-cbc-hmac-sha-512': {
-        'cipher_algo': 'aes-256-cbc', 
-        'hash_algo': 'sha512', 
-        'len': 32
+    "aes-256-cbc-hmac-sha-512": {
+        "cipher_algo": "aes-256-cbc", 
+        "hash_algo": "sha512", 
+        "len": 32
       }
   };
 
@@ -208,74 +204,77 @@ var decrypt_AES_CBC_HMAC_SHA2 = (algorithm, key, cipherText, iv, aad, authTag) =
 
   // check if we have a supported algorithm
   if (!algorithm)
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: algorithm is not provided');
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: algorithm is not provided");
   if (!algInfo[algorithm])
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: unsupported algorithm: ' + algorithm);
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: unsupported algorithm: " + algorithm);
 
-  var algo = algInfo[algorithm];
+  const algo = algInfo[algorithm];
 
   // check the size of key
   if (!key)
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: key is not provided');
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: key is not provided");
   if (!(key instanceof Buffer))
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: key must be a buffer');
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: key must be a buffer");
   if (key.length !== algInfo[algorithm].len * 2)
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: key has size ' + key.length + ', it must have size ' + algo.len * 2);
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: key has size " + key.length + ", it must have size " + algo.len * 2);
   
   // check the size of iv
   if (!iv)
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: iv is not provided');
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: iv is not provided");
   if (!(iv instanceof Buffer))
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: iv must be a buffer');
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: iv must be a buffer");
   if (iv.length !== 16)
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: iv has size ' + iv.length + ', it must have size 16');
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: iv has size " + iv.length + ", it must have size 16");
 
   // check the existence of aad
   if (!aad)
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: aad is not provided');
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: aad is not provided");
   if (!(aad instanceof Buffer))
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: aad must be a buffer');
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: aad must be a buffer");
 
   // 2. Split key
 
   // first half is mac_key and the second half is enc_key
-  var mac_key = key.slice(0, algo.len);
-  var enc_key = key.slice(algo.len);
+  const mac_key = key.slice(0, algo.len);
+  const enc_key = key.slice(algo.len);
 
   // 3. Verify tag
 
-  // tag should be: hash(aad + iv + cipherText + aad_len) where aad_len is the
-  // number of bits in aad expressed as a 64-bit unsigned big-endian integer
+  /*
+   * tag should be: hash(aad + iv + cipherText + aad_len) where aad_len is the
+   * number of bits in aad expressed as a 64-bit unsigned big-endian integer
+   */
 
   // 3.1 compute aad_len
-  var aad_len = createBuffer(8);
+  const aad_len = createBuffer(8);
   aad_len.writeUInt32BE(aad.length * 8, 4);
   aad_len.writeUInt32BE(0, 0);
 
   // 3.2 create hmac algorithm
-  var hmac = crypto.createHmac(algo.hash_algo, mac_key);
+  const hmac = crypto.createHmac(algo.hash_algo, mac_key);
   hmac.write(aad);
   hmac.write(iv);
   hmac.update(cipherText);
   hmac.update(aad_len);
-  var computed_authTag = hmac.digest().slice(0, algo.len);
+  const computed_authTag = hmac.digest().slice(0, algo.len);
 
   // 3.3 verify the tag
-  if (!authTag || !computed_authTag || (authTag.toString('hex') !== computed_authTag.toString('hex')))
-    throw new Error('In decrypt_AES_CBC_HMAC_SHA2: invalid authentication tag');
+  if (!authTag || !computed_authTag || (authTag.toString("hex") !== computed_authTag.toString("hex")))
+    throw new Error("In decrypt_AES_CBC_HMAC_SHA2: invalid authentication tag");
 
   // 4. Decrypt cipherText
-  var decipher = crypto.createDecipheriv(algo.cipher_algo, enc_key, iv);
-  var plainText = decipher.update(cipherText);
+  const decipher = crypto.createDecipheriv(algo.cipher_algo, enc_key, iv);
+  let plainText = decipher.update(cipherText);
   plainText = Buffer.concat([plainText, decipher.final()]);
   
   return plainText;
 };
 
-
-/******************************************************************************
+/**
+ *****************************************************************************
  * JWE decryption
- *****************************************************************************/
+ ****************************************************************************
+ */
 
 /**
  * decrypt cek helper function
@@ -285,44 +284,44 @@ var decrypt_AES_CBC_HMAC_SHA2 = (algorithm, key, cipherText, iv, aad, authTag) =
  * @param{Buffer}  key: encryption key
  * @return{Function}  log: logging function
  */
-var decryptCEKHelper = (alg, encrypted_cek, key, log) => {
-  var error = null;
-  var cek = null;
+const decryptCEKHelper = (alg, encrypted_cek, key, log) => {
+  let error = null;
+  let cek = null;
 
   try {
-    var key_to_use;
+    let key_to_use;
 
-    if (alg === 'RSA1_5' || alg === 'RSA-OAEP') {
-      if (key['privatePemKey']) {
-        log.info('using RSA privatePemKey to decrypt cek');
-        key_to_use = key['privatePemKey'];
+    if (alg === "RSA1_5" || alg === "RSA-OAEP") {
+      if (key["privatePemKey"]) {
+        log.info("using RSA privatePemKey to decrypt cek");
+        key_to_use = key["privatePemKey"];
       } else {
-        log.info('converting jwk to RSA privatePemKey to decrypt cek');
+        log.info("converting jwk to RSA privatePemKey to decrypt cek");
         return { "error": "converting jwk to RSA privatePemKey to decrypt cek", cek: key };
       }
-    } else if (alg === 'A128KW' || alg === 'A256KW') {
-      log.info('using symmetric key to decrypt cek');
+    } else if (alg === "A128KW" || alg === "A256KW") {
+      log.info("using symmetric key to decrypt cek");
       key_to_use = base64url.toBuffer(key.k);
     } else {
-      log.info('unsupported alg: ' + alg);
-      return {'error': error, 'cek': null};
+      log.info("unsupported alg: " + alg);
+      return {"error": error, "cek": null};
     }
 
-    if (alg === 'RSA1_5')
+    if (alg === "RSA1_5")
       cek = crypto.privateDecrypt({ key: key_to_use, padding: constants.RSA_PKCS1_PADDING }, encrypted_cek);
-    else if (alg === 'RSA-OAEP')
+    else if (alg === "RSA-OAEP")
       cek = crypto.privateDecrypt({ key: key_to_use, padding: constants.RSA_PKCS1_OAEP_PADDING }, encrypted_cek);
-    else if (alg === 'A128KW')
-      cek = AESKeyUnWrap('aes-128-ecb', encrypted_cek, key_to_use);
-    else if (alg === 'A256KW')
-      cek = AESKeyUnWrap('aes-256-ecb', encrypted_cek, key_to_use);
+    else if (alg === "A128KW")
+      cek = AESKeyUnWrap("aes-128-ecb", encrypted_cek, key_to_use);
+    else if (alg === "A256KW")
+      cek = AESKeyUnWrap("aes-256-ecb", encrypted_cek, key_to_use);
     else
       cek = key_to_use;  // dir 
   } catch (ex) {
     error = ex;
   }
 
-  return {'error': error, 'cek': cek};
+  return {"error": error, "cek": cek};
 };
 
 /**
@@ -333,41 +332,41 @@ var decryptCEKHelper = (alg, encrypted_cek, key, log) => {
  * @param{Object}  jweKeyStore: list of keys
  * @return{Function}  log: logging function
  */
-var decryptCEK = (header, encrypted_cek, jweKeyStore, log) => {
-  var algKtyMapper = { 'RSA1_5': 'RSA', 'RSA-OAEP': 'RSA', 'A128KW': 'oct', 'A256KW': 'oct'};
+const decryptCEK = (header, encrypted_cek, jweKeyStore, log) => {
+  const algKtyMapper = { "RSA1_5": "RSA", "RSA-OAEP": "RSA", "A128KW": "oct", "A256KW": "oct"};
 
   if (!header.alg)
-    return { 'error': new Error('alg is missing in JWE header'), 'cek': null };
-  if(['RSA1_5', 'RSA-OAEP', 'dir', 'A128KW', 'A256KW'].indexOf(header.alg) === -1)
-    return { 'error' : new Error('Unsupported alg in JWE header: ' + header.alg), 'cek': null };
+    return { "error": new Error("alg is missing in JWE header"), "cek": null };
+  if(["RSA1_5", "RSA-OAEP", "dir", "A128KW", "A256KW"].indexOf(header.alg) === -1)
+    return { "error" : new Error("Unsupported alg in JWE header: " + header.alg), "cek": null };
 
-  var key = null;
+  let key = null;
 
   if (header.kid) {
-    for (var i = 0; i < jweKeyStore.length; i++) {
+    for (let i = 0; i < jweKeyStore.length; i++) {
       if (header.kid === jweKeyStore[i].kid && algKtyMapper[header.alg] === jweKeyStore[i].kty) {
         key = jweKeyStore[i];
-        log.info('found a key matching kid: ' + header.kid);
+        log.info("found a key matching kid: " + header.kid);
         return decryptCEKHelper(header.alg, encrypted_cek, key, log);
       }
     }
 
-    return { 'error': new Error('cannot find a key matching kid: ' + header.kid), 'cek': null };
+    return { "error": new Error("cannot find a key matching kid: " + header.kid), "cek": null };
   }
 
-  log.info('kid is not provided in JWE header, now we try all the possible keys');
+  log.info("kid is not provided in JWE header, now we try all the possible keys");
 
   // kid matching failed, now we try every possible key
-  for(var i = 0; i < jweKeyStore.length; i++) {
+  for(let i = 0; i < jweKeyStore.length; i++) {
     if (jweKeyStore[i].kty === algKtyMapper[header.alg]) {
-      var result = decryptCEKHelper(header.alg, encrypted_cek, jweKeyStore[i], log);
+      const result = decryptCEKHelper(header.alg, encrypted_cek, jweKeyStore[i], log);
       if (result.cek) {
         return result;
       }
     }
   }
 
-  return { 'error': new Error('tried all keys to decrypt cek but none of them works'), 'cek': null };
+  return { "error": new Error("tried all keys to decrypt cek but none of them works"), "cek": null };
 };
 
 /**
@@ -381,25 +380,25 @@ var decryptCEK = (header, encrypted_cek, jweKeyStore, log) => {
  * @param{Buffer}  aad: additional authentication information
  * @return{Function}  log: logging function
  */
-var decryptContent = (header, cek, cipherText, iv, authTag, aad, log) => {
+const decryptContent = (header, cek, cipherText, iv, authTag, aad) => {
   if (!header.enc)
-    return { 'error': new Error('enc is missing in JWE header'), 'content': null };
-  if (['A128GCM', 'A256GCM', 'A128CBC-HS256', 'A192CBC-HS384', 'A256CBC-HS512'].indexOf(header.enc) === -1)
-    return { 'error' : new Error('Unsupported enc in JWE header: ' + header.enc), 'content': null };
+    return { "error": new Error("enc is missing in JWE header"), "content": null };
+  if (["A128GCM", "A256GCM", "A128CBC-HS256", "A192CBC-HS384", "A256CBC-HS512"].indexOf(header.enc) === -1)
+    return { "error" : new Error("Unsupported enc in JWE header: " + header.enc), "content": null };
 
-  var mapper = { 
-    'A128GCM': 'aes-128-gcm', 
-    'A256GCM': 'aes-256-gcm', 
-    'A128CBC-HS256': 'aes-128-cbc-hmac-sha-256',
-    'A192CBC-HS384': 'aes-192-cbc-hmac-sha-384',
-    'A256CBC-HS512': 'aes-256-cbc-hmac-sha-512'
+  const mapper = { 
+    "A128GCM": "aes-128-gcm", 
+    "A256GCM": "aes-256-gcm", 
+    "A128CBC-HS256": "aes-128-cbc-hmac-sha-256",
+    "A192CBC-HS384": "aes-192-cbc-hmac-sha-384",
+    "A256CBC-HS512": "aes-256-cbc-hmac-sha-512"
   };
 
   try {
-    var content = null;
+    let content = null;
 
-    if (header.enc === 'A128GCM' || header.enc === 'A256GCM') {
-      var decipher = crypto.createDecipheriv(mapper[header.enc], cek, iv);
+    if (header.enc === "A128GCM" || header.enc === "A256GCM") {
+      const decipher = crypto.createDecipheriv(mapper[header.enc], cek, iv);
       decipher.setAAD(aad);
       decipher.setAuthTag(authTag);
       content = decipher.update(cipherText);
@@ -408,9 +407,9 @@ var decryptContent = (header, cek, cipherText, iv, authTag, aad, log) => {
       content = decrypt_AES_CBC_HMAC_SHA2(mapper[header.enc], cek, cipherText, iv, aad, authTag);    
     }
 
-    return { 'error': null, 'content': content.toString() };
+    return { "error": null, "content": content.toString() };
   } catch (ex) {
-    return { 'error': ex, 'content': null };
+    return { "error": ex, "content": null };
   }
 };
 
@@ -425,15 +424,15 @@ var decryptContent = (header, cek, cipherText, iv, authTag, aad, log) => {
  * @param{Buffer}  aad: additional authentication information
  * @return{Function}  log: logging function
  */
-var decryptContentForDir = (header, jweKeyStore, cipherText, iv, authTag, aad, log) => {
-  var key = null;
+const decryptContentForDir = (header, jweKeyStore, cipherText, iv, authTag, aad, log) => {
+  let key = null;
 
   // try the key with the corresponding kid
   if (header.kid) {
-    for (var i = 0; i < jweKeyStore.length; i++) {
-      if (header.kid === jweKeyStore[i].kid && jweKeyStore[i].kty === 'oct') {
+    for (let i = 0; i < jweKeyStore.length; i++) {
+      if (header.kid === jweKeyStore[i].kid && jweKeyStore[i].kty === "oct") {
         key = jweKeyStore[i];
-        log.info('Decrypting JWE content, header.alg == dir, found a key matching kid: ' + header.kid);
+        log.info("Decrypting JWE content, header.alg == dir, found a key matching kid: " + header.kid);
         break;
       }
     }
@@ -441,22 +440,22 @@ var decryptContentForDir = (header, jweKeyStore, cipherText, iv, authTag, aad, l
     if (key)
       return decryptContent(header, base64url.toBuffer(key.k), cipherText, iv, authTag, aad, log);
     else
-      return { 'error': new Error('cannot find a key matching kid: ' + header.kid), 'cek': null };
+      return { "error": new Error("cannot find a key matching kid: " + header.kid), "cek": null };
   }
 
-  log.info('In decryptContentForDir: kid is not provided in JWE header, now we try all the possible keys');
+  log.info("In decryptContentForDir: kid is not provided in JWE header, now we try all the possible keys");
 
   // kid matching failed, now we try every possible key
-  for(var i = 0; i < jweKeyStore.length; i++) {
-    if (jweKeyStore[i].kty === 'oct') {
-      var result = decryptContent(header, base64url.toBuffer(jweKeyStore[i].k), cipherText, iv, authTag, aad, log);
+  for(let i = 0; i < jweKeyStore.length; i++) {
+    if (jweKeyStore[i].kty === "oct") {
+      const result = decryptContent(header, base64url.toBuffer(jweKeyStore[i].k), cipherText, iv, authTag, aad, log);
       if (!result.error)
         return result;
     }
   }
 
-  log.info('In decryptContentForDir: tried all keys to decrypt the content but all failed');
-  return { error: new Error('In decryptContentForDir: tried all keys to decrypt the content but all failed'), content_result: null };
+  log.info("In decryptContentForDir: tried all keys to decrypt the content but all failed");
+  return { error: new Error("In decryptContentForDir: tried all keys to decrypt the content but all failed"), content_result: null };
 };
 
 /**
@@ -468,7 +467,8 @@ var decryptContentForDir = (header, jweKeyStore, cipherText, iv, authTag, aad, l
  * @return{Function}  callback: callback function
  */
 exports.decrypt = (jweString, jweKeyStore, log, callback) => {
-  /****************************************************************************
+  /**
+   ***************************************************************************
    *   JWE compact format structure
    ****************************************************************************
    * BASE64URL(UTF8(JWE Protected Header)) || '.' ||
@@ -476,48 +476,51 @@ exports.decrypt = (jweString, jweKeyStore, log, callback) => {
    * BASE64URL(JWE Initialization Vector) || '.' || 
    * BASE64URL(JWE Ciphertext) || '.' || 
    * BASE64URL(JWE Authentication Tag)
-   ***************************************************************************/
-  var parts = jweString.split('.');
+   **************************************************************************
+   */
+  const parts = jweString.split(".");
   if (parts.length !== 5)
-    return callback(new Error('In jwe.decrypt: invalid JWE string, it has ' + parts.length + ' parts instead of 5'), null);
+    return callback(new Error("In jwe.decrypt: invalid JWE string, it has " + parts.length + " parts instead of 5"), null);
   
-  var header;
+  let header;
   try {
-    header = JSON.parse(base64url.decode(parts[0], 'binary'));
+    header = JSON.parse(base64url.decode(parts[0], "binary"));
   } catch (ex) {
-    return callback(new Error('In jwe.decrypt: failed to parse JWE header'), null);
+    return callback(new Error("In jwe.decrypt: failed to parse JWE header"), null);
   }
 
-  var aad = createBuffer(parts[0]);
-  var encrypted_cek = base64url.toBuffer(parts[1]);
-  var iv = base64url.toBuffer(parts[2]);
-  var cipherText = base64url.toBuffer(parts[3]);
-  var authTag = base64url.toBuffer(parts[4]);
+  const aad = createBuffer(parts[0]);
+  const encrypted_cek = base64url.toBuffer(parts[1]);
+  const iv = base64url.toBuffer(parts[2]);
+  const cipherText = base64url.toBuffer(parts[3]);
+  const authTag = base64url.toBuffer(parts[4]);
 
-  log.info('In jwe.decrypt: the header is ' + JSON.stringify(header));
+  log.info("In jwe.decrypt: the header is " + JSON.stringify(header));
 
-  var cek_result;
-  var content_result;
+  let cek_result;
+  let content_result;
 
   // special treatment of 'dir'
-  if (header.alg === 'dir') {
+  if (header.alg === "dir") {
     content_result = decryptContentForDir(header, jweKeyStore, cipherText, iv, authTag, aad, log);
   } else {
-    /****************************************************************************
+    /**
+     ***************************************************************************
      *  cek decryption
-     ***************************************************************************/
-    var cek_result = decryptCEK(header, encrypted_cek, jweKeyStore, log);
+     **************************************************************************
+     */
+    cek_result = decryptCEK(header, encrypted_cek, jweKeyStore, log);
     if (cek_result.error) {
       if (cek_result.error === "converting jwk to RSA privatePemKey to decrypt cek") {
         jose.JWK.asKey(cek_result.cek, "pem").then((pemKey) => {
           let cek;
-          if (header.alg === 'RSA1_5')
+          if (header.alg === "RSA1_5")
             cek = crypto.privateDecrypt({ key: pemKey.toPEM(true), padding: constants.RSA_PKCS1_PADDING }, encrypted_cek);
-          else if (header.alg === 'RSA-OAEP')
+          else if (header.alg === "RSA-OAEP")
             cek = crypto.privateDecrypt({ key: pemKey.toPEM(true), padding: constants.RSA_PKCS1_OAEP_PADDING }, encrypted_cek);
-          var decryptedPemResult = decryptContent(header, cek, cipherText, iv, authTag, aad, log);
+          const decryptedPemResult = decryptContent(header, cek, cipherText, iv, authTag, aad, log);
           if (!decryptedPemResult.error) {
-            log.info('In jwe.decrypt: successfully decrypted id_token');
+            log.info("In jwe.decrypt: successfully decrypted id_token");
           }
           return callback(decryptedPemResult.error, decryptedPemResult.content);
         });
@@ -526,20 +529,20 @@ exports.decrypt = (jweString, jweKeyStore, log, callback) => {
       return callback(cek_result.error);
     }
 
-    /****************************************************************************
+    /**
+     ***************************************************************************
      *  content decryption
-     ***************************************************************************/
-    var content_result = decryptContent(header, cek_result.cek, cipherText, iv, authTag, aad, log);
+     **************************************************************************
+     */
+    content_result = decryptContent(header, cek_result.cek, cipherText, iv, authTag, aad, log);
   }
 
   if (!content_result.error) {
-    log.info('In jwe.decrypt: successfully decrypted id_token');
+    log.info("In jwe.decrypt: successfully decrypted id_token");
   }
   
   return callback(content_result.error, content_result.content);
 };
 
 exports.createBuffer = createBuffer;
-
-
 

--- a/maintenance/passport-azure-ad/lib/jwe.js
+++ b/maintenance/passport-azure-ad/lib/jwe.js
@@ -12,9 +12,7 @@ const base64url = require("base64url");
 const jose = require("node-jose");
 
 /**
- *****************************************************************************
  * utility functions
- ****************************************************************************
  */
 
 /**
@@ -64,9 +62,7 @@ const xor = (a, b) => {
 };
 
 /**
- *****************************************************************************
  * AES key unwrap algorithms
- ****************************************************************************
  */
 
 /**
@@ -80,23 +76,19 @@ const xor = (a, b) => {
 const AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
 
   /**
-   ***************************************************************************
    * Inputs: CipherText, (n+1) 64-bit values {C0, C1, ..., Cn}, and 
    *         Key, K (the KEK)
    * Outputs: Plaintext, n 64-bit values {P0, P1, K, Pn}
-   **************************************************************************
    */
   const C = wrapped_cek;
   const n = C.length/8-1;
   const K = kek;
 
   /**
-   ***************************************************************************
    * 1) Initialize variables
    *    Set A = C[0]
    *    For i = 1 to b
    *      R[i] = C[i]
-   **************************************************************************
    */
   let A = C.slice(0,8);
   const R = [createBuffer(1)];
@@ -104,14 +96,12 @@ const AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
     R.push(C.slice(8*i, 8*i+8));
 
   /**
-   ***************************************************************************
    * 2) compute intermediate values
    *    For j = 5 to 0
    *      For i = n to 1
    *        B = AES-1(K, (A^t) | R[i]) where t = n*j+i
    *        A = MSB(64, B)
    *        R[i] = LSB(64, B)
-   **************************************************************************
    */
   for(let j=5; j >= 0; j--) {
     for(let i=n; i >= 1; i--) {
@@ -137,7 +127,6 @@ const AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
   }
 
   /**
-   ***************************************************************************
    * 3) Output results.
    *    If A is an appropriate initial value
    *    Then
@@ -145,7 +134,6 @@ const AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
    *        P[i] = R[i]
    *    Else
    *      Return an error
-   **************************************************************************
    */
   
   // check A
@@ -161,9 +149,7 @@ const AESKeyUnWrap = (algorithm, wrapped_cek, kek) => {
 };
 
 /**
- *****************************************************************************
  * AES-CBC-HMAC-SHA2 decryption
- ****************************************************************************
  */
 
 /**
@@ -271,9 +257,7 @@ const decrypt_AES_CBC_HMAC_SHA2 = (algorithm, key, cipherText, iv, aad, authTag)
 };
 
 /**
- *****************************************************************************
  * JWE decryption
- ****************************************************************************
  */
 
 /**
@@ -468,15 +452,13 @@ const decryptContentForDir = (header, jweKeyStore, cipherText, iv, authTag, aad,
  */
 exports.decrypt = (jweString, jweKeyStore, log, callback) => {
   /**
-   ***************************************************************************
-   *   JWE compact format structure
-   ****************************************************************************
+   * JWE compact format structure
+   *
    * BASE64URL(UTF8(JWE Protected Header)) || '.' ||
    * BASE64URL(JWE Encrypted Key) || '.' || 
    * BASE64URL(JWE Initialization Vector) || '.' || 
    * BASE64URL(JWE Ciphertext) || '.' || 
    * BASE64URL(JWE Authentication Tag)
-   **************************************************************************
    */
   const parts = jweString.split(".");
   if (parts.length !== 5)
@@ -505,9 +487,7 @@ exports.decrypt = (jweString, jweKeyStore, log, callback) => {
     content_result = decryptContentForDir(header, jweKeyStore, cipherText, iv, authTag, aad, log);
   } else {
     /**
-     ***************************************************************************
      *  cek decryption
-     **************************************************************************
      */
     cek_result = decryptCEK(header, encrypted_cek, jweKeyStore, log);
     if (cek_result.error) {
@@ -530,9 +510,7 @@ exports.decrypt = (jweString, jweKeyStore, log, callback) => {
     }
 
     /**
-     ***************************************************************************
      *  content decryption
-     **************************************************************************
      */
     content_result = decryptContent(header, cek_result.cek, cipherText, iv, authTag, aad, log);
   }

--- a/maintenance/passport-azure-ad/lib/logging.js
+++ b/maintenance/passport-azure-ad/lib/logging.js
@@ -1,40 +1,23 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the 'Software'), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
-'use strict';
 
-const bunyan = require('bunyan');
+"use strict";
+
+const bunyan = require("bunyan");
 
 function getLogger(name) {
   const log = bunyan.createLogger({
     name,
     streams: [{
       stream: process.stderr,
-      level: 'error',
-      name: 'error',
+      level: "error",
+      name: "error",
     }, {
       stream: process.stdout,
-      level: 'warn',
-      name: 'console',
+      level: "warn",
+      name: "console",
     }],
   });
   return log;

--- a/maintenance/passport-azure-ad/lib/oidcstrategy.js
+++ b/maintenance/passport-azure-ad/lib/oidcstrategy.js
@@ -408,12 +408,10 @@ function Strategy(options, verify) {
     options.clockSkew = CONSTANTS.CLOCK_SKEW;
 
   /**
-   ***************************************************************************************
    * Take care of identityMetadata
    * (1) Check if it is common endpoint
    * (2) For B2C, one cannot use the common endpoint. tenant name or guid must be specified
    * (3) We add telemetry to identityMetadata automatically
-   **************************************************************************************
    */
 
   // check existence
@@ -439,7 +437,6 @@ function Strategy(options, verify) {
   );
 
   /**
-   ***************************************************************************************
    * Take care of issuer and audience
    * (1) We use user provided `issuer`, and the issuer value from metadata if the metadata
    *     comes from tenant-specific endpoint (in other words, either the identityMetadata
@@ -451,7 +448,6 @@ function Strategy(options, verify) {
    *     must be set to false
    * (2) `validateIssuer` is true by default. we validate issuer unless validateIssuer is set false
    * (3) `audience` must be the clientID of this app
-   **************************************************************************************
    */
   if (options.validateIssuer !== false)
     options.validateIssuer = true;
@@ -468,10 +464,9 @@ function Strategy(options, verify) {
   options.allowMultiAudiencesInToken = false;
 
   /**
-   ***************************************************************************************
    * Take care of scope
-   **************************************************************************************
    */
+
   // make scope an array
   if (!options.scope)
     options.scope = [];
@@ -483,18 +478,15 @@ function Strategy(options, verify) {
   options.scope = options.scope.join(" ");
 
   /**
-   ***************************************************************************************
    * Check if we are using v2 endpoint, v2 doesn't have an userinfo endpoint
-   **************************************************************************************
    */
   if (options.identityMetadata.indexOf("/v2.0/") !== -1)
     options._isV2 = true;
 
   /**
-   ***************************************************************************************
    * validate other necessary option items provided, we validate them here and only once
-   **************************************************************************************
    */
+
   // change responseType 'id_token code' to 'code id_token' since the former is not supported by B2C
   if (options.responseType === "id_token code")
     options.responseType = "code id_token";
@@ -525,7 +517,7 @@ function Strategy(options, verify) {
       // for B2C, clientSecret is required to redeem authorization code.
       throw new Error("clientSecret must be provided for B2C hybrid flow and authorization code flow.");
     } else if (!options.clientSecret) {
-      /*
+      /**
        * for non-B2C, we can use either clientSecret or clientAssertion to redeem authorization code.
        * Therefore, we need either clientSecret, or privatePEMKey and thumbprint (so we can create clientAssertion).
        */
@@ -612,28 +604,22 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
   async.waterfall(
     [
       /**
-       ****************************************************************************
        * Step 1. Collect information from the req and save the info into params
-       ***************************************************************************
        */
       (next) => {
         return self.collectInfoFromReq(params, req, next, response);
       },
 
       /**
-       ****************************************************************************
        * Step 2. Load metadata, use the information from 'params' and 'self._options'
        * to configure 'oauthConfig' and 'optionsToValidate'
-       ***************************************************************************
        */
       (next) => {
         return self.setOptions(params, oauthConfig, optionsToValidate, next);
       },
 
       /**
-       ****************************************************************************
        * Step 3. Handle the flows
-       *----------------------------------------------------------------------------
        * (1) implicit flow (response_type = 'id_token')
        *     This case we get a 'id_token'
        * (2) hybrid flow (response_type = 'id_token code')
@@ -642,7 +628,6 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
        *     This case we get a 'code', we will use it to get 'access_token' and 'id_token'
        * (4) for any other request, we will ask for authorization and initialize
        *     the authorization process
-       ***************************************************************************
        */
       (next) => {
         if (params.err) {
@@ -689,18 +674,14 @@ Strategy.prototype.collectInfoFromReq = function (params, req, next, response) {
    */
 
   /*
-   * -------------------------------------------------------------------------
    * we shouldn't get any access_token or refresh_token from the request
-   * -------------------------------------------------------------------------
    */
   if ((req.query && (req.query.access_token || req.query.refresh_token)) ||
     (req.body && (req.body.access_token || req.body.refresh_token)))
     return next(new Error("In collectInfoFromReq: neither access token nor refresh token is expected in the incoming request"));
 
   /*
-   * -------------------------------------------------------------------------
    * we might get err, id_token, code, state from the request
-   * -------------------------------------------------------------------------
    */
   let source = null;
 
@@ -729,11 +710,9 @@ Strategy.prototype.collectInfoFromReq = function (params, req, next, response) {
   }
 
   /*
-   * -------------------------------------------------------------------------
    * If we received code, id_token or err, we must have received state, now we
    * find the state/nonce/policy tuple from session.
    * If we received none of them, find policy in query
-   * -------------------------------------------------------------------------
    */
   if (params.id_token || params.code || params.err) {
     if (!params.state)
@@ -791,10 +770,8 @@ Strategy.prototype.collectInfoFromReq = function (params, req, next, response) {
     return next(new Error("In collectInfoFromReq: we are using common endpoint for B2C but tenantIdOrName is not provided"));
 
   /*
-   * -------------------------------------------------------------------------
    * calculate metadataUrl, create a cachekey and an Metadata object instance
    * we will fetch the metadata, save it into the object using the cachekey
-   * -------------------------------------------------------------------------
    */
   let metadataUrl = self._options.identityMetadata;
 
@@ -836,9 +813,7 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
 
   async.waterfall([
     /*
-     * ------------------------------------------------------------------------
      * load metadata
-     * ------------------------------------------------------------------------
      */
     (next) => {
       memoryCache.wrap(params.cachekey, (cacheCallback) => {
@@ -852,9 +827,7 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
     },
 
     /*
-     * ------------------------------------------------------------------------
      * set oauthConfig: the information we need for oauth flow like redeeming code/access_token
-     * ------------------------------------------------------------------------
      */
     (metadata, next) => {
       if (!metadata.oidc)
@@ -909,11 +882,9 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
     },
 
     /*
-     * ------------------------------------------------------------------------
      * set optionsToValidate: the information we need for id_token validation.
      * we do this only if params has id_token or code, otherwise there is no
      * id_token to validate
-     * ------------------------------------------------------------------------
      */
     (metadata, next) => {
       if (!params.id_token && !params.code)

--- a/maintenance/passport-azure-ad/lib/oidcstrategy.js
+++ b/maintenance/passport-azure-ad/lib/oidcstrategy.js
@@ -1,73 +1,55 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the 'Software'), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
 
-'use strict';
+"use strict";
 
 /* eslint no-underscore-dangle: 0 */
 
 // third party packages
-const async = require('async');
-const base64url = require('base64url');
-const cacheManager = require('cache-manager');
-const _ = require('lodash');
-const jws = require('jws');
-const passport = require('passport');
-const querystring = require('querystring');
-const url = require('url');
-const urlValidator = require('valid-url');
-const util = require('util');
+const async = require("async");
+const base64url = require("base64url");
+const cacheManager = require("cache-manager");
+const _ = require("lodash");
+const jws = require("jws");
+const passport = require("passport");
+const querystring = require("querystring");
+const url = require("url");
+const urlValidator = require("valid-url");
+const util = require("util");
 
 // packages from this library
-const aadutils = require('./aadutils');
-const CONSTANTS = require('./constants');
-const jwt = require('./jsonWebToken');
-const jwe = require('./jwe');
+const aadutils = require("./aadutils");
+const CONSTANTS = require("./constants");
+const jwt = require("./jsonWebToken");
+const jwe = require("./jwe");
 
 // For the following packages we get a constructor and we will use 'new' to create an instance
-const InternalOAuthError = require('./errors/internaloautherror');
-const InternalOpenIDError = require('./errors/internalopeniderror');
-const Log = require('./logging').getLogger;
-const Metadata = require('./metadata').Metadata;
-const OAuth2 = require('oauth').OAuth2;
-const HttpsProxyAgent = require('https-proxy-agent');
-const SessionContentHandler = require('./sessionContentHandler').SessionContentHandler;
-const CookieContentHandler = require('./cookieContentHandler').CookieContentHandler;
-const Validator = require('./validator').Validator;
+const Log = require("./logging").getLogger;
+const Metadata = require("./metadata").Metadata;
+const OAuth2 = require("oauth").OAuth2;
+const HttpsProxyAgent = require("https-proxy-agent");
+const SessionContentHandler = require("./sessionContentHandler").SessionContentHandler;
+const CookieContentHandler = require("./cookieContentHandler").CookieContentHandler;
+const Validator = require("./validator").Validator;
 
 // global variable definitions
-const log = new Log('AzureAD: OIDC Passport Strategy');
+const log = new Log("AzureAD: OIDC Passport Strategy");
 
-const memoryCache = cacheManager.caching({ store: 'memory', max: 3600, ttl: 1800 /* seconds */ });
+const memoryCache = cacheManager.caching({ store: "memory", max: 3600, ttl: 1800 /* seconds */ });
 const ttl = 1800; // 30 minutes cache
 // Note: callback is optional in set() and del().
 
-// For each microsoft login page, we generate a tuple containing nonce/state/etc, and save it in session.
-// 1. NONCE_LIFE_TIME is the default life time of the tuple. The default value is 3600 seconds. The life
-//    time is configurable by user.
-// 2. NONCE_MAX_AMOUNT is the max amount of tuples a user's session can have. We limit it to 10.
-//    This value limits the amount of microsoft login page tabs a user can open before the user types
-//    username and password to 10. If the user opens more than 10 login tabs, we only honor the most
-//    recent 10 tabs within the life time.
+/*
+ * For each microsoft login page, we generate a tuple containing nonce/state/etc, and save it in session.
+ * 1. NONCE_LIFE_TIME is the default life time of the tuple. The default value is 3600 seconds. The life
+ *    time is configurable by user.
+ * 2. NONCE_MAX_AMOUNT is the max amount of tuples a user's session can have. We limit it to 10.
+ *    This value limits the amount of microsoft login page tabs a user can open before the user types
+ *    username and password to 10. If the user opens more than 10 login tabs, we only honor the most
+ *    recent 10 tabs within the life time.
+ */
 const NONCE_MAX_AMOUNT = 10;
 const NONCE_LIFE_TIME = 3600; // second
 
@@ -100,11 +82,11 @@ function onProfileLoaded(strategy, args) {
   }
 
   const verifyArityArgsMap = {
-    8: 'iss sub profile jwtClaims access_token refresh_token params',
-    7: 'iss sub profile access_token refresh_token params',
-    6: 'iss sub profile access_token refresh_token',
-    4: 'iss sub profile',
-    3: 'iss sub',
+    8: "iss sub profile jwtClaims access_token refresh_token params",
+    7: "iss sub profile access_token refresh_token params",
+    6: "iss sub profile access_token refresh_token",
+    4: "iss sub profile",
+    3: "iss sub",
   };
 
   const arity = (strategy._passReqToCallback) ? strategy._verify.length - 1 : strategy._verify.length;
@@ -112,7 +94,7 @@ function onProfileLoaded(strategy, args) {
 
   if (verifyArityArgsMap[arity]) {
     verifyArgs = verifyArityArgsMap[arity]
-      .split(' ')
+      .split(" ")
       .map((argName) => {
         return args[argName];
       })
@@ -342,7 +324,7 @@ function Strategy(options, verify) {
    *  More comments at the beginning of `Strategy.prototype.authenticate`.
    */
   this._options = options;
-  this.name = 'azuread-openidconnect';
+  this.name = "azuread-openidconnect";
 
   // stuff related to the verify function
   this._verify = verify;
@@ -354,10 +336,12 @@ function Strategy(options, verify) {
     this._useCookieInsteadOfSession = false;
 
   if (!this._useCookieInsteadOfSession) {
-    // For each microsoft login page tab, we generate a {state, nonce, policy, timeStamp} tuple,
-    // normally user won't keep opening microsoft login page in new tabs without putting their
-    // password for more than 10 tabs, so we only keep the most recent 10 tuples in session.
-    // The lifetime of each tuple is 60 minutes or user specified.
+    /*
+     * For each microsoft login page tab, we generate a {state, nonce, policy, timeStamp} tuple,
+     * normally user won't keep opening microsoft login page in new tabs without putting their
+     * password for more than 10 tabs, so we only keep the most recent 10 tuples in session.
+     * The lifetime of each tuple is 60 minutes or user specified.
+     */
     this._sessionContentHandler = new SessionContentHandler(options.nonceMaxAmount || NONCE_MAX_AMOUNT, options.nonceLifetime || NONCE_LIFE_TIME);
   } else {
     this._cookieContentHandler = new CookieContentHandler(
@@ -369,7 +353,8 @@ function Strategy(options, verify) {
     );
   }
 
-  /* When a user is authenticated for the first time, passport adds a new field
+  /*
+   * When a user is authenticated for the first time, passport adds a new field
    * to req.session called 'passport', and puts a 'user' property inside (or your
    * choice of field name and property name if you change passport._key and
    * passport._userProperty values). req.session['passport']['user'] is usually
@@ -401,42 +386,44 @@ function Strategy(options, verify) {
    *               |--- ...
    *               |--- 'user':  full user info
    */
-  this._key = options.sessionKey || ('OIDC: ' + options.clientID);
+  this._key = options.sessionKey || ("OIDC: " + options.clientID);
 
   if (!options.identityMetadata) {
     // default value should be https://login.microsoftonline.com/common/.well-known/openid-configuration
-    log.error('OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.');
-    throw new TypeError(`OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.`);
+    log.error("OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.");
+    throw new TypeError("OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.");
   }
 
   // if logging level specified, switch to it.
-  if (options.loggingLevel) { log.levels('console', options.loggingLevel); }
+  if (options.loggingLevel) { log.levels("console", options.loggingLevel); }
   this.log = log;
 
-  if (options.loggingNoPII != false)
+  if (options.loggingNoPII !== false)
     options.loggingNoPII = true;
 
   // clock skew. Must be a postive integer
-  if (options.clockSkew && (typeof options.clockSkew !== 'number' || options.clockSkew <= 0 || options.clockSkew % 1 !== 0))
-    throw new Error('clockSkew must be a positive integer');
+  if (options.clockSkew && (typeof options.clockSkew !== "number" || options.clockSkew <= 0 || options.clockSkew % 1 !== 0))
+    throw new Error("clockSkew must be a positive integer");
   if (!options.clockSkew)
     options.clockSkew = CONSTANTS.CLOCK_SKEW;
 
-  /****************************************************************************************
+  /**
+   ***************************************************************************************
    * Take care of identityMetadata
    * (1) Check if it is common endpoint
    * (2) For B2C, one cannot use the common endpoint. tenant name or guid must be specified
    * (3) We add telemetry to identityMetadata automatically
-   ***************************************************************************************/
+   **************************************************************************************
+   */
 
   // check existence
   if (!options.identityMetadata) {
-    log.error('OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.');
-    throw new TypeError(`OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.`);
+    log.error("OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.");
+    throw new TypeError("OIDCStrategy requires a metadata location that contains cert data for RSA and ECDSA callback.");
   }
 
   // check if we are using the common endpoint
-  options.isCommonEndpoint = (options.identityMetadata.indexOf('/common/') != -1);
+  options.isCommonEndpoint = (options.identityMetadata.indexOf("/common/") !== -1);
 
   // isB2C is false by default
   if (options.isB2C !== true)
@@ -451,7 +438,8 @@ function Strategy(options, verify) {
     ]
   );
 
-  /****************************************************************************************
+  /**
+   ***************************************************************************************
    * Take care of issuer and audience
    * (1) We use user provided `issuer`, and the issuer value from metadata if the metadata
    *     comes from tenant-specific endpoint (in other words, either the identityMetadata
@@ -463,13 +451,14 @@ function Strategy(options, verify) {
    *     must be set to false
    * (2) `validateIssuer` is true by default. we validate issuer unless validateIssuer is set false
    * (3) `audience` must be the clientID of this app
-   ***************************************************************************************/
+   **************************************************************************************
+   */
   if (options.validateIssuer !== false)
     options.validateIssuer = true;
   if (!options.validateIssuer)
-    log.warn(`Production environments should always validate the issuer.`);
+    log.warn("Production environments should always validate the issuer.");
 
-  if (options.issuer === '')
+  if (options.issuer === "")
     options.issuer = null;
   // make issuer an array
   if (options.issuer && !Array.isArray(options.issuer))
@@ -478,36 +467,42 @@ function Strategy(options, verify) {
   options.audience = options.clientID;
   options.allowMultiAudiencesInToken = false;
 
-  /****************************************************************************************
+  /**
+   ***************************************************************************************
    * Take care of scope
-   ***************************************************************************************/
+   **************************************************************************************
+   */
   // make scope an array
   if (!options.scope)
     options.scope = [];
   if (!Array.isArray(options.scope))
     options.scope = [options.scope];
   // always have 'openid' scope for openID Connect
-  if (options.scope.indexOf('openid') === -1)
-    options.scope.push('openid');
-  options.scope = options.scope.join(' ');
+  if (options.scope.indexOf("openid") === -1)
+    options.scope.push("openid");
+  options.scope = options.scope.join(" ");
 
-  /****************************************************************************************
+  /**
+   ***************************************************************************************
    * Check if we are using v2 endpoint, v2 doesn't have an userinfo endpoint
-   ***************************************************************************************/
-  if (options.identityMetadata.indexOf('/v2.0/') != -1)
+   **************************************************************************************
+   */
+  if (options.identityMetadata.indexOf("/v2.0/") !== -1)
     options._isV2 = true;
 
-  /****************************************************************************************
+  /**
+   ***************************************************************************************
    * validate other necessary option items provided, we validate them here and only once
-   ***************************************************************************************/
+   **************************************************************************************
+   */
   // change responseType 'id_token code' to 'code id_token' since the former is not supported by B2C
-  if (options.responseType === 'id_token code')
-    options.responseType = 'code id_token';
+  if (options.responseType === "id_token code")
+    options.responseType = "code id_token";
 
-  var itemsToValidate = {};
-  aadutils.copyObjectFields(options, itemsToValidate, ['clientID', 'redirectUrl', 'responseType', 'responseMode', 'identityMetadata']);
+  const itemsToValidate = {};
+  aadutils.copyObjectFields(options, itemsToValidate, ["clientID", "redirectUrl", "responseType", "responseMode", "identityMetadata"]);
 
-  var validatorConfiguration = {
+  const validatorConfiguration = {
     clientID: Validator.isNonEmpty,
     responseType: Validator.isTypeLegal,
     responseMode: Validator.isModeLegal,
@@ -521,27 +516,29 @@ function Strategy(options, verify) {
     validatorConfiguration.redirectUrl = Validator.isHttpsURL;
 
   // validator will throw exception if a required option is missing
-  var validator = new Validator(validatorConfiguration);
+  const validator = new Validator(validatorConfiguration);
   validator.validate(itemsToValidate);
 
   // validate client secret, thumbprint and privatePEMKey for hybrid and authorization flow
-  if (options.responseType !== 'id_token') {
+  if (options.responseType !== "id_token") {
     if (options.isB2C && !options.clientSecret) {
       // for B2C, clientSecret is required to redeem authorization code.
-      throw new Error('clientSecret must be provided for B2C hybrid flow and authorization code flow.');
+      throw new Error("clientSecret must be provided for B2C hybrid flow and authorization code flow.");
     } else if (!options.clientSecret) {
-      // for non-B2C, we can use either clientSecret or clientAssertion to redeem authorization code.
-      // Therefore, we need either clientSecret, or privatePEMKey and thumbprint (so we can create clientAssertion).
+      /*
+       * for non-B2C, we can use either clientSecret or clientAssertion to redeem authorization code.
+       * Therefore, we need either clientSecret, or privatePEMKey and thumbprint (so we can create clientAssertion).
+       */
       if (!options.privatePEMKey)
-        throw new Error('privatePEMKey is not provided. Please provide either clientSecret, or privatePEMKey and thumbprint.');
+        throw new Error("privatePEMKey is not provided. Please provide either clientSecret, or privatePEMKey and thumbprint.");
       if (!options.thumbprint)
-        throw new Error('thumbprint is not provided. Please provide either clientSecret, or privatePEMKey and thumbprint.');
+        throw new Error("thumbprint is not provided. Please provide either clientSecret, or privatePEMKey and thumbprint.");
     }
   }
 
   // we allow 'http' for the redirectUrl, but don't recommend using 'http'
   if (urlValidator.isHttpUri(options.redirectUrl))
-    log.warn(`Using http for redirectUrl is not recommended, please consider using https`);
+    log.warn("Using http for redirectUrl is not recommended, please consider using https");
 }
 
 // Inherit from `passport.Strategy`.
@@ -595,41 +592,46 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
    */
   const self = this;
 
-  var resource = options && options.resourceURL;
-  var customState = options && options.customState;
-  var tenantIdOrName = options && options.tenantIdOrName;
-  var login_hint = options && options.login_hint;
-  var domain_hint = options && options.domain_hint;
-  var prompt = options && options.prompt;
-  var extraAuthReqQueryParams = options && options.extraAuthReqQueryParams;
-  var extraTokenReqQueryParams = options && options.extraTokenReqQueryParams;
-  var response = options && options.response || req.res;
+  const resource = options && options.resourceURL;
+  const customState = options && options.customState;
+  const tenantIdOrName = options && options.tenantIdOrName;
+  const login_hint = options && options.login_hint;
+  const domain_hint = options && options.domain_hint;
+  const prompt = options && options.prompt;
+  const extraAuthReqQueryParams = options && options.extraAuthReqQueryParams;
+  const extraTokenReqQueryParams = options && options.extraTokenReqQueryParams;
+  const response = options && options.response || req.res;
 
   // 'params': items we get from the request or metadata, such as id_token, code, policy, metadata, cacheKey, etc
-  var params = { 'proxy': self._options.proxy, 'tenantIdOrName': tenantIdOrName, 'extraAuthReqQueryParams': extraAuthReqQueryParams, 'extraTokenReqQueryParams': extraTokenReqQueryParams };
+  const params = { "proxy": self._options.proxy, "tenantIdOrName": tenantIdOrName, "extraAuthReqQueryParams": extraAuthReqQueryParams, "extraTokenReqQueryParams": extraTokenReqQueryParams };
   // 'oauthConfig': items needed for oauth flow (like redirection, code redemption), such as token_endpoint, userinfo_endpoint, etc
-  var oauthConfig = { 'proxy': self._options.proxy, 'resource': resource, 'customState': customState, 'domain_hint': domain_hint, 'login_hint': login_hint, 'prompt': prompt, 'response': response };
+  const oauthConfig = { "proxy": self._options.proxy, "resource": resource, "customState": customState, "domain_hint": domain_hint, "login_hint": login_hint, "prompt": prompt, "response": response };
   // 'optionsToValidate': items we need to validate id_token against, such as issuer, audience, etc
-  var optionsToValidate = {};
+  const optionsToValidate = {};
 
   async.waterfall(
     [
-      /*****************************************************************************
+      /**
+       ****************************************************************************
        * Step 1. Collect information from the req and save the info into params
-       ****************************************************************************/
+       ***************************************************************************
+       */
       (next) => {
         return self.collectInfoFromReq(params, req, next, response);
       },
 
-      /*****************************************************************************
+      /**
+       ****************************************************************************
        * Step 2. Load metadata, use the information from 'params' and 'self._options'
        * to configure 'oauthConfig' and 'optionsToValidate'
-       ****************************************************************************/
+       ***************************************************************************
+       */
       (next) => {
         return self.setOptions(params, oauthConfig, optionsToValidate, next);
       },
 
-      /*****************************************************************************
+      /**
+       ****************************************************************************
        * Step 3. Handle the flows
        *----------------------------------------------------------------------------
        * (1) implicit flow (response_type = 'id_token')
@@ -640,7 +642,8 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
        *     This case we get a 'code', we will use it to get 'access_token' and 'id_token'
        * (4) for any other request, we will ask for authorization and initialize
        *     the authorization process
-       ****************************************************************************/
+       ***************************************************************************
+       */
       (next) => {
         if (params.err) {
           // handle the error
@@ -680,20 +683,26 @@ Strategy.prototype.authenticate = function authenticateStrategy(req, options) {
 Strategy.prototype.collectInfoFromReq = function (params, req, next, response) {
   const self = this;
 
-  // the things we will put into 'params':
-  // err, err_description, id_token, code, policy, state, nonce, cachekey, metadata
+  /*
+   * the things we will put into 'params':
+   * err, err_description, id_token, code, policy, state, nonce, cachekey, metadata
+   */
 
-  // -------------------------------------------------------------------------
-  // we shouldn't get any access_token or refresh_token from the request
-  // -------------------------------------------------------------------------
+  /*
+   * -------------------------------------------------------------------------
+   * we shouldn't get any access_token or refresh_token from the request
+   * -------------------------------------------------------------------------
+   */
   if ((req.query && (req.query.access_token || req.query.refresh_token)) ||
     (req.body && (req.body.access_token || req.body.refresh_token)))
-    return next(new Error('In collectInfoFromReq: neither access token nor refresh token is expected in the incoming request'));
+    return next(new Error("In collectInfoFromReq: neither access token nor refresh token is expected in the incoming request"));
 
-  // -------------------------------------------------------------------------
-  // we might get err, id_token, code, state from the request
-  // -------------------------------------------------------------------------
-  var source = null;
+  /*
+   * -------------------------------------------------------------------------
+   * we might get err, id_token, code, state from the request
+   * -------------------------------------------------------------------------
+   */
+  let source = null;
 
   if (req.query && (req.query.error || req.query.id_token || req.query.code))
     source = req.query;
@@ -707,26 +716,30 @@ Strategy.prototype.collectInfoFromReq = function (params, req, next, response) {
     params.code = source.code;
     params.state = source.state;
     if (source.state && source.state.length >= 38) {
-      // the random generated state always has 32 characters. This state is longer than 32
-      // so it must be a custom state. We added 'CUSTOM' prefix and a random 32 byte long
-      // string in front of the original custom state, now we change it back.
-      if (!source.state.startsWith('CUSTOM'))
-        return next(new Error(`In collectInfoFromReq: invalid custom state ${state}`));
+      /*
+       * the random generated state always has 32 characters. This state is longer than 32
+       * so it must be a custom state. We added 'CUSTOM' prefix and a random 32 byte long
+       * string in front of the original custom state, now we change it back.
+       */
+      if (!source.state.startsWith("CUSTOM"))
+        return next(new Error(`In collectInfoFromReq: invalid custom state ${source.state}`));
 
       source.state = source.state.substring(38);
     }
   }
 
-  // -------------------------------------------------------------------------
-  // If we received code, id_token or err, we must have received state, now we
-  // find the state/nonce/policy tuple from session.
-  // If we received none of them, find policy in query
-  // -------------------------------------------------------------------------
+  /*
+   * -------------------------------------------------------------------------
+   * If we received code, id_token or err, we must have received state, now we
+   * find the state/nonce/policy tuple from session.
+   * If we received none of them, find policy in query
+   * -------------------------------------------------------------------------
+   */
   if (params.id_token || params.code || params.err) {
     if (!params.state)
-      return next(new Error('In collectInfoFromReq: missing state in the request'));
+      return next(new Error("In collectInfoFromReq: missing state in the request"));
 
-    var tuple;
+    let tuple;
 
     if (!self._useCookieInsteadOfSession)
       tuple = self._sessionContentHandler.findAndDeleteTupleByState(req, self._key, params.state);
@@ -734,20 +747,20 @@ Strategy.prototype.collectInfoFromReq = function (params, req, next, response) {
       tuple = self._cookieContentHandler.findAndDeleteTupleByState(req, response, params.state);
 
     if (!tuple)
-      return next(new Error('In collectInfoFromReq: invalid state received in the request'));
+      return next(new Error("In collectInfoFromReq: invalid state received in the request"));
 
-    params.nonce = tuple['nonce'];
-    params.policy = tuple['policy'];
-    params.resource = tuple['resource'];
+    params.nonce = tuple["nonce"];
+    params.policy = tuple["policy"];
+    params.resource = tuple["resource"];
 
     // user provided tenantIdOrName will be ignored for redirectUrl, since we saved the one we used in session
     if (params.tenantIdOrName) {
       if (self._options.loggingNoPII)
-        log.info('user provided tenantIdOrName is ignored for redirectUrl, we will use the one stored in session');
+        log.info("user provided tenantIdOrName is ignored for redirectUrl, we will use the one stored in session");
       else
         log.info(`user provided tenantIdOrName '${params.tenantIdOrName}' is ignored for redirectUrl, we will use the one stored in session`);
     }
-    params.tenantIdOrName = tuple['tenantIdOrName'];
+    params.tenantIdOrName = tuple["tenantIdOrName"];
   } else {
     params.policy = req.query.p ? req.query.p.toLowerCase() : null;
   }
@@ -755,37 +768,41 @@ Strategy.prototype.collectInfoFromReq = function (params, req, next, response) {
   // if we are not using the common endpoint, but we have tenantIdOrName, just ignore it
   if (!self._options.isCommonEndpoint && params.tenantIdOrName) {
     if (self._options.loggingNoPII)
-      log.info('identityMetadata is tenant-specific, so we ignore the tenantIdOrName provided');
+      log.info("identityMetadata is tenant-specific, so we ignore the tenantIdOrName provided");
     else
       log.info(`identityMetadata is tenant-specific, so we ignore the tenantIdOrName '${params.tenantIdOrName}'`);
     params.tenantIdOrName = null;
   }
 
-  // if we are using the common endpoint and we want to validate issuer, then user has to
-  // provide issuer in config, or provide tenant id or name using tenantIdOrName option in
-  // passport.authenticate. Otherwise we won't know the issuer.
+  /*
+   * if we are using the common endpoint and we want to validate issuer, then user has to
+   * provide issuer in config, or provide tenant id or name using tenantIdOrName option in
+   * passport.authenticate. Otherwise we won't know the issuer.
+   */
   if (self._options.isCommonEndpoint && self._options.validateIssuer &&
     (!self._options.issuer && !params.tenantIdOrName))
-    return next(new Error('In collectInfoFromReq: issuer or tenantIdOrName must be provided in order to validate issuer on common endpoint'));
+    return next(new Error("In collectInfoFromReq: issuer or tenantIdOrName must be provided in order to validate issuer on common endpoint"));
 
   // for B2C, we must have policy
   if (self._options.isB2C && !params.policy)
-    return next(new Error('In collectInfoFromReq: policy is missing'));
+    return next(new Error("In collectInfoFromReq: policy is missing"));
   // for B2C, if we are using common endpoint, we must have tenantIdOrName provided
   if (self._options.isB2C && self._options.isCommonEndpoint && !params.tenantIdOrName)
-    return next(new Error('In collectInfoFromReq: we are using common endpoint for B2C but tenantIdOrName is not provided'));
+    return next(new Error("In collectInfoFromReq: we are using common endpoint for B2C but tenantIdOrName is not provided"));
 
-  // -------------------------------------------------------------------------
-  // calculate metadataUrl, create a cachekey and an Metadata object instance
-  // we will fetch the metadata, save it into the object using the cachekey
-  // -------------------------------------------------------------------------
-  var metadataUrl = self._options.identityMetadata;
+  /*
+   * -------------------------------------------------------------------------
+   * calculate metadataUrl, create a cachekey and an Metadata object instance
+   * we will fetch the metadata, save it into the object using the cachekey
+   * -------------------------------------------------------------------------
+   */
+  let metadataUrl = self._options.identityMetadata;
 
   // if we are using common endpoint and we are given the tenantIdOrName, let's replace it
   if (self._options.isCommonEndpoint && params.tenantIdOrName) {
-    metadataUrl = metadataUrl.replace('/common/', `/${params.tenantIdOrName}/`);
+    metadataUrl = metadataUrl.replace("/common/", `/${params.tenantIdOrName}/`);
     if (self._options.loggingNoPII)
-      log.info(`we are replacing 'common' with the tenantIdOrName provided`);
+      log.info("we are replacing 'common' with the tenantIdOrName provided");
     else
       log.info(`we are replacing 'common' with the tenantIdOrName ${params.tenantIdOrName}`);
   }
@@ -796,7 +813,7 @@ Strategy.prototype.collectInfoFromReq = function (params, req, next, response) {
 
   // we use the metadataUrl as the cachekey
   params.cachekey = metadataUrl;
-  params.metadata = new Metadata(metadataUrl, 'oidc', self._options);
+  params.metadata = new Metadata(metadataUrl, "oidc", self._options);
 
   if (!self._options.loggingNoPII) {
     log.info(`metadataUrl is: ${metadataUrl}`);
@@ -818,9 +835,11 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
   const self = this;
 
   async.waterfall([
-    // ------------------------------------------------------------------------
-    // load metadata
-    // ------------------------------------------------------------------------
+    /*
+     * ------------------------------------------------------------------------
+     * load metadata
+     * ------------------------------------------------------------------------
+     */
     (next) => {
       memoryCache.wrap(params.cachekey, (cacheCallback) => {
         params.metadata.fetch((fetchMetadataError) => {
@@ -832,17 +851,19 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
       }, { ttl }, next);
     },
 
-    // ------------------------------------------------------------------------
-    // set oauthConfig: the information we need for oauth flow like redeeming code/access_token
-    // ------------------------------------------------------------------------
+    /*
+     * ------------------------------------------------------------------------
+     * set oauthConfig: the information we need for oauth flow like redeeming code/access_token
+     * ------------------------------------------------------------------------
+     */
     (metadata, next) => {
       if (!metadata.oidc)
-        return next(new Error('In setOptions: failed to load metadata'));
+        return next(new Error("In setOptions: failed to load metadata"));
       params.metadata = metadata;
 
       // copy the fields needed into 'oauthConfig'
-      aadutils.copyObjectFields(metadata.oidc, oauthConfig, ['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint']);
-      aadutils.copyObjectFields(self._options, oauthConfig, ['clientID', 'clientSecret', 'privatePEMKey', 'thumbprint', 'responseType', 'responseMode', 'scope', 'redirectUrl']);
+      aadutils.copyObjectFields(metadata.oidc, oauthConfig, ["authorization_endpoint", "token_endpoint", "userinfo_endpoint"]);
+      aadutils.copyObjectFields(self._options, oauthConfig, ["clientID", "clientSecret", "privatePEMKey", "thumbprint", "responseType", "responseMode", "scope", "redirectUrl"]);
       oauthConfig.tenantIdOrName = params.tenantIdOrName;
       oauthConfig.extraAuthReqQueryParams = params.extraAuthReqQueryParams;
       oauthConfig.extraTokenReqQueryParams = params.extraTokenReqQueryParams;
@@ -864,24 +885,21 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
 
       // for B2C, verify the endpoints in oauthConfig has the correct policy
       if (self._options.isB2C) {
-        var policyChecker = (endpoint, policy) => {
-          var u = {};
-          try {
-            u = url.parse(endpoint);
-          } catch (ex) {
-          }
+        const policyChecker = (endpoint, policy) => {
+          let u = {};
+          u = url.parse(endpoint);
           return u.pathname && _.includes(u.path, policy.toLowerCase());
         };
         // B2C has no userinfo_endpoint, so no need to check it
         if (!policyChecker(oauthConfig.authorization_endpoint, params.policy)) {
           if (self._options.loggingNoPII)
-            return next(new Error('invalid policy'));
+            return next(new Error("invalid policy"));
           else
             return next(new Error(`policy in ${oauthConfig.authorization_endpoint} should be ${params.policy}`));
         }
         if (!policyChecker(oauthConfig.token_endpoint, params.policy)) {
           if (self._options.loggingNoPII)
-            return next(new Error('invalid policy'));
+            return next(new Error("invalid policy"));
           else
             return next(new Error(`policy in ${oauthConfig.token_endpoint} should be ${params.policy}`));
         }
@@ -890,25 +908,27 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
       return next(null, metadata);
     },
 
-    // ------------------------------------------------------------------------
-    // set optionsToValidate: the information we need for id_token validation.
-    // we do this only if params has id_token or code, otherwise there is no
-    // id_token to validate
-    // ------------------------------------------------------------------------
+    /*
+     * ------------------------------------------------------------------------
+     * set optionsToValidate: the information we need for id_token validation.
+     * we do this only if params has id_token or code, otherwise there is no
+     * id_token to validate
+     * ------------------------------------------------------------------------
+     */
     (metadata, next) => {
       if (!params.id_token && !params.code)
         return next(null);
 
       // set items from self._options
       aadutils.copyObjectFields(self._options, optionsToValidate,
-        ['validateIssuer', 'audience', 'allowMultiAudiencesInToken', 'ignoreExpiration', 'allowMultiAudiencesInToken']);
+        ["validateIssuer", "audience", "allowMultiAudiencesInToken", "ignoreExpiration", "allowMultiAudiencesInToken"]);
 
       // algorithms
-      var algorithms = metadata.oidc.algorithms;
+      const algorithms = metadata.oidc.algorithms;
       if (!algorithms)
-        return next(new Error('In setOptions: algorithms is missing in metadata'));
-      if (!Array.isArray(algorithms) || algorithms.length == 0 || (algorithms.length === 1 && algorithms[0] === 'none'))
-        return next(new Error('In setOptions: algorithms must be an array containing at least one algorithm'));
+        return next(new Error("In setOptions: algorithms is missing in metadata"));
+      if (!Array.isArray(algorithms) || algorithms.length === 0 || (algorithms.length === 1 && algorithms[0] === "none"))
+        return next(new Error("In setOptions: algorithms must be an array containing at least one algorithm"));
       optionsToValidate.algorithms = algorithms;
 
       // nonce
@@ -920,8 +940,10 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
       // jweKeyStore
       optionsToValidate.jweKeyStore = self._options.jweKeyStore;
 
-      // issuer
-      // if the metadata is not coming from common endpoint, we record the issuer value from metadata
+      /*
+       * issuer
+       * if the metadata is not coming from common endpoint, we record the issuer value from metadata
+       */
       if (!self._options.isCommonEndpoint || (self._options.isCommonEndpoint && params.tenantIdOrName))
         optionsToValidate.issuer = [metadata.oidc.issuer];
       else
@@ -931,7 +953,7 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
         optionsToValidate.issuer = optionsToValidate.issuer.concat(self._options.issuer);
       // if we don't get any issuer value and we want to validate issuer, we should fail
       if (optionsToValidate.issuer.length === 0 && self._options.validateIssuer)
-        return next(new Error('In setOptions: we want to validate issuer but issuer is not found'));
+        return next(new Error("In setOptions: we want to validate issuer but issuer is not found"));
 
       return next(null);
     },
@@ -951,14 +973,13 @@ Strategy.prototype.setOptions = function setOptions(params, oauthConfig, options
 Strategy.prototype._idTokenHandler = function idTokenHandler(params, optionsToValidate, req, next, callback) {
   const self = this;
 
-  var id_token = params.id_token;
-  var parts = id_token.split('.');
+  const id_token = params.id_token;
+  const parts = id_token.split(".");
 
   if (parts.length === 3)
     return self._validateResponse(params, optionsToValidate, req, next, callback);
   else if (parts.length === 5) {
-    log.info('In _idTokenHandler: we received an id_token of JWE format, we are decrypting it');
-    var decrypted_token;
+    log.info("In _idTokenHandler: we received an id_token of JWE format, we are decrypting it");
 
     return jwe.decrypt(id_token, optionsToValidate.jweKeyStore, log, (err, decrypted_token) => {
       if (err)
@@ -984,38 +1005,38 @@ Strategy.prototype._idTokenHandler = function idTokenHandler(params, optionsToVa
 Strategy.prototype._validateResponse = function validateResponse(params, optionsToValidate, req, next, callback) {
   const self = this;
 
-  var id_token = params.id_token;
-  var code = params.code;
-  var access_token = params.access_token;
+  const id_token = params.id_token;
+  const code = params.code;
+  const access_token = params.access_token;
 
   // decode id_token
   const decoded = jws.decode(id_token);
-  if (decoded == null)
-    return next(new Error('In _validateResponse: Invalid JWT token'));
+  if (decoded === null)
+    return next(new Error("In _validateResponse: Invalid JWT token"));
 
   if (self._options.loggingNoPII)
-    log.info('token is decoded successfully');
+    log.info("token is decoded successfully");
   else
-    log.info('token decoded: ', decoded);
+    log.info("token decoded: ", decoded);
 
   // get Pem Key
-  var PEMkey = null;
+  let PEMkey = null;
   try {
     if (decoded.header.kid) {
       PEMkey = params.metadata.generateOidcPEM(decoded.header.kid);
     } else if (decoded.header.x5t) {
       PEMkey = params.metadata.generateOidcPEM(decoded.header.x5t);
     } else {
-      return next(new Error('In _validateResponse: We did not receive a token we know how to validate'));
+      return next(new Error("In _validateResponse: We did not receive a token we know how to validate"));
     }
   } catch (error) {
-    return next(new Error('In _validateResponse: failed to generate PEM key due to: ' + error.message));
+    return next(new Error("In _validateResponse: failed to generate PEM key due to: " + error.message));
   }
 
   if (self._options.loggingNoPII)
-    log.info('PEMkey is generated');
+    log.info("PEMkey is generated");
   else
-    log.info('PEMkey generated: ' + PEMkey);
+    log.info("PEMkey generated: " + PEMkey);
 
   // verify id_token signature and claims
   return jwt.verify(id_token, PEMkey, optionsToValidate, (err, jwtClaims) => {
@@ -1027,27 +1048,29 @@ Strategy.prototype._validateResponse = function validateResponse(params, options
     else
       log.info("Claims received: ", jwtClaims);
 
-    // jwt checks the 'nbf', 'exp', 'aud', 'iss' claims
-    // there are a few other things we will check below
+    /*
+     * jwt checks the 'nbf', 'exp', 'aud', 'iss' claims
+     * there are a few other things we will check below
+     */
 
     // For B2C, check the policy
     if (self._options.isB2C) {
-      var policy_in_idToken;
+      let policy_in_idToken;
 
       if (jwtClaims.acr && CONSTANTS.POLICY_REGEX.test(jwtClaims.acr))
         policy_in_idToken = jwtClaims.acr;
       else if (jwtClaims.tfp && CONSTANTS.POLICY_REGEX.test(jwtClaims.tfp))
         policy_in_idToken = jwtClaims.tfp.toLowerCase();
       else
-        return next(new Error('In _validateResponse: invalid B2C policy in id_token'));
+        return next(new Error("In _validateResponse: invalid B2C policy in id_token"));
 
       if (params.policy !== policy_in_idToken)
         return next(new Error("In _validateResponse: policy in id_token does not match the policy used"));
     }
 
     // check nonce
-    if (!jwtClaims.nonce || jwtClaims.nonce === '' || jwtClaims.nonce !== optionsToValidate.nonce)
-      return next(new Error('In _validateResponse: invalid nonce'));
+    if (!jwtClaims.nonce || jwtClaims.nonce === "" || jwtClaims.nonce !== optionsToValidate.nonce)
+      return next(new Error("In _validateResponse: invalid nonce"));
 
     // check c_hash
     if (jwtClaims.c_hash) {
@@ -1064,8 +1087,8 @@ Strategy.prototype._validateResponse = function validateResponse(params, options
     }
 
     // return jwt claims and jwt claims string
-    var idTokenSegments = id_token.split('.');
-    var jwtClaimsStr = base64url.decode(idTokenSegments[1]);
+    const idTokenSegments = id_token.split(".");
+    const jwtClaimsStr = base64url.decode(idTokenSegments[1]);
     return callback(jwtClaimsStr, jwtClaims);
   });
 };
@@ -1080,13 +1103,15 @@ Strategy.prototype._validateResponse = function validateResponse(params, options
 Strategy.prototype._errorResponseHandler = function errorResponseHandler(err, err_description, next) {
   const self = this;
 
-  log.info('Error received in the response was: ', err);
+  log.info("Error received in the response was: ", err);
   if (err_description && !self._options.loggingNoPII)
-    log.info('Error description received in the response was: ', err_description);
+    log.info("Error description received in the response was: ", err_description);
 
-  // Unfortunately, we cannot return the 'error description' to the user, since
-  // it goes to http header by default and it usually contains characters that
-  // http header doesn't like, which causes the program to crash.
+  /*
+   * Unfortunately, we cannot return the 'error description' to the user, since
+   * it goes to http header by default and it usually contains characters that
+   * http header doesn't like, which causes the program to crash.
+   */
   return next(new Error(err));
 };
 
@@ -1099,7 +1124,8 @@ Strategy.prototype._errorResponseHandler = function errorResponseHandler(err, er
  * @params {Function} next  -- callback to pass error to async.waterfall
  */
 Strategy.prototype._implicitFlowHandler = function implicitFlowHandler(params, optionsToValidate, req, next) {
-  /* we will do the following things in order
+  /*
+   * we will do the following things in order
    * (1) validate id_token
    * (2) use the claims in the id_token for user's profile
    */
@@ -1107,16 +1133,16 @@ Strategy.prototype._implicitFlowHandler = function implicitFlowHandler(params, o
   const self = this;
 
   if (self._options.loggingNoPII)
-    log.info('entering Strategy.prototype._implicitFlowHandler');
+    log.info("entering Strategy.prototype._implicitFlowHandler");
   else
-    log.info('entering Strategy.prototype._implicitFlowHandler, received id_token: ' + params.id_token);
+    log.info("entering Strategy.prototype._implicitFlowHandler, received id_token: " + params.id_token);
 
   // validate the id_token
   return self._idTokenHandler(params, optionsToValidate, req, next, (jwtClaimsStr, jwtClaims) => {
     const sub = jwtClaims.sub;
     const iss = jwtClaims.iss;
 
-    log.info('we are in implicit flow, use the content in id_token as the profile');
+    log.info("we are in implicit flow, use the content in id_token as the profile");
 
     return onProfileLoaded(self, {
       req,
@@ -1141,7 +1167,8 @@ Strategy.prototype._implicitFlowHandler = function implicitFlowHandler(params, o
  * @params {Function} next  -- callback to pass error to async.waterfall
  */
 Strategy.prototype._hybridFlowHandler = function hybridFlowHandler(params, oauthConfig, optionsToValidate, req, next) {
-  /* we will do the following things in order
+  /*
+   * we will do the following things in order
    * (1) validate the id_token and the code
    * (2) if there is no userinfo token needed (or ignored if using AAD v2 ), we use
    *     the claims in id_token for user's profile
@@ -1150,17 +1177,21 @@ Strategy.prototype._hybridFlowHandler = function hybridFlowHandler(params, oauth
   const self = this;
 
   if (self._options.loggingNoPII)
-    log.info('entering Strategy.prototype._hybridFlowHandler');
+    log.info("entering Strategy.prototype._hybridFlowHandler");
   else
-    log.info('entering Strategy.prototype._hybridFlowHandler, received code: ' + params.code + ', received id_token: ' + params.id_token);
+    log.info("entering Strategy.prototype._hybridFlowHandler, received code: " + params.code + ", received id_token: " + params.id_token);
 
-  // save nonce, since if we use the authorization code flow later, we have to check
-  // nonce again.
+  /*
+   * save nonce, since if we use the authorization code flow later, we have to check
+   * nonce again.
+   */
 
   // validate the id_token and the code
   return self._idTokenHandler(params, optionsToValidate, req, next, (jwtClaimsStr, jwtClaims) => {
-    // c_hash is required for 'code id_token' flow. If we have c_hash, then _validateResponse already
-    // validates it; otherwise, _validateResponse ignores the c_hash check, and we check here
+    /*
+     * c_hash is required for 'code id_token' flow. If we have c_hash, then _validateResponse already
+     * validates it; otherwise, _validateResponse ignores the c_hash check, and we check here
+     */
     if (!jwtClaims.c_hash)
       return next(new Error("In _hybridFlowHandler: we are in hybrid flow using code id_token, but c_hash is not found in id_token"));
 
@@ -1188,52 +1219,53 @@ Strategy.prototype._hybridFlowHandler = function hybridFlowHandler(params, oauth
  * @params {String} sub
  */
 Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, oauthConfig, optionsToValidate, req, next, iss, sub) {
-  /* we will do the following things in order:
+  /*
+   * we will do the following things in order:
    * (1) use code to get id_token and access_token
    * (2) validate the id_token and the access_token received
    * (3) if user asks for userinfo and we are using AAD v1, then we use access_token to get
    *     userinfo, then make sure the userinfo has the same 'sub' as that in the 'id_token'
    */
   const self = this;
-  var code = params.code;
+  const code = params.code;
 
   if (self._options.loggingNoPII)
-    log.info('entering Strategy.prototype._authCodeFlowHandler');
+    log.info("entering Strategy.prototype._authCodeFlowHandler");
   else
-    log.info('entering Strategy.prototype._authCodeFlowHandler, received code: ' + code);
+    log.info("entering Strategy.prototype._authCodeFlowHandler, received code: " + code);
 
-  var issFromPrevIdToken = iss;
-  var subFromPrevIdToken = sub;
+  const issFromPrevIdToken = iss;
+  const subFromPrevIdToken = sub;
 
   return self._getAccessTokenBySecretOrAssertion(code, oauthConfig, next, (getOAuthAccessTokenError, items) => {
     if (getOAuthAccessTokenError) {
       if (self._options.loggingNoPII)
-        return next(new Error('In _authCodeFlowHandler: failed to redeem authorization code'));
+        return next(new Error("In _authCodeFlowHandler: failed to redeem authorization code"));
       else
         return next(new Error(`In _authCodeFlowHandler: failed to redeem authorization code: ${aadutils.getErrorMessage(getOAuthAccessTokenError)}`));
     }
 
-    var access_token = items.access_token;
-    var refresh_token = items.refresh_token;
+    const access_token = items.access_token;
+    const refresh_token = items.refresh_token;
 
     // id_token should be present
     if (!items.id_token)
-      return next(new Error('In _authCodeFlowHandler: id_token is not received'));
+      return next(new Error("In _authCodeFlowHandler: id_token is not received"));
 
     // if we get access token, we must have token_type as well
     if (items.access_token && !items.token_type)
-      return next(new Error('In _authCodeFlowHandler: token_type is missing'));
+      return next(new Error("In _authCodeFlowHandler: token_type is missing"));
 
     // token_type must be 'Bearer' ignoring the case
-    if (items.token_type && items.token_type.toLowerCase() !== 'bearer') {
-      log.info('token_type received is: ', items.token_type);
-      return next(new Error(`In _authCodeFlowHandler: token_type received is not 'Bearer' ignoring the case`));
+    if (items.token_type && items.token_type.toLowerCase() !== "bearer") {
+      log.info("token_type received is: ", items.token_type);
+      return next(new Error("In _authCodeFlowHandler: token_type received is not 'Bearer' ignoring the case"));
     }
 
     if (!self._options.loggingNoPII) {
-      log.info('received id_token: ', items.id_token);
-      log.info('received access_token: ', access_token);
-      log.info('received refresh_token: ', refresh_token);
+      log.info("received id_token: ", items.id_token);
+      log.info("received access_token: ", access_token);
+      log.info("received refresh_token: ", refresh_token);
     }
 
     // validate id_token and access_token, so put them into params
@@ -1241,18 +1273,22 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, o
     params.id_token = items.id_token;
 
     return self._idTokenHandler(params, optionsToValidate, req, next, (jwtClaimsStr, jwtClaims) => {
-      // for 'code id_token' flow, check iss/sub in the id_token from the authorization endpoint
-      // with those in the id_token from token endpoint
+      /*
+       * for 'code id_token' flow, check iss/sub in the id_token from the authorization endpoint
+       * with those in the id_token from token endpoint
+       */
       if (issFromPrevIdToken && issFromPrevIdToken !== jwtClaims.iss)
-        return next(new Error('In _authCodeFlowHandler: After redeeming the code, iss in id_token from authorize_endpoint does not match iss in id_token from token_endpoint'));
+        return next(new Error("In _authCodeFlowHandler: After redeeming the code, iss in id_token from authorize_endpoint does not match iss in id_token from token_endpoint"));
       if (subFromPrevIdToken && subFromPrevIdToken !== jwtClaims.sub)
-        return next(new Error('In _authCodeFlowHandler: After redeeming the code, sub in id_token from authorize_endpoint does not match sub in id_token from token_endpoint'));
+        return next(new Error("In _authCodeFlowHandler: After redeeming the code, sub in id_token from authorize_endpoint does not match sub in id_token from token_endpoint"));
 
       const sub = jwtClaims.sub;
       const iss = jwtClaims.iss;
 
-      // load the userinfo, if this is not v2 and if we don't specify the resource
-      // for v1 if we don't specify the resource, then the access_token we got is for userinfo endpoint, so we can use it to get userinfo
+      /*
+       * load the userinfo, if this is not v2 and if we don't specify the resource
+       * for v1 if we don't specify the resource, then the access_token we got is for userinfo endpoint, so we can use it to get userinfo
+       */
       if (!self._options._isV2 && !params.resource) {
         // make sure we get an access_token
         if (!access_token)
@@ -1263,45 +1299,45 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, o
           parsedUrl = url.parse(oauthConfig.userinfo_endpoint, true);
         } catch (urlParseException) {
           if (self._options.loggingNoPII)
-            return next(new Error(`In _authCodeFlowHandler: Failed to parse config property 'userInfoUrl'`));
+            return next(new Error("In _authCodeFlowHandler: Failed to parse config property 'userInfoUrl'"));
           else
             return next(new Error(`In _authCodeFlowHandler: Failed to parse config property 'userInfoURL' with value ${oauthConfig.userinfo_endpoint}`));
         }
 
-        parsedUrl.query.schema = 'openid';
+        parsedUrl.query.schema = "openid";
         delete parsedUrl.search; // delete operations are slow; should we rather just overwrite it with {}
         const userInfoURL = url.format(parsedUrl);
 
         // ask oauth2 to use authorization header to bearer access token
-        var oauth2 = createOauth2Instance(oauthConfig);
+        const oauth2 = createOauth2Instance(oauthConfig);
         oauth2.useAuthorizationHeaderforGET(true);
         return oauth2.get(userInfoURL, access_token, (getUserInfoError, body) => {
           if (getUserInfoError) {
             if (self._options.loggingNoPII)
-              return next(new Error('In _authCodeFlowHandler: failed to fetch user profile'));
+              return next(new Error("In _authCodeFlowHandler: failed to fetch user profile"));
             else
               return next(new Error(`In _authCodeFlowHandler: failed to fetch user profile: ${aadutils.getErrorMessage(getUserInfoError)}`));
           }
 
           if (self._options.loggingNoPII)
-            log.info('Profile is loaded from MS identity');
+            log.info("Profile is loaded from MS identity");
           else
-            log.info('Profile loaded from MS identity', body);
+            log.info("Profile loaded from MS identity", body);
 
-          var userinfoReceived = null;
+          let userinfoReceived = null;
           // use try / catch around JSON.parse --> could fail unexpectedly
           try {
             userinfoReceived = JSON.parse(body);
           } catch (ex) {
             if (self._options.loggingNoPII)
-              return next(new Error('In _authCodeFlowHandler: failed to parse userinfo'));
+              return next(new Error("In _authCodeFlowHandler: failed to parse userinfo"));
             else
               return next(new Error(`In _authCodeFlowHandler: failed to parse userinfo ${body}, due to ${aadutils.getErrorMessage(ex)}`));
           }
 
           // make sure the 'sub' in userinfo is the same as the one in 'id_token'
           if (userinfoReceived.sub !== jwtClaims.sub)
-            return next(new Error('In _authCodeFlowHandler: sub received in userinfo and id_token do not match'));
+            return next(new Error("In _authCodeFlowHandler: sub received in userinfo and id_token do not match"));
 
           return onProfileLoaded(self, {
             req,
@@ -1316,7 +1352,7 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, o
         });
       } else {
         // v2 doesn't have userinfo endpoint, so we use the content in id_token as the profile
-        log.info('v2 has no userinfo endpoint, using the content in id_token as the profile');
+        log.info("v2 has no userinfo endpoint, using the content in id_token as the profile");
 
         return onProfileLoaded(self, {
           req,
@@ -1341,62 +1377,64 @@ Strategy.prototype._authCodeFlowHandler = function authCodeFlowHandler(params, o
  * @params {Function} next  -- callback to pass error to async.waterfall
  */
 Strategy.prototype._flowInitializationHandler = function flowInitializationHandler(oauthConfig, req, next) {
-  // The request being authenticated is initiating OpenID Connect
-  // authentication. Prior to redirecting to the provider, configuration will
-  // be loaded. The configuration is typically either pre-configured or
-  // discovered dynamically. When using dynamic discovery, a user supplies
-  // their identifer as input.
+  /*
+   * The request being authenticated is initiating OpenID Connect
+   * authentication. Prior to redirecting to the provider, configuration will
+   * be loaded. The configuration is typically either pre-configured or
+   * discovered dynamically. When using dynamic discovery, a user supplies
+   * their identifer as input.
+   */
 
   const self = this;
 
-  log.info(`entering Strategy.prototype._flowInitializationHandler`);
+  log.info("entering Strategy.prototype._flowInitializationHandler");
 
   const params = {
-    'redirect_uri': oauthConfig.redirectUrl,
-    'response_type': oauthConfig.responseType,
-    'response_mode': oauthConfig.responseMode,
-    'client_id': oauthConfig.clientID
+    "redirect_uri": oauthConfig.redirectUrl,
+    "response_type": oauthConfig.responseType,
+    "response_mode": oauthConfig.responseMode,
+    "client_id": oauthConfig.clientID
   };
 
-  log.info('We are sending the response_type: ', params.response_type);
-  log.info('We are sending the response_mode: ', params.response_mode);
+  log.info("We are sending the response_type: ", params.response_type);
+  log.info("We are sending the response_mode: ", params.response_mode);
 
   if (oauthConfig.domain_hint)
-    params['domain_hint'] = oauthConfig.domain_hint;
+    params["domain_hint"] = oauthConfig.domain_hint;
   if (oauthConfig.login_hint)
-    params['login_hint'] = oauthConfig.login_hint;
+    params["login_hint"] = oauthConfig.login_hint;
   if (oauthConfig.prompt)
-    params['prompt'] = oauthConfig.prompt;
+    params["prompt"] = oauthConfig.prompt;
   if (oauthConfig.extraAuthReqQueryParams) {
     // copy the extra query parameters into params
-    for (var attributeName in oauthConfig.extraAuthReqQueryParams) {
-      if (oauthConfig.extraAuthReqQueryParams.hasOwnProperty(attributeName))
+    for (const attributeName in oauthConfig.extraAuthReqQueryParams) {
+      if (Object.prototype.hasOwnProperty.call(oauthConfig.extraAuthReqQueryParams, attributeName))
         params[attributeName] = oauthConfig.extraAuthReqQueryParams[attributeName];
     }
   }
 
-  var policy = null;
+  let policy = null;
   if (self._options.isB2C) {
-    if (!req.query.p || req.query.p === '')
-      return next(new Error('In _flowInitializationHandler: missing policy in the request for B2C'));
+    if (!req.query.p || req.query.p === "")
+      return next(new Error("In _flowInitializationHandler: missing policy in the request for B2C"));
     // policy is not case sensitive. AAD turns policy to lower case.
     policy = req.query.p.toLowerCase();
     if (!policy || !CONSTANTS.POLICY_REGEX.test(policy)) {
       if (self._options.loggingNoPII)
-        return next(new Error('In _flowInitializationHandler: the given policy in the request is invalid'));
+        return next(new Error("In _flowInitializationHandler: the given policy in the request is invalid"));
       else
         return next(new Error(`In _flowInitializationHandler: the given policy ${policy} given in the request is invalid`));
     }
   }
 
   // add state/nonce/policy/timeStamp tuple to session or cookie
-  let state = params.state = oauthConfig.customState ? ('CUSTOM' + aadutils.uid(32) + oauthConfig.customState) : aadutils.uid(32);
-  let nonce = params.nonce = aadutils.uid(32);
-  let resource = oauthConfig.resource ? oauthConfig.resource : null;
+  const state = params.state = oauthConfig.customState ? ("CUSTOM" + aadutils.uid(32) + oauthConfig.customState) : aadutils.uid(32);
+  const nonce = params.nonce = aadutils.uid(32);
+  const resource = oauthConfig.resource ? oauthConfig.resource : null;
   if (resource)
     params.resource = resource;
 
-  var tuple = { state: state, nonce: nonce };
+  const tuple = { state: state, nonce: nonce };
   if (policy)
     tuple.policy = policy;
   if (resource)
@@ -1408,8 +1446,10 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
     tuple.timeStamp = Date.now();
     self._sessionContentHandler.add(req, self._key, tuple);
   } else {
-    // we don't need to record timestamp if we use cookie, since we can set the
-    // expiration when we set cookie
+    /*
+     * we don't need to record timestamp if we use cookie, since we can set the
+     * expiration when we set cookie
+     */
     self._cookieContentHandler.add(req, oauthConfig.response, tuple);
   }
 
@@ -1433,56 +1473,56 @@ Strategy.prototype._flowInitializationHandler = function flowInitializationHandl
  * @params {Function} callback
  */
 Strategy.prototype._getAccessTokenBySecretOrAssertion = function getAccessTokenBySecretOrAssertion(code, oauthConfig, next, callback) {
-  var post_headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+  const post_headers = { "Content-Type": "application/x-www-form-urlencoded" };
 
   const self = this;
 
-  var post_params = {
+  const post_params = {
     code: code,
     client_id: oauthConfig.clientID,
     redirect_uri: oauthConfig.redirectUrl,
     scope: oauthConfig.scope,
-    grant_type: 'authorization_code'
+    grant_type: "authorization_code"
   };
 
   if (oauthConfig.extraTokenReqQueryParams) {
     // copy the extra query parameters into post_params
-    for (var attributeName in oauthConfig.extraTokenReqQueryParams) {
-      if (oauthConfig.extraTokenReqQueryParams.hasOwnProperty(attributeName))
+    for (const attributeName in oauthConfig.extraTokenReqQueryParams) {
+      if (Object.prototype.hasOwnProperty.call(oauthConfig.extraTokenReqQueryParams, attributeName))
         post_params[attributeName] = oauthConfig.extraTokenReqQueryParams[attributeName];
     }
   }
 
   if (oauthConfig.clientSecret) {
     // use client secret if it exists
-    post_params['client_secret'] = oauthConfig.clientSecret;
-    log.info('In _getAccessTokenBySecretOrAssertion: we are using client secret');
+    post_params["client_secret"] = oauthConfig.clientSecret;
+    log.info("In _getAccessTokenBySecretOrAssertion: we are using client secret");
   } else {
     // otherwise generate a client assertion
-    post_params['client_assertion_type'] = CONSTANTS.CLIENT_ASSERTION_TYPE;
+    post_params["client_assertion_type"] = CONSTANTS.CLIENT_ASSERTION_TYPE;
 
     jwt.generateClientAssertion(oauthConfig.clientID, oauthConfig.token_endpoint, oauthConfig.privatePEMKey, oauthConfig.thumbprint,
       (err, assertion) => {
         if (err)
           return next(err);
         else
-          post_params['client_assertion'] = assertion;
+          post_params["client_assertion"] = assertion;
       });
 
     if (self._options.loggingNoPII)
-      log.info('In _getAccessTokenBySecretOrAssertion: we created a client assertion');
+      log.info("In _getAccessTokenBySecretOrAssertion: we created a client assertion");
     else
-      log.info('In _getAccessTokenBySecretOrAssertion: we created a client assertion with thumbprint ' + oauthConfig.thumbprint);
-  };
+      log.info("In _getAccessTokenBySecretOrAssertion: we created a client assertion with thumbprint " + oauthConfig.thumbprint);
+  }
 
-  var post_data = querystring.stringify(post_params);
+  const post_data = querystring.stringify(post_params);
 
-  var oauth2 = createOauth2Instance(oauthConfig);
+  const oauth2 = createOauth2Instance(oauthConfig);
 
-  oauth2._request('POST', oauthConfig.token_endpoint, post_headers, post_data, null, (error, data, response) => {
+  oauth2._request("POST", oauthConfig.token_endpoint, post_headers, post_data, null, (error, data) => {
     if (error) callback(error);
     else {
-      var results;
+      let results;
       try {
         results = JSON.parse(data);
       } catch (e) {
@@ -1508,16 +1548,14 @@ Strategy.prototype.failWithLog = function(message) {
  *
  * @params {Object} oauthConfig
  */
-var createOauth2Instance = function(oauthConfig) {
-  let libraryVersion = aadutils.getLibraryVersion();
-  let libraryVersionParameterName = aadutils.getLibraryVersionParameterName();
-  let libraryProduct = aadutils.getLibraryProduct();
-  let libraryProductParameterName = aadutils.getLibraryProductParameterName();
+const createOauth2Instance = function(oauthConfig) {
+  const libraryVersion = aadutils.getLibraryVersion();
+  const libraryProduct = aadutils.getLibraryProduct();
 
-  var oauth2 = new OAuth2(
+  const oauth2 = new OAuth2(
     oauthConfig.clientID, // consumerKey
     oauthConfig.clientSecret, // consumer secret
-    '', // baseURL (empty string because we use absolute urls for authorize and token paths)
+    "", // baseURL (empty string because we use absolute urls for authorize and token paths)
     oauthConfig.authorization_endpoint, // authorizePath
     oauthConfig.token_endpoint, // accessTokenPath
     {libraryProductParameterName : libraryProduct,

--- a/maintenance/passport-azure-ad/lib/pem.js
+++ b/maintenance/passport-azure-ad/lib/pem.js
@@ -24,10 +24,10 @@
  * and \n's in the content.
  */
 
-/* eslint-disable max-len */
-const CERT_REGEX = /-----BEGIN\sCERTIFICATE-----\s+([a-zA-Z0-9+/=\r\n]+)\s+-----END\sCERTIFICATE-----/;
-const PRIVATE_KEY_REGEX = /-----BEGIN\sPRIVATE\sKEY-----\s+([a-zA-Z0-9+/=\r\n]+)\s+-----END\sPRIVATE\sKEY-----/;
-/* eslint-enable max-len */
+/* eslint-disable max-len no-useless-escape*/
+const CERT_REGEX = /-----BEGIN\sCERTIFICATE-----\s+([a-zA-Z0-9+\/=\r\n]+)\s+-----END\sCERTIFICATE-----/;
+const PRIVATE_KEY_REGEX = /-----BEGIN\sPRIVATE\sKEY-----\s+([a-zA-Z0-9+\/=\r\n]+)\s+-----END\sPRIVATE\sKEY-----/;
+/* eslint-enable max-len no-useless-escape*/
 
 function getFirstCapturingGroup(str, regex) {
   if (typeof str !== "string") {

--- a/maintenance/passport-azure-ad/lib/pem.js
+++ b/maintenance/passport-azure-ad/lib/pem.js
@@ -24,10 +24,10 @@
  * and \n's in the content.
  */
 
-/* eslint-disable max-len no-useless-escape*/
+/* eslint-disable max-len, no-useless-escape*/
 const CERT_REGEX = /-----BEGIN\sCERTIFICATE-----\s+([a-zA-Z0-9+\/=\r\n]+)\s+-----END\sCERTIFICATE-----/;
 const PRIVATE_KEY_REGEX = /-----BEGIN\sPRIVATE\sKEY-----\s+([a-zA-Z0-9+\/=\r\n]+)\s+-----END\sPRIVATE\sKEY-----/;
-/* eslint-enable max-len no-useless-escape*/
+/* eslint-enable max-len, no-useless-escape*/
 
 function getFirstCapturingGroup(str, regex) {
   if (typeof str !== "string") {

--- a/maintenance/passport-azure-ad/lib/pem.js
+++ b/maintenance/passport-azure-ad/lib/pem.js
@@ -1,33 +1,14 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the "Software"), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
 
-'use strict';
+"use strict";
 
 /**
  * How to create SAML Logout signing keys on linux/mac
  * openssl req -x509 -nodes -days 365 -newkey rsa:2048 -sha1 -keyout private.pem -out public.pem
  */
-
 
 /*
  * certificate string and private key string have the following format:
@@ -44,20 +25,22 @@
  */
 
 /* eslint-disable max-len */
-const CERT_REGEX = /-----BEGIN\sCERTIFICATE-----\s+([a-zA-Z0-9+\/=\r\n]+)\s+-----END\sCERTIFICATE-----/;
-const PRIVATE_KEY_REGEX = /-----BEGIN\sPRIVATE\sKEY-----\s+([a-zA-Z0-9+\/=\r\n]+)\s+-----END\sPRIVATE\sKEY-----/;
+const CERT_REGEX = /-----BEGIN\sCERTIFICATE-----\s+([a-zA-Z0-9+/=\r\n]+)\s+-----END\sCERTIFICATE-----/;
+const PRIVATE_KEY_REGEX = /-----BEGIN\sPRIVATE\sKEY-----\s+([a-zA-Z0-9+/=\r\n]+)\s+-----END\sPRIVATE\sKEY-----/;
 /* eslint-enable max-len */
 
 function getFirstCapturingGroup(str, regex) {
-  if (typeof str !== 'string') {
+  if (typeof str !== "string") {
     throw new Error(`'str' must be of type "String", actually is ${typeof str}`);
   }
   const matches = str.match(regex);
-  // if str matches the regex (either CERT_REGEX or PRIVATE_KEY_REGEX), then
-  // matches will always have two groups:
-  // matches[0]: this is always the entire match, in this case, the certificate/key str 
-  // matches[1]: this is the first (and the only) group we want to capture in the regex,
-  // which is the certifcate/key content
+  /*
+   * if str matches the regex (either CERT_REGEX or PRIVATE_KEY_REGEX), then
+   * matches will always have two groups:
+   * matches[0]: this is always the entire match, in this case, the certificate/key str 
+   * matches[1]: this is the first (and the only) group we want to capture in the regex,
+   * which is the certifcate/key content
+   */
   if (!Array.isArray(matches) || matches.length !== 2) {
     return null;
   }
@@ -65,10 +48,10 @@ function getFirstCapturingGroup(str, regex) {
 }
 
 function removeRN(str) {
-  if (typeof str !== 'string') {
+  if (typeof str !== "string") {
     throw new Error(`'str' must be of type "String", actually is ${typeof str}`);
   }
-  return str.replace(/[\r\n]/g, '');
+  return str.replace(/[\r\n]/g, "");
 }
 
 exports.getCertificate = function getCertificate(pem) {
@@ -80,10 +63,10 @@ exports.getPrivateKey = function getPrivateKey(pem) {
 };
 
 exports.certToPEM = function certToPEM(cert) {
-  const BEGIN_CERT = '-----BEGIN CERTIFICATE-----';
-  const END_CERT = '-----END CERTIFICATE-----';
+  const BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+  const END_CERT = "-----END CERTIFICATE-----";
   return [BEGIN_CERT]
     .concat(cert.match(/.{1,64}/g))
     .concat([END_CERT])
-    .join('\n');
+    .join("\n");
 };

--- a/maintenance/passport-azure-ad/lib/sessionContentHandler.js
+++ b/maintenance/passport-azure-ad/lib/sessionContentHandler.js
@@ -1,29 +1,11 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the "Software"), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
 
-'use restrict';
+"use restrict";
 
-const aadutils = require('./aadutils');
+const aadutils = require("./aadutils");
 
 /*
  * the handler for state/nonce/policy
@@ -31,20 +13,20 @@ const aadutils = require('./aadutils');
  * @maxAge            - when a tuple in session expires in seconds
  */ 
 function SessionContentHandler(maxAmount, maxAge) {
-  if (!maxAmount || (typeof maxAmount !== 'number' || maxAmount <= 0 || maxAmount % 1 !== 0))
-    throw new Error('SessionContentHandler: maxAmount must be a positive integer');
-  if (!maxAge || (typeof maxAge !== 'number' || maxAge <= 0))
-    throw new Error('SessionContentHandler: maxAge must be a positive number');
+  if (!maxAmount || (typeof maxAmount !== "number" || maxAmount <= 0 || maxAmount % 1 !== 0))
+    throw new Error("SessionContentHandler: maxAmount must be a positive integer");
+  if (!maxAge || (typeof maxAge !== "number" || maxAge <= 0))
+    throw new Error("SessionContentHandler: maxAge must be a positive number");
   this.maxAge = maxAge;  // seconds
   this.maxAmount = maxAmount;
 }
 
 SessionContentHandler.prototype.findAndDeleteTupleByState = function(req, sessionKey, stateToFind) {
   if (!req.session)
-    throw new Error('OIDC strategy requires session support. Did you forget to use session middleware such as express-session?');
+    throw new Error("OIDC strategy requires session support. Did you forget to use session middleware such as express-session?");
 
   // the array in session
-  var array = req.session[sessionKey] && req.session[sessionKey]['content'];
+  let array = req.session[sessionKey] && req.session[sessionKey]["content"];
   if (!array)
     array = [];
 
@@ -52,11 +34,11 @@ SessionContentHandler.prototype.findAndDeleteTupleByState = function(req, sessio
   aadutils.processArray(array, this.maxAmount, this.maxAge);
 
   // find the tuple by state value
-  var tuple = aadutils.findAndDeleteTupleByState(array, stateToFind);
+  const tuple = aadutils.findAndDeleteTupleByState(array, stateToFind);
 
   // clear empty array, and clear the session if there is nothing inside
   if (req.session[sessionKey] && array.length === 0)
-    delete req.session[sessionKey]['content'];
+    delete req.session[sessionKey]["content"];
   if (req.session[sessionKey] && Object.keys(req.session[sessionKey]).length === 0)
     delete req.session[sessionKey];
 
@@ -68,10 +50,10 @@ SessionContentHandler.prototype.add = function(req, sessionKey, tupleToAdd) {
     req.session = {};
   if (!req.session[sessionKey])
     req.session[sessionKey] = {};
-  if (!req.session[sessionKey]['content'])
-    req.session[sessionKey]['content'] = [];
+  if (!req.session[sessionKey]["content"])
+    req.session[sessionKey]["content"] = [];
 
-  var array = req.session[sessionKey]['content'];
+  const array = req.session[sessionKey]["content"];
   aadutils.processArray(array, this.maxAmount-1, this.maxAge);
 
   array.push(tupleToAdd);

--- a/maintenance/passport-azure-ad/lib/validator.js
+++ b/maintenance/passport-azure-ad/lib/validator.js
@@ -1,29 +1,11 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the "Software"), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
 
-'use strict';
+"use strict";
 
-const UrlValidator = require('valid-url');
+const UrlValidator = require("valid-url");
 
 const types = {};
 
@@ -35,7 +17,7 @@ Validator.prototype.validate = function validate(options) {
   const opts = options || {};
 
   Object.keys(this.config).forEach((item) => {
-    if (!this.config.hasOwnProperty(item)) {
+    if (!Object.prototype.hasOwnProperty.call(this.config, item)) {
       throw new TypeError(`Missing value for ${item}`);
     }
     const type = this.config[item];
@@ -53,55 +35,55 @@ Validator.prototype.validate = function validate(options) {
   });
 };
 
-Validator.isNonEmpty = 'isNonEmpty';
+Validator.isNonEmpty = "isNonEmpty";
 types.isNonEmpty = {
   validate: (value) => {
-    return value !== '' && value !== undefined && value !== null;
+    return value !== "" && value !== undefined && value !== null;
   },
-  error: 'The value cannot be empty',
+  error: "The value cannot be empty",
 };
 
-Validator.isTypeLegal = 'isTypeLegal';
+Validator.isTypeLegal = "isTypeLegal";
 types.isTypeLegal = {
   validate: (value) => {
-    return value === 'id_token' || value === 'id_token code' || value === 'code id_token' || value === 'code';
+    return value === "id_token" || value === "id_token code" || value === "code id_token" || value === "code";
   },
-  error: 'The responseType: must be either id_token, id_token code, code id_token or code.',
+  error: "The responseType: must be either id_token, id_token code, code id_token or code.",
 };
 
-Validator.isModeLegal = 'isModeLegal';
+Validator.isModeLegal = "isModeLegal";
 types.isModeLegal = {
   validate: (value) => {
-    return value === 'query' || value === 'form_post';
+    return value === "query" || value === "form_post";
   },
-  error: 'The responseMode: must be either query or form_post.',
+  error: "The responseMode: must be either query or form_post.",
 };
 
-Validator.isURL = 'isURL';
+Validator.isURL = "isURL";
 types.isURL = {
   validate: (value) => {
     return UrlValidator.isHttpUri(value) || UrlValidator.isHttpsUri(value);
   },
-  error: 'The URL must be valid and be https:// or http://',
+  error: "The URL must be valid and be https:// or http://",
 };
 
-Validator.isHttpURL = 'isHttpURL';
+Validator.isHttpURL = "isHttpURL";
 types.isHttpURL = {
   validate: (value) => {
     return UrlValidator.isHttpUri(value);
   },
-  error: 'The URL must be valid and be http://',
+  error: "The URL must be valid and be http://",
 };
 
-Validator.isHttpsURL = 'isHttpsURL';
+Validator.isHttpsURL = "isHttpsURL";
 types.isHttpsURL = {
   validate: (value) => {
     return UrlValidator.isHttpsUri(value);
   },
-  error: 'The URL must be valid and be https://',
+  error: "The URL must be valid and be https://",
 };
 
-Validator.isHttpsURLIfExists = 'isHttpsURLIfExists';
+Validator.isHttpsURLIfExists = "isHttpsURLIfExists";
 types.isHttpsURLIfExists = {
   validate: (value) => {
     if (value)
@@ -109,7 +91,7 @@ types.isHttpsURLIfExists = {
     else
       return true;
   },
-  error: 'The URL must be valid and be https://',
+  error: "The URL must be valid and be https://",
 };
 
 exports.Validator = Validator;

--- a/maintenance/passport-azure-ad/package-lock.json
+++ b/maintenance/passport-azure-ad/package-lock.json
@@ -56,14 +56,12 @@
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/highlight": {
       "version": "7.13.10",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
       "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
@@ -74,7 +72,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -83,7 +80,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -94,7 +90,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -102,20 +97,17 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -182,18 +174,69 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        }
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+    },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "debug": "4"
       }
     },
     "ajv": {
@@ -207,6 +250,11 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -217,9 +265,18 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "append-transform": {
@@ -247,7 +304,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       },
@@ -255,8 +311,7 @@
         "sprintf-js": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-          "dev": true
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         }
       }
     },
@@ -291,10 +346,24 @@
       "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
       "dev": true
     },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "async-hook-domain": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-1.1.3.tgz",
+      "integrity": "sha512-ZovMxSbADV3+biB7oR1GL5lGyptI24alp0LWHlmz1OFc5oL47pz3EiIF6nXOkDW7yLqih4NtsiYduzdDW0i+Wg==",
+      "dev": true,
+      "requires": {
+        "source-map-support": "^0.5.11"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -333,6 +402,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
     },
     "bind-obj-methods": {
       "version": "2.0.2",
@@ -423,6 +498,11 @@
         "write-file-atomic": "^2.4.2"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -460,10 +540,25 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       }
     },
     "clean-yaml-object": {
@@ -483,11 +578,16 @@
         "wrap-ansi": "^5.1.0"
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -495,8 +595,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-support": {
       "version": "1.1.3",
@@ -620,11 +719,11 @@
       "dev": true
     },
     "debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -641,6 +740,11 @@
       "requires": {
         "type-detect": "0.1.1"
       }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
       "version": "2.0.0",
@@ -663,10 +767,24 @@
       "dev": true
     },
     "diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
+    },
+    "diff-frag": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diff-frag/-/diff-frag-1.1.1.tgz",
+      "integrity": "sha512-y0YLhUGviNXaypPimkzmOCaZf8ruocRb+dpOL/lfoicxBua2gkExddlbWxIP56Z5BpSg4gL5sAWhBN2iQm4HVQ==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -712,6 +830,14 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -732,19 +858,192 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "eslint": {
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "requires": {
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.9",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "globals": {
+          "version": "13.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "eslint-plugin-header": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg=="
+    },
+    "eslint-plugin-security": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.4.0.tgz",
+      "integrity": "sha512-xlS7P2PLMXeqfhyf3NpqbvbnW04kN8M9NtmhpR3XGyOvt/vNKS7XPXT5EDbwKW9vCjWH4PpfQvgD/+JgN0VJKA==",
+      "requires": {
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
     },
     "esm": {
       "version": "3.2.25",
@@ -752,11 +1051,67 @@
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "eventemitter2": {
       "version": "0.4.14",
@@ -805,6 +1160,28 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "filelist": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+      "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -833,6 +1210,12 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
+    },
+    "findit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
+      "integrity": "sha1-ZQnwEmr0wXhVHPqZOU4DLhOk1W4=",
+      "dev": true
     },
     "findup-sync": {
       "version": "0.3.0",
@@ -876,6 +1259,60 @@
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
       "dev": true
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+    },
+    "flow-parser": {
+      "version": "0.158.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.158.0.tgz",
+      "integrity": "sha512-0hMsPkBTRrkII/0YiG9ehOxFXy4gOWdk8RSRze5WbfeKAQpL5kC2K4BmumyTfU9o5gr7/llgElF3UpSSrjzQAA==",
+      "dev": true
+    },
+    "flow-remove-types": {
+      "version": "2.158.0",
+      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.158.0.tgz",
+      "integrity": "sha512-mLDU+B2LuiCg0KA9V0A5OdgI5evugWlHKqG+GLlNIrtOPEPO497p3PJAUxGD3SR+gJmtxCDdgL+qLZnw5op9bA==",
+      "dev": true,
+      "requires": {
+        "flow-parser": "^0.158.0",
+        "pirates": "^3.0.2",
+        "vlq": "^0.2.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -926,8 +1363,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -940,6 +1383,11 @@
       "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.2.tgz",
       "integrity": "sha512-Iw4MzMfS3udk/rqxTiDDCllhGwlOrsr50zViTOO/W6lS/9y6B1J0BD2VZzrnWUYBJsl3aeqjgR5v7bWWhZSYbA==",
       "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -972,6 +1420,14 @@
         "minimatch": "2 || 3",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "global-modules": {
@@ -1096,23 +1552,1325 @@
       }
     },
     "grunt-contrib-nodeunit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-nodeunit/-/grunt-contrib-nodeunit-2.1.0.tgz",
-      "integrity": "sha512-cg3+lf6T5tDmnOFFf4+78b8xa5tsrw9u1NSlfCHjUrjeO+S/Ly0Dpo1BUV3QgsJ4k/0bgMmhbVjNXoP4AyYHuA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-nodeunit/-/grunt-contrib-nodeunit-3.0.0.tgz",
+      "integrity": "sha512-MPWjKmAwrvqLMnRg0FtdxMzAtcWct8/CPcdaRS9lgqGkZDMC42ro7wDy1xHH+TzuTc/wZSQPrc+e8EqWSNOV6g==",
       "dev": true,
       "requires": {
-        "nodeunit-x": "^0.13.0"
+        "nodeunit-x": "^0.14.0"
       },
       "dependencies": {
-        "nodeunit-x": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/nodeunit-x/-/nodeunit-x-0.13.0.tgz",
-          "integrity": "sha512-64AZrL+3JaiLm76KclMlZu2i0YKU10i8I4mQzERqs8Xf7UgqoQ5CuXPJmx4c+x8duiwategZ+g2DQCNORuGXLA==",
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
-            "ejs": "^2.5.2",
-            "tap": "^12.6.2"
+            "ms": "2.1.2"
           }
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "ejs": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+          "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+          "dev": true,
+          "requires": {
+            "jake": "^10.6.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "nodeunit-x": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/nodeunit-x/-/nodeunit-x-0.14.0.tgz",
+          "integrity": "sha512-BPoDkUvDDpE4pgjbImFkPKQZp2G3oN+Y0JYv9IS/6KdaBGFnqP+jXb6aq2mXXWdGXTIRntWbm/4UCTE6dGDHMg==",
+          "dev": true,
+          "requires": {
+            "ejs": "^3.1.6",
+            "tap": "^14.11.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "tap": {
+          "version": "14.11.0",
+          "resolved": "https://registry.npmjs.org/tap/-/tap-14.11.0.tgz",
+          "integrity": "sha512-z8qnNFVyIjLh/bNoTLFRkEk09XZUDAZbCkz/BjvHHly3ao5H+y60gPnedALfheEjA6dA4tpp/mrKq2NWlMuq0A==",
+          "dev": true,
+          "requires": {
+            "@types/react": "^16.9.16",
+            "async-hook-domain": "^1.1.3",
+            "bind-obj-methods": "^2.0.0",
+            "browser-process-hrtime": "^1.0.0",
+            "chokidar": "^3.3.0",
+            "color-support": "^1.1.0",
+            "coveralls": "^3.0.11",
+            "diff": "^4.0.1",
+            "esm": "^3.2.25",
+            "findit": "^2.0.0",
+            "flow-remove-types": "^2.112.0",
+            "foreground-child": "^1.3.3",
+            "fs-exists-cached": "^1.0.0",
+            "function-loop": "^1.0.2",
+            "glob": "^7.1.6",
+            "import-jsx": "^3.1.0",
+            "ink": "^2.6.0",
+            "isexe": "^2.0.0",
+            "istanbul-lib-processinfo": "^1.0.0",
+            "jackspeak": "^1.4.0",
+            "minipass": "^3.1.1",
+            "mkdirp": "^0.5.4",
+            "nyc": "^14.1.1",
+            "opener": "^1.5.1",
+            "own-or": "^1.0.0",
+            "own-or-env": "^1.0.1",
+            "react": "^16.12.0",
+            "rimraf": "^2.7.1",
+            "signal-exit": "^3.0.0",
+            "source-map-support": "^0.5.16",
+            "stack-utils": "^1.0.3",
+            "tap-mocha-reporter": "^5.0.0",
+            "tap-parser": "^10.0.1",
+            "tap-yaml": "^1.0.0",
+            "tcompare": "^3.0.0",
+            "treport": "^1.0.2",
+            "trivial-deferred": "^1.0.1",
+            "ts-node": "^8.5.2",
+            "typescript": "^3.7.2",
+            "which": "^2.0.2",
+            "write-file-atomic": "^3.0.1",
+            "yaml": "^1.7.2",
+            "yapool": "^1.0.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.10.4"
+              }
+            },
+            "@babel/core": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.10.5",
+                "@babel/helper-module-transforms": "^7.10.5",
+                "@babel/helpers": "^7.10.4",
+                "@babel/parser": "^7.10.5",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.5",
+                "@babel/types": "^7.10.5",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.1",
+                "json5": "^2.1.2",
+                "lodash": "^4.17.21",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.7",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "@babel/generator": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.10.5",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.7",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "@babel/helper-annotate-as-pure": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-builder-react-jsx": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-builder-react-jsx-experimental": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/types": "^7.10.5"
+              }
+            },
+            "@babel/helper-function-name": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-get-function-arity": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-member-expression-to-functions": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.10.5"
+              }
+            },
+            "@babel/helper-module-imports": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-module-transforms": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.5",
+                "lodash": "^4.17.21"
+              }
+            },
+            "@babel/helper-optimise-call-expression": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true
+            },
+            "@babel/helper-replace-supers": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-simple-access": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-split-export-declaration": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/helper-validator-identifier": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true
+            },
+            "@babel/helpers": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true
+            },
+            "@babel/plugin-proposal-object-rest-spread": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-transform-parameters": "^7.10.4"
+              }
+            },
+            "@babel/plugin-syntax-jsx": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+              }
+            },
+            "@babel/plugin-syntax-object-rest-spread": {
+              "version": "7.8.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+              }
+            },
+            "@babel/plugin-transform-destructuring": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+              }
+            },
+            "@babel/plugin-transform-parameters": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+              }
+            },
+            "@babel/plugin-transform-react-jsx": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-builder-react-jsx": "^7.10.4",
+                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+              }
+            },
+            "@babel/template": {
+              "version": "7.10.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
+              }
+            },
+            "@babel/traverse": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.10.5",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "@babel/parser": "^7.10.5",
+                "@babel/types": "^7.10.5",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.21"
+              }
+            },
+            "@babel/types": {
+              "version": "7.10.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.21",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "@types/color-name": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "@types/prop-types": {
+              "version": "15.7.3",
+              "bundled": true,
+              "dev": true
+            },
+            "@types/react": {
+              "version": "16.9.43",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@types/prop-types": "*",
+                "csstype": "^2.2.0"
+              }
+            },
+            "@types/yoga-layout": {
+              "version": "1.9.2",
+              "bundled": true,
+              "dev": true
+            },
+            "ansi-escapes": {
+              "version": "4.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "type-fest": "^0.11.0"
+              }
+            },
+            "ansi-regex": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "ansicolors": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true
+            },
+            "arrify": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "astral-regex": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "auto-bind": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "caller-callsite": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "callsites": "^2.0.0"
+              }
+            },
+            "caller-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "caller-callsite": "^2.0.0"
+              }
+            },
+            "callsites": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cardinal": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansicolors": "~0.3.2",
+                "redeyed": "~2.1.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "ci-info": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cli-cursor": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "restore-cursor": "^3.1.0"
+              }
+            },
+            "cli-truncate": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true
+            },
+            "convert-source-map": {
+              "version": "1.7.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "csstype": {
+              "version": "2.6.11",
+              "bundled": true,
+              "dev": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "emoji-regex": {
+              "version": "8.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "esprima": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "events-to-array": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "gensync": {
+              "version": "1.0.0-beta.1",
+              "bundled": true,
+              "dev": true
+            },
+            "globals": {
+              "version": "11.12.0",
+              "bundled": true,
+              "dev": true
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "import-jsx": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@babel/core": "^7.5.5",
+                "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+                "@babel/plugin-transform-destructuring": "^7.5.0",
+                "@babel/plugin-transform-react-jsx": "^7.3.0",
+                "caller-path": "^2.0.0",
+                "resolve-from": "^3.0.0"
+              }
+            },
+            "ink": {
+              "version": "2.7.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-escapes": "^4.2.1",
+                "arrify": "^2.0.1",
+                "auto-bind": "^4.0.0",
+                "chalk": "^3.0.0",
+                "cli-cursor": "^3.1.0",
+                "cli-truncate": "^2.1.0",
+                "is-ci": "^2.0.0",
+                "lodash.throttle": "^4.1.1",
+                "log-update": "^3.0.0",
+                "prop-types": "^15.6.2",
+                "react-reconciler": "^0.24.0",
+                "scheduler": "^0.18.0",
+                "signal-exit": "^3.0.2",
+                "slice-ansi": "^3.0.0",
+                "string-length": "^3.1.0",
+                "widest-line": "^3.1.0",
+                "wrap-ansi": "^6.2.0",
+                "yoga-layout-prebuilt": "^1.9.3"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "@types/color-name": "^1.1.1",
+                    "color-convert": "^2.0.1"
+                  }
+                },
+                "chalk": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-styles": "^4.1.0",
+                    "supports-color": "^7.1.0"
+                  }
+                },
+                "color-convert": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "color-name": "~1.1.4"
+                  }
+                },
+                "color-name": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true
+                },
+                "has-flag": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "supports-color": {
+                  "version": "7.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^4.0.0"
+                  }
+                }
+              }
+            },
+            "is-ci": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ci-info": "^2.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "jsesc": {
+              "version": "2.5.2",
+              "bundled": true,
+              "dev": true
+            },
+            "json5": {
+              "version": "2.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "lodash": {
+              "version": "4.17.21",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.throttle": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "log-update": {
+              "version": "3.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-escapes": "^3.2.0",
+                "cli-cursor": "^2.1.0",
+                "wrap-ansi": "^5.0.0"
+              },
+              "dependencies": {
+                "ansi-escapes": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "ansi-regex": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "cli-cursor": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "restore-cursor": "^2.0.0"
+                  }
+                },
+                "emoji-regex": {
+                  "version": "7.0.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "mimic-fn": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "onetime": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "mimic-fn": "^1.0.0"
+                  }
+                },
+                "restore-cursor": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "onetime": "^2.0.0",
+                    "signal-exit": "^3.0.2"
+                  }
+                },
+                "string-width": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "emoji-regex": "^7.0.1",
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
+                  }
+                },
+                "wrap-ansi": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-styles": "^3.2.0",
+                    "string-width": "^3.0.0",
+                    "strip-ansi": "^5.0.0"
+                  }
+                }
+              }
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "mimic-fn": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true
+            },
+            "minipass": {
+              "version": "3.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              },
+              "dependencies": {
+                "yallist": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "onetime": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mimic-fn": "^2.1.0"
+              }
+            },
+            "path-parse": {
+              "version": "1.0.7",
+              "bundled": true,
+              "dev": true
+            },
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "react-is": {
+              "version": "16.13.1",
+              "bundled": true,
+              "dev": true
+            },
+            "react-reconciler": {
+              "version": "0.24.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "scheduler": "^0.18.0"
+              }
+            },
+            "redeyed": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "esprima": "~4.0.0"
+              }
+            },
+            "resolve": {
+              "version": "1.17.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-parse": "^1.0.7"
+              }
+            },
+            "resolve-from": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "restore-cursor": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "scheduler": {
+              "version": "0.18.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+              }
+            },
+            "semver": {
+              "version": "5.7.1",
+              "bundled": true,
+              "dev": true
+            },
+            "signal-exit": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "slice-ansi": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "@types/color-name": "^1.1.1",
+                    "color-convert": "^2.0.1"
+                  }
+                },
+                "color-convert": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "color-name": "~1.1.4"
+                  }
+                },
+                "color-name": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "string-length": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "astral-regex": "^1.0.0",
+                "strip-ansi": "^5.2.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "astral-regex": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "4.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "tap-parser": {
+              "version": "10.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "events-to-array": "^1.0.1",
+                "minipass": "^3.0.0",
+                "tap-yaml": "^1.0.0"
+              }
+            },
+            "tap-yaml": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yaml": "^1.5.0"
+              }
+            },
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "treport": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cardinal": "^2.1.1",
+                "chalk": "^3.0.0",
+                "import-jsx": "^3.1.0",
+                "ink": "^2.6.0",
+                "ms": "^2.1.2",
+                "string-length": "^3.1.0",
+                "tap-parser": "^10.0.1",
+                "unicode-length": "^2.0.2"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "@types/color-name": "^1.1.1",
+                    "color-convert": "^2.0.1"
+                  }
+                },
+                "chalk": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-styles": "^4.1.0",
+                    "supports-color": "^7.1.0"
+                  }
+                },
+                "color-convert": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "color-name": "~1.1.4"
+                  }
+                },
+                "color-name": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true
+                },
+                "has-flag": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "supports-color": {
+                  "version": "7.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^4.0.0"
+                  }
+                }
+              }
+            },
+            "type-fest": {
+              "version": "0.11.0",
+              "bundled": true,
+              "dev": true
+            },
+            "unicode-length": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "punycode": "^2.0.0",
+                "strip-ansi": "^3.0.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "widest-line": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "^4.0.0"
+              }
+            },
+            "wrap-ansi": {
+              "version": "6.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "@types/color-name": "^1.1.1",
+                    "color-convert": "^2.0.1"
+                  }
+                },
+                "color-convert": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "color-name": "~1.1.4"
+                  }
+                },
+                "color-name": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "yaml": {
+              "version": "1.10.0",
+              "bundled": true,
+              "dev": true
+            },
+            "yoga-layout-prebuilt": {
+              "version": "1.9.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "@types/yoga-layout": "1.9.2"
+              }
+            }
+          }
+        },
+        "tap-mocha-reporter": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.1.tgz",
+          "integrity": "sha512-1knFWOwd4khx/7uSEnUeaP9IPW3w+sqTgJMhrwah6t46nZ8P25atOKAjSvVDsT67lOPu0nfdOqUwoyKn+3E5pA==",
+          "dev": true,
+          "requires": {
+            "color-support": "^1.1.0",
+            "debug": "^4.1.1",
+            "diff": "^4.0.1",
+            "escape-string-regexp": "^2.0.0",
+            "glob": "^7.0.5",
+            "tap-parser": "^10.0.0",
+            "tap-yaml": "^1.0.0",
+            "unicode-length": "^2.0.2"
+          }
+        },
+        "tap-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
+          "integrity": "sha512-FujQeciDaOiOvaIVGS1Rpb0v4R6XkOjvWCWowlz5oKuhPkEJ8U6pxgqt38xuzYhPt8dWEnfHn2jqpZdJEkW7pA==",
+          "dev": true,
+          "requires": {
+            "events-to-array": "^1.0.1",
+            "minipass": "^3.0.0",
+            "tap-yaml": "^1.0.0"
+          }
+        },
+        "unicode-length": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.0.2.tgz",
+          "integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.0.0",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -1141,7 +2899,7 @@
       "dev": true,
       "requires": {
         "chalk": "~4.1.0",
-        "lodash": "~4.17.19"
+        "lodash": "~4.17.21"
       }
     },
     "grunt-legacy-util": {
@@ -1212,8 +2970,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "hasha": {
       "version": "3.0.0",
@@ -1268,12 +3025,12 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "iconv-lite": {
@@ -1290,11 +3047,24 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1338,6 +3108,15 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
@@ -1350,8 +3129,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -1363,7 +3141,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -1428,8 +3205,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -1477,6 +3253,57 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        }
+      }
+    },
+    "istanbul-lib-processinfo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-1.0.0.tgz",
+      "integrity": "sha512-FY0cPmWa4WoQNlvB8VOcafiRoB5nB+l2Pz2xGuXHRSy1KM8QFOYfz/rN+bGMCAeejrY3mrpF5oJHcN0s/garCg==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^6.0.5",
+        "istanbul-lib-coverage": "^2.0.3",
+        "rimraf": "^2.6.3",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -1576,17 +3403,179 @@
         "html-escaper": "^2.0.0"
       }
     },
+    "jackspeak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.4.0.tgz",
+      "integrity": "sha512-VDcSunT+wcccoG46FtzuBAyQKlzhHjli4q31e1fIHGOsRspqNUFjVzGb+7eIFDlTvqLygxapDHPHS0ouT2o/tw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "jake": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+      "dev": true,
+      "requires": {
+        "async": "0.9.x",
+        "chalk": "^2.4.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1618,6 +3607,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1665,6 +3659,15 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
       "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
       "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
     },
     "liftup": {
       "version": "3.0.1",
@@ -1742,6 +3745,16 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+    },
     "log-driver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
@@ -1752,6 +3765,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "4.0.0",
@@ -1881,7 +3903,7 @@
         "browser-stdout": "1.3.1",
         "commander": "2.15.1",
         "debug": "3.1.0",
-        "diff": "3.5.0",
+        "diff": "4.0.1",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
         "growl": "1.10.5",
@@ -1901,8 +3923,8 @@
           }
         },
         "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
           "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
         },
@@ -1965,9 +3987,9 @@
       "optional": true
     },
     "ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mv": {
       "version": "2.1.1",
@@ -1986,6 +4008,11 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
     "ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -1996,6 +4023,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-forge": {
@@ -2011,13 +4044,19 @@
         "base64url": "^3.0.1",
         "buffer": "^5.5.0",
         "es6-promise": "^4.2.8",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "long": "^4.0.0",
         "node-forge": "^0.10.0",
         "pako": "^1.0.11",
         "process": "^0.11.10",
         "uuid": "^3.3.3"
       }
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
     },
     "nodeunit": {
       "version": "0.11.3",
@@ -2049,6 +4088,18 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nyc": {
       "version": "14.1.1",
@@ -2118,6 +4169,12 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object.defaults": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
@@ -2162,6 +4219,19 @@
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
       "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -2241,6 +4311,14 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -2293,10 +4371,16 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-root": {
@@ -2353,6 +4437,15 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
+    "pirates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
+      "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -2361,6 +4454,11 @@
       "requires": {
         "find-up": "^3.0.0"
       }
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "process": {
       "version": "0.11.10",
@@ -2373,6 +4471,22 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "optional": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -2393,6 +4507,23 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -2440,6 +4571,15 @@
         }
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "rechoir": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
@@ -2448,6 +4588,11 @@
       "requires": {
         "resolve": "^1.9.0"
       }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -2491,6 +4636,11 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -2504,7 +4654,7 @@
       "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "path-parse": "^1.0.7"
       }
     },
     "resolve-dir": {
@@ -2520,8 +4670,12 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rimraf": {
       "version": "2.4.5",
@@ -2543,6 +4697,14 @@
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "optional": true
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2560,11 +4722,43 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        }
+      }
     },
     "source-map": {
       "version": "0.5.7",
@@ -2745,13 +4939,81 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "table": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+          "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "tap": {
@@ -2829,7 +5091,7 @@
       "requires": {
         "color-support": "^1.1.0",
         "debug": "^2.1.3",
-        "diff": "^1.3.2",
+        "diff": "^4.0.1",
         "escape-string-regexp": "^1.0.3",
         "glob": "^7.0.5",
         "js-yaml": "^3.3.1",
@@ -2891,6 +5153,24 @@
         "minipass": "^2.2.0"
       }
     },
+    "tap-yaml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.0.tgz",
+      "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
+      "dev": true,
+      "requires": {
+        "yaml": "^1.5.0"
+      }
+    },
+    "tcompare": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-3.0.5.tgz",
+      "integrity": "sha512-+tmloQj1buaShBX+LP1i1NF5riJm110Yr0flIJAEoKf01tFVoMZvW2jq1JLqaW8fspOUVPm5NKKW5qLwT0ETDQ==",
+      "dev": true,
+      "requires": {
+        "diff-frag": "^1.0.1"
+      }
+    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -2918,6 +5198,11 @@
           }
         }
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "tmatch": {
       "version": "4.0.0",
@@ -2995,11 +5280,33 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
     "type-detect": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
       "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
       "dev": true
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "typescript": {
       "version": "3.9.9",
@@ -3075,6 +5382,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+    },
     "v8flags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
@@ -3109,6 +5421,12 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -3123,6 +5441,11 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wrap-ansi": {
       "version": "5.1.0",
@@ -3187,6 +5510,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
     },
     "yapool": {
       "version": "1.0.0",

--- a/maintenance/passport-azure-ad/package.json
+++ b/maintenance/passport-azure-ad/package.json
@@ -26,7 +26,7 @@
     "chai": "2.x.x",
     "chai-passport-strategy": "1.x.x",
     "grunt": "^1.0.1",
-    "grunt-contrib-nodeunit": "^2.1.0",
+    "grunt-contrib-nodeunit": "^3.0.0",
     "grunt-mocha-test": "^0.12.7",
     "mocha": "^5.2.0",
     "nodeunit": "^0.11.3"
@@ -36,7 +36,10 @@
     "base64url": "^3.0.0",
     "bunyan": "^1.8.14",
     "cache-manager": "2.10.2",
-    "https-proxy-agent": "^2.2.2",
+    "eslint": "^7.32.0",
+    "eslint-plugin-header": "^3.1.1",
+    "eslint-plugin-security": "^1.4.0",
+    "https-proxy-agent": "^5.0.0",
     "jws": "^3.1.3",
     "lodash": "^4.11.2",
     "node-jose": "^2.0.0",
@@ -46,7 +49,8 @@
     "valid-url": "^1.0.6"
   },
   "scripts": {
-    "test": "grunt run_tests"
+    "test": "grunt run_tests",
+    "lint": "./node_modules/.bin/eslint lib/**"
   },
   "engines": {
     "node": ">= 8.0.0"


### PR DESCRIPTION
**NOTE: This PR replaces #3983, which had failing tests related to upgrading `mocha`.**

This PR adds linting and updates dependencies for the passport-azure-ad library. 

- Upgrades `grunt-contrib-nodeunit`
- Upgrades `https-proxy-agent`, addressing issue #3914 
- Upgrades `lodash` in the package-lock, addressing security advisory [1673](https://www.npmjs.com/advisories/1673)
- Upgrades `path-parse` in the package-lock, addressing security advisory [1773](https://www.npmjs.com/advisories/1773)
- Upgrades `diff` in the package-lock, addressing security advisory [1631](https://www.npmjs.com/advisories/1631)
- Adds `eslint`, `eslint-plugin-header`, `eslint-plugin-security` and lint rules in line with the rest of MSAL.js libraries. Lint errors and warnings addressed. 
- Cleans up comments.

Note: Does not upgrade `mocha`, despite low warning for prototype pollution(security advisory [1179](https://npmjs.com/advisories/1179)), as `mocha` is a dev dependency, and upgrading breaks existing tests.