### PR TITLE
Include original request params on /token request in acquireTokenInteractive

### DIFF
--- a/change/@azure-msal-node-8976fdb7-eaee-4575-a4bf-a064d10388a1.json
+++ b/change/@azure-msal-node-8976fdb7-eaee-4575-a4bf-a064d10388a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Include original request params on /token request in acquireTokenInteractive #5403",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -98,7 +98,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
 
         const validRequest: AuthorizationUrlRequest = {
             ...remainingProperties,
-            scopes: request.scopes || [],
+            scopes: request.scopes || OIDC_DEFAULT_SCOPES,
             redirectUri: redirectUri,
             responseMode: ResponseMode.QUERY,
             codeChallenge: challenge, 
@@ -120,10 +120,9 @@ export class PublicClientApplication extends ClientApplication implements IPubli
         const clientInfo = authCodeResponse.client_info;
         const tokenRequest: AuthorizationCodeRequest = {
             code: authCodeResponse.code,
-            scopes: OIDC_DEFAULT_SCOPES,
-            redirectUri: validRequest.redirectUri,
             codeVerifier: verifier,
-            clientInfo: clientInfo || CommonConstants.EMPTY_STRING
+            clientInfo: clientInfo || CommonConstants.EMPTY_STRING,
+            ...validRequest
         };
         return this.acquireTokenByCode(tokenRequest);
     }

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -238,7 +238,8 @@ describe('PublicClientApplication', () => {
             return Promise.resolve(TEST_CONSTANTS.AUTH_CODE_URL);
         });
 
-        jest.spyOn(MockAuthorizationCodeClient.prototype, "acquireToken").mockImplementation(() => {
+        jest.spyOn(MockAuthorizationCodeClient.prototype, "acquireToken").mockImplementation((tokenRequest) => {
+            expect(tokenRequest.scopes).toEqual([...TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE, ...TEST_CONSTANTS.DEFAULT_OIDC_SCOPES]);
             return Promise.resolve(mockAuthenticationResult);
         });
 

--- a/lib/msal-node/test/utils/TestConstants.ts
+++ b/lib/msal-node/test/utils/TestConstants.ts
@@ -17,6 +17,7 @@ export const TEST_CONSTANTS = {
     REDIRECT_URI: "http://localhost:8080",
     CLIENT_SECRET: "MOCK_CLIENT_SECRET",
     DEFAULT_GRAPH_SCOPE: ["user.read"],
+    DEFAULT_OIDC_SCOPES: ["openid", "profile", "offline_access"],
     USERNAME: "mockuser",
     PASSWORD: "mockpassword",
     AUTHORIZATION_CODE:


### PR DESCRIPTION
A bug in `acquireTokenInteractive` resulted in provided `scopes` and other request parameters being ignored on the `/token` request. This PR ensures that the `/token` request parameters match the parameters from the `/authorize` request

Fixes #5390 