### PR TITLE
Add dotenv vscode extension to recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,7 +10,8 @@
         "ms-azure-devops.azure-pipelines",
         "ziyasal.vscode-open-in-github",
         "christian-kohler.npm-intellisense",
-        "ryanluker.vscode-coverage-gutters"
+        "ryanluker.vscode-coverage-gutters",
+        "mikestead.dotenv"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [


### PR DESCRIPTION
Adds this extension for better `.env` syntax support: https://marketplace.visualstudio.com/items?itemName=mikestead.dotenv