### PR TITLE
Add event vis change listener in PopupClient

### DIFF
--- a/change/@azure-msal-browser-b1ca436a-f28a-45d3-95d1-96f5899fb212.json
+++ b/change/@azure-msal-browser-b1ca436a-f28a-45d3-95d1-96f5899fb212.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "popup-add listener",
+  "packageName": "@azure/msal-browser",
+  "email": "bmahal@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-b1ca436a-f28a-45d3-95d1-96f5899fb212.json
+++ b/change/@azure-msal-browser-b1ca436a-f28a-45d3-95d1-96f5899fb212.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "popup-add listener",
+  "type": "minor",
+  "comment": "popup-add listener #5476",
   "packageName": "@azure/msal-browser",
   "email": "bmahal@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/change/@azure-msal-common-d441634d-a734-4af6-9a5a-ed53811b251f.json
+++ b/change/@azure-msal-common-d441634d-a734-4af6-9a5a-ed53811b251f.json
@@ -1,7 +1,7 @@
 {
   "type": "minor",
-  "comment": "popup-add listener",
+  "comment": "popup-add listener #5476",
   "packageName": "@azure/msal-common",
   "email": "bmahal@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/change/@azure-msal-common-d441634d-a734-4af6-9a5a-ed53811b251f.json
+++ b/change/@azure-msal-common-d441634d-a734-4af6-9a5a-ed53811b251f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "popup-add listener",
+  "packageName": "@azure/msal-common",
+  "email": "bmahal@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -398,20 +398,13 @@ export class PopupClient extends StandardInteractionClient {
 
     private trackPageVisibility():void {
         if(!this.openPopupMeasurement) return;
-
-        this.logger.info("tp: add static field");
-        /*
-         * this.openPopupMeasurement.addStaticField({
-         *  visChange:true
-         * });
-         */
+        this.logger.info("Perf: Visibility change detected");
         this.openPopupMeasurement.addStaticFields({
             visChange: true,
         });
         this.openPopupMeasurement.endMeasurement({
             success: true,
-        });
-        this.logger.info("tp: calling endMeas");                    
+        });                  
         document.removeEventListener("visibilitychange",this.trackPageVisibility);
     }
 

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -125,6 +125,7 @@ export enum PerformanceEvents {
      * Time taken for acquiring cached refresh token 
      */
     RefreshTokenClientAcquireTokenWithCachedRefreshToken = "refreshTokenClientAcquireTokenWithCachedRefreshToken",
+    OpenPopup= "openPopup"
 }
 
 /**
@@ -343,5 +344,6 @@ export type PerformanceEvent = StaticFields & {
      * 
      * @type {?string}
      */
-    requestId?: string
+    requestId?: string,
+    visChange?: boolean;
 };

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -206,8 +206,9 @@ export type StaticFields = {
     matsSilentBiSubCode?: number;
     matsSilentMessage?: string;
     matsSilentStatus?: number;
-    matsHttpStatus?: number
+    matsHttpStatus?: number;
     matsHttpEventCount?: number;
+    visChange?: boolean;
 };
 
 /**
@@ -345,5 +346,4 @@ export type PerformanceEvent = StaticFields & {
      * @type {?string}
      */
     requestId?: string,
-    visChange?: boolean;
 };


### PR DESCRIPTION
This PR-

Adds a boolean(visChange) to performance data to indicate when Page Visibility changes during the AcquireTokenPopup flow.
This covers the AcquireTokenPopup event only.