### PR TITLE
Make guardConfig and interceptorConfig nullable

### DIFF
--- a/change/@azure-msal-angular-78278c74-496e-4083-8956-27811f8b8082.json
+++ b/change/@azure-msal-angular-78278c74-496e-4083-8956-27811f8b8082.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make guardConfig and interceptorConfig nullable",
+  "packageName": "@azure/msal-angular",
+  "email": "eman@onlythebible.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/src/msal.module.ts
+++ b/lib/msal-angular/src/msal.module.ts
@@ -27,8 +27,8 @@ import { MsalRedirectComponent } from "./msal.redirect.component";
 export class MsalModule {
     static forRoot(
         msalInstance: IPublicClientApplication,
-        guardConfig: MsalGuardConfiguration,
-        interceptorConfig: MsalInterceptorConfiguration
+        guardConfig: MsalGuardConfiguration | null,
+        interceptorConfig: MsalInterceptorConfiguration | null
     ): ModuleWithProviders<MsalModule> {
         return {
             ngModule: MsalModule,

--- a/lib/msal-angular/src/msal.module.ts
+++ b/lib/msal-angular/src/msal.module.ts
@@ -5,7 +5,7 @@
 
 import { ModuleWithProviders, NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { IPublicClientApplication } from "@azure/msal-browser";
+import { IPublicClientApplication, InteractionType } from "@azure/msal-browser";
 import { MsalGuardConfiguration } from "./msal.guard.config";
 import { MsalInterceptorConfiguration } from "./msal.interceptor.config";
 import { MsalGuard } from "./msal.guard";
@@ -25,6 +25,7 @@ import { MsalRedirectComponent } from "./msal.redirect.component";
     ]
 })
 export class MsalModule {
+    private static _defaultInteractionType = InteractionType.Popup;
     static forRoot(
         msalInstance: IPublicClientApplication,
         guardConfig: MsalGuardConfiguration | null,
@@ -39,11 +40,11 @@ export class MsalModule {
                 },
                 {
                     provide: MSAL_GUARD_CONFIG,
-                    useValue: guardConfig
+                    useValue: guardConfig ?? { interactionType: MsalModule._defaultInteractionType }
                 },
                 {
                     provide: MSAL_INTERCEPTOR_CONFIG,
-                    useValue: interceptorConfig
+                    useValue: interceptorConfig ?? { interactionType: MsalModule._defaultInteractionType, protectedResourceMap: new Map() }
                 },
                 MsalService
             ]


### PR DESCRIPTION
The [official docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-v2-angular-auth-code) provide an example where these values are null:

![image](https://user-images.githubusercontent.com/422748/170847694-d8a2a3a0-0c85-40db-86d4-c877bdcd6986.png)

The type definitions, however, do not allow this currently:

![image](https://user-images.githubusercontent.com/422748/170847709-87f18c7d-73f9-434e-8dcf-678583a774b3.png)
