### PR TITLE
Dynamically generate release PR title

### DIFF
--- a/.github/workflows/release_automate.yml
+++ b/.github/workflows/release_automate.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && !contains(github.head_ref, 'release')
-    name: Bump versions and create changelog PR --updation
+    name: Bump versions and create changelogs
     runs-on: ubuntu-latest
     env:
       BEACHBALL: 1
@@ -32,6 +32,10 @@ jobs:
       - name: bump package versions
         run: npm run beachball:bump
 
+      - name: Get release date
+        id: release-date
+        run: echo "::set-output name=date::$(node release-scripts/getReleaseDate.js)"
+
       # Create/update Pull Request
       - name: Create Pull Request
         id: pr
@@ -39,7 +43,7 @@ jobs:
         with:
           commit-message: Bump package versions
           branch: release-staging
-          title: "Next release"
+          title: "${{ steps.release-date.outputs.date }} Release"
           body: |
-            Release PR : This PR contains the changelogs and version bumps for the next releases.
+            Release PR : This PR contains the changelogs and version bumps for the ${{ steps.month.outputs.month }} releases.
           draft: true

--- a/release-scripts/getReleaseDate.js
+++ b/release-scripts/getReleaseDate.js
@@ -1,0 +1,21 @@
+const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const date = new Date();
+const currentDay = date.getDate();
+const currentDayOfWeek = date.getDay();
+let month = date.getMonth();
+let year = date.getFullYear();
+
+const releaseDay = 1; // Monday
+const dateOfNextRelease = (7 + releaseDay - currentDayOfWeek) % 7 + currentDay;
+if (dateOfNextRelease > 7) {
+    // If date of next release is not 1-6, this month's release has already happened and we should prepare next month's release instead
+    if (month === 11) {
+        // New year
+        month = 0;
+        year++;
+    } else {
+        month++;
+    }
+}
+
+console.log(months[month], year);


### PR DESCRIPTION
Adds the month of the next release to the title of the release PR that is opened on merges to the dev branch

For example the currently open PR will be renamed to "October 2021 Release"