### PR TITLE
Added the client-credentials sample to the msal-node github workflow

### DIFF
--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -35,6 +35,7 @@ jobs:
         node: [ 14, 16, 18 ]
         sample:
           - 'auth-code'
+          - 'client-credentials'
           - 'device-code'
           - 'silent-flow'
           - 'b2c-user-flows'


### PR DESCRIPTION
This is being done so we have more Confidential Client e2e test coverage.