### PR TITLE
Include Angular 14 as supported version in README

### DIFF
--- a/lib/msal-angular/README.md
+++ b/lib/msal-angular/README.md
@@ -44,7 +44,7 @@ At a minimum, `@azure/msal-angular` will follow the [support schedule of the mai
 
 | MSAL Angular version | MSAL support status     | Supported Angular versions |
 |----------------------|-------------------------|----------------------------|
-| MSAL Angular v2      | Active development      | 9, 10, 11, 12, 13          |
+| MSAL Angular v2      | Active development      | 9, 10, 11, 12, 13, 14      |
 | MSAL Angular v1      | Active development      | 6, 7, 8, 9                 |
 | MSAL Angular v0      | In maintenance          | 4, 5                       |
 


### PR DESCRIPTION
Angular 14 is supported, but it is missing from the docs at npm
https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4876

![image](https://user-images.githubusercontent.com/88324093/183855329-ae91b567-a395-4f1b-8aa5-a1ccddecba1e.png)
