### PR TITLE
Use Windows 2019 for build-test instead of 2016

### DIFF
--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -118,7 +118,7 @@ jobs:
 
   extensions-build-test:
     needs: pre-check
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: needs.pre-check.outputs.extensions == 'true'
   
     name: msal-node-extensions

--- a/.github/workflows/build-test-push-to-dev.yml
+++ b/.github/workflows/build-test-push-to-dev.yml
@@ -68,7 +68,7 @@ jobs:
         flags: ${{ matrix.library }}
         
   extensions-build-test:
-    runs-on: windows-latest
+    runs-on: windows-2019
   
     name: msal-node-extensions
     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,9 +5,9 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 jobs:
-  - job: rolling_VS2017_build
-    displayName: 'Build Job for JS (VS2017)'
+  - job: windows-2019
+    displayName: 'Build Job for JS (VS2019)'
     pool:
-      name: Hosted VS2017
+      name: Hosted VS2019
     steps:
       - template: build/sdl-tasks.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,9 +5,9 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 jobs:
-  - job: windows-2019
+  - job: Windows
     displayName: 'Build Job for JS (VS2019)'
     pool:
-      name: Hosted VS2019
+      vmImage: 'windows-2019'
     steps:
       - template: build/sdl-tasks.yml


### PR DESCRIPTION
Windows Server 2016 is being deprecated and brownout is causing our pipelines to fail.