### PR TITLE
Configure dependabot to update caniuse-lite dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/lib/msal-angular" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "caniuse-lite"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/lib/msal-browser" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "caniuse-lite"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/lib/msal-common" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "caniuse-lite"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/lib/msal-core" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "caniuse-lite"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/lib/msal-node" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "caniuse-lite"
+      
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/lib/msal-react" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "caniuse-lite"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/extensions/msal-node-extensions" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "caniuse-lite"

--- a/build/postinstall.js
+++ b/build/postinstall.js
@@ -14,17 +14,6 @@ if (parseInt(process.env.BEACHBALL)) {
         }
     });
 } else {
-    // Update caniuse browser db to ensure we're using up to date browserlist
-    exec("lerna exec \"npx browserslist@latest --update-db\"", function (error, stdout, stderr) {
-        if (stdout) {
-            console.log('browserslist update stdout: ' + stdout);
-        }
-        console.error('browserslist update stderr: ' + stderr);
-        if (error !== null) {
-             console.log('browserslist update exec error: ' + error);
-        }
-    });
-
     console.log("Running full bootstrap");
     exec("lerna bootstrap", function (error, stdout, stderr) {
         if (stdout) {


### PR DESCRIPTION
`caniuse-lite` tells our bundler which browsers need to be supported and needs to be updated from time to time. This PR configures dependabot to update this dependency monthly (1st of the month) replacing the post-install step we are using currently.

As a general note: dependabot doesn't currently support wildcards in the directory field, but it is on their roadmap. For now, until that feature is implemented or we start using to npm workspaces, dependency updates need to be configured per lib :(