### PR TITLE
Fixed broken homeAccountId check in CacheManager

### DIFF
--- a/change/@azure-msal-common-f46053c3-36ec-417f-b7a2-250e2a580f76.json
+++ b/change/@azure-msal-common-f46053c3-36ec-417f-b7a2-250e2a580f76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed broken homeAccountId check in CacheManager",
+  "packageName": "@azure/msal-common",
+  "email": "rgins16@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-f46053c3-36ec-417f-b7a2-250e2a580f76.json
+++ b/change/@azure-msal-common-f46053c3-36ec-417f-b7a2-250e2a580f76.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Fixed broken homeAccountId check in CacheManager",
   "packageName": "@azure/msal-common",
-  "email": "rgins16@gmail.com",
+  "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@azure-msal-common-f46053c3-36ec-417f-b7a2-250e2a580f76.json
+++ b/change/@azure-msal-common-f46053c3-36ec-417f-b7a2-250e2a580f76.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fixed broken homeAccountId check in CacheManager",
+  "comment": "Fixed broken homeAccountId check in CacheManager #5246",
   "packageName": "@azure/msal-common",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -294,7 +294,7 @@ export abstract class CacheManager implements ICacheManager {
             }
 
             // homeAccountId can undefined, and we want to filter out cached items that have a homeAccountId of ""
-            if ((typeof homeAccountId === "string") && !this.matchHomeAccountId(entity, homeAccountId)) {
+            if (!!homeAccountId && !this.matchHomeAccountId(entity, homeAccountId)) {
                 return;
             }
 

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -293,7 +293,8 @@ export abstract class CacheManager implements ICacheManager {
                 return;
             }
 
-            if (!!homeAccountId && !this.matchHomeAccountId(entity, homeAccountId)) {
+            // homeAccountId can undefined, and we want to filter out cached items that have a homeAccountId of ""
+            if ((typeof homeAccountId === "string") && !this.matchHomeAccountId(entity, homeAccountId)) {
                 return;
             }
 
@@ -390,8 +391,8 @@ export abstract class CacheManager implements ICacheManager {
                 return;
             }
 
-            // homeAccountId can be an empty string, and !!("") = false
-            if (!!(typeof homeAccountId === "string") && !this.matchHomeAccountId(entity, homeAccountId)) {
+            // homeAccountId can undefined, and we want to filter out cached items that have a homeAccountId of ""
+            if ((typeof homeAccountId === "string") && !this.matchHomeAccountId(entity, homeAccountId)) {
                 return;
             }
 
@@ -842,7 +843,7 @@ export abstract class CacheManager implements ICacheManager {
      * @param homeAccountId
      */
     private matchHomeAccountId(entity: AccountEntity | CredentialEntity, homeAccountId: string): boolean {
-        return !!(entity.homeAccountId && homeAccountId === entity.homeAccountId);
+        return !!((typeof entity.homeAccountId === "string") && (homeAccountId === entity.homeAccountId));
     }
 
     /**

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -293,7 +293,6 @@ export abstract class CacheManager implements ICacheManager {
                 return;
             }
 
-            // homeAccountId can undefined, and we want to filter out cached items that have a homeAccountId of ""
             if (!!homeAccountId && !this.matchHomeAccountId(entity, homeAccountId)) {
                 return;
             }

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -390,7 +390,8 @@ export abstract class CacheManager implements ICacheManager {
                 return;
             }
 
-            if (!!homeAccountId && !this.matchHomeAccountId(entity, homeAccountId)) {
+            // homeAccountId can be an empty string, and !!("") = false
+            if (!!(typeof homeAccountId === "string") && !this.matchHomeAccountId(entity, homeAccountId)) {
                 return;
             }
 

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -390,7 +390,10 @@ export abstract class CacheManager implements ICacheManager {
                 return;
             }
 
-            // homeAccountId can undefined, and we want to filter out cached items that have a homeAccountId of ""
+            /*
+             * homeAccountId can undefined, and we want to filter out cached items that have a homeAccountId of ""
+             * because we don't want a client_credential request to return a cached token that has a homeAccountId
+             */
             if ((typeof homeAccountId === "string") && !this.matchHomeAccountId(entity, homeAccountId)) {
                 return;
             }

--- a/lib/msal-common/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-common/test/client/ClientCredentialClient.spec.ts
@@ -79,7 +79,8 @@ describe("ClientCredentialClient unit tests", () => {
         expect(returnVal.includes(`${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`)).toBe(true);
     });
 
-    it.only("Multiple access tokens would match, but one of them has a Home Account ID of \"\"", async () => {
+    // regression test for https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/5134
+    it("Multiple access tokens would match, but one of them has a Home Account ID of \"\"", async () => {
         sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
         sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").resolves(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT);
         

--- a/lib/msal-common/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-common/test/client/ClientCredentialClient.spec.ts
@@ -6,7 +6,9 @@ import {
     TEST_TOKENS,
     CORS_SIMPLE_REQUEST_HEADERS,
     DSTS_OPENID_CONFIG_RESPONSE,
-    DSTS_CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT
+    DSTS_CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT,
+    AUTHENTICATION_RESULT_DEFAULT_SCOPES,
+    ID_TOKEN_CLAIMS
 } from "../test_kit/StringConstants";
 import { BaseClient } from "../../src/client/BaseClient";
 import { AADServerParamKeys, GrantType, Constants, AuthenticationScheme, ThrottlingConstants } from "../../src/utils/Constants";
@@ -14,13 +16,15 @@ import { ClientTestUtils, mockCrypto } from "./ClientTestUtils";
 import { Authority } from "../../src/authority/Authority";
 import { ClientCredentialClient } from "../../src/client/ClientCredentialClient";
 import { CommonClientCredentialRequest } from "../../src/request/CommonClientCredentialRequest";
+import { UsernamePasswordClient } from "../../src/client/UsernamePasswordClient";
+import { CommonUsernamePasswordRequest } from "../../src/request/CommonUsernamePasswordRequest";
 import { AccessTokenEntity } from "../../src/cache/entities/AccessTokenEntity"
 import { TimeUtils } from "../../src/utils/TimeUtils";
 import { CredentialCache } from "../../src/cache/utils/CacheTypes";
 import { CacheManager } from "../../src/cache/CacheManager";
 import { ClientAuthError } from "../../src/error/ClientAuthError";
 import { AuthenticationResult } from "../../src/response/AuthenticationResult";
-import { AppTokenProviderResult, IAppTokenProvider } from "../../src";
+import { AppTokenProviderResult, AuthToken, IAppTokenProvider } from "../../src";
 
 describe("ClientCredentialClient unit tests", () => {
     afterEach(() => {
@@ -73,6 +77,45 @@ describe("ClientCredentialClient unit tests", () => {
         expect(returnVal.includes(`${AADServerParamKeys.X_APP_NAME}=${TEST_CONFIG.applicationName}`)).toBe(true);
         expect(returnVal.includes(`${AADServerParamKeys.X_APP_VER}=${TEST_CONFIG.applicationVersion}`)).toBe(true);
         expect(returnVal.includes(`${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`)).toBe(true);
+    });
+
+    it.only("Multiple access tokens would match, but one of them has a Home Account ID of \"\"", async () => {
+        sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+        sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").resolves(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT);
+        
+        const authenticationScopes = AUTHENTICATION_RESULT_DEFAULT_SCOPES;
+        authenticationScopes.body.scope = "https://graph.microsoft.com/.default";
+        sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(authenticationScopes);
+
+        const idTokenClaims = {
+            ...ID_TOKEN_CLAIMS,
+            tid: "common",
+        };
+        sinon.stub(AuthToken, "extractTokenClaims").returns(idTokenClaims);
+
+        const config = await ClientTestUtils.createTestClientConfiguration();
+
+        const client = new ClientCredentialClient(config);
+        const clientCredentialRequest: CommonClientCredentialRequest = {
+            authority: "https://login.microsoftonline.com/common",
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            scopes: ["https://graph.microsoft.com/.default"],
+        };
+
+        const client2 = new UsernamePasswordClient(config);
+        const usernamePasswordRequest: CommonUsernamePasswordRequest = {
+            authority: "https://login.microsoftonline.com/common",
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            scopes: ["https://graph.microsoft.com/.default"],
+            username: "mock_name",
+            password: "mock_password",
+        };
+
+        const authResult = await client.acquireToken(clientCredentialRequest) as AuthenticationResult;
+        expect(authResult.fromCache).toBe(false);
+        const authResult2 = await client2.acquireToken(usernamePasswordRequest) as AuthenticationResult;
+        expect(authResult2.fromCache).toBe(false);
+        await expect(client.acquireToken(clientCredentialRequest)).resolves.not.toThrow(ClientAuthError.createMultipleMatchingTokensInCacheError());
     });
 
     it("acquires a token from dSTS authority", async () => {


### PR DESCRIPTION
The homeAccountId check in CacheManager.ts did not account for a homeAccountId that was an empty string.

For example, say the following two access tokens exist in the cache for a confidential client application - one for an application and the other for a user account:

```
        "-login.windows.net-accesstoken-[...]-https://graph.microsoft.com/.default--": {
            "home_account_id": "",
            "credential_type": "AccessToken",
            ...
        },
        "[...]-login.windows.net-accesstoken-[...]-profile openid email https://graph.microsoft.com/user.read https://graph.microsoft.com/user.read.all https://graph.microsoft.com/.default--": {
            "home_account_id": "[...]",
            "credential_type": "AccessToken",
            ...
        }
```

Under the old homeAccountId logic, both access tokens were returned when an application called `acquireTokenByClientCredential` because !!("") equates to false, and the rest of the homeAccountId comparison was not being performed. Now, only the matching access token is returned.