### PR TITLE
Fallback to web flow when native broker throws 'DISABLED' status

### DIFF
--- a/change/@azure-msal-browser-8cb89fc5-2c6f-40fe-96b4-99dfe7fb89aa.json
+++ b/change/@azure-msal-browser-8cb89fc5-2c6f-40fe-96b4-99dfe7fb89aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fallback to web flow when native broker throws 'DISABLED' status #4837",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/error/NativeAuthError.ts
+++ b/lib/msal-browser/src/error/NativeAuthError.ts
@@ -20,6 +20,7 @@ export enum NativeStatusCode {
     NO_NETWORK = "NO_NETWORK",
     TRANSIENT_ERROR = "TRANSIENT_ERROR",
     PERSISTENT_ERROR = "PERSISTENT_ERROR", 
+    DISABLED = "DISABLED"
 }
 
 export const NativeAuthErrorMessage = {
@@ -47,7 +48,7 @@ export class NativeAuthError extends AuthError {
      * These errors should result in a fallback to the 'standard' browser based auth flow.
      */
     isFatal(): boolean {
-        if (this.ext && this.ext.status && this.ext.status === NativeStatusCode.PERSISTENT_ERROR) {
+        if (this.ext && this.ext.status && (this.ext.status === NativeStatusCode.PERSISTENT_ERROR || this.ext.status === NativeStatusCode.DISABLED)) {
             return true;
         }
         

--- a/lib/msal-browser/test/error/NativeAuthError.spec.ts
+++ b/lib/msal-browser/test/error/NativeAuthError.spec.ts
@@ -1,0 +1,84 @@
+import { NativeAuthError, NativeAuthErrorMessage, NativeStatusCode } from "../../src/error/NativeAuthError";
+import { InteractionRequiredAuthError } from "@azure/msal-common";
+import { BrowserAuthError, BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
+
+describe("NativeAuthError Unit Tests", () => {
+    describe("NativeAuthError", () => {
+        describe("isFatal tests", () => {
+            it("should return true for isFatal when WAM status is PERSISTENT_ERROR", () => {
+                const error = new NativeAuthError("testError", "testErrorDescription", {
+                    error: 1,
+                    protocol_error: "testProtocolError",
+                    properties: {},
+                    status: NativeStatusCode.PERSISTENT_ERROR
+                });
+                expect(error.isFatal()).toBe(true);
+            });
+    
+            it("should return true for isFatal when WAM status is DISABLED", () => {
+                const error = new NativeAuthError("testError", "testErrorDescription", {
+                    error: 1,
+                    protocol_error: "testProtocolError",
+                    properties: {},
+                    status: NativeStatusCode.DISABLED
+                });
+                expect(error.isFatal()).toBe(true);
+            });
+    
+            it("should return true for isFatal when extension throws an error", () => {
+                const error = new NativeAuthError(NativeAuthErrorMessage.extensionError.code, "extension threw error");
+                expect(error.isFatal()).toBe(true);
+            });
+    
+            it("should return false for isFatal", () => {
+                const error = new NativeAuthError("testError", "testErrorDescription", {
+                    error: 1,
+                    protocol_error: "testProtocolError",
+                    properties: {},
+                    status: NativeStatusCode.TRANSIENT_ERROR
+                });
+                expect(error.isFatal()).toBe(false);
+            });
+        });
+
+        describe("createError tests", () => {
+            it("Returns a NativeAuthError", () => {
+                const error = NativeAuthError.createError("testError", "testWamError");
+                expect(error).toBeInstanceOf(NativeAuthError);
+            });
+
+            it("translates USER_INTERACTION_REQUIRED status into corresponding InteractionRequiredError", () => {
+                const error = NativeAuthError.createError("interaction_required", "interaction is required", {
+                    error: 1,
+                    protocol_error: "testProtocolError",
+                    properties: {},
+                    status: NativeStatusCode.USER_INTERACTION_REQUIRED
+                });
+                expect(error).toBeInstanceOf(InteractionRequiredAuthError);
+                expect(error.errorCode).toBe("interaction_required");
+            });
+
+            it("translates USER_CANCEL status into corresponding BrowserAuthError", () => {
+                const error = NativeAuthError.createError("user_cancel", "user cancelled", {
+                    error: 1,
+                    protocol_error: "testProtocolError",
+                    properties: {},
+                    status: NativeStatusCode.USER_CANCEL
+                });
+                expect(error).toBeInstanceOf(BrowserAuthError);
+                expect(error.errorCode).toBe(BrowserAuthErrorMessage.userCancelledError.code);
+            });
+
+            it("translates NO_NETWORK status into corresponding BrowserAuthError", () => {
+                const error = NativeAuthError.createError("no_network", "no network", {
+                    error: 1,
+                    protocol_error: "testProtocolError",
+                    properties: {},
+                    status: NativeStatusCode.NO_NETWORK
+                });
+                expect(error).toBeInstanceOf(BrowserAuthError);
+                expect(error.errorCode).toBe(BrowserAuthErrorMessage.noNetworkConnectivity.code);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Adds support for what we've termed the "registry key fallback" where the native broker will return a "DISABLED" status and MSAL.js should fallback to the web flow.