### PR TITLE
fix: allow use passport without vulnerabilities

### DIFF
--- a/maintenance/passport-azure-ad/package.json
+++ b/maintenance/passport-azure-ad/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.11.2",
     "node-jose": "^2.0.0",
     "oauth": "0.9.15",
-    "passport": "^0.4.1",
+    "passport": "^0.4.1 || ^0.5.0 || ^0.6.0",
     "valid-url": "^1.0.6"
   },
   "scripts": {


### PR DESCRIPTION
Currently, there is a vulnerability in the passport before 0.6.0.

> $ npm audit report
> 
> passport  <0.6.0
> Severity: moderate
> Improper session management in passport - https://github.com/advisories/GHSA-v923-w3x8-wh69
> fix available via `npm audit fix --force`
> Will install passport-azure-ad@1.4.4, which is a breaking change
> node_modules/passport-azure-ad/node_modules/passport
>   passport-azure-ad  <=0.0.5 || >=1.4.5
>   Depends on vulnerable versions of passport
>   node_modules/passport-azure-ad
> 
> 2 moderate severity vulnerabilities
> 
> To address all issues (including breaking changes), run:
>   npm audit fix --force

This fix allows using the 0.6.0 version and higher.