### PR TITLE
Clarify user switch error code in WAM docs

### DIFF
--- a/change/@azure-msal-browser-5f160da8-948d-4783-b0e0-c32f1099c5bc.json
+++ b/change/@azure-msal-browser-5f160da8-948d-4783-b0e0-c32f1099c5bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update WAM docs #4952",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-browser/docs/device-bound-tokens.md
+++ b/lib/msal-browser/docs/device-bound-tokens.md
@@ -53,4 +53,4 @@ There are a few things that may behave a little differently when acquiring token
 
 - The `forceRefresh` parameter for `acquireTokenSilent` calls is not supported by WAM. You may receive a cached token from WAM regardless of what this flag is set to.
 - If WAM needs to prompt the user for interaction a system prompt will be opened. This prompt looks a bit different from the browser popup windows you may be used to.
-- Switching your account in the WAM prompt is not supported and MSAL.js will throw an error if this happens. It is your app's responsibility to catch this error and handle it in a way that makes sense for your scenarios (e.g. Show an error page, retry with the new account, retry with the original account, etc.)
+- Switching your account in the WAM prompt is not supported and MSAL.js will throw an error (Error Code: user_switch) if this happens. It is your app's responsibility to catch this error and handle it in a way that makes sense for your scenarios (e.g. Show an error page, retry with the new account, retry with the original account, etc.)


### PR DESCRIPTION
Updates WAM integration docs to specify the error code that will be thrown in the user switch case