### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/beachball-bump.yml
+++ b/.github/workflows/beachball-bump.yml
@@ -11,8 +11,14 @@ concurrency:
   group: beachball-bump
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   bump:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.event.pull_request.merged == true && !contains(github.head_ref, 'release')
     name: Bump versions and create changelogs
     runs-on: ubuntu-latest

--- a/.github/workflows/beachball-check.yml
+++ b/.github/workflows/beachball-check.yml
@@ -12,8 +12,14 @@ concurrency:
   group: beachball-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   beachball-check:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -15,8 +15,14 @@ concurrency:
   group: ci-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pre-check:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     runs-on: ubuntu-latest
     outputs: 
       # Expose matched filters as job 'packages' output variable

--- a/.github/workflows/build-test-push-to-dev.yml
+++ b/.github/workflows/build-test-push-to-dev.yml
@@ -13,6 +13,9 @@ concurrency:
   group: dev-ci-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lib-build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,16 @@ on:
   schedule:
     - cron: '0 12 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
 
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     strategy:
       fail-fast: false
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,8 +13,14 @@ concurrency:
   group: labeler-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   label:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.event.pull_request.head.repo.full_name == github.repository) && (github.actor != 'dependabot[bot]')
     steps:

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -5,8 +5,13 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   lock:
+    permissions:
+      issues: write  # for dessant/lock-threads to lock issues
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2

--- a/.github/workflows/msal-angular-e2e.yml
+++ b/.github/workflows/msal-angular-e2e.yml
@@ -23,6 +23,9 @@ concurrency:
   group: angular-e2e-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))

--- a/.github/workflows/msal-browser-e2e.yml
+++ b/.github/workflows/msal-browser-e2e.yml
@@ -22,6 +22,9 @@ concurrency:
   group: browser-e2e-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))

--- a/.github/workflows/msal-core-e2e.yml
+++ b/.github/workflows/msal-core-e2e.yml
@@ -19,6 +19,9 @@ concurrency:
   group: core-e2e-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -22,6 +22,9 @@ concurrency:
   group: node-e2e-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))

--- a/.github/workflows/msal-react-e2e.yml
+++ b/.github/workflows/msal-react-e2e.yml
@@ -23,6 +23,9 @@ concurrency:
   group: react-e2e-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -23,6 +23,9 @@ concurrency:
   group: audit-${{github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   audit-root:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,8 +35,14 @@ concurrency:
   group: publish-packages
 
 # Job will run on a ubuntu instance
+permissions:
+  contents: read
+
 jobs:
   pre-publish:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     if: (github.event.pull_request.merged == true && github.head_ref == 'release-staging')
     runs-on: ubuntu-latest
 
@@ -65,6 +71,8 @@ jobs:
           list-files: json
 
   publish-msal-core:
+    permissions:
+      contents: none
     name: msal-core
     needs: pre-publish
     if: |
@@ -82,6 +90,8 @@ jobs:
       CDN_USWE_SAS: ${{ secrets.CDN_USWE_SAS }}
 
   publish-msal-common:
+    permissions:
+      contents: none
     name: msal-common
     needs: pre-publish
     if: |
@@ -96,6 +106,8 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-msal-browser:
+    permissions:
+      contents: none
     name: msal-browser
     needs: [pre-publish, publish-msal-common]
     if: |
@@ -113,6 +125,8 @@ jobs:
       CDN_USWE_SAS: ${{ secrets.CDN_USWE_SAS }}
 
   publish-msal-node:
+    permissions:
+      contents: none
     name: msal-node
     needs: [pre-publish, publish-msal-common]
     if: |
@@ -127,6 +141,8 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-msal-angular:
+    permissions:
+      contents: none
     name: msal-angular
     needs: [pre-publish, publish-msal-browser]
     if: |
@@ -141,6 +157,8 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-msal-react:
+    permissions:
+      contents: none
     name: msal-react
     needs: [pre-publish, publish-msal-browser]
     if: |
@@ -155,6 +173,8 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-msal-node-extensions:
+    permissions:
+      contents: none
     name: msal-node-extensions
     needs: [pre-publish, publish-msal-common]
     if: |
@@ -169,6 +189,9 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   post-publish:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     needs: [
       publish-msal-core, 
       publish-msal-common, 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,9 +5,15 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
 
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
