### PR TITLE
fix: incorrect import path for SSOSilentRequest

### DIFF
--- a/samples/msal-browser-samples/TypescriptTestApp2.0/src/AuthModule.ts
+++ b/samples/msal-browser-samples/TypescriptTestApp2.0/src/AuthModule.ts
@@ -1,6 +1,5 @@
-import { PublicClientApplication, SilentRequest, AuthenticationResult, Configuration, LogLevel, AccountInfo, InteractionRequiredAuthError, RedirectRequest, PopupRequest, EndSessionRequest } from "@azure/msal-browser";
+import { PublicClientApplication, SilentRequest, AuthenticationResult, Configuration, LogLevel, AccountInfo, InteractionRequiredAuthError, RedirectRequest, PopupRequest, EndSessionRequest, SsoSilentRequest } from "@azure/msal-browser";
 import { UIManager } from "./UIManager";
-import { SsoSilentRequest } from "@azure/msal-browser/dist/request/SsoSilentRequest";
 
 /**
  * Configuration class for @azure/msal-browser: 

--- a/samples/msal-browser-samples/TypescriptTestApp2.0/src/AuthModule.ts
+++ b/samples/msal-browser-samples/TypescriptTestApp2.0/src/AuthModule.ts
@@ -1,6 +1,6 @@
 import { PublicClientApplication, SilentRequest, AuthenticationResult, Configuration, LogLevel, AccountInfo, InteractionRequiredAuthError, RedirectRequest, PopupRequest, EndSessionRequest } from "@azure/msal-browser";
 import { UIManager } from "./UIManager";
-import { SsoSilentRequest } from "@azure/msal-browser/dist/src/request/SsoSilentRequest";
+import { SsoSilentRequest } from "@azure/msal-browser/dist/request/SsoSilentRequest";
 
 /**
  * Configuration class for @azure/msal-browser: 


### PR DESCRIPTION
Hi!

When running the `TypescriptTestApp2.0` sample, `npm start` was failing on an incorrect import path for the `SsoSilentRequest` object. This PR fixes that import path, and gets `npm start` working again. 

### Before

```sh
~/code/scentregroup/microsoft-authentication-library-for-js/samples/msal-browser-samples/TypescriptTestApp2.0 dev
❯ npm run start

> typescript-test-app-2.0@1.0.0 prestart
> npm run clean && npm run build && npm run copy-views


> typescript-test-app-2.0@1.0.0 clean
> npm run clean:build && rimraf dist


> typescript-test-app-2.0@1.0.0 clean:build
> rimraf build-tsc build-babel


> typescript-test-app-2.0@1.0.0 build
> tsc && npm run build:babel && npm run build:webpack && npm run clean:build

src/AuthModule.ts:3:34 - error TS2307: Cannot find module '@azure/msal-browser/dist/src/request/SsoSilentRequest' or its corresponding type declarations.

3 import { SsoSilentRequest } from "@azure/msal-browser/dist/src/request/SsoSilentRequest";
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

### After

```sh
❯ npm run start

> typescript-test-app-2.0@1.0.0 prestart
> npm run clean && npm run build && npm run copy-views


> typescript-test-app-2.0@1.0.0 clean
> npm run clean:build && rimraf dist


> typescript-test-app-2.0@1.0.0 clean:build
> rimraf build-tsc build-babel


> typescript-test-app-2.0@1.0.0 build
> tsc && npm run build:babel && npm run build:webpack && npm run clean:build


> typescript-test-app-2.0@1.0.0 build:babel
> babel build-tsc --out-dir build-babel --source-maps

Successfully compiled 6 files with Babel (314ms).

> typescript-test-app-2.0@1.0.0 build:webpack
> webpack

#... webpack output


Listening on port 30662...
```