### PR TITLE
Node testing mock behaviour updation

### DIFF
--- a/lib/msal-node/test/cache/TokenCache.spec.ts
+++ b/lib/msal-node/test/cache/TokenCache.spec.ts
@@ -5,6 +5,9 @@ import { promises as fs } from 'fs';
 import { version, name } from '../../package.json';
 import { DEFAULT_CRYPTO_IMPLEMENTATION, TEST_CONSTANTS } from '../utils/TestConstants';
 import * as msalCommon from '@azure/msal-common';
+import { Deserializer } from '../../src/cache/serializer/Deserializer';
+import { JsonCache } from '../../src';
+import { toKeyAlias } from '@babel/types';
 
 describe("TokenCache tests", () => {
 
@@ -43,9 +46,16 @@ describe("TokenCache tests", () => {
         expect(tokenCache.hasChanged()).toEqual(false);
     });
 
+    it("TokenCache should not fail when attempting to deserialize an empty string", () => {
+        const cache = "";
+        const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
+        const tokenCache = new TokenCache(storage, logger);
+
+        tokenCache.deserialize(cache);
+        expect(tokenCache.hasChanged()).toEqual(false);
+    });
+
     it("TokenCache serialize/deserialize, does not remove unrecognized entities", () => {
-        // TokenCache should not remove unrecognized entities from JSON file, even if they
-        // are deeply nested, and should write them back out
         const cache = require('./cache-test-files/cache-unrecognized-entities.json');
         const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
         const tokenCache = new TokenCache(storage, logger);
@@ -59,8 +69,7 @@ describe("TokenCache tests", () => {
     });
 
     it("TokenCache.mergeRemovals removes entities from the cache, but does not remove other entities", async () => {
-        // TokenCache should not remove unrecognized entities from JSON file, even if they
-        // are deeply nested, and should write them back out
+        // TokenCache should not remove unrecognized entities from JSON file
         const cache = require('./cache-test-files/cache-unrecognized-entities.json');
         const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
         const tokenCache = new TokenCache(storage, logger);
@@ -104,7 +113,7 @@ describe("TokenCache tests", () => {
             tokenCache
         }
 
-        jest.spyOn(msalCommon, 'TokenCacheContext')
+        jest.spyOn(msalCommon, 'TokenCacheContext') // ???
             .mockImplementation(() => mockTokenCacheContextInstance as unknown as TokenCacheContext)
 
         const accounts = await tokenCache.getAllAccounts();
@@ -116,9 +125,35 @@ describe("TokenCache tests", () => {
         try {
             await fs.unlink(cachePath);
         } catch (err) {
-            if (err.code == "ENOENT") {
+            if ((err as any).code == "ENOENT") {
                 console.log("Tried to delete temp cache file but it does not exist");
             }
         }
     });
+
+    it('should return an empty KV store if TokenCache is empty', () => {
+        const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
+        const tokenCache = new TokenCache(storage, logger);
+
+        expect(tokenCache.getKVStore()).toEqual({});
+    })
+
+    it('should return stored entities in KV store', () => {
+        const cache: JsonCache = require('./cache-test-files/default-cache.json');
+        const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
+        const tokenCache = new TokenCache(storage, logger);
+
+        tokenCache.deserialize(JSON.stringify(cache));
+
+        const expectedCachedEntities = Deserializer.deserializeAllCache(cache);
+
+        const kvStore = tokenCache.getKVStore();
+
+        Object.values(expectedCachedEntities).forEach(expectedCacheSection => {
+            Object.keys(expectedCacheSection).forEach(cacheKey => {
+                expect(kvStore[cacheKey]).toEqual(expectedCacheSection[cacheKey]);
+            })
+        })
+    })
+
 });

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -148,7 +148,7 @@ describe('PublicClientApplication', () => {
 
 
         const authApp = new PublicClientApplication(appConfig);
-        await authApp.getAuthCodeUrl(request); // ??????
+        await authApp.getAuthCodeUrl(request);
         expect(AuthorizationCodeClient).toHaveBeenCalledTimes(1);
         expect(AuthorizationCodeClient).toHaveBeenCalledWith(
             expect.objectContaining(expectedConfig)
@@ -180,7 +180,6 @@ describe('PublicClientApplication', () => {
 
     test('acquireToken default authority', async () => {
         // No authority set in app configuration or request, should default to common authority 
-        // ?????
         const config: Configuration = {
             auth: {
                 clientId: TEST_CONSTANTS.CLIENT_ID,
@@ -191,8 +190,6 @@ describe('PublicClientApplication', () => {
             scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
             refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
         };
-
-        //Mocking Authority using AuthorityFactory's mock, but not RefreshToken Client ????
 
         const authorityMock = mocked(AuthorityFactory.createDiscoveredInstance);
         authorityMock.mockResolvedValue(authority);
@@ -223,7 +220,6 @@ describe('PublicClientApplication', () => {
             authority: TEST_CONSTANTS.ALTERNATE_AUTHORITY,
         };
 
-        //mocking Authority using Authority Factory's mock ???
         const authorityMock = mocked(AuthorityFactory.createDiscoveredInstance);
         authorityMock.mockResolvedValue(authority);
 

--- a/lib/msal-node/test/client/test-fixtures.ts
+++ b/lib/msal-node/test/client/test-fixtures.ts
@@ -48,14 +48,3 @@ export const setupAuthorityFactory_createDiscoveredInstance_mock = (authority = 
     jest.spyOn(AuthorityFactory, 'createDiscoveredInstance')
         .mockReturnValue(Promise.resolve(authority));
 }
-
-
-/*
-export function mockMSALClass <T> (cls: keyof T, mod: T): typeof T  {
-    const MockClass = jest.genMockFromModule<typeof msalCommon>("@azure/msal-common")[cls];
-    jest.spyOn(msalCommon, cls).mockImplementation((...args) => new MockClass(...args));
-    return MockClass;
-}
-
-
-*/

--- a/lib/msal-node/test/client/test-fixtures.ts
+++ b/lib/msal-node/test/client/test-fixtures.ts
@@ -1,0 +1,61 @@
+import { ServerTelemetryManager, Authority, AuthorityFactory } from '@azure/msal-common';
+
+import * as msalCommon from '@azure/msal-common';
+
+// @ts-ignore
+const mockServerTelemetryManager: ServerTelemetryManager = {
+    cacheManager: undefined,
+    apiId: undefined,
+    correlationId: undefined,
+    telemetryCacheKey: undefined,
+    wrapperSKU: undefined,
+    wrapperVer: undefined,
+    regionUsed: undefined,
+    regionSource: undefined,
+    regionOutcome: undefined,
+    cacheOutcome: undefined,
+    generateCurrentRequestHeaderValue: jest.fn(),
+    generateLastRequestHeaderValue: jest.fn().mockImplementation(() => "someFakeHeader"),
+    cacheFailedRequest: jest.fn(),
+    incrementCacheHits: jest.fn(),
+    getLastRequests: jest.fn(),
+    clearTelemetryCache: jest.fn(),
+    getRegionDiscoveryFields: jest.fn(),
+    updateRegionDiscoveryMetadata: jest.fn(),
+    setCacheOutcome: jest.fn()
+}
+
+export const setupServerTelemetryManagerMock = () => {
+    jest.spyOn(msalCommon, 'ServerTelemetryManager')
+            .mockImplementation(() =>  mockServerTelemetryManager as unknown as ServerTelemetryManager)
+
+    return mockServerTelemetryManager;
+}
+
+export const fakeAuthority: Authority = {
+    regionDiscoveryMetadata: { region_used: undefined, region_source: undefined, region_outcome: undefined },
+    resolveEndpointsAsync: () => {
+        return new Promise<void>(resolve => {
+            resolve();
+        });
+    },
+    discoveryComplete: () => {
+        return true;
+    },
+} as unknown as Authority;
+
+export const setupAuthorityFactory_createDiscoveredInstance_mock = (authority = fakeAuthority) => {
+    jest.spyOn(AuthorityFactory, 'createDiscoveredInstance')
+        .mockReturnValue(Promise.resolve(authority));
+}
+
+
+/*
+export function mockMSALClass <T> (cls: keyof T, mod: T): typeof T  {
+    const MockClass = jest.genMockFromModule<typeof msalCommon>("@azure/msal-common")[cls];
+    jest.spyOn(msalCommon, cls).mockImplementation((...args) => new MockClass(...args));
+    return MockClass;
+}
+
+
+*/

--- a/lib/msal-node/test/utils/MockUtils.ts
+++ b/lib/msal-node/test/utils/MockUtils.ts
@@ -1,0 +1,4 @@
+import * as msalCommon from '@azure/msal-common';
+type MSALCommonModule = typeof msalCommon;
+
+export const getMsalCommonAutoMock = (): MSALCommonModule => jest.genMockFromModule('@azure/msal-common')


### PR DESCRIPTION
- Client : Removed mocking for msal-common module as a whole and updated accordingly. 
- Cache: Added new tests in Storage.spec.ts & TokenCache.spec.ts to improve coverage
- More tests to be added in Cache. 

