### PR TITLE
Extend msal-browser TokenCache loadExternalTokens to load refresh tokens

### DIFF
--- a/change/@azure-msal-browser-321fc9fc-e44c-4168-8b90-7b77291857d1.json
+++ b/change/@azure-msal-browser-321fc9fc-e44c-4168-8b90-7b77291857d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Extend msal-browser TokenCache to load refresh tokens",
+  "packageName": "@azure/msal-browser",
+  "email": "louisv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-321fc9fc-e44c-4168-8b90-7b77291857d1.json
+++ b/change/@azure-msal-browser-321fc9fc-e44c-4168-8b90-7b77291857d1.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Extend msal-browser TokenCache to load refresh tokens",
+  "comment": "Extend msal-browser TokenCache to load refresh tokens #5233",
   "packageName": "@azure/msal-browser",
   "email": "louisv@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-4922da53-5379-4871-ab08-329b7ada9d93.json
+++ b/change/@azure-msal-common-4922da53-5379-4871-ab08-329b7ada9d93.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Include refresh token in ExternalTokenResponse",
+  "packageName": "@azure/msal-common",
+  "email": "louisv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-4922da53-5379-4871-ab08-329b7ada9d93.json
+++ b/change/@azure-msal-common-4922da53-5379-4871-ab08-329b7ada9d93.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Include refresh token in ExternalTokenResponse",
+  "comment": "Include refresh token in ExternalTokenResponse #5233",
   "packageName": "@azure/msal-common",
   "email": "louisv@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/src/cache/ITokenCache.ts
+++ b/lib/msal-browser/src/cache/ITokenCache.ts
@@ -9,6 +9,10 @@ import { LoadTokenOptions } from "./TokenCache";
 
 export interface ITokenCache {
 
-    /** API to side-load tokens to MSAL cache */
-    loadExternalTokens(request: SilentRequest, response: ExternalTokenResponse, options: LoadTokenOptions): void;
+    /**
+     * API to side-load tokens to MSAL cache
+     * @returns The homeAccountId of the account associated with the response.
+     */
+    loadExternalTokens(request: SilentRequest, response: ExternalTokenResponse, options: LoadTokenOptions): string;
+
 }

--- a/lib/msal-browser/src/cache/ITokenCache.ts
+++ b/lib/msal-browser/src/cache/ITokenCache.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ExternalTokenResponse } from "@azure/msal-common";
+import { ExternalTokenResponse, CacheRecord } from "@azure/msal-common";
 import { SilentRequest } from "../request/SilentRequest";
 import { LoadTokenOptions } from "./TokenCache";
 
@@ -11,8 +11,8 @@ export interface ITokenCache {
 
     /**
      * API to side-load tokens to MSAL cache
-     * @returns The homeAccountId of the account associated with the response.
+     * @returns A `CacheRecord` containing the entities that were loaded.
      */
-    loadExternalTokens(request: SilentRequest, response: ExternalTokenResponse, options: LoadTokenOptions): string;
+    loadExternalTokens(request: SilentRequest, response: ExternalTokenResponse, options: LoadTokenOptions): CacheRecord;
 
 }

--- a/lib/msal-browser/src/cache/ITokenCache.ts
+++ b/lib/msal-browser/src/cache/ITokenCache.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ExternalTokenResponse, CacheRecord } from "@azure/msal-common";
+import { ExternalTokenResponse, AuthenticationResult } from "@azure/msal-common";
 import { SilentRequest } from "../request/SilentRequest";
 import { LoadTokenOptions } from "./TokenCache";
 
@@ -11,8 +11,8 @@ export interface ITokenCache {
 
     /**
      * API to side-load tokens to MSAL cache
-     * @returns A `CacheRecord` containing the entities that were loaded.
+     * @returns `AuthenticationResult` for the response that was loaded.
      */
-    loadExternalTokens(request: SilentRequest, response: ExternalTokenResponse, options: LoadTokenOptions): CacheRecord;
+    loadExternalTokens(request: SilentRequest, response: ExternalTokenResponse, options: LoadTokenOptions): AuthenticationResult;
 
 }

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -107,11 +107,15 @@ export class TokenCache implements ITokenCache {
     private loadIdToken(idToken: string, clientInfo: string, environment: string, tenantId: string, options: LoadTokenOptions, authorityType?: AuthorityType, homeAccountId?: string): CacheRecord {
 
         const idAuthToken = new AuthToken(idToken, this.cryptoObj);
-        const idTokenHomeAccountId = homeAccountId ?
-            homeAccountId :
-            authorityType !== undefined ?
-                AccountEntity.generateHomeAccountId(clientInfo, authorityType, this.logger, this.cryptoObj, idAuthToken) :
-                clientInfo;
+
+        let idTokenHomeAccountId;
+        if (homeAccountId) {
+            idTokenHomeAccountId = homeAccountId;
+        } else if (authorityType !== undefined) {
+            idTokenHomeAccountId = AccountEntity.generateHomeAccountId(clientInfo, authorityType, this.logger, this.cryptoObj, idAuthToken);
+        } else {
+            idTokenHomeAccountId = clientInfo;
+        }
 
         const idTokenEntity = IdTokenEntity.createIdTokenEntity(idTokenHomeAccountId, environment, idToken, this.config.auth.clientId, tenantId);
         const accountEntity = options.clientInfo ?

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -106,12 +106,12 @@ describe("TokenCache tests", () => {
                 id_token: testIdToken
             };
             const options: LoadTokenOptions = {};
-            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
+            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
 
             const testIdTokenEntity = IdTokenEntity.createIdTokenEntity(requestHomeAccountId, testEnvironment, TEST_TOKENS.IDTOKEN_V2, configuration.auth.clientId, TEST_CONFIG.TENANT);
             const testIdTokenKey = testIdTokenEntity.generateCredentialKey();
 
-            expect(cacheHomeAccountId).toEqual(requestHomeAccountId);
+            expect(cacheRecord.idToken).toEqual(testIdTokenEntity);
             expect(browserStorage.getIdTokenCredential(testIdTokenKey)).toEqual(testIdTokenEntity);
         });
 
@@ -127,9 +127,9 @@ describe("TokenCache tests", () => {
                 clientInfo: testClientInfo
             };
 
-            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
+            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
+            expect(cacheRecord.idToken).toEqual(idTokenEntity);
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
         });
 
@@ -154,9 +154,10 @@ describe("TokenCache tests", () => {
                 localAccountId: TEST_DATA_CLIENT_INFO.TEST_LOCAL_ACCOUNT_ID
             };
             const testAccountKey = AccountEntity.generateAccountCacheKey(testAccountInfo);
-            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
+            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
+            expect(cacheRecord.idToken).toEqual(idTokenEntity);
+            expect(cacheRecord.account).toEqual(testAccount);
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
             expect(browserStorage.getAccount(testAccountKey)).toEqual(testAccount);
         });
@@ -171,9 +172,9 @@ describe("TokenCache tests", () => {
                 client_info: testClientInfo
             };
             const options: LoadTokenOptions = {};
-            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
+            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
+            expect(cacheRecord.idToken).toEqual(idTokenEntity);
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
         });
 
@@ -280,10 +281,10 @@ describe("TokenCache tests", () => {
                 expiresOn: TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP,
                 extendedExpiresOn: TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP
             };
-            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
+            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
 
             expect(parseInt(accessTokenEntity.expiresOn)).toBeGreaterThan(TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN);
-            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
+            expect(cacheRecord.accessToken).toEqual(accessTokenEntity);
             expect(browserStorage.getAccessTokenCredential(accessTokenKey)).toEqual(accessTokenEntity);
         });
 
@@ -322,9 +323,9 @@ describe("TokenCache tests", () => {
                 clientInfo: testClientInfo,
             };
 
-            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
+            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
+            expect(cacheRecord.refreshToken).toEqual(refreshTokenEntity);
             expect(browserStorage.getRefreshTokenCredential(refreshTokenKey)).toEqual(refreshTokenEntity);
         });
 

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -106,12 +106,12 @@ describe("TokenCache tests", () => {
                 id_token: testIdToken
             };
             const options: LoadTokenOptions = {};
-            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
+            const result = tokenCache.loadExternalTokens(request, response, options);
 
             const testIdTokenEntity = IdTokenEntity.createIdTokenEntity(requestHomeAccountId, testEnvironment, TEST_TOKENS.IDTOKEN_V2, configuration.auth.clientId, TEST_CONFIG.TENANT);
             const testIdTokenKey = testIdTokenEntity.generateCredentialKey();
 
-            expect(cacheRecord.idToken).toEqual(testIdTokenEntity);
+            expect(result.idToken).toEqual(TEST_TOKENS.IDTOKEN_V2);
             expect(browserStorage.getIdTokenCredential(testIdTokenKey)).toEqual(testIdTokenEntity);
         });
 
@@ -127,9 +127,9 @@ describe("TokenCache tests", () => {
                 clientInfo: testClientInfo
             };
 
-            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
+            const result = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(cacheRecord.idToken).toEqual(idTokenEntity);
+            expect(result.idToken).toEqual(TEST_TOKENS.IDTOKEN_V2);
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
         });
 
@@ -154,10 +154,10 @@ describe("TokenCache tests", () => {
                 localAccountId: TEST_DATA_CLIENT_INFO.TEST_LOCAL_ACCOUNT_ID
             };
             const testAccountKey = AccountEntity.generateAccountCacheKey(testAccountInfo);
-            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
+            const result = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(cacheRecord.idToken).toEqual(idTokenEntity);
-            expect(cacheRecord.account).toEqual(testAccount);
+            expect(result.idToken).toEqual(TEST_TOKENS.IDTOKEN_V2);
+            expect(result.account).toEqual(testAccount.getAccountInfo());
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
             expect(browserStorage.getAccount(testAccountKey)).toEqual(testAccount);
         });
@@ -172,9 +172,9 @@ describe("TokenCache tests", () => {
                 client_info: testClientInfo
             };
             const options: LoadTokenOptions = {};
-            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
+            const result = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(cacheRecord.idToken).toEqual(idTokenEntity);
+            expect(result.idToken).toEqual(TEST_TOKENS.IDTOKEN_V2);
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
         });
 
@@ -281,10 +281,10 @@ describe("TokenCache tests", () => {
                 expiresOn: TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP,
                 extendedExpiresOn: TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP
             };
-            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
+            const result = tokenCache.loadExternalTokens(request, response, options);
 
             expect(parseInt(accessTokenEntity.expiresOn)).toBeGreaterThan(TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN);
-            expect(cacheRecord.accessToken).toEqual(accessTokenEntity);
+            expect(result.accessToken).toEqual(accessTokenEntity.secret);
             expect(browserStorage.getAccessTokenCredential(accessTokenKey)).toEqual(accessTokenEntity);
         });
 
@@ -323,9 +323,9 @@ describe("TokenCache tests", () => {
                 clientInfo: testClientInfo,
             };
 
-            const cacheRecord = tokenCache.loadExternalTokens(request, response, options);
+            const result = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(cacheRecord.refreshToken).toEqual(refreshTokenEntity);
+            expect(result.idToken).toEqual(TEST_TOKENS.IDTOKEN_V2);
             expect(browserStorage.getRefreshTokenCredential(refreshTokenKey)).toEqual(refreshTokenEntity);
         });
 

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import sinon from "sinon";
-import { Logger, LogLevel,IdTokenEntity, AccessTokenEntity, ScopeSet, ExternalTokenResponse, AccountEntity, AuthToken } from "@azure/msal-common";
+import { Logger, LogLevel,IdTokenEntity, AccessTokenEntity, ScopeSet, ExternalTokenResponse, AccountEntity, AuthToken, AuthorityType, RefreshTokenEntity } from "@azure/msal-common";
 import { TokenCache, LoadTokenOptions } from "../../src/cache/TokenCache";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { BrowserCacheManager } from "../../src/cache/BrowserCacheManager";
@@ -52,27 +52,38 @@ describe("TokenCache tests", () => {
         let testEnvironment: string;
         let testClientInfo: string;
         let testIdToken: string;
+        let testIdAuthToken: AuthToken;
+        let testHomeAccountId: string;
         let idTokenEntity: IdTokenEntity;
         let idTokenKey: string;
         let testAccessToken: string;
         let accessTokenEntity: AccessTokenEntity;
         let accessTokenKey: string;
         let scopeString: string;
+        let testRefreshToken: string;
+        let refreshTokenEntity: RefreshTokenEntity;
+        let refreshTokenKey: string;
 
         beforeEach(() => {
             tokenCache = new TokenCache(configuration, browserStorage, logger, cryptoObj);
-            testEnvironment = 'login.microsoftonline.com';
+            testEnvironment = "login.microsoftonline.com";
 
             testClientInfo = `${TEST_DATA_CLIENT_INFO.TEST_UID_ENCODED}.${TEST_DATA_CLIENT_INFO.TEST_UTID_ENCODED}`;
-
             testIdToken = TEST_TOKENS.IDTOKEN_V2;
-            idTokenEntity = IdTokenEntity.createIdTokenEntity(TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID, testEnvironment, TEST_TOKENS.IDTOKEN_V2, configuration.auth.clientId, TEST_CONFIG.TENANT)
+            testIdAuthToken = new AuthToken(testIdToken, cryptoObj);
+            testHomeAccountId = AccountEntity.generateHomeAccountId(testClientInfo, AuthorityType.Default, logger, cryptoObj, testIdAuthToken);
+
+            idTokenEntity = IdTokenEntity.createIdTokenEntity(testHomeAccountId, testEnvironment, TEST_TOKENS.IDTOKEN_V2, configuration.auth.clientId, TEST_CONFIG.TENANT);
             idTokenKey = idTokenEntity.generateCredentialKey();
 
             scopeString = new ScopeSet(TEST_CONFIG.DEFAULT_SCOPES).printScopes();
             testAccessToken = TEST_TOKENS.ACCESS_TOKEN,
-            accessTokenEntity = AccessTokenEntity.createAccessTokenEntity(TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID, testEnvironment, testAccessToken, configuration.auth.clientId, TEST_CONFIG.TENANT, scopeString, TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP, TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP, cryptoObj);
+            accessTokenEntity = AccessTokenEntity.createAccessTokenEntity(testHomeAccountId, testEnvironment, testAccessToken, configuration.auth.clientId, TEST_CONFIG.TENANT, scopeString, TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP, TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP, cryptoObj);
             accessTokenKey = accessTokenEntity.generateCredentialKey();
+
+            testRefreshToken = TEST_TOKENS.REFRESH_TOKEN;
+            refreshTokenEntity = RefreshTokenEntity.createRefreshTokenEntity(testHomeAccountId, testEnvironment, testRefreshToken, configuration.auth.clientId);
+            refreshTokenKey = refreshTokenEntity.generateCredentialKey();
         });
 
         afterEach(() => {
@@ -80,10 +91,11 @@ describe("TokenCache tests", () => {
         });
 
         it("loads id token with a request account", () => {
+            const requestHomeAccountId = TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID;
             const request: SilentRequest = {
                 scopes: TEST_CONFIG.DEFAULT_SCOPES,
                 account: {
-                    homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                    homeAccountId: requestHomeAccountId,
                     environment: testEnvironment,
                     tenantId: TEST_CONFIG.TENANT,
                     username: "username",
@@ -94,9 +106,13 @@ describe("TokenCache tests", () => {
                 id_token: testIdToken
             };
             const options: LoadTokenOptions = {};
-            tokenCache.loadExternalTokens(request, response, options);
+            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
 
-            expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
+            const testIdTokenEntity = IdTokenEntity.createIdTokenEntity(requestHomeAccountId, testEnvironment, TEST_TOKENS.IDTOKEN_V2, configuration.auth.clientId, TEST_CONFIG.TENANT);
+            const testIdTokenKey = testIdTokenEntity.generateCredentialKey();
+
+            expect(cacheHomeAccountId).toEqual(requestHomeAccountId);
+            expect(browserStorage.getIdTokenCredential(testIdTokenKey)).toEqual(testIdTokenEntity);
         });
 
         it("loads id token with request authority and client info provided in options", () => {
@@ -110,8 +126,10 @@ describe("TokenCache tests", () => {
             const options: LoadTokenOptions = {
                 clientInfo: testClientInfo
             };
-            tokenCache.loadExternalTokens(request, response, options);
 
+            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
+
+            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
         });
 
@@ -126,18 +144,19 @@ describe("TokenCache tests", () => {
             const options: LoadTokenOptions = {
                 clientInfo: testClientInfo
             };
-            const testIdAuthToken = new AuthToken(testIdToken, cryptoObj);
-            const testAccount = AccountEntity.createAccount(testClientInfo, TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID, testIdAuthToken, undefined, undefined, undefined, testEnvironment, undefined);
+
+            const testAccount = AccountEntity.createAccount(testClientInfo, testHomeAccountId, testIdAuthToken, undefined, undefined, undefined, testEnvironment, undefined);
             const testAccountInfo = {
-                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                homeAccountId: testHomeAccountId,
                 environment: testEnvironment,
                 tenantId: TEST_CONFIG.MSAL_TENANT_ID,
                 username: "AbeLi@microsoft.com",
                 localAccountId: TEST_DATA_CLIENT_INFO.TEST_LOCAL_ACCOUNT_ID
             };
             const testAccountKey = AccountEntity.generateAccountCacheKey(testAccountInfo);
-            tokenCache.loadExternalTokens(request, response, options);
+            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
 
+            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
             expect(browserStorage.getAccount(testAccountKey)).toEqual(testAccount);
         });
@@ -152,8 +171,9 @@ describe("TokenCache tests", () => {
                 client_info: testClientInfo
             };
             const options: LoadTokenOptions = {};
-            tokenCache.loadExternalTokens(request, response, options);
+            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
 
+            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
             expect(browserStorage.getIdTokenCredential(idTokenKey)).toEqual(idTokenEntity);
         });
 
@@ -244,7 +264,7 @@ describe("TokenCache tests", () => {
             const request: SilentRequest = {
                 scopes: TEST_CONFIG.DEFAULT_SCOPES,
                 account: {
-                    homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                    homeAccountId: testHomeAccountId,
                     environment: testEnvironment,
                     tenantId: TEST_CONFIG.TENANT,
                     username: "username",
@@ -260,9 +280,10 @@ describe("TokenCache tests", () => {
                 expiresOn: TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP,
                 extendedExpiresOn: TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP
             };
-            tokenCache.loadExternalTokens(request, response, options);
+            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
 
             expect(parseInt(accessTokenEntity.expiresOn)).toBeGreaterThan(TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN);
+            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
             expect(browserStorage.getAccessTokenCredential(accessTokenKey)).toEqual(accessTokenEntity);
         });
 
@@ -286,6 +307,25 @@ describe("TokenCache tests", () => {
             const options: LoadTokenOptions = {};
 
             expect(() => tokenCache.loadExternalTokens(request, response, options)).toThrowError(`${BrowserAuthErrorMessage.unableToLoadTokenError.code}: ${BrowserAuthErrorMessage.unableToLoadTokenError.desc} | loadExternalTokens is designed to work in browser environments only.`);
+        });
+
+        it("loads refresh token with request authority and client info provided in options", () => {
+            const request: SilentRequest = {
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                authority: `${TEST_URIS.DEFAULT_INSTANCE}${TEST_CONFIG.TENANT}`
+            };
+            const response: ExternalTokenResponse = {
+                id_token: testIdToken,
+                refresh_token: testRefreshToken,
+            };
+            const options: LoadTokenOptions = {
+                clientInfo: testClientInfo,
+            };
+
+            const cacheHomeAccountId = tokenCache.loadExternalTokens(request, response, options);
+
+            expect(cacheHomeAccountId).toEqual(testHomeAccountId);
+            expect(browserStorage.getRefreshTokenCredential(refreshTokenKey)).toEqual(refreshTokenEntity);
         });
 
     });

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -35,6 +35,7 @@ export { ProtocolMode } from "./authority/ProtocolMode";
 // Cache
 export { CacheManager, DefaultStorageClass } from "./cache/CacheManager";
 export { AccountCache, AccessTokenCache, IdTokenCache, RefreshTokenCache, AppMetadataCache, ValidCacheType, ValidCredentialType } from "./cache/utils/CacheTypes";
+export { CacheRecord } from "./cache/entities/CacheRecord";
 export { CredentialEntity } from "./cache/entities/CredentialEntity";
 export { AppMetadataEntity } from "./cache/entities/AppMetadataEntity";
 export { AccountEntity } from "./cache/entities/AccountEntity";

--- a/lib/msal-common/src/response/ExternalTokenResponse.ts
+++ b/lib/msal-common/src/response/ExternalTokenResponse.ts
@@ -11,10 +11,11 @@ import { ServerAuthorizationTokenResponse } from "./ServerAuthorizationTokenResp
  * - scope: The scopes that the access_token is valid for.
  * - expires_in: How long the access token is valid (in seconds).
  * - id_token: A JSON Web Token (JWT). The app can decode the segments of this token to request information about the user who signed in.
+ * - refresh_token: An OAuth 2.0 refresh token. The app can use this token acquire additional access tokens after the current access token expires.
  * - access_token: The requested access token. The app can use this token to authenticate to the secured resource, such as a web API.
  * - client_info: Client info object 
  */
-export type ExternalTokenResponse = Pick<ServerAuthorizationTokenResponse, "token_type" | "scope" | "expires_in" | "id_token"> & {
+export type ExternalTokenResponse = Pick<ServerAuthorizationTokenResponse, "token_type" | "scope" | "expires_in" | "id_token" | "refresh_token"> & {
     access_token?: string,
     client_info?: string
 };


### PR DESCRIPTION
This change extends the `TokenCache.loadExternalTokens` method to support loading refresh tokens. It also makes a few small changes in `TokenCache` to make it easier to use this functionality from an application:
- `TokenCache.loadExternalTokens` now returns a `AuthenticationResult` for the response that was loaded. This allows the calling code to easily get access to the newly loaded account without having to know anything about how msal creates the account id from the Request/Response that was loaded (ie. from `IPublicClientApplication.getAccountByHomeId`).
- Changes the way in which `TokenCache.loadIdToken` generates the `homeAccountId` from the request to match the same method used in `NativeInteractionClient`, using `AccountEntity.generateHomeAccountId`. This change was made so that the tokens that are initially side loaded via the `TokenCache.loadExternalTokens` method can be found in the cache and refreshed when acquiring access tokens via a supported path like `IPublicClientApplication.acquireTokenSilent`.
- Updates to TokenCache tests to account for and cover these changes.