### PR TITLE
Add retry to E2E tests

### DIFF
--- a/samples/msal-angular-v2-samples/angular10-sample-app/test/home.spec.ts
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/test/home.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Home Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular10-sample-app/test/profile.spec.ts
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/test/profile.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Profile Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular10-sample-app/tsconfig.e2e.json
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/tsconfig.e2e.json
@@ -1,0 +1,13 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+      "types": [
+          "jest"
+      ]
+    },
+    "include": [
+      "test/**/*.spec.ts"
+    ]
+  }
+  

--- a/samples/msal-angular-v2-samples/angular10-sample-app/tsconfig.json
+++ b/samples/msal-angular-v2-samples/angular10-sample-app/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./tsconfig.e2e.json"
     }
 ]
 }

--- a/samples/msal-angular-v2-samples/angular11-sample-app/test/detail.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/test/detail.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Detail Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular11-sample-app/test/home.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/test/home.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Home Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular11-sample-app/test/lazy.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/test/lazy.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Lazy Loading Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular11-sample-app/test/profile.spec.ts
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/test/profile.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Profile Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular11-sample-app/tsconfig.json
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/tsconfig.json
@@ -20,6 +20,9 @@
     "lib": [
       "es2018",
       "dom"
+    ],
+    "types": [
+      "jest"
     ]
   },
   "angularCompilerOptions": {

--- a/samples/msal-angular-v2-samples/angular12-sample-app/test/home.spec.ts
+++ b/samples/msal-angular-v2-samples/angular12-sample-app/test/home.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Home Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular12-sample-app/test/profile.spec.ts
+++ b/samples/msal-angular-v2-samples/angular12-sample-app/test/profile.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Profile Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular12-sample-app/tsconfig.json
+++ b/samples/msal-angular-v2-samples/angular12-sample-app/tsconfig.json
@@ -17,6 +17,9 @@
       "es2018",
       "dom"
     ],
+    "types": [
+      "jest"
+    ],
     "paths": { 
       "@angular/*": ["./node_modules/@angular/*"] 
     }

--- a/samples/msal-angular-v2-samples/angular9-v2-sample-app/test/home.spec.ts
+++ b/samples/msal-angular-v2-samples/angular9-v2-sample-app/test/home.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Home Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-angular-v2-samples/angular9-v2-sample-app/tsconfig.json
+++ b/samples/msal-angular-v2-samples/angular9-v2-sample-app/tsconfig.json
@@ -12,12 +12,12 @@
     "esModuleInterop": true,
     "importHelpers": true,
     "target": "es2015",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
     "lib": [
       "es2018",
       "dom"
+    ],
+    "types": [
+      "jest"
     ]
   },
   "angularCompilerOptions": {

--- a/samples/msal-node-samples/auth-code/test/auth-code-aad.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-aad.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import "jest";
 import puppeteer from "puppeteer";
 import { Screenshot, createFolder, setupCredentials } from "../../../e2eTestUtils/TestUtils";
 import { NodeCacheTestUtils } from "../../../e2eTestUtils/NodeCacheTestUtils";
@@ -32,6 +31,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 const config = require("../config/AAD.json");
 
 describe("Auth Code AAD PPE Tests", () => {
+    jest.retryTimes(1);
     jest.setTimeout(45000);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;

--- a/samples/msal-node-samples/auth-code/test/auth-code-adfs.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-adfs.spec.ts
@@ -1,4 +1,3 @@
-import "jest";
 import puppeteer from "puppeteer";
 import { Screenshot, createFolder, setupCredentials } from "../../../e2eTestUtils/TestUtils";
 import { NodeCacheTestUtils } from "../../../e2eTestUtils/NodeCacheTestUtils";
@@ -25,6 +24,7 @@ let username: string;
 let accountPwd: string;
 
 describe('Auth Code ADFS PPE Tests', () => {
+    jest.retryTimes(1);
     jest.setTimeout(45000);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;

--- a/samples/msal-node-samples/device-code/test/device-code-aad.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-aad.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import "jest";
 import puppeteer from "puppeteer";
 import { Screenshot, createFolder, setupCredentials } from "../../../e2eTestUtils/TestUtils";
 import { NodeCacheTestUtils } from "../../../e2eTestUtils/NodeCacheTestUtils";
@@ -34,6 +33,7 @@ const config = require("../config/AAD.json");
 
 describe('Device Code AAD PPE Tests', () => {
     jest.setTimeout(45000);
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import "jest";
 import puppeteer from "puppeteer";
 import { Screenshot, createFolder, setupCredentials } from "../../../e2eTestUtils/TestUtils";
 import { NodeCacheTestUtils } from "../../../e2eTestUtils/NodeCacheTestUtils";
@@ -33,6 +32,7 @@ const config = require("../config/ADFS.json");
 
 describe('Device Code ADFS PPE Tests', () => {
     jest.setTimeout(45000);
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-aad.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-aad.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import "jest";
 import puppeteer from "puppeteer";
 import { Screenshot, createFolder, setupCredentials } from "../../../e2eTestUtils/TestUtils";
 import { NodeCacheTestUtils } from "../../../e2eTestUtils/NodeCacheTestUtils";
@@ -34,6 +33,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 const config = require("../config/AAD.json");
 
 describe("Silent Flow AAD PPE Tests", () => {
+    jest.retryTimes(1);
     jest.setTimeout(45000);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-adfs.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-adfs.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import "jest";
 import puppeteer from "puppeteer";
 import { Screenshot, createFolder, setupCredentials } from "../../../e2eTestUtils/TestUtils";
 import { NodeCacheTestUtils } from "../../../e2eTestUtils/NodeCacheTestUtils";
@@ -34,6 +33,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 const config = require("../config/ADFS.json");
 
 describe("Silent Flow ADFS 2019 Tests", () => {
+    jest.retryTimes(1);
     jest.setTimeout(45000);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;

--- a/samples/msal-react-samples/gatsby-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/gatsby-sample/test/home.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Home Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/gatsby-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/gatsby-sample/test/profile.spec.ts
@@ -22,6 +22,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/profile', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/nextjs-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/nextjs-sample/test/home.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Home Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/nextjs-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/nextjs-sample/test/profile.spec.ts
@@ -22,6 +22,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/profile', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/react-router-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/home.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Home Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/react-router-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profile.spec.ts
@@ -22,6 +22,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/profile', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/react-router-sample/test/profileRawContext.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profileRawContext.spec.ts
@@ -22,6 +22,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/profileRawContext', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/react-router-sample/test/profileWithMsal.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profileWithMsal.spec.ts
@@ -22,6 +22,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/profileWithMsal', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/typescript-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/typescript-sample/test/home.spec.ts
@@ -19,6 +19,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/ (Home Page)', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;

--- a/samples/msal-react-samples/typescript-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/typescript-sample/test/profile.spec.ts
@@ -22,6 +22,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
 }
 
 describe('/profile', () => {
+    jest.retryTimes(1);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;


### PR DESCRIPTION
Adds a retry to the E2E tests to help alleviate intermittent timeout issues. Each test can be retried individually if a failure occurs