### PR TITLE
Msal-common post release January 2023 patch #2

### DIFF
--- a/lib/msal-common/package-lock.json
+++ b/lib/msal-common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure/msal-common",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/msal-common",
-      "version": "9.1.0",
+      "version": "9.1.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.7.2",


### PR DESCRIPTION
This PR updates the package-lock.json for msal-common as part of the v9.1.1 release.