### PR TITLE
Add x-ms-request-id to perf telemetry logging

### DIFF
--- a/change/@azure-msal-browser-a62c8acd-1177-4e1c-8f54-58a5d94140b0.json
+++ b/change/@azure-msal-browser-a62c8acd-1177-4e1c-8f54-58a5d94140b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add x-ms-request-id to perf telemetry logging #5244",
+  "packageName": "@azure/msal-browser",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-08a34c2d-85fa-4abb-8c29-6291df630f13.json
+++ b/change/@azure-msal-common-08a34c2d-85fa-4abb-8c29-6291df630f13.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add x-ms-request-id to perf telemetry logging #5244",
+  "packageName": "@azure/msal-common",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -353,6 +353,7 @@ export abstract class ClientApplication {
                     isNativeBroker: true,
                     accessTokenSize: response.accessToken.length,
                     idTokenSize: response.idToken.length,
+                    requestId: response.requestId
                 });
                 atPopupMeasurement.flushMeasurement();
                 return response;
@@ -390,6 +391,7 @@ export abstract class ClientApplication {
                 success: true,
                 accessTokenSize: result.accessToken.length,
                 idTokenSize: result.idToken.length,
+                requestId: result.requestId
             });
 
             atPopupMeasurement.flushMeasurement();
@@ -468,7 +470,8 @@ export abstract class ClientApplication {
                 success: true,
                 isNativeBroker: response.fromNativeBroker,
                 accessTokenSize: response.accessToken.length,
-                idTokenSize: response.idToken.length
+                idTokenSize: response.idToken.length,
+                requestId: response.requestId
             });
             ssoSilentMeasurement.flushMeasurement();
             return response;
@@ -518,7 +521,8 @@ export abstract class ClientApplication {
                                 success: true,
                                 accessTokenSize: result.accessToken.length,
                                 idTokenSize: result.idToken.length,
-                                isNativeBroker: result.fromNativeBroker
+                                isNativeBroker: result.fromNativeBroker,
+                                requestId: result.requestId
                             });
                             atbcMeasurement.flushMeasurement();
                             return result;

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -136,6 +136,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                         idTokenSize: result.idToken.length,
                         isNativeBroker: result.fromNativeBroker,
                         cacheLookupPolicy: request.cacheLookupPolicy,
+                        requestId: result.requestId
                     });
                     atsMeasurement.flushMeasurement();
                     return result;
@@ -241,7 +242,8 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                 fromCache: response.fromCache,
                 accessTokenSize: response.accessToken.length,
                 idTokenSize: response.idToken.length,
-                isNativeBroker: response.fromNativeBroker
+                isNativeBroker: response.fromNativeBroker,
+                requestId: response.requestId
             });
             return response;
         }).catch((tokenRenewalError: AuthError) => {

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -79,7 +79,8 @@ export class NativeInteractionClient extends BaseInteractionClient {
             .then((result: AuthenticationResult) => {
                 nativeATMeasurement.endMeasurement({
                     success: true,
-                    isNativeBroker: true
+                    isNativeBroker: true,
+                    requestId: result.requestId
                 });
                 return result;
             })

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -64,7 +64,8 @@ export class SilentIframeClient extends StandardInteractionClient {
             return await this.silentTokenHelper(authClient, silentRequest).then((result: AuthenticationResult) => {
                 acquireTokenMeasurement.endMeasurement({
                     success: true,
-                    fromCache: false
+                    fromCache: false,
+                    requestId: result.requestId
                 });
                 return result;
             });

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -28,7 +28,8 @@ export class SilentRefreshClient extends StandardInteractionClient {
             .then((result: AuthenticationResult) => {
                 acquireTokenMeasurement.endMeasurement({
                     success: true,
-                    fromCache: result.fromCache
+                    fromCache: result.fromCache,
+                    requestId: result.requestId
                 });
 
                 return result;

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -2637,6 +2637,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(events[0].accessTokenSize).toBe(3);
                 expect(events[0].idTokenSize).toBe(4);
                 expect(events[0].isNativeBroker).toBe(true);
+                expect(events[0].requestId).toBe(undefined);
 
                 pca.removePerformanceCallback(callbackId);
                 done();

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -71,7 +71,7 @@ export class AuthorizationCodeClient extends BaseClient {
         const response = await this.executeTokenRequest(this.authority, request);
 
         // Retrieve requestId from response headers
-        const requestId = response.headers && response.headers[HeaderNames.X_MS_REQUEST_ID] ? response.headers[HeaderNames.X_MS_REQUEST_ID] : undefined;
+        const requestId = response.headers?[HeaderNames.X_MS_REQUEST_ID];
 
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -8,7 +8,7 @@ import { CommonAuthorizationUrlRequest } from "../request/CommonAuthorizationUrl
 import { CommonAuthorizationCodeRequest } from "../request/CommonAuthorizationCodeRequest";
 import { Authority } from "../authority/Authority";
 import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { GrantType, AuthenticationScheme, PromptValue, Separators, AADServerParamKeys } from "../utils/Constants";
+import { GrantType, AuthenticationScheme, PromptValue, Separators, AADServerParamKeys, HeaderNames } from "../utils/Constants";
 import { ClientConfiguration } from "../config/ClientConfiguration";
 import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
 import { NetworkResponse } from "../network/NetworkManager";
@@ -70,6 +70,9 @@ export class AuthorizationCodeClient extends BaseClient {
         const reqTimestamp = TimeUtils.nowSeconds();
         const response = await this.executeTokenRequest(this.authority, request);
 
+        // Retrieve requestId from response headers
+        const requestId = response.headers[HeaderNames.X_MS_REQUEST_ID];
+
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,
             this.cacheManager,
@@ -81,7 +84,17 @@ export class AuthorizationCodeClient extends BaseClient {
 
         // Validate response. This function throws a server error if an error is returned by the server.
         responseHandler.validateTokenResponse(response.body);
-        return await responseHandler.handleServerTokenResponse(response.body, this.authority, reqTimestamp, request, authCodePayload);
+        return await responseHandler.handleServerTokenResponse(
+            response.body, 
+            this.authority, 
+            reqTimestamp, 
+            request, 
+            authCodePayload,
+            undefined,
+            undefined,
+            undefined,
+            requestId
+        );
     }
 
     /**

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -71,7 +71,7 @@ export class AuthorizationCodeClient extends BaseClient {
         const response = await this.executeTokenRequest(this.authority, request);
 
         // Retrieve requestId from response headers
-        const requestId = response.headers?[HeaderNames.X_MS_REQUEST_ID];
+        const requestId = response.headers?.[HeaderNames.X_MS_REQUEST_ID];
 
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -71,7 +71,7 @@ export class AuthorizationCodeClient extends BaseClient {
         const response = await this.executeTokenRequest(this.authority, request);
 
         // Retrieve requestId from response headers
-        const requestId = response.headers[HeaderNames.X_MS_REQUEST_ID];
+        const requestId = response.headers && response.headers[HeaderNames.X_MS_REQUEST_ID] ? response.headers[HeaderNames.X_MS_REQUEST_ID] : undefined;
 
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -41,7 +41,7 @@ export class RefreshTokenClient extends BaseClient {
         const response = await this.executeTokenRequest(request, this.authority);
 
         // Retrieve requestId from response headers
-        const requestId = response.headers?[HeaderNames.X_MS_REQUEST_ID];
+        const requestId = response.headers?.[HeaderNames.X_MS_REQUEST_ID];
 
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -9,7 +9,7 @@ import { CommonRefreshTokenRequest } from "../request/CommonRefreshTokenRequest"
 import { Authority } from "../authority/Authority";
 import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
 import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { GrantType, AuthenticationScheme, Errors } from "../utils/Constants";
+import { GrantType, AuthenticationScheme, Errors, HeaderNames } from "../utils/Constants";
 import { ResponseHandler } from "../response/ResponseHandler";
 import { AuthenticationResult } from "../response/AuthenticationResult";
 import { PopTokenGenerator } from "../crypto/PopTokenGenerator";
@@ -40,6 +40,9 @@ export class RefreshTokenClient extends BaseClient {
         const reqTimestamp = TimeUtils.nowSeconds();
         const response = await this.executeTokenRequest(request, this.authority);
 
+        // Retrieve requestId from response headers
+        const requestId = response.headers[HeaderNames.X_MS_REQUEST_ID];
+
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,
             this.cacheManager,
@@ -58,7 +61,8 @@ export class RefreshTokenClient extends BaseClient {
             undefined,
             undefined,
             true,
-            request.forceCache
+            request.forceCache,
+            requestId
         );
     }
 

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -41,7 +41,7 @@ export class RefreshTokenClient extends BaseClient {
         const response = await this.executeTokenRequest(request, this.authority);
 
         // Retrieve requestId from response headers
-        const requestId = response.headers[HeaderNames.X_MS_REQUEST_ID];
+        const requestId = response.headers && response.headers[HeaderNames.X_MS_REQUEST_ID] ? response.headers[HeaderNames.X_MS_REQUEST_ID] : undefined;
 
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -41,7 +41,7 @@ export class RefreshTokenClient extends BaseClient {
         const response = await this.executeTokenRequest(request, this.authority);
 
         // Retrieve requestId from response headers
-        const requestId = response.headers && response.headers[HeaderNames.X_MS_REQUEST_ID] ? response.headers[HeaderNames.X_MS_REQUEST_ID] : undefined;
+        const requestId = response.headers?[HeaderNames.X_MS_REQUEST_ID];
 
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,

--- a/lib/msal-common/src/response/AuthenticationResult.ts
+++ b/lib/msal-common/src/response/AuthenticationResult.ts
@@ -19,6 +19,7 @@ import { AccountInfo } from "../account/AccountInfo";
  * - extExpiresOn           - Javascript Date object representing extended relative expiration of access token in case of server outage
  * - state                  - Value passed in by user in request
  * - familyId               - Family ID identifier, usually only used for refresh tokens
+ * - requestId              - Request ID returned as part of the response
  */
 export type AuthenticationResult = {
     authority: string;
@@ -33,6 +34,7 @@ export type AuthenticationResult = {
     expiresOn: Date | null;
     tokenType: string;
     correlationId: string;
+    requestId?: string;
     extExpiresOn?: Date;
     state?: string;
     familyId?: string;

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -113,7 +113,8 @@ export class ResponseHandler {
         authCodePayload?: AuthorizationCodePayload,
         userAssertionHash?: string,
         handlingRefreshTokenResponse?: boolean,
-        forceCacheRefreshTokenResponse?: boolean): Promise<AuthenticationResult> {
+        forceCacheRefreshTokenResponse?: boolean,
+        serverRequestId?: string): Promise<AuthenticationResult> {
 
         // create an idToken object (not entity)
         let idTokenObj: AuthToken | undefined;
@@ -169,7 +170,7 @@ export class ResponseHandler {
                 const account = this.cacheStorage.getAccount(key);
                 if (!account) {
                     this.logger.warning("Account used to refresh tokens not in persistence, refreshed tokens will not be stored in the cache");
-                    return ResponseHandler.generateAuthenticationResult(this.cryptoObj, authority, cacheRecord, false, request, idTokenObj, requestStateObj, undefined);
+                    return ResponseHandler.generateAuthenticationResult(this.cryptoObj, authority, cacheRecord, false, request, idTokenObj, requestStateObj, undefined, serverRequestId);
                 }
             }
             await this.cacheStorage.saveCacheRecord(cacheRecord);
@@ -179,7 +180,7 @@ export class ResponseHandler {
                 await this.persistencePlugin.afterCacheAccess(cacheContext);
             }
         }
-        return ResponseHandler.generateAuthenticationResult(this.cryptoObj, authority, cacheRecord, false, request, idTokenObj, requestStateObj, serverTokenResponse.spa_code);
+        return ResponseHandler.generateAuthenticationResult(this.cryptoObj, authority, cacheRecord, false, request, idTokenObj, requestStateObj, serverTokenResponse.spa_code, serverRequestId);
     }
 
     /**
@@ -320,6 +321,7 @@ export class ResponseHandler {
         idTokenObj?: AuthToken,
         requestState?: RequestStateObject,
         code?: string,
+        requestId?: string
     ): Promise<AuthenticationResult> {
         let accessToken: string = Constants.EMPTY_STRING;
         let responseScopes: Array<string> = [];
@@ -363,6 +365,7 @@ export class ResponseHandler {
             fromCache: fromTokenCache,
             expiresOn: expiresOn,
             correlationId: request.correlationId,
+            requestId: requestId || Constants.EMPTY_STRING,
             extExpiresOn: extExpiresOn,
             familyId: familyId,
             tokenType: cacheRecord.accessToken?.tokenType || Constants.EMPTY_STRING,

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -298,5 +298,12 @@ export type PerformanceEvent = {
      *
      * @type {?(number | undefined)}
      */
-    cacheLookupPolicy?: number | undefined
+    cacheLookupPolicy?: number | undefined,
+
+    /**
+     * Request ID returned from the response
+     * 
+     * @type {?string}
+     */
+    requestId?: string
 };

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -72,7 +72,8 @@ export enum HeaderNames {
     RETRY_AFTER = "Retry-After",
     CCS_HEADER = "X-AnchorMailbox",
     WWWAuthenticate = "WWW-Authenticate",
-    AuthenticationInfo = "Authentication-Info"
+    AuthenticationInfo = "Authentication-Info",
+    X_MS_REQUEST_ID = "x-ms-request-id"
 }
 
 /**

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -14,7 +14,9 @@ import {
     AUTHENTICATION_RESULT_WITH_FOCI,
     CORS_SIMPLE_REQUEST_HEADERS,
     POP_AUTHENTICATION_RESULT,
-    SSH_AUTHENTICATION_RESULT
+    SSH_AUTHENTICATION_RESULT,
+    AUTHENTICATION_RESULT_WITH_HEADERS,
+    CORS_RESPONSE_HEADERS
 } from "../test_kit/StringConstants";
 import { BaseClient} from "../../src/client/BaseClient";
 import { AADServerParamKeys, GrantType, Constants, CredentialType, AuthenticationScheme, ThrottlingConstants } from "../../src/utils/Constants";
@@ -418,6 +420,42 @@ describe("RefreshTokenClient unit tests", () => {
             expect(result.includes(`${AADServerParamKeys.X_APP_NAME}=${TEST_CONFIG.applicationName}`)).toBe(true);
             expect(result.includes(`${AADServerParamKeys.X_APP_VER}=${TEST_CONFIG.applicationVersion}`)).toBe(true);
             expect(result.includes(`${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`)).toBe(true);
+        });
+
+        it("includes the requestId in the result when received in server response", async () => {
+            sinon.stub(RefreshTokenClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT_WITH_HEADERS);
+            const client = new RefreshTokenClient(config,stubPerformanceClient);
+            const refreshTokenRequest: CommonRefreshTokenRequest = {
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
+                claims: TEST_CONFIG.CLAIMS,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                authenticationScheme: TEST_CONFIG.TOKEN_TYPE_BEARER as AuthenticationScheme
+            };
+
+            const authResult: AuthenticationResult = await client.acquireToken(refreshTokenRequest);
+
+            expect(authResult.requestId).toBeTruthy;
+            expect(authResult.requestId).toEqual(CORS_RESPONSE_HEADERS.xMsRequestId);
+        });
+
+        it("does not include the requestId in the result when none in server response", async () => {
+            sinon.stub(RefreshTokenClient.prototype, <any>"executePostToTokenEndpoint").resolves(AUTHENTICATION_RESULT);
+            const client = new RefreshTokenClient(config,stubPerformanceClient);
+            const refreshTokenRequest: CommonRefreshTokenRequest = {
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                refreshToken: TEST_TOKENS.REFRESH_TOKEN,
+                claims: TEST_CONFIG.CLAIMS,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                authenticationScheme: TEST_CONFIG.TOKEN_TYPE_BEARER as AuthenticationScheme
+            };
+
+            const authResult: AuthenticationResult = await client.acquireToken(refreshTokenRequest);
+
+            expect(authResult.requestId).toBeFalsy;
+            expect(authResult.requestId).toEqual("");
         });
     });
 

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -364,6 +364,22 @@ describe("ResponseHandler.ts", () => {
             expect(result.tokenType).toBe(AuthenticationScheme.POP);
             expect(result.accessToken).toBe(signedJwt);
         });
+
+        it("sets default value if requestId not provided", async () => {
+            const testRequest: BaseAuthRequest = {
+                authority: testAuthority.canonicalAuthority,
+                correlationId: "CORRELATION_ID",
+                scopes: ["openid", "profile", "User.Read", "email"]
+            };
+            const testResponse: ServerAuthorizationTokenResponse = {...AUTHENTICATION_RESULT.body};
+            testResponse.refresh_token = undefined;
+
+            const responseHandler = new ResponseHandler("this-is-a-client-id", testCacheManager, cryptoInterface, new Logger(loggerOptions), null, null);
+            const timestamp = TimeUtils.nowSeconds();
+            const result = await responseHandler.handleServerTokenResponse(testResponse, testAuthority, timestamp, testRequest);
+
+            expect(result.requestId).toBe("");
+        });
     });
 
     describe("validateServerAuthorizationCodeResponse", () => {

--- a/lib/msal-common/test/test_kit/StringConstants.ts
+++ b/lib/msal-common/test/test_kit/StringConstants.ts
@@ -421,6 +421,27 @@ export const AUTHENTICATION_RESULT_DEFAULT_SCOPES = {
     }
 };
 
+export const CORS_RESPONSE_HEADERS = {
+    xMsRequestId: "xMsRequestId"
+};
+
+export const AUTHENTICATION_RESULT_WITH_HEADERS = {
+    status: 200,
+    headers: {
+        "x-ms-request-id": CORS_RESPONSE_HEADERS.xMsRequestId
+    },
+    body: {
+        "token_type": AuthenticationScheme.BEARER,
+        "scope": "openid profile offline_access User.Read",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "thisIs.an.accessT0ken",
+        "refresh_token": "thisIsARefreshT0ken",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
+        "client_info": `${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}`
+    }
+};
+
 export const CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT = {
     status: 200,
     body: {


### PR DESCRIPTION
This PR:
- Allows retrieval of `x-ms-request-id` (ESTS request ID) from server response headers to be added to `AuthenticationResult` as `requestId`
- These request IDs are then added to existing performance telemetry in msal-browser
- Unit tests for msal-common changes (data point changes added to msal-browser were tested in Kusto)