### PR TITLE
[passport-azure-ad] - Replace 'request' with native 'https' module

### DIFF
--- a/maintenance/passport-azure-ad/CHANGELOG.md
+++ b/maintenance/passport-azure-ad/CHANGELOG.md
@@ -1,5 +1,8 @@
 <a name="4.0.0"></a>
 
+# 4.3.3.
+- Replace `request` with native `https` module to resolve security vulnerability: #4805
+
 # 4.3.2
 - Update `async` to resolve dependency alert: #4724
 - Update `cache-manager` to resolve dependency alert: #4781

--- a/maintenance/passport-azure-ad/package.json
+++ b/maintenance/passport-azure-ad/package.json
@@ -45,7 +45,6 @@
     "node-jose": "^2.0.0",
     "oauth": "0.9.15",
     "passport": "^0.4.1",
-    "request": "^2.72.0",
     "valid-url": "^1.0.6"
   },
   "scripts": {

--- a/maintenance/passport-azure-ad/package.json
+++ b/maintenance/passport-azure-ad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-azure-ad",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "license": "MIT",
   "keywords": [
     "azure active directory",

--- a/maintenance/passport-azure-ad/test/Chai-passport_test/oidc_dynamic_tenant_test.js
+++ b/maintenance/passport-azure-ad/test/Chai-passport_test/oidc_dynamic_tenant_test.js
@@ -1,67 +1,48 @@
-/**
- * Copyright (c) Microsoft Corporation
- *  All Rights Reserved
- *  MIT License
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this
- * software and associated documentation files (the "Software"), to deal in the Software
- * without restriction, including without limitation the rights to use, copy, modify,
- * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
- * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
- * OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
  */
  
  /* eslint-disable no-new */
 
- 'use restrict';
+ "use restrict";
 
-var chai = require('chai');
-var url = require('url');
-var OIDCStrategy = require('../../lib/index').OIDCStrategy;
+const chai = require("chai");
+const url = require("url");
+const OIDCStrategy = require("../../lib/index").OIDCStrategy;
 
-chai.use(require('chai-passport-strategy'));
+chai.use(require("chai-passport-strategy"));
 
 const TEST_TIMEOUT = 1000000; // 1000 seconds
 
 // Mock options required to create a OIDC strategy
-var options = {
-  redirectUrl: 'https://returnURL',
-  clientID: 'my_client_id',
-  clientSecret: 'my_client_secret',
-  identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
-  responseType: 'id_token',
-  responseMode: 'form_post',
+const options = {
+  redirectUrl: "https://returnURL",
+  clientID: "my_client_id",
+  clientSecret: "my_client_secret",
+  identityMetadata: "https://login.microsoftonline.com/common/.well-known/openid-configuration",
+  responseType: "id_token",
+  responseMode: "form_post",
   validateIssuer: true,
   passReqToCallback: false,
   loggingNoPII: false,
-  sessionKey: 'my_key'    //optional sessionKey
+  sessionKey: "my_key"    // optional sessionKey
 };
 
-describe('OIDCStrategy dynamic tenant test', function() {
+describe("OIDCStrategy dynamic tenant test", function() {
   this.timeout(TEST_TIMEOUT);
 
-  var redirectUrl;
-  var challenge;
-  var request;
+  let redirectUrl;
+  let challenge;
+  let request;
 
-  var testPrepare = function(validateIssuer, issuer, tenantIdOrName, isB2C, policy) {
+  const testPrepare = function(validateIssuer, issuer, tenantIdOrName, isB2C, policy) {
     return function(done) {
       options.validateIssuer = validateIssuer;
       options.issuer = issuer;
       options.isB2C = isB2C;
 
-      var testStrategy = new OIDCStrategy(options, function(profile, done) {});
-
+      const testStrategy = new OIDCStrategy(options, function(profile, done) {});
       chai.passport
         .use(testStrategy)
         .redirect(function(u) {redirectUrl = u; done(); })
@@ -76,50 +57,49 @@ describe('OIDCStrategy dynamic tenant test', function() {
     };
   };
 
-  describe('should succeed', function() {
-    before(testPrepare(true, null, 'sijun.onmicrosoft.com', false));
+  describe("should succeed", function() {
+    before(testPrepare(true, null, "sijun.onmicrosoft.com", false));
 
-    it('should have replaced common with tenantIdOrName and saved tenantIdOrName in session', function() {
-      var u = url.parse(redirectUrl, true);
-      chai.expect(request.session['my_key']['content'][0]['tenantIdOrName']).to.equal('sijun.onmicrosoft.com');
-      chai.expect(u.pathname).to.equal('/268da1a1-9db4-48b9-b1fe-683250ba90cc/oauth2/authorize');
+    it("should have replaced common with tenantIdOrName and saved tenantIdOrName in session", function() {
+      const u = url.parse(redirectUrl, true);
+      chai.expect(request.session["my_key"]["content"][0]["tenantIdOrName"]).to.equal("sijun.onmicrosoft.com");
+      chai.expect(u.pathname).to.equal("/268da1a1-9db4-48b9-b1fe-683250ba90cc/oauth2/authorize");
     });
   });
 
-  describe('should fail without issuer and tenantIdOrName for common endpoint', function() {
-    before(testPrepare(true, null, '', false));
+  describe("should fail without issuer and tenantIdOrName for common endpoint", function() {
+    before(testPrepare(true, null, "", false));
 
-    it('should fail with invalid tenant name', function() {
-      chai.expect(challenge).to.equal('In collectInfoFromReq: issuer or tenantIdOrName must be provided in order to validate issuer on common endpoint');
+    it("should fail with invalid tenant name", function() {
+      chai.expect(challenge).to.equal("In collectInfoFromReq: issuer or tenantIdOrName must be provided in order to validate issuer on common endpoint");
     });
   });
 
-  describe('should fail with invalid tenant name', function() {
-    before(testPrepare(true, null, 'xxx', false));
+  describe("should fail with invalid tenant name", function() {
+    before(testPrepare(true, null, "xxx", false));
 
-    it('should have replaced common with tenantIdOrName and saved tenantIdOrName in session', function() {
+    it("should have replaced common with tenantIdOrName and saved tenantIdOrName in session", function() {
       console.log(challenge);
-      chai.expect(challenge.startsWith('Error: 400')).to.equal(true);
+      chai.expect(challenge.startsWith("Error: 400")).to.equal(true);
     });
   });
 });
 
-describe('OIDCStrategy dynamic B2C tenant test', function() {
+describe("OIDCStrategy dynamic B2C tenant test", function() {
   this.timeout(TEST_TIMEOUT);
   
-  var redirectUrl;
-  var challenge;
-  var request;
+  let redirectUrl;
+  let challenge;
+  let request;
 
-  var testPrepare = function(validateIssuer, issuer, tenantIdOrName) {
+  const testPrepare = function(validateIssuer, issuer, tenantIdOrName) {
     return function(done) {
       options.validateIssuer = validateIssuer;
       options.issuer = issuer;
       options.isB2C = true;
-      options.identityMetadata = 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration';
+      options.identityMetadata = "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration";
 
-      var testStrategy = new OIDCStrategy(options, function(profile, done) {});
-
+      const testStrategy = new OIDCStrategy(options, function(profile, done) {});
       chai.passport
         .use(testStrategy)
         .redirect(function(u) { redirectUrl = u; done(); })
@@ -127,18 +107,18 @@ describe('OIDCStrategy dynamic B2C tenant test', function() {
         .req(function(req) {
           request = req;
           req.session = {}; 
-          req.query = { p: 'b2c_1_signin' }; 
+          req.query = { p: "b2c_1_signin" }; 
           challenge = null;
         })
         .authenticate({ tenantIdOrName: tenantIdOrName });
     };
   };
 
-  describe('should fail without tenantIdOrName for using B2C common endpoint', function() {
-    before(testPrepare(true, ['my_issuer'], '', true));
+  describe("should fail without tenantIdOrName for using B2C common endpoint", function() {
+    before(testPrepare(true, ["my_issuer"], "", true));
 
-    it('should fail with invalid tenant name', function() {
-      chai.expect(challenge).to.equal('In collectInfoFromReq: we are using common endpoint for B2C but tenantIdOrName is not provided');
+    it("should fail with invalid tenant name", function() {
+      chai.expect(challenge).to.equal("In collectInfoFromReq: we are using common endpoint for B2C but tenantIdOrName is not provided");
     });
   });
 });

--- a/maintenance/passport-azure-ad/test/End_to_end_test/package.json
+++ b/maintenance/passport-azure-ad/test/End_to_end_test/package.json
@@ -14,7 +14,6 @@
     "express": "^3.21.2",
     "express-session": "^1.14.2",
     "method-override": "^2.3.6",
-    "passport": "*",
-    "request": "^2.78.0"
+    "passport": "*"
   }
 }


### PR DESCRIPTION
This PR replaces the usage of `request.get` in the `metadata.js` module with the native `https.get` API in order to resolve a security vulnerability now that `request` is deprecated and will no longer have security updates.
- Addresses #4598