### PR TITLE
Fix password encoding on UsernamePassword flow

### DIFF
--- a/change/@azure-msal-common-00400af1-6f04-4c51-921f-d96e55fa3fe5.json
+++ b/change/@azure-msal-common-00400af1-6f04-4c51-921f-d96e55fa3fe5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix password encoding on UsernamePassword flow #4807",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-common/src/client/UsernamePasswordClient.ts
@@ -90,7 +90,7 @@ export class UsernamePasswordClient extends BaseClient {
 
         parameterBuilder.addClientId(this.config.authOptions.clientId);
         parameterBuilder.addUsername(request.username);
-        parameterBuilder.addPassword(encodeURIComponent(request.password));
+        parameterBuilder.addPassword(request.password);
 
         parameterBuilder.addScopes(request.scopes);
 

--- a/lib/msal-common/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-common/src/client/UsernamePasswordClient.ts
@@ -90,7 +90,7 @@ export class UsernamePasswordClient extends BaseClient {
 
         parameterBuilder.addClientId(this.config.authOptions.clientId);
         parameterBuilder.addUsername(request.username);
-        parameterBuilder.addPassword(request.password);
+        parameterBuilder.addPassword(encodeURIComponent(request.password));
 
         parameterBuilder.addScopes(request.scopes);
 

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -372,7 +372,7 @@ export class RequestParameterBuilder {
      * @param username
      */
     addUsername(username: string): void {
-        this.parameters.set(PasswordGrantConstants.username, username);
+        this.parameters.set(PasswordGrantConstants.username, encodeURIComponent(username));
     }
 
     /**
@@ -380,7 +380,7 @@ export class RequestParameterBuilder {
      * @param password
      */
     addPassword(password: string): void {
-        this.parameters.set(PasswordGrantConstants.password, password);
+        this.parameters.set(PasswordGrantConstants.password, encodeURIComponent(password));
     }
 
     /**

--- a/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
+++ b/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
@@ -199,6 +199,60 @@ describe("Username Password unit tests", () => {
         expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.CLIENT_ASSERTION_TYPE}=${encodeURIComponent(TEST_CONFIG.TEST_ASSERTION_TYPE)}`)).toBe(true);
     });
 
+    it("properly encodes special characters in emails (usernames)", async () => {
+        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
+
+        const createTokenRequestBodySpy = sinon.spy(UsernamePasswordClient.prototype, <any>"createTokenRequestBody");
+
+        const client = new UsernamePasswordClient(config);
+        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
+            authority: Constants.DEFAULT_AUTHORITY,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            username: "mock+name",
+            password: "mock_password",
+            claims: TEST_CONFIG.CLAIMS,
+            correlationId: RANDOM_TEST_GUID
+        };
+
+        const authResult = await client.acquireToken(usernamePasswordRequest) as AuthenticationResult;
+        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
+        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
+        expect(authResult.state).toHaveLength(0);
+
+        expect(createTokenRequestBodySpy.calledWith(usernamePasswordRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${PasswordGrantConstants.username}=mock%2Bname`)).toBe(true);
+    });
+
+    it("properly encodes special characters in passwords", async () => {
+        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
+
+        const createTokenRequestBodySpy = sinon.spy(UsernamePasswordClient.prototype, <any>"createTokenRequestBody");
+
+        const client = new UsernamePasswordClient(config);
+        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
+            authority: Constants.DEFAULT_AUTHORITY,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            username: "mock_name",
+            password: "mock_password&+",
+            claims: TEST_CONFIG.CLAIMS,
+            correlationId: RANDOM_TEST_GUID
+        };
+
+        const authResult = await client.acquireToken(usernamePasswordRequest) as AuthenticationResult;
+        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
+        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
+        expect(authResult.state).toHaveLength(0);
+
+        expect(createTokenRequestBodySpy.calledWith(usernamePasswordRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${PasswordGrantConstants.password}=mock_password%26%2B`)).toBe(true);
+    });
+
 
     it("Does not include claims if empty object is passed", async () => {
         sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);

--- a/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
+++ b/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
@@ -126,6 +126,33 @@ describe("Username Password unit tests", () => {
         expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.RESPONSE_TYPE}=${Constants.TOKEN_RESPONSE_TYPE}%20${Constants.ID_TOKEN_RESPONSE_TYPE}`)).toBe(true);
     });
 
+    it("properly encodes special characters in emails (usernames)", async () => {
+        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
+
+        const createTokenRequestBodySpy = sinon.spy(UsernamePasswordClient.prototype, <any>"createTokenRequestBody");
+
+        const client = new UsernamePasswordClient(config);
+        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
+            authority: Constants.DEFAULT_AUTHORITY,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            username: "mock+name",
+            password: "mock_password",
+            claims: TEST_CONFIG.CLAIMS,
+            correlationId: RANDOM_TEST_GUID
+        };
+
+        const authResult = await client.acquireToken(usernamePasswordRequest) as AuthenticationResult;
+        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
+        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
+        expect(authResult.state).toHaveLength(0);
+
+        expect(createTokenRequestBodySpy.calledWith(usernamePasswordRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${PasswordGrantConstants.username}=mock%2Bname`)).toBe(true);
+    });
+
     it("properly encodes special characters in passwords", async () => {
         sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
 

--- a/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
+++ b/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
@@ -126,6 +126,33 @@ describe("Username Password unit tests", () => {
         expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.RESPONSE_TYPE}=${Constants.TOKEN_RESPONSE_TYPE}%20${Constants.ID_TOKEN_RESPONSE_TYPE}`)).toBe(true);
     });
 
+    it("properly encodes special characters in passwords", async () => {
+        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
+
+        const createTokenRequestBodySpy = sinon.spy(UsernamePasswordClient.prototype, <any>"createTokenRequestBody");
+
+        const client = new UsernamePasswordClient(config);
+        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
+            authority: Constants.DEFAULT_AUTHORITY,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            username: "mock_name",
+            password: "mock_password&+",
+            claims: TEST_CONFIG.CLAIMS,
+            correlationId: RANDOM_TEST_GUID
+        };
+
+        const authResult = await client.acquireToken(usernamePasswordRequest) as AuthenticationResult;
+        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
+        expect(authResult.scopes).toEqual(expectedScopes);
+        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
+        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
+        expect(authResult.state).toHaveLength(0);
+
+        expect(createTokenRequestBodySpy.calledWith(usernamePasswordRequest)).toBe(true);
+
+        expect(createTokenRequestBodySpy.returnValues[0].includes(`${PasswordGrantConstants.password}=mock_password%26%2B`)).toBe(true);
+    });
+
     it("Does not include claims if empty object is passed", async () => {
         sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
 

--- a/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
+++ b/lib/msal-common/test/client/UsernamePasswordClient.spec.ts
@@ -126,60 +126,6 @@ describe("Username Password unit tests", () => {
         expect(createTokenRequestBodySpy.returnValues[0].includes(`${AADServerParamKeys.RESPONSE_TYPE}=${Constants.TOKEN_RESPONSE_TYPE}%20${Constants.ID_TOKEN_RESPONSE_TYPE}`)).toBe(true);
     });
 
-    it("properly encodes special characters in emails (usernames)", async () => {
-        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
-
-        const createTokenRequestBodySpy = sinon.spy(UsernamePasswordClient.prototype, <any>"createTokenRequestBody");
-
-        const client = new UsernamePasswordClient(config);
-        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
-            authority: Constants.DEFAULT_AUTHORITY,
-            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
-            username: "mock+name",
-            password: "mock_password",
-            claims: TEST_CONFIG.CLAIMS,
-            correlationId: RANDOM_TEST_GUID
-        };
-
-        const authResult = await client.acquireToken(usernamePasswordRequest) as AuthenticationResult;
-        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
-        expect(authResult.scopes).toEqual(expectedScopes);
-        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
-        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
-        expect(authResult.state).toHaveLength(0);
-
-        expect(createTokenRequestBodySpy.calledWith(usernamePasswordRequest)).toBe(true);
-
-        expect(createTokenRequestBodySpy.returnValues[0].includes(`${PasswordGrantConstants.username}=mock%2Bname`)).toBe(true);
-    });
-
-    it("properly encodes special characters in passwords", async () => {
-        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
-
-        const createTokenRequestBodySpy = sinon.spy(UsernamePasswordClient.prototype, <any>"createTokenRequestBody");
-
-        const client = new UsernamePasswordClient(config);
-        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
-            authority: Constants.DEFAULT_AUTHORITY,
-            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
-            username: "mock_name",
-            password: "mock_password&+",
-            claims: TEST_CONFIG.CLAIMS,
-            correlationId: RANDOM_TEST_GUID
-        };
-
-        const authResult = await client.acquireToken(usernamePasswordRequest) as AuthenticationResult;
-        const expectedScopes = [Constants.OPENID_SCOPE, Constants.PROFILE_SCOPE, Constants.OFFLINE_ACCESS_SCOPE, TEST_CONFIG.DEFAULT_GRAPH_SCOPE[0]];
-        expect(authResult.scopes).toEqual(expectedScopes);
-        expect(authResult.idToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.id_token);
-        expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT_DEFAULT_SCOPES.body.access_token);
-        expect(authResult.state).toHaveLength(0);
-
-        expect(createTokenRequestBodySpy.calledWith(usernamePasswordRequest)).toBe(true);
-
-        expect(createTokenRequestBodySpy.returnValues[0].includes(`${PasswordGrantConstants.password}=mock_password%26%2B`)).toBe(true);
-    });
-
     it("Does not include claims if empty object is passed", async () => {
         sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_DEFAULT_SCOPES);
 

--- a/samples/msal-node-samples/username-password/package.json
+++ b/samples/msal-node-samples/username-password/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node index.js",
     "build:package": "cd ../../../lib/msal-common && npm run build && cd ../msal-node && npm run build",
-    "start:build": "npm run build:package && npm start"
+    "start:build": "npm run build:package && npm start",
+    "install:local": "npm install ../../../lib/msal-node"
   },
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
This PR:
- Fixes #4326 
- Wraps password paramenter inside `encodeURIComponent` before adding to the token request in `UsernamePasswordClient`
- Adds tests to cover changes