### PR TITLE
Update ProtectedResourceScopes type to allow unprotected resource for…

### DIFF
--- a/change/@azure-msal-angular-23138cda-3399-422a-86fc-b437d64e40d0.json
+++ b/change/@azure-msal-angular-23138cda-3399-422a-86fc-b437d64e40d0.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Update ProtectedResourceScopes type to allow unprotected resource for concrete request type",
+  "comment": "Update ProtectedResourceScopes type to allow unprotected resource for concrete request type (#5563)",
   "packageName": "@azure/msal-angular",
   "email": "milos.buda@hotmail.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-angular-23138cda-3399-422a-86fc-b437d64e40d0.json
+++ b/change/@azure-msal-angular-23138cda-3399-422a-86fc-b437d64e40d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update ProtectedResourceScopes type to allow unprotected resource for concrete request type",
+  "packageName": "@azure/msal-angular",
+  "email": "milos.buda@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/src/msal.interceptor.config.ts
+++ b/lib/msal-angular/src/msal.interceptor.config.ts
@@ -17,7 +17,7 @@ export type MsalInterceptorConfiguration = {
 
 export type ProtectedResourceScopes = {
     httpMethod: string,
-    scopes: Array<string>
+    scopes: Array<string> | null
 };
 
 export type MatchingResources = {


### PR DESCRIPTION
… concrete request type

In the Interceptor documentation (https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/v2-docs/msal-interceptor.md), it is stated that it should be possible to use scope value 'null' to indicate that the resource should be unprotected, even only for the concrete request type. This Pull requests ensures that the typing follows such logic.