### PR TITLE
Revert circular dependency and msal-node-extensions package-lock changes

### DIFF
--- a/extensions/msal-node-extensions/package-lock.json
+++ b/extensions/msal-node-extensions/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/msal-common": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-5.1.0.tgz",
+      "integrity": "sha512-4zHZ5Ec7jAgTIWZO3ap1ozgIPGAirF1wL8UhsmPF9QDoZz0cMHdaNmtov5i2+6Xq37YMzhN5s50EFHBuXd7sDQ==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -2922,7 +2930,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -6480,8 +6487,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
+++ b/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { BrowserAuthError, BrowserAuthErrorMessage, Logger } from "..";
+import { Logger } from "@azure/msal-common";
+import { BrowserAuthError, BrowserAuthErrorMessage } from "../error/BrowserAuthError";
 import { DatabaseStorage } from "./DatabaseStorage";
 import { IAsyncStorage } from "./IAsyncMemoryStorage";
 import { MemoryStorage } from "./MemoryStorage";

--- a/lib/msal-common/src/request/AuthenticationHeaderParser.ts
+++ b/lib/msal-common/src/request/AuthenticationHeaderParser.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ClientConfigurationError } from "..";
+import { ClientConfigurationError } from "../error/ClientConfigurationError";
 import { HeaderNames } from "../utils/Constants";
 
 type WWWAuthenticateChallenges = {


### PR DESCRIPTION
This PR reverts changes that were incorrectly pushed directly into dev branch