### PR TITLE
Update cdn-usage.md

### DIFF
--- a/lib/msal-browser/docs/cdn-usage.md
+++ b/lib/msal-browser/docs/cdn-usage.md
@@ -44,7 +44,7 @@ In the unlikely event that a CDN build is broken or the CDN itself is inaccessib
 ```html
 <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.3.0/js/msal-browser.min.js"></script>
 <script type="text/javascript">
-    if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/browser/2.3.0/js/msal-browser.min.js' type='text/javascript' %3E%3C/script%3E"));
+    if(typeof msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/browser/2.3.0/js/msal-browser.min.js' type='text/javascript' %3E%3C/script%3E"));
 </script>
 ```
 


### PR DESCRIPTION
Msal will always fail, so pages will always use the fallback. It's 'msal'