### PR TITLE
Update msal-node OBO sample README to include redirect URI config step

### DIFF
--- a/samples/msal-node-samples/on-behalf-of/README.md
+++ b/samples/msal-node-samples/on-behalf-of/README.md
@@ -78,6 +78,7 @@ const config = {
 1. In the **Register an application page** that appears, enter your application's registration information:
    - In the **Name** section, enter a meaningful application name that will be displayed to users of the app, for example `msal-node-webapp`.
    - Under **Supported account types**, select **Accounts in this organizational directory only**.
+   - Under **Redirect URI (optional)**, select **Web** and set the redirect URI to **http://localhost:3000/redirect** 
 1. Select **Register** to create the application.
 1. In the app's registration screen, find and note the **Application (client) ID**. You use this value in your app's configuration file(s) later in your code.
 1. Select **Save** to save your changes.


### PR DESCRIPTION
This PR:
- Adds an instruction to set redirect URI in web app registration for the OBO sample README
- Addresses #4161 