### PR TITLE
Consistently export error types thrown by msal-browser

### DIFF
--- a/change/@azure-msal-browser-5d9d1587-039a-4462-8dd3-b48d09664add.json
+++ b/change/@azure-msal-browser-5d9d1587-039a-4462-8dd3-b48d09664add.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Consistently export error types and messages for errors thrown by msal-browser.",
+  "comment": "Consistently export error types and messages for errors thrown by MSAL.",
   "packageName": "@azure/msal-browser",
   "email": "jagore@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-5d9d1587-039a-4462-8dd3-b48d09664add.json
+++ b/change/@azure-msal-browser-5d9d1587-039a-4462-8dd3-b48d09664add.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Consistently export error types and messages for errors thrown by msal-browser.",
+  "packageName": "@azure/msal-browser",
+  "email": "jagore@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-5d9d1587-039a-4462-8dd3-b48d09664add.json
+++ b/change/@azure-msal-browser-5d9d1587-039a-4462-8dd3-b48d09664add.json
@@ -1,6 +1,6 @@
 {
-  "type": "minor",
-  "comment": "Consistently export error types and messages for errors thrown by MSAL.",
+  "type": "patch",
+  "comment": "Consistently export error types and messages for errors thrown by MSAL #4117",
   "packageName": "@azure/msal-browser",
   "email": "jagore@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-7aa16f1c-8c7e-45db-b518-f5dbb0c48ea3.json
+++ b/change/@azure-msal-common-7aa16f1c-8c7e-45db-b518-f5dbb0c48ea3.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Consistently export error types and messages for errors thrown by msal-browser.",
+  "comment": "Consistently export error types and messages for errors thrown by MSAL.",
   "packageName": "@azure/msal-common",
   "email": "jagore@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-7aa16f1c-8c7e-45db-b518-f5dbb0c48ea3.json
+++ b/change/@azure-msal-common-7aa16f1c-8c7e-45db-b518-f5dbb0c48ea3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Consistently export error types and messages for errors thrown by msal-browser.",
+  "packageName": "@azure/msal-common",
+  "email": "jagore@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-7aa16f1c-8c7e-45db-b518-f5dbb0c48ea3.json
+++ b/change/@azure-msal-common-7aa16f1c-8c7e-45db-b518-f5dbb0c48ea3.json
@@ -1,6 +1,6 @@
 {
-  "type": "minor",
-  "comment": "Consistently export error types and messages for errors thrown by MSAL.",
+  "type": "patch",
+  "comment": "Consistently export error types and messages for errors thrown by MSAL #4117",
   "packageName": "@azure/msal-common",
   "email": "jagore@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-node-c27ce924-c732-41ee-adff-ed3093aafbed.json
+++ b/change/@azure-msal-node-c27ce924-c732-41ee-adff-ed3093aafbed.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Consistently export error types and messages for errors thrown by msal-browser.",
+  "comment": "Consistently export error types and messages for errors thrown by MSAL.",
   "packageName": "@azure/msal-node",
   "email": "jagore@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-node-c27ce924-c732-41ee-adff-ed3093aafbed.json
+++ b/change/@azure-msal-node-c27ce924-c732-41ee-adff-ed3093aafbed.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Consistently export error types and messages for errors thrown by msal-browser.",
+  "packageName": "@azure/msal-node",
+  "email": "jagore@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-c27ce924-c732-41ee-adff-ed3093aafbed.json
+++ b/change/@azure-msal-node-c27ce924-c732-41ee-adff-ed3093aafbed.json
@@ -1,6 +1,6 @@
 {
-  "type": "minor",
-  "comment": "Consistently export error types and messages for errors thrown by MSAL.",
+  "type": "patch",
+  "comment": "Consistently export error types and messages for errors thrown by MSAL #4117",
   "packageName": "@azure/msal-node",
   "email": "jagore@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -47,12 +47,14 @@ export {
     // Response
     AuthenticationResult,
     // Error
-    InteractionRequiredAuthError,
-    InteractionRequiredAuthErrorMessage,
     AuthError,
     AuthErrorMessage,
     ClientAuthError,
     ClientAuthErrorMessage,
+    ClientConfigurationError,
+    ClientConfigurationErrorMessage,
+    InteractionRequiredAuthError,
+    InteractionRequiredAuthErrorMessage,
     ServerError,
     // Network
     INetworkModule,

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -48,8 +48,12 @@ export {
     AuthenticationResult,
     // Error
     InteractionRequiredAuthError,
+    InteractionRequiredAuthErrorMessage,
     AuthError,
     AuthErrorMessage,
+    ClientAuthError,
+    ClientAuthErrorMessage,
+    ServerError,
     // Network
     INetworkModule,
     NetworkResponse,

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -78,7 +78,7 @@ export { ScopeSet } from "./request/ScopeSet";
 // Logger Callback
 export { ILoggerCallback, LogLevel, Logger } from "./logger/Logger";
 // Errors
-export { InteractionRequiredAuthError } from "./error/InteractionRequiredAuthError";
+export { InteractionRequiredAuthError, InteractionRequiredAuthErrorMessage } from "./error/InteractionRequiredAuthError";
 export { AuthError, AuthErrorMessage } from "./error/AuthError";
 export { ServerError } from "./error/ServerError";
 export { ClientAuthError, ClientAuthErrorMessage } from "./error/ClientAuthError";

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -51,12 +51,13 @@ export {
     // Error
     AuthError,
     AuthErrorMessage,
-    InteractionRequiredAuthError,
-    ServerError,
     ClientAuthError,
     ClientAuthErrorMessage,
     ClientConfigurationError,
     ClientConfigurationErrorMessage,
+    InteractionRequiredAuthError,
+    InteractionRequiredAuthErrorMessage,
+    ServerError,
     // Network Interface
     INetworkModule,
     NetworkRequestOptions,


### PR DESCRIPTION
Consistently exports error types thrown by `msal-browser` per #4115.

Resolves #4115 