### PR TITLE
Fix node extensions beachball bump

### DIFF
--- a/change/@azure-msal-angular-21727384-afef-4632-b791-fc7ccb8406ba.json
+++ b/change/@azure-msal-angular-21727384-afef-4632-b791-fc7ccb8406ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disallow major bumps",
+  "packageName": "@azure/msal-angular",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-browser-66228f71-938f-4236-b100-1efc13a71386.json
+++ b/change/@azure-msal-browser-66228f71-938f-4236-b100-1efc13a71386.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disallow major bumps",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-node-49a54e51-6f76-4091-a9ee-71918de2f248.json
+++ b/change/@azure-msal-node-49a54e51-6f76-4091-a9ee-71918de2f248.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disallow major bumps",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-node-extensions-eec3de90-af9b-4bcc-b3e5-d9af82025a79.json
+++ b/change/@azure-msal-node-extensions-eec3de90-af9b-4bcc-b3e5-d9af82025a79.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update beachball config",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-react-b2f4225a-da79-4b88-a10d-cc0a2c8bdc66.json
+++ b/change/@azure-msal-react-b2f4225a-da79-4b88-a10d-cc0a2c8bdc66.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disallow major bumps",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/msal-cbeac37d-4179-45a1-8a3c-668e52a40e08.json
+++ b/change/msal-cbeac37d-4179-45a1-8a3c-668e52a40e08.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disallow major bumps",
+  "packageName": "msal",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/extensions/msal-node-extensions/package.json
+++ b/extensions/msal-node-extensions/package.json
@@ -36,6 +36,9 @@
     "url": "https://www.microsoft.com"
   },
   "module": "dist/test.esm.js",
+  "beachball": {
+    "disallowedChangeTypes": ["patch", "minor", "major"]
+  },
   "dependencies": {
     "@azure/msal-common": "^5.0.0",
     "bindings": "git://github.com/samuelkubai/node-bindings.git#v1.6.0",

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -31,6 +31,9 @@
   },
   "main": "./dist/bundles/azure-msal-angular.umd.js",
   "typings": "./dist/azure-msal-angular.d.ts",
+  "beachball": {
+    "disallowedChangeTypes": ["major"]
+  },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1102.11",
     "@angular/animations": "~11.2.12",

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -28,6 +28,9 @@
   "engines": {
     "node": ">=0.8.0"
   },
+  "beachball": {
+    "disallowedChangeTypes": ["major"]
+  },
   "directories": {
     "test": "test"
   },

--- a/lib/msal-core/package.json
+++ b/lib/msal-core/package.json
@@ -26,6 +26,9 @@
   "engines": {
     "node": ">=0.8.0"
   },
+  "beachball": {
+    "disallowedChangeTypes": ["major"]
+  },
   "scripts": {
     "cdn": "npm run build && npm run cdn:upload && npm run cdn:sri",
     "cdn:upload": "node ./cdn-upload.js",

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -53,6 +53,9 @@
       "<rootDir>/test/**/*.spec.ts"
     ]
   },
+  "beachball": {
+    "disallowedChangeTypes": ["major"]
+  },
   "module": "dist/msal-node.esm.js",
   "devDependencies": {
     "@types/jest": "^25.2.3",

--- a/lib/msal-react/package.json
+++ b/lib/msal-react/package.json
@@ -20,6 +20,9 @@
   "engines": {
     "node": ">=10"
   },
+  "beachball": {
+    "disallowedChangeTypes": ["major"]
+  },
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build --tsconfig ./tsconfig.build.json",


### PR DESCRIPTION
- Disallows change types other than `prerelease` and `none` for msal-node-extensions, preventing unexpected bumps to `1.0.0`
- Disallows major version bumps in all other packages (with the exception of msal-common)