### PR TITLE
fix typedoc workflow syntax issue

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -8,12 +8,12 @@ on:
     branches:
       - dev
 
-permissions:
-  contents: read
-
 jobs:
   deploy:
     if: ((github.event.pull_request.merged == true && contains(github.head_ref,'post-release')) || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+      pages: write
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
@@ -37,9 +37,6 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        permissions:
-          contents: read
-          pages: write
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./ref

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   deploy:
     if: ((github.event.pull_request.merged == true && contains(github.head_ref,'post-release')) || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-18.04
     permissions:
       contents: read
       pages: write
-    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Typedoc workflow is failing as invalid. This PR moves up the permissions definition to resolve. cc @tnorling 