### PR TITLE
Truncate integral telemetry fields

### DIFF
--- a/change/@azure-msal-common-f0ffeb92-455e-492c-8572-513a8654cb54.json
+++ b/change/@azure-msal-common-f0ffeb92-455e-492c-8572-513a8654cb54.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Truncate integral telemetry fields #5627",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -101,7 +101,7 @@ export { ServerTelemetryRequest } from "./telemetry/server/ServerTelemetryReques
 
 // Performance Telemetry
 export { IPerformanceClient, PerformanceCallbackFunction, InProgressPerformanceEvent, QueueMeasurement } from "./telemetry/performance/IPerformanceClient";
-export { PerformanceEvent, PerformanceEvents, PerformanceEventStatus, StaticFields } from "./telemetry/performance/PerformanceEvent";
+export { Counters, IntFields, PerformanceEvent, PerformanceEvents, PerformanceEventStatus, StaticFields } from "./telemetry/performance/PerformanceEvent";
 export { IPerformanceMeasurement } from "./telemetry/performance/IPerformanceMeasurement";
 export { PerformanceClient } from "./telemetry/performance/PerformanceClient";
 export { StubPerformanceClient } from "./telemetry/performance/StubPerformanceClient";

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -7,7 +7,14 @@ import { ApplicationTelemetry } from "../../config/ClientConfiguration";
 import { Logger } from "../../logger/Logger";
 import { InProgressPerformanceEvent, IPerformanceClient, PerformanceCallbackFunction, QueueMeasurement } from "./IPerformanceClient";
 import { IPerformanceMeasurement } from "./IPerformanceMeasurement";
-import { Counters, PerformanceEvent, PerformanceEvents, PerformanceEventStatus, StaticFields } from "./PerformanceEvent";
+import {
+    Counters,
+    PerformanceEvent,
+    IntFields,
+    PerformanceEvents,
+    PerformanceEventStatus,
+    StaticFields
+} from "./PerformanceEvent";
 
 export abstract class PerformanceClient implements IPerformanceClient {
     protected authority: string;
@@ -131,6 +138,13 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @returns
      */
     abstract setPreQueueTime(eventName: PerformanceEvents, correlationId?: string): void;
+
+    /**
+     * Get integral fields.
+     */
+    getIntFields(): ReadonlySet<string> {
+        return IntFields;
+    }
 
     /**
      * Gets map of pre-queue times by correlation Id
@@ -506,6 +520,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
                     queuedCount: totalQueueCount,
                     incompleteSubsCount
                 };
+                this.truncateIntegralFields(finalEvent, this.getIntFields());
 
                 this.emitEvents([finalEvent], eventToEmit.correlationId);
             } else {
@@ -588,4 +603,16 @@ export abstract class PerformanceClient implements IPerformanceClient {
         });
     }
 
+    /**
+     * Enforce truncation of integral fields in performance event.
+     * @param {PerformanceEvent} event performance event to update.
+     * @param {Set<string>} intFields integral fields.
+     */
+    private truncateIntegralFields(event: PerformanceEvent, intFields: ReadonlySet<string>): void {
+        intFields.forEach((key) => {
+            if (key in event && typeof event[key] === "number") {
+                event[key] = Math.floor(event[key]);
+            }
+        });
+    }
 }

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -141,6 +141,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
 
     /**
      * Get integral fields.
+     * Override to change the set.
      */
     getIntFields(): ReadonlySet<string> {
         return IntFields;

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -322,12 +322,6 @@ export type StaticFields = {
     matsHttpEventCount?: number;
     httpVerToken?: string;
     httpVerAuthority?: string;
-
-    // Broker timeouts used by 1p browser lib
-    brokerInteractionTimeoutMs?: number;
-    brokerMessageTimeoutMs?: number;
-    brokerHandshakeTimeoutMs?: number;
-    brokerIframeTimeoutMs?: number;
 };
 
 /**
@@ -495,3 +489,15 @@ export type PerformanceEvent = StaticFields & Counters & {
      */
     queuedCount?: number
 };
+
+export const IntFields: ReadonlySet<string> = new Set([
+    "accessTokenSize",
+    "durationMs",
+    "idTokenSize",
+    "matsSilentStatus",
+    "matsHttpStatus",
+    "refreshTokenSize",
+    "queuedTimeMs",
+    "startTimeMs",
+    "status",
+]);


### PR DESCRIPTION
- Truncate integral telemetry fields.
- Remove broker timeouts (declared in 1p).