### PR TITLE
Optimize credential regular expressions

### DIFF
--- a/change/@azure-msal-common-e3ebfcb3-2148-4553-ae21-31b9f4b734f6.json
+++ b/change/@azure-msal-common-e3ebfcb3-2148-4553-ae21-31b9f4b734f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Optimize credential regular expressions #5621",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/cache/entities/CredentialEntity.ts
+++ b/lib/msal-common/src/cache/entities/CredentialEntity.ts
@@ -42,8 +42,8 @@ export class CredentialEntity {
     keyId?: string;
     requestedClaimsHash?: string;
 
-    // Match host names like "login.microsoftonline.com", "https://accounts.google.com:4000", etc.
-    private static credentialDomainRegex = "(https?:\\/\\/)?([\\w-]+\\.)*([\\w-]{1,63})(\\.(\\w{2,63}))(\\:[0-9]{4,5})?";
+    // Match host names like "login.microsoftonline.com", "https://accounts.google.com:4000", https://localhost:5000, etc.
+    private static credentialDomainRegex = "(https?:\\/\\/)?((([\\w-]+\\.)*([\\w-]{1,63})(\\.(\\w{2,63})))|(localhost))(\\:[0-9]{4,5})?";
     // Maps {CredentialType} to the corresponding regular expression.
     private static credentialRegexMap: Map<CredentialType, RegExp>;
 

--- a/lib/msal-common/src/cache/entities/CredentialEntity.ts
+++ b/lib/msal-common/src/cache/entities/CredentialEntity.ts
@@ -42,6 +42,34 @@ export class CredentialEntity {
     keyId?: string;
     requestedClaimsHash?: string;
 
+    // Match host names like "login.microsoftonline.com", "https://accounts.google.com:4000", etc.
+    private static credentialDomainRegex = "(https?:\\/\\/)?([\\w-]+\\.)*([\\w-]{1,63})(\\.(\\w{2,63}))(\\:[0-9]{4,5})?";
+    // Maps {CredentialType} to the corresponding regular expression.
+    private static credentialRegexMap: Map<CredentialType, RegExp>;
+
+    /**
+     * Initializes a map with credential {CredentialType} regular expressions.
+     */
+    static _initRegex(): void {
+        const separator = Separators.CACHE_KEY_SEPARATOR;
+        CredentialEntity.credentialRegexMap = new Map<CredentialType, RegExp>();
+        for (const credKey of Object.keys(CredentialType)) {
+            const credVal = CredentialType[credKey].toLowerCase();
+
+            try {
+                // Verify credential type is preceded by a valid host name (environment) using lookbehind
+                CredentialEntity.credentialRegexMap.set(
+                    CredentialType[credKey],
+                    new RegExp(`(?<=${separator}${CredentialEntity.credentialDomainRegex})${separator}${credVal}${separator}`));
+            } catch (err) {
+                // Lookbehind is not supported (Safari or older versions of IE) - removing it
+                CredentialEntity.credentialRegexMap.set(
+                    CredentialType[credKey],
+                    new RegExp(`${separator}${CredentialEntity.credentialDomainRegex}${separator}${credVal}${separator}`));
+            }
+        }
+    }
+
     /**
      * Generate Account Id key component as per the schema: <home_account_id>-<environment>
      */
@@ -108,14 +136,8 @@ export class CredentialEntity {
      * @param key
      */
     static getCredentialType(key: string): string {
-        const separator = Separators.CACHE_KEY_SEPARATOR;
-        // Match host names like "login.microsoftonline.com", "https://accounts.google.com:4000", etc.
-        const domainRe = "(https?:\\/\\/)?([\\w-]+\\.)*([\\w-]{1,63})(\\.(\\w{2,63}))(\\:[0-9]{4,5})?";
-
         for (const credKey of Object.keys(CredentialType)) {
-            const credVal = CredentialType[credKey].toLowerCase();
-            // Verify credential type is preceded by a valid host name (environment)
-            if (key.toLowerCase().search(`${separator}${domainRe}${separator}${credVal}${separator}`) !== -1) {
+            if (this.credentialRegexMap.get(CredentialType[credKey])?.test(key.toLowerCase())) {
                 return CredentialType[credKey];
             }
         }
@@ -213,3 +235,5 @@ export class CredentialEntity {
         return (tokenType && tokenType.toLowerCase() !== AuthenticationScheme.BEARER.toLowerCase()) ? tokenType.toLowerCase() : Constants.EMPTY_STRING;
     }
 }
+
+CredentialEntity._initRegex();

--- a/lib/msal-common/test/cache/entities/CredentialEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/CredentialEntity.spec.ts
@@ -154,6 +154,27 @@ describe("CredentialEntity.ts Unit Tests", () => {
             expect(CredentialEntity.getCredentialType(atKey)).toEqual(CredentialType.ACCESS_TOKEN);
         });
 
+        it("Localhost - Is access token", () => {
+            const atEntity = new AccessTokenEntity();
+            Object.assign(atEntity, {
+                homeAccountId,
+                environment: "https://localhost:5000",
+                credentialType: "AccessToken",
+                clientId: "mock_client_id",
+                secret: "an access token sample",
+                realm: "microsoft",
+                target: "scope6 scope7",
+                cachedAt: "1000",
+                expiresOn: "4600",
+                extendedExpiresOn: "4600",
+                tokenType: "Bearer"
+            });
+
+            const atKey = atEntity.generateCredentialKey();
+
+            expect(CredentialEntity.getCredentialType(atKey)).toEqual(CredentialType.ACCESS_TOKEN);
+        });
+
         it("Metadata key - empty result", () => {
             const key = `authority-metadata-${clientId}-login.microsoftonline.com`;
             expect(CredentialEntity.getCredentialType(key)).toEqual(Constants.NOT_DEFINED);


### PR DESCRIPTION
Reduce CPU load by optimizing credential regular expressions. Improves performance significantly for longer keys.

Changes:
- Compile credential regular expressions statically.
- Attempt to use lookbehind in credential regular expressions if supported.
- Capture "localhost" in credential domain regex.

Short key perf sampling:

![short_key_regex_test](https://user-images.githubusercontent.com/119362382/215576383-6a6a07b2-9918-47ee-9290-d1fcecd0a7df.png)

Long key perf sampling:

![long_key_regex_test](https://user-images.githubusercontent.com/119362382/215576423-4f84d22c-af78-4e1d-ac53-500b1d517f0e.png)


