### PR TITLE
Fix broken angular configuration documentation link

### DIFF
--- a/lib/msal-angular/docs/v2-docs/configuration.md
+++ b/lib/msal-angular/docs/v2-docs/configuration.md
@@ -12,7 +12,7 @@ This guide will detail how to leverage each method for your application.
 
 `@azure/msal-angular` accepts three configuration objects:
 
-1. [Configuration](https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/modules/_src_config_configuration_.html): This is the same configuration object that is used for the core `@azure/msal-browser` library. All configuration options can be found [here](https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/modules/_src_config_configuration_.html).
+1. [Configuration](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#configuration): This is the same configuration object that is used for the core `@azure/msal-browser` library. All configuration options can be found [here](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#configuration).
 2. [`MsalGuardConfiguration`](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/src/msal.guard.config.ts): A set of options specifically for the Angular guard.
 3. [`MsalInterceptorConfiguration`](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/src/msal.interceptor.config.ts): A set of options specifically for the Angular interceptor.
 


### PR DESCRIPTION
This PR updates an outdated link to the MSAL Browser configuration documentation in the MSAL Angular README docs
- Fixes #5094 