### PR TITLE
Rename native request scopes to scope

### DIFF
--- a/change/@azure-msal-browser-0dbbacaa-cadd-49fc-a0ec-b0c23a5380a6.json
+++ b/change/@azure-msal-browser-0dbbacaa-cadd-49fc-a0ec-b0c23a5380a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Rename native request property scopes to scope #5043",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/broker/nativeBroker/NativeRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeRequest.ts
@@ -14,7 +14,7 @@ export type NativeTokenRequest = {
     clientId: string;
     authority: string;
     redirectUri: string;
-    scopes: string;
+    scope: string;
     correlationId: string;
     windowTitleSubstring: string; // The name of the document title. This helps the native prompt properly "parent" to the window making the request
     prompt?: string;

--- a/lib/msal-browser/src/broker/nativeBroker/NativeResponse.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeResponse.ts
@@ -22,7 +22,7 @@ export type NativeResponse = {
     expires_in: number;
     id_token: string;
     properties: NativeResponseProperties;
-    scopes: string;
+    scope: string;
     state: string;
     shr?: string;
     extendedLifetimeToken?: boolean;

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -104,7 +104,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
         return {
             authority: request.authority,
             correlationId: this.correlationId,
-            scopes: ScopeSet.fromString(request.scopes).asArray(),
+            scopes: ScopeSet.fromString(request.scope).asArray(),
             account: cachedAccount,
             forceRefresh: false,
         };
@@ -242,7 +242,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
         this.browserStorage.setAccount(accountEntity);
 
         // If scopes not returned in server response, use request scopes
-        const responseScopes = response.scopes ? ScopeSet.fromString(response.scopes) : ScopeSet.fromString(request.scopes);
+        const responseScopes = response.scope ? ScopeSet.fromString(response.scope) : ScopeSet.fromString(request.scope);
 
         const accountProperties = response.account.properties || {};
         const uid = accountProperties["UID"] || idTokenObj.claims.oid || idTokenObj.claims.sub || Constants.EMPTY_STRING;
@@ -359,7 +359,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             response.hasOwnProperty("id_token") &&
             response.hasOwnProperty("client_info") &&
             response.hasOwnProperty("account") &&
-            response.hasOwnProperty("scopes") &&
+            response.hasOwnProperty("scope") &&
             response.hasOwnProperty("expires_in")
         ) {
             return response as NativeResponse;
@@ -410,8 +410,9 @@ export class NativeInteractionClient extends BaseInteractionClient {
         const canonicalAuthority = new UrlString(authority);
         canonicalAuthority.validateAsUri();
 
-        const scopes = request && request.scopes || [];
-        const scopeSet = new ScopeSet(scopes);
+        // scopes are expected to be received by the native broker as "scope" and will be added to the request below. Other properties that should be dropped from the request to the native broker can be included in the object destructuring here.
+        const { scopes, ...remainingProperties } = request; 
+        const scopeSet = new ScopeSet(scopes || []);
         scopeSet.appendScopes(OIDC_DEFAULT_SCOPES);
 
         const getPrompt = () => {
@@ -443,13 +444,13 @@ export class NativeInteractionClient extends BaseInteractionClient {
                     throw BrowserAuthError.createNativePromptParameterNotSupportedError();
             }
         };
-
+        
         const validatedRequest: NativeTokenRequest = {
-            ...request,
+            ...remainingProperties,
             accountId: this.accountId,
             clientId: this.config.auth.clientId,
             authority: canonicalAuthority.urlString,
-            scopes: scopeSet.printScopes(),
+            scope: scopeSet.printScopes(),
             redirectUri: this.getRedirectUri(request.redirectUri),
             prompt: getPrompt(),
             correlationId: this.correlationId,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -201,7 +201,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const nativeRequest: NativeTokenRequest = {
                 authority: TEST_CONFIG.validAuthority,
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
-                scopes: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
+                scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
                 accountId: testAccount.nativeAccountId!,
                 redirectUri: window.location.href,
                 correlationId: RANDOM_TEST_GUID,

--- a/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
@@ -122,7 +122,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -151,7 +151,7 @@ describe("NativeInteractionClient Tests", () => {
             expect(response.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
             expect(response.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
             expect(response.authority).toEqual(TEST_CONFIG.validAuthority);
-            expect(response.scopes).toContain(mockWamResponse.scopes);
+            expect(response.scopes).toContain(mockWamResponse.scope);
             expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
             expect(response.account).toEqual(testAccount);
             expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
@@ -183,7 +183,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -215,7 +215,7 @@ describe("NativeInteractionClient Tests", () => {
             expect(response.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
             expect(response.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
             expect(response.authority).toEqual(TEST_CONFIG.validAuthority);
-            expect(response.scopes).toContain(mockWamResponse.scopes);
+            expect(response.scopes).toContain(mockWamResponse.scope);
             expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
             expect(response.account).toEqual(testAccount);
             expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
@@ -225,7 +225,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -257,7 +257,7 @@ describe("NativeInteractionClient Tests", () => {
             expect(response.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
             expect(response.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
             expect(response.authority).toEqual(TEST_CONFIG.validAuthority);
-            expect(response.scopes).toContain(mockWamResponse.scopes);
+            expect(response.scopes).toContain(mockWamResponse.scope);
             expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
             expect(response.account).toEqual(testAccount);
             expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
@@ -267,7 +267,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -299,7 +299,7 @@ describe("NativeInteractionClient Tests", () => {
             expect(response.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
             expect(response.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
             expect(response.authority).toEqual(TEST_CONFIG.validAuthority);
-            expect(response.scopes).toContain(mockWamResponse.scopes);
+            expect(response.scopes).toContain(mockWamResponse.scope);
             expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
             expect(response.account).toEqual(testAccount);
             expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
@@ -309,7 +309,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -334,7 +334,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -369,7 +369,7 @@ describe("NativeInteractionClient Tests", () => {
             expect(response.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
             expect(response.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
             expect(response.authority).toEqual(TEST_CONFIG.validAuthority);
-            expect(response.scopes).toContain(mockWamResponse.scopes);
+            expect(response.scopes).toContain(mockWamResponse.scope);
             expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
             expect(response.account).toEqual(testAccount);
             expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
@@ -379,7 +379,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -414,7 +414,7 @@ describe("NativeInteractionClient Tests", () => {
             expect(response.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
             expect(response.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
             expect(response.authority).toEqual(TEST_CONFIG.validAuthority);
-            expect(response.scopes).toContain(mockWamResponse.scopes);
+            expect(response.scopes).toContain(mockWamResponse.scope);
             expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
             expect(response.account).toEqual(testAccount);
             expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
@@ -426,7 +426,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -462,7 +462,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -499,7 +499,7 @@ describe("NativeInteractionClient Tests", () => {
                 authority: TEST_CONFIG.validAuthority,
                 uniqueId: testAccount.localAccountId,
                 tenantId: testAccount.tenantId,
-                scopes: mockWamResponse.scopes.split(" "),
+                scopes: mockWamResponse.scope.split(" "),
                 idToken: mockWamResponse.id_token,
                 idTokenClaims: ID_TOKEN_CLAIMS,
                 accessToken: mockWamResponse.access_token,
@@ -518,7 +518,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {
@@ -559,7 +559,7 @@ describe("NativeInteractionClient Tests", () => {
             const mockWamResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2,
-                scopes: "User.Read",
+                scope: "User.Read",
                 expires_in: 3600,
                 client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                 account: {


### PR DESCRIPTION
WAM now expects the scope property to be provided as `scope` rather than `scopes` for consistency with the protocol.