### PR TITLE
Extend AuthenticationHeaderParser to parse claims challenge

### DIFF
--- a/change/@azure-msal-common-9225282c-37fd-429e-9678-857859c5334f.json
+++ b/change/@azure-msal-common-9225282c-37fd-429e-9678-857859c5334f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Extend AuthenticationHeaderParser to parse claims challenge #5188",
+  "packageName": "@azure/msal-common",
+  "email": "dogan.erisen@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-9225282c-37fd-429e-9678-857859c5334f.json
+++ b/change/@azure-msal-common-9225282c-37fd-429e-9678-857859c5334f.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Extend AuthenticationHeaderParser to parse claims challenge #5188",
   "packageName": "@azure/msal-common",
-  "email": "dogan.erisen@gmail.com",
+  "email": "v-derisen@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -97,10 +97,6 @@ export const ClientConfigurationErrorMessage = {
         code: "missing_nonce_authentication_header",
         desc: "Unable to find an authentication header containing server nonce. Either the Authentication-Info or WWW-Authenticate headers must be present in order to obtain a server nonce."
     },
-    missingClaimsAuthenticationHeader: {
-        code: "missing_claims_authentication_header",
-        desc: "Unable to find an authentication header containing claims. The WWW-Authenticate header must be present in order to obtain a claims challenge."
-    },
     invalidAuthenticationHeader: {
         code: "invalid_authentication_header",
         desc: "Invalid authentication header provided"
@@ -298,14 +294,6 @@ export class ClientConfigurationError extends ClientAuthError {
     static createMissingNonceAuthenticationHeadersError(): ClientConfigurationError {
         return new ClientConfigurationError(ClientConfigurationErrorMessage.missingNonceAuthenticationHeader.code,
             ClientConfigurationErrorMessage.missingNonceAuthenticationHeader.desc);
-    }
-
-    /**
-     * Throws error when provided headers don't contain a header that a claims challenge can be extracted from
-     */
-    static createMissingClaimsAuthenticationHeadersError(): ClientConfigurationError {
-        return new ClientConfigurationError(ClientConfigurationErrorMessage.missingClaimsAuthenticationHeader.code,
-            ClientConfigurationErrorMessage.missingClaimsAuthenticationHeader.desc);
     }
 
     /**

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -301,7 +301,7 @@ export class ClientConfigurationError extends ClientAuthError {
     }
 
     /**
-     * Throws error when provided headers don't contain a header that a server nonce can be extracted from
+     * Throws error when provided headers don't contain a header that a claims challenge can be extracted from
      */
     static createMissingClaimsAuthenticationHeadersError(): ClientConfigurationError {
         return new ClientConfigurationError(ClientConfigurationErrorMessage.missingClaimsAuthenticationHeader.code,

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -97,6 +97,10 @@ export const ClientConfigurationErrorMessage = {
         code: "missing_nonce_authentication_header",
         desc: "Unable to find an authentication header containing server nonce. Either the Authentication-Info or WWW-Authenticate headers must be present in order to obtain a server nonce."
     },
+    missingClaimsAuthenticationHeader: {
+        code: "missing_claims_authentication_header",
+        desc: "Unable to find an authentication header containing claims. The WWW-Authenticate header must be present in order to obtain a claims challenge."
+    },
     invalidAuthenticationHeader: {
         code: "invalid_authentication_header",
         desc: "Invalid authentication header provided"
@@ -294,6 +298,14 @@ export class ClientConfigurationError extends ClientAuthError {
     static createMissingNonceAuthenticationHeadersError(): ClientConfigurationError {
         return new ClientConfigurationError(ClientConfigurationErrorMessage.missingNonceAuthenticationHeader.code,
             ClientConfigurationErrorMessage.missingNonceAuthenticationHeader.desc);
+    }
+
+    /**
+     * Throws error when provided headers don't contain a header that a server nonce can be extracted from
+     */
+    static createMissingClaimsAuthenticationHeadersError(): ClientConfigurationError {
+        return new ClientConfigurationError(ClientConfigurationErrorMessage.missingClaimsAuthenticationHeader.code,
+            ClientConfigurationErrorMessage.missingClaimsAuthenticationHeader.desc);
     }
 
     /**

--- a/lib/msal-common/src/request/AuthenticationHeaderParser.ts
+++ b/lib/msal-common/src/request/AuthenticationHeaderParser.ts
@@ -56,11 +56,11 @@ export class AuthenticationHeaderParser {
     }
 
     /**
-     * This method parses the claims value out of the WWW-Authenticate authentication header.
+     * This method parses the claims value (if present) out of the WWW-Authenticate authentication header.
      * See: https://docs.microsoft.com/en-us/azure/active-directory/develop/claims-challenge
      * @returns 
      */
-    getClaims(): string {
+    getClaims(): string | null {
         // Attempt to parse claims from WWW-Authenticate
         const wwwAuthenticate = this.headers[HeaderNames.WWWAuthenticate];
         if (wwwAuthenticate) {
@@ -68,11 +68,9 @@ export class AuthenticationHeaderParser {
             if (wwwAuthenticateChallenges.claims){
                 return wwwAuthenticateChallenges.claims;
             }
-            throw ClientConfigurationError.createInvalidAuthenticationHeaderError(HeaderNames.WWWAuthenticate, "claims challenge is missing.");
         }
 
-        // If header is not present, throw missing headers error
-        throw ClientConfigurationError.createMissingClaimsAuthenticationHeadersError();
+        return null;
     }
 
     /**

--- a/lib/msal-common/test/request/AuthenticationHeaderParser.spec.ts
+++ b/lib/msal-common/test/request/AuthenticationHeaderParser.spec.ts
@@ -45,21 +45,16 @@ describe("AuthenticationHeaderParser unit tests", () => {
 			headers = {};
 		});
 
-		it("should return a claims challenge when a valid WWW-Authenticate header is present", () => {
+		it("should return a claims challenge when a valid WWW-Authenticate header is present and has claims", () => {
 			headers[HeaderNames.WWWAuthenticate] = TEST_AUTHENTICATION_HEADERS_CLAIMS.wwwAuthenticate;
 			const authenticationHeaderParser = new AuthenticationHeaderParser(headers);
 			expect(authenticationHeaderParser.getClaims()).toStrictEqual(TEST_CLAIMS_CHALLENGE_VALUES.CLAIMS_CHALLENGE_ENCODED);
 		});
 
-		it ("should throw an error if WWWAuthenticate is present but does not contain claims", () => {
-			headers[HeaderNames.WWWAuthenticate] = TEST_AUTHENTICATION_HEADERS_CLAIMS.invalidWwwAuthenticate;
+		it("should return null when a valid WWW-Authenticate header is present but has no claims", () => {
+			headers[HeaderNames.WWWAuthenticate] = TEST_AUTHENTICATION_HEADERS_CLAIMS.wwwAuthenticateNoClaims;
 			const authenticationHeaderParser = new AuthenticationHeaderParser(headers);
-			expect(() => authenticationHeaderParser.getClaims()).toThrow(ClientConfigurationError.createInvalidAuthenticationHeaderError(HeaderNames.WWWAuthenticate, "claims challenge is missing."));	
-		});
-
-		it("should throw an error if WWW-Authenticate headers is not present", () => {
-			const authenticationHeaderParser = new AuthenticationHeaderParser({});
-			expect(() => authenticationHeaderParser.getClaims()).toThrow(ClientConfigurationError.createMissingClaimsAuthenticationHeadersError());
+			expect(authenticationHeaderParser.getClaims()).toStrictEqual(null);
 		});
 	});
 });

--- a/lib/msal-common/test/test_kit/StringConstants.ts
+++ b/lib/msal-common/test/test_kit/StringConstants.ts
@@ -533,7 +533,7 @@ export const TEST_AUTHENTICATION_HEADERS_NONCE = {
 };
 
 export const TEST_AUTHENTICATION_HEADERS_CLAIMS = {
-    wwwAuthenticate: `Bearer authorization_uri="https://login.windows.net/common/oauth2/authorize", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwNDEwNjY1MSJ9fX0="`,
+    wwwAuthenticate: `Bearer realm="", authorization_uri="https://login.windows.net/common/oauth2/authorize", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwNDEwNjY1MSJ9fX0="`,
     invalidWwwAuthenticate: `Bearer test_challenge="test_challenge`
 };
 

--- a/lib/msal-common/test/test_kit/StringConstants.ts
+++ b/lib/msal-common/test/test_kit/StringConstants.ts
@@ -534,6 +534,7 @@ export const TEST_AUTHENTICATION_HEADERS_NONCE = {
 
 export const TEST_AUTHENTICATION_HEADERS_CLAIMS = {
     wwwAuthenticate: `Bearer realm="", authorization_uri="https://login.windows.net/common/oauth2/authorize", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwNDEwNjY1MSJ9fX0="`,
+    wwwAuthenticateNoClaims: `Bearer realm="", authorization_uri="https://login.windows.net/common/oauth2/authorize", error="insufficient_claims"`,
     invalidWwwAuthenticate: `Bearer test_challenge="test_challenge`
 };
 

--- a/lib/msal-common/test/test_kit/StringConstants.ts
+++ b/lib/msal-common/test/test_kit/StringConstants.ts
@@ -164,6 +164,10 @@ export const TEST_POP_VALUES = {
     SHR_NONCE: "eyJhbGciOiJIUzI1NiIsImtpZCI6IktJRCIsInR5cCI6IkpXVCJ9.eyJ0cyI6IjE2MjU2NzI1MjkifQ.rA5ho63Lbdwo8eqZ_gUtQxY3HaseL0InIVwdgf7L_fc"
 };
 
+export const TEST_CLAIMS_CHALLENGE_VALUES = {
+    CLAIMS_CHALLENGE_ENCODED: "eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwNDEwNjY1MSJ9fX0",
+};
+
 export const TEST_SSH_VALUES = {
     SSH_JWK: "{\"kty\":\"RSA\",\"n\":\"wDJwv083ZhGGkpMPVcBMwtSBNLu7qhT2VmKv7AyPEz_dWb8GQzNEnWT1niNjFI0isDMFWQ7X2O-dhTL9J1QguQ==\",\"e\":\"AQAB\"}",
     ENCODED_SSH_JWK: "%7B%22kty%22%3A%22RSA%22%2C%22n%22%3A%22wDJwv083ZhGGkpMPVcBMwtSBNLu7qhT2VmKv7AyPEz_dWb8GQzNEnWT1niNjFI0isDMFWQ7X2O-dhTL9J1QguQ%3D%3D%22%2C%22e%22%3A%22AQAB%22%7D",
@@ -521,11 +525,16 @@ export const CORS_SIMPLE_REQUEST_HEADERS = [
     "content-type"
 ];
 
-export const TEST_AUTHENTICATION_HEADERS = {
+export const TEST_AUTHENTICATION_HEADERS_NONCE = {
     authenticationInfo: `PoP nextnonce="eyJhbGciOiJIUzI1NiIsImtpZCI6IktJRCIsInR5cCI6IkpXVCJ9.eyJ0cyI6IjE2MjU2NzI1MjkifQ.rA5ho63Lbdwo8eqZ_gUtQxY3HaseL0InIVwdgf7L_fc"`,
     invalidAuthenticationInfo: `PoP test_challenge="test_challenge"`,
     wwwAuthenticate: `PoP nonce="eyJhbGciOiJIUzI1NiIsImtpZCI6IktJRCIsInR5cCI6IkpXVCJ9.eyJ0cyI6IjE2MjU2NzI1MjkifQ.rA5ho63Lbdwo8eqZ_gUtQxY3HaseL0InIVwdgf7L_fc", error="nonce_malformed"`,
     invalidWwwAuthenticate: `PoP test_challenge="test_challenge`
+};
+
+export const TEST_AUTHENTICATION_HEADERS_CLAIMS = {
+    wwwAuthenticate: `Bearer authorization_uri="https://login.windows.net/common/oauth2/authorize", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYwNDEwNjY1MSJ9fX0="`,
+    invalidWwwAuthenticate: `Bearer test_challenge="test_challenge`
 };
 
 export const TEST_CRYPTO_ALGORITHMS = {


### PR DESCRIPTION
* Adds method for parsing claims challenges to support CAE, auth context and etc
* Changes access modifiers to allow extending the class