### PR TITLE
fix: use double ampersand to chain command

### DIFF
--- a/samples/msal-react-samples/nextjs-sample/package.json
+++ b/samples/msal-react-samples/nextjs-sample/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "test": "jest",
     "build": "next build",
-    "build:package": "cd ../../../lib/msal-react & npm run build:all",
+    "build:package": "cd ../../../lib/msal-react && npm run build:all",
     "start": "next start",
     "install:local": "npm install ../../../lib/msal-react ../../../lib/msal-react/node_modules/react ../../../lib/msal-react/node_modules/react-dom ../../../lib/msal-browser",
     "install:published": "npm install @azure/msal-browser@latest @azure/msal-react@latest react@^17 react-dom@^17"


### PR DESCRIPTION
Hi!

In running the `nextjs` sample, I saw that the `build:local` command used a `&` instead of `&&` to chain some commands. This caused a failure when following the `README.md` documentation. 

This PR adds that `&&` to chain the `cd ...` and `npm run ...` command together. 

Previously, the single `&` caused the `cd ...` command to run in the background and the `npm run ...` command to run in the foreground and in the current directory. 