### PR TITLE
Ensure correlation is passed to all interaction clients in acquireTokenSilent

### DIFF
--- a/change/@azure-msal-browser-13bcbac9-f836-4a62-b930-c26ccf80ec20.json
+++ b/change/@azure-msal-browser-13bcbac9-f836-4a62-b930-c26ccf80ec20.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure correlation is passed to all interaction clients in acquireTokenSilent #4186",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -324,7 +324,7 @@ export abstract class ClientApplication {
             if (isServerError && isInvalidGrantError && !isInteractionRequiredError) {
                 this.logger.verbose("Refresh token expired or invalid, attempting acquire token by iframe", request.correlationId);
 
-                const silentIframeClient = new SilentIframeClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, ApiId.acquireTokenSilent_authCode);
+                const silentIframeClient = new SilentIframeClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, ApiId.acquireTokenSilent_authCode, request.correlationId);
                 return silentIframeClient.acquireToken(request);
             }
             throw e;

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -128,7 +128,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
      * @returns {Promise.<AuthenticationResult>} - a promise that is fulfilled when this function has completed, or rejected if an error was raised. Returns the {@link AuthResponse} 
      */
     private async acquireTokenSilentAsync(request: SilentRequest, account: AccountInfo): Promise<AuthenticationResult>{
-        const silentCacheClient = new SilentCacheClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient);
+        const silentCacheClient = new SilentCacheClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, request.correlationId);
         const silentRequest = silentCacheClient.initializeSilentRequest(request, account);
         this.eventHandler.emitEvent(EventType.ACQUIRE_TOKEN_START, InteractionType.Silent, request);
 


### PR DESCRIPTION
Currently, we are not passing `request.correlationId` to the `SilentIframeClient` and `SilentCacheClient` created during `acquireTokenSilent`, which results in the logger not having the right correlation id. Couldn't figure out how to easily unit test this without lots of refactoring, manually tested, screenshots below.

Before:

![image](https://user-images.githubusercontent.com/443409/138494361-5f09db1e-1b92-4de6-bf8c-826b75514208.png)


After: 

![image](https://user-images.githubusercontent.com/443409/138494031-5e2e1230-fd09-4e6e-aa74-9fb92260ff7d.png)
