### PR TITLE
fix: msal-browser not working in non enumerable context (storage)

### DIFF
--- a/change/@azure-msal-browser-e936bf87-f0c4-456a-a850-da2f7fc384a5.json
+++ b/change/@azure-msal-browser-e936bf87-f0c4-456a-a850-da2f7fc384a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: BrowserStorage was not working properly one enumerable context (getKeys, containsKey)",
+  "packageName": "@azure/msal-browser",
+  "email": "bartheleway@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserStorage.ts
+++ b/lib/msal-browser/src/cache/BrowserStorage.ts
@@ -50,6 +50,7 @@ export class BrowserStorage implements IWindowStorage<string> {
     }
 
     containsKey(key: string): boolean {
-        return this.windowStorage.hasOwnProperty(key);
+        // Use getKeys to properly support environments where localStorage/sessionStorage are not enumerable, e.g. Salesforce
+        return this.getKeys().includes(key);
     }
 }

--- a/lib/msal-browser/src/cache/BrowserStorage.ts
+++ b/lib/msal-browser/src/cache/BrowserStorage.ts
@@ -39,7 +39,14 @@ export class BrowserStorage implements IWindowStorage<string> {
     }
 
     getKeys(): string[] {
-        return Object.keys(this.windowStorage);
+        const keys: string[] = [];
+
+        // Manually iterate to properly support environments where localStorage/sessionStorage are not enumerable, e.g. Salesforce
+        for (let i = 0; i < this.windowStorage.length; ++i) {
+            keys.push(this.windowStorage.key(i) || "");
+        }
+
+        return keys;
     }
 
     containsKey(key: string): boolean {

--- a/lib/msal-browser/test/cache/BrowserStorage.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserStorage.spec.ts
@@ -1,0 +1,87 @@
+import { BrowserStorage } from "../../src/cache/BrowserStorage";
+import { BrowserCacheLocation } from "../../src/utils/BrowserConstants";
+
+describe("BrowserStorage.ts unit tests", () => {
+    describe("Non enumarable context (proxy for storage)", () => {
+        class ProxyStorage {
+            private browserStorage: any
+
+            constructor(storage: any) {
+                this.browserStorage = storage
+
+                Object.defineProperty(this, "browserStorage", {
+                    enumerable: false
+                })
+            }
+
+            key(n: number) {
+                return this.browserStorage.key(n);
+            }
+
+            setItem (key: string, value: string) {
+                this.browserStorage.setItem(key, value);
+            }
+
+            getItem(key: string) {
+                return this.browserStorage.getItem(key);
+            }
+
+            removeItem(key: string) {
+                this.browserStorage.removeItem(key)
+            }
+
+            clear() {
+                this.browserStorage.clear();
+            }
+
+            get length() {
+                return this.browserStorage.length
+            }
+        }
+
+        const localStorage = new ProxyStorage(window[BrowserCacheLocation.LocalStorage]);
+        const sessionStorage = new ProxyStorage(window[BrowserCacheLocation.SessionStorage]);
+
+        Object.defineProperty(globalThis, BrowserCacheLocation.LocalStorage, {
+            get: () => localStorage
+        });
+        Object.defineProperty(globalThis, BrowserCacheLocation.SessionStorage, {
+            get: () => sessionStorage
+        });
+
+        const browserLocalStorage = new BrowserStorage(BrowserCacheLocation.LocalStorage);
+        const browserSessionStorage = new BrowserStorage(BrowserCacheLocation.SessionStorage);
+
+        const msalKey = 'test';
+        const msalKey2 = 'test2';
+        const val = 'value';
+
+        beforeEach(() => {
+            browserLocalStorage.setItem(msalKey, val);
+            browserSessionStorage.setItem(msalKey2, val);
+        });
+
+        afterEach(async () => {
+            for (const key in browserLocalStorage.getKeys()) {
+                browserLocalStorage.removeItem(key)
+            }
+
+            for (const key in browserSessionStorage.getKeys()) {
+                browserSessionStorage.removeItem(key)
+            }
+        });
+
+        it("getKeys()", () => {
+            // Old version of getKeys was using Object.keys
+            expect(Object.keys(localStorage)).toHaveLength(0);
+            expect(Object.keys(sessionStorage)).toHaveLength(0);
+
+            expect(localStorage.length).toEqual(1);
+            expect(sessionStorage.length).toEqual(1);
+            expect(browserLocalStorage.getKeys()).toHaveLength(1);
+            expect(browserSessionStorage.getKeys()).toHaveLength(1);
+            expect(browserLocalStorage.getItem(msalKey)).toEqual(val);
+            expect(browserSessionStorage.getItem(msalKey2)).toEqual(val);
+        })
+    })
+})

--- a/lib/msal-browser/test/cache/BrowserStorage.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserStorage.spec.ts
@@ -83,5 +83,14 @@ describe("BrowserStorage.ts unit tests", () => {
             expect(browserLocalStorage.getItem(msalKey)).toEqual(val);
             expect(browserSessionStorage.getItem(msalKey2)).toEqual(val);
         })
+
+        it("containsKey()", () => {
+            // Old version of containsKey was using hasOwnProperty
+            expect(localStorage.hasOwnProperty(msalKey)).toEqual(false);
+            expect(sessionStorage.hasOwnProperty(msalKey2)).toEqual(false);
+
+            expect(browserLocalStorage.containsKey(msalKey)).toEqual(true);
+            expect(browserSessionStorage.containsKey(msalKey2)).toEqual(true);
+        })
     })
 })


### PR DESCRIPTION
When window storage is being proxied key might not be enumerable anymore. Safe way is to use key() which returns the n-th key of the storage.

This intends to fix #4379.

I did test modifying directly the code into the compiled source and report that it is working as expected.