### PR TITLE
Handle account unavailable error status

### DIFF
--- a/change/@azure-msal-browser-d21e1aab-de60-4ceb-897c-fded93de06f2.json
+++ b/change/@azure-msal-browser-d21e1aab-de60-4ceb-897c-fded93de06f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Handle ACCOUNT_UNAVAILABLE error status from native broker #4951",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-5069a279-63d5-46d3-874e-dcdf656c422f.json
+++ b/change/@azure-msal-common-5069a279-63d5-46d3-874e-dcdf656c422f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add InteractionRequired error for native account unavailable #4951",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -278,8 +278,8 @@ export abstract class ClientApplication {
                     return redirectClient.acquireToken(request);
                 } else if (e instanceof InteractionRequiredAuthError) {
                     this.logger.verbose("acquireTokenRedirect - Resolving interaction required error thrown by native broker by falling back to web flow");
-                    const popupClient = this.createRedirectClient(request.correlationId);
-                    return popupClient.acquireToken(request);
+                    const redirectClient = this.createRedirectClient(request.correlationId);
+                    return redirectClient.acquireToken(request);
                 }
                 this.browserStorage.setInteractionInProgress(false);
                 throw e;

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -276,6 +276,10 @@ export abstract class ClientApplication {
                     this.nativeExtensionProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to attempt
                     const redirectClient = this.createRedirectClient(request.correlationId);
                     return redirectClient.acquireToken(request);
+                } else if (e instanceof InteractionRequiredAuthError) {
+                    this.logger.verbose("acquireTokenRedirect - Resolving interaction required error thrown by native broker by falling back to web flow");
+                    const popupClient = this.createRedirectClient(request.correlationId);
+                    return popupClient.acquireToken(request);
                 }
                 throw e;
             });
@@ -340,6 +344,10 @@ export abstract class ClientApplication {
             }).catch((e: AuthError) => {
                 if (e instanceof NativeAuthError && e.isFatal()) {
                     this.nativeExtensionProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to attempt
+                    const popupClient = this.createPopupClient(request.correlationId);
+                    return popupClient.acquireToken(request);
+                } else if (e instanceof InteractionRequiredAuthError) {
+                    this.logger.verbose("acquireTokenPopup - Resolving interaction required error thrown by native broker by falling back to web flow");
                     const popupClient = this.createPopupClient(request.correlationId);
                     return popupClient.acquireToken(request);
                 }

--- a/lib/msal-browser/src/error/NativeAuthError.ts
+++ b/lib/msal-browser/src/error/NativeAuthError.ts
@@ -4,7 +4,6 @@
  */
 
 import { AuthError, InteractionRequiredAuthError } from "@azure/msal-common";
-import { ApiId } from "../utils/BrowserConstants";
 import { BrowserAuthError } from "./BrowserAuthError";
 
 export type OSError = {

--- a/lib/msal-browser/src/error/NativeAuthError.ts
+++ b/lib/msal-browser/src/error/NativeAuthError.ts
@@ -4,6 +4,7 @@
  */
 
 import { AuthError, InteractionRequiredAuthError } from "@azure/msal-common";
+import { ApiId } from "../utils/BrowserConstants";
 import { BrowserAuthError } from "./BrowserAuthError";
 
 export type OSError = {
@@ -20,7 +21,8 @@ export enum NativeStatusCode {
     NO_NETWORK = "NO_NETWORK",
     TRANSIENT_ERROR = "TRANSIENT_ERROR",
     PERSISTENT_ERROR = "PERSISTENT_ERROR", 
-    DISABLED = "DISABLED"
+    DISABLED = "DISABLED",
+    ACCOUNT_UNAVAILABLE = "ACCOUNT_UNAVAILABLE"
 }
 
 export const NativeAuthErrorMessage = {
@@ -70,6 +72,8 @@ export class NativeAuthError extends AuthError {
     static createError(code: string, description: string, ext?: OSError): AuthError {
         if (ext && ext.status) {
             switch (ext.status) {
+                case NativeStatusCode.ACCOUNT_UNAVAILABLE:
+                    return InteractionRequiredAuthError.createNativeAccountUnavailableError();
                 case NativeStatusCode.USER_INTERACTION_REQUIRED:
                     return new InteractionRequiredAuthError(code, description);
                 case NativeStatusCode.USER_CANCEL:

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -6,7 +6,7 @@
 import sinon from "sinon";
 import { PublicClientApplication } from "../../src/app/PublicClientApplication";
 import { TEST_CONFIG, TEST_URIS, TEST_TOKENS, TEST_DATA_CLIENT_INFO, TEST_TOKEN_LIFETIMES, RANDOM_TEST_GUID, testNavUrl, testLogoutUrl, TEST_STATE_VALUES, TEST_HASHES, DEFAULT_TENANT_DISCOVERY_RESPONSE, DEFAULT_OPENID_CONFIG_RESPONSE, testNavUrlNoRequest, TEST_SSH_VALUES, TEST_CRYPTO_VALUES } from "../utils/StringConstants";
-import { ServerError, Constants, AccountInfo, TokenClaims, AuthenticationResult, CommonAuthorizationUrlRequest, AuthorizationCodeClient, ResponseMode, AccountEntity, ProtocolUtils, AuthenticationScheme, RefreshTokenClient, Logger, ServerTelemetryEntity, CommonSilentFlowRequest, LogLevel, CommonAuthorizationCodeRequest } from "@azure/msal-common";
+import { ServerError, Constants, AccountInfo, TokenClaims, AuthenticationResult, CommonAuthorizationUrlRequest, AuthorizationCodeClient, ResponseMode, AccountEntity, ProtocolUtils, AuthenticationScheme, RefreshTokenClient, Logger, ServerTelemetryEntity, CommonSilentFlowRequest, LogLevel, CommonAuthorizationCodeRequest, InteractionRequiredAuthError } from "@azure/msal-common";
 import { ApiId, InteractionType, WrapperSKU, TemporaryCacheKeys, BrowserConstants, BrowserCacheLocation } from "../../src/utils/BrowserConstants";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { EventType } from "../../src/event/EventType";
@@ -614,6 +614,44 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(redirectSpy.calledOnce).toBeTruthy();
         });
 
+        it("falls back to web flow if native broker call fails due to interaction_required error", async () => {
+            pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                },
+                system: {
+                    allowNativeBroker: true
+                }
+            });
+
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com",
+                nativeAccountId: "test-nativeAccountId"
+            };
+
+            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
+                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
+            });
+            await pca.initialize();
+            const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireTokenRedirect").callsFake(async () => {
+                throw InteractionRequiredAuthError.createNativeAccountUnavailableError();
+            });
+            const redirectSpy = sinon.stub(RedirectClient.prototype, "acquireToken").callsFake(async () => {
+                return;
+            });
+            await pca.acquireTokenRedirect({
+                scopes: ["User.Read"],
+                account: testAccount
+            });
+
+            expect(nativeAcquireTokenSpy.calledOnce).toBeTruthy();
+            expect(redirectSpy.calledOnce).toBeTruthy();
+        });
+
         it("throws error if native broker call fails due to non-fatal error", async () => {
             pca = new PublicClientApplication({
                 auth: {
@@ -1091,6 +1129,59 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw new NativeAuthError("ContentError", "error in extension");
+            });
+            const popupSpy = sinon.stub(PopupClient.prototype, "acquireToken").callsFake(async () => {
+                return testTokenResponse;
+            });
+            const response = await pca.acquireTokenPopup({
+                scopes: ["User.Read"],
+                account: testAccount
+            });
+
+            expect(response).toBe(testTokenResponse);
+            expect(nativeAcquireTokenSpy.calledOnce).toBeTruthy();
+            expect(popupSpy.calledOnce).toBeTruthy();
+        });
+
+        it("falls back to web flow if native broker call fails due to interaction_required error", async () => {
+            pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                },
+                system: {
+                    allowNativeBroker: true
+                }
+            });
+
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com",
+                nativeAccountId: "test-nativeAccountId"
+            };
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: new Date(Date.now() + 3600000),
+                account: testAccount,
+                tokenType: AuthenticationScheme.BEARER
+            };
+
+            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
+                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
+            });
+            await pca.initialize();
+            const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
+                throw InteractionRequiredAuthError.createNativeAccountUnavailableError();
             });
             const popupSpy = sinon.stub(PopupClient.prototype, "acquireToken").callsFake(async () => {
                 return testTokenResponse;

--- a/lib/msal-browser/test/error/NativeAuthError.spec.ts
+++ b/lib/msal-browser/test/error/NativeAuthError.spec.ts
@@ -1,5 +1,5 @@
 import { NativeAuthError, NativeAuthErrorMessage, NativeStatusCode } from "../../src/error/NativeAuthError";
-import { InteractionRequiredAuthError } from "@azure/msal-common";
+import { InteractionRequiredAuthError, InteractionRequiredAuthErrorMessage } from "@azure/msal-common";
 import { BrowserAuthError, BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
 
 describe("NativeAuthError Unit Tests", () => {
@@ -56,6 +56,17 @@ describe("NativeAuthError Unit Tests", () => {
                 });
                 expect(error).toBeInstanceOf(InteractionRequiredAuthError);
                 expect(error.errorCode).toBe("interaction_required");
+            });
+
+            it("translates ACCOUNT_UNAVAILABLE status into corresponding InteractionRequiredError", () => {
+                const error = NativeAuthError.createError("interaction_required", "interaction is required", {
+                    error: 1,
+                    protocol_error: "testProtocolError",
+                    properties: {},
+                    status: NativeStatusCode.ACCOUNT_UNAVAILABLE
+                });
+                expect(error).toBeInstanceOf(InteractionRequiredAuthError);
+                expect(error.errorCode).toBe(InteractionRequiredAuthErrorMessage.native_account_unavailable.code);
             });
 
             it("translates USER_CANCEL status into corresponding BrowserAuthError", () => {

--- a/lib/msal-common/src/error/InteractionRequiredAuthError.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthError.ts
@@ -29,6 +29,10 @@ export const InteractionRequiredAuthErrorMessage = {
     noTokensFoundError: {
         code: "no_tokens_found",
         desc: "No refresh token found in the cache. Please sign-in."
+    },
+    native_account_unavailable: {
+        code: "native_account_unavailable",
+        desc: "The requested account is not available in the native broker. It may have been deleted or logged out. Please sign-in again using an interactive API."
     }
 };
 
@@ -65,5 +69,13 @@ export class InteractionRequiredAuthError extends AuthError {
      */
     static createNoTokensFoundError(): InteractionRequiredAuthError {
         return new InteractionRequiredAuthError(InteractionRequiredAuthErrorMessage.noTokensFoundError.code, InteractionRequiredAuthErrorMessage.noTokensFoundError.desc);
+    }
+
+    /**
+     * Creates an error thrown when the native broker returns ACCOUNT_UNAVAILABLE status, indicating that the account was removed and interactive sign-in is required
+     * @returns 
+     */
+    static createNativeAccountUnavailableError(): InteractionRequiredAuthError {
+        return new InteractionRequiredAuthError(InteractionRequiredAuthErrorMessage.native_account_unavailable.code, InteractionRequiredAuthErrorMessage.native_account_unavailable.desc);
     }
 }

--- a/lib/msal-common/test/error/InteractionRequiredAuthError.spec.ts
+++ b/lib/msal-common/test/error/InteractionRequiredAuthError.spec.ts
@@ -66,4 +66,17 @@ describe("InteractionRequiredAuthError.ts Class Unit Tests", () => {
         expect(err.name).toBe("InteractionRequiredAuthError");
         expect(err.stack?.includes("InteractionRequiredAuthError.spec.ts")).toBe(true);
     });
+
+    it("createNativeAccountUnavailableError creates an InteractionRequiredAuthError object", () => {
+        const err: InteractionRequiredAuthError = InteractionRequiredAuthError.createNativeAccountUnavailableError();
+
+        expect(err instanceof InteractionRequiredAuthError).toBe(true);
+        expect(err instanceof AuthError).toBe(true);
+        expect(err instanceof Error).toBe(true);
+        expect(err.errorCode).toBe(InteractionRequiredAuthErrorMessage.native_account_unavailable.code);
+        expect(err.errorMessage.includes(InteractionRequiredAuthErrorMessage.native_account_unavailable.desc)).toBe(true);
+        expect(err.message.includes(InteractionRequiredAuthErrorMessage.native_account_unavailable.desc)).toBe(true);
+        expect(err.name).toBe("InteractionRequiredAuthError");
+        expect(err.stack?.includes("InteractionRequiredAuthError.spec.ts")).toBe(true);
+    });
 });


### PR DESCRIPTION
If a user has removed their account from WAM and MSAL.js makes a request for that account, WAM will return an ACCOUNT_UNAVAILABLE error. For silent calls this needs to be surfaced as an `InteractionRequired` error and for interactive calls this should be caught and handled by falling back to web.