### PR TITLE
Restore error codes for acquireTokenSilent telemetry

### DIFF
--- a/change/@azure-msal-browser-ed69ce0f-5af1-43ba-9afc-d615d4a33389.json
+++ b/change/@azure-msal-browser-ed69ce0f-5af1-43ba-9afc-d615d4a33389.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restore error codes for acquireTokenSilent telemetry #5190",
+  "packageName": "@azure/msal-browser",
+  "email": "janutter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -136,6 +136,8 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                 .catch((error: AuthError) => {
                     this.activeSilentTokenRequests.delete(silentRequestKey);
                     atsMeasurement.endMeasurement({
+                        errorCode: error.errorCode,
+                        subErrorCode: error.subError,
                         success: false
                     });
                     atsMeasurement.flushMeasurement();

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -6,7 +6,7 @@
 import sinon from "sinon";
 import { PublicClientApplication } from "../../src/app/PublicClientApplication";
 import { TEST_CONFIG, TEST_URIS, TEST_TOKENS, ID_TOKEN_CLAIMS, TEST_DATA_CLIENT_INFO, TEST_TOKEN_LIFETIMES, RANDOM_TEST_GUID, testNavUrl, testLogoutUrl, TEST_STATE_VALUES, TEST_HASHES, DEFAULT_TENANT_DISCOVERY_RESPONSE, DEFAULT_OPENID_CONFIG_RESPONSE, testNavUrlNoRequest, TEST_SSH_VALUES, TEST_CRYPTO_VALUES } from "../utils/StringConstants";
-import { AuthorityMetadataEntity, ServerError, Constants, AccountInfo, TokenClaims, AuthenticationResult, CommonAuthorizationUrlRequest, AuthorizationCodeClient, ResponseMode, AccountEntity, ProtocolUtils, AuthenticationScheme, RefreshTokenClient, Logger, ServerTelemetryEntity, CommonSilentFlowRequest, LogLevel, CommonAuthorizationCodeRequest, InteractionRequiredAuthError, IdTokenEntity, CacheManager } from "@azure/msal-common";
+import { AuthorityMetadataEntity, ServerError, Constants, AccountInfo, TokenClaims, AuthenticationResult, CommonAuthorizationUrlRequest, AuthorizationCodeClient, ResponseMode, AccountEntity, ProtocolUtils, AuthenticationScheme, RefreshTokenClient, Logger, ServerTelemetryEntity, CommonSilentFlowRequest, LogLevel, CommonAuthorizationCodeRequest, InteractionRequiredAuthError, IdTokenEntity, CacheManager, AppMetadataEntity } from "@azure/msal-common";
 import { ApiId, InteractionType, WrapperSKU, TemporaryCacheKeys, BrowserConstants, BrowserCacheLocation } from "../../src/utils/BrowserConstants";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { EventType } from "../../src/event/EventType";
@@ -38,6 +38,19 @@ const cacheConfig = {
     storeAuthStateInCookie: false,
     secureCookies: false
 };
+
+
+jest.mock("../../src/telemetry/BrowserPerformanceMeasurement", () => {
+    return {
+        BrowserPerformanceMeasurement: jest.fn().mockImplementation(() => {
+            return {
+                startMeasurement: () => {},
+                endMeasurement: () => {},
+                flushMeasurement: () => 50
+            }
+        })
+    }
+});
 
 describe("PublicClientApplication.ts Class Unit Tests", () => {
     globalThis.MessageChannel = require("worker_threads").MessageChannel; // jsdom does not include an implementation for MessageChannel
@@ -2558,6 +2571,146 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             expect(tokenResp).toEqual(testTokenResponse);
             expect(silentTokenHelperStub.args[0][1]).toEqual(expect.objectContaining(expectedRequest));
+        });
+
+        it("emits expect performance event when successful", (done) => {
+            const testServerTokenResponse = {
+                token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,
+                scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
+                expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+                ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+                access_token: TEST_TOKENS.ACCESS_TOKEN,
+                refresh_token: TEST_TOKENS.REFRESH_TOKEN,
+                id_token: TEST_TOKENS.IDTOKEN_V2
+            };
+
+            const testIdTokenClaims: TokenClaims = {
+                "ver": "2.0",
+                "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                "name": "Abe Lincoln",
+                "preferred_username": "AbeLi@microsoft.com",
+                "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+                "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+                "nonce": "123523",
+            };
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || ""
+            };
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testIdTokenClaims.oid || "",
+                tenantId: testIdTokenClaims.tid || "",
+                scopes: [...TEST_CONFIG.DEFAULT_SCOPES, "User.Read"],
+                idToken: testServerTokenResponse.id_token,
+                idTokenClaims: testIdTokenClaims,
+                accessToken: testServerTokenResponse.access_token,
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
+                account: testAccount,
+                tokenType: AuthenticationScheme.BEARER
+            };
+
+            sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
+            sinon.stub(ProtocolUtils, "setRequestState").returns(TEST_STATE_VALUES.TEST_STATE_SILENT);
+            const silentRequest: SilentRequest = {
+                scopes: ["User.Read"],
+                account: testAccount
+            };
+
+            const atsSpy = sinon.stub(PublicClientApplication.prototype, <any>"acquireTokenSilentAsync").resolves({
+                fromCache :true,
+                accessToken: "abc",
+                idToken: "defg",
+                fromNativeBroker: true
+            });
+
+            const callbackId = pca.addPerformanceCallback((events => {
+                expect(events[0].correlationId).toBe(RANDOM_TEST_GUID)
+                expect(events[0].success).toBe(true);
+                expect(events[0].fromCache).toBe(true);
+                expect(events[0].accessTokenSize).toBe(3);
+                expect(events[0].idTokenSize).toBe(4);
+                expect(events[0].isNativeBroker).toBe(true);
+
+                pca.removePerformanceCallback(callbackId);
+                done();
+            }));
+
+            pca.acquireTokenSilent(silentRequest);
+        });
+
+        it("emits expect performance event when there is an error", (done) => {
+            const testServerTokenResponse = {
+                token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,
+                scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
+                expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+                ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+                access_token: TEST_TOKENS.ACCESS_TOKEN,
+                refresh_token: TEST_TOKENS.REFRESH_TOKEN,
+                id_token: TEST_TOKENS.IDTOKEN_V2
+            };
+
+            const testIdTokenClaims: TokenClaims = {
+                "ver": "2.0",
+                "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                "name": "Abe Lincoln",
+                "preferred_username": "AbeLi@microsoft.com",
+                "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+                "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+                "nonce": "123523",
+            };
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || ""
+            };
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testIdTokenClaims.oid || "",
+                tenantId: testIdTokenClaims.tid || "",
+                scopes: [...TEST_CONFIG.DEFAULT_SCOPES, "User.Read"],
+                idToken: testServerTokenResponse.id_token,
+                idTokenClaims: testIdTokenClaims,
+                accessToken: testServerTokenResponse.access_token,
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
+                account: testAccount,
+                tokenType: AuthenticationScheme.BEARER
+            };
+
+            sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
+            sinon.stub(ProtocolUtils, "setRequestState").returns(TEST_STATE_VALUES.TEST_STATE_SILENT);
+            const silentRequest: SilentRequest = {
+                scopes: ["User.Read"],
+                account: testAccount
+            };
+
+            const atsSpy = sinon.stub(PublicClientApplication.prototype, <any>"acquireTokenSilentAsync").rejects({
+                errorCode: "abc",
+                subError: "defg"
+            });
+
+            const callbackId = pca.addPerformanceCallback((events => {
+                expect(events[0].correlationId).toBe(RANDOM_TEST_GUID)
+                expect(events[0].success).toBe(false);
+                expect(events[0].errorCode).toBe("abc");
+                expect(events[0].subErrorCode).toBe("defg");
+
+                pca.removePerformanceCallback(callbackId);
+                done();
+            }));
+
+            pca.acquireTokenSilent(silentRequest).catch(() => {})
         });
     });
 


### PR DESCRIPTION
This was mistankely removed in https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/4973/files#diff-827dd2c804974fc1c04ca2f8fa2372b1d42f06b7d0c248f0b390da147e208931L137-L138