### PR TITLE
Add ability to set Client Assertion on a per-request basis

### DIFF
--- a/change/@azure-msal-common-f43c09ab-0291-4feb-a15e-9cb763014329.json
+++ b/change/@azure-msal-common-f43c09ab-0291-4feb-a15e-9cb763014329.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add ability to set Client Assertion on a per-request basis #4806",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -226,8 +226,10 @@ export class AuthorizationCodeClient extends BaseClient {
             parameterBuilder.addClientSecret(this.config.clientCredentials.clientSecret);
         }
 
-        if (this.config.clientCredentials.clientAssertion) {
-            const clientAssertion = this.config.clientCredentials.clientAssertion;
+        // Use clientAssertion from request, fallback to client assertion in base configuration
+        const clientAssertion = request.clientAssertion || this.config.clientCredentials.clientAssertion;
+
+        if (clientAssertion) {
             parameterBuilder.addClientAssertion(clientAssertion.assertion);
             parameterBuilder.addClientAssertionType(clientAssertion.assertionType);
         }

--- a/lib/msal-common/src/client/ClientCredentialClient.ts
+++ b/lib/msal-common/src/client/ClientCredentialClient.ts
@@ -179,8 +179,10 @@ export class ClientCredentialClient extends BaseClient {
             parameterBuilder.addClientSecret(this.config.clientCredentials.clientSecret);
         }
 
-        if (this.config.clientCredentials.clientAssertion) {
-            const clientAssertion = this.config.clientCredentials.clientAssertion;
+        // Use clientAssertion from request, fallback to client assertion in base configuration
+        const clientAssertion = request.clientAssertion || this.config.clientCredentials.clientAssertion;
+
+        if (clientAssertion) {
             parameterBuilder.addClientAssertion(clientAssertion.assertion);
             parameterBuilder.addClientAssertionType(clientAssertion.assertionType);
         }

--- a/lib/msal-common/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-common/src/client/OnBehalfOfClient.ts
@@ -233,8 +233,10 @@ export class OnBehalfOfClient extends BaseClient {
             parameterBuilder.addClientSecret(this.config.clientCredentials.clientSecret);
         }
 
-        if (this.config.clientCredentials.clientAssertion) {
-            const clientAssertion = this.config.clientCredentials.clientAssertion;
+        // Use clientAssertion from request, fallback to client assertion in base configuration
+        const clientAssertion = request.clientAssertion || this.config.clientCredentials.clientAssertion;
+
+        if (clientAssertion) {
             parameterBuilder.addClientAssertion(clientAssertion.assertion);
             parameterBuilder.addClientAssertionType(clientAssertion.assertionType);
         }

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -199,8 +199,10 @@ export class RefreshTokenClient extends BaseClient {
             parameterBuilder.addClientSecret(this.config.clientCredentials.clientSecret);
         }
 
-        if (this.config.clientCredentials.clientAssertion) {
-            const clientAssertion = this.config.clientCredentials.clientAssertion;
+        // Use clientAssertion from request, fallback to client assertion in base configuration
+        const clientAssertion = request.clientAssertion || this.config.clientCredentials.clientAssertion;
+
+        if (clientAssertion) {
             parameterBuilder.addClientAssertion(clientAssertion.assertion);
             parameterBuilder.addClientAssertionType(clientAssertion.assertionType);
         }

--- a/lib/msal-common/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-common/src/client/UsernamePasswordClient.ts
@@ -114,8 +114,10 @@ export class UsernamePasswordClient extends BaseClient {
             parameterBuilder.addClientSecret(this.config.clientCredentials.clientSecret);
         }
 
-        if (this.config.clientCredentials.clientAssertion) {
-            const clientAssertion = this.config.clientCredentials.clientAssertion;
+        // Use clientAssertion from request, fallback to client assertion in base configuration
+        const clientAssertion = request.clientAssertion || this.config.clientCredentials.clientAssertion;
+
+        if (clientAssertion) {
             parameterBuilder.addClientAssertion(clientAssertion.assertion);
             parameterBuilder.addClientAssertionType(clientAssertion.assertionType);
         }

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -119,12 +119,15 @@ export type LibraryInfo = {
 /**
  * Credentials for confidential clients
  */
+
+export type ClientAssertion = {
+    assertion: string,
+    assertionType: string
+};
+
 export type ClientCredentials = {
     clientSecret?: string,
-    clientAssertion? : {
-        assertion: string,
-        assertionType: string
-    };
+    clientAssertion?: ClientAssertion
 };
 
 /**

--- a/lib/msal-common/src/request/BaseAuthRequest.ts
+++ b/lib/msal-common/src/request/BaseAuthRequest.ts
@@ -4,7 +4,7 @@
  */
 
 import { AuthenticationScheme } from "../utils/Constants";
-import { AzureCloudOptions } from "../config/ClientConfiguration";
+import { AzureCloudOptions, ClientAssertion } from "../config/ClientConfiguration";
 
 /**
  * BaseAuthRequest
@@ -19,8 +19,9 @@ import { AzureCloudOptions } from "../config/ClientConfiguration";
  * - resourceRequestUri      - URI that token will be used for. Used for proof-of-possession flows.
  * - sshJwk                  - A stringified JSON Web Key representing a public key that can be signed by an SSH certificate.
  * - sshKid                  - Key ID that uniquely identifies the SSH public key mentioned above.
- * - azureCloudOptions        - Convenience string enums for users to provide public/sovereign cloud ids
- * - requestedClaimsHash        - SHA 256 hash string of the requested claims string, used as part of an access token cache key so tokens can be filtered by requested claims
+ * - azureCloudOptions       - Convenience string enums for users to provide public/sovereign cloud ids
+ * - requestedClaimsHash     - SHA 256 hash string of the requested claims string, used as part of an access token cache key so tokens can be filtered by requested claims
+ * - clientAssertion         - Client assertion passed by the user for confidential client flows
  */
 export type BaseAuthRequest = {
     authority: string;
@@ -36,4 +37,5 @@ export type BaseAuthRequest = {
     sshKid?: string,
     azureCloudOptions?: AzureCloudOptions;
     requestedClaimsHash?: string;
+    clientAssertion?: ClientAssertion;
 };

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -995,6 +995,200 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(returnVal.includes(`${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`)).toBe(true);
         });
 
+        it("Adds clientAssertion from ClientConfiguration to /token request", async () => {
+            sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+            sinon.stub(AuthorizationCodeClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT);
+            const createTokenRequestBodySpy = sinon.spy(AuthorizationCodeClient.prototype, <any>"createTokenRequestBody");
+
+            const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+            if (!config.cryptoInterface) {
+                throw TestError.createTestSetupError("configuration cryptoInterface not initialized correctly.");
+            }
+
+            config.clientCredentials = {
+                ...config.clientCredentials,
+                clientAssertion: {
+                    assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                    assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+                }
+            }
+
+            // Set up required objects and mocked return values
+            const testState = `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9${Constants.RESOURCE_DELIM}userState`;
+            const decodedLibState = "{ \"id\": \"testid\", \"ts\": 1592846482 }";
+            
+            sinon.stub(config.cryptoInterface, "base64Decode").callsFake(input => {
+                switch (input) {
+                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        return TEST_POP_VALUES.DECODED_REQ_CNF;
+                    case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
+                        return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    case "eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9":
+                        return decodedLibState;
+                    default:
+                        return input;
+                }
+            });
+            
+            sinon.stub(config.cryptoInterface, "base64Encode").callsFake(input => {
+                switch (input) {
+                    case TEST_POP_VALUES.DECODED_REQ_CNF:
+                        return TEST_POP_VALUES.ENCODED_REQ_CNF;
+                    case "123-test-uid":
+                        return "MTIzLXRlc3QtdWlk";
+                    case "456-test-utid":
+                        return "NDU2LXRlc3QtdXRpZA==";
+                    case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
+                        return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    default:
+                        return input;
+                }
+            });
+
+            // Set up stubs
+            const idTokenClaims = {
+                "ver": "2.0",
+                "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
+                "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                "exp": 1536361411,
+                "name": "Abe Lincoln",
+                "preferred_username": "AbeLi@microsoft.com",
+                "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+                "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+                "nonce": "123523",
+            };
+            sinon.stub(AuthToken, "extractTokenClaims").returns(idTokenClaims);
+            const client = new AuthorizationCodeClient(config);
+            const authCodeRequest: CommonAuthorizationCodeRequest = {
+                authority: Constants.DEFAULT_AUTHORITY,
+                scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE, ...TEST_CONFIG.DEFAULT_SCOPES],
+                redirectUri: TEST_URIS.TEST_REDIRECT_URI_LOCALHOST,
+                code: TEST_TOKENS.AUTHORIZATION_CODE,
+                codeVerifier: TEST_CONFIG.TEST_VERIFIER,
+                claims: TEST_CONFIG.CLAIMS,
+                correlationId: RANDOM_TEST_GUID,
+                authenticationScheme: AuthenticationScheme.BEARER
+            };
+
+            const authenticationResult = await client.acquireToken(authCodeRequest, {
+                code: authCodeRequest.code,
+                nonce: idTokenClaims.nonce,
+                state: testState
+            });
+            if (!authenticationResult.expiresOn) {
+                throw TestError.createTestSetupError("mockedAccountInfo does not have a value");
+            }
+
+            expect(authenticationResult.accessToken).toEqual(AUTHENTICATION_RESULT.body.access_token);
+            // @ts-ignore
+            expect((Date.now() + (AUTHENTICATION_RESULT.body.expires_in * 1000)) >= authenticationResult.expiresOn.getMilliseconds()).toBe(true);
+            expect(createTokenRequestBodySpy.calledWith(authCodeRequest)).toBeTruthy();
+
+            const returnVal = await createTokenRequestBodySpy.returnValues[0] as string;
+            expect(returnVal.includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(true);
+            expect(returnVal.includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
+        });
+
+        it("Adds clientAssertion from request to /token request, overriding config assertion", async () => {
+            sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+            sinon.stub(AuthorizationCodeClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT);
+            const createTokenRequestBodySpy = sinon.spy(AuthorizationCodeClient.prototype, <any>"createTokenRequestBody");
+
+            const config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
+            if (!config.cryptoInterface) {
+                throw TestError.createTestSetupError("configuration cryptoInterface not initialized correctly.");
+            }
+
+            config.clientCredentials = {
+                ...config.clientCredentials,
+                clientAssertion: {
+                    assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                    assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+                }
+            }
+
+            // Set up required objects and mocked return values
+            const testState = `eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9${Constants.RESOURCE_DELIM}userState`;
+            const decodedLibState = "{ \"id\": \"testid\", \"ts\": 1592846482 }";
+            
+            sinon.stub(config.cryptoInterface, "base64Decode").callsFake(input => {
+                switch (input) {
+                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                        return TEST_POP_VALUES.DECODED_REQ_CNF;
+                    case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
+                        return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    case "eyAiaWQiOiAidGVzdGlkIiwgInRzIjogMTU5Mjg0NjQ4MiB9":
+                        return decodedLibState;
+                    default:
+                        return input;
+                }
+            });
+            
+            sinon.stub(config.cryptoInterface, "base64Encode").callsFake(input => {
+                switch (input) {
+                    case TEST_POP_VALUES.DECODED_REQ_CNF:
+                        return TEST_POP_VALUES.ENCODED_REQ_CNF;
+                    case "123-test-uid":
+                        return "MTIzLXRlc3QtdWlk";
+                    case "456-test-utid":
+                        return "NDU2LXRlc3QtdXRpZA==";
+                    case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
+                        return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
+                    default:
+                        return input;
+                }
+            });
+
+            // Set up stubs
+            const idTokenClaims = {
+                "ver": "2.0",
+                "iss": `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
+                "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                "exp": 1536361411,
+                "name": "Abe Lincoln",
+                "preferred_username": "AbeLi@microsoft.com",
+                "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+                "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+                "nonce": "123523",
+            };
+            sinon.stub(AuthToken, "extractTokenClaims").returns(idTokenClaims);
+            const client = new AuthorizationCodeClient(config);
+            const authCodeRequest: CommonAuthorizationCodeRequest = {
+                authority: Constants.DEFAULT_AUTHORITY,
+                scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE, ...TEST_CONFIG.DEFAULT_SCOPES],
+                redirectUri: TEST_URIS.TEST_REDIRECT_URI_LOCALHOST,
+                code: TEST_TOKENS.AUTHORIZATION_CODE,
+                codeVerifier: TEST_CONFIG.TEST_VERIFIER,
+                claims: TEST_CONFIG.CLAIMS,
+                correlationId: RANDOM_TEST_GUID,
+                authenticationScheme: AuthenticationScheme.BEARER,
+                clientAssertion: {
+                    assertion: TEST_CONFIG.TEST_REQUEST_ASSERTION,
+                    assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+                }
+            };
+
+            const authenticationResult = await client.acquireToken(authCodeRequest, {
+                code: authCodeRequest.code,
+                nonce: idTokenClaims.nonce,
+                state: testState
+            });
+            if (!authenticationResult.expiresOn) {
+                throw TestError.createTestSetupError("mockedAccountInfo does not have a value");
+            }
+
+            expect(authenticationResult.accessToken).toEqual(AUTHENTICATION_RESULT.body.access_token);
+            // @ts-ignore
+            expect((Date.now() + (AUTHENTICATION_RESULT.body.expires_in * 1000)) >= authenticationResult.expiresOn.getMilliseconds()).toBe(true);
+            expect(createTokenRequestBodySpy.calledWith(authCodeRequest)).toBeTruthy();
+
+            const returnVal = await createTokenRequestBodySpy.returnValues[0] as string;
+
+            expect(returnVal.includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(false);
+            expect(returnVal.includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_REQUEST_ASSERTION)}`)).toBe(true);
+            expect(returnVal.includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
+        });
+
         it("Adds tokenQueryParameters to the /token request", () => {
             sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
             sinon.stub(AuthorizationCodeClient.prototype, <any>"executePostToTokenEndpoint").callsFake((url: string) => {

--- a/lib/msal-common/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-common/test/client/ClientCredentialClient.spec.ts
@@ -146,6 +146,103 @@ describe("ClientCredentialClient unit tests", () => {
         expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLAIMS}=${encodeURIComponent(TEST_CONFIG.CLAIMS)}`)).toBe(false);
     });
 
+    it("Uses clientAssertion from ClientConfiguration when no client assertion is added to request", async () => {
+        sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+        sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").resolves(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT);
+
+        const createTokenRequestBodySpy = sinon.spy(ClientCredentialClient.prototype, <any>"createTokenRequestBody");
+
+        const config = await ClientTestUtils.createTestClientConfiguration();
+        config.clientCredentials = {
+            ...config.clientCredentials,
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        }
+        const client = new ClientCredentialClient(config);
+        const clientCredentialRequest: CommonClientCredentialRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            claims: "{}"
+        };
+
+        const authResult = await client.acquireToken(clientCredentialRequest) as AuthenticationResult;
+        const expectedScopes = [TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.accessToken).toEqual(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT.body.access_token);
+        expect(authResult.state).toBe("");
+
+        expect(createTokenRequestBodySpy.calledWith(clientCredentialRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.GRANT_TYPE}=${GrantType.CLIENT_CREDENTIALS_GRANT}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_SECRET}=${TEST_CONFIG.MSAL_CLIENT_SECRET}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_CLIENT_SKU}=${Constants.SKU}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_CLIENT_VER}=${TEST_CONFIG.TEST_VERSION}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_CLIENT_OS}=${TEST_CONFIG.TEST_OS}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_CLIENT_CPU}=${TEST_CONFIG.TEST_CPU}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_APP_NAME}=${TEST_CONFIG.applicationName}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_APP_VER}=${TEST_CONFIG.applicationVersion}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLAIMS}=${encodeURIComponent(TEST_CONFIG.CLAIMS)}`)).toBe(false);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(true)
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true)
+    });
+
+    it("Uses the clientAssertion included in the request instead of the one in ClientConfiguration", async () => {
+        sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+        sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").resolves(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT);
+
+        const createTokenRequestBodySpy = sinon.spy(ClientCredentialClient.prototype, <any>"createTokenRequestBody");
+
+        const config = await ClientTestUtils.createTestClientConfiguration();
+        config.clientCredentials = {
+            ...config.clientCredentials,
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        }
+        const client = new ClientCredentialClient(config);
+        const clientCredentialRequest: CommonClientCredentialRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            claims: "{}",
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_REQUEST_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        };
+
+        const authResult = await client.acquireToken(clientCredentialRequest) as AuthenticationResult;
+        const expectedScopes = [TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.accessToken).toEqual(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT.body.access_token);
+        expect(authResult.state).toBe("");
+
+        expect(createTokenRequestBodySpy.calledWith(clientCredentialRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ID}=${TEST_CONFIG.MSAL_CLIENT_ID}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.GRANT_TYPE}=${GrantType.CLIENT_CREDENTIALS_GRANT}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_SECRET}=${TEST_CONFIG.MSAL_CLIENT_SECRET}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_CLIENT_SKU}=${Constants.SKU}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_CLIENT_VER}=${TEST_CONFIG.TEST_VERSION}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_CLIENT_OS}=${TEST_CONFIG.TEST_OS}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_CLIENT_CPU}=${TEST_CONFIG.TEST_CPU}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_APP_NAME}=${TEST_CONFIG.applicationName}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_APP_VER}=${TEST_CONFIG.applicationVersion}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLAIMS}=${encodeURIComponent(TEST_CONFIG.CLAIMS)}`)).toBe(false);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(false)
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_REQUEST_ASSERTION)}`)).toBe(true)
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true)
+    });
+
     it("Does not add headers that do not qualify for a simple request", async () => {
         // For more information about this test see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
         let stubCalled = false;

--- a/lib/msal-common/test/client/OnBehalfOfClient.spec.ts
+++ b/lib/msal-common/test/client/OnBehalfOfClient.spec.ts
@@ -259,4 +259,77 @@ describe("OnBehalfOf unit tests", () => {
 
         await expect(client.acquireToken(onBehalfOfRequest)).rejects.toMatchObject(ClientAuthError.createMultipleMatchingTokensInCacheError());
     });
+
+    it("Adds clientAssertion from ClientConfiguration to /token request", async () => {
+        sinon.stub(OnBehalfOfClient.prototype, <any>"getCachedAuthenticationResult").resolves(null);
+        sinon.stub(OnBehalfOfClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
+
+        const createTokenRequestBodySpy = sinon.spy(OnBehalfOfClient.prototype, <any>"createTokenRequestBody");
+        config.clientCredentials = {
+            ...config.clientCredentials,
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        }
+        const client = new OnBehalfOfClient(config);
+        const onBehalfOfRequest: CommonOnBehalfOfRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            oboAssertion: TEST_TOKENS.ACCESS_TOKEN,
+            skipCache: false
+        };
+
+        const authResult = await client.acquireToken(onBehalfOfRequest) as AuthenticationResult;
+        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
+        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
+        expect(authResult.state).toHaveLength(0);
+
+        expect(createTokenRequestBodySpy.calledWith(onBehalfOfRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
+    });
+
+    it("Adds clientAssertion from request to /token request, overriding config assertion", async () => {
+        sinon.stub(OnBehalfOfClient.prototype, <any>"getCachedAuthenticationResult").resolves(null);
+        sinon.stub(OnBehalfOfClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
+
+        const createTokenRequestBodySpy = sinon.spy(OnBehalfOfClient.prototype, <any>"createTokenRequestBody");
+        config.clientCredentials = {
+            ...config.clientCredentials,
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        }
+        const client = new OnBehalfOfClient(config);
+        const onBehalfOfRequest: CommonOnBehalfOfRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            oboAssertion: TEST_TOKENS.ACCESS_TOKEN,
+            skipCache: false,
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_REQUEST_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        };
+
+        const authResult = await client.acquireToken(onBehalfOfRequest) as AuthenticationResult;
+        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
+        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
+        expect(authResult.state).toHaveLength(0);
+
+        expect(createTokenRequestBodySpy.calledWith(onBehalfOfRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(false);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_REQUEST_ASSERTION)}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
+    });
 });

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -215,6 +215,88 @@ describe("RefreshTokenClient unit tests", () => {
             expect(result.includes(`${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`)).toBe(true);
         });
 
+        it("Adds clientAssertion from ClientConfiguration to /token request", async () => {
+            sinon.stub(RefreshTokenClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT);
+            config.clientCredentials = {
+                ...config.clientCredentials,
+                clientAssertion: {
+                    assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                    assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+                }
+            }
+            const createTokenRequestBodySpy = sinon.spy(RefreshTokenClient.prototype, <any>"createTokenRequestBody");
+            const client = new RefreshTokenClient(config);
+            const refreshTokenRequest: CommonRefreshTokenRequest = {
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
+                claims: TEST_CONFIG.CLAIMS,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                authenticationScheme: TEST_CONFIG.TOKEN_TYPE_BEARER as AuthenticationScheme
+            };
+
+            const authResult: AuthenticationResult = await client.acquireToken(refreshTokenRequest);
+            const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0], "email"];
+
+            expect(authResult.uniqueId).toEqual(ID_TOKEN_CLAIMS.oid);
+            expect(authResult.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
+            expect(authResult.scopes).toEqual(expectedScopes);
+            expect(authResult.account).toEqual(testAccount);
+            expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT.body.id_token);
+            expect(authResult.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
+            expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT.body.access_token);
+            expect(authResult.state).toHaveLength(0);
+            expect(createTokenRequestBodySpy.calledWith(refreshTokenRequest)).toBe(true);
+
+            const result = await createTokenRequestBodySpy.returnValues[0] as string;
+            expect(result.includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(true);
+            expect(result.includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
+        });
+
+        it("Adds clientAssertion from request to /token request, overriding config assertion", async () => {
+            sinon.stub(RefreshTokenClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT);
+            config.clientCredentials = {
+                ...config.clientCredentials,
+                clientAssertion: {
+                    assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                    assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+                }
+            }
+            const createTokenRequestBodySpy = sinon.spy(RefreshTokenClient.prototype, <any>"createTokenRequestBody");
+            const client = new RefreshTokenClient(config);
+            const refreshTokenRequest: CommonRefreshTokenRequest = {
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
+                claims: TEST_CONFIG.CLAIMS,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                authenticationScheme: TEST_CONFIG.TOKEN_TYPE_BEARER as AuthenticationScheme,
+                clientAssertion: {
+                    assertion: TEST_CONFIG.TEST_REQUEST_ASSERTION,
+                    assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+                }
+            };
+
+            const authResult: AuthenticationResult = await client.acquireToken(refreshTokenRequest);
+            const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0], "email"];
+
+            expect(authResult.uniqueId).toEqual(ID_TOKEN_CLAIMS.oid);
+            expect(authResult.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
+            expect(authResult.scopes).toEqual(expectedScopes);
+            expect(authResult.account).toEqual(testAccount);
+            expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT.body.id_token);
+            expect(authResult.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
+            expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT.body.access_token);
+            expect(authResult.state).toHaveLength(0);
+            expect(createTokenRequestBodySpy.calledWith(refreshTokenRequest)).toBe(true);
+
+            const result = await createTokenRequestBodySpy.returnValues[0] as string;
+            expect(result.includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(false);
+            expect(result.includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_REQUEST_ASSERTION)}`)).toBe(true);
+            expect(result.includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
+        });
+
+
         it("acquireTokenByRefreshToken refreshes a token", async () => {
             sinon.stub(RefreshTokenClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT);
             const silentFlowRequest: CommonSilentFlowRequest = {

--- a/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
+++ b/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
@@ -126,6 +126,80 @@ describe("Username Password unit tests", () => {
         expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.RESPONSE_TYPE}=${Constants.TOKEN_RESPONSE_TYPE}%20${Constants.ID_TOKEN_RESPONSE_TYPE}`)).toBe(true);
     });
 
+   it("Adds clientAssertion from ClientConfiguration to /token request", async () => {
+        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
+
+        const createTokenRequestBodySpy = sinon.spy(UsernamePasswordClient.prototype, <any>"createTokenRequestBody");
+        config.clientCredentials = {
+            ...config.clientCredentials,
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        }
+        const client = new UsernamePasswordClient(config);
+        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
+            authority: Constants.DEFAULT_AUTHORITY,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            username: "mock_name",
+            password: "mock_password",
+            claims: TEST_CONFIG.CLAIMS,
+            correlationId: RANDOM_TEST_GUID
+        };
+
+        const authResult = await client.acquireToken(usernamePasswordRequest) as AuthenticationResult;
+        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
+        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
+        expect(authResult.state).toHaveLength(0);
+
+        expect(createTokenRequestBodySpy.calledWith(usernamePasswordRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
+    });
+
+   it("Adds clientAssertion from request to /token request, overriding config assertion", async () => {
+        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
+
+        const createTokenRequestBodySpy = sinon.spy(UsernamePasswordClient.prototype, <any>"createTokenRequestBody");
+        config.clientCredentials = {
+            ...config.clientCredentials,
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_CONFIG_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        }
+        const client = new UsernamePasswordClient(config);
+        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
+            authority: Constants.DEFAULT_AUTHORITY,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            username: "mock_name",
+            password: "mock_password",
+            claims: TEST_CONFIG.CLAIMS,
+            correlationId: RANDOM_TEST_GUID,
+            clientAssertion: {
+                assertion: TEST_CONFIG.TEST_REQUEST_ASSERTION,
+                assertionType: TEST_CONFIG.TEST_ASSERTION_TYPE
+            }
+        };
+
+        const authResult = await client.acquireToken(usernamePasswordRequest) as AuthenticationResult;
+        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
+        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
+        expect(authResult.state).toHaveLength(0);
+
+        expect(createTokenRequestBodySpy.calledWith(usernamePasswordRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_CONFIG_ASSERTION)}`)).toBe(false);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION}=${encodeURIComponent(TEST_CONFIG.TEST_REQUEST_ASSERTION)}`)).toBe(true);
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
+    });
+
+
     it("Does not include claims if empty object is passed", async () => {
         sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
 

--- a/lib/msal-common/test/test_kit/StringConstants.ts
+++ b/lib/msal-common/test/test_kit/StringConstants.ts
@@ -145,7 +145,9 @@ export const TEST_CONFIG = {
     TEST_APP_VER: "1.0.0",
     TEST_ASSERTION_TYPE: "jwt_bearer",
     THE_FAMILY_ID: "1",
-    DEFAULT_TOKEN_RENEWAL_OFFSET: 300
+    DEFAULT_TOKEN_RENEWAL_OFFSET: 300,
+    TEST_CONFIG_ASSERTION: "DefaultAssertion",
+    TEST_REQUEST_ASSERTION: "RequestAssertion"
 };
 
 export const RANDOM_TEST_GUID = "11553a9b-7116-48b1-9d48-f6d4a8ff8371";


### PR DESCRIPTION
This PR:
- Solves #4481
- Adds `clientAssertion` to `BaseAuthRequest`
- Adds logic that gives request client assertion priority over ClientConfig client assertion when building request body in `AuthorizationCode`, `RefreshToken`, `OnBehalfOf` `UsernamePassword` and `ClientCredentials` clients
- Adds unit tests to cover changes