### PR TITLE
Add startPerformanceMeasurement to IPerformanceClient

### DIFF
--- a/change/@azure-msal-common-0cd14f7c-26de-40ee-b02a-b146173019ac.json
+++ b/change/@azure-msal-common-0cd14f7c-26de-40ee-b02a-b146173019ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add startPerformanceMeasurement to IPerformanceClient #5583",
+  "packageName": "@azure/msal-common",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
@@ -28,5 +28,6 @@ export interface IPerformanceClient {
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
     emitEvents(events: PerformanceEvent[], correlationId: string): void;
     startPerformanceMeasuremeant(measureName: string, correlationId: string): IPerformanceMeasurement;
+    startPerformanceMeasurement(measureName: string, correlationId: string): IPerformanceMeasurement;
     generateId(): string;
 }

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -71,22 +71,36 @@ export abstract class PerformanceClient implements IPerformanceClient {
     }
 
     /**
-     * Starts and returns an platform-specific implementation of IPerformanceMeasurement.
-     *
-     * @abstract
-     * @param {string} measureName
-     * @param {string} correlationId
-     * @returns {IPerformanceMeasurement}
-     */
-    abstract startPerformanceMeasuremeant(measureName: string, correlationId: string): IPerformanceMeasurement;
-
-    /**
      * Generates and returns a unique id, typically a guid.
      *
      * @abstract
      * @returns {string}
      */
     abstract generateId(): string;
+
+    /**
+     * Starts and returns an platform-specific implementation of IPerformanceMeasurement.
+     * Note: this function can be changed to abstract at the next major version bump.
+     *
+     * @param {string} measureName
+     * @param {string} correlationId
+     * @returns {IPerformanceMeasurement}
+     */
+    startPerformanceMeasurement(measureName: string, correlationId: string): IPerformanceMeasurement {
+        return {} as IPerformanceMeasurement;
+    };
+
+    /**
+     * Starts and returns an platform-specific implementation of IPerformanceMeasurement.
+     * Note: this incorrectly-named function will be removed at the next major version bump.
+     *
+     * @param {string} measureName
+     * @param {string} correlationId
+     * @returns {IPerformanceMeasurement}
+     */
+    startPerformanceMeasuremeant(measureName: string, correlationId: string): IPerformanceMeasurement {
+        return {} as IPerformanceMeasurement;
+    };
 
     /**
      * Starts measuring performance for a given operation. Returns a function that should be used to end the measurement.

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -86,9 +86,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @param {string} correlationId
      * @returns {IPerformanceMeasurement}
      */
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     startPerformanceMeasurement(measureName: string, correlationId: string): IPerformanceMeasurement {
         return {} as IPerformanceMeasurement;
-    };
+    }
 
     /**
      * Starts and returns an platform-specific implementation of IPerformanceMeasurement.
@@ -98,9 +99,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @param {string} correlationId
      * @returns {IPerformanceMeasurement}
      */
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     startPerformanceMeasuremeant(measureName: string, correlationId: string): IPerformanceMeasurement {
         return {} as IPerformanceMeasurement;
-    };
+    }
 
     /**
      * Starts measuring performance for a given operation. Returns a function that should be used to end the measurement.

--- a/lib/msal-common/src/telemetry/performance/StubPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/StubPerformanceClient.ts
@@ -26,4 +26,8 @@ export class StubPerformanceClient extends PerformanceClient implements IPerform
     startPerformanceMeasuremeant(): IPerformanceMeasurement {
         return new StubPerformanceMeasurement();
     }
+
+    startPerformanceMeasurement(): IPerformanceMeasurement {
+        return new StubPerformanceMeasurement();
+    }
 }

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -2019,6 +2019,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 addPerformanceCallback: jest.fn(),
                 emitEvents: jest.fn(),
                 startPerformanceMeasuremeant: jest.fn(),
+                startPerformanceMeasurement: jest.fn(),
                 generateId: jest.fn(),
             }
             performanceClient.startMeasurement.mockImplementation(() => {
@@ -2074,6 +2075,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 addPerformanceCallback: jest.fn(),
                 emitEvents: jest.fn(),
                 startPerformanceMeasuremeant: jest.fn(),
+                startPerformanceMeasurement: jest.fn(),
                 generateId: jest.fn()
             }
             performanceClient.startMeasurement.mockImplementation(() => {

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -506,6 +506,7 @@ describe("RefreshTokenClient unit tests", () => {
                 addPerformanceCallback: jest.fn(),
                 emitEvents: jest.fn(),
                 startPerformanceMeasuremeant: jest.fn(),
+                startPerformanceMeasurement: jest.fn(),
                 generateId: jest.fn()
             }
             performanceClient.startMeasurement.mockImplementation(() => {
@@ -539,6 +540,7 @@ describe("RefreshTokenClient unit tests", () => {
                 addPerformanceCallback: jest.fn(),
                 emitEvents: jest.fn(),
                 startPerformanceMeasuremeant: jest.fn(),
+                startPerformanceMeasurement: jest.fn(),
                 generateId: jest.fn()
             }
             performanceClient.startMeasurement.mockImplementation(() => {

--- a/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
+++ b/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
@@ -64,6 +64,10 @@ class MockPerformanceClient extends PerformanceClient implements IPerformanceCli
     startPerformanceMeasuremeant(measureName: string, correlationId?: string): IPerformanceMeasurement {
         return new MockPerformanceMeasurement();
     }
+
+    startPerformanceMeasurement(measureName: string, correlationId?: string): IPerformanceMeasurement {
+        return new MockPerformanceMeasurement();
+    }
 }
 
 class UnsupportedBrowserPerformanceClient extends MockPerformanceClient {


### PR DESCRIPTION
Addresses potential breaking changes as a result of #5531.
Follow up to #5582.