### PR TITLE
Update Puppeteer to v12

### DIFF
--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -1910,9 +1910,9 @@
             "dev": true
         },
         "devtools-protocol": {
-            "version": "0.0.901419",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
-            "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
+            "version": "0.0.937139",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
+            "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==",
             "dev": true
         },
         "diff-sequences": {
@@ -4200,21 +4200,11 @@
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
-        "mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5"
-            }
-        },
         "mkdirp-classic": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "ms": {
             "version": "2.1.2",
@@ -4270,10 +4260,37 @@
             "optional": true
         },
         "node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-            "dev": true
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+            "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+                    "dev": true
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+                    "dev": true
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+                    "dev": true,
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
+                }
+            }
         },
         "node-int64": {
             "version": "0.4.0",
@@ -4535,9 +4552,9 @@
             "optional": true
         },
         "progress": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-            "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
         "prompts": {
@@ -4579,50 +4596,29 @@
             "dev": true
         },
         "puppeteer": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.2.0.tgz",
-            "integrity": "sha512-OR2CCHRashF+f30+LBOtAjK6sNtz2HEyTr5FqAvhf8lR/qB3uBRoIZOwQKgwoyZnMBsxX7ZdazlyBgGjpnkiMw==",
+            "version": "12.0.1",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.1.tgz",
+            "integrity": "sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==",
             "dev": true,
             "requires": {
-                "debug": "4.3.1",
-                "devtools-protocol": "0.0.901419",
+                "debug": "4.3.2",
+                "devtools-protocol": "0.0.937139",
                 "extract-zip": "2.0.1",
                 "https-proxy-agent": "5.0.0",
-                "node-fetch": "2.6.1",
+                "node-fetch": "2.6.5",
                 "pkg-dir": "4.2.0",
-                "progress": "2.0.1",
+                "progress": "2.0.3",
                 "proxy-from-env": "1.1.0",
                 "rimraf": "3.0.2",
-                "tar-fs": "2.0.0",
-                "unbzip2-stream": "1.3.3",
-                "ws": "7.4.6"
+                "tar-fs": "2.1.1",
+                "unbzip2-stream": "1.4.3",
+                "ws": "8.2.3"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "tar-fs": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-                    "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
-                    "dev": true,
-                    "requires": {
-                        "chownr": "^1.1.1",
-                        "mkdirp": "^0.5.1",
-                        "pump": "^3.0.0",
-                        "tar-stream": "^2.0.0"
-                    }
-                },
                 "ws": {
-                    "version": "7.4.6",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-                    "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+                    "version": "8.2.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+                    "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
                     "dev": true
                 }
             }
@@ -4994,7 +4990,6 @@
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
             "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -5189,9 +5184,9 @@
             "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
         },
         "unbzip2-stream": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-            "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
             "dev": true,
             "requires": {
                 "buffer": "^5.2.1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -16,7 +16,7 @@
         "dotenv": "^8.2.0",
         "find-process": "^1.4.4",
         "jest": "^27.0.4",
-        "puppeteer": "^10.0.0",
+        "puppeteer": "^12.0.1",
         "ts-jest": "^27.0.3",
         "wait-on": "^5.2.1"
     }


### PR DESCRIPTION
Puppeteer updates the version of Chromium it uses in each major version. This ensures we're testing on the latest version of Chromium.