### PR TITLE
setInteractionInProgress should not throw for different client ids

### DIFF
--- a/change/@azure-msal-browser-66879877-e54b-49f6-a42d-445e712e2624.json
+++ b/change/@azure-msal-browser-66879877-e54b-49f6-a42d-445e712e2624.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "setInteractionInProgress should not throw for different client ids",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -962,7 +962,8 @@ export class BrowserCacheManager extends CacheManager {
         // Ensure we don't overwrite interaction in progress for a different clientId
         const key = `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`;
         if (inProgress) {
-            if (this.getInteractionInProgress()) {
+            // For pairwise broker, ensure same frame embedded app can invoke interaction, as both instances will set this flag
+            if (this.isInteractionInProgress(true)) {
                 throw BrowserAuthError.createInteractionInProgressError();
             } else {
                 // No interaction is in progress

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -236,6 +236,17 @@ describe("BrowserCacheManager tests", () => {
                     expect(browserLocalStorage.getAccount(testAccount.generateAccountKey())).toEqual(testAccount);
                     expect(browserLocalStorage.getAccount(testAccount.generateAccountKey())).toBeInstanceOf(AccountEntity);
                 });
+
+                it("setInteractionInProgress doesnt throw for different clientids", () => {
+                    // Test needed for same frame pairwise broker scenarios
+                    const cacheManager1 = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig, browserCrypto, logger);
+
+                    // Use tenant_id as fake client id
+                    const cacheManager2 = new BrowserCacheManager(TEST_CONFIG.MSAL_TENANT_ID, cacheConfig, browserCrypto, logger);
+
+                    cacheManager1.setInteractionInProgress(true);
+                    cacheManager2.setInteractionInProgress(true);
+                });
             });
 
             describe("IdTokenCredential", () => {


### PR DESCRIPTION
For pairwise broker, there are scenarios were the broker and embedded application are in the same frame, and then embedded application can invoke a popup. Today, this throws because the embedded application will call setInteractionInProgress with its client id, then send a message to the broker, which attempts to do the same thing but with its client id, which throws. This call no longer throws, allowing the popup request to go through.