### PR TITLE
Mitigate `noAccountError` #2098678

### DIFF
--- a/change/@azure-msal-browser-f537622d-9856-4148-b525-46daa087795e.json
+++ b/change/@azure-msal-browser-f537622d-9856-4148-b525-46daa087795e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Log number of accounts in trace mode. #5529",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -403,19 +403,19 @@ export class BrowserCacheManager extends CacheManager {
     getActiveAccount(): AccountInfo | null {
         const activeAccountKeyFilters = this.generateCacheKey(PersistentCacheKeys.ACTIVE_ACCOUNT_FILTERS);
         const activeAccountValueFilters = this.getItem(activeAccountKeyFilters);
-        if (!activeAccountValueFilters) { 
+        if (!activeAccountValueFilters) {
             // if new active account cache type isn't found, it's an old version, so look for that instead
-            this.logger.trace("No active account filters cache schema found, looking for legacy schema");
+            this.logger.trace("BrowserCacheManager.getActiveAccount: No active account filters cache schema found, looking for legacy schema");
             const activeAccountKeyLocal = this.generateCacheKey(PersistentCacheKeys.ACTIVE_ACCOUNT);
             const activeAccountValueLocal = this.getItem(activeAccountKeyLocal);
             if(!activeAccountValueLocal) {
-                this.logger.trace("No active account found");
+                this.logger.trace("BrowserCacheManager.getActiveAccount: No active account found");
                 return null;
             }
             const activeAccount = this.getAccountInfoByFilter({localAccountId: activeAccountValueLocal})[0] || null;
             if(activeAccount) {
-                this.logger.trace("Legacy active account cache schema found");
-                this.logger.trace("Adding active account filters cache schema");
+                this.logger.trace("BrowserCacheManager.getActiveAccount: Legacy active account cache schema found");
+                this.logger.trace("BrowserCacheManager.getActiveAccount: Adding active account filters cache schema");
                 this.setActiveAccount(activeAccount);
                 return activeAccount;
             }
@@ -423,13 +423,13 @@ export class BrowserCacheManager extends CacheManager {
         }
         const activeAccountValueObj = this.validateAndParseJson(activeAccountValueFilters) as AccountInfo;
         if(activeAccountValueObj) {
-            this.logger.trace("Active account filters schema found");
+            this.logger.trace("BrowserCacheManager.getActiveAccount: Active account filters schema found");
             return this.getAccountInfoByFilter({
                 homeAccountId: activeAccountValueObj.homeAccountId,
                 localAccountId: activeAccountValueObj.localAccountId
             })[0] || null;
         }
-        this.logger.trace("No active account found");
+        this.logger.trace("BrowserCacheManager.getActiveAccount: No active account found");
         return null;
     }
 
@@ -461,6 +461,8 @@ export class BrowserCacheManager extends CacheManager {
      */
     getAccountInfoByFilter(accountFilter: Partial<Omit<AccountInfo, "idTokenClaims"|"name">>): AccountInfo[] {
         const allAccounts = this.getAllAccounts();
+        this.logger.trace(`BrowserCacheManager.getAccountInfoByFilter: total ${allAccounts.length} accounts found`);
+
         return allAccounts.filter((accountObj) => {
             if (accountFilter.username && accountFilter.username.toLowerCase() !== accountObj.username.toLowerCase()) {
                 return false;
@@ -1069,10 +1071,10 @@ export class BrowserCacheManager extends CacheManager {
     getRedirectRequestContext(): string | null {
         return this.getTemporaryCache(TemporaryCacheKeys.REDIRECT_CONTEXT, true);
     }
-     
+
     /**
      * Sets application id as the redirect context during AcquireTokenRedirect flow.
-     * @param value 
+     * @param value
      */
     setRedirectRequestContext(value: string): void {
         this.setTemporaryCache(TemporaryCacheKeys.REDIRECT_CONTEXT, value, true);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -6,7 +6,31 @@
 import sinon from "sinon";
 import { PublicClientApplication } from "../../src/app/PublicClientApplication";
 import { TEST_CONFIG, TEST_URIS, TEST_TOKENS, ID_TOKEN_CLAIMS, TEST_DATA_CLIENT_INFO, TEST_TOKEN_LIFETIMES, RANDOM_TEST_GUID, testLogoutUrl, TEST_STATE_VALUES, TEST_HASHES, DEFAULT_TENANT_DISCOVERY_RESPONSE, DEFAULT_OPENID_CONFIG_RESPONSE, testNavUrlNoRequest, TEST_SSH_VALUES, TEST_CRYPTO_VALUES } from "../utils/StringConstants";
-import { AuthorityMetadataEntity, ServerError, Constants, AccountInfo, TokenClaims, AuthenticationResult, CommonAuthorizationUrlRequest, AuthorizationCodeClient, ResponseMode, AccountEntity, ProtocolUtils, AuthenticationScheme, RefreshTokenClient, Logger, ServerTelemetryEntity, CommonSilentFlowRequest, LogLevel, CommonAuthorizationCodeRequest, InteractionRequiredAuthError, IdTokenEntity, CacheManager, ClientAuthError } from "@azure/msal-common";
+import {
+    AuthorityMetadataEntity,
+    ServerError,
+    Constants,
+    AccountInfo,
+    TokenClaims,
+    AuthenticationResult,
+    CommonAuthorizationUrlRequest,
+    AuthorizationCodeClient,
+    ResponseMode,
+    AccountEntity,
+    ProtocolUtils,
+    AuthenticationScheme,
+    RefreshTokenClient,
+    Logger,
+    ServerTelemetryEntity,
+    CommonSilentFlowRequest,
+    LogLevel,
+    CommonAuthorizationCodeRequest,
+    InteractionRequiredAuthError,
+    IdTokenEntity,
+    CacheManager,
+    ClientAuthError,
+    PersistentCacheKeys
+} from "@azure/msal-common";
 import { ApiId, InteractionType, WrapperSKU, TemporaryCacheKeys, BrowserConstants, BrowserCacheLocation, CacheLookupPolicy } from "../../src/utils/BrowserConstants";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { EventType } from "../../src/event/EventType";
@@ -429,7 +453,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(tokenResponse1.idTokenClaims).toEqual(expect.objectContaining(testTokenResponse.idTokenClaims));
             expect(tokenResponse1.accessToken).toEqual(testTokenResponse.accessToken);
             expect(testTokenResponse.expiresOn && tokenResponse1.expiresOn && testTokenResponse.expiresOn.getMilliseconds() >= tokenResponse1.expiresOn.getMilliseconds()).toBeTruthy();
-            
+
             // Response from second promise
             expect(tokenResponse2.uniqueId).toEqual(testTokenResponse.uniqueId);
             expect(tokenResponse2.tenantId).toEqual(testTokenResponse.tenantId);
@@ -724,7 +748,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const newWindow = {
                 ...window
             };
-            
+
             delete window.opener;
             delete window.name;
             window.opener = newWindow;
@@ -898,7 +922,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(request.scopes).toContain("openid");
                 expect(request.scopes).toContain("profile");
                 done();
-                
+
                 return testTokenResponse;
             });
 
@@ -1378,7 +1402,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const newWindow = {
                 ...window
             };
-            
+
             delete window.opener;
             delete window.name;
             window.opener = newWindow;
@@ -2562,7 +2586,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 account: testAccount,
                 extraQueryParameters: {
                     queryKey: "queryValue"
-                }, 
+                },
                 forceRefresh: false
             };
             const expectedRequest: CommonAuthorizationUrlRequest = {
@@ -2753,12 +2777,12 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             afterEach(() => {
                 sinon.restore();
             });
-            
+
             it("Calls SilentCacheClient.acquireToken, SilentRefreshClient.acquireToken and SilentIframeClient.acquireToken if cache lookup throws and refresh token is expired when CacheLookupPolicy is set to Default", async () => {
                 const silentCacheSpy = sinon.stub(SilentCacheClient.prototype, "acquireToken").rejects(refreshRequiredCacheError);
                 const silentRefreshSpy = sinon.stub(SilentRefreshClient.prototype, "acquireToken").rejects(refreshRequiredServerError);
                 const silentIframeSpy = sinon.stub(SilentIframeClient.prototype, "acquireToken").resolves(testTokenResponse);
-                
+
                 const response = pca.acquireTokenSilent({scopes: ["openid"], account: testAccount, cacheLookupPolicy: CacheLookupPolicy.Default});
                 await expect(response).resolves.toEqual(testTokenResponse);
                 expect(silentCacheSpy.calledOnce).toBeTruthy();
@@ -2835,7 +2859,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 done();
                 return Promise.resolve();
             });
-    
+
             pca.logout({postLogoutRedirectUri: "/logout"});
         });
 
@@ -2970,7 +2994,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         testAccount2.name = testAccountInfo2.name;
         testAccount2.authorityType = "MSSTS";
         testAccount2.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
-        
+
         const idTokenData2 = {
             "realm": testAccountInfo2.tenantId,
             "environment": testAccountInfo2.environment,
@@ -2979,7 +3003,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             "clientId": TEST_CONFIG.MSAL_CLIENT_ID,
             "homeAccountId": testAccountInfo2.homeAccountId,
         };
-        
+
         beforeEach(() => {
             sinon.stub(CacheManager.prototype, "getAuthorityMetadataByAlias").callsFake((host) => {
                 const authorityMetadata = new AuthorityMetadataEntity();
@@ -3108,7 +3132,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         testAccount1.name = testAccountInfo1.name;
         testAccount1.authorityType = "MSSTS";
         testAccount1.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
-        
+
         const idTokenData1 = {
             "realm": testAccountInfo1.tenantId,
             "environment": testAccountInfo1.environment,
@@ -3143,7 +3167,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     return authorityMetadata;
                 });
             });
-    
+
             afterEach(() => {
                 sinon.restore();
             });
@@ -3152,7 +3176,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 // Public client should initialze with active account set to null.
                 expect(pca.getActiveAccount()).toBe(null);
             });
-    
+
             it("setActiveAccount() sets the active account local id value correctly", () => {
                 expect(pca.getActiveAccount()).toBe(null);
                 pca.setActiveAccount(testAccountInfo1);
@@ -3160,13 +3184,13 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(activeAccount?.idToken).not.toBeUndefined();
                 expect(activeAccount).toEqual(testAccountInfo1);
             });
-    
+
             it("getActiveAccount looks up the current account values and returns them", () => {
                 pca.setActiveAccount(testAccountInfo1);
                 const activeAccount1 = pca.getActiveAccount();
                 expect(activeAccount1?.idToken).not.toBeUndefined();
                 expect(activeAccount1).toEqual(testAccountInfo1);
-                
+
                 const newName = "Ben Franklin";
                 const newTestAccountInfo1 = {
                     ...testAccountInfo1,
@@ -3176,13 +3200,39 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     ...testAccount1,
                     name: newName,
                 };
-                
+
                 const cacheKey = AccountEntity.generateAccountCacheKey(newTestAccountInfo1);
                 window.sessionStorage.setItem(cacheKey, JSON.stringify(newTestAccount1));
-    
+
                 const activeAccount2 = pca.getActiveAccount();
                 expect(activeAccount2?.idToken).not.toBeUndefined();
                 expect(activeAccount2).toEqual(newTestAccountInfo1);
+            });
+
+            it("getActiveAccount picks up legacy account id from local storage", () => {
+                const pcaLocal = new PublicClientApplication({
+                    auth: {
+                        clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                    },
+                    telemetry: {
+                        application: {
+                            appName: TEST_CONFIG.applicationName,
+                            appVersion: TEST_CONFIG.applicationVersion
+                        }
+                    },
+                    cache: {
+                        cacheLocation: BrowserCacheLocation.LocalStorage
+                    }
+                });
+                expect(pcaLocal.getActiveAccount()).toBe(null);
+
+                // @ts-ignore
+                const localStorage = pcaLocal.browserStorage;
+                localStorage.setItem(AccountEntity.generateAccountCacheKey(testAccountInfo1), JSON.stringify(testAccount1));
+                localStorage.setItem(localStorage.generateCacheKey(PersistentCacheKeys.ACTIVE_ACCOUNT), testAccount1.localAccountId);
+
+                const activeAccount = pcaLocal.getActiveAccount();
+                expect(activeAccount).not.toBeNull();
             });
 
             describe("activeAccount tests with two accounts, both with same localId", () => {
@@ -3197,7 +3247,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     idToken: TEST_TOKENS.IDTOKEN_V2,
                     idTokenClaims: ID_TOKEN_CLAIMS,
                 };
-    
+
                 const testAccount1: AccountEntity = new AccountEntity();
                 testAccount1.homeAccountId = testAccountInfo1.homeAccountId;
                 testAccount1.localAccountId = TEST_CONFIG.OID;
@@ -3207,7 +3257,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 testAccount1.name = testAccountInfo1.name;
                 testAccount1.authorityType = "MSSTS";
                 testAccount1.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
-    
+
                 const idTokenData1 = {
                     "realm": testAccountInfo1.tenantId,
                     "environment": testAccountInfo1.environment,
@@ -3216,7 +3266,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     "clientId": TEST_CONFIG.MSAL_CLIENT_ID,
                     "homeAccountId": testAccountInfo1.homeAccountId,
                 };
-    
+
                 // Account 2
                 const testAccountInfo2: AccountInfo = {
                     homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID + ".flow2",
@@ -3228,7 +3278,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     idToken: TEST_TOKENS.IDTOKEN_V2,
                     idTokenClaims: ID_TOKEN_CLAIMS,
                 };
-    
+
                 const testAccount2: AccountEntity = new AccountEntity();
                 testAccount2.homeAccountId = testAccountInfo2.homeAccountId;
                 testAccount2.localAccountId = TEST_CONFIG.OID;
@@ -3238,7 +3288,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 testAccount2.name = testAccountInfo2.name;
                 testAccount2.authorityType = "MSSTS";
                 testAccount2.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
-    
+
                 const idTokenData2 = {
                     "realm": testAccountInfo2.tenantId,
                     "environment": testAccountInfo2.environment,
@@ -3247,30 +3297,30 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     "clientId": TEST_CONFIG.MSAL_CLIENT_ID,
                     "homeAccountId": testAccountInfo2.homeAccountId,
                 };
-    
+
                 const cacheKey1 = AccountEntity.generateAccountCacheKey(testAccountInfo1);
                 const idToken1 = CacheManager.toObject(new IdTokenEntity(), idTokenData1);
                 const idTokenKey1 = idToken1.generateCredentialKey();
-    
+
                 const cacheKey2 = AccountEntity.generateAccountCacheKey(testAccountInfo2);
                 const idToken2 = CacheManager.toObject(new IdTokenEntity(), idTokenData2);
                 const idTokenKey2 = idToken2.generateCredentialKey();
-    
+
                 beforeEach(() => {
                     window.sessionStorage.setItem(cacheKey1, JSON.stringify(testAccount1));
                     window.sessionStorage.setItem(idTokenKey1, JSON.stringify(idToken1));
-    
+
                     window.sessionStorage.setItem(cacheKey2, JSON.stringify(testAccount2));
                     window.sessionStorage.setItem(idTokenKey2, JSON.stringify(idToken2));
                 });
-    
+
                 afterEach(() => {
                     window.sessionStorage.clear();
                 });
-    
+
                 it("setActiveAccount sets both home id and local id", () => {
                     expect(pca.getActiveAccount()).toBe(null);
-    
+
                     pca.setActiveAccount(testAccountInfo1);
                     const activeAccount = pca.getActiveAccount();
                     expect(activeAccount).not.toBeNull();
@@ -3278,39 +3328,39 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(activeAccount?.homeAccountId).toEqual(testAccountInfo1.homeAccountId);
                     expect(activeAccount?.localAccountId).toEqual(testAccountInfo1.localAccountId);
                 });
-    
+
                 it("getActiveAccount gets correct account when two accounts with same local id are present in cache", () => {
                     expect(pca.getActiveAccount()).toBe(null);
-    
+
                     pca.setActiveAccount(testAccountInfo1);
                     let activeAccount = pca.getActiveAccount();
                     expect(activeAccount?.idToken).not.toBeUndefined();
                     expect(activeAccount).toEqual(testAccountInfo1);
                     expect(activeAccount).not.toEqual(testAccountInfo2);
-    
+
                     pca.setActiveAccount(testAccountInfo2);
                     activeAccount = pca.getActiveAccount();
                     expect(activeAccount?.idToken).not.toBeUndefined();
                     expect(pca.getActiveAccount()).not.toEqual(testAccountInfo1);
                     expect(pca.getActiveAccount()).toEqual(testAccountInfo2);
                 });
-    
+
                 it("getActiveAccount returns null when active account is removed from cache when another account with same local id is present", () => {
                     expect(pca.getActiveAccount()).toBe(null);
-    
+
                     pca.setActiveAccount(testAccountInfo2);
                     const activeAccount = pca.getActiveAccount();
                     expect(activeAccount?.idToken).not.toBeUndefined();
                     expect(activeAccount).not.toEqual(testAccountInfo1);
                     expect(activeAccount).toEqual(testAccountInfo2);
-    
+
                     window.sessionStorage.removeItem(cacheKey2);
                     window.sessionStorage.removeItem(idTokenKey2);
                     expect(pca.getActiveAccount()).toBe(null);
                 });
             });
         });
-        
+
         describe("activeAccount logout", () => {
             const testAccountInfo2: AccountInfo = {
                 homeAccountId: "different-home-account-id",
@@ -3326,7 +3376,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 idToken: undefined,
                 idTokenClaims: undefined,
             };
-            
+
             beforeEach(() => {
                 pca.setActiveAccount(testAccountInfo3);
                 sinon.stub(AuthorizationCodeClient.prototype, "getLogoutUri").returns(testLogoutUrl);
@@ -3350,7 +3400,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 await pca.logoutRedirect();
                 expect(pca.getActiveAccount()).toBe(null);
             });
-    
+
             it("Clears active account on logoutRedirect when the given account info matches", async () => {
                     expect(pca.getActiveAccount()).toEqual(testAccountInfo3);
                     await pca.logoutRedirect({
@@ -3374,7 +3424,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 await pca.logoutPopup();
                 expect(pca.getActiveAccount()).toBe(null);
             });
-    
+
             it("Clears active account on logoutPopup when the given account info matches", async () => {
                     expect(pca.getActiveAccount()).toEqual(testAccountInfo3);
                     await pca.logoutPopup({
@@ -3426,10 +3476,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 loggerCallback: (level, message, containsPii) => {
                     expect(message).toContain("Message");
                     expect(message).toContain(LogLevel[2]);
-    
+
                     expect(level).toEqual(LogLevel.Info);
                     expect(containsPii).toBeFalsy();
-    
+
                     done();
                 },
                 piiLoggingEnabled: false
@@ -3444,10 +3494,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
         test("logger undefined", async () => {
             const authApp = new PublicClientApplication(testAppConfig);
-    
+
            expect(authApp.getLogger()).toBeDefined();
            expect(authApp.getLogger().info("Test logger")).toEqual(undefined);
-            
+
         });
     });
 


### PR DESCRIPTION
- Log number of accounts in trace mode.
- Validate that `getActiveAccount()` picks up legacy account identifier from local storage.