### PR TITLE
Update extensions package-lock to fix audit

### DIFF
--- a/change/@azure-msal-node-extensions-29700ff3-7571-410f-ac8f-0b8051de228d.json
+++ b/change/@azure-msal-node-extensions-29700ff3-7571-410f-ac8f-0b8051de228d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update extensions package-lock to fix audit #4786",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/extensions/msal-node-extensions/package-lock.json
+++ b/extensions/msal-node-extensions/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@azure/msal-node-extensions",
-  "version": "1.0.0-alpha.16",
+  "version": "1.0.0-alpha.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/msal-node-extensions",
-      "version": "1.0.0-alpha.16",
+      "version": "1.0.0-alpha.17",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "^6.2.0",
+        "@azure/msal-common": "^6.3.0",
         "bindings": "git+https://github.com/samuelkubai/node-bindings.git#v1.6.0",
         "keytar": "^7.8.0",
         "nan": "^2.13.2"
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.2.0.tgz",
-      "integrity": "sha512-SU2/vfbKn1WvtKM8tsBKZAbmRJvO8E3H773ZT0GGKuO9rwLfxP5qOzTHV5crCEm8DgvL/IppmWh2lsUFieDi1A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.3.0.tgz",
+      "integrity": "sha512-ZyLq9GdnLBi/83YpysE86TFKbA0TuvfNAN5Psqu20cdAjLo/4rw4ttiItdh1G//XeGErHk9qn57gi2AYU1b5/Q==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -12806,9 +12806,9 @@
   },
   "dependencies": {
     "@azure/msal-common": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.2.0.tgz",
-      "integrity": "sha512-SU2/vfbKn1WvtKM8tsBKZAbmRJvO8E3H773ZT0GGKuO9rwLfxP5qOzTHV5crCEm8DgvL/IppmWh2lsUFieDi1A=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.3.0.tgz",
+      "integrity": "sha512-ZyLq9GdnLBi/83YpysE86TFKbA0TuvfNAN5Psqu20cdAjLo/4rw4ttiItdh1G//XeGErHk9qn57gi2AYU1b5/Q=="
     },
     "@babel/code-frame": {
       "version": "7.12.13",


### PR DESCRIPTION
This PR updates the msal-node-extensions package-lock to reconcile the msal-common version in the package.json file.