### PR TITLE
Support React version 16.8.0+

### DIFF
--- a/change/@azure-msal-react-01b47d81-7abf-43d6-b1c8-8a23bf6f3fd4.json
+++ b/change/@azure-msal-react-01b47d81-7abf-43d6-b1c8-8a23bf6f3fd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support React version 16.8.0+",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-react/package.json
+++ b/lib/msal-react/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@azure/msal-browser": "^2.18.0",
-    "react": "^16.13.0 || ^17"
+    "react": "^16.8.0 || ^17"
   },
   "module": "dist/msal-react.esm.js",
   "devDependencies": {


### PR DESCRIPTION
This PR increases the allowable range of React versions that msal-react supports. 16.8.0 is the earliest version that can be supported as that is when hooks were introduced.

Fixes #3764