### PR TITLE
Fix React inProgress startup bug

### DIFF
--- a/change/@azure-msal-react-c93b2a90-5aee-462b-a101-6eadcceacfa6.json
+++ b/change/@azure-msal-react-c93b2a90-5aee-462b-a101-6eadcceacfa6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix inProgress stuck in startup state #4302",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-react/src/MsalProvider.tsx
+++ b/lib/msal-react/src/MsalProvider.tsx
@@ -86,6 +86,15 @@ export function MsalProvider({instance, children}: MsalProviderProps): React.Rea
         instance.handleRedirectPromise().catch(() => {
             // Errors should be handled by listening to the LOGIN_FAILURE event
             return;
+        }).finally(() => {
+            /*
+             * If handleRedirectPromise returns a cached promise the necessary events may not be fired
+             * This is a fallback to prevent inProgress from getting stuck in 'startup'
+             */
+            if (inProgressRef.current === InteractionStatus.Startup) {
+                inProgressRef.current = InteractionStatus.None;
+                setInProgress(InteractionStatus.None);
+            }
         });
 
         return () => {

--- a/lib/msal-react/test/MsalProvider.spec.tsx
+++ b/lib/msal-react/test/MsalProvider.spec.tsx
@@ -63,6 +63,7 @@ describe("MsalProvider tests", () => {
 
     afterEach(() => {
         // cleanup on exiting
+        jest.restoreAllMocks();
         jest.clearAllMocks();
         cachedAccounts = [];
     });
@@ -118,6 +119,30 @@ describe("MsalProvider tests", () => {
                     callback(eventMessage);
                 });
             });
+    
+            expect(await screen.findByText("Test Success!")).toBeInTheDocument();
+        });
+
+        test("inProgress is set to None even if handleRedirectPromise is called before MsalProvider is rendered", async () => {
+            jest.restoreAllMocks();
+
+            const TestComponent = ({inProgress}: IMsalContext) => {    
+                if (inProgress === InteractionStatus.None) {
+                    return <p>Test Success!</p>;
+                } else {
+                    return <p>Interaction Status: { inProgress }</p>;
+                }
+            };
+
+            await pca.handleRedirectPromise();
+    
+            render(
+                <MsalProvider instance={pca}>
+                    <MsalConsumer>
+                        {TestComponent}
+                    </MsalConsumer>
+                </MsalProvider>
+            );
     
             expect(await screen.findByText("Test Success!")).toBeInTheDocument();
         });

--- a/lib/msal-react/test/components/UnauthenticatedTemplate.spec.tsx
+++ b/lib/msal-react/test/components/UnauthenticatedTemplate.spec.tsx
@@ -172,6 +172,7 @@ describe("UnauthenticatedTemplate tests", () => {
     test("Does not show child component if inProgress value is startup", async () => {        
         const handleRedirectSpy = jest.spyOn(pca, "handleRedirectPromise").mockImplementation(() => {
             // Prevent handleRedirectPromise from raising an event and updating inProgress
+            expect(screen.queryByText("No user is authenticated!")).not.toBeInTheDocument();
             return Promise.resolve(null);
         });
         render(
@@ -185,7 +186,7 @@ describe("UnauthenticatedTemplate tests", () => {
 
         await waitFor(() => expect(handleRedirectSpy).toHaveBeenCalledTimes(1));
         expect(screen.queryByText("This text will always display.")).toBeInTheDocument();
-        expect(screen.queryByText("No user is authenticated!")).not.toBeInTheDocument();
+        expect(screen.queryByText("No user is authenticated!")).toBeInTheDocument();
     });
 
     test("Does not show child component if inProgress value is handleRedirect", async () => {        


### PR DESCRIPTION
If `handleRedirectPromise` is called before `MsalProvider` is rendered, the event callbacks that `MsalProvider` relies on to set `inProgress` state won't be available yet resulting in `inProgress` being forever stuck in `startup`. This PR fixes this by setting `inProgress` to `none` in the `finally` block of its own call to `handleRedirectPromise`

Fixes #4282