### PR TITLE
Node token validation build fix

### DIFF
--- a/change/@azure-node-token-validation-8173c0e5-75b2-4d7a-aeb5-e32353a468da.json
+++ b/change/@azure-node-token-validation-8173c0e5-75b2-4d7a-aeb5-e32353a468da.json
@@ -2,6 +2,6 @@
   "comment": "Build command fix in package.json",
   "type": "none",
   "packageName": "@azure/node-token-validation",
-  "email": "joliuac@gmail.com",
+  "email": "joarroyo@microsoft.com",
   "dependentChangeType": "none"
 }

--- a/change/@azure-node-token-validation-8173c0e5-75b2-4d7a-aeb5-e32353a468da.json
+++ b/change/@azure-node-token-validation-8173c0e5-75b2-4d7a-aeb5-e32353a468da.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Build command fix in package.json",
+  "type": "none",
+  "packageName": "@azure/node-token-validation",
+  "email": "joliuac@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/lib/node-token-validation/package.json
+++ b/lib/node-token-validation/package.json
@@ -44,11 +44,12 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:coverage:only": "npm run clean:coverage && npm run test:coverage",
+    "build:common": "cd ../msal-common && npm run build",
     "build:modules": "rollup -c",
     "build:modules:watch": "rollup -cw",
     "build": "npm run clean && npm run build:modules",
-    "build:all": "npm run build",
-    "prepack": "npm run build"
+    "build:all": "npm run build:common && npm run build",
+    "prepack": "npm run build:all"
   },
   "bugs": {
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js/issues"


### PR DESCRIPTION
Fixes command in package.json which was missing msal-common build.

Addresses concerns in PR #4680