### PR TITLE
Provide Github token to create-releases script

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -229,6 +229,8 @@ jobs:
         run: npm install
 
       - name: Create Github Releases and Discussions
+        env:
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN}}
         run: node ./.github/create-releases.js
 
       - name: Get release date


### PR DESCRIPTION
Github token was missing from create-releases step (accidentally removed with recent changes) causing a "Bad Credentials" error in the most recent release. This PR addresses this.