### PR TITLE
Clear hash only if it contains known properties

### DIFF
--- a/change/@azure-msal-browser-d035acdb-e020-47fd-a9a0-9d5553244604.json
+++ b/change/@azure-msal-browser-d035acdb-e020-47fd-a9a0-9d5553244604.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clear hash only if it contains known response properties #4415",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -83,7 +83,6 @@ export class RedirectClient extends StandardInteractionClient {
             let state: string;
             try {
                 state = this.validateAndExtractStateFromHash(responseHash, InteractionType.Redirect);
-                BrowserUtils.clearHash(window);
                 this.logger.verbose("State extracted from hash");
             } catch (e) {
                 this.logger.info(`handleRedirectPromise was unable to extract state due to: ${e}`);
@@ -166,13 +165,15 @@ export class RedirectClient extends StandardInteractionClient {
         this.logger.verbose("getRedirectResponseHash called");
         // Get current location hash from window or cache.
         const isResponseHash: boolean = UrlString.hashContainsKnownProperties(hash);
-        const cachedHash = this.browserStorage.getTemporaryCache(TemporaryCacheKeys.URL_HASH, true);
-        this.browserStorage.removeItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.URL_HASH));
 
         if (isResponseHash) {
+            BrowserUtils.clearHash(window);
             this.logger.verbose("Hash contains known properties, returning response hash");
             return hash;
         }
+
+        const cachedHash = this.browserStorage.getTemporaryCache(TemporaryCacheKeys.URL_HASH, true);
+        this.browserStorage.removeItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.URL_HASH));
 
         this.logger.verbose("Hash does not contain known properties, returning cached hash");
         return cachedHash;

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -766,6 +766,24 @@ describe("RedirectClient", () => {
             });
         });
 
+        it("Does not clear custom hash if response hash is retrieved from temporary cache", () => {
+            browserStorage.setInteractionInProgress(true);
+            window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`, window.location.href);
+            window.sessionStorage.setItem(`${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.URL_HASH}`, TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT);
+
+            window.location.hash = "testHash";
+            const clearHashSpy = sinon.spy(BrowserUtils, "clearHash");
+            
+            sinon.stub(RedirectClient.prototype, <any>"handleHash").callsFake((responseHash) => {
+                expect(responseHash).toEqual(TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT);
+            });
+
+            redirectClient.handleRedirectPromise().then(() => {
+                expect(clearHashSpy.notCalled).toBe(true);
+                expect(window.location.hash).toEqual("#testHash");
+            });
+        });
+
         it("processes hash if navigateToLoginRequestUri is true and loginRequestUrl contains trailing slash", (done) => {
             browserStorage.setInteractionInProgress(true);
             const loginRequestUrl = window.location.href.endsWith("/") ? window.location.href.slice(0, -1) : window.location.href + "/";


### PR DESCRIPTION
`handleRedirectPromise` clears the current hash before processing the redirect response. Today this logic doesn't care if the hash came from the current url or from the cache. This causes problems for hash routing scenarios where a custom (non-msal) hash may be removed, causing a route change before the hash can be processed.

This PR fixes this behavior by only clearing the current hash if it contains known response properties 

Fixes #4400