### PR TITLE
POC. Use performance client as a singleton across the app

### DIFF
--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -22,7 +22,7 @@ export type CachedKeyPair = {
 };
 
 /**
- * This class implements MSAL's crypto interface, which allows it to perform base64 encoding and decoding, generating cryptographically random GUIDs and 
+ * This class implements MSAL's crypto interface, which allows it to perform base64 encoding and decoding, generating cryptographically random GUIDs and
  * implementing Proof Key for Code Exchange specs for the OAuth Authorization Code Flow using PKCE (rfc here: https://tools.ietf.org/html/rfc7636).
  */
 export class CryptoOps implements ICrypto {
@@ -44,7 +44,7 @@ export class CryptoOps implements ICrypto {
     private static EXTRACTABLE: boolean = true;
     private cache: CryptoKeyStore;
 
-    constructor(logger: Logger, performanceClient?: IPerformanceClient, cryptoConfig?: CryptoOptions) {
+    constructor(logger: Logger, cryptoConfig?: CryptoOptions) {
         this.logger = logger;
         // Browser crypto needs to be validated first before any other classes can be set.
         this.browserCrypto = new BrowserCrypto(this.logger, cryptoConfig);
@@ -53,7 +53,6 @@ export class CryptoOps implements ICrypto {
         this.guidGenerator = new GuidGenerator(this.browserCrypto);
         this.pkceGenerator = new PkceGenerator(this.browserCrypto);
         this.cache = new CryptoKeyStore(this.logger);
-        this.performanceClient = performanceClient;
     }
 
     /**
@@ -66,15 +65,15 @@ export class CryptoOps implements ICrypto {
 
     /**
      * Encodes input string to base64.
-     * @param input 
+     * @param input
      */
     base64Encode(input: string): string {
         return this.b64Encode.encode(input);
-    }    
-    
+    }
+
     /**
      * Decodes input string from base64.
-     * @param input 
+     * @param input
      */
     base64Decode(input: string): string {
         return this.b64Decode.decode(input);
@@ -99,13 +98,13 @@ export class CryptoOps implements ICrypto {
 
         // Generate Thumbprint for Public Key
         const publicKeyJwk: JsonWebKey = await this.browserCrypto.exportJwk(keyPair.publicKey);
-        
+
         const pubKeyThumprintObj: JsonWebKey = {
             e: publicKeyJwk.e,
             kty: publicKeyJwk.kty,
             n: publicKeyJwk.n
         };
-        
+
         const publicJwkString: string = BrowserStringUtils.getSortedObjectString(pubKeyThumprintObj);
         const publicJwkHash = await this.hashString(publicJwkString);
 
@@ -116,7 +115,7 @@ export class CryptoOps implements ICrypto {
 
         // Store Keypair data in keystore
         await this.cache.asymmetricKeys.setItem(
-            publicJwkHash, 
+            publicJwkHash,
             {
                 privateKey: unextractablePrivateKey,
                 publicKey: keyPair.publicKey,
@@ -136,7 +135,7 @@ export class CryptoOps implements ICrypto {
 
     /**
      * Removes cryptographic keypair from key store matching the keyId passed in
-     * @param kid 
+     * @param kid
      */
     async removeTokenBindingKey(kid: string): Promise<boolean> {
         await this.cache.asymmetricKeys.removeItem(kid);
@@ -153,13 +152,13 @@ export class CryptoOps implements ICrypto {
 
     /**
      * Signs the given object as a jwt payload with private key retrieved by given kid.
-     * @param payload 
-     * @param kid 
+     * @param payload
+     * @param kid
      */
     async signJwt(payload: SignedHttpRequest, kid: string, correlationId?: string): Promise<string> {
         const signJwtMeasurement = this.performanceClient?.startMeasurement(PerformanceEvents.CryptoOptsSignJwt, correlationId);
         const cachedKeyPair = await this.cache.asymmetricKeys.getItem(kid);
-        
+
         if (!cachedKeyPair) {
             throw BrowserAuthError.createSigningKeyNotFoundInStorageError(kid);
         }
@@ -170,7 +169,7 @@ export class CryptoOps implements ICrypto {
 
         // Base64URL encode public key thumbprint with keyId only: BASE64URL({ kid: "FULL_PUBLIC_KEY_HASH" })
         const encodedKeyIdThumbprint = this.b64Encode.urlEncode(JSON.stringify({ kid: kid }));
-        
+
         // Generate header
         const shrHeader = JoseHeader.getShrHeaderString({ kid: encodedKeyIdThumbprint, alg: publicKeyJwk.alg });
         const encodedShrHeader = this.b64Encode.urlEncode(shrHeader);

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICrypto, INetworkModule, Logger, AuthenticationResult, AccountInfo, AccountEntity, BaseAuthRequest, AuthenticationScheme, UrlString, ServerTelemetryManager, ServerTelemetryRequest, ClientConfigurationError, StringUtils, Authority, AuthorityOptions, AuthorityFactory, IPerformanceClient, PerformanceEvents } from "@azure/msal-common";
+import { ICrypto, INetworkModule, Logger, AuthenticationResult, AccountInfo, AccountEntity, BaseAuthRequest, AuthenticationScheme, UrlString, ServerTelemetryManager, ServerTelemetryRequest, ClientConfigurationError, StringUtils, Authority, AuthorityOptions, AuthorityFactory, PerformanceEvents } from "@azure/msal-common";
 import { BrowserConfiguration } from "../config/Configuration";
 import { BrowserCacheManager } from "../cache/BrowserCacheManager";
 import { EventHandler } from "../event/EventHandler";
@@ -16,6 +16,7 @@ import { BrowserConstants } from "../utils/BrowserConstants";
 import { BrowserUtils } from "../utils/BrowserUtils";
 import { INavigationClient } from "../navigation/INavigationClient";
 import { NativeMessageHandler } from "../broker/nativeBroker/NativeMessageHandler";
+import {BrowserTelemetryFactory} from "../telemetry/BrowserTelemetryFactory";
 
 export abstract class BaseInteractionClient {
 
@@ -28,9 +29,8 @@ export abstract class BaseInteractionClient {
     protected navigationClient: INavigationClient;
     protected nativeMessageHandler: NativeMessageHandler | undefined;
     protected correlationId: string;
-    protected performanceClient: IPerformanceClient;
 
-    constructor(config: BrowserConfiguration, storageImpl: BrowserCacheManager, browserCrypto: ICrypto, logger: Logger, eventHandler: EventHandler, navigationClient: INavigationClient, performanceClient: IPerformanceClient, nativeMessageHandler?: NativeMessageHandler, correlationId?: string) {
+    constructor(config: BrowserConfiguration, storageImpl: BrowserCacheManager, browserCrypto: ICrypto, logger: Logger, eventHandler: EventHandler, navigationClient: INavigationClient, nativeMessageHandler?: NativeMessageHandler, correlationId?: string) {
         this.config = config;
         this.browserStorage = storageImpl;
         this.browserCrypto = browserCrypto;
@@ -40,7 +40,6 @@ export abstract class BaseInteractionClient {
         this.nativeMessageHandler = nativeMessageHandler;
         this.correlationId = correlationId || this.browserCrypto.createNewGuid();
         this.logger = logger.clone(BrowserConstants.MSAL_SKU, version, this.correlationId);
-        this.performanceClient = performanceClient;
     }
 
     abstract acquireToken(request: RedirectRequest|PopupRequest|SsoSilentRequest): Promise<AuthenticationResult|void>;
@@ -78,7 +77,7 @@ export abstract class BaseInteractionClient {
      * @param request
      */
     protected async initializeBaseRequest(request: Partial<BaseAuthRequest>): Promise<BaseAuthRequest> {
-        this.performanceClient.addQueueMeasurement(PerformanceEvents.InitializeBaseRequest, request.correlationId);
+        BrowserTelemetryFactory.client().addQueueMeasurement(PerformanceEvents.InitializeBaseRequest, request.correlationId);
         this.logger.verbose("Initializing BaseAuthRequest");
         const authority = request.authority || this.config.auth.authority;
 

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthenticationResult, CommonAuthorizationCodeRequest, AuthorizationCodeClient, UrlString, AuthError, ServerTelemetryManager, Constants, ProtocolUtils, ServerAuthorizationCodeResponse, ThrottlingUtils, ICrypto, Logger, IPerformanceClient, PerformanceEvents } from "@azure/msal-common";
+import { AuthenticationResult, CommonAuthorizationCodeRequest, AuthorizationCodeClient, UrlString, AuthError, ServerTelemetryManager, Constants, ProtocolUtils, ServerAuthorizationCodeResponse, ThrottlingUtils, ICrypto, Logger, PerformanceEvents } from "@azure/msal-common";
 import { StandardInteractionClient } from "./StandardInteractionClient";
 import { ApiId, InteractionType, TemporaryCacheKeys } from "../utils/BrowserConstants";
 import { RedirectHandler } from "../interaction_handler/RedirectHandler";
@@ -19,12 +19,13 @@ import { BrowserConfiguration } from "../config/Configuration";
 import { BrowserCacheManager } from "../cache/BrowserCacheManager";
 import { EventHandler } from "../event/EventHandler";
 import { INavigationClient } from "../navigation/INavigationClient";
+import {BrowserTelemetryFactory} from "../telemetry/BrowserTelemetryFactory";
 
 export class RedirectClient extends StandardInteractionClient {
     protected nativeStorage: BrowserCacheManager;
 
-    constructor(config: BrowserConfiguration, storageImpl: BrowserCacheManager, browserCrypto: ICrypto, logger: Logger, eventHandler: EventHandler, navigationClient: INavigationClient, performanceClient: IPerformanceClient, nativeStorageImpl: BrowserCacheManager, nativeMessageHandler?: NativeMessageHandler, correlationId?: string) {
-        super(config, storageImpl, browserCrypto, logger, eventHandler, navigationClient, performanceClient, nativeMessageHandler, correlationId);
+    constructor(config: BrowserConfiguration, storageImpl: BrowserCacheManager, browserCrypto: ICrypto, logger: Logger, eventHandler: EventHandler, navigationClient: INavigationClient, nativeStorageImpl: BrowserCacheManager, nativeMessageHandler?: NativeMessageHandler, correlationId?: string) {
+        super(config, storageImpl, browserCrypto, logger, eventHandler, navigationClient, nativeMessageHandler, correlationId);
         this.nativeStorage = nativeStorageImpl;
     }
 
@@ -33,7 +34,7 @@ export class RedirectClient extends StandardInteractionClient {
      * @param request
      */
     async acquireToken(request: RedirectRequest): Promise<void> {
-        this.performanceClient.setPreQueueTime(PerformanceEvents.StandardInteractionClientInitializeAuthorizationRequest, request.correlationId);
+        BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.StandardInteractionClientInitializeAuthorizationRequest, request.correlationId);
         const validRequest = await this.initializeAuthorizationRequest(request, InteractionType.Redirect);
         this.browserStorage.updateCacheEntries(validRequest.state, validRequest.nonce, validRequest.authority, validRequest.loginHint || Constants.EMPTY_STRING, validRequest.account || null);
         const serverTelemetryManager = this.initializeServerTelemetryManager(ApiId.acquireTokenRedirect);
@@ -48,16 +49,16 @@ export class RedirectClient extends StandardInteractionClient {
 
         try {
             // Create auth code request and generate PKCE params
-            this.performanceClient.setPreQueueTime(PerformanceEvents.StandardInteractionClientInitializeAuthorizationCodeRequest, request.correlationId);
+            BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.StandardInteractionClientInitializeAuthorizationCodeRequest, request.correlationId);
             const authCodeRequest: CommonAuthorizationCodeRequest = await this.initializeAuthorizationCodeRequest(validRequest);
 
             // Initialize the client
-            this.performanceClient.setPreQueueTime(PerformanceEvents.StandardInteractionClientCreateAuthCodeClient, request.correlationId);
+            BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.StandardInteractionClientCreateAuthCodeClient, request.correlationId);
             const authClient: AuthorizationCodeClient = await this.createAuthCodeClient(serverTelemetryManager, validRequest.authority, validRequest.azureCloudOptions);
             this.logger.verbose("Auth code client created");
 
             // Create redirect interaction handler.
-            const interactionHandler = new RedirectHandler(authClient, this.browserStorage, authCodeRequest, this.logger, this.browserCrypto, this.performanceClient);
+            const interactionHandler = new RedirectHandler(authClient, this.browserStorage, authCodeRequest, this.logger, this.browserCrypto);
 
             // Create acquire token url.
             const navigateUrl = await authClient.getAuthCodeUrl({
@@ -228,7 +229,7 @@ export class RedirectClient extends StandardInteractionClient {
             if (!this.nativeMessageHandler) {
                 throw BrowserAuthError.createNativeConnectionNotEstablishedError();
             }
-            const nativeInteractionClient = new NativeInteractionClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, ApiId.acquireTokenPopup, this.performanceClient, this.nativeMessageHandler, serverParams.accountId, this.browserStorage, cachedRequest.correlationId);
+            const nativeInteractionClient = new NativeInteractionClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, ApiId.acquireTokenPopup, this.nativeMessageHandler, serverParams.accountId, this.browserStorage, cachedRequest.correlationId);
             const { userRequestState } = ProtocolUtils.parseRequestState(this.browserCrypto, state);
             return nativeInteractionClient.acquireToken({
                 ...cachedRequest,
@@ -244,11 +245,11 @@ export class RedirectClient extends StandardInteractionClient {
         if (!currentAuthority) {
             throw BrowserAuthError.createNoCachedAuthorityError();
         }
-        this.performanceClient.setPreQueueTime(PerformanceEvents.StandardInteractionClientCreateAuthCodeClient, cachedRequest.correlationId);
+        BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.StandardInteractionClientCreateAuthCodeClient, cachedRequest.correlationId);
         const authClient = await this.createAuthCodeClient(serverTelemetryManager, currentAuthority);
         this.logger.verbose("Auth code client created");
         ThrottlingUtils.removeThrottle(this.browserStorage, this.config.auth.clientId, cachedRequest);
-        const interactionHandler = new RedirectHandler(authClient, this.browserStorage, cachedRequest, this.logger, this.browserCrypto, this.performanceClient);
+        const interactionHandler = new RedirectHandler(authClient, this.browserStorage, cachedRequest, this.logger, this.browserCrypto);
         return await interactionHandler.handleCodeResponseFromHash(hash, state, authClient.authority, this.networkClient);
     }
 
@@ -273,7 +274,7 @@ export class RedirectClient extends StandardInteractionClient {
                 timeout: this.config.system.redirectNavigationTimeout,
                 noHistory: false
             };
-            this.performanceClient.setPreQueueTime(PerformanceEvents.StandardInteractionClientCreateAuthCodeClient, validLogoutRequest.correlationId);
+            BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.StandardInteractionClientCreateAuthCodeClient, validLogoutRequest.correlationId);
             const authClient = await this.createAuthCodeClient(serverTelemetryManager, logoutRequest && logoutRequest.authority);
             this.logger.verbose("Auth code client created");
 

--- a/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
@@ -8,6 +8,7 @@ import { CommonSilentFlowRequest, AuthenticationResult, SilentFlowClient, Server
 import { SilentRequest } from "../request/SilentRequest";
 import { ApiId } from "../utils/BrowserConstants";
 import { BrowserAuthError, BrowserAuthErrorMessage } from "../error/BrowserAuthError";
+import {BrowserTelemetryFactory} from "../telemetry/BrowserTelemetryFactory";
 
 export class SilentCacheClient extends StandardInteractionClient {
     /**
@@ -15,7 +16,7 @@ export class SilentCacheClient extends StandardInteractionClient {
      * @param silentRequest
      */
     async acquireToken(silentRequest: CommonSilentFlowRequest): Promise<AuthenticationResult> {
-        const acquireTokenMeasurement = this.performanceClient.startMeasurement(PerformanceEvents.SilentCacheClientAcquireToken, silentRequest.correlationId);
+        const acquireTokenMeasurement = BrowserTelemetryFactory.client().startMeasurement(PerformanceEvents.SilentCacheClientAcquireToken, silentRequest.correlationId);
         // Telemetry manager only used to increment cacheHits here
         const serverTelemetryManager = this.initializeServerTelemetryManager(ApiId.acquireTokenSilent_silentFlow);
 
@@ -58,15 +59,15 @@ export class SilentCacheClient extends StandardInteractionClient {
      */
     protected async createSilentFlowClient(serverTelemetryManager: ServerTelemetryManager, authorityUrl?: string, azureCloudOptions?: AzureCloudOptions): Promise<SilentFlowClient> {
         // Create auth module.
-        this.performanceClient.setPreQueueTime(PerformanceEvents.StandardInteractionClientGetClientConfiguration, this.correlationId);
+        BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.StandardInteractionClientGetClientConfiguration, this.correlationId);
         const clientConfig = await this.getClientConfiguration(serverTelemetryManager, authorityUrl, azureCloudOptions);
-        return new SilentFlowClient(clientConfig, this.performanceClient);
+        return new SilentFlowClient(clientConfig, BrowserTelemetryFactory.client());
     }
 
     async initializeSilentRequest(request: SilentRequest, account: AccountInfo): Promise<CommonSilentFlowRequest> {
-        this.performanceClient.addQueueMeasurement(PerformanceEvents.InitializeSilentRequest, this.correlationId);
+        BrowserTelemetryFactory.client().addQueueMeasurement(PerformanceEvents.InitializeSilentRequest, this.correlationId);
 
-        this.performanceClient.setPreQueueTime(PerformanceEvents.InitializeBaseRequest, this.correlationId);
+        BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.InitializeBaseRequest, this.correlationId);
         return {
             ...request,
             ...await this.initializeBaseRequest(request),

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -7,6 +7,7 @@ import { StandardInteractionClient } from "./StandardInteractionClient";
 import { CommonSilentFlowRequest, AuthenticationResult, ServerTelemetryManager, RefreshTokenClient, AuthError, AzureCloudOptions, PerformanceEvents } from "@azure/msal-common";
 import { ApiId } from "../utils/BrowserConstants";
 import { BrowserAuthError } from "../error/BrowserAuthError";
+import {BrowserTelemetryFactory} from "../telemetry/BrowserTelemetryFactory";
 
 export class SilentRefreshClient extends StandardInteractionClient {
     /**
@@ -14,20 +15,20 @@ export class SilentRefreshClient extends StandardInteractionClient {
      * @param request
      */
     async acquireToken(request: CommonSilentFlowRequest): Promise<AuthenticationResult> {
-        this.performanceClient.addQueueMeasurement(PerformanceEvents.SilentRefreshClientAcquireToken, request.correlationId);
+        BrowserTelemetryFactory.client().addQueueMeasurement(PerformanceEvents.SilentRefreshClientAcquireToken, request.correlationId);
 
-        this.performanceClient.setPreQueueTime(PerformanceEvents.InitializeBaseRequest, request.correlationId);
+        BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.InitializeBaseRequest, request.correlationId);
         const silentRequest: CommonSilentFlowRequest = {
             ...request,
             ...await this.initializeBaseRequest(request)
         };
-        const acquireTokenMeasurement = this.performanceClient.startMeasurement(PerformanceEvents.SilentRefreshClientAcquireToken, silentRequest.correlationId);
+        const acquireTokenMeasurement = BrowserTelemetryFactory.client().startMeasurement(PerformanceEvents.SilentRefreshClientAcquireToken, silentRequest.correlationId);
         const serverTelemetryManager = this.initializeServerTelemetryManager(ApiId.acquireTokenSilent_silentFlow);
 
         const refreshTokenClient = await this.createRefreshTokenClient(serverTelemetryManager, silentRequest.authority, silentRequest.azureCloudOptions);
         this.logger.verbose("Refresh token client created");
         // Send request to renew token. Auth module will throw errors if token cannot be renewed.
-        this.performanceClient.setPreQueueTime(PerformanceEvents.RefreshTokenClientAcquireTokenByRefreshToken, request.correlationId);
+        BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.RefreshTokenClientAcquireTokenByRefreshToken, request.correlationId);
         return refreshTokenClient.acquireTokenByRefreshToken(silentRequest)
             .then((result: AuthenticationResult) => {
                 acquireTokenMeasurement.endMeasurement({
@@ -67,8 +68,8 @@ export class SilentRefreshClient extends StandardInteractionClient {
      */
     protected async createRefreshTokenClient(serverTelemetryManager: ServerTelemetryManager, authorityUrl?: string, azureCloudOptions?: AzureCloudOptions): Promise<RefreshTokenClient> {
         // Create auth module.
-        this.performanceClient.setPreQueueTime(PerformanceEvents.StandardInteractionClientGetClientConfiguration, this.correlationId);
+        BrowserTelemetryFactory.client().setPreQueueTime(PerformanceEvents.StandardInteractionClientGetClientConfiguration, this.correlationId);
         const clientConfig = await this.getClientConfiguration(serverTelemetryManager, authorityUrl, azureCloudOptions);
-        return new RefreshTokenClient(clientConfig, this.performanceClient);
+        return new RefreshTokenClient(clientConfig, BrowserTelemetryFactory.client());
     }
 }

--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthorizationCodeClient, StringUtils, CommonAuthorizationCodeRequest, ICrypto, AuthenticationResult, Authority, INetworkModule, ClientAuthError, Logger, ServerError, IPerformanceClient } from "@azure/msal-common";
+import { AuthorizationCodeClient, StringUtils, CommonAuthorizationCodeRequest, ICrypto, AuthenticationResult, Authority, INetworkModule, ClientAuthError, Logger, ServerError } from "@azure/msal-common";
 import { BrowserAuthError, BrowserAuthErrorMessage } from "../error/BrowserAuthError";
 import { ApiId, TemporaryCacheKeys } from "../utils/BrowserConstants";
 import { BrowserCacheManager } from "../cache/BrowserCacheManager";
@@ -22,8 +22,8 @@ export class RedirectHandler extends InteractionHandler {
 
     private browserCrypto: ICrypto;
 
-    constructor(authCodeModule: AuthorizationCodeClient, storageImpl: BrowserCacheManager, authCodeRequest: CommonAuthorizationCodeRequest, logger: Logger, browserCrypto: ICrypto, performanceClient: IPerformanceClient) {
-        super(authCodeModule, storageImpl, authCodeRequest, logger, performanceClient);
+    constructor(authCodeModule: AuthorizationCodeClient, storageImpl: BrowserCacheManager, authCodeRequest: CommonAuthorizationCodeRequest, logger: Logger, browserCrypto: ICrypto) {
+        super(authCodeModule, storageImpl, authCodeRequest, logger);
         this.browserCrypto = browserCrypto;
     }
 
@@ -50,7 +50,7 @@ export class RedirectHandler extends InteractionHandler {
                 timeout: params.redirectTimeout,
                 noHistory: false
             };
-            
+
             // If onRedirectNavigate is implemented, invoke it and provide requestUrl
             if (typeof params.onRedirectNavigate === "function") {
                 this.logger.verbose("RedirectHandler.initiateAuthRequest: Invoking onRedirectNavigate callback");

--- a/lib/msal-browser/src/telemetry/BrowserTelemetryFactory.ts
+++ b/lib/msal-browser/src/telemetry/BrowserTelemetryFactory.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {PerfClientParams, TelemetryFactory, IPerformanceClient, ICrypto} from "@azure/msal-common";
+import {BrowserPerformanceClient} from "./BrowserPerformanceClient";
+
+export interface BrowserPerfClientParams extends PerfClientParams {
+    isBrowserEnv?: boolean;
+    crypto: ICrypto;
+}
+
+export class BrowserTelemetryFactory extends TelemetryFactory {
+
+    public static initClient(params: BrowserPerfClientParams): void {
+        super.initClient(params);
+    }
+
+    public static newClient(params: BrowserPerfClientParams): IPerformanceClient {
+        return params.isBrowserEnv ?
+            new BrowserPerformanceClient(params.clientId, params.authority, params.logger, params.name, params.version, params.application, params.crypto):
+            super.newClient(params);
+    }
+}
+

--- a/lib/msal-browser/test/app/IPublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/IPublicClientApplication.spec.ts
@@ -3,10 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { stubbedPublicClientApplication } from "../../src/app/IPublicClientApplication";
-import { BrowserConfigurationAuthErrorMessage } from "../../src/error/BrowserConfigurationAuthError";
+import { stubbedPublicClientApplication } from "../../src";
+import { BrowserConfigurationAuthErrorMessage } from "../../src";
+import {stubPerformanceClient} from "../utils/TelemetryUtils";
+import sinon from "sinon";
 
 describe("IPublicClientApplication.ts Class Unit Tests", () => {
+    beforeAll(() => {
+        stubPerformanceClient();
+    })
+
+    afterAll(() => {
+        sinon.restore();
+    })
+
     describe("stubbedPublicClientApplication tests", () => {
         it("acquireTokenPopup throws", (done) => {
             stubbedPublicClientApplication.acquireTokenPopup({scopes: ["openid"]}).catch(e => {

--- a/lib/msal-browser/test/app/PCANonBrowser.spec.ts
+++ b/lib/msal-browser/test/app/PCANonBrowser.spec.ts
@@ -4,8 +4,18 @@
 import { TEST_CONFIG } from "../utils/StringConstants";
 import { PublicClientApplication } from "../../src/app/PublicClientApplication";
 import { BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
+import {stubPerformanceClient} from "../utils/TelemetryUtils";
+import sinon from "sinon";
 
 describe("Non-browser environment", () => {
+
+    beforeAll(() => {
+        stubPerformanceClient();
+    })
+
+    afterAll(() => {
+        sinon.restore();
+    })
 
     it("Constructor doesnt throw if window is undefined", () => {
         new PublicClientApplication({

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -56,6 +56,8 @@ import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessag
 import { NativeInteractionClient } from "../../src/interaction_client/NativeInteractionClient";
 import { NativeTokenRequest } from "../../src/broker/nativeBroker/NativeRequest";
 import { NativeAuthError } from "../../src/error/NativeAuthError";
+import {mockPerformanceClient} from "../utils/TelemetryUtils";
+import {BrowserTelemetryFactory} from "../../src/telemetry/BrowserTelemetryFactory";
 
 const cacheConfig = {
     cacheLocation: BrowserCacheLocation.SessionStorage,

--- a/lib/msal-browser/test/utils/TelemetryUtils.ts
+++ b/lib/msal-browser/test/utils/TelemetryUtils.ts
@@ -1,0 +1,45 @@
+import sinon from "sinon";
+import {BrowserTelemetryFactory} from "../../src/telemetry/BrowserTelemetryFactory";
+import {TEST_CONFIG} from "./StringConstants";
+import {IPerformanceClient, Logger} from "@azure/msal-common";
+import {CryptoOps} from "../../src/crypto/CryptoOps";
+
+export function stubPerformanceClient(performanceClient?: IPerformanceClient): IPerformanceClient {
+    const client = performanceClient || {
+        startMeasurement: jest.fn(),
+        endMeasurement: jest.fn(),
+        addStaticFields: jest.fn(),
+        flushMeasurements: jest.fn(),
+        discardMeasurements: jest.fn(),
+        removePerformanceCallback: jest.fn(),
+        addPerformanceCallback: jest.fn(),
+        emitEvents: jest.fn(),
+        startPerformanceMeasurement: jest.fn(),
+        startPerformanceMeasuremeant: jest.fn(),
+        generateId: jest.fn(),
+        calculateQueuedTime: jest.fn(),
+        addQueueMeasurement: jest.fn(),
+        setPreQueueTime: jest.fn()
+    };
+
+    sinon.stub(BrowserTelemetryFactory, "client").returns(client);
+
+    return client;
+}
+
+export function mockPerformanceClient(): void {
+    const logger = new Logger({});
+    BrowserTelemetryFactory.initClient({
+        clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+        logger,
+        name: TEST_CONFIG.applicationName,
+        version: TEST_CONFIG.applicationVersion,
+        application: {
+            appName: TEST_CONFIG.applicationName,
+            appVersion: TEST_CONFIG.applicationVersion,
+        },
+        authority: "test-authority",
+        isBrowserEnv: true,
+        crypto: new CryptoOps(logger)
+    });
+}

--- a/lib/msal-common/src/authority/AuthorityFactory.ts
+++ b/lib/msal-common/src/authority/AuthorityFactory.ts
@@ -11,8 +11,8 @@ import { ClientAuthError } from "../error/ClientAuthError";
 import { ICacheManager } from "../cache/interface/ICacheManager";
 import { AuthorityOptions } from "./AuthorityOptions";
 import { Logger } from "../logger/Logger";
-import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient";
 import { PerformanceEvents } from "../telemetry/performance/PerformanceEvent";
+import {TelemetryFactory} from "../telemetry/TelemetryFactory";
 
 export class AuthorityFactory {
 
@@ -32,10 +32,9 @@ export class AuthorityFactory {
         cacheManager: ICacheManager,
         authorityOptions: AuthorityOptions,
         logger: Logger,
-        performanceClient?: IPerformanceClient,
         correlationId?: string
     ): Promise<Authority> {
-        performanceClient?.addQueueMeasurement(PerformanceEvents.AuthorityFactoryCreateDiscoveredInstance, correlationId);
+        TelemetryFactory.client()?.addQueueMeasurement(PerformanceEvents.AuthorityFactoryCreateDiscoveredInstance, correlationId);
 
         // Initialize authority and perform discovery endpoint check.
         const acquireTokenAuthority: Authority = AuthorityFactory.createInstance(
@@ -44,12 +43,11 @@ export class AuthorityFactory {
             cacheManager,
             authorityOptions,
             logger,
-            performanceClient,
             correlationId
         );
 
         try {
-            performanceClient?.setPreQueueTime(PerformanceEvents.AuthorityResolveEndpointsAsync, correlationId);
+            TelemetryFactory.client()?.setPreQueueTime(PerformanceEvents.AuthorityResolveEndpointsAsync, correlationId);
             await acquireTokenAuthority.resolveEndpointsAsync();
             return acquireTokenAuthority;
         } catch (e) {
@@ -73,7 +71,6 @@ export class AuthorityFactory {
         cacheManager: ICacheManager,
         authorityOptions: AuthorityOptions,
         logger: Logger,
-        performanceClient?: IPerformanceClient,
         correlationId?: string
     ): Authority {
         // Throw error if authority url is empty
@@ -81,6 +78,6 @@ export class AuthorityFactory {
             throw ClientConfigurationError.createUrlEmptyError();
         }
 
-        return new Authority(authorityUrl, networkInterface, cacheManager, authorityOptions, logger, performanceClient, correlationId);
+        return new Authority(authorityUrl, networkInterface, cacheManager, authorityOptions, logger, correlationId);
     }
 }

--- a/lib/msal-common/src/authority/RegionDiscovery.ts
+++ b/lib/msal-common/src/authority/RegionDiscovery.ts
@@ -9,14 +9,12 @@ import { IMDSBadResponse } from "../response/IMDSBadResponse";
 import { Constants, RegionDiscoverySources, ResponseCodes } from "../utils/Constants";
 import { RegionDiscoveryMetadata } from "./RegionDiscoveryMetadata";
 import { ImdsOptions } from "./ImdsOptions";
-import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient";
 import { PerformanceEvents } from "../telemetry/performance/PerformanceEvent";
+import {TelemetryFactory} from "../telemetry/TelemetryFactory";
 
 export class RegionDiscovery {
     // Network interface to make requests with.
     protected networkInterface: INetworkModule;
-    // Performance client
-    protected performanceClient: IPerformanceClient | undefined;
     // CorrelationId
     protected correlationId: string | undefined;
     // Options for the IMDS endpoint request
@@ -26,45 +24,44 @@ export class RegionDiscovery {
         },
     };
 
-    constructor(networkInterface: INetworkModule, performanceClient?: IPerformanceClient, correlationId?: string) {
+    constructor(networkInterface: INetworkModule, correlationId?: string) {
         this.networkInterface = networkInterface;
-        this.performanceClient = performanceClient;
         this.correlationId = correlationId;
     }
 
     /**
      * Detect the region from the application's environment.
-     * 
+     *
      * @returns Promise<string | null>
      */
     public async detectRegion(environmentRegion: string | undefined, regionDiscoveryMetadata: RegionDiscoveryMetadata): Promise<string | null> {
-        this.performanceClient?.addQueueMeasurement(PerformanceEvents.RegionDiscoveryDetectRegion, this.correlationId);
-        
-        // Initialize auto detected region with the region from the envrionment 
+        TelemetryFactory.client()?.addQueueMeasurement(PerformanceEvents.RegionDiscoveryDetectRegion, this.correlationId);
+
+        // Initialize auto detected region with the region from the envrionment
         let autodetectedRegionName = environmentRegion;
 
-        // Check if a region was detected from the environment, if not, attempt to get the region from IMDS 
+        // Check if a region was detected from the environment, if not, attempt to get the region from IMDS
         if (!autodetectedRegionName) {
             const options = RegionDiscovery.IMDS_OPTIONS;
 
             try {
-                this.performanceClient?.setPreQueueTime(PerformanceEvents.RegionDiscoveryGetRegionFromIMDS, this.correlationId);
+                TelemetryFactory.client()?.setPreQueueTime(PerformanceEvents.RegionDiscoveryGetRegionFromIMDS, this.correlationId);
                 const localIMDSVersionResponse = await this.getRegionFromIMDS(Constants.IMDS_VERSION, options);
                 if (localIMDSVersionResponse.status === ResponseCodes.httpSuccess) {
                     autodetectedRegionName = localIMDSVersionResponse.body;
                     regionDiscoveryMetadata.region_source = RegionDiscoverySources.IMDS;
-                } 
-                
-                // If the response using the local IMDS version failed, try to fetch the current version of IMDS and retry. 
+                }
+
+                // If the response using the local IMDS version failed, try to fetch the current version of IMDS and retry.
                 if (localIMDSVersionResponse.status === ResponseCodes.httpBadRequest) {
-                    this.performanceClient?.setPreQueueTime(PerformanceEvents.RegionDiscoveryGetCurrentVersion, this.correlationId);
+                    TelemetryFactory.client()?.setPreQueueTime(PerformanceEvents.RegionDiscoveryGetCurrentVersion, this.correlationId);
                     const currentIMDSVersion = await this.getCurrentVersion(options);
                     if (!currentIMDSVersion) {
                         regionDiscoveryMetadata.region_source = RegionDiscoverySources.FAILED_AUTO_DETECTION;
                         return null;
                     }
 
-                    this.performanceClient?.setPreQueueTime(PerformanceEvents.RegionDiscoveryGetRegionFromIMDS, this.correlationId);
+                    TelemetryFactory.client()?.setPreQueueTime(PerformanceEvents.RegionDiscoveryGetRegionFromIMDS, this.correlationId);
                     const currentIMDSVersionResponse = await this.getRegionFromIMDS(currentIMDSVersion, options);
                     if (currentIMDSVersionResponse.status === ResponseCodes.httpSuccess) {
                         autodetectedRegionName = currentIMDSVersionResponse.body;
@@ -74,7 +71,7 @@ export class RegionDiscovery {
             } catch(e) {
                 regionDiscoveryMetadata.region_source = RegionDiscoverySources.FAILED_AUTO_DETECTION;
                 return null;
-            } 
+            }
         } else {
             regionDiscoveryMetadata.region_source = RegionDiscoverySources.ENVIRONMENT_VARIABLE;
         }
@@ -89,22 +86,22 @@ export class RegionDiscovery {
 
     /**
      * Make the call to the IMDS endpoint
-     * 
+     *
      * @param imdsEndpointUrl
      * @returns Promise<NetworkResponse<string>>
      */
     private async getRegionFromIMDS(version: string, options: ImdsOptions): Promise<NetworkResponse<string>> {
-        this.performanceClient?.addQueueMeasurement(PerformanceEvents.RegionDiscoveryGetRegionFromIMDS, this.correlationId);
+        TelemetryFactory.client()?.addQueueMeasurement(PerformanceEvents.RegionDiscoveryGetRegionFromIMDS, this.correlationId);
         return this.networkInterface.sendGetRequestAsync<string>(`${Constants.IMDS_ENDPOINT}?api-version=${version}&format=text`, options, Constants.IMDS_TIMEOUT);
     }
 
     /**
      * Get the most recent version of the IMDS endpoint available
-     *  
+     *
      * @returns Promise<string | null>
      */
     private async getCurrentVersion(options: ImdsOptions): Promise<string | null> {
-        this.performanceClient?.addQueueMeasurement(PerformanceEvents.RegionDiscoveryGetCurrentVersion, this.correlationId);
+        TelemetryFactory.client()?.addQueueMeasurement(PerformanceEvents.RegionDiscoveryGetCurrentVersion, this.correlationId);
         try {
             const response = await this.networkInterface.sendGetRequestAsync<IMDSBadResponse>(`${Constants.IMDS_ENDPOINT}?format=json`, options);
 

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -105,6 +105,7 @@ export { Counters, IntFields, PerformanceEvent, PerformanceEvents, PerformanceEv
 export { IPerformanceMeasurement } from "./telemetry/performance/IPerformanceMeasurement";
 export { PerformanceClient } from "./telemetry/performance/PerformanceClient";
 export { StubPerformanceClient } from "./telemetry/performance/StubPerformanceClient";
+export { PerfClientParams, TelemetryFactory } from "./telemetry/TelemetryFactory";
 
 export { PopTokenGenerator } from "./crypto/PopTokenGenerator";
 

--- a/lib/msal-common/src/telemetry/TelemetryFactory.ts
+++ b/lib/msal-common/src/telemetry/TelemetryFactory.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {Logger} from "../logger/Logger";
+import {ApplicationTelemetry} from "../config/ClientConfiguration";
+import {IPerformanceClient} from "./performance/IPerformanceClient";
+import {StubPerformanceClient} from "./performance/StubPerformanceClient";
+
+export interface PerfClientParams {
+    clientId: string;
+    authority: string;
+    logger: Logger;
+    application: ApplicationTelemetry;
+    name: string;
+    version: string;
+}
+
+export class TelemetryFactory {
+
+    protected static perfClient?: IPerformanceClient;
+
+    public static initClient(params: PerfClientParams): void {
+        if (!this.perfClient) {
+            this.perfClient = this.newClient(params);
+        }
+    }
+
+    public static client(): IPerformanceClient | undefined {
+        return this.perfClient;
+    }
+
+    public static newClient(params: PerfClientParams): IPerformanceClient {
+        return new StubPerformanceClient(params.clientId, params.authority, params.logger, params.name, params.version, params.application);
+    }
+}
+

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -1,6 +1,6 @@
-import { Authority } from "../../src/authority/Authority";
-import { INetworkModule, NetworkRequestOptions } from "../../src/network/INetworkModule";
-import { Constants } from "../../src/utils/Constants";
+import { Authority } from "../../src";
+import { INetworkModule, NetworkRequestOptions } from "../../src";
+import { Constants } from "../../src";
 import {
     TEST_URIS,
     RANDOM_TEST_GUID,
@@ -9,12 +9,12 @@ import {
     DEFAULT_TENANT_DISCOVERY_RESPONSE,
     B2C_OPENID_CONFIG_RESPONSE
 } from "../test_kit/StringConstants";
-import { ClientConfigurationErrorMessage, ClientConfigurationError } from "../../src/error/ClientConfigurationError";
+import { ClientConfigurationErrorMessage, ClientConfigurationError } from "../../src";
 import { MockStorageClass, mockCrypto } from "../client/ClientTestUtils";
-import { ClientAuthErrorMessage, ClientAuthError } from "../../src/error/ClientAuthError";
-import { AuthorityOptions } from "../../src/authority/AuthorityOptions";
-import { ProtocolMode } from "../../src/authority/ProtocolMode";
-import { AuthorityMetadataEntity } from "../../src/cache/entities/AuthorityMetadataEntity";
+import { ClientAuthErrorMessage, ClientAuthError } from "../../src";
+import { AuthorityOptions } from "../../src";
+import { ProtocolMode } from "../../src";
+import { AuthorityMetadataEntity } from "../../src";
 import { OpenIdConfigResponse } from "../../src/authority/OpenIdConfigResponse";
 import { Logger, LogLevel } from "../../src";
 
@@ -954,7 +954,7 @@ describe("Authority.ts Class Unit Tests", () => {
                 };
                 jest.spyOn(Authority.prototype, <any>"updateEndpointMetadata").mockResolvedValue("cache");
                 authority = new Authority(Constants.DEFAULT_AUTHORITY, networkInterface, mockStorage, authorityOptions, logger);
-                
+
                 await authority.resolveEndpointsAsync();
                 expect(authority.isAlias("login.microsoftonline.com")).toBe(true);
             });


### PR DESCRIPTION
- Use performance client as a singleton across the app.
- Add `TelemetryFactory` to instantiate telemetry artifacts.
- Simplify imports.