### PR TITLE
Trigger e2e tests only for PRs that are ready for review

### DIFF
--- a/.github/workflows/msal-angular-e2e.yml
+++ b/.github/workflows/msal-angular-e2e.yml
@@ -1,13 +1,19 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# Will not trigger unless PR is ready for review.
 
 name: msal-angular E2E Tests
 
 on:
+  push:
+    branches:
+      - dev
+      - master
   pull_request:
-    paths: 
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
       - 'lib/msal-angular/**/*'
-      - 'lib/msal-browser/**/*' 
+      - 'lib/msal-browser/**/*'
       - 'lib/msal-common/**/*'
       - 'samples/msal-angular-v2-samples/**/*'
       - 'samples/e2eTestUtils/**/*'
@@ -26,7 +32,7 @@ permissions:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group')) && !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/msal-angular-e2e.yml
+++ b/.github/workflows/msal-angular-e2e.yml
@@ -5,10 +5,6 @@
 name: msal-angular E2E Tests
 
 on:
-  push:
-    branches:
-      - dev
-      - master
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:

--- a/.github/workflows/msal-browser-e2e.yml
+++ b/.github/workflows/msal-browser-e2e.yml
@@ -1,12 +1,18 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# Will not trigger unless PR is ready for review.
 
 name: msal-browser E2E Tests
 
 on:
+  push:
+    branches:
+      - dev
+      - master
   pull_request:
-    paths: 
-      - 'lib/msal-browser/**/*' 
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'lib/msal-browser/**/*'
       - 'lib/msal-common/**/*'
       - 'samples/msal-browser-samples/VanillaJSTestApp2.0/**/*'
       - 'samples/e2eTestUtils/**/*'
@@ -25,7 +31,7 @@ permissions:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group'))  && !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:
@@ -52,7 +58,7 @@ jobs:
     - name: Restore node_modules for test tools
       uses: actions/cache@v3
       id: test-tools-cache
-      with: 
+      with:
         path: |
           samples/node_modules
           samples/.cache/puppeteer
@@ -66,7 +72,7 @@ jobs:
     - name: Restore node_modules for sample
       uses: actions/cache@v3
       id: sample-cache
-      with: 
+      with:
         path: samples/msal-browser-samples/VanillaJSTestApp2.0/node_modules
         key: ${{ runner.os }}-browser-sample-${{ hashFiles('samples/msal-browser-samples/VanillaJSTestApp2.0/package.json', 'samples/package-lock.json') }}
 

--- a/.github/workflows/msal-browser-e2e.yml
+++ b/.github/workflows/msal-browser-e2e.yml
@@ -5,10 +5,6 @@
 name: msal-browser E2E Tests
 
 on:
-  push:
-    branches:
-      - dev
-      - master
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:

--- a/.github/workflows/msal-core-e2e.yml
+++ b/.github/workflows/msal-core-e2e.yml
@@ -1,11 +1,17 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# Will not trigger unless PR is ready for review.
 
 name: msal-core E2E Tests
 
 on:
+  push:
+    branches:
+      - dev
+      - master
   pull_request:
-    paths: 
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
       - 'lib/msal-core/**/*'
       - 'samples/msal-core-samples/VanillaJSTestApp/**/*'
       - '!**.md'
@@ -22,7 +28,7 @@ permissions:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group')) && !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
 
@@ -50,7 +56,7 @@ jobs:
     - name: Restore node_modules for sample
       uses: actions/cache@v3
       id: sample-cache
-      with: 
+      with:
         path: samples/msal-core-samples/VanillaJSTestApp/node_modules
         key: ${{ runner.os }}-core-e2e-${{ hashFiles('samples/msal-core-samples/VanillaJSTestApp/package.json') }}
 

--- a/.github/workflows/msal-core-e2e.yml
+++ b/.github/workflows/msal-core-e2e.yml
@@ -5,10 +5,6 @@
 name: msal-core E2E Tests
 
 on:
-  push:
-    branches:
-      - dev
-      - master
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -5,10 +5,6 @@
 name: msal-node E2E Tests
 
 on:
-  push:
-    branches:
-      - dev
-      - master
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
@@ -275,7 +271,7 @@ jobs:
     - name: Install Playwright
       working-directory: samples/msal-node-samples/${{ matrix.sample }}
       run: npx playwright install
-      
+
     - name: Build Sample
       working-directory: samples/msal-node-samples/${{ matrix.sample }}
       run: |

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -5,6 +5,10 @@
 name: msal-node E2E Tests
 
 on:
+  push:
+    branches:
+      - dev
+      - master
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
@@ -203,7 +207,7 @@ jobs:
   #       path: samples/**/screenshots
 
   run-electron-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group')) && !github.event.pull_request.draft
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -1,10 +1,12 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# Will not trigger unless PR is ready for review.
 
 name: msal-node E2E Tests
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'lib/msal-node/**/*'
       - 'lib/msal-common/**/*'
@@ -25,7 +27,7 @@ permissions:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group')) && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/msal-react-e2e.yml
+++ b/.github/workflows/msal-react-e2e.yml
@@ -1,13 +1,19 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# Will not trigger unless PR is ready for review.
 
 name: msal-react E2E Tests
 
 on:
+  push:
+    branches:
+      - dev
+      - master
   pull_request:
-    paths: 
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
       - 'lib/msal-react/**/*'
-      - 'lib/msal-browser/**/*' 
+      - 'lib/msal-browser/**/*'
       - 'lib/msal-common/**/*'
       - 'samples/msal-react-samples/**/*'
       - 'samples/e2eTestUtils/**/*'
@@ -26,7 +32,7 @@ permissions:
 
 jobs:
   run-e2e:
-    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group'))
+    if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group')) && !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     strategy:
@@ -69,7 +75,7 @@ jobs:
     - name: Restore node_modules for test tools
       uses: actions/cache@v3
       id: test-tools-cache
-      with: 
+      with:
         path: |
           samples/node_modules
           samples/.cache/puppeteer
@@ -83,7 +89,7 @@ jobs:
     - name: Restore node_modules for sample
       uses: actions/cache@v3
       id: sample-cache
-      with: 
+      with:
         path: samples/msal-react-samples/${{ matrix.sample }}/node_modules
         key: ${{ runner.os }}-react-e2e-${{ hashFiles(format('samples/msal-react-samples/{0}/package.json', matrix.sample), 'samples/package-lock.json') }}
 

--- a/.github/workflows/msal-react-e2e.yml
+++ b/.github/workflows/msal-react-e2e.yml
@@ -5,10 +5,6 @@
 name: msal-react E2E Tests
 
 on:
-  push:
-    branches:
-      - dev
-      - master
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:


### PR DESCRIPTION
- Trigger e2e tests only for PRs that are ready for review.

A follow-up for https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/5649.