### PR TITLE
Move helper functions to BaseInteractionClient

### DIFF
--- a/change/@azure-msal-browser-6b3118fa-4a40-4074-b6e6-b6105beaf751.json
+++ b/change/@azure-msal-browser-6b3118fa-4a40-4074-b6e6-b6105beaf751.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move helper functions up to BaseInteractionClient #4049",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-8d31f6e8-6bea-49fa-858f-a2ab0c94b0ec.json
+++ b/change/@azure-msal-browser-8d31f6e8-6bea-49fa-858f-a2ab0c94b0ec.json
@@ -1,0 +1,6 @@
+{
+  "type": "none",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Constants, PersistentCacheKeys, StringUtils, CommonAuthorizationCodeRequest, ICrypto, AccountEntity, IdTokenEntity, AccessTokenEntity, RefreshTokenEntity, AppMetadataEntity, CacheManager, ServerTelemetryEntity, ThrottlingEntity, ProtocolUtils, Logger, AuthorityMetadataEntity, DEFAULT_CRYPTO_IMPLEMENTATION, AccountInfo, CcsCredential, CcsCredentialType } from "@azure/msal-common";
+import { Constants, PersistentCacheKeys, StringUtils, CommonAuthorizationCodeRequest, ICrypto, AccountEntity, IdTokenEntity, AccessTokenEntity, RefreshTokenEntity, AppMetadataEntity, CacheManager, ServerTelemetryEntity, ThrottlingEntity, ProtocolUtils, Logger, AuthorityMetadataEntity, DEFAULT_CRYPTO_IMPLEMENTATION, AccountInfo, CcsCredential, CcsCredentialType, IdToken } from "@azure/msal-common";
 import { CacheOptions } from "../config/Configuration";
 import { BrowserAuthError } from "../error/BrowserAuthError";
 import { BrowserCacheLocation, InteractionType, TemporaryCacheKeys, InMemoryCacheKeys } from "../utils/BrowserConstants";
@@ -917,6 +917,43 @@ export class BrowserCacheManager extends CacheManager {
         } else if (!inProgress && clientId === this.clientId) {
             this.removeItem(key);
         }
+    }
+
+    /**
+     * Returns username retrieved from ADAL or MSAL v1 idToken
+     */
+    getLegacyLoginHint(): string | null {
+        // Only check for adal/msal token if no SSO params are being used
+        const adalIdTokenString = this.getTemporaryCache(PersistentCacheKeys.ADAL_ID_TOKEN);
+        if (adalIdTokenString) {
+            this.browserStorage.removeItem(PersistentCacheKeys.ADAL_ID_TOKEN);
+            this.logger.verbose("Cached ADAL id token retrieved.");
+        }
+
+        // Check for cached MSAL v1 id token
+        const msalIdTokenString = this.getTemporaryCache(PersistentCacheKeys.ID_TOKEN, true);
+        if (msalIdTokenString) {
+            this.removeItem(this.generateCacheKey(PersistentCacheKeys.ID_TOKEN));
+            this.logger.verbose("Cached MSAL.js v1 id token retrieved");
+        }
+
+        const cachedIdTokenString = msalIdTokenString || adalIdTokenString;
+        if (cachedIdTokenString) {
+            const cachedIdToken = new IdToken(cachedIdTokenString, this.cryptoImpl);
+            if (cachedIdToken.claims && cachedIdToken.claims.preferred_username) {
+                this.logger.verbose("No SSO params used and ADAL/MSAL v1 token retrieved, setting ADAL/MSAL v1 preferred_username as loginHint");
+                return cachedIdToken.claims.preferred_username;
+            }
+            else if (cachedIdToken.claims && cachedIdToken.claims.upn) {
+                this.logger.verbose("No SSO params used and ADAL/MSAL v1 token retrieved, setting ADAL/MSAL v1 upn as loginHint");
+                return cachedIdToken.claims.upn;
+            }
+            else {
+                this.logger.verbose("No SSO params used and ADAL/MSAL v1 token retrieved, however, no account hint claim found. Enable preferred_username or upn id token claim to get SSO.");
+            }
+        }
+
+        return null;
     }
 }
 

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICrypto, INetworkModule, Logger, AuthenticationResult, AccountInfo, AccountEntity } from "@azure/msal-common";
+import { ICrypto, INetworkModule, Logger, AuthenticationResult, AccountInfo, AccountEntity, BaseAuthRequest, AuthenticationScheme, UrlString } from "@azure/msal-common";
 import { BrowserConfiguration } from "../config/Configuration";
 import { BrowserCacheManager } from "../cache/BrowserCacheManager";
 import { EventHandler } from "../event/EventHandler";
@@ -13,6 +13,7 @@ import { PopupRequest } from "../request/PopupRequest";
 import { SsoSilentRequest } from "../request/SsoSilentRequest";
 import { version } from "../packageMetadata";
 import { BrowserConstants } from "../utils/BrowserConstants";
+import { BrowserUtils } from "../utils/BrowserUtils";
 
 export abstract class BaseInteractionClient {
 
@@ -62,5 +63,46 @@ export abstract class BaseInteractionClient {
                 this.logger.error("Attempted to clear all MSAL cache items and failed. Local cache unchanged.");
             }
         }
+    }
+
+    /**
+     * Initializer function for all request APIs
+     * @param request
+     */
+    protected initializeBaseRequest(request: Partial<BaseAuthRequest>): BaseAuthRequest {
+        this.logger.verbose("Initializing BaseAuthRequest");
+        const authority = request.authority || this.config.auth.authority;
+
+        const scopes = [...((request && request.scopes) || [])];
+
+        // Set authenticationScheme to BEARER if not explicitly set in the request
+        if (!request.authenticationScheme) {
+            request.authenticationScheme = AuthenticationScheme.BEARER;
+            this.logger.verbose("Authentication Scheme wasn't explicitly set in request, defaulting to \"Bearer\" request");
+        } else {
+            this.logger.verbose(`Authentication Scheme set to "${request.authenticationScheme}" as configured in Auth request`);
+        }
+
+        const validatedRequest: BaseAuthRequest = {
+            ...request,
+            correlationId: this.correlationId,
+            authority,
+            scopes
+        };
+
+        return validatedRequest;
+    }
+
+    /**
+     *
+     * Use to get the redirect uri configured in MSAL or null.
+     * @param requestRedirectUri
+     * @returns Redirect URL
+     *
+     */
+    protected getRedirectUri(requestRedirectUri?: string): string {
+        this.logger.verbose("getRedirectUri called");
+        const redirectUri = requestRedirectUri || this.config.auth.redirectUri || BrowserUtils.getCurrentUri();
+        return UrlString.getAbsoluteUrl(redirectUri, BrowserUtils.getCurrentUri());
     }
 }

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICrypto, INetworkModule, Logger, AuthenticationResult, AccountInfo, AccountEntity, BaseAuthRequest, AuthenticationScheme, UrlString } from "@azure/msal-common";
+import { ICrypto, INetworkModule, Logger, AuthenticationResult, AccountInfo, AccountEntity, BaseAuthRequest, AuthenticationScheme, UrlString, ServerTelemetryManager, ServerTelemetryRequest } from "@azure/msal-common";
 import { BrowserConfiguration } from "../config/Configuration";
 import { BrowserCacheManager } from "../cache/BrowserCacheManager";
 import { EventHandler } from "../event/EventHandler";
@@ -104,5 +104,25 @@ export abstract class BaseInteractionClient {
         this.logger.verbose("getRedirectUri called");
         const redirectUri = requestRedirectUri || this.config.auth.redirectUri || BrowserUtils.getCurrentUri();
         return UrlString.getAbsoluteUrl(redirectUri, BrowserUtils.getCurrentUri());
+    }
+
+    /**
+     *
+     * @param apiId
+     * @param correlationId
+     * @param forceRefresh
+     */
+    protected initializeServerTelemetryManager(apiId: number, forceRefresh?: boolean): ServerTelemetryManager {
+        this.logger.verbose("initializeServerTelemetryManager called");
+        const telemetryPayload: ServerTelemetryRequest = {
+            clientId: this.config.auth.clientId,
+            correlationId: this.correlationId,
+            apiId: apiId,
+            forceRefresh: forceRefresh || false,
+            wrapperSKU: this.browserStorage.getWrapperMetadata()[0],
+            wrapperVer: this.browserStorage.getWrapperMetadata()[1]
+        };
+
+        return new ServerTelemetryManager(telemetryPayload, this.browserStorage);
     }
 }

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICrypto, Logger, ServerTelemetryManager, ServerTelemetryRequest, CommonAuthorizationCodeRequest, Constants, AuthorizationCodeClient, ClientConfiguration, AuthorityOptions, Authority, AuthorityFactory, ServerAuthorizationCodeResponse, UrlString, CommonEndSessionRequest, ProtocolUtils, ResponseMode, StringUtils } from "@azure/msal-common";
+import { ICrypto, Logger, ServerTelemetryManager, CommonAuthorizationCodeRequest, Constants, AuthorizationCodeClient, ClientConfiguration, AuthorityOptions, Authority, AuthorityFactory, ServerAuthorizationCodeResponse, UrlString, CommonEndSessionRequest, ProtocolUtils, ResponseMode, StringUtils } from "@azure/msal-common";
 import { BaseInteractionClient } from "./BaseInteractionClient";
 import { BrowserConfiguration } from "../config/Configuration";
 import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
@@ -189,26 +189,6 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
 
         this.logger.verbose("Creating discovered authority with configured authority");
         return await AuthorityFactory.createDiscoveredInstance(this.config.auth.authority, this.config.system.networkClient, this.browserStorage, authorityOptions);
-    }
-
-    /**
-     *
-     * @param apiId
-     * @param correlationId
-     * @param forceRefresh
-     */
-    protected initializeServerTelemetryManager(apiId: number, forceRefresh?: boolean): ServerTelemetryManager {
-        this.logger.verbose("initializeServerTelemetryManager called");
-        const telemetryPayload: ServerTelemetryRequest = {
-            clientId: this.config.auth.clientId,
-            correlationId: this.correlationId,
-            apiId: apiId,
-            forceRefresh: forceRefresh || false,
-            wrapperSKU: this.browserStorage.getWrapperMetadata()[0],
-            wrapperVer: this.browserStorage.getWrapperMetadata()[1]
-        };
-
-        return new ServerTelemetryManager(telemetryPayload, this.browserStorage);
     }
 
     /**


### PR DESCRIPTION
WAM integration will need to use several helper functions that are currently one level deeper than they need to be. This moves the necessary helpers up to `BaseInteractionClient` so they can be used by the forthcoming `WamInteractionClient`