### PR TITLE
Update cache-manager in passport-azure-ad

### DIFF
--- a/maintenance/passport-azure-ad/CHANGELOG.md
+++ b/maintenance/passport-azure-ad/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 4.3.2
 - Update `async` to resolve dependency alert: #4724
+- Update `cache-manager` to resolve dependency alert
 
 # 4.3.1
 

--- a/maintenance/passport-azure-ad/CHANGELOG.md
+++ b/maintenance/passport-azure-ad/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 4.3.2
 - Update `async` to resolve dependency alert: #4724
-- Update `cache-manager` to resolve dependency alert
+- Update `cache-manager` to resolve dependency alert: #4781
 
 # 4.3.1
 

--- a/maintenance/passport-azure-ad/lib/bearerstrategy.js
+++ b/maintenance/passport-azure-ad/lib/bearerstrategy.js
@@ -21,7 +21,7 @@ const Log = require("./logging").getLogger;
 const UrlValidator = require("valid-url");
 
 const log = new Log("AzureAD: Bearer Strategy");
-const memoryCache = cacheManager.caching({ store: "memory", max: 3600, ttl: 1800 /* seconds */ });
+const memoryCache = cacheManager.caching({ store: "memory", max: 3600, shouldCloneBeforeSet: false, ttl: 1800 /* seconds */ });
 const ttl = 1800; // 30 minutes cache
 
 /**

--- a/maintenance/passport-azure-ad/lib/oidcstrategy.js
+++ b/maintenance/passport-azure-ad/lib/oidcstrategy.js
@@ -37,7 +37,7 @@ const Validator = require("./validator").Validator;
 // global variable definitions
 const log = new Log("AzureAD: OIDC Passport Strategy");
 
-const memoryCache = cacheManager.caching({ store: "memory", max: 3600, ttl: 1800 /* seconds */ });
+const memoryCache = cacheManager.caching({ store: "memory", max: 3600, shouldCloneBeforeSet: false, ttl: 1800 /* seconds */ });
 const ttl = 1800; // 30 minutes cache
 // Note: callback is optional in set() and del().
 

--- a/maintenance/passport-azure-ad/package.json
+++ b/maintenance/passport-azure-ad/package.json
@@ -38,7 +38,7 @@
     "async": "^3.2.3",
     "base64url": "^3.0.0",
     "bunyan": "^1.8.14",
-    "cache-manager": "2.10.2",
+    "cache-manager": "^3.6.1",
     "https-proxy-agent": "^5.0.0",
     "jws": "^3.1.3",
     "lodash": "^4.11.2",


### PR DESCRIPTION
Updates `cache-manager` to v3, including breaking change detailed here: https://github.com/BryanDonovan/node-cache-manager/pull/135/files