### PR TITLE
Don't reassign request object properties

### DIFF
--- a/change/@azure-msal-browser-7cbf844d-07a3-4eba-bcbc-2204a5809fbe.json
+++ b/change/@azure-msal-browser-7cbf844d-07a3-4eba-bcbc-2204a5809fbe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't reassign request object properties #4563",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -75,12 +75,19 @@ export abstract class BaseInteractionClient {
 
         const scopes = [...((request && request.scopes) || [])];
 
+        const validatedRequest: BaseAuthRequest = {
+            ...request,
+            correlationId: this.correlationId,
+            authority,
+            scopes
+        };
+
         // Set authenticationScheme to BEARER if not explicitly set in the request
-        if (!request.authenticationScheme) {
-            request.authenticationScheme = AuthenticationScheme.BEARER;
+        if (!validatedRequest.authenticationScheme) {
+            validatedRequest.authenticationScheme = AuthenticationScheme.BEARER;
             this.logger.verbose("Authentication Scheme wasn't explicitly set in request, defaulting to \"Bearer\" request");
         } else {
-            if (request.authenticationScheme === AuthenticationScheme.SSH) {
+            if (validatedRequest.authenticationScheme === AuthenticationScheme.SSH) {
                 if (!request.sshJwk) {
                     throw ClientConfigurationError.createMissingSshJwkError();
                 }
@@ -88,20 +95,13 @@ export abstract class BaseInteractionClient {
                     throw ClientConfigurationError.createMissingSshKidError();
                 }
             }
-            this.logger.verbose(`Authentication Scheme set to "${request.authenticationScheme}" as configured in Auth request`);
+            this.logger.verbose(`Authentication Scheme set to "${validatedRequest.authenticationScheme}" as configured in Auth request`);
         }
 
         // Set requested claims hash if claims were requested
         if (request.claims && !StringUtils.isEmpty(request.claims)) {
-            request.requestedClaimsHash = await this.browserCrypto.hashString(request.claims);
+            validatedRequest.requestedClaimsHash = await this.browserCrypto.hashString(request.claims);
         } 
-
-        const validatedRequest: BaseAuthRequest = {
-            ...request,
-            correlationId: this.correlationId,
-            authority,
-            scopes
-        };
 
         return validatedRequest;
     }

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1016,6 +1016,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             };
             sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
             sinon.stub(CryptoOps.prototype, "hashString").resolves(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
+            const atsSpy = sinon.spy(PublicClientApplication.prototype, <any>"acquireTokenSilentAsync");
             const silentATStub = sinon.stub(RefreshTokenClient.prototype, "acquireTokenByRefreshToken").resolves(testTokenResponse);
             const tokenRequest: CommonSilentFlowRequest = {
                 scopes: ["User.Read"],
@@ -1042,6 +1043,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const parallelResponse = await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
 
             expect(silentATStub.calledWith(expectedTokenRequest)).toBeTruthy();
+            expect(atsSpy.calledOnce).toBe(true);
             expect(silentATStub.callCount).toEqual(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);
             expect(parallelResponse[1]).toEqual(testTokenResponse);
@@ -1316,6 +1318,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tenantId: "testTenantId",
                 username: "username@contoso.com"
             };
+            const atsSpy = sinon.spy(PublicClientApplication.prototype, <any>"acquireTokenSilentAsync");
             sinon.stub(RefreshTokenClient.prototype, <any>"acquireTokenByRefreshToken").rejects(testError);
             try {
                 const tokenRequest = {
@@ -1328,6 +1331,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
             } catch (e) {
                 // Test that error was cached for telemetry purposes and then thrown
+                expect(atsSpy.calledOnce).toBe(true);
                 expect(window.sessionStorage).toHaveLength(1);
                 const failures = window.sessionStorage.getItem(`server-telemetry-${TEST_CONFIG.MSAL_CLIENT_ID}`);
                 const failureObj = JSON.parse(failures || "") as ServerTelemetryEntity;


### PR DESCRIPTION
`initializeBaseRequest` currently reassigns some properties of the original request causing issues with thumbprinting for concurrent requests. This PR fixes this behavior.