### PR TITLE
Gracefully handle B2C ROPC policies not setting end_session_endpoint property

### DIFF
--- a/change/@azure-msal-common-bfcbb6e1-25b2-44c5-bec5-a07e14a8d5fb.json
+++ b/change/@azure-msal-common-bfcbb6e1-25b2-44c5-bec5-a07e14a8d5fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Gracefully handle B2C ROPC policies not setting end_session_endpoint property",
+  "packageName": "@azure/msal-common",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-bfcbb6e1-25b2-44c5-bec5-a07e14a8d5fb.json
+++ b/change/@azure-msal-common-bfcbb6e1-25b2-44c5-bec5-a07e14a8d5fb.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Gracefully handle B2C ROPC policies not setting end_session_endpoint property",
+  "comment": "Gracefully handle B2C ROPC policies not setting end_session_endpoint property #4173",
   "packageName": "@azure/msal-common",
   "email": "janutter@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -531,7 +531,10 @@ export class Authority {
         metadata.authorization_endpoint = Authority.buildRegionalAuthorityString(metadata.authorization_endpoint, azureRegion);
         // TODO: Enquire on whether we should leave the query string or remove it before releasing the feature
         metadata.token_endpoint = Authority.buildRegionalAuthorityString(metadata.token_endpoint, azureRegion, "allowestsrnonmsi=true");
-        metadata.end_session_endpoint = Authority.buildRegionalAuthorityString(metadata.end_session_endpoint, azureRegion);
+
+        if (metadata.end_session_endpoint) {
+            metadata.end_session_endpoint = Authority.buildRegionalAuthorityString(metadata.end_session_endpoint, azureRegion);
+        }
         
         return metadata;
     }

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -157,6 +157,10 @@ export class Authority {
      */
     public get endSessionEndpoint(): string {
         if(this.discoveryComplete()) {
+            // ROPC policies may not have end_session_endpoint set
+            if (!this.metadata.end_session_endpoint) {
+                throw ClientAuthError.createLogoutNotSupportedError();
+            }
             const endpoint = this.replacePath(this.metadata.end_session_endpoint);
             return this.replaceTenant(endpoint);
         } else {

--- a/lib/msal-common/src/authority/OpenIdConfigResponse.ts
+++ b/lib/msal-common/src/authority/OpenIdConfigResponse.ts
@@ -9,7 +9,7 @@
 export type OpenIdConfigResponse = {
     authorization_endpoint: string;
     token_endpoint: string;
-    end_session_endpoint: string;
+    end_session_endpoint?: string;
     issuer: string;
 };
 
@@ -17,7 +17,6 @@ export function isOpenIdConfigResponse(response: object): boolean {
     return (
         response.hasOwnProperty("authorization_endpoint") &&
         response.hasOwnProperty("token_endpoint") && 
-        response.hasOwnProperty("end_session_endpoint") &&
         response.hasOwnProperty("issuer")
     );
 }

--- a/lib/msal-common/src/cache/entities/AuthorityMetadataEntity.ts
+++ b/lib/msal-common/src/cache/entities/AuthorityMetadataEntity.ts
@@ -15,7 +15,7 @@ export class AuthorityMetadataEntity {
     canonical_authority: string;
     authorization_endpoint: string;
     token_endpoint: string;
-    end_session_endpoint: string;
+    end_session_endpoint?: string;
     issuer: string;
     aliasesFromNetwork: boolean;
     endpointsFromNetwork: boolean;
@@ -90,7 +90,6 @@ export class AuthorityMetadataEntity {
             entity.hasOwnProperty("canonical_authority") &&
             entity.hasOwnProperty("authorization_endpoint") &&
             entity.hasOwnProperty("token_endpoint") &&
-            entity.hasOwnProperty("end_session_endpoint") &&
             entity.hasOwnProperty("issuer") &&
             entity.hasOwnProperty("aliasesFromNetwork") &&
             entity.hasOwnProperty("endpointsFromNetwork") &&

--- a/lib/msal-common/src/error/ClientAuthError.ts
+++ b/lib/msal-common/src/error/ClientAuthError.ts
@@ -185,6 +185,10 @@ export const ClientAuthErrorMessage = {
     bindingKeyNotRemovedError: {
         code: "binding_key_not_removed",
         desc: "Could not remove the credential's binding key from storage."
+    },
+    logoutNotSupported: {
+        code: "end_session_endpoint_not_supported",
+        desc: "Provided authority does not support logout."
     }
 };
 
@@ -504,5 +508,12 @@ export class ClientAuthError extends AuthError {
 
     static createBindingKeyNotRemovedError(): ClientAuthError {
         return new ClientAuthError(ClientAuthErrorMessage.bindingKeyNotRemovedError.code, ClientAuthErrorMessage.bindingKeyNotRemovedError.desc);
+    }
+
+    /**
+     * Thrown when logout is attempted for an authority that doesnt have an end_session_endpoint
+     */
+    static createLogoutNotSupportedError(): ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.logoutNotSupported.code, ClientAuthErrorMessage.logoutNotSupported.desc);
     }
 }

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -75,7 +75,7 @@ export const ClientConfigurationErrorMessage = {
     },
     invalidAuthorityMetadata: {
         code: "invalid_authority_metadata",
-        desc: "Invalid authorityMetadata provided. Must by a stringified JSON object containing authorization_endpoint, token_endpoint, end_session_endpoint, issuer fields."
+        desc: "Invalid authorityMetadata provided. Must by a stringified JSON object containing authorization_endpoint, token_endpoint, issuer fields."
     },
     untrustedAuthority: {
         code: "untrusted_authority",

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -15,6 +15,7 @@ import { ClientAuthErrorMessage, ClientAuthError } from "../../src/error/ClientA
 import { AuthorityOptions } from "../../src/authority/AuthorityOptions";
 import { ProtocolMode } from "../../src/authority/ProtocolMode";
 import { AuthorityMetadataEntity } from "../../src/cache/entities/AuthorityMetadataEntity";
+import { OpenIdConfigResponse } from "../../src/authority/OpenIdConfigResponse";
 
 let mockStorage: MockStorageClass;
 
@@ -289,6 +290,21 @@ describe("Authority.ts Class Unit Tests", () => {
             expect(authority.discoveryComplete()).toBe(true);
         });
 
+        it("discoveryComplete returns true if resolveEndpointsAsync resolves successfully without end_session_endpoint", async () => {
+            const metadata: OpenIdConfigResponse = {
+                authorization_endpoint: DEFAULT_OPENID_CONFIG_RESPONSE.body.authorization_endpoint,
+                issuer: DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer,
+                token_endpoint: DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint
+            }
+            networkInterface.sendGetRequestAsync = (url: string, options?: NetworkRequestOptions): any => {
+                return {
+                    body: metadata
+                };
+            };
+            await authority.resolveEndpointsAsync();
+            expect(authority.discoveryComplete()).toBe(true);
+        });
+
         
         describe("Endpoint Metadata", () => {
             it("Gets endpoints from config", async () => {
@@ -341,6 +357,24 @@ describe("Authority.ts Class Unit Tests", () => {
                     expect(e.errorMessage).toBe(ClientConfigurationErrorMessage.invalidAuthorityMetadata.desc);
                     done();
                 });
+            });
+
+            it("Throws error if authority does not containn end_session_endpoint but calls logout", async () => {
+                const authorityJson = {
+                    ...DEFAULT_OPENID_CONFIG_RESPONSE.body,
+                    end_session_endpoint: undefined
+                }
+
+                const options = {
+                    protocolMode: ProtocolMode.AAD,
+                    knownAuthorities: [Constants.DEFAULT_AUTHORITY_HOST],
+                    cloudDiscoveryMetadata: "",
+                    authorityMetadata: JSON.stringify(authorityJson)
+                };
+                authority = new Authority(Constants.DEFAULT_AUTHORITY, networkInterface, mockStorage, options);
+                await authority.resolveEndpointsAsync();
+
+                expect(() => authority.endSessionEndpoint).toThrowError(ClientAuthError.createLogoutNotSupportedError())
             });
 
             it("Gets endpoints from cache", async () => {
@@ -774,6 +808,18 @@ describe("Authority.ts Class Unit Tests", () => {
 
             await authority.resolveEndpointsAsync();
             expect(endpoint).toBe(`${authorityUrl}.well-known/openid-configuration`);
+        })
+    });
+
+    describe("replaceWithRegionalInformation", () => {
+        it("doesnt set end_session_endpoint if not included", () => {
+            const originResponse: OpenIdConfigResponse = {
+                ...DEFAULT_OPENID_CONFIG_RESPONSE.body,
+                end_session_endpoint: undefined
+            };
+
+            const regionalResponse = Authority.replaceWithRegionalInformation(originResponse, "westus2.login.microsoft.com");
+            expect(regionalResponse.end_session_endpoint).toBeUndefined();
         })
     });
 });

--- a/lib/msal-common/test/cache/entities/AuthorityMetadataEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AuthorityMetadataEntity.spec.ts
@@ -23,6 +23,14 @@ describe("AuthorityMetadataEntity.ts Unit Tests", () => {
         expect(AuthorityMetadataEntity.isAuthorityMetadataEntity(key, testObj)).toBe(true);
     });
 
+    it("Verify if an object is a AuthorityMetadataEntity (without end_session_endpoint)", () => {
+        const metadata = {
+            ...testObj
+        }
+        delete metadata["end_session_endpoint"];
+        expect(AuthorityMetadataEntity.isAuthorityMetadataEntity(key, metadata)).toBe(true);
+    });
+
     it("Verify an object is not a AuthorityMetadataEntity", () => {
         // @ts-ignore
         expect(AuthorityMetadataEntity.isAuthorityMetadataEntity(key, null)).toBe(false);

--- a/lib/msal-common/test/error/ClientAuthError.spec.ts
+++ b/lib/msal-common/test/error/ClientAuthError.spec.ts
@@ -277,4 +277,19 @@ describe("ClientAuthError.ts Class Unit Tests", () => {
         expect(err.name).toBe("ClientAuthError");
         expect(err.stack?.includes("ClientAuthError.spec.ts")).toBe(true);
     });
+
+    it("createLogoutNotSupportedError creates a ClientAuthError object", () => {
+        const err: ClientAuthError = ClientAuthError.createLogoutNotSupportedError();
+
+        expect(err instanceof ClientAuthError).toBe(true);
+        expect(err instanceof AuthError).toBe(true);
+        expect(err instanceof Error).toBe(true);
+        expect(err.errorCode).toBe(ClientAuthErrorMessage.logoutNotSupported.code);
+        expect(err.errorMessage.includes(ClientAuthErrorMessage.logoutNotSupported.desc)).toBe(true);
+        expect(err.message.includes(ClientAuthErrorMessage.logoutNotSupported.desc)).toBe(true);
+        expect(err.name).toBe("ClientAuthError");
+        expect(err.stack?.includes("ClientAuthError.spec.ts")).toBe(true);
+    });
+
+
 });


### PR DESCRIPTION
B2C ROPC policies do not set an end_session_endpoint property, which the library currently asserts must be present for authority metadata to be considered valid. This PR makes this field optional, and adds a new error in case logout is attempted.