### PR TITLE
Add extensions to metadata update script

### DIFF
--- a/change/@azure-msal-node-extensions-d8d8732b-4dd9-4779-8dc4-5d0867e51d89.json
+++ b/change/@azure-msal-node-extensions-d8d8732b-4dd9-4779-8dc4-5d0867e51d89.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Include packageMetadata in bundle #5638",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/src/packageMetadata.ts
+++ b/extensions/msal-node-extensions/src/packageMetadata.ts
@@ -1,0 +1,3 @@
+/* eslint-disable header/header */
+export const name = "@azure/msal-node-extensions";
+export const version = "1.0.0-alpha.29";

--- a/extensions/msal-node-extensions/tsconfig.json
+++ b/extensions/msal-node-extensions/tsconfig.json
@@ -15,5 +15,10 @@
     },
     "jsx": "react",
     "esModuleInterop": true
-  }
+  },
+  "references": [
+    {
+        "path": "../../lib/msal-common"
+    }
+  ]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -29,7 +29,8 @@
             "@azure/msal-common",
             "@azure/msal-node",
             "@azure/msal-react",
-            "@azure/msal-angular"
+            "@azure/msal-angular",
+            "@azure/msal-node-extensions"
       ],
       "stream": true
     }

--- a/release-scripts/updateVersion.js
+++ b/release-scripts/updateVersion.js
@@ -10,15 +10,16 @@ const exclude = ["msal-angularjs"]; // Libs that should be excluded
 const failures = 0;
 
 const LIB_DIR = path.resolve(process.cwd(), "lib");
+const EXTENSIONS_DIR = path.resolve(process.cwd(), "extensions");
 const libFolders = fs.readdirSync(LIB_DIR, { withFileTypes: true }).filter(function(file) {
     return file.isDirectory() && exclude.indexOf(file.name) === -1 && fs.existsSync(path.resolve(LIB_DIR, file.name, "package.json"));
 }).map(function(file) {
     return file.name;
 });
 
-libFolders.forEach((lib) => {
-    const packageJsonPath = path.resolve(LIB_DIR, lib, "package.json");
-    const outputFilepath = path.resolve(LIB_DIR, lib, "src", "packageMetadata.ts");
+function updatePackageMetadata(libPath) {
+    const packageJsonPath = path.resolve(libPath, "package.json");
+    const outputFilepath = path.resolve(libPath, "src", "packageMetadata.ts");
     const packageJson = require(packageJsonPath);
 
     console.log(`Updating ${packageJson.name} to version ${packageJson.version}`);
@@ -35,7 +36,15 @@ libFolders.forEach((lib) => {
         failures += 1;
         console.error(`Failed to update version for ${packageJson.name}`);
     }
+};
+
+libFolders.forEach((lib) => {
+    const packagePath = path.resolve(LIB_DIR, lib);
+    updatePackageMetadata(packagePath);
 });
+
+const nodeExtensionsPath = path.resolve(EXTENSIONS_DIR, "msal-node-extensions");
+updatePackageMetadata(nodeExtensionsPath);
 
 if (failures > 0) {
     console.error(`Failed to update versions on ${failures} packages`);


### PR DESCRIPTION
Adds a few things to msal-node-extensions in preparation for MsalRuntime integration:

- Includes msal-common as a project reference
- Adds packageMetdata file
- Includes msal-node-extensions in the bootstrap step
- Adds msal-node-extensions to the version update script