### PR TITLE
[msal-node] export AuthorizationCodePayload type from msal-common

### DIFF
--- a/change/@azure-msal-node-2c44a8b8-4645-4ad0-8963-8ba5b369789a.json
+++ b/change/@azure-msal-node-2c44a8b8-4645-4ad0-8963-8ba5b369789a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "export AuthorizationCodePayload type from msal-common #4803",
+  "packageName": "@azure/msal-node",
+  "email": "git@hens.by",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -46,6 +46,7 @@ export {
     // Request
     PromptValue,
     ResponseMode,
+    AuthorizationCodePayload,
     // Response
     AuthenticationResult,
     // Cache


### PR DESCRIPTION
The `ClientApplication.acquireTokenByCode()` method accepts two arguments, the second is an optional argument of type `AuthorizationCodePayload`.

So that consumers of `msal-node` don't need to require `msal-common` themselves to obtain this type definition, it should be exported by `msal-node`.