### PR TITLE
Update React 18 sample to use GA version

### DIFF
--- a/samples/msal-react-samples/react-18-sample/package.json
+++ b/samples/msal-react-samples/react-18-sample/package.json
@@ -10,8 +10,8 @@
     "@mui/icons-material": "^5.3.1",
     "@mui/material": "^5.4.0",
     "@mui/styles": "^5.3.0",
-    "react": "^18.0.0-rc.0",
-    "react-dom": "^18.0.0-rc.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0"
   },


### PR DESCRIPTION
React 18 has been released - updates the React 18 sample to use the GA version instead of the release candidate