### PR TITLE
Non-fatal native broker errors should clear interaction in progress flag

### DIFF
--- a/change/@azure-msal-browser-41be5575-c576-4d73-817a-0911842684d9.json
+++ b/change/@azure-msal-browser-41be5575-c576-4d73-817a-0911842684d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Non-fatal native broker errors should clear interaction in progress flag #4950",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -277,6 +277,7 @@ export abstract class ClientApplication {
                     const redirectClient = this.createRedirectClient(request.correlationId);
                     return redirectClient.acquireToken(request);
                 }
+                this.browserStorage.setInteractionInProgress(false);
                 throw e;
             });
         } else {
@@ -343,6 +344,7 @@ export abstract class ClientApplication {
                     const popupClient = this.createPopupClient(request.correlationId);
                     return popupClient.acquireToken(request);
                 }
+                this.browserStorage.setInteractionInProgress(false);
                 throw e;
             });
         } else {

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -648,6 +648,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["User.Read"],
                 account: testAccount
             }).catch(e => {
+                // @ts-ignore
+                expect(pca.browserStorage.getInteractionInProgress()).toBeFalsy();
                 expect(e.message).toEqual("testError");
             });
             expect(nativeAcquireTokenSpy.calledOnce).toBeTruthy();
@@ -1139,6 +1141,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["User.Read"],
                 account: testAccount
             }).catch(e => {
+                // @ts-ignore
+                expect(pca.browserStorage.getInteractionInProgress()).toBeFalsy();
                 expect(e.message).toEqual("testError");
             });
             expect(nativeAcquireTokenSpy.calledOnce).toBeTruthy();


### PR DESCRIPTION
- Fixes bug where direct to WAM interactive requests that throw (such as closing the window) would not clear interaction in progress