### PR TITLE
Update discardCache in PerformanceClient

### DIFF
--- a/change/@azure-msal-common-561ebfb3-3186-4a91-933a-64d367f4f94f.json
+++ b/change/@azure-msal-common-561ebfb3-3186-4a91-933a-64d367f4f94f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update discardCache in PerformanceClient #5645",
+  "packageName": "@azure/msal-common",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -445,8 +445,6 @@ export abstract class PerformanceClient implements IPerformanceClient {
             totalQueueCount++;
         });
 
-        this.queueMeasurements.delete(correlationId);
-
         const eventsForCorrelationId = this.eventsByCorrelationId.get(correlationId);
         const staticFields = this.staticFieldsByCorrelationId.get(correlationId);
         const counters = this.countersByCorrelationId.get(correlationId);
@@ -555,6 +553,12 @@ export abstract class PerformanceClient implements IPerformanceClient {
 
         this.logger.trace("PerformanceClient: Counters discarded", correlationId);
         this.countersByCorrelationId.delete(correlationId);
+
+        this.logger.trace("PerformanceClient: QueueMeasurements discarded", correlationId);
+        this.queueMeasurements.delete(correlationId);
+
+        this.logger.trace("PerformanceClient: Pre-queue times discarded", correlationId);
+        this.preQueueTimeByCorrelationId.delete(correlationId);
     }
 
     /**


### PR DESCRIPTION
This PR moves the deletion of `QueueMeasurement` to `discardCache()` and adds the deletion of `preQueueTimeByCorrelationId`.