### PR TITLE
Fix prompt behavior for native requests

### DIFF
--- a/change/@azure-msal-browser-254f5907-5359-4a92-8878-3ae3a838508a.json
+++ b/change/@azure-msal-browser-254f5907-5359-4a92-8878-3ae3a838508a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix prompt behavior for native broker requests #4949",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -829,6 +829,7 @@ export abstract class ClientApplication {
             switch (request.prompt) {
                 case PromptValue.NONE:
                 case PromptValue.CONSENT:
+                case PromptValue.LOGIN:
                     this.logger.trace("canUseNative: prompt is compatible with native flow");
                     break;
                 default:

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -319,7 +319,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
         const scopeSet = new ScopeSet(scopes);
         scopeSet.appendScopes(OIDC_DEFAULT_SCOPES);
 
-        const prompt = () => {
+        const getPrompt = () => {
             // If request is silent, prompt is always none
             switch (this.apiId) {
                 case ApiId.ssoSilent:
@@ -330,12 +330,13 @@ export class NativeInteractionClient extends BaseInteractionClient {
                     break;
             }
 
-            // If request is interactive, check if prompt is allowed to go directly to native broker
+            // Prompt not provided, request may proceed and native broker decides if it needs to prompt
             if (!request.prompt) {
                 this.logger.trace("initializeNativeRequest: prompt was not provided");
                 return undefined;
             }
-
+            
+            // If request is interactive, check if prompt provided is allowed to go directly to native broker
             switch (request.prompt) {
                 case PromptValue.NONE:
                 case PromptValue.CONSENT:
@@ -355,7 +356,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             authority: canonicalAuthority.urlString,
             scopes: scopeSet.printScopes(),
             redirectUri: this.getRedirectUri(request.redirectUri),
-            prompt: prompt(),
+            prompt: getPrompt(),
             correlationId: this.correlationId,
             tokenType: request.authenticationScheme,
             windowTitleSubstring: document.title,

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -331,6 +331,11 @@ export class NativeInteractionClient extends BaseInteractionClient {
             }
 
             // If request is interactive, check if prompt is allowed to go directly to native broker
+            if (!request.prompt) {
+                this.logger.trace("initializeNativeRequest: prompt was not provided");
+                return undefined;
+            }
+
             switch (request.prompt) {
                 case PromptValue.NONE:
                 case PromptValue.CONSENT:

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -532,7 +532,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             await pca.acquireTokenRedirect({
                 scopes: ["User.Read"],
                 account: testAccount,
-                prompt: "login"
+                prompt: "select_account"
             });
 
             expect(nativeAcquireTokenSpy.calledOnce).toBeFalsy();

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -502,43 +502,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(redirectSpy.calledOnce).toBeFalsy();
         });
 
-        it("falls back to web flow if prompt is login", async () => {
-            pca = new PublicClientApplication({
-                auth: {
-                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
-                },
-                system: {
-                    allowNativeBroker: true
-                }
-            });
-
-            const testAccount: AccountInfo = {
-                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
-                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
-                environment: "login.windows.net",
-                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
-                username: "AbeLi@microsoft.com",
-                nativeAccountId: "test-nativeAccountId"
-            };
-
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
-            await pca.initialize();
-            const nativeAcquireTokenSpy = sinon.spy(NativeInteractionClient.prototype, "acquireTokenRedirect");
-            const redirectSpy = sinon.stub(RedirectClient.prototype, "acquireToken").callsFake(async () => {
-                return;
-            });
-            await pca.acquireTokenRedirect({
-                scopes: ["User.Read"],
-                account: testAccount,
-                prompt: "login"
-            });
-
-            expect(nativeAcquireTokenSpy.calledOnce).toBeFalsy();
-            expect(redirectSpy.calledOnce).toBeTruthy();
-        });
-
         it("falls back to web flow if prompt is select_account", async () => {
             pca = new PublicClientApplication({
                 auth: {
@@ -946,58 +909,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(response).toEqual(testTokenResponse);
             expect(nativeAcquireTokenSpy.calledOnce).toBeTruthy();
             expect(popupSpy.calledOnce).toBeFalsy();
-        });
-
-        it("falls back to web flow if prompt is login", async () => {
-            pca = new PublicClientApplication({
-                auth: {
-                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
-                },
-                system: {
-                    allowNativeBroker: true
-                }
-            });
-
-            const testAccount: AccountInfo = {
-                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
-                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
-                environment: "login.windows.net",
-                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
-                username: "AbeLi@microsoft.com",
-                nativeAccountId: "test-nativeAccountId"
-            };
-            const testTokenResponse: AuthenticationResult = {
-                authority: TEST_CONFIG.validAuthority,
-                uniqueId: testAccount.localAccountId,
-                tenantId: testAccount.tenantId,
-                scopes: TEST_CONFIG.DEFAULT_SCOPES,
-                idToken: "test-idToken",
-                idTokenClaims: {},
-                accessToken: "test-accessToken",
-                fromCache: false,
-                correlationId: RANDOM_TEST_GUID,
-                expiresOn: new Date(Date.now() + 3600000),
-                account: testAccount,
-                tokenType: AuthenticationScheme.BEARER
-            };
-
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
-            await pca.initialize();
-            const nativeAcquireTokenSpy = sinon.spy(NativeInteractionClient.prototype, "acquireToken");
-            const popupSpy = sinon.stub(PopupClient.prototype, "acquireToken").callsFake(async () => {
-                return testTokenResponse;
-            });
-            const response = await pca.acquireTokenPopup({
-                scopes: ["User.Read"],
-                account: testAccount,
-                prompt: "login"
-            });
-
-            expect(response).toBe(testTokenResponse);
-            expect(nativeAcquireTokenSpy.calledOnce).toBeFalsy();
-            expect(popupSpy.calledOnce).toBeTruthy();
         });
 
         it("falls back to web flow if prompt is select_account", async () => {


### PR DESCRIPTION
- Fixes bug where calling a silent API with prompt != none throws and instead overwrites prompt to always be none for silent calls
- Fixes bug where prompt=login skips the native broker and goes directly to web