### PR TITLE
Fix build:package command for Gatsby sample

### DIFF
--- a/samples/msal-react-samples/gatsby-sample/package.json
+++ b/samples/msal-react-samples/gatsby-sample/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "scripts": {
     "build": "gatsby build",
-    "build:package": "cd ../../../lib/msal-react & npm run build:all",
+    "build:package": "cd ../../../lib/msal-react && npm run build:all",
     "develop": "gatsby develop -p 3000",
     "start": "gatsby serve -p 3000",
     "serve": "gatsby serve",


### PR DESCRIPTION
Missing script: "build:all" will occur as double ampersands are needed to run an AND on both commands for build:package to execute