### PR TITLE
Remove user hint requirement on ssoSilent API

### DIFF
--- a/change/@azure-msal-angular-696d0cf4-bd65-4b35-b426-786857e97f89.json
+++ b/change/@azure-msal-angular-696d0cf4-bd65-4b35-b426-786857e97f89.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs update for ssoSilent #4123",
+  "packageName": "@azure/msal-angular",
+  "email": "prkanher@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-browser-b1bbc41b-8045-4fe7-8f7c-3e0eff7d177d.json
+++ b/change/@azure-msal-browser-b1bbc41b-8045-4fe7-8f7c-3e0eff7d177d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove requirement of user hint on ssoSilent API #4123",
+  "packageName": "@azure/msal-browser",
+  "email": "prkanher@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-react-bf95a9c8-65e5-4362-9e2f-7da9ed29069d.json
+++ b/change/@azure-msal-react-bf95a9c8-65e5-4362-9e2f-7da9ed29069d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "docs update for ssoSilent #4123",
+  "packageName": "@azure/msal-react",
+  "email": "prkanher@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-angular/docs/v2-docs/ssosilent.md
+++ b/lib/msal-angular/docs/v2-docs/ssosilent.md
@@ -1,7 +1,16 @@
 # Silent login with ssoSilent()
 
 If you already have a session that exists with the authentication server, you can use the `ssoSilent()` API to make a request for tokens without interaction.
-You will need to pass a `loginHint` in the request object in order to successfully obtain a token silently. The `loginHint` can be retrieved from the account object `username` property or the `upn` claim in the ID token, and can also be retrieved from the `emails` claim for B2C use cases. Alternatively, `sid` can be passed instead of `loginHint` for AAD use cases.
+
+## With User Hint
+
+If you already have the user's sign-in information, you can pass this into the API to improve performance and ensure that the authorization server will look for the correct account session. You can pass one of the following into the request object in order to successfully obtain a token silently.
+
+- `account` (which can be retrieved using on of the [account APIs](./accounts.md))
+- `sid` (which can be retrieved from the `idTokenClaims` of an `account` object)
+- `login_hint` (which can be retrieved from the account object `username` property or the `upn` claim in the ID token)
+
+Passing an account will look for sid in the token claims, then fall back to loginHint (if provided) or account username.
 
 ```js
 const silentRequest: SsoSilentRequest = {
@@ -15,6 +24,26 @@ this.authService.ssoSilent(silentRequest)
         error: (error) => console.log(error) // Handle error
     });
 ```
+
+## Without User Hint
+
+If there is not enough information available about the user, you can attempt to use the `ssoSilent` API **without** passing an `account`, `sid` or `login_hint`.
+
+```javascript
+const silentRequest = {
+    scopes: ["User.Read", "Mail.Read"]
+};
+```
+
+However, be aware that if your application has code paths for multiple users in a single browser session, or if the user has multiple accounts for that single browser session, then there is a higher likelihood of silent sign-in errors. You may see the following error show up in the event of multiple account sessions found by the authorization server:
+
+```txt
+InteractionRequiredAuthError: interaction_required: AADSTS16000: Either multiple user identities are available for the current request or selected account is not supported for the scenario.
+```
+
+This indicates that the server could not determine which account to sign into, and will require either one of the parameters above (`account`, `login_hint`, `sid`) or an interactive sign-in to choose the account.
+
+## Handling Failures
 
 If ssoSilent() fails, we recommend handling this error by logging in interactively. Here is an example of ssoSilent() being used in an application's `app.component.ts`:
 

--- a/lib/msal-browser/docs/iframe-usage.md
+++ b/lib/msal-browser/docs/iframe-usage.md
@@ -25,7 +25,11 @@ Iframed and parent apps with the same-origin may have access to the same MSAL.js
 
 ### Apps with cross-origin
 
-Iframed and parent apps with cross-origin can make use of the [ssoSilent()](./login-user.md#silent-login-with-ssosilent) API to achieve single sign-on. To do so, the parent app needs to pass down either an **account**, a **loginHint** (username) or a **session id** (sid) to the iframed app. For cross-origin communication between iframed and parent apps, there are a few alternatives you can consider:
+Iframed and parent apps with cross-origin can make use of the [ssoSilent()](./login-user.md#silent-login-with-ssosilent) API to achieve single sign-on. To do so, the parent app should pass down either an **account**, a **loginHint** (username) or a **session id** (sid) to the iframed app. 
+
+Apps can attempt to use `ssoSilent` without any of the above parameters. However be aware that there are [additional considerations](./login-user.md#silent-login-with-ssosilent) when using `ssoSilent` without providing any information about the user's session.
+
+For cross-origin communication between iframed and parent apps, there are a few alternatives you can consider:
 
 - You can add query strings to iframe's source in the parent app and retrieve them later in the child:
 

--- a/lib/msal-browser/docs/login-user.md
+++ b/lib/msal-browser/docs/login-user.md
@@ -97,7 +97,7 @@ These APIs will return an account object or an array of account objects with the
 
 ## Silent login with ssoSilent()
 
-If you already have a session that exists with the authentication server, you can use the ssoSilent() API to make request for tokens without interaction.
+If you already have a session that exists with the authentication server, you can use the ssoSilent() API to make requests for tokens without interaction.
 
 ### With User Hint
 

--- a/lib/msal-browser/docs/login-user.md
+++ b/lib/msal-browser/docs/login-user.md
@@ -97,7 +97,11 @@ These APIs will return an account object or an array of account objects with the
 
 ## Silent login with ssoSilent()
 
-If you already have a session that exists with the authentication server, you can use the ssoSilent() API to make request for tokens without interaction. You will need to pass one of the following into the request object in order to successfully obtain a token silently.
+### With User Hint
+
+If you already have a session that exists with the authentication server, you can use the ssoSilent() API to make request for tokens without interaction.
+
+If you already have the user's sign-in information, you can pass this into the API to improve performance and ensure that the authorization server will look for the correct account session. You can pass one of the following into the request object in order to successfully obtain a token silently.
 
 - `account` (which can be retrieved using on of the [account APIs](./accounts.md))
 - `sid` (which can be retrieved from the `idTokenClaims` of an `account` object)
@@ -123,6 +127,24 @@ try {
     }
 }
 ```
+
+### Without User Hint
+
+If there is not enough information available about the user, you can attempt to use the `ssoSilent` API **without** passing an `account`, `sid` or `login_hint`.
+
+```javascript
+const silentRequest = {
+    scopes: ["User.Read", "Mail.Read"]
+};
+```
+
+However, be aware that if your application has code paths for multiple users in a single browser session, or if the user has multiple accounts for that single browser session, then there is a higher likelihood of silent sign-in errors. You may see the following error show up in the event of multiple account session found by the authorization server:
+
+```txt
+InteractionRequiredAuthError: interaction_required: AADSTS16000: Either multiple user identities are available for the current request or selected account is not supported for the scenario.
+```
+
+This indicates that the server could not determine which account to sign into, and will require either one of the parameters above (`account`, `login_hint`, `sid`) or an interactive sign-in to choose the account.
 
 ## RedirectUri Considerations
 

--- a/lib/msal-browser/docs/login-user.md
+++ b/lib/msal-browser/docs/login-user.md
@@ -97,9 +97,9 @@ These APIs will return an account object or an array of account objects with the
 
 ## Silent login with ssoSilent()
 
-### With User Hint
-
 If you already have a session that exists with the authentication server, you can use the ssoSilent() API to make request for tokens without interaction.
+
+### With User Hint
 
 If you already have the user's sign-in information, you can pass this into the API to improve performance and ensure that the authorization server will look for the correct account session. You can pass one of the following into the request object in order to successfully obtain a token silently.
 

--- a/lib/msal-browser/docs/login-user.md
+++ b/lib/msal-browser/docs/login-user.md
@@ -138,7 +138,7 @@ const silentRequest = {
 };
 ```
 
-However, be aware that if your application has code paths for multiple users in a single browser session, or if the user has multiple accounts for that single browser session, then there is a higher likelihood of silent sign-in errors. You may see the following error show up in the event of multiple account session found by the authorization server:
+However, be aware that if your application has code paths for multiple users in a single browser session, or if the user has multiple accounts for that single browser session, then there is a higher likelihood of silent sign-in errors. You may see the following error show up in the event of multiple account sessions found by the authorization server:
 
 ```txt
 InteractionRequiredAuthError: interaction_required: AADSTS16000: Either multiple user identities are available for the current request or selected account is not supported for the scenario.

--- a/lib/msal-browser/src/error/BrowserAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserAuthError.ts
@@ -85,10 +85,6 @@ export const BrowserAuthErrorMessage = {
         code: "iframe_closed_prematurely",
         desc: "The iframe being monitored was closed prematurely."
     },
-    silentSSOInsufficientInfoError: {
-        code: "silent_sso_error",
-        desc: "Silent SSO could not be completed - insufficient information was provided. Please provide either a loginHint or sid."
-    },
     silentLogoutUnsupportedError: {
         code: "silent_logout_unsupported",
         desc: "Silent logout not supported. Please call logoutRedirect or logoutPopup instead."
@@ -317,13 +313,6 @@ export class BrowserAuthError extends AuthError {
      */
     static createIframeClosedPrematurelyError(): BrowserAuthError {
         return new BrowserAuthError(BrowserAuthErrorMessage.iframeClosedPrematurelyError.code, BrowserAuthErrorMessage.iframeClosedPrematurelyError.desc);
-    }
-
-    /**
-     * Creates an error thrown when the login_hint, sid or account object is not provided in the ssoSilent API.
-     */
-    static createSilentSSOInsufficientInfoError(): BrowserAuthError {
-        return new BrowserAuthError(BrowserAuthErrorMessage.silentSSOInsufficientInfoError.code, BrowserAuthErrorMessage.silentSSOInsufficientInfoError.desc);
     }
 
     /**

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthenticationResult, ICrypto, Logger, PromptValue, CommonAuthorizationCodeRequest, AuthorizationCodeClient, AuthError } from "@azure/msal-common";
+import { AuthenticationResult, ICrypto, Logger, StringUtils, PromptValue, CommonAuthorizationCodeRequest, AuthorizationCodeClient, AuthError } from "@azure/msal-common";
 import { StandardInteractionClient } from "./StandardInteractionClient";
 import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
 import { BrowserConfiguration } from "../config/Configuration";
@@ -29,6 +29,10 @@ export class SilentIframeClient extends StandardInteractionClient {
      */
     async acquireToken(request: SsoSilentRequest): Promise<AuthenticationResult> {
         this.logger.verbose("acquireTokenByIframe called");
+        // Check that we have some SSO data
+        if (StringUtils.isEmpty(request.loginHint) && StringUtils.isEmpty(request.sid) && (!request.account || StringUtils.isEmpty(request.account.username))) {
+            this.logger.warning("No user hint provided. The authorization server may need more information to complete this request.");
+        }
 
         // Check that prompt is set to none, throw error if it is set to anything else.
         if (request.prompt && request.prompt !== PromptValue.NONE) {

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthenticationResult, ICrypto, Logger, StringUtils, PromptValue, CommonAuthorizationCodeRequest, AuthorizationCodeClient, AuthError } from "@azure/msal-common";
+import { AuthenticationResult, ICrypto, Logger, PromptValue, CommonAuthorizationCodeRequest, AuthorizationCodeClient, AuthError } from "@azure/msal-common";
 import { StandardInteractionClient } from "./StandardInteractionClient";
 import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
 import { BrowserConfiguration } from "../config/Configuration";
@@ -29,10 +29,6 @@ export class SilentIframeClient extends StandardInteractionClient {
      */
     async acquireToken(request: SsoSilentRequest): Promise<AuthenticationResult> {
         this.logger.verbose("acquireTokenByIframe called");
-        // Check that we have some SSO data
-        if (StringUtils.isEmpty(request.loginHint) && StringUtils.isEmpty(request.sid) && (!request.account || StringUtils.isEmpty(request.account.username))) {
-            throw BrowserAuthError.createSilentSSOInsufficientInfoError();
-        }
 
         // Check that prompt is set to none, throw error if it is set to anything else.
         if (request.prompt && request.prompt !== PromptValue.NONE) {

--- a/lib/msal-browser/test/error/BrowserAuthError.spec.ts
+++ b/lib/msal-browser/test/error/BrowserAuthError.spec.ts
@@ -229,20 +229,7 @@ describe("BrowserAuthError Unit Tests", () => {
         expect(err.stack?.includes("BrowserAuthError.spec.ts")).toBe(true);
     });
 
-    it("createSilentSSOInsufficientInfoError()", () => {
-        const err: BrowserAuthError = BrowserAuthError.createSilentSSOInsufficientInfoError();
-
-        expect(err instanceof BrowserAuthError).toBe(true);
-        expect(err instanceof AuthError).toBe(true);
-        expect(err instanceof Error).toBe(true);
-        expect(err.errorCode).toBe(BrowserAuthErrorMessage.silentSSOInsufficientInfoError.code);
-        expect(err.errorMessage.includes(BrowserAuthErrorMessage.silentSSOInsufficientInfoError.desc)).toBe(true);
-        expect(err.message.includes(BrowserAuthErrorMessage.silentSSOInsufficientInfoError.desc)).toBe(true);
-        expect(err.name).toBe("BrowserAuthError");
-        expect(err.stack?.includes("BrowserAuthError.spec.ts")).toBe(true);
-    });
-
-    it("createSilentSSOInsufficientInfoError()", () => {
+    it("createSilentPromptValueError()", () => {
         const promptVal = "notAPrompt";
         const err: BrowserAuthError = BrowserAuthError.createSilentPromptValueError(promptVal);
 

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -34,13 +34,6 @@ describe("SilentIframeClient", () => {
     });
 
     describe("acquireToken", () => {
-        it("throws error if loginHint or sid are empty", async () => {
-            await expect(silentIframeClient.acquireToken({
-                redirectUri: TEST_URIS.TEST_REDIR_URI,
-                scopes: [TEST_CONFIG.MSAL_CLIENT_ID]
-            })).rejects.toMatchObject(BrowserAuthError.createSilentSSOInsufficientInfoError());
-        });
-
         it("throws error if prompt is not set to 'none'", async () => {
             const req: CommonAuthorizationUrlRequest = {
                 redirectUri: TEST_URIS.TEST_REDIR_URI,

--- a/lib/msal-react/docs/hooks.md
+++ b/lib/msal-react/docs/hooks.md
@@ -123,7 +123,7 @@ Docs for the APIs `PublicClientApplication` exposes can be found in the `@azure/
 
 The `useMsalAuthentication` hook will initiate a login if a user is not already signed in. It accepts an `interactionType` ("Popup", "Redirect", or "Silent") and optionally accepts a [request object](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/msal-react-feature-branch/lib/msal-browser/docs/request-response-object.md#request) and an `accountIdentifiers` object if you would like to ensure a specific user is signed in. The hook will return the `response` or `error` from the login call and the `login` callback which can be used to retry a failed login.
 
-Note: Passing the "Silent" interaction type will call `ssoSilent` which attempts to open a hidden iframe and reuse an existing session with AAD. This will not work in browsers that block 3rd party cookies such as Safari. Additionally, when using the "Silent" type the request object is required and must contain either a `loginHint` or `sid` parameter.
+Note: Passing the "Silent" interaction type will call `ssoSilent` which attempts to open a hidden iframe and reuse an existing session with AAD. This will not work in browsers that block 3rd party cookies such as Safari. Additionally, when using the "Silent" type the request object is required and should contain either a `loginHint` or `sid` parameter.
 
 ### `ssoSilent` example
 

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/auth.js
@@ -1,0 +1,115 @@
+// Browser check variables
+// If you support IE, our recommendation is that you sign-in using Redirect APIs
+// If you as a developer are testing using Edge InPrivate mode, please add "isEdge" to the if check
+const ua = window.navigator.userAgent;
+const msie = ua.indexOf("MSIE ");
+const msie11 = ua.indexOf("Trident/");
+const msedge = ua.indexOf("Edge/");
+const isIE = msie > 0 || msie11 > 0;
+const isEdge = msedge > 0;
+
+let signInType;
+let accountId = "";
+
+// Create the main myMSALObj instance
+// configuration parameters are located at authConfig.js
+const myMSALObj = new msal.PublicClientApplication(msalConfig);
+
+// Redirect: once login is successful and redirects with tokens, call Graph API
+myMSALObj.handleRedirectPromise().then(handleResponse).catch(err => {
+    console.error(err);
+});
+
+function handleResponse(resp) {
+    if (resp !== null) {
+        accountId = resp.account.homeAccountId;
+        myMSALObj.setActiveAccount(resp.account);
+        showWelcomeMessage(resp.account);
+    } else {
+        // need to call getAccount here?
+        const currentAccounts = myMSALObj.getAllAccounts();
+        if (!currentAccounts || currentAccounts.length < 1) {
+            myMSALObj.ssoSilent(loginRequest).then((response) => {
+                accountId = response.account.homeAccountId;
+                showWelcomeMessage(response.account);
+                getTokenRedirect(loginRequest, response.account);
+            }).catch(error => {
+                console.error("Silent Error: " + error);
+                if (error instanceof msal.InteractionRequiredAuthError) {
+                    myMSALObj.ssoSilent(silentRequest).then((response) => {
+                        accountId = response.account.homeAccountId;
+                        showWelcomeMessage(response.account);
+                        getTokenRedirect(loginRequest, response.account);
+                    }).catch(err => {
+                        console.error("Silent Error: " + err);
+                        if (err instanceof msal.InteractionRequiredAuthError) {
+                            console.log("popup sign in")
+                            signIn("popup");
+                        }
+                    })
+                }
+            });
+            return;
+        } else if (currentAccounts.length > 1) {
+            // Add choose account code here
+        } else if (currentAccounts.length === 1) {
+            const activeAccount = currentAccounts[0];
+            myMSALObj.setActiveAccount(activeAccount);
+            accountId = activeAccount.homeAccountId;
+            showWelcomeMessage(activeAccount);
+        }
+    }
+}
+
+async function signIn(method) {
+    signInType = isIE ? "redirect" : method;
+    if (signInType === "popup") {
+        return myMSALObj.loginPopup(loginRequest).then(handleResponse).catch(function (error) {
+            console.log(error);
+        });
+    } else if (signInType === "redirect") {
+        return myMSALObj.loginRedirect(loginRequest)
+    }
+}
+
+function signOut(interactionType) {
+    const logoutRequest = {
+        account: myMSALObj.getAccountByHomeId(accountId)
+    };
+
+    if (interactionType === "popup") {
+        myMSALObj.logoutPopup(logoutRequest).then(() => {
+            window.location.reload();
+        });
+    } else {
+        myMSALObj.logoutRedirect(logoutRequest);
+    }
+}
+
+async function getTokenPopup(request, account) {
+    return await myMSALObj.acquireTokenSilent(request).catch(async (error) => {
+        console.log("silent token acquisition fails.");
+        if (error instanceof msal.InteractionRequiredAuthError) {
+            console.log("acquiring token using popup");
+            return myMSALObj.acquireTokenPopup(request).catch(error => {
+                console.error(error);
+            });
+        } else {
+            console.error(error);
+        }
+    });
+}
+
+// This function can be removed if you do not need to support IE
+async function getTokenRedirect(request, account) {
+    return await myMSALObj.acquireTokenSilent(request).catch(async (error) => {
+        console.log("silent token acquisition fails.");
+        if (error instanceof msal.InteractionRequiredAuthError) {
+            // fallback to interaction when silent call fails
+            console.log("acquiring token using redirect");
+            myMSALObj.acquireTokenRedirect(request);
+        } else {
+            console.error(error);
+        }
+    });
+}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/authConfig.js
@@ -1,0 +1,57 @@
+// Config object to be passed to Msal on creation
+const msalConfig = {
+    auth: {
+        clientId: "3fba556e-5d4a-48e3-8e1a-fd57c12cb82e",
+        authority: "https://login.windows-ppe.net/common/"
+    },
+    cache: {
+        cacheLocation: "sessionStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        loggerOptions: {
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {	
+                    return;	
+                }
+                switch (level) {	
+                    case msal.LogLevel.Error:	
+                        console.error(message);	
+                        return;	
+                    case msal.LogLevel.Info:	
+                        console.info(message);	
+                        return;	
+                    case msal.LogLevel.Verbose:	
+                        console.debug(message);	
+                        return;	
+                    case msal.LogLevel.Warning:	
+                        console.warn(message);	
+                        return;	
+                }
+            }
+        }
+    }
+};
+
+// Add here scopes for id token to be used at MS Identity Platform endpoints.
+const loginRequest = {
+    scopes: ["User.Read"]
+};
+
+// Add here the endpoints for MS Graph API services you would like to use.
+const graphConfig = {
+    graphMeEndpoint: "https://graph.microsoft-ppe.com/v1.0/me",
+    graphMailEndpoint: "https://graph.microsoft-ppe.com/v1.0/me/messages"
+};
+
+// Add here scopes for access token to be used at MS Graph API endpoints.
+const tokenRequest = {
+    scopes: ["Mail.Read"],
+    forceRefresh: false // Set this to "true" to skip a cached token and go to the server to get a new token
+};
+
+const silentRequest = {
+    loginHint: "IDLAB@msidlab0.ccsctp.net"
+};
+
+const logoutRequest = {}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/graph.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/graph.js
@@ -1,0 +1,64 @@
+// Helper function to call MS Graph API endpoint 
+// using authorization bearer token scheme
+function callMSGraph(endpoint, accessToken, callback) {
+    const headers = new Headers();
+    const bearer = `Bearer ${accessToken}`;
+
+    headers.append("Authorization", bearer);
+
+    const options = {
+        method: "GET",
+        headers: headers
+    };
+
+    console.log('request made to Graph API at: ' + new Date().toString());
+
+    fetch(endpoint, options)
+        .then(response => response.json())
+        .then(response => callback(response, endpoint))
+        .catch(error => console.log(error));
+}
+
+async function seeProfile() {
+    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
+    if (currentAcc) {
+        const response = await getTokenPopup(loginRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+        profileButton.style.display = 'none';
+    }
+}
+
+async function readMail() {
+    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
+    if (currentAcc) {
+        const response = await getTokenPopup(tokenRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMailEndpoint, response.accessToken, updateUI);
+        mailButton.style.display = 'none';
+    }
+}
+
+async function seeProfileRedirect() {
+    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
+    if (currentAcc) {
+        const response = await getTokenRedirect(loginRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+        profileButton.style.display = 'none';
+    }
+}
+
+async function readMailRedirect() {
+    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
+    if (currentAcc) {
+        const response = await getTokenRedirect(tokenRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMailEndpoint, response.accessToken, updateUI);
+        mailButton.style.display = 'none';
+    }
+}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/index.html
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>Quickstart | MSAL.JS Vanilla JavaScript SPA</title>
+    
+    <script src="../../lib/msal-browser.js"></script>
+    
+    <!-- adding Bootstrap 4 for UI components  -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link rel="SHORTCUT ICON" href="https://c.s-microsoft.com/favicon.ico?v2" type="image/x-icon">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <a class="navbar-brand" href="/">MS Identity Platform</a>
+      <div class="btn-group ml-auto dropleft">
+          <button type="button" id="SignIn" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Sign In
+          </button>
+          <div class="dropdown-menu">
+            <button class="dropdown-item" id="popup" onclick="signIn(this.id)">Sign in using Popup</button>
+            <button class="dropdown-item" id="redirect" onclick="signIn(this.id)">Sign in using Redirect</button>
+          </div>
+      </div>
+    </nav>
+    <br>
+    <h5 class="card-header text-center">Vanilla JavaScript SPA calling MS Graph API with MSAL.JS</h5>
+    <br>
+    <div class="row" style="margin:auto" >
+    <div id="card-div" class="col-md-3" style="display:none">
+    <div class="card text-center">
+      <div class="card-body">
+        <h5 class="card-title" id="WelcomeMessage">Please sign-in to see your profile and read your mails</h5>
+        <div id="profile-div"></div>
+        <br>
+        <br>
+        <button class="btn btn-primary" id="seeProfile" onclick="seeProfile()">See Profile</button>
+        <br>
+        <br>
+        <button class="btn btn-primary" id="readMail" onclick="readMail()">Read Mails</button>
+      </div>
+    </div>
+    </div>
+    <br>
+    <br>
+      <div class="col-md-4">
+        <div class="list-group" id="list-tab" role="tablist">
+        </div>
+      </div>
+      <div class="col-md-5">
+        <div class="tab-content" id="nav-tabContent">
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+
+    <!-- importing bootstrap.js and supporting js libraries -->
+    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>  
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    
+    <!-- importing app scripts | load order is important -->
+    <script type="text/javascript" src="./authConfig.js"></script>
+    <script type="text/javascript" src="./ui.js"></script>  
+    <script type="text/javascript" src="./auth.js"></script>
+    <script type="text/javascript" src="./graph.js"></script>
+  </body>
+</html>

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/ui.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/ssoSilentNoHint/ui.js
@@ -1,0 +1,70 @@
+// Select DOM elements to work with
+const welcomeDiv = document.getElementById("WelcomeMessage");
+const signInButton = document.getElementById("SignIn");
+const popupButton = document.getElementById("popup");
+const redirectButton = document.getElementById("redirect");
+const cardDiv = document.getElementById("card-div");
+const mailButton = document.getElementById("readMail");
+const profileButton = document.getElementById("seeProfile");
+const profileDiv = document.getElementById("profile-div");
+
+function showWelcomeMessage(account) {
+    // Reconfiguring DOM elements
+    cardDiv.style.display = 'initial';
+    welcomeDiv.innerHTML = `Welcome ${account.username}`;
+    signInButton.setAttribute('class', "btn btn-success dropdown-toggle");
+    signInButton.innerHTML = "Sign Out";
+    popupButton.setAttribute('onClick', "signOut(this.id)");
+    popupButton.innerHTML = "Sign Out with Popup";
+    redirectButton.setAttribute('onClick', "signOut(this.id)");
+    redirectButton.innerHTML = "Sign Out with Redirect";
+}
+
+function updateUI(data, endpoint) {
+    console.log('Graph API responded at: ' + new Date().toString());
+
+    if (endpoint === graphConfig.graphMeEndpoint) {
+        const title = document.createElement('p');
+        title.innerHTML = "<strong>Title: </strong>" + data.jobTitle;
+        const email = document.createElement('p');
+        email.innerHTML = "<strong>Mail: </strong>" + data.mail;
+        const phone = document.createElement('p');
+        phone.innerHTML = "<strong>Phone: </strong>" + data.businessPhones[0];
+        const address = document.createElement('p');
+        address.innerHTML = "<strong>Location: </strong>" + data.officeLocation;
+        profileDiv.appendChild(title);
+        profileDiv.appendChild(email);
+        profileDiv.appendChild(phone);
+        profileDiv.appendChild(address);
+    } else if (endpoint === graphConfig.graphMailEndpoint) {
+        if (data.value.length < 1) {
+            alert("Your mailbox is empty!")
+        } else {
+            const tabList = document.getElementById("list-tab");
+            const tabContent = document.getElementById("nav-tabContent");
+
+            data.value.map((d, i) => {
+                // Keeping it simple
+                if (i < 10) {
+                    const listItem = document.createElement("a");
+                    listItem.setAttribute("class", "list-group-item list-group-item-action")
+                    listItem.setAttribute("id", "list" + i + "list")
+                    listItem.setAttribute("data-toggle", "list")
+                    listItem.setAttribute("href", "#list" + i)
+                    listItem.setAttribute("role", "tab")
+                    listItem.setAttribute("aria-controls", i)
+                    listItem.innerHTML = d.subject;
+                    tabList.appendChild(listItem)
+
+                    const contentItem = document.createElement("div");
+                    contentItem.setAttribute("class", "tab-pane fade")
+                    contentItem.setAttribute("id", "list" + i)
+                    contentItem.setAttribute("role", "tabpanel")
+                    contentItem.setAttribute("aria-labelledby", "list" + i + "list")
+                    contentItem.innerHTML = "<strong> from: " + d.from.emailAddress.address + "</strong><br><br>" + d.bodyPreview + "...";
+                    tabContent.appendChild(contentItem);
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR removes the restriction on the ssoSilent API to require an `account`, `login_hint` or `sid` to initiate a request in a hidden iframe and receive a new authorization code. The API will no longer throw an error, but log a warning that there may not be enough information.