### PR TITLE
Node testing mock overhaul

### DIFF
--- a/change/@azure-msal-node-95afe8ab-6566-4464-a5dc-a45498275294.json
+++ b/change/@azure-msal-node-95afe8ab-6566-4464-a5dc-a45498275294.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
+  "type": "none",
   "comment": "Update node testing to overhaul msal-common mocking and add new tests #4391",
   "packageName": "@azure/msal-node",
   "email": "bmahal@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@azure-msal-node-95afe8ab-6566-4464-a5dc-a45498275294.json
+++ b/change/@azure-msal-node-95afe8ab-6566-4464-a5dc-a45498275294.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update node testing to overhaul msal-common mocking and add new tests",
+  "packageName": "@azure/msal-node",
+  "email": "bmahal@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-95afe8ab-6566-4464-a5dc-a45498275294.json
+++ b/change/@azure-msal-node-95afe8ab-6566-4464-a5dc-a45498275294.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Update node testing to overhaul msal-common mocking and add new tests",
+  "comment": "Update node testing to overhaul msal-common mocking and add new tests #4391",
   "packageName": "@azure/msal-node",
   "email": "bmahal@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-node/test/cache/Storage.spec.ts
+++ b/lib/msal-node/test/cache/Storage.spec.ts
@@ -1,11 +1,9 @@
-import { LogLevel, Logger, AccountEntity, CacheManager, AccessTokenEntity, AuthorityMetadataEntity, ThrottlingEntity, IdTokenEntity, RefreshTokenClient, RefreshTokenEntity } from '@azure/msal-common';
+import { LogLevel, Logger, AccountEntity, CacheManager, AccessTokenEntity, AuthorityMetadataEntity, IdTokenEntity, RefreshTokenEntity } from '@azure/msal-common';
 import { JsonCache, InMemoryCache } from './../../src/cache/serializer/SerializerTypes';
 import { Deserializer } from './../../src/cache/serializer/Deserializer';
 import { NodeStorage } from '../../src/cache/NodeStorage';
 import { version, name } from '../../package.json';
 import { DEFAULT_CRYPTO_IMPLEMENTATION, DEFAULT_OPENID_CONFIG_RESPONSE, TEST_CONSTANTS } from '../utils/TestConstants';
-import { hasUncaughtExceptionCaptureCallback } from 'process';
-import { notDeepStrictEqual } from 'assert';
 
 const cacheJson = require('./serializer/cache.json');
 const clientId = TEST_CONSTANTS.CLIENT_ID;
@@ -29,7 +27,7 @@ describe("Storage tests for msal-node: ", () => {
 
         const loggerOptions = {
             loggerCallback: () => {
-               // allow user to not set a loggerCallback
+                // allow user to not set a loggerCallback
             },
             piiLoggingEnabled: false,
             logLevel: LogLevel.Info,
@@ -196,7 +194,6 @@ describe("Storage tests for msal-node: ", () => {
     it('setIdTokenCredential() and getIdTokenCredential() tests', () => {
         const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
 
-        //                  uid1.utid1-login.windows.net-idtoken-mock_client_id-samplerealm-
         const idTokenKey = 'uid1.utid1-login.windows.net-idtoken-mock_client_id-samplerealm-';
         const invalidIdTokenKey = 'uid1.utid1-login.windows.net-idtoken_invalid-mock_client_id-samplerealm-';
         const newMockEntityData = {
@@ -213,7 +210,6 @@ describe("Storage tests for msal-node: ", () => {
 
         nodeStorage.setIdTokenCredential(idToken);
 
-        require('fs').writeFileSync("temp.json", JSON.stringify(nodeStorage.getCache(), undefined, 2))
         const fetchedIdToken = nodeStorage.getIdTokenCredential(idTokenKey);
         const invalidIdToken = nodeStorage.getIdTokenCredential(invalidIdTokenKey);
 
@@ -224,7 +220,6 @@ describe("Storage tests for msal-node: ", () => {
     it('setRefreshTokenCredential() and getRefreshTokenCredential() tests', () => {
         const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
 
-        //                  uid1.utid1-login.windows.net-idtoken-mock_client_id-samplerealm-
         const refreshTokenKey = 'uid1.utid1-login.windows.net-refreshtoken-mock_client_id-samplerealm-';
         const invalidRefreshTokenKey = 'uid1.utid1-login.windows.net-refreshtoken_invalid-mock_client_id-samplerealm-';
         const newMockEntityData = {
@@ -241,7 +236,6 @@ describe("Storage tests for msal-node: ", () => {
 
         nodeStorage.setRefreshTokenCredential(refreshToken);
 
-        require('fs').writeFileSync("temp.json", JSON.stringify(nodeStorage.getCache(), undefined, 2))
         const fetchedRefreshToken = nodeStorage.getRefreshTokenCredential(refreshTokenKey);
         const invalidRefreshToken = nodeStorage.getRefreshTokenCredential(invalidRefreshTokenKey);
 
@@ -287,7 +281,7 @@ describe("Storage tests for msal-node: ", () => {
         nodeStorage.clear();
 
         expect(nodeStorage.getAccount(accountKey)).toBeNull();
-        
+
         const newInMemoryCache = nodeStorage.getInMemoryCache();
         Object.values(newInMemoryCache).forEach(cacheSection => {
             expect(cacheSection).toEqual({});
@@ -296,7 +290,7 @@ describe("Storage tests for msal-node: ", () => {
     })
 
     describe("Getters and Setters", () => {
-        describe("AuthorityMetadata", () =>{
+        describe("AuthorityMetadata", () => {
             const host = "login.microsoftonline.com";
             const key = `authority-metadata-${clientId}-${host}`;
             const testObj: AuthorityMetadataEntity = new AuthorityMetadataEntity();

--- a/lib/msal-node/test/cache/Storage.spec.ts
+++ b/lib/msal-node/test/cache/Storage.spec.ts
@@ -1,9 +1,11 @@
-import { LogLevel, Logger, AccountEntity, CacheManager, AccessTokenEntity, AuthorityMetadataEntity } from '@azure/msal-common';
+import { LogLevel, Logger, AccountEntity, CacheManager, AccessTokenEntity, AuthorityMetadataEntity, ThrottlingEntity, IdTokenEntity, RefreshTokenClient, RefreshTokenEntity } from '@azure/msal-common';
 import { JsonCache, InMemoryCache } from './../../src/cache/serializer/SerializerTypes';
 import { Deserializer } from './../../src/cache/serializer/Deserializer';
 import { NodeStorage } from '../../src/cache/NodeStorage';
 import { version, name } from '../../package.json';
 import { DEFAULT_CRYPTO_IMPLEMENTATION, DEFAULT_OPENID_CONFIG_RESPONSE, TEST_CONSTANTS } from '../utils/TestConstants';
+import { hasUncaughtExceptionCaptureCallback } from 'process';
+import { notDeepStrictEqual } from 'assert';
 
 const cacheJson = require('./serializer/cache.json');
 const clientId = TEST_CONSTANTS.CLIENT_ID;
@@ -49,6 +51,16 @@ describe("Storage tests for msal-node: ", () => {
         const inMemoryCache = nodeStorage.getInMemoryCache();
         expect(Object.keys(inMemoryCache.accessTokens).length).toBe(0);
     });
+
+    it('emits a change event when changeEmitter is registered', () => {
+        const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
+        const changeEmitter = jest.fn();
+
+        nodeStorage.registerChangeEmitter(changeEmitter);
+        nodeStorage.setInMemoryCache(inMemoryCache);
+
+        expect(changeEmitter).toHaveBeenCalledTimes(2);
+    })
 
     it('setInMemoryCache() and getInMemoryCache() tests - tests for an account', () => {
         const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
@@ -98,8 +110,12 @@ describe("Storage tests for msal-node: ", () => {
         const accountKey = 'uid.utid-login.microsoftonline.com-microsoft';
         const fetchedAccount = nodeStorage.getAccount(accountKey);
 
+        const invalidAccountKey = 'uid.utid-login.microsoftonline.com-invalid';
+        const invalidAccount = nodeStorage.getAccount(invalidAccountKey);
+
         expect(fetchedAccount).toBeInstanceOf(AccountEntity);
         expect(fetchedAccount).toEqual(inMemoryCache.accounts[accountKey]);
+        expect(invalidAccount).toBeNull();
 
         const mockAccountData = {
             username: 'Jane Doe',
@@ -147,10 +163,12 @@ describe("Storage tests for msal-node: ", () => {
         expect(readCache[accessTokenKey]).toEqual(accessToken);
     });
 
+
     it('setAccessTokenCredential() and getAccessTokenCredential() tests', () => {
         const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
 
         const accessTokenKey = 'uid1.utid1-login.windows.net-accesstoken-mock_client_id-samplerealm-scoperead scopewrite--';
+        const invalidAccessTokenKey = 'uid1.utid1-login.windows.net-accesstoken_invalid-mock_client_id-samplerealm-scoperead scopewrite';
         const newMockATData = {
             homeAccountId: 'uid1.utid1',
             environment: 'login.windows.net',
@@ -169,8 +187,68 @@ describe("Storage tests for msal-node: ", () => {
 
         nodeStorage.setAccessTokenCredential(accessToken);
         const fetchedAccessToken = nodeStorage.getAccessTokenCredential(accessTokenKey);
+        const invalidAccessToken = nodeStorage.getAccessTokenCredential(invalidAccessTokenKey);
+
         expect(fetchedAccessToken).toEqual(accessToken);
+        expect(invalidAccessToken).toBeNull();
     });
+
+    it('setIdTokenCredential() and getIdTokenCredential() tests', () => {
+        const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
+
+        //                  uid1.utid1-login.windows.net-idtoken-mock_client_id-samplerealm-
+        const idTokenKey = 'uid1.utid1-login.windows.net-idtoken-mock_client_id-samplerealm-';
+        const invalidIdTokenKey = 'uid1.utid1-login.windows.net-idtoken_invalid-mock_client_id-samplerealm-';
+        const newMockEntityData = {
+            homeAccountId: 'uid1.utid1',
+            environment: 'login.windows.net',
+            credentialType: 'IdToken',
+            clientId: 'mock_client_id',
+            secret: 'an access token',
+            realm: 'samplerealm',
+        };
+
+        // <home_account_id*>-\<environment>-<credential_type>-<client_id>-<realm\*>-<target\*>-<scheme\*>
+        const idToken = CacheManager.toObject(new IdTokenEntity(), newMockEntityData);
+
+        nodeStorage.setIdTokenCredential(idToken);
+
+        require('fs').writeFileSync("temp.json", JSON.stringify(nodeStorage.getCache(), undefined, 2))
+        const fetchedIdToken = nodeStorage.getIdTokenCredential(idTokenKey);
+        const invalidIdToken = nodeStorage.getIdTokenCredential(invalidIdTokenKey);
+
+        expect(fetchedIdToken).toEqual(idToken);
+        expect(invalidIdToken).toBeNull();
+    });
+
+    it('setRefreshTokenCredential() and getRefreshTokenCredential() tests', () => {
+        const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
+
+        //                  uid1.utid1-login.windows.net-idtoken-mock_client_id-samplerealm-
+        const refreshTokenKey = 'uid1.utid1-login.windows.net-refreshtoken-mock_client_id-samplerealm-';
+        const invalidRefreshTokenKey = 'uid1.utid1-login.windows.net-refreshtoken_invalid-mock_client_id-samplerealm-';
+        const newMockEntityData = {
+            homeAccountId: 'uid1.utid1',
+            environment: 'login.windows.net',
+            credentialType: 'RefreshToken',
+            clientId: 'mock_client_id',
+            secret: 'a refresh token',
+            realm: 'samplerealm',
+        };
+
+        // <home_account_id*>-\<environment>-<credential_type>-<client_id>-<realm\*>-<target\*>-<scheme\*>
+        const refreshToken = CacheManager.toObject(new RefreshTokenEntity(), newMockEntityData);
+
+        nodeStorage.setRefreshTokenCredential(refreshToken);
+
+        require('fs').writeFileSync("temp.json", JSON.stringify(nodeStorage.getCache(), undefined, 2))
+        const fetchedRefreshToken = nodeStorage.getRefreshTokenCredential(refreshTokenKey);
+        const invalidRefreshToken = nodeStorage.getRefreshTokenCredential(invalidRefreshTokenKey);
+
+        expect(fetchedRefreshToken).toEqual(refreshToken);
+        expect(invalidRefreshToken).toBeNull();
+    });
+
 
     it('containsKey() tests - tests for an accountKey', () => {
         const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
@@ -199,6 +277,23 @@ describe("Storage tests for msal-node: ", () => {
         nodeStorage.removeItem(accountKey);
         expect(newInMemoryCache.accounts[accountKey]).toBeUndefined;
     });
+
+    it('should remove all keys from the cache when clear() is called', () => {
+        const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
+        nodeStorage.setInMemoryCache(inMemoryCache);
+
+        const accountKey = 'uid.utid-login.microsoftonline.com-microsoft';
+
+        nodeStorage.clear();
+
+        expect(nodeStorage.getAccount(accountKey)).toBeNull();
+        
+        const newInMemoryCache = nodeStorage.getInMemoryCache();
+        Object.values(newInMemoryCache).forEach(cacheSection => {
+            expect(cacheSection).toEqual({});
+        })
+
+    })
 
     describe("Getters and Setters", () => {
         describe("AuthorityMetadata", () =>{

--- a/lib/msal-node/test/cache/Storage.spec.ts
+++ b/lib/msal-node/test/cache/Storage.spec.ts
@@ -194,7 +194,7 @@ describe("Storage tests for msal-node: ", () => {
     it('setIdTokenCredential() and getIdTokenCredential() tests', () => {
         const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
 
-        const idTokenKey = 'uid1.utid1-login.windows.net-idtoken-mock_client_id-samplerealm-';
+        const idTokenKey = 'uid1.utid1-login.windows.net-idtoken-mock_client_id-samplerealm---';
         const invalidIdTokenKey = 'uid1.utid1-login.windows.net-idtoken_invalid-mock_client_id-samplerealm-';
         const newMockEntityData = {
             homeAccountId: 'uid1.utid1',
@@ -220,7 +220,7 @@ describe("Storage tests for msal-node: ", () => {
     it('setRefreshTokenCredential() and getRefreshTokenCredential() tests', () => {
         const nodeStorage = new NodeStorage(logger, clientId, DEFAULT_CRYPTO_IMPLEMENTATION);
 
-        const refreshTokenKey = 'uid1.utid1-login.windows.net-refreshtoken-mock_client_id-samplerealm-';
+        const refreshTokenKey = 'uid1.utid1-login.windows.net-refreshtoken-mock_client_id-samplerealm---';
         const invalidRefreshTokenKey = 'uid1.utid1-login.windows.net-refreshtoken_invalid-mock_client_id-samplerealm-';
         const newMockEntityData = {
             homeAccountId: 'uid1.utid1',

--- a/lib/msal-node/test/cache/TokenCache.spec.ts
+++ b/lib/msal-node/test/cache/TokenCache.spec.ts
@@ -68,7 +68,7 @@ describe("TokenCache tests", () => {
     });
 
     it("TokenCache.mergeRemovals removes entities from the cache, but does not remove other entities", async () => {
-        // TokenCache should not remove unrecognized entities from JSON file, even if they are
+        // TokenCache should not remove unrecognized entities from JSON file, even if they
         // are deeply nested, and should write them back out
         const cache = require('./cache-test-files/cache-unrecognized-entities.json');
         const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);

--- a/lib/msal-node/test/cache/TokenCache.spec.ts
+++ b/lib/msal-node/test/cache/TokenCache.spec.ts
@@ -68,7 +68,8 @@ describe("TokenCache tests", () => {
     });
 
     it("TokenCache.mergeRemovals removes entities from the cache, but does not remove other entities", async () => {
-        // TokenCache should not remove unrecognized entities from JSON file
+        // TokenCache should not remove unrecognized entities from JSON file, even if they are
+        // are deeply nested, and should write them back out
         const cache = require('./cache-test-files/cache-unrecognized-entities.json');
         const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
         const tokenCache = new TokenCache(storage, logger);
@@ -124,7 +125,7 @@ describe("TokenCache tests", () => {
         try {
             await fs.unlink(cachePath);
         } catch (err) {
-            if ((err as any).code == "ENOENT") {
+            if (err.code == "ENOENT") {
                 console.log("Tried to delete temp cache file but it does not exist");
             }
         }

--- a/lib/msal-node/test/cache/TokenCache.spec.ts
+++ b/lib/msal-node/test/cache/TokenCache.spec.ts
@@ -5,6 +5,9 @@ import { promises as fs } from 'fs';
 import { version, name } from '../../package.json';
 import { DEFAULT_CRYPTO_IMPLEMENTATION, TEST_CONSTANTS } from '../utils/TestConstants';
 import * as msalCommon from '@azure/msal-common';
+import { Deserializer } from '../../src/cache/serializer/Deserializer';
+import { JsonCache } from '../../src';
+import { toKeyAlias } from '@babel/types';
 
 describe("TokenCache tests", () => {
 
@@ -43,9 +46,16 @@ describe("TokenCache tests", () => {
         expect(tokenCache.hasChanged()).toEqual(false);
     });
 
+    it("TokenCache should not fail when attempting to deserialize an empty string", () => {
+        const cache = "";
+        const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
+        const tokenCache = new TokenCache(storage, logger);
+
+        tokenCache.deserialize(cache);
+        expect(tokenCache.hasChanged()).toEqual(false);
+    });
+
     it("TokenCache serialize/deserialize, does not remove unrecognized entities", () => {
-        // TokenCache should not remove unrecognized entities from JSON file, even if they
-        // are deeply nested, and should write them back out
         const cache = require('./cache-test-files/cache-unrecognized-entities.json');
         const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
         const tokenCache = new TokenCache(storage, logger);
@@ -59,8 +69,7 @@ describe("TokenCache tests", () => {
     });
 
     it("TokenCache.mergeRemovals removes entities from the cache, but does not remove other entities", async () => {
-        // TokenCache should not remove unrecognized entities from JSON file, even if they
-        // are deeply nested, and should write them back out
+        // TokenCache should not remove unrecognized entities from JSON file
         const cache = require('./cache-test-files/cache-unrecognized-entities.json');
         const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
         const tokenCache = new TokenCache(storage, logger);
@@ -104,7 +113,7 @@ describe("TokenCache tests", () => {
             tokenCache
         }
 
-        jest.spyOn(msalCommon, 'TokenCacheContext')
+        jest.spyOn(msalCommon, 'TokenCacheContext') // ???
             .mockImplementation(() => mockTokenCacheContextInstance as unknown as TokenCacheContext)
 
         const accounts = await tokenCache.getAllAccounts();
@@ -116,9 +125,35 @@ describe("TokenCache tests", () => {
         try {
             await fs.unlink(cachePath);
         } catch (err) {
-            if (err.code == "ENOENT") {
+            if ((err as any).code == "ENOENT") {
                 console.log("Tried to delete temp cache file but it does not exist");
             }
         }
     });
+
+    it('should return an empty KV store if TokenCache is empty', () => {
+        const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
+        const tokenCache = new TokenCache(storage, logger);
+
+        expect(tokenCache.getKVStore()).toEqual({});
+    })
+
+    it('should return stored entities in KV store', () => {
+        const cache: JsonCache = require('./cache-test-files/default-cache.json');
+        const storage: NodeStorage = new NodeStorage(logger, TEST_CONSTANTS.CLIENT_ID, DEFAULT_CRYPTO_IMPLEMENTATION);
+        const tokenCache = new TokenCache(storage, logger);
+
+        tokenCache.deserialize(JSON.stringify(cache));
+
+        const expectedCachedEntities = Deserializer.deserializeAllCache(cache);
+
+        const kvStore = tokenCache.getKVStore();
+
+        Object.values(expectedCachedEntities).forEach(expectedCacheSection => {
+            Object.keys(expectedCacheSection).forEach(cacheKey => {
+                expect(kvStore[cacheKey]).toEqual(expectedCacheSection[cacheKey]);
+            })
+        })
+    })
+
 });

--- a/lib/msal-node/test/cache/TokenCache.spec.ts
+++ b/lib/msal-node/test/cache/TokenCache.spec.ts
@@ -7,7 +7,6 @@ import { DEFAULT_CRYPTO_IMPLEMENTATION, TEST_CONSTANTS } from '../utils/TestCons
 import * as msalCommon from '@azure/msal-common';
 import { Deserializer } from '../../src/cache/serializer/Deserializer';
 import { JsonCache } from '../../src';
-import { toKeyAlias } from '@babel/types';
 
 describe("TokenCache tests", () => {
 
@@ -113,7 +112,7 @@ describe("TokenCache tests", () => {
             tokenCache
         }
 
-        jest.spyOn(msalCommon, 'TokenCacheContext') // ???
+        jest.spyOn(msalCommon, 'TokenCacheContext')
             .mockImplementation(() => mockTokenCacheContextInstance as unknown as TokenCacheContext)
 
         const accounts = await tokenCache.getAllAccounts();

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -13,8 +13,6 @@ import { ClientCredentialRequest } from '../../src/request/ClientCredentialReque
 import { OnBehalfOfRequest } from '../../src';
 import { getMsalCommonAutoMock } from '../utils/MockUtils';
 
-// jest.mock('@azure/msal-common');
-
 
 describe('ConfidentialClientApplication', () => {
     let appConfig: Configuration = {

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -157,5 +157,36 @@ describe('ConfidentialClientApplication', () => {
             expect.objectContaining(expectedConfig)
         );
     });
+    
+    
+    
+    test('acquireTokenByClientCredential handles AuthErrors as expected', async () => {
+        const request: ClientCredentialRequest = {
+            scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
+            skipCache: false
+        };
+
+        setupAuthorityFactory_createDiscoveredInstance_mock();
+        const MockClientCredentialClient = getMsalCommonAutoMock().ClientCredentialClient;
+
+        jest.spyOn(msalCommon, 'ClientCredentialClient')
+            .mockImplementation((conf) => new MockClientCredentialClient(conf));
+
+        jest.spyOn(AuthError.prototype, 'setCorrelationId');
+
+        mocked(MockClientCredentialClient.prototype.acquireToken)
+            .mockImplementation(() => {
+                throw new AuthError();
+            });
+
+
+        try {
+            const authApp = new ConfidentialClientApplication(appConfig);
+            await authApp.acquireTokenByClientCredential(request);
+        } catch (e) {
+            expect(e).toBeInstanceOf(AuthError);
+            expect(AuthError.prototype.setCorrelationId).toHaveBeenCalledTimes(1);
+        }
+    });
 
 });

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -54,9 +54,8 @@ describe('ConfidentialClientApplication', () => {
 
             acquireToken: jest.fn()
         }
-        // const { AuthorizationCodeClient: MockAuthorizationCodeClient } = jest.genMockFromModule<typeof msalCommon>("@azure/msal-common")
         jest.spyOn(msalCommon, 'AuthorizationCodeClient')
-            .mockImplementation(() => mockAuthCodeClientInstance as unknown as AuthorizationCodeClient) // new MockAuthorizationCodeClient(config));
+            .mockImplementation(() => mockAuthCodeClientInstance as unknown as AuthorizationCodeClient)
 
         const authApp = new ConfidentialClientApplication(appConfig);
         await authApp.acquireTokenByCode(request);
@@ -77,8 +76,6 @@ describe('ConfidentialClientApplication', () => {
 
 
         const { RefreshTokenClient: mockRefreshTokenClient } = getMsalCommonAutoMock();
-        // const mockRefreshTokenClient = getMsalCommonAutoMock().RefreshTokenClient;
-        // const { RefreshTokenClient } = getMsalCommonAutoMock();
 
 
         jest.spyOn(msalCommon, 'RefreshTokenClient')

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -12,7 +12,7 @@ import * as msalCommon from '@azure/msal-common';
 import { ClientCredentialRequest } from '../../src/request/ClientCredentialRequest';
 import { OnBehalfOfRequest } from '../../src';
 import { getMsalCommonAutoMock } from '../utils/MockUtils';
-
+import { AuthError } from "@azure/msal-common";
 
 describe('ConfidentialClientApplication', () => {
     let appConfig: Configuration = {
@@ -155,9 +155,7 @@ describe('ConfidentialClientApplication', () => {
             expect.objectContaining(expectedConfig)
         );
     });
-    
-    
-    
+
     test('acquireTokenByClientCredential handles AuthErrors as expected', async () => {
         const request: ClientCredentialRequest = {
             scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
@@ -186,5 +184,4 @@ describe('ConfidentialClientApplication', () => {
             expect(AuthError.prototype.setCorrelationId).toHaveBeenCalledTimes(1);
         }
     });
-
 });

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -64,15 +64,6 @@ describe('PublicClientApplication', () => {
         };
 
 
-
-        // @ts-ignore
-        const mockDeviceCodeClient: DeviceCodeClient = {
-            acquireToken: jest.fn(),
-            createTokenRequestHeaders: jest.fn(),
-            executePostToTokenEndpoint: jest.fn(),
-            updateAuthority: jest.fn(),
-        }
-
         const MockDeviceCodeClient2 = getMsalCommonAutoMock().DeviceCodeClient;
 
 

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -16,6 +16,7 @@ import { mocked } from 'ts-jest/utils';
 
 import * as msalCommon from '@azure/msal-common';
 import { fakeAuthority, setupAuthorityFactory_createDiscoveredInstance_mock, setupServerTelemetryManagerMock } from './test-fixtures';
+import { getMsalCommonAutoMock } from '../utils/MockUtils';
 
 describe('PublicClientApplication', () => {
 
@@ -69,7 +70,7 @@ describe('PublicClientApplication', () => {
             updateAuthority: jest.fn(),
         }
 
-        const MockDeviceCodeClient2 = jest.genMockFromModule<typeof msalCommon>('@azure/msal-common').DeviceCodeClient;
+        const MockDeviceCodeClient2 = getMsalCommonAutoMock().DeviceCodeClient;
 
 
         jest.spyOn(msalCommon, 'DeviceCodeClient')
@@ -90,9 +91,7 @@ describe('PublicClientApplication', () => {
         console.log(expectedConfig)
     });
 
-    test.only('acquireTokenByAuthorizationCode', async () => {
-        //mock AuthorityFactory (alfrady done in beforeEach()
-        //mock AuthoritizationCodeClient
+    test('acquireTokenByAuthorizationCode', async () => {
 
 
         const request: AuthorizationCodeRequest = {
@@ -103,7 +102,8 @@ describe('PublicClientApplication', () => {
 
 
 
-        const MockAuthorizationCodeClient = jest.genMockFromModule<typeof msalCommon>("@azure/msal-common").AuthorizationCodeClient
+        const MockAuthorizationCodeClient = getMsalCommonAutoMock().AuthorizationCodeClient;
+
         jest.spyOn(msalCommon, 'AuthorizationCodeClient')
             .mockImplementation((config) => new MockAuthorizationCodeClient(config));
 
@@ -125,7 +125,7 @@ describe('PublicClientApplication', () => {
             refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
         };
 
-        const mockRefreshTokenClient = jest.genMockFromModule<typeof msalCommon>("@azure/msal-common").RefreshTokenClient
+        const mockRefreshTokenClient = getMsalCommonAutoMock().RefreshTokenClient;
         jest.spyOn(msalCommon, 'RefreshTokenClient')
             .mockImplementation((config) => new mockRefreshTokenClient(config));
 
@@ -148,7 +148,7 @@ describe('PublicClientApplication', () => {
 
 
         const authApp = new PublicClientApplication(appConfig);
-        await authApp.getAuthCodeUrl(request); // ??????
+        await authApp.getAuthCodeUrl(request);
         expect(AuthorizationCodeClient).toHaveBeenCalledTimes(1);
         expect(AuthorizationCodeClient).toHaveBeenCalledWith(
             expect.objectContaining(expectedConfig)
@@ -164,7 +164,7 @@ describe('PublicClientApplication', () => {
             password: TEST_CONSTANTS.PASSWORD
         };
 
-        const mockUsernamePasswordClient = jest.genMockFromModule<typeof msalCommon>("@azure/msal-common").UsernamePasswordClient
+        const mockUsernamePasswordClient = getMsalCommonAutoMock().UsernamePasswordClient;
         jest.spyOn(msalCommon, 'UsernamePasswordClient')
             .mockImplementation((config) => new mockUsernamePasswordClient(config));
 
@@ -180,7 +180,6 @@ describe('PublicClientApplication', () => {
 
     test('acquireToken default authority', async () => {
         // No authority set in app configuration or request, should default to common authority 
-        // ?????
         const config: Configuration = {
             auth: {
                 clientId: TEST_CONSTANTS.CLIENT_ID,
@@ -192,7 +191,6 @@ describe('PublicClientApplication', () => {
             refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
         };
 
-        //Mocking Authority using AuthorityFactory's mock, but not RefreshToken Client ????
 
         const authorityMock = mocked(AuthorityFactory.createDiscoveredInstance);
         authorityMock.mockResolvedValue(authority);
@@ -223,7 +221,7 @@ describe('PublicClientApplication', () => {
             authority: TEST_CONSTANTS.ALTERNATE_AUTHORITY,
         };
 
-        //mocking Authority using Authority Factory's mock ???
+
         const authorityMock = mocked(AuthorityFactory.createDiscoveredInstance);
         authorityMock.mockResolvedValue(authority);
 

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -38,11 +38,6 @@ describe('PublicClientApplication', () => {
         },
     };
 
-    // const expectedOauthClientConfig: ClientConfiguration = {
-    //     authOptions: appConfig.auth,
-    // };
-
-
     beforeEach(() => {
         jest.clearAllMocks();
 
@@ -193,7 +188,8 @@ describe('PublicClientApplication', () => {
         };
 
 
-        const authorityMock = setupAuthorityFactory_createDiscoveredInstance_mock();
+        const fakeAuthority = ...;
+        const authorityMock = setupAuthorityFactory_createDiscoveredInstance_mock(fakeAuthority);
 
         const authApp = new PublicClientApplication(config);
         await authApp.acquireTokenByRefreshToken(request);

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -2,7 +2,7 @@ import { PublicClientApplication } from './../../src/client/PublicClientApplicat
 import { Configuration } from './../../src/index';
 import { TEST_CONSTANTS } from '../utils/TestConstants';
 import {
-    DeviceCodeClient, ClientConfiguration, AuthenticationResult,
+    ClientConfiguration, AuthenticationResult,
     AuthorizationCodeClient, RefreshTokenClient, UsernamePasswordClient, ProtocolMode, Logger, LogLevel
 } from '@azure/msal-common';
 import { DeviceCodeRequest } from '../../src/request/DeviceCodeRequest';
@@ -18,7 +18,7 @@ import * as msalCommon from '@azure/msal-common';
 import { fakeAuthority, setupAuthorityFactory_createDiscoveredInstance_mock, setupServerTelemetryManagerMock } from './test-fixtures';
 import { getMsalCommonAutoMock } from '../utils/MockUtils';
 
-import {NodeStorage} from '../../src/cache/NodeStorage'
+import { NodeStorage } from '../../src/cache/NodeStorage'
 import { version, name } from '../../package.json'
 
 describe('PublicClientApplication', () => {
@@ -179,7 +179,6 @@ describe('PublicClientApplication', () => {
         };
 
 
-        const fakeAuthority = ...;
         const authorityMock = setupAuthorityFactory_createDiscoveredInstance_mock(fakeAuthority);
 
         const authApp = new PublicClientApplication(config);

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -18,6 +18,9 @@ import * as msalCommon from '@azure/msal-common';
 import { fakeAuthority, setupAuthorityFactory_createDiscoveredInstance_mock, setupServerTelemetryManagerMock } from './test-fixtures';
 import { getMsalCommonAutoMock } from '../utils/MockUtils';
 
+import {NodeStorage} from '../../src/cache/NodeStorage'
+import { version, name } from '../../package.json'
+
 describe('PublicClientApplication', () => {
 
     let appConfig: Configuration = {
@@ -87,8 +90,6 @@ describe('PublicClientApplication', () => {
             expect.objectContaining(expectedConfig)
         );
         expect(result).toEqual(fakeAuthResult);
-
-        console.log(expectedConfig)
     });
 
     test('acquireTokenByAuthorizationCode', async () => {
@@ -192,8 +193,7 @@ describe('PublicClientApplication', () => {
         };
 
 
-        const authorityMock = mocked(AuthorityFactory.createDiscoveredInstance);
-        authorityMock.mockResolvedValue(authority);
+        const authorityMock = setupAuthorityFactory_createDiscoveredInstance_mock();
 
         const authApp = new PublicClientApplication(config);
         await authApp.acquireTokenByRefreshToken(request);
@@ -222,8 +222,7 @@ describe('PublicClientApplication', () => {
         };
 
 
-        const authorityMock = mocked(AuthorityFactory.createDiscoveredInstance);
-        authorityMock.mockResolvedValue(authority);
+        const authorityMock = setupAuthorityFactory_createDiscoveredInstance_mock()
 
         const authApp = new PublicClientApplication(appConfig);
         await authApp.acquireTokenByRefreshToken(request);

--- a/lib/msal-node/test/client/test-fixtures.ts
+++ b/lib/msal-node/test/client/test-fixtures.ts
@@ -48,14 +48,3 @@ export const setupAuthorityFactory_createDiscoveredInstance_mock = (authority = 
     jest.spyOn(AuthorityFactory, 'createDiscoveredInstance')
         .mockReturnValue(Promise.resolve(authority));
 }
-
-
-/*
-export function mockMSALClass <T> (cls: keyof T, mod: T): typeof T  {
-    const MockClass = jest.genMockFromModule<typeof msalCommon>("@azure/msal-common")[cls];
-    jest.spyOn(msalCommon, cls).mockImplementation((...args) => new MockClass(...args));
-    return MockClass;
-}
-
-
-*/

--- a/lib/msal-node/test/client/test-fixtures.ts
+++ b/lib/msal-node/test/client/test-fixtures.ts
@@ -45,6 +45,6 @@ export const fakeAuthority: Authority = {
 } as unknown as Authority;
 
 export const setupAuthorityFactory_createDiscoveredInstance_mock = (authority = fakeAuthority) => {
-    jest.spyOn(AuthorityFactory, 'createDiscoveredInstance')
+    return jest.spyOn(AuthorityFactory, 'createDiscoveredInstance')
         .mockReturnValue(Promise.resolve(authority));
 }

--- a/lib/msal-node/test/client/test-fixtures.ts
+++ b/lib/msal-node/test/client/test-fixtures.ts
@@ -1,0 +1,61 @@
+import { ServerTelemetryManager, Authority, AuthorityFactory } from '@azure/msal-common';
+
+import * as msalCommon from '@azure/msal-common';
+
+// @ts-ignore
+const mockServerTelemetryManager: ServerTelemetryManager = {
+    cacheManager: undefined,
+    apiId: undefined,
+    correlationId: undefined,
+    telemetryCacheKey: undefined,
+    wrapperSKU: undefined,
+    wrapperVer: undefined,
+    regionUsed: undefined,
+    regionSource: undefined,
+    regionOutcome: undefined,
+    cacheOutcome: undefined,
+    generateCurrentRequestHeaderValue: jest.fn(),
+    generateLastRequestHeaderValue: jest.fn().mockImplementation(() => "someFakeHeader"),
+    cacheFailedRequest: jest.fn(),
+    incrementCacheHits: jest.fn(),
+    getLastRequests: jest.fn(),
+    clearTelemetryCache: jest.fn(),
+    getRegionDiscoveryFields: jest.fn(),
+    updateRegionDiscoveryMetadata: jest.fn(),
+    setCacheOutcome: jest.fn()
+}
+
+export const setupServerTelemetryManagerMock = () => {
+    jest.spyOn(msalCommon, 'ServerTelemetryManager')
+            .mockImplementation(() =>  mockServerTelemetryManager as unknown as ServerTelemetryManager)
+
+    return mockServerTelemetryManager;
+}
+
+export const fakeAuthority: Authority = {
+    regionDiscoveryMetadata: { region_used: undefined, region_source: undefined, region_outcome: undefined },
+    resolveEndpointsAsync: () => {
+        return new Promise<void>(resolve => {
+            resolve();
+        });
+    },
+    discoveryComplete: () => {
+        return true;
+    },
+} as unknown as Authority;
+
+export const setupAuthorityFactory_createDiscoveredInstance_mock = (authority = fakeAuthority) => {
+    jest.spyOn(AuthorityFactory, 'createDiscoveredInstance')
+        .mockReturnValue(Promise.resolve(authority));
+}
+
+
+/*
+export function mockMSALClass <T> (cls: keyof T, mod: T): typeof T  {
+    const MockClass = jest.genMockFromModule<typeof msalCommon>("@azure/msal-common")[cls];
+    jest.spyOn(msalCommon, cls).mockImplementation((...args) => new MockClass(...args));
+    return MockClass;
+}
+
+
+*/

--- a/lib/msal-node/test/utils/MockUtils.ts
+++ b/lib/msal-node/test/utils/MockUtils.ts
@@ -1,0 +1,4 @@
+import * as msalCommon from '@azure/msal-common';
+type MSALCommonModule = typeof msalCommon;
+
+export const getMsalCommonAutoMock = (): MSALCommonModule => jest.genMockFromModule('@azure/msal-common')


### PR DESCRIPTION
This PR makes the following changes to msal-node testing:--

TestFixtures.ts : Common mocks for usage , ex: Authority Factory, Telemetry Manager, etc.
 
For Client test classes:-
-Removes jest.mock("@azure/msal-common")
-Uses mock Authority & AuthorityFactory-createDiscoveredInstance's mock from 'test-fixtures.ts'
-Spies on AuthorizationCodeClient from common
-Mock implementation for various TokenClients 


For Cache test classes:-
-Added more tests based on the Coverage report.

 Storage.spec.ts:-
Tests supporting->
i) Change event being emitted when ChangeEmitter is registered
ii) Coverage for Catch blocks for setter and getter for Account, AccessToken, IdToken, RefreshToken

TokenCache.spec.ts:-
Tests supporting->
i) Edge cases like deserializing an empty cache, empty KVStore in case of empty Cache. 
