### PR TITLE
Add logger messages for cache misses

### DIFF
--- a/change/@azure-msal-common-570c6596-9a99-4972-ab02-9d57da3fa644.json
+++ b/change/@azure-msal-common-570c6596-9a99-4972-ab02-9d57da3fa644.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Log reason for cache miss",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-570c6596-9a99-4972-ab02-9d57da3fa644.json
+++ b/change/@azure-msal-common-570c6596-9a99-4972-ab02-9d57da3fa644.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Log reason for cache miss",
+  "comment": "Log reason for cache miss #4199",
   "packageName": "@azure/msal-common",
   "email": "thomas.norling@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -52,22 +52,31 @@ export class SilentFlowClient extends BaseClient {
             throw ClientConfigurationError.createEmptyTokenRequestError();
         }
 
+        if (request.forceRefresh) {
+            // Must refresh due to present force_refresh flag.
+            this.serverTelemetryManager?.setCacheOutcome(CacheOutcome.FORCE_REFRESH);
+            this.logger.info("SilentFlowClient:acquireCachedToken - Skipping cache because forceRefresh is true.");
+            throw ClientAuthError.createRefreshRequiredError();
+        } else if (!StringUtils.isEmptyObj(request.claims)) {
+            // Must refresh due to request parameters.
+            this.logger.info("SilentFlowClient:acquireCachedToken - Skipping cache because claims are requested.");
+            throw ClientAuthError.createRefreshRequiredError();
+        }
+
         // We currently do not support silent flow for account === null use cases; This will be revisited for confidential flow usecases
         if (!request.account) {
             throw ClientAuthError.createNoAccountInSilentRequestError();
         }
+
         const requestScopes = new ScopeSet(request.scopes || []);
         const environment = request.authority || this.authority.getPreferredCache();
         const authScheme = request.authenticationScheme || AuthenticationScheme.BEARER;
         const cacheRecord = this.cacheManager.readCacheRecord(request.account, this.config.authOptions.clientId, requestScopes, environment, authScheme, request.sshKid);
         
-        if (request.forceRefresh) {
-            // Must refresh due to present force_refresh flag.
-            this.serverTelemetryManager?.setCacheOutcome(CacheOutcome.FORCE_REFRESH);
-            throw ClientAuthError.createRefreshRequiredError();
-        } else if (!cacheRecord.accessToken) {
+        if (!cacheRecord.accessToken) {
             // Must refresh due to non-existent access_token.
             this.serverTelemetryManager?.setCacheOutcome(CacheOutcome.NO_CACHED_ACCESS_TOKEN);
+            this.logger.info("SilentFlowClient:acquireCachedToken - No access token found in cache for the given properties.");
             throw ClientAuthError.createRefreshRequiredError();
         } else if (
             TimeUtils.wasClockTurnedBack(cacheRecord.accessToken.cachedAt) ||
@@ -75,13 +84,12 @@ export class SilentFlowClient extends BaseClient {
         ) {
             // Must refresh due to expired access_token.
             this.serverTelemetryManager?.setCacheOutcome(CacheOutcome.CACHED_ACCESS_TOKEN_EXPIRED);
+            this.logger.info(`SilentFlowClient:acquireCachedToken - Cached access token is expired or will expire within ${this.config.systemOptions.tokenRenewalOffsetSeconds} seconds.`);
             throw ClientAuthError.createRefreshRequiredError();
         } else if (cacheRecord.accessToken.refreshOn && TimeUtils.isTokenExpired(cacheRecord.accessToken.refreshOn, 0)) {
             // Must refresh due to the refresh_in value.
             this.serverTelemetryManager?.setCacheOutcome(CacheOutcome.REFRESH_CACHED_ACCESS_TOKEN);
-            throw ClientAuthError.createRefreshRequiredError();
-        } else if (!StringUtils.isEmptyObj(request.claims)) {
-            // Must refresh due to request parameters.
+            this.logger.info("SilentFlowClient:acquireCachedToken - Cached access token's refreshOn property has been exceeded'.");
             throw ClientAuthError.createRefreshRequiredError();
         }
 


### PR DESCRIPTION
- Adds log messages with the reason for a cache miss
- Moves early return for `forceRefresh` and `claims` before the actual cache lookup occurs