### PR TITLE
Populate msal v2 loginHint from cached msal v1 id token

### DIFF
--- a/change/@azure-msal-browser-8f6a38ac-ffe9-4d7d-af8e-873ea9411e80.json
+++ b/change/@azure-msal-browser-8f6a38ac-ffe9-4d7d-af8e-873ea9411e80.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Populate msal v2 loginHint from cached msal v1 id token",
+  "comment": "Populate msal v2 loginHint from cached msal v1 id token #4027",
   "packageName": "@azure/msal-browser",
   "email": "janutter@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-8f6a38ac-ffe9-4d7d-af8e-873ea9411e80.json
+++ b/change/@azure-msal-browser-8f6a38ac-ffe9-4d7d-af8e-873ea9411e80.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Populate msal v2 loginHint from cached msal v1 id token",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -270,23 +270,35 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
             validatedRequest.account = account;
         }
 
-        // Check for ADAL SSO
+        // Check for ADAL/MSAL v1 SSO
         if (StringUtils.isEmpty(validatedRequest.loginHint)) {
-            // Only check for adal token if no SSO params are being used
+            // Only check for adal/msal token if no SSO params are being used
             const adalIdTokenString = this.browserStorage.getTemporaryCache(PersistentCacheKeys.ADAL_ID_TOKEN);
             if (adalIdTokenString) {
-                const adalIdToken = new IdToken(adalIdTokenString, this.browserCrypto);
+                this.logger.verbose("Cached ADAL id token retrieved.");
+            }
+
+            // Check for cached MSAL v1 id token
+            const msalIdTokenString = this.browserStorage.getTemporaryCache(PersistentCacheKeys.ID_TOKEN, true);
+            if (msalIdTokenString) {
+                this.logger.verbose("Cached MSAL.js v1 id token retrieved");
+            }
+
+            const cachedIdTokenString = msalIdTokenString || adalIdTokenString;
+            if (cachedIdTokenString) {
+                const cachedIdToken = new IdToken(cachedIdTokenString, this.browserCrypto);
                 this.browserStorage.removeItem(PersistentCacheKeys.ADAL_ID_TOKEN);
-                if (adalIdToken.claims && adalIdToken.claims.preferred_username) {
-                    this.logger.verbose("No SSO params used and ADAL token retrieved, setting ADAL preferred_username as loginHint");
-                    validatedRequest.loginHint = adalIdToken.claims.preferred_username;
+                this.browserStorage.removeItem(this.browserStorage.generateCacheKey(PersistentCacheKeys.ID_TOKEN));
+                if (cachedIdToken.claims && cachedIdToken.claims.preferred_username) {
+                    this.logger.verbose("No SSO params used and ADAL/MSAL v1 token retrieved, setting ADAL/MSAL v1 preferred_username as loginHint");
+                    validatedRequest.loginHint = cachedIdToken.claims.preferred_username;
                 }
-                else if (adalIdToken.claims && adalIdToken.claims.upn) {
-                    this.logger.verbose("No SSO params used and ADAL token retrieved, setting ADAL upn as loginHint");
-                    validatedRequest.loginHint = adalIdToken.claims.upn;
+                else if (cachedIdToken.claims && cachedIdToken.claims.upn) {
+                    this.logger.verbose("No SSO params used and ADAL/MSAL v1 token retrieved, setting ADAL/MSAL v1 upn as loginHint");
+                    validatedRequest.loginHint = cachedIdToken.claims.upn;
                 }
                 else {
-                    this.logger.verbose("No SSO params used and ADAL token retrieved, however, no account hint claim found. Enable preferred_username or upn id token claim to get SSO.");
+                    this.logger.verbose("No SSO params used and ADAL/MSAL v1 token retrieved, however, no account hint claim found. Enable preferred_username or upn id token claim to get SSO.");
                 }
             }
         }

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -271,24 +271,24 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
         }
 
         // Check for ADAL/MSAL v1 SSO
-        if (StringUtils.isEmpty(validatedRequest.loginHint)) {
+        if (StringUtils.isEmpty(validatedRequest.loginHint) && !account) {
             // Only check for adal/msal token if no SSO params are being used
             const adalIdTokenString = this.browserStorage.getTemporaryCache(PersistentCacheKeys.ADAL_ID_TOKEN);
             if (adalIdTokenString) {
+                this.browserStorage.removeItem(PersistentCacheKeys.ADAL_ID_TOKEN);
                 this.logger.verbose("Cached ADAL id token retrieved.");
             }
 
             // Check for cached MSAL v1 id token
             const msalIdTokenString = this.browserStorage.getTemporaryCache(PersistentCacheKeys.ID_TOKEN, true);
             if (msalIdTokenString) {
+                this.browserStorage.removeItem(this.browserStorage.generateCacheKey(PersistentCacheKeys.ID_TOKEN));
                 this.logger.verbose("Cached MSAL.js v1 id token retrieved");
             }
 
             const cachedIdTokenString = msalIdTokenString || adalIdTokenString;
             if (cachedIdTokenString) {
                 const cachedIdToken = new IdToken(cachedIdTokenString, this.browserCrypto);
-                this.browserStorage.removeItem(PersistentCacheKeys.ADAL_ID_TOKEN);
-                this.browserStorage.removeItem(this.browserStorage.generateCacheKey(PersistentCacheKeys.ID_TOKEN));
                 if (cachedIdToken.claims && cachedIdToken.claims.preferred_username) {
                     this.logger.verbose("No SSO params used and ADAL/MSAL v1 token retrieved, setting ADAL/MSAL v1 preferred_username as loginHint");
                     validatedRequest.loginHint = cachedIdToken.claims.preferred_username;

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -1148,6 +1148,59 @@ describe("RedirectClient", () => {
             expect(loginUrlSpy.calledWith(validatedRequest)).toBeTruthy();
         });
 
+        it("Uses msal v1 token from cache if it is present and sets preferred_name as the login hint.", async () => {
+            const idTokenClaims: TokenClaims = {
+                "iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",
+                "exp": 1536279024,
+                "name": "abeli",
+                "nonce": "123523",
+                "oid": "05833b6b-aa1d-42d4-9ec0-1b2bb9194438",
+                "sub": "5_J9rSss8-jvt_Icu6ueRNL8xXb8LF4Fsg_KooC2RJQ",
+                "tid": "fa15d692-e9c7-4460-a743-29f2956fd429",
+                "ver": "1.0",
+                "preferred_username": "AbeLincoln@contoso.com"
+            };
+            sinon.stub(AuthToken, "extractTokenClaims").returns(idTokenClaims);
+            const browserCrypto = new CryptoOps();
+            const testLogger = new Logger(loggerOptions);
+            const browserStorage: BrowserCacheManager = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig, browserCrypto, testLogger);
+            browserStorage.setTemporaryCache(PersistentCacheKeys.ID_TOKEN, TEST_TOKENS.IDTOKEN_V1, true);
+            const loginUrlSpy = sinon.spy(AuthorizationCodeClient.prototype, "getAuthCodeUrl");
+            sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                challenge: TEST_CONFIG.TEST_CHALLENGE,
+                verifier: TEST_CONFIG.TEST_VERIFIER
+            });
+            sinon.stub(NavigationClient.prototype, "navigateExternal").callsFake((urlNavigate: string, options: NavigationOptions): Promise<boolean> => {
+                expect(options.noHistory).toBeFalsy();
+                expect(urlNavigate).not.toBe("");
+                return Promise.resolve(true);
+            });
+            const emptyRequest: CommonAuthorizationUrlRequest = {
+                redirectUri: TEST_URIS.TEST_REDIR_URI,
+                scopes: [],
+                state: TEST_STATE_VALUES.USER_STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                responseMode: TEST_CONFIG.RESPONSE_MODE as ResponseMode,
+                nonce: "",
+                authenticationScheme: TEST_CONFIG.TOKEN_TYPE_BEARER as AuthenticationScheme
+            };
+            await redirectClient.acquireToken(emptyRequest);
+            const validatedRequest: CommonAuthorizationUrlRequest = {
+                ...emptyRequest,
+                scopes: [],
+                loginHint: idTokenClaims.preferred_username,
+                state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
+                correlationId: RANDOM_TEST_GUID,
+                nonce: RANDOM_TEST_GUID,
+                authority: `${Constants.DEFAULT_AUTHORITY}`,
+                responseMode: ResponseMode.FRAGMENT,
+                codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                codeChallengeMethod: Constants.S256_CODE_CHALLENGE_METHOD
+            };
+            expect(loginUrlSpy.calledWith(validatedRequest)).toBeTruthy();
+        });
+
         it("Does not use adal token from cache if it is present and SSO params have been given.", async () => {
             const idTokenClaims: TokenClaims = {
                 "iss": "https://sts.windows.net/fa15d692-e9c7-4460-a743-29f2956fd429/",


### PR DESCRIPTION
Today, when `loginHint` isn't set, we'll look for a cached ADAL id token, and use it to populate the `login_hint` parameter if one is found. It has been requested that we always perform similar SSO for MSAL v1 id tokens.