### PR TITLE
Include Angular 13 and 14 as supported versions in FAQ

### DIFF
--- a/lib/msal-angular/docs/FAQ.md
+++ b/lib/msal-angular/docs/FAQ.md
@@ -42,7 +42,7 @@ Please see [here](https://github.com/AzureAD/microsoft-authentication-library-fo
 
 ### What versions of Angular are supported?
 
-Msal Angular currently supports Angular 9, 10, 11, and 12.
+Msal Angular currently supports Angular 9, 10, 11, 12, 13 and 14.
 
 ### Does `@azure/msal-angular` support Server Side Rendering?
 


### PR DESCRIPTION
It seems the FAQ is outdated on supported Angular versions.
https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/5092