### PR TITLE
update doc to demonstrate usage of Persistence

### DIFF
--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -167,10 +167,14 @@ const lockOptions = {
 
 const persistence = await PersistenceCreator.createPersistence(persistenceConfiguration);
 const persistenceCachePlugin = new PersistenceCachePlugin(persistence, lockOptions); // or any of the other ones
-// Pass the persistence to msal config's cachePlugin
-msalConfig.cache.cachePlugin = persistenceCachePlugin;
-// Initialize the electron authenticator
-authProvider = new AuthProvider(msalConfig);
+const pca = new PublicClientApplication({
+    auth: {
+            clientId: "CLIENT_ID_HERE",
+        },
+    cache: {
+            cachePlugin: persistenceCachePlugin
+        },
+    });
 
 ```
 

--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -81,8 +81,6 @@ const cachePath = "path/to/cache/file.json";
 const serviceName = "test-msal-electron-service";
 const accountName = "test-msal-electron-account";
 const macPersistence = await KeychainPersistence.create(cachePath, serviceName, accountName);
-// Pass the persistence to msal config's cachePlugin
-msalConfig.cache.cachePlugin = new PersistenceCachePlugin(macPersistence);
 // Use the persistence object to initialize an MSAL PublicClientApplication with cachePlugin
 const pca = new PublicClientApplication({
                 auth: {

--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -178,8 +178,8 @@ const pca = new PublicClientApplication({
 
 ```
 
-### Setting the PersistenceCachePlugin on the MSAL Node PublicClientApplication configuration
-Once you have a `PersistenceCachePlugin`, that can be set on the MSAL Node `PublicClientApplication`, by setting it as part of the [configuration](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_node.html#configuration) object.
+### Setting the PersistenceCachePlugin on the MSAL Node PublicClientApplication configuration (with an example)
+To summarize, once you have a `PersistenceCachePlugin`, that can be set on the MSAL Node `PublicClientApplication`, by setting it as part of the [configuration](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_node.html#configuration) object as shown below.
 
 ```js
 import { PublicClientApplication } from "@azure/msal-node";

--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -146,7 +146,7 @@ authProvider = new AuthProvider(msalConfig);
 
 > :https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/e7ea9fd970c035aaee9f8d3c3d3196334fd1c0de/extensions/msal-node-extensions/src/persistence/FilePersistence.ts#L18: If file or directory has not been created, `FilePersistence.create()` will create the file and any directories in the path recursively.
 
-### Creating the cache plugin
+### Passing lock options to the Cache plugin for concurrency
 Create the PersistenceCachePlugin, by passing in the persistence object that was created in the previous step.
 
 ```js
@@ -155,11 +155,11 @@ const { PersistenceCachePlugin } = require("@azure/msal-node-extensions");
 const persistenceCachePlugin = new PersistenceCachePlugin(windowsPersistence); // or any of the other ones.
 ```
 
-To support concurrent access my multiple processess, the extensions use a file based lock. You can configure the retry number and retry delay for lock acquisition through CrossPlatformLockOptions.
+To support concurrent access by multiple processess, the extensions use a file based lock. You can configure the retry number and retry delay for lock acquisition through CrossPlatformLockOptions.
 
 ```js
 const {
-  PersistenceCreator
+  PersistenceCreator,
   PersistenceCachePlugin,
 } = require("@azure/msal-node-extensions");
 
@@ -245,7 +245,7 @@ module.exports = {
 
 ```
 
-Note that MSAL will not read and write to persistence by default. You will have to call PublicClientApplication.tokenCache.readFromPersistence() and PublicClientApplication.tokenCache.writeToPersistence() anytime you trigger and MSAL Node operation that alters the token cache.
+
 
 
 ### Note for Electron Developers:
@@ -262,3 +262,8 @@ This error is probably due to Node.js version differences between the Electron p
 - Install ```electron-rebuild``` with the command ```npm i -D electron-rebuild``` if you don't already have it installed.
 - Remove ```packages-lock.json``` from your project if it exists
 - Run ```./node_modules/.bin/electron-rebuild```
+
+
+### Samples
+1) [Electron-webpack sample for persistence](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/extensions/samples/electron-webpack)
+2) [Msal-node extensions sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/extensions/samples/msal-node-extensions)

--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -130,9 +130,14 @@ const { FilePersistence } = require("@azure/msal-node-extensions");
 const filePath = "path/to/cache/file.json";
 const filePersistence = await FilePersistence.create(filePath, loggerOptions);
 // Pass the persistence to msal config's cachePlugin
-msalConfig.cache.cachePlugin = new PersistenceCachePlugin(filePersistence);
- // Initialize the electron authenticator
-authProvider = new AuthProvider(msalConfig); 
+const pca = new PublicClientApplication({
+    auth: {
+            clientId: "CLIENT_ID_HERE",
+        },
+    cache: {
+            cachePlugin: new PersistenceCachePlugin(filePersistence);
+        },
+  });
 
 ```
 

--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -33,8 +33,6 @@ const persistence = await PersistenceCreator.createPersistence({
                 accountName: "test-msal-electron-account",
                 usePlaintextFileOnLinux: false,
           });
-// Pass the persistence to msal config's cachePlugin
-msalConfig.cache.cachePlugin = new PersistenceCachePlugin(persistence);
 // Use the persistence object to initialize an MSAL PublicClientApplication with cachePlugin
 const pca = new PublicClientApplication({
                 auth: {

--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -107,8 +107,6 @@ const cachePath = "path/to/cache/file.json";
 const serviceName = "test-msal-electron-service";
 const accountName = "test-msal-electron-account";
 const linuxPersistence = await LibSecretPersistence.create(cachePath, serviceName, accountName);
-// Pass the persistence to msal config's cachePlugin
-msalConfig.cache.cachePlugin = new PersistenceCachePlugin(linuxPersistence);
 // Use the persistence object to initialize an MSAL PublicClientApplication with cachePlugin
 const pca = new PublicClientApplication({
                 auth: {

--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -57,8 +57,6 @@ const cachePath = "path/to/cache/file.json";
 const dataProtectionScope = DataProtectionScope.CurrentUser;
 const optionalEntropy = ""; //specifies password or other additional entropy used to encrypt the data.
 const windowsPersistence = await FilePersistenceWithDataProtection.create(cachePath, dataProtectionScope, optionalEntropy);
-// Pass the persistence to msal config's cachePlugin
-msalConfig.cache.cachePlugin = new PersistenceCachePlugin(windowsPersistence);
 // Use the persistence object to initialize an MSAL PublicClientApplication with cachePlugin
 const pca = new PublicClientApplication({
                 auth: {

--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -249,7 +249,8 @@ Note that MSAL will not read and write to persistence by default. You will have 
 
 
 ### Note for Electron Developers:
-Electron sample  link will be added here soon for clarity. 
+Electron sample :
+This [sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/extensions/samples/electron-webpack) depicts how to integrate the msal-node-extensions library to your electron application that has been bundled by webpack.
 
 If you are using this extension for Electron, you might face an error similar to this:
 ```


### PR DESCRIPTION
This PR updates the persistence doc to address gaps in implementation of PersistenceLayer , particularly for Node-js desktop env.  An Electron sample containing full working code is being tracked as part of a separate work [item](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2138133/), however this doc includes the relevant code snippets with generic explanation wherever relevant. 