### PR TITLE
Add release pipeline

### DIFF
--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -1,0 +1,161 @@
+#################################################################################
+#                      OneBranch Pipelines - PR Build                           #
+# This pipeline was created by EasyStart from a sample located at:              #
+#   https://aka.ms/obpipelines/easystart/samples                                #
+# Documentation:  https://aka.ms/obpipelines                                    #
+# Yaml Schema:    https://aka.ms/obpipelines/yaml/schema                        #
+# Retail Tasks:   https://aka.ms/obpipelines/tasks                              #
+# Support:        https://aka.ms/onebranchsup                                   #
+#################################################################################
+
+trigger: none # https://aka.ms/obpipelines/triggers
+
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+
+variables:
+  CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
+  system.debug: ${{ parameters.debug }}
+  ENABLE_PRS_DELAYSIGN: 0
+  ROOT: $(Build.SourcesDirectory)
+  REPOROOT: $(Build.SourcesDirectory)
+  OUTPUTROOT: $(REPOROOT)\out
+  NUGET_XMLDOC_MODE: none
+
+  LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-2004:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+
+resources:
+  repositories: 
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
+  parameters:
+    globalSdl: # https://aka.ms/obpipelines/sdl
+      tsa:
+        enabled: false # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
+      # credscan:
+      #   suppressionsFile: $(Build.SourcesDirectory)\.config\CredScanSuppressions.json
+      binskim:
+        break: true # always break the build on binskim issues. You can disable it by setting to 'false'
+      policheck:
+        break: true # always break the build on policheck issues. You can disable it by setting to 'false'
+      # suppression:
+      #   suppressionFile: $(Build.SourcesDirectory)\.gdn\global.gdnsuppress
+
+    stages:
+    - stage: pre_release
+      displayName: Pre-Publish
+      jobs:
+        - job: filter
+          pool:
+            type: linux
+          variables:
+            repoName: 'msal-javascript-internal'
+            ob_outputDirectory: '$(REPOROOT)/' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+            ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
+          steps:
+          - task: ShellScript@2
+            inputs:
+              scriptPath: "release-scripts/prepublish.sh"
+            name: filter
+    # PUBLISH v1
+    - stage: publish_msal_v1
+      dependsOn: pre_release
+      displayName: 'Publish MSAL v1'
+      variables:
+        publishMsalCore: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalCore'] ]
+      jobs:
+      # Release MSAL Core
+        - template: .pipelines/custom-templates/publish-template.yml@self
+          parameters:
+            jobName: 'publish_msal_core'
+            path: 'lib'
+            libName: 'msal-core'
+            cdn: true
+            publishFlagName: 'MsalCore'
+
+    # PUBLISH Common
+    - stage: publish_msal_common
+      dependsOn: pre_release
+      displayName: 'Publish MSAL Common'
+      variables:
+        publishMsalCommon: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalCommon'] ]
+      jobs:
+      # Release MSAL Common
+        - template: .pipelines/custom-templates/publish-template.yml@self
+          parameters:
+            jobName: 'publish_msal_common'
+            path: 'lib'
+            libName: 'msal-common'
+            cdn: true
+            publishFlagName: 'MsalCommon'
+
+    # PUBLISH BROWSER, REACT AND ANGULAR
+    - stage: publish_browser_packages
+      dependsOn:
+        - pre_release 
+        - publish_msal_common
+      displayName: 'Publish Browser Packages'
+      variables:
+        publishMsalBrowser: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalBrowser'] ]
+        publishMsalReact: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalReact'] ]
+        publishMsalAngular: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalAngular'] ]
+      jobs:
+        # Release MSAL Browser
+        - template: .pipelines/custom-templates/publish-template.yml@self
+          parameters:
+            jobName: 'publish_msal_browser'
+            path: 'lib'
+            libName: 'msal-browser'
+            cdn: true
+            publishFlagName: 'MsalBrowser'
+      # Release MSAL React
+        - template: .pipelines/custom-templates/publish-template.yml@self
+          parameters:
+            jobName: 'publish_msal_react'
+            path: 'lib'
+            libName: 'msal-react'
+            cdn: false
+            publishFlagName: 'MsalReact'
+            dependsOn: 'publish_msal_browser'
+      # Release MSAL Angular
+        - template: .pipelines/custom-templates/publish-template.yml@self
+          parameters:
+            jobName: 'publish_msal_angular'
+            path: 'lib'
+            libName: 'msal-angular'
+            cdn: false
+            publishFlagName: 'MsalAngular'
+            dependsOn: 'publish_msal_browser'
+    # PUBLISH Node
+    - stage: publish_msal_node
+      dependsOn: 
+        - pre_release
+        - publish_msal_common
+      displayName: 'Publish MSAL Node'
+      variables:
+        publishMsalNode: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalNode'] ]
+      jobs:
+        # Release MSAL Node
+        - template: .pipelines/custom-templates/publish-template.yml@self
+          parameters:
+            jobName: 'release_msal_node'
+            path: 'lib'
+            libName: 'msal-node'
+            cdn: false
+            publishFlagName: 'MsalNode'
+        # Release MSAL Node Extensions
+        - template: .pipelines/custom-templates/publish-template.yml@self
+          parameters:
+            jobName: 'release_msal_node_extensions'
+            path: 'extensions'
+            libName: 'msal-node-extensions'
+            cdn: false
+            publishFlagName: 'MsalNodeExtensions'

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -1,5 +1,5 @@
 #################################################################################
-#                      OneBranch Pipelines - PR Build                           #
+#                      OneBranch Pipelines - Publish                            #
 # This pipeline was created by EasyStart from a sample located at:              #
 #   https://aka.ms/obpipelines/easystart/samples                                #
 # Documentation:  https://aka.ms/obpipelines                                    #
@@ -37,6 +37,8 @@ resources:
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
   parameters:
+    cloudvault: # https://aka.ms/obpipelines/cloudvault
+      enabled: false
     globalSdl: # https://aka.ms/obpipelines/sdl
       tsa:
         enabled: false # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
@@ -66,11 +68,17 @@ extends:
               scriptPath: "release-scripts/prepublish.sh"
             name: filter
     # PUBLISH v1
-    - stage: publish_msal_v1
+    - stage: publish
       dependsOn: pre_release
-      displayName: 'Publish MSAL v1'
+      displayName: 'Publish Packages'
       variables:
         publishMsalCore: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalCore'] ]
+        publishMsalCommon: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalCommon'] ]
+        publishMsalBrowser: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalBrowser'] ]
+        publishMsalReact: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalReact'] ]
+        publishMsalAngular: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalAngular'] ]
+        publishMsalNode: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalNode'] ]
+        publishMsalNodeExtensions: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalNodeExtensions'] ]
       jobs:
       # Release MSAL Core
         - template: .pipelines/custom-templates/publish-template.yml@self
@@ -80,14 +88,6 @@ extends:
             libName: 'msal-core'
             cdn: true
             publishFlagName: 'MsalCore'
-
-    # PUBLISH Common
-    - stage: publish_msal_common
-      dependsOn: pre_release
-      displayName: 'Publish MSAL Common'
-      variables:
-        publishMsalCommon: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalCommon'] ]
-      jobs:
       # Release MSAL Common
         - template: .pipelines/custom-templates/publish-template.yml@self
           parameters:
@@ -96,19 +96,7 @@ extends:
             libName: 'msal-common'
             cdn: true
             publishFlagName: 'MsalCommon'
-
-    # PUBLISH BROWSER, REACT AND ANGULAR
-    - stage: publish_browser_packages
-      dependsOn:
-        - pre_release 
-        - publish_msal_common
-      displayName: 'Publish Browser Packages'
-      variables:
-        publishMsalBrowser: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalBrowser'] ]
-        publishMsalReact: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalReact'] ]
-        publishMsalAngular: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalAngular'] ]
-      jobs:
-        # Release MSAL Browser
+      # Release MSAL Browser
         - template: .pipelines/custom-templates/publish-template.yml@self
           parameters:
             jobName: 'publish_msal_browser'
@@ -116,6 +104,7 @@ extends:
             libName: 'msal-browser'
             cdn: true
             publishFlagName: 'MsalBrowser'
+            dependsOn: 'publish_msal_common'
       # Release MSAL React
         - template: .pipelines/custom-templates/publish-template.yml@self
           parameters:
@@ -134,16 +123,7 @@ extends:
             cdn: false
             publishFlagName: 'MsalAngular'
             dependsOn: 'publish_msal_browser'
-    # PUBLISH Node
-    - stage: publish_msal_node
-      dependsOn: 
-        - pre_release
-        - publish_msal_common
-      displayName: 'Publish MSAL Node'
-      variables:
-        publishMsalNode: $[ stageDependencies.pre_release.filter.outputs['filter.publishMsalNode'] ]
-      jobs:
-        # Release MSAL Node
+      # Release MSAL Node
         - template: .pipelines/custom-templates/publish-template.yml@self
           parameters:
             jobName: 'release_msal_node'
@@ -151,6 +131,7 @@ extends:
             libName: 'msal-node'
             cdn: false
             publishFlagName: 'MsalNode'
+            dependsOn: 'publish_msal_common'
         # Release MSAL Node Extensions
         - template: .pipelines/custom-templates/publish-template.yml@self
           parameters:

--- a/.pipelines/custom-templates/publish-template.yml
+++ b/.pipelines/custom-templates/publish-template.yml
@@ -25,7 +25,7 @@ jobs:
       repoName: 'msal-javascript-internal'
       ob_outputDirectory: '${{ parameters.path }}/${{ parameters.libName }}' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
       ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
-    condition: eq(variables.publish${{ parameters.publishFlagName }}, true)
+    condition: and(succeeded(), eq(variables.publish${{ parameters.publishFlagName }}, true))
     steps:
       - task: NodeTool@0
         displayName: Install Node
@@ -121,7 +121,3 @@ jobs:
       #   displayName: Create GitHub releases, discussions and milestones
       #   workingDirectory: 'release-scripts/'
       #   continueOnError: true
-
-
-    
-  

--- a/.pipelines/custom-templates/publish-template.yml
+++ b/.pipelines/custom-templates/publish-template.yml
@@ -1,0 +1,127 @@
+parameters:
+  - name: jobName
+    type: string
+  - name: path
+    type: string
+  - name: libName
+    type: string
+  - name: dependsOn
+    type: string
+    default: 'none'
+  - name: cdn
+    type: boolean
+    default: false
+  - name: publishFlagName
+    type: string
+
+jobs:
+  - job: ${{ parameters.jobName }}
+    displayName: 'Publish ${{ parameters.libName }}'
+    ${{ if not(eq(parameters.dependsOn, 'none')) }}:
+      dependsOn: ${{ parameters.dependsOn }}
+    pool:
+      type: linux
+    variables:
+      repoName: 'msal-javascript-internal'
+      ob_outputDirectory: '${{ parameters.path }}/${{ parameters.libName }}' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+      ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
+    condition: eq(variables.publish${{ parameters.publishFlagName }}, true)
+    steps:
+      - task: NodeTool@0
+        displayName: Install Node
+        inputs:
+          versionSpec: '16.x'
+          checkLatest: true
+      # Install dependencies
+      - task: Npm@1
+        displayName: Install dependencies
+        inputs:
+          command: 'install'
+          workingDir: '${{ parameters.path }}/${{ parameters.libName }}'
+          verbose: false
+      # Runs lerna bootstrap scoped to this package and any local dependencies so that npm run build:all commands work
+      - task: Npm@1
+        displayName: Link dependencies
+        inputs:
+          command: 'custom'
+          workingDir: '${{ parameters.path }}/${{ parameters.libName }}'
+          customCommand: 'run link:localDeps --if-present'
+
+  # Publish to CDN
+      # KeyVault connection
+      - task: AzureKeyVault@2
+        inputs:
+          azureSubscription: 'MSIDLABKeyVault'
+          KeyVaultName: 'ADALTestInfo'
+          SecretsFilter: 'MSALJS-CDN-SAS-EUNO, MSALJS-CDN-SAS-USWE, MSALJSNPMTOKEN'
+          RunAsPreJob: false
+      # Publish to CDN
+      - task: Npm@1
+        displayName: Publish to CDN
+        condition: ${{ parameters.cdn }}
+        workingDirectory: '${{ parameters.path }}/${{ parameters.libName }}'
+        inputs:
+          command: 'custom'
+          customCommand: 'run cdn'
+        env:
+          CDN_SAS_EUNO: $(MSALJS-CDN-SAS-UNO)
+          CDN_SAS_USWE: $(MSALJS-CDN-SAS-USWE)
+
+      # Write NPM authToken
+      - task: CmdLine@2
+        displayName: Write npm authToken
+        inputs:
+        # This script should overwrite .npmrc, but for some reason it appends.
+        # script: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          script: echo $NPM_TOKEN > .npmrc
+          workingDirectory: '${{ parameters.path }}/${{ parameters.libName }}'
+        env:
+          NPM_TOKEN: $(MSALJSNPMTOKEN)
+
+      # Publish to npm
+      - task: Npm@1
+        displayName: Publish to npm
+        condition: ${{ not(eq(parameters.libName, 'msal-angular')) }}
+        inputs:
+          workingDir: '${{ parameters.path }}/${{ parameters.libName }}'
+          command: 'publish'
+        env:
+          NPM_TOKEN: $(MSALJSNPMTOKEN)
+
+      # Deploy to npm (Angular only)
+      - task: Npm@1
+        displayName: Deploy to npm (Angular only)
+        condition: ${{ eq(parameters.libName, 'msal-angular') }}
+        inputs:
+          command: 'custom'
+          workingDir: '${{ parameters.path }}/${{ parameters.libName }}'
+          customCommand: 'deploy'
+        env:
+          NPM_TOKEN: $(MSALJSNPMTOKEN)
+
+      # Remove .npmrc file
+      - script: rm .npmrc
+        displayName: Remove .npmrc file
+        workingDirectory: '${{ parameters.path }}/${{ parameters.libName }}'
+
+      # Install Release Scripts dependencies
+      - task: Npm@1
+        displayName: Install release scripts dependencies
+        inputs:
+          command: 'install'
+          workingDir: 'release-scripts/'
+
+      # Check npm for package availability
+      - script: node checkPackageAvailability.js ${{ parameters.path}}/${{ parameters.libName }}
+        displayName: Check npm for package availability
+        workingDirectory: 'release-scripts/'
+      
+      # Create GitHub releases, discussions and milestones
+      # - script: echo 'Run node create-releases.js -lib ${{ parameters.path }}/${{ parameters.libName }}'
+      #   displayName: Create GitHub releases, discussions and milestones
+      #   workingDirectory: 'release-scripts/'
+      #   continueOnError: true
+
+
+    
+  

--- a/release-scripts/prepublish.sh
+++ b/release-scripts/prepublish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-libNames=("msal-core" "msal-common" "msal-browser" "msal-node" "msal-angular" "msal-react" "msal-node-extensions");
+libNames=("msal-core" "msal-common" "msal-browser" "msal-node" "msal-angular" "msal-react");
 
 declare -A publishFlagNames;
 
@@ -34,3 +34,19 @@ for i in "${libNames[@]}"; do
         echo "##vso[task.setvariable variable=${varName};isoutput=true]false"
     fi
 done
+
+# Same for extensions
+
+libPath="../extensions/msal-node-extensions/package.json"
+varName=publishMsalNodeExtensions;
+git diff --exit-code --name-only HEAD HEAD~1 -- $libPath
+
+if [ $? -eq 1 ]
+then
+    echo "msal-node-extensions publish flag set to TRUE";
+    echo "##vso[task.setvariable variable=${varName};isoutput=true]true"
+else
+    echo "msal-node-extensions publish flag set to FALSE";
+    echo "##vso[task.setvariable variable=${varName};isoutput=true]false"
+fi
+

--- a/release-scripts/prepublish.sh
+++ b/release-scripts/prepublish.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+libNames=("msal-core" "msal-common" "msal-browser" "msal-node" "msal-angular" "msal-react" "msal-node-extensions");
+
+declare -A publishFlagNames;
+
+publishFlagNames["msal-core"]=publishMsalCore;
+publishFlagNames["msal-common"]=publishMsalCommon;
+publishFlagNames["msal-browser"]=publishMsalBrowser;
+publishFlagNames["msal-node"]=publishMsalNode;
+publishFlagNames["msal-angular"]=publishMsalAngular;
+publishFlagNames["msal-react"]=publishMsalReact;
+publishFlagNames["msal-node-extensions"]=publishMsalNodeExtensions;
+
+# Iterate each library directory name
+for i in "${libNames[@]}"; do
+    libPath="../lib/${i}/package.json"
+    # Git diff --name-only prints the file name in the input path given that
+    # that file has changed between the two commits referenced and
+    # --exit-code sets the successful or failed result into $?
+    # so if there are changes to a library's package.json, $? will have a 1 (success),
+    # no changes means $? is 0, therefore library won't be release unless it's dependent
+    # packages have been updated (dependent logic is out of scope for this script)
+    git diff --exit-code --name-only HEAD HEAD~1 -- $libPath 
+
+    if [ $? -eq 1 ]
+    then
+        echo "${i} publish flag set to TRUE";
+        varName=${publishFlagNames[$i]};
+        echo "##vso[task.setvariable variable=${varName};isoutput=true]true"
+    else
+     echo "${i} publish flag set to FALSE";
+        varName=${publishFlagNames[$i]};
+        echo "##vso[task.setvariable variable=${varName};isoutput=true]false"
+    fi
+done


### PR DESCRIPTION
This PR:
- Adds .pipelines directory with a governed build and release workflow and a publish template that matches our current github pre-release and release workflows (post-release workflows missing)
- Adds a prepublish script that filters the libraries to be released based on whether their package.json was updated in the last commit