### PR TITLE
Fix state update on unmounted component

### DIFF
--- a/change/@azure-msal-react-9a364466-3600-4d0a-b623-6977277a96b0.json
+++ b/change/@azure-msal-react-9a364466-3600-4d0a-b623-6977277a96b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix state update on unmounted component #5396",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
If `useMsalAuthentication` is unmounted while an acquireToken is in progress it will result in an attempt to update state on an unmounted component. This is a no-op but it prints a warning to the console. This PR fixes this behavior by checking if the component is mounted prior to updating state.

Unfortunately there's not a good way to test this in our CI.

Fixes #5245 