### PR TITLE
Added missing fields to InteractionRequiredAuthError

### DIFF
--- a/change/@azure-msal-common-f3d1a9d0-c7d7-46c6-9452-120d89b132cf.json
+++ b/change/@azure-msal-common-f3d1a9d0-c7d7-46c6-9452-120d89b132cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added missing fields to InteractionRequiredAuthError",
+  "packageName": "@azure/msal-common",
+  "email": "rgins16@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-f3d1a9d0-c7d7-46c6-9452-120d89b132cf.json
+++ b/change/@azure-msal-common-f3d1a9d0-c7d7-46c6-9452-120d89b132cf.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added missing fields to InteractionRequiredAuthError",
+  "comment": "Added missing fields to InteractionRequiredAuthError #5566",
   "packageName": "@azure/msal-common",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-f3d1a9d0-c7d7-46c6-9452-120d89b132cf.json
+++ b/change/@azure-msal-common-f3d1a9d0-c7d7-46c6-9452-120d89b132cf.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Added missing fields to InteractionRequiredAuthError",
   "packageName": "@azure/msal-common",
-  "email": "rgins16@gmail.com",
+  "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/lib/msal-common/src/error/InteractionRequiredAuthError.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthError.ts
@@ -52,7 +52,13 @@ export class InteractionRequiredAuthError extends AuthError {
     traceId: string;
 
     /**
-     * Claims associated with the error that can be used to get a token
+     * https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-common/docs/claims-challenge.md
+     * 
+     * A string with extra claims needed for the token request to succeed
+     * web site: redirect the user to the authorization page and set the extra claims
+     * web api: include the claims in the WWW-Authenticate header that are sent back to the client so that it knows to request a token with the extra claims
+     * desktop application or browser context: include the claims when acquiring the token interactively
+     * app to app context (client_credentials): include the claims in the AcquireTokenByClientCredential request
      */
     claims: string;
 

--- a/lib/msal-common/src/error/InteractionRequiredAuthError.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthError.ts
@@ -41,19 +41,30 @@ export const InteractionRequiredAuthErrorMessage = {
  * Error thrown when user interaction is required.
  */
 export class InteractionRequiredAuthError extends AuthError {
+    /**
+     * The time the error occured at
+     */
     timestamp: string;
+
+    /**
+     * TraceId associated with the error
+     */
     traceId: string;
+
+    /**
+     * Claims associated with the error that can be used to get a token
+     */
     claims: string;
 
     constructor(errorCode?: string, errorMessage?: string, subError?: string, timestamp?: string, traceId?: string, correlationId?: string, claims?: string) {
         super(errorCode, errorMessage, subError);
-        this.name = "InteractionRequiredAuthError";
-        this.timestamp = timestamp || Constants.NOT_APPLICABLE;
-        this.traceId = traceId || Constants.NOT_APPLICABLE;
-        this.correlationId = correlationId || Constants.NOT_APPLICABLE;
-        this.claims = claims || Constants.NOT_APPLICABLE;
-
         Object.setPrototypeOf(this, InteractionRequiredAuthError.prototype);
+        
+        this.timestamp = timestamp || Constants.EMPTY_STRING;
+        this.traceId = traceId || Constants.EMPTY_STRING;
+        this.correlationId = correlationId || Constants.EMPTY_STRING;
+        this.claims = claims || Constants.EMPTY_STRING;
+        this.name = "InteractionRequiredAuthError";
     }
 
     /**

--- a/lib/msal-common/src/error/InteractionRequiredAuthError.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthError.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { Constants } from "../utils/Constants";
 import { AuthError } from "./AuthError";
 
 /**
@@ -40,10 +41,17 @@ export const InteractionRequiredAuthErrorMessage = {
  * Error thrown when user interaction is required.
  */
 export class InteractionRequiredAuthError extends AuthError {
+    timestamp: string;
+    traceId: string;
+    claims: string;
 
-    constructor(errorCode?: string, errorMessage?: string, subError?: string) {
+    constructor(errorCode?: string, errorMessage?: string, subError?: string, timestamp?: string, traceId?: string, correlationId?: string, claims?: string) {
         super(errorCode, errorMessage, subError);
         this.name = "InteractionRequiredAuthError";
+        this.timestamp = timestamp || Constants.NOT_APPLICABLE;
+        this.traceId = traceId || Constants.NOT_APPLICABLE;
+        this.correlationId = correlationId || Constants.NOT_APPLICABLE;
+        this.claims = claims || Constants.NOT_APPLICABLE;
 
         Object.setPrototypeOf(this, InteractionRequiredAuthError.prototype);
     }

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -73,7 +73,15 @@ export class ResponseHandler {
         // Check for error
         if (serverResponseHash.error || serverResponseHash.error_description || serverResponseHash.suberror) {
             if (InteractionRequiredAuthError.isInteractionRequiredError(serverResponseHash.error, serverResponseHash.error_description, serverResponseHash.suberror)) {
-                throw new InteractionRequiredAuthError(serverResponseHash.error || Constants.EMPTY_STRING, serverResponseHash.error_description, serverResponseHash.suberror);
+                throw new InteractionRequiredAuthError(
+                    serverResponseHash.error || Constants.EMPTY_STRING,
+                    serverResponseHash.error_description,
+                    serverResponseHash.suberror,
+                    serverResponseHash.timestamp || Constants.NOT_APPLICABLE,
+                    serverResponseHash.trace_id || Constants.NOT_APPLICABLE,
+                    serverResponseHash.correlation_id || Constants.NOT_APPLICABLE,
+                    serverResponseHash.claims || Constants.NOT_APPLICABLE,
+                );
             }
 
             throw new ServerError(serverResponseHash.error || Constants.EMPTY_STRING, serverResponseHash.error_description, serverResponseHash.suberror);
@@ -92,7 +100,15 @@ export class ResponseHandler {
         // Check for error
         if (serverResponse.error || serverResponse.error_description || serverResponse.suberror) {
             if (InteractionRequiredAuthError.isInteractionRequiredError(serverResponse.error, serverResponse.error_description, serverResponse.suberror)) {
-                throw new InteractionRequiredAuthError(serverResponse.error, serverResponse.error_description, serverResponse.suberror);
+                throw new InteractionRequiredAuthError(
+                    serverResponse.error,
+                    serverResponse.error_description,
+                    serverResponse.suberror,
+                    serverResponse.timestamp || Constants.NOT_APPLICABLE,
+                    serverResponse.trace_id || Constants.NOT_APPLICABLE,
+                    serverResponse.correlation_id || Constants.NOT_APPLICABLE,
+                    serverResponse.claims || Constants.NOT_APPLICABLE,
+                );
             }
 
             const errString = `${serverResponse.error_codes} - [${serverResponse.timestamp}]: ${serverResponse.error_description} - Correlation ID: ${serverResponse.correlation_id} - Trace ID: ${serverResponse.trace_id}`;

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -77,10 +77,10 @@ export class ResponseHandler {
                     serverResponseHash.error || Constants.EMPTY_STRING,
                     serverResponseHash.error_description,
                     serverResponseHash.suberror,
-                    serverResponseHash.timestamp || Constants.NOT_APPLICABLE,
-                    serverResponseHash.trace_id || Constants.NOT_APPLICABLE,
-                    serverResponseHash.correlation_id || Constants.NOT_APPLICABLE,
-                    serverResponseHash.claims || Constants.NOT_APPLICABLE,
+                    serverResponseHash.timestamp || Constants.EMPTY_STRING,
+                    serverResponseHash.trace_id || Constants.EMPTY_STRING,
+                    serverResponseHash.correlation_id || Constants.EMPTY_STRING,
+                    serverResponseHash.claims || Constants.EMPTY_STRING,
                 );
             }
 
@@ -104,10 +104,10 @@ export class ResponseHandler {
                     serverResponse.error,
                     serverResponse.error_description,
                     serverResponse.suberror,
-                    serverResponse.timestamp || Constants.NOT_APPLICABLE,
-                    serverResponse.trace_id || Constants.NOT_APPLICABLE,
-                    serverResponse.correlation_id || Constants.NOT_APPLICABLE,
-                    serverResponse.claims || Constants.NOT_APPLICABLE,
+                    serverResponse.timestamp || Constants.EMPTY_STRING,
+                    serverResponse.trace_id || Constants.EMPTY_STRING,
+                    serverResponse.correlation_id || Constants.EMPTY_STRING,
+                    serverResponse.claims || Constants.EMPTY_STRING,
                 );
             }
 

--- a/lib/msal-common/src/response/ServerAuthorizationCodeResponse.ts
+++ b/lib/msal-common/src/response/ServerAuthorizationCodeResponse.ts
@@ -24,6 +24,10 @@ export type ServerAuthorizationCodeResponse = {
     error?: string,
     error_description?: string;
     suberror?: string;
+    timestamp?: string;
+    trace_id?: string;
+    correlation_id?: string;
+    claims?: string;
     // Native Account ID
     accountId?: string;
 };

--- a/lib/msal-common/src/response/ServerAuthorizationTokenResponse.ts
+++ b/lib/msal-common/src/response/ServerAuthorizationTokenResponse.ts
@@ -47,4 +47,5 @@ export type ServerAuthorizationTokenResponse = {
     timestamp?: string;
     trace_id?: string;
     correlation_id?: string;
+    claims?: string;
 };

--- a/lib/msal-common/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-common/test/client/ClientCredentialClient.spec.ts
@@ -24,7 +24,7 @@ import { CredentialCache } from "../../src/cache/utils/CacheTypes";
 import { CacheManager } from "../../src/cache/CacheManager";
 import { ClientAuthError } from "../../src/error/ClientAuthError";
 import { AuthenticationResult } from "../../src/response/AuthenticationResult";
-import { AppTokenProviderResult, AuthToken, IAppTokenProvider } from "../../src";
+import { AppTokenProviderResult, AuthToken, IAppTokenProvider, InteractionRequiredAuthError } from "../../src";
 
 describe("ClientCredentialClient unit tests", () => {
     afterEach(() => {
@@ -42,7 +42,7 @@ describe("ClientCredentialClient unit tests", () => {
             expect(client instanceof BaseClient).toBe(true);
         });
     });
-
+    
     it("acquires a token", async () => {
         sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
         sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").resolves(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT);
@@ -77,6 +77,44 @@ describe("ClientCredentialClient unit tests", () => {
         expect(returnVal.includes(`${AADServerParamKeys.X_APP_NAME}=${TEST_CONFIG.applicationName}`)).toBe(true);
         expect(returnVal.includes(`${AADServerParamKeys.X_APP_VER}=${TEST_CONFIG.applicationVersion}`)).toBe(true);
         expect(returnVal.includes(`${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`)).toBe(true);
+    });
+
+    it("acquireToken's interactionRequiredAuthError error contains claims", async () => {
+        const errorResponse = {
+            error: "interaction_required",
+            error_description: "AADSTS50079: Due to a configuration change made by your administrator, or because you moved to a new location, you must enroll in multifactor authentication to access 'bf8d80f9-9098-4972-b203-500f535113b1'.\r\nTrace ID: b72a68c3-0926-4b8e-bc35-3150069c2800\r\nCorrelation ID: 73d656cf-54b1-4eb2-b429-26d8165a52d7\r\nTimestamp: 2017-05-01 22:43:20Z",
+            error_codes: [50079],
+            timestamp: "2017-05-01 22:43:20Z",
+            trace_id: "b72a68c3-0926-4b8e-bc35-3150069c2800",
+            correlation_id: "73d656cf-54b1-4eb2-b429-26d8165a52d7",
+            claims: "{\"access_token\":{\"polids\":{\"essential\":true,\"values\":[\"9ab03e19-ed42-4168-b6b7-7001fb3e933a\"]}}}",
+        };
+
+        sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+        sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").resolves({
+            headers: [],
+            body: errorResponse,
+            status: 400,
+        });
+
+        const config = await ClientTestUtils.createTestClientConfiguration();
+        const client = new ClientCredentialClient(config);
+        const clientCredentialRequest: CommonClientCredentialRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+        };
+
+        const interactionRequiredAuthError = new InteractionRequiredAuthError(
+            "interaction_required",
+            "AADSTS50079: Due to a configuration change made by your administrator, or because you moved to a new location, you must enroll in multifactor authentication to access 'bf8d80f9-9098-4972-b203-500f535113b1'.\r\nTrace ID: b72a68c3-0926-4b8e-bc35-3150069c2800\r\nCorrelation ID: 73d656cf-54b1-4eb2-b429-26d8165a52d7\r\nTimestamp: 2017-05-01 22:43:20Z",
+            "",
+            "2017-05-01 22:43:20Z",
+            "b72a68c3-0926-4b8e-bc35-3150069c2800",
+            "73d656cf-54b1-4eb2-b429-26d8165a52d7",
+            "{\"access_token\":{\"polids\":{\"essential\":true,\"values\":[\"9ab03e19-ed42-4168-b6b7-7001fb3e933a\"]}}}"
+        );
+        await expect(client.acquireToken(clientCredentialRequest)).rejects.toEqual(interactionRequiredAuthError);
     });
 
     // regression test for https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/5134

--- a/lib/msal-common/test/error/InteractionRequiredAuthError.spec.ts
+++ b/lib/msal-common/test/error/InteractionRequiredAuthError.spec.ts
@@ -7,7 +7,11 @@ describe("InteractionRequiredAuthError.ts Class Unit Tests", () => {
     it("InteractionRequiredAuthError object can be created", () => {
         const TEST_ERROR_CODE: string = "test";
         const TEST_ERROR_MSG: string = "This is a test error";
-        const err: InteractionRequiredAuthError = new InteractionRequiredAuthError(TEST_ERROR_CODE, TEST_ERROR_MSG);
+        const TEST_ERROR_TIMESTAMP = "2017-05-01 22:43:20Z";
+        const TEST_ERROR_TRACE_ID = "b72a68c3-0926-4b8e-bc35-3150069c2800";
+        const TEST_ERROR_CORRELATION_ID = "73d656cf-54b1-4eb2-b429-26d8165a52d7";
+        const TEST_ERROR_CLAIMS = '{\"access_token\":{\"polids\":{\"essential\":true,\"values\":[\"9ab03e19-ed42-4168-b6b7-7001fb3e933a\"]}}}';
+        const err: InteractionRequiredAuthError = new InteractionRequiredAuthError(TEST_ERROR_CODE, TEST_ERROR_MSG, "N/A", TEST_ERROR_TIMESTAMP, TEST_ERROR_TRACE_ID, TEST_ERROR_CORRELATION_ID, TEST_ERROR_CLAIMS);
 
         expect(err instanceof InteractionRequiredAuthError).toBe(true);
         expect(err instanceof AuthError).toBe(true);
@@ -16,6 +20,10 @@ describe("InteractionRequiredAuthError.ts Class Unit Tests", () => {
         expect(err.errorMessage).toBe(TEST_ERROR_MSG);
         expect(err.message).toBe(`${TEST_ERROR_CODE}: ${TEST_ERROR_MSG}`);
         expect(err.name).toBe("InteractionRequiredAuthError");
+        expect(err.timestamp).toBe(TEST_ERROR_TIMESTAMP);
+        expect(err.traceId).toBe(TEST_ERROR_TRACE_ID);
+        expect(err.correlationId).toBe(TEST_ERROR_CORRELATION_ID);
+        expect(err.claims).toBe(TEST_ERROR_CLAIMS);
         expect(err.stack?.includes("InteractionRequiredAuthError.spec.ts")).toBe(true);
     });
 


### PR DESCRIPTION
Added missing fields to the InteractionRequiredAuthError as described in the Error response sample [here](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow)

timestamp
trace_id
correlation_id
claims