### PR TITLE
Mark temporary cache cookies as SameSite lax

### DIFF
--- a/change/@azure-msal-browser-a0c60e1e-0205-4316-b099-d598f43c0317.json
+++ b/change/@azure-msal-browser-a0c60e1e-0205-4316-b099-d598f43c0317.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Mark temporary cache cookies as SameSite lax",
+  "comment": "Mark temporary cache cookies as SameSite lax #4957",
   "packageName": "@azure/msal-browser",
   "email": "janutter@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-a0c60e1e-0205-4316-b099-d598f43c0317.json
+++ b/change/@azure-msal-browser-a0c60e1e-0205-4316-b099-d598f43c0317.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark temporary cache cookies as SameSite lax",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -621,7 +621,7 @@ export class BrowserCacheManager extends CacheManager {
      * @param expires
      */
     setItemCookie(cookieName: string, cookieValue: string, expires?: number): void {
-        let cookieStr = `${encodeURIComponent(cookieName)}=${encodeURIComponent(cookieValue)};path=/;`;
+        let cookieStr = `${encodeURIComponent(cookieName)}=${encodeURIComponent(cookieValue)};path=/;SameSite=Lax;`;
         if (expires) {
             const expireTime = this.getCookieExpirationTime(expires);
             cookieStr += `expires=${expireTime};`;

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -831,6 +831,12 @@ describe("BrowserCacheManager tests", () => {
             expect(document.cookie).toBe(`${msalCacheKey}=${cacheVal}`);
         });
 
+        it("sets samesite", () => {
+            const cookieSpy = jest.spyOn(document, "cookie", "set");
+            browserSessionStorage.setItemCookie(msalCacheKey, cacheVal);
+            expect(cookieSpy.mock.calls[0][0]).toContain("SameSite=Lax");
+        });
+
         it("getItemCookie()", () => {
             browserSessionStorage.setItemCookie(msalCacheKey, cacheVal);
             expect(browserSessionStorage.getItemCookie(msalCacheKey)).toBe(cacheVal);


### PR DESCRIPTION
Mark cookies used by MSAL.js for temporary cache as `SameSite=Lax`, which is the default in most browsers. `SameSite` controls whether cookies are sent in cross-site contexts, which shouldn't be needed for temporary cache values. More: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#lax

![Screenshot 2022-06-30 132915](https://user-images.githubusercontent.com/443409/176778985-e34d1dc3-114f-4e29-b737-7a2193a47869.png)
