### PR TITLE
Remove prompt from redirect to prevent WAM from double prompting

### DIFF
--- a/change/@azure-msal-browser-d04a0bb7-1d77-4edb-a0e0-c9b816964438.json
+++ b/change/@azure-msal-browser-d04a0bb7-1d77-4edb-a0e0-c9b816964438.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix double prompt in native broker redirect flow #5239",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -178,7 +178,8 @@ export class NativeInteractionClient extends BaseInteractionClient {
             return null;
         }
 
-        const cachedRequest = this.browserStorage.getCachedNativeRequest();
+        // remove prompt from the request to prevent WAM from prompting twice
+        const {prompt, ...cachedRequest} = this.browserStorage.getCachedNativeRequest();
         if (!cachedRequest) {
             this.logger.verbose("NativeInteractionClient - handleRedirectPromise called but there is no cached request, returning null.");
             return null;

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -179,17 +179,22 @@ export class NativeInteractionClient extends BaseInteractionClient {
         }
 
         // remove prompt from the request to prevent WAM from prompting twice
-        const {prompt, ...cachedRequest} = this.browserStorage.getCachedNativeRequest();
+        const cachedRequest = this.browserStorage.getCachedNativeRequest();
         if (!cachedRequest) {
             this.logger.verbose("NativeInteractionClient - handleRedirectPromise called but there is no cached request, returning null.");
             return null;
+        }
+
+        const { prompt, ...request} = cachedRequest;
+        if (prompt) {
+            this.logger.verbose("NativeInteractionClient - handleRedirectPromise called and prompt was included in the original request, removing prompt from cached request to prevent second interaction with native broker window.");
         }
 
         this.browserStorage.removeItem(this.browserStorage.generateCacheKey(TemporaryCacheKeys.NATIVE_REQUEST));
 
         const messageBody: NativeExtensionRequestBody = {
             method: NativeExtensionMethod.GetToken,
-            request: cachedRequest
+            request: request
         };
 
         const reqTimestamp = TimeUtils.nowSeconds();
@@ -198,7 +203,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             this.logger.verbose("NativeInteractionClient - handleRedirectPromise sending message to native broker.");
             const response: object = await this.nativeMessageHandler.sendMessage(messageBody);
             this.validateNativeResponse(response);
-            const result = this.handleNativeResponse(response as NativeResponse, cachedRequest, reqTimestamp);
+            const result = this.handleNativeResponse(response as NativeResponse, request, reqTimestamp);
             this.browserStorage.setInteractionInProgress(false);
             return result;
         } catch (e) {


### PR DESCRIPTION
WAM prompts twice when calling `acquireTokenredirect` in the native component. This bug fixes the behavior.