### PR TITLE
Assign CC issues to MSAL.js primary on-call

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1316,21 +1316,10 @@
         "taskName": "Assign confidential client issues",
         "actions": [
           {
-            "name": "assignToUser",
+            "name": "assignToIcmUserGroup",
             "parameters": {
-              "user": "jennyf19"
-            }
-          },
-          {
-            "name": "assignToUser",
-            "parameters": {
-              "user": "jmprieur"
-            }
-          },
-          {
-            "name": "assignToUser",
-            "parameters": {
-              "user": "bgavrilMS"
+              "groupId": "60ddfa574ab5702958084812",
+              "assignmentTarget": "Primary"
             }
           }
         ]


### PR DESCRIPTION
Reverts change to assign new CC issues to CC team. MSAL.js team will handle triage for now.