### PR TITLE
Node testing mock overhaul

### DIFF
--- a/change/@azure-msal-node-03eb944d-e367-43d4-8dc3-931b2e5aaf90.json
+++ b/change/@azure-msal-node-03eb944d-e367-43d4-8dc3-931b2e5aaf90.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "Node testing overhaul",
+  "type": "none",
+  "comment": "Node testing overhaul #4433",
   "packageName": "@azure/msal-node",
   "email": "bmahal@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@azure-msal-node-03eb944d-e367-43d4-8dc3-931b2e5aaf90.json
+++ b/change/@azure-msal-node-03eb944d-e367-43d4-8dc3-931b2e5aaf90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Node testing overhaul",
+  "packageName": "@azure/msal-node",
+  "email": "bmahal@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/test/client/test-fixtures.ts
+++ b/lib/msal-node/test/client/test-fixtures.ts
@@ -1,0 +1,50 @@
+import { ServerTelemetryManager, Authority, AuthorityFactory } from '@azure/msal-common';
+
+import * as msalCommon from '@azure/msal-common';
+
+// @ts-ignore
+const mockServerTelemetryManager: ServerTelemetryManager = {
+    cacheManager: undefined,
+    apiId: undefined,
+    correlationId: undefined,
+    telemetryCacheKey: undefined,
+    wrapperSKU: undefined,
+    wrapperVer: undefined,
+    regionUsed: undefined,
+    regionSource: undefined,
+    regionOutcome: undefined,
+    cacheOutcome: undefined,
+    generateCurrentRequestHeaderValue: jest.fn(),
+    generateLastRequestHeaderValue: jest.fn().mockImplementation(() => "someFakeHeader"),
+    cacheFailedRequest: jest.fn(),
+    incrementCacheHits: jest.fn(),
+    getLastRequests: jest.fn(),
+    clearTelemetryCache: jest.fn(),
+    getRegionDiscoveryFields: jest.fn(),
+    updateRegionDiscoveryMetadata: jest.fn(),
+    setCacheOutcome: jest.fn()
+}
+
+export const setupServerTelemetryManagerMock = () => {
+    jest.spyOn(msalCommon, 'ServerTelemetryManager')
+            .mockImplementation(() =>  mockServerTelemetryManager as unknown as ServerTelemetryManager)
+
+    return mockServerTelemetryManager;
+}
+
+export const fakeAuthority: Authority = {
+    regionDiscoveryMetadata: { region_used: undefined, region_source: undefined, region_outcome: undefined },
+    resolveEndpointsAsync: () => {
+        return new Promise<void>(resolve => {
+            resolve();
+        });
+    },
+    discoveryComplete: () => {
+        return true;
+    },
+} as unknown as Authority;
+
+export const setupAuthorityFactory_createDiscoveredInstance_mock = (authority = fakeAuthority) => {
+    return jest.spyOn(AuthorityFactory, 'createDiscoveredInstance')
+        .mockReturnValue(Promise.resolve(authority));
+}

--- a/lib/msal-node/test/utils/MockUtils.ts
+++ b/lib/msal-node/test/utils/MockUtils.ts
@@ -1,0 +1,4 @@
+import * as msalCommon from '@azure/msal-common';
+type MSALCommonModule = typeof msalCommon;
+
+export const getMsalCommonAutoMock = (): MSALCommonModule => jest.genMockFromModule('@azure/msal-common')


### PR DESCRIPTION
This PR makes the following changes to msal-node testing:--

TestFixtures.ts : Common mocks for usage , ex: Authority Factory, Telemetry Manager, etc.

For Client test classes:-
-Removes jest.mock("@azure/msal-common")
-Uses mock Authority & AuthorityFactory-createDiscoveredInstance's mock from 'test-fixtures.ts'
-Spies on AuthorizationCodeClient from common
-Mock implementation for various TokenClients

For Cache test classes:-
-Added more tests based on the Coverage report.

Storage.spec.ts:-
Tests supporting->
i) Change event being emitted when ChangeEmitter is registered
ii) Coverage for Catch blocks for setter and getter for Account, AccessToken, IdToken, RefreshToken

TokenCache.spec.ts:-
Tests supporting->
i) Edge cases like deserializing an empty cache, empty KVStore in case of empty Cache.