### PR TITLE
Fix msal-react SSR hydration errors

### DIFF
--- a/change/@azure-msal-react-53c15c14-42d6-4a84-a024-5a1b7fe271c5.json
+++ b/change/@azure-msal-react-53c15c14-42d6-4a84-a024-5a1b7fe271c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix SSR hydration errors #5399",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-react/src/hooks/useIsAuthenticated.ts
+++ b/lib/msal-react/src/hooks/useIsAuthenticated.ts
@@ -6,7 +6,7 @@
 import { useState, useEffect } from "react";
 import { useMsal } from "./useMsal";
 import { AccountIdentifiers } from "../types/AccountIdentifiers";
-import { AccountInfo } from "@azure/msal-browser";
+import { AccountInfo, InteractionStatus } from "@azure/msal-browser";
 import { getAccountByIdentifiers } from "../utils/utilities";
 
 function isAuthenticated(allAccounts: AccountInfo[], matchAccount?: AccountIdentifiers): boolean {
@@ -22,9 +22,14 @@ function isAuthenticated(allAccounts: AccountInfo[], matchAccount?: AccountIdent
  * @param matchAccount 
  */
 export function useIsAuthenticated(matchAccount?: AccountIdentifiers): boolean {
-    const { accounts: allAccounts } = useMsal();
+    const { accounts: allAccounts, inProgress } = useMsal();
 
-    const [hasAuthenticated, setHasAuthenticated] = useState<boolean>(() => isAuthenticated(allAccounts, matchAccount));
+    const [hasAuthenticated, setHasAuthenticated] = useState<boolean>(() => {
+        if (inProgress === InteractionStatus.Startup) {
+            return false;
+        }
+        return isAuthenticated(allAccounts, matchAccount);
+    });
 
     useEffect(() => {
         setHasAuthenticated(isAuthenticated(allAccounts, matchAccount));

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -864,4 +864,32 @@ describe("MsalAuthenticationTemplate tests", () => {
         expect(await screen.findByText("In Progress: login")).toBeInTheDocument();
         expect(screen.queryByText("A user is authenticated!")).not.toBeInTheDocument();
     });
+
+    test("Renders nothing when inProgress is Startup", async () => {
+        handleRedirectSpy = jest.spyOn(pca, "handleRedirectPromise").mockImplementation(() =>{
+            return Promise.resolve(null);
+        });
+        const loginPopupSpy = jest.spyOn(pca, "loginPopup").mockImplementation(() => {
+            return Promise.reject(null);
+        })
+
+        const loadingMessage = ({inProgress}: IMsalContext) => {
+            return <p>In Progress: {inProgress}</p>;
+        };
+
+        render(
+            <MsalProvider instance={pca}>
+                <p>This text will always display.</p>
+                <MsalAuthenticationTemplate interactionType={InteractionType.Popup} loadingComponent={loadingMessage}>
+                    <span> A user is authenticated!</span>
+                </MsalAuthenticationTemplate>
+            </MsalProvider>
+        );
+
+        await waitFor(() => expect(handleRedirectSpy).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(loginPopupSpy).toHaveBeenCalledTimes(1));
+        expect(screen.queryByText("This text will always display.")).toBeInTheDocument();
+        expect(screen.queryByText("In Progress: login")).not.toBeInTheDocument();
+        expect(screen.queryByText("A user is authenticated!")).not.toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
When attempting to use msal-react in an SSR app it results in hydration errors when a using `MsalAuthenticationTemplate` or `useIsAuthenticated`. This PR fixes this behavior by defaulting the value of `useIsAuthenticated` to `false` when `inProgress` is `Startup` (which it will always be server-side and on the first render client-side)