### PR TITLE
[msal-browser] Add support for logout_hint

### DIFF
--- a/change/@azure-msal-browser-09d437d1-34ec-4523-a226-c6faa0408b18.json
+++ b/change/@azure-msal-browser-09d437d1-34ec-4523-a226-c6faa0408b18.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for logout_hint #4450",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-cb7088fe-a140-4c7c-8bd3-2b47e6e43445.json
+++ b/change/@azure-msal-common-cb7088fe-a140-4c7c-8bd3-2b47e6e43445.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for logout_hint #4450",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/docs/logout.md
+++ b/lib/msal-browser/docs/logout.md
@@ -105,7 +105,7 @@ await msalInstance.logoutPopup({
 
 ## Promptless logout
 
-If your client application has the [login_hint optional claim](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set) enabled for ID Tokens, you can leverage the ID Token's `login_hint` claim to perform a "silent" or promptless logout while using either `logoutRedirect` or `logoutPopup`. There are two ways to achieve a promptless logout:
+If your client application has the [login_hint optional claim](https://docs.microsoft.com/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set) enabled for ID Tokens, you can leverage the ID Token's `login_hint` claim to perform a "silent" or promptless logout while using either `logoutRedirect` or `logoutPopup`. There are two ways to achieve a promptless logout:
 
 ### Option 1: Let MSAL automatically parse the login_hint out of the account's ID token claims
 

--- a/lib/msal-browser/docs/logout.md
+++ b/lib/msal-browser/docs/logout.md
@@ -103,6 +103,34 @@ await msalInstance.logoutPopup({
 });
 ```
 
+## Promptless logout
+
+If your client application has the [login_hint optional claim](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set) enabled for ID Tokens, you can leverage the ID Token's `login_hint` claim to perform a "silent" or promptless logout while using either `logoutRedirect` or `logoutPopup`. There are two ways to achieve a promptless logout:
+
+### Option 1: Let MSAL automatically parse the login_hint out of the account's ID token claims
+
+The first and simplest option is to provide the account object you want to end the session for to the logout API. MSAL will check to see if the `login_hint` claim is available in the account's ID token and automatically add it to the end session request as `logout_hint` to skip the account picker prompt.
+
+```javascript
+const currentAccount = msalInstance.getAccountByHomeId(homeAccountId);
+// The account's ID Token must contain the login_hint optional claim to avoid the account picker
+await msalInstance.logoutRedirect({ account: currentAccount});
+```
+
+### Option 2: Manually set the logoutHint option in the logout request
+
+Alternatively, if you prefer to manually set the `logoutHint`, you can extract the `login_hint` claim in your app and set it as the `logoutHint` in the logout request: 
+
+```javascript
+const currentAccount = msalInstance.getAccountByHomeId(homeAccountId);
+
+// Extract login hint to use as logout hint
+const logoutHint = currentAccount.idTokenClaims.login_hint;
+await msalInstance.logoutPopup({ logoutHint: logoutHint });
+```
+
+***Note: Depending on the API you choose (redirect/popup), the app will still redirect or open a popup to terminate the server session. The difference is that the user will not see or have to interact with the server's account picker prompt.***
+
 ## Front-channel logout
 
 Azure AD and Azure AD B2C support the [OAuth front-channel logout feature](https://openid.net/specs/openid-connect-frontchannel-1_0.html), which enables single-sign out across all applications when a user initiates logout. To take advantage of this feature with MSAL.js, perform the following steps:

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -70,7 +70,7 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
         };
 
         /**
-         * Set logout_hint to be preferred_username from ID Token Claims if present
+         * Set logout_hint to be login_hint from ID Token Claims if present
          * and logoutHint attribute wasn't manually set in logout request
          */
         if (logoutRequest) {
@@ -79,7 +79,7 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
                 if(logoutRequest.account) {
                     const logoutHint = this.getLogoutHintFromIdTokenClaims(logoutRequest.account);
                     if (logoutHint) {
-                        this.logger.verbose("Setting logoutHint to preferred_username ID Token Claim value for the account provided");
+                        this.logger.verbose("Setting logoutHint to login_hint ID Token Claim value for the account provided");
                         validLogoutRequest.logoutHint = logoutHint; 
                     }
                 } else {
@@ -117,17 +117,17 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
     }
 
     /**
-     * Parses preferred_username ID Token Claim out of AccountInfo object to be used as 
+     * Parses login_hint ID Token Claim out of AccountInfo object to be used as 
      * logout_hint in end session request.
      * @param account 
      */
     protected getLogoutHintFromIdTokenClaims(account: AccountInfo): string | null {
         const idTokenClaims: IdTokenClaims | undefined = account.idTokenClaims;
         if (idTokenClaims) {
-            if (idTokenClaims.preferred_username) {
-                return idTokenClaims.preferred_username;
+            if (idTokenClaims.login_hint) {
+                return idTokenClaims.login_hint;
             } else {
-                this.logger.verbose("The ID Token Claims tied to the provided account do not contain a preferred_username claim, logoutHint will not be added to logout request");
+                this.logger.verbose("The ID Token Claims tied to the provided account do not contain a login_hint claim, logoutHint will not be added to logout request");
             }
         } else {
             this.logger.verbose("The provided account does not contain ID Token Claims, logoutHint will not be added to logout request");

--- a/lib/msal-browser/src/request/EndSessionPopupRequest.ts
+++ b/lib/msal-browser/src/request/EndSessionPopupRequest.ts
@@ -15,6 +15,7 @@ import { PopupWindowAttributes } from "../utils/PopupUtils";
  * - idTokenHint            - ID Token used by B2C to validate logout if required by the policy
  * - mainWindowRedirectUri  - URI to navigate the main window to after logout is complete
  * - popupWindowAttributes  - Optional popup window attributes. popupSize with height and width, and popupPosition with top and left can be set.
+ * - logoutHint             - A string that specifies the account that is being logged out in order to skip the server account picker on logout
  */
 export type EndSessionPopupRequest = Partial<CommonEndSessionRequest> & {
     authority?: string;

--- a/lib/msal-browser/src/request/EndSessionRequest.ts
+++ b/lib/msal-browser/src/request/EndSessionRequest.ts
@@ -13,6 +13,7 @@ import { CommonEndSessionRequest } from "@azure/msal-common";
  * - correlationId          - Unique GUID set per request to trace a request end-to-end for telemetry purposes.
  * - idTokenHint            - ID Token used by B2C to validate logout if required by the policy
  * - onRedirectNavigate     - Callback that will be passed the url that MSAL will navigate to. Returning false in the callback will stop navigation.
+ * - logoutHint             - A string that specifies the account that is being logged out in order to skip the server account picker on logout
  */
 export type EndSessionRequest = Partial<CommonEndSessionRequest> & {
     authority?: string;

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -437,10 +437,11 @@ describe("PopupClient", () => {
                 "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
                 "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
                 "name": "Abe Lincoln",
-                "preferred_username": logoutHint,
+                "preferred_username": "AbeLi@microsoft.com",
                 "oid": "00000000-0000-0000-66f3-3332eca7ea81",
                 "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
                 "nonce": "123523",
+                "login_hint": logoutHint
             };
 
             const testAccountInfo: AccountInfo = {
@@ -476,16 +477,17 @@ describe("PopupClient", () => {
             //@ts-ignore
             popupClient = new PopupClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient);
             const logoutHint = "test@user.com";
-            const preferredUsername = "anothertest@user.com";
+            const loginHint = "anothertest@user.com";
             const testIdTokenClaims: TokenClaims = {
                 "ver": "2.0",
                 "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
                 "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
                 "name": "Abe Lincoln",
-                "preferred_username": preferredUsername,
+                "preferred_username": "AbeLi@microsoft.com",
                 "oid": "00000000-0000-0000-66f3-3332eca7ea81",
                 "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
                 "nonce": "123523",
+                "login_hint": loginHint
             };
 
             const testAccountInfo: AccountInfo = {
@@ -499,7 +501,7 @@ describe("PopupClient", () => {
 
             sinon.stub(PopupUtils, "openSizedPopup").callsFake((urlNavigate) => {
                 expect(urlNavigate).toContain(`logout_hint=${encodeURIComponent(logoutHint)}`);
-                expect(urlNavigate).not.toContain(`logout_hint=${encodeURIComponent(preferredUsername)}`);
+                expect(urlNavigate).not.toContain(`logout_hint=${encodeURIComponent(loginHint)}`);
                 done();
                 throw "Stop Test";
             });

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -393,6 +393,123 @@ describe("PopupClient", () => {
             popupClient.logout().catch(() => {});
         });
 
+        it("includes logoutHint if it is set on request", (done) => {
+            const pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                },
+                system: {
+                    asyncPopups: true
+                }
+            });
+
+            //@ts-ignore
+            popupClient = new PopupClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient);
+            const logoutHint = "test@user.com";
+
+            sinon.stub(PopupUtils, "openSizedPopup").callsFake((urlNavigate) => {
+                expect(urlNavigate).toContain(`logout_hint=${encodeURIComponent(logoutHint)}`);
+                done();
+                throw "Stop Test";
+            });
+
+            popupClient.logout({
+                logoutHint
+            }).catch(() => {});
+        });
+
+        it("includes logoutHint from ID token claims if account is passed in and logoutHint is not", (done) => {
+            const pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                },
+                system: {
+                    asyncPopups: true
+                }
+            });
+
+            //@ts-ignore
+            popupClient = new PopupClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient);
+            
+            const logoutHint = "test@user.com";
+            const testIdTokenClaims: TokenClaims = {
+                "ver": "2.0",
+                "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                "name": "Abe Lincoln",
+                "preferred_username": logoutHint,
+                "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+                "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+                "nonce": "123523",
+            };
+
+            const testAccountInfo: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || "",
+                idTokenClaims: testIdTokenClaims
+            };
+
+            sinon.stub(PopupUtils, "openSizedPopup").callsFake((urlNavigate) => {
+                expect(urlNavigate).toContain(`logout_hint=${encodeURIComponent(logoutHint)}`);
+                done();
+                throw "Stop Test";
+            });
+
+            popupClient.logout({
+                account: testAccountInfo
+            }).catch(() => {});
+        });
+
+        it("logoutHint attribute takes precedence over ID Token Claims from provided account when setting logout_hint", (done) => {
+            const pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                },
+                system: {
+                    asyncPopups: true
+                }
+            });
+            
+            //@ts-ignore
+            popupClient = new PopupClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient);
+            const logoutHint = "test@user.com";
+            const preferredUsername = "anothertest@user.com";
+            const testIdTokenClaims: TokenClaims = {
+                "ver": "2.0",
+                "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                "name": "Abe Lincoln",
+                "preferred_username": preferredUsername,
+                "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+                "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+                "nonce": "123523",
+            };
+
+            const testAccountInfo: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || "",
+                idTokenClaims: testIdTokenClaims
+            };
+
+            sinon.stub(PopupUtils, "openSizedPopup").callsFake((urlNavigate) => {
+                expect(urlNavigate).toContain(`logout_hint=${encodeURIComponent(logoutHint)}`);
+                expect(urlNavigate).not.toContain(`logout_hint=${encodeURIComponent(preferredUsername)}`);
+                done();
+                throw "Stop Test";
+            });
+
+            popupClient.logout({
+                account: testAccountInfo,
+                logoutHint
+            }).catch(() => {});
+        });
+
         it("redirects main window when logout is complete", (done) => {
             const popupWindow = {...window};
             sinon.stub(PopupUtils, "openSizedPopup").returns(popupWindow);

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -1743,7 +1743,7 @@ describe("RedirectClient", () => {
                 done();
                 return Promise.resolve(true);
             });
-            redirectClient.logout({ logoutHint: logoutHint});
+            redirectClient.logout({ logoutHint: logoutHint });
         });
 
         it("includes logoutHint from ID token claims if account is passed in and logoutHint is not", (done) => {
@@ -1753,10 +1753,11 @@ describe("RedirectClient", () => {
                 "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
                 "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
                 "name": "Abe Lincoln",
-                "preferred_username": logoutHint,
+                "preferred_username": "AbeLi@microsoft.com",
                 "oid": "00000000-0000-0000-66f3-3332eca7ea81",
                 "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
                 "nonce": "123523",
+                "login_hint": logoutHint
             };
 
             const testAccountInfo: AccountInfo = {
@@ -1773,21 +1774,22 @@ describe("RedirectClient", () => {
                 done();
                 return Promise.resolve(true);
             });
-            redirectClient.logout({ account: testAccountInfo});
+            redirectClient.logout({ account: testAccountInfo });
         });
 
         it("logoutHint attribute takes precedence over ID Token Claims from provided account when setting logout_hint", (done) => {
             const logoutHint = "test@user.com";
-            const preferredUsername = "anothertest@user.com";
+            const loginHint = "anothertest@user.com";
             const testIdTokenClaims: TokenClaims = {
                 "ver": "2.0",
                 "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
                 "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
                 "name": "Abe Lincoln",
-                "preferred_username": preferredUsername,
+                "preferred_username": "AbeLi@microsoft.com",
                 "oid": "00000000-0000-0000-66f3-3332eca7ea81",
                 "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
                 "nonce": "123523",
+                "login_hint": loginHint
             };
 
             const testAccountInfo: AccountInfo = {
@@ -1801,7 +1803,7 @@ describe("RedirectClient", () => {
 
             sinon.stub(NavigationClient.prototype, "navigateExternal").callsFake((urlNavigate: string, options: NavigationOptions): Promise<boolean> => {
                 expect(urlNavigate).toContain(`logout_hint=${encodeURIComponent(logoutHint)}`);
-                expect(urlNavigate).not.toContain(`logout_hint=${encodeURIComponent(preferredUsername)}`);
+                expect(urlNavigate).not.toContain(`logout_hint=${encodeURIComponent(loginHint)}`);
                 done();
                 return Promise.resolve(true);
             });

--- a/lib/msal-common/src/account/TokenClaims.ts
+++ b/lib/msal-common/src/account/TokenClaims.ts
@@ -15,6 +15,7 @@ export type TokenClaims = {
     ver?: string,
     upn?: string,
     preferred_username?: string,
+    login_hint?: string,
     emails?: string[],
     name?: string,
     nonce?: string,

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -429,6 +429,10 @@ export class AuthorizationCodeClient extends BaseClient {
             parameterBuilder.addState(request.state);
         }
 
+        if (request.logoutHint) {
+            parameterBuilder.addLogoutHint(request.logoutHint);
+        }
+
         if (request.extraQueryParameters) {
             parameterBuilder.addExtraQueryParameters(request.extraQueryParameters);
         }

--- a/lib/msal-common/src/request/CommonEndSessionRequest.ts
+++ b/lib/msal-common/src/request/CommonEndSessionRequest.ts
@@ -13,6 +13,7 @@ import { StringDict } from "../utils/MsalTypes";
  * - correlationId          - Unique GUID set per request to trace a request end-to-end for telemetry purposes.
  * - idTokenHint            - ID Token used by B2C to validate logout if required by the policy
  * - state                  - A value included in the request to the logout endpoint which will be returned in the query string upon post logout redirection
+ * - logoutHint             - A string that specifies the account that is being logged out in order to skip the server account picker on logout
  */
 export type CommonEndSessionRequest = {
     correlationId: string
@@ -20,5 +21,6 @@ export type CommonEndSessionRequest = {
     postLogoutRedirectUri?: string | null,
     idTokenHint?: string,
     state?: string,
+    logoutHint?: string,
     extraQueryParameters?: StringDict 
 };

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -384,6 +384,13 @@ export class RequestParameterBuilder {
     }
 
     /**
+     * Adds logout_hint parameter for "silent" logout which prevent server account picker
+     */
+    addLogoutHint(logoutHint: string): void {
+        this.parameters.set(AADServerParamKeys.LOGOUT_HINT, encodeURIComponent(logoutHint));
+    }
+
+    /**
      * Utility to create a URL from the params map
      */
     createQueryString(): string {

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -137,7 +137,8 @@ export enum AADServerParamKeys {
     ON_BEHALF_OF = "on_behalf_of",
     FOCI = "foci",
     CCS_HEADER = "X-AnchorMailbox",
-    RETURN_SPA_CODE = "return_spa_code"
+    RETURN_SPA_CODE = "return_spa_code",
+    LOGOUT_HINT = "logout_hint"
 }
 
 /**

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -148,7 +148,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             const client = new AuthorizationCodeClient(config);
             const testAccount = TEST_ACCOUNT_INFO;
             // @ts-ignore
-            const testTokenClaims: Required<Omit<TokenClaims, "home_oid"|"upn"|"cloud_instance_host_name"|"cnf"|"emails">> = {
+            const testTokenClaims: Required<Omit<TokenClaims, "home_oid"|"upn"|"cloud_instance_host_name"|"cnf"|"emails"|"login_hint">> = {
                 ver: "2.0",
                 iss: `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
                 sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
@@ -313,7 +313,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
             const client = new AuthorizationCodeClient(config);
             const testAccount = TEST_ACCOUNT_INFO;
-            const testTokenClaims: Required<Omit<TokenClaims, "home_oid"|"upn"|"cloud_instance_host_name"|"cnf"|"emails"|"iat"|"x5c_ca"|"ts"|"at"|"u"|"p"|"m">> = {
+            const testTokenClaims: Required<Omit<TokenClaims, "home_oid"|"upn"|"cloud_instance_host_name"|"cnf"|"emails"|"iat"|"x5c_ca"|"ts"|"at"|"u"|"p"|"m"|"login_hint">> = {
                 ver: "2.0",
                 iss: `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
                 sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
@@ -350,7 +350,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
             const client = new AuthorizationCodeClient(config);
             const testAccount = TEST_ACCOUNT_INFO;
-            const testTokenClaims: Required<Omit<TokenClaims, "home_oid"|"upn"|"cloud_instance_host_name"|"cnf"|"emails"|"sid"|"iat"|"x5c_ca"|"ts"|"at"|"u"|"p"|"m">> = {
+            const testTokenClaims: Required<Omit<TokenClaims, "home_oid"|"upn"|"cloud_instance_host_name"|"cnf"|"emails"|"sid"|"iat"|"x5c_ca"|"ts"|"at"|"u"|"p"|"m"|"login_hint">> = {
                 ver: "2.0",
                 iss: `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
                 sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",

--- a/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
+++ b/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
@@ -39,6 +39,7 @@ describe("RequestParameterBuilder unit tests", () => {
         requestParameterBuilder.addCodeVerifier(TEST_CONFIG.TEST_VERIFIER);
         requestParameterBuilder.addGrantType(GrantType.DEVICE_CODE_GRANT);
         requestParameterBuilder.addSid(TEST_CONFIG.SID);
+        requestParameterBuilder.addLogoutHint(TEST_CONFIG.LOGIN_HINT);
 
         const requestQueryString = requestParameterBuilder.createQueryString();
         expect(requestQueryString.includes(`${AADServerParamKeys.RESPONSE_TYPE}=${Constants.CODE_RESPONSE_TYPE}`)).toBe(true);
@@ -59,6 +60,7 @@ describe("RequestParameterBuilder unit tests", () => {
         expect(requestQueryString.includes(`${AADServerParamKeys.DEVICE_CODE}=${encodeURIComponent(DEVICE_CODE_RESPONSE.deviceCode)}`)).toBe(true);
         expect(requestQueryString.includes(`${AADServerParamKeys.CODE_VERIFIER}=${encodeURIComponent(TEST_CONFIG.TEST_VERIFIER)}`)).toBe(true);
         expect(requestQueryString.includes(`${SSOTypes.SID}=${encodeURIComponent(TEST_CONFIG.SID)}`)).toBe(true);
+        expect(requestQueryString.includes(`${AADServerParamKeys.LOGOUT_HINT}=${encodeURIComponent(TEST_CONFIG.LOGIN_HINT)}`)).toBe(true);
     });
 
     it("Adds token type and req_cnf correctly for proof-of-possession tokens", () => {


### PR DESCRIPTION
This PR:
- Adds `logoutHint` attribute to `CommonEndSessionRequest` type
- Adds logic in `StandardInteractionClient.initializeLogoutRequest` to parse `login_hint` from ID token claims in the account (if) passed in and set it as `logout_hint` in the end session request
- Adds `addLogoutHint` API to `RequestParameterBuilder` and calls it on `AuthorizationCodeClient.getLogoutUri()` to populate the `logout_hint` query parameter of the end session endpoint request
- Adds unit tests that cover these changes and scenarios