### PR TITLE
Reduce `preQueueTimeByCorrelationId` RAM footprint

### DIFF
--- a/change/@azure-msal-browser-0008266c-881d-4acc-84f1-0ce6773593a7.json
+++ b/change/@azure-msal-browser-0008266c-881d-4acc-84f1-0ce6773593a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reduce preQueueTimeByCorrelationId RAM footprint #5681",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-03c582a6-40c2-4307-8e8f-652813550479.json
+++ b/change/@azure-msal-common-03c582a6-40c2-4307-8e8f-652813550479.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reduce preQueueTimeByCorrelationId RAM footprint #5681",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
@@ -121,7 +121,7 @@ export class BrowserPerformanceClient extends PerformanceClient implements IPerf
          */
         if (preQueueEvent) {
             this.logger.trace(`BrowserPerformanceClient: Incomplete pre-queue ${preQueueEvent.name} found`, correlationId);
-            this.addQueueMeasurement(preQueueEvent.name, correlationId);
+            this.addQueueMeasurement(preQueueEvent.name, correlationId, undefined, true);
         }
         this.preQueueTimeByCorrelationId.set(eventName, { name: eventName, time: window.performance.now() });
     }
@@ -131,9 +131,11 @@ export class BrowserPerformanceClient extends PerformanceClient implements IPerf
      *
      * @param {PerformanceEvents} eventName
      * @param {?string} correlationId
+     * @param {?number} queueTime
+     * @param {?boolean} manuallyCompleted - indicator for manually completed queue measurements
      * @returns
      */
-    addQueueMeasurement(eventName: PerformanceEvents, correlationId?: string): void {
+    addQueueMeasurement(eventName: PerformanceEvents, correlationId?: string, queueTime?: number, manuallyCompleted?: boolean): void {
         if (!this.supportsBrowserPerformanceNow()) {
             this.logger.trace(`BrowserPerformanceClient: window performance API not available, unable to add queue measurement for ${eventName}`);
             return;
@@ -150,8 +152,8 @@ export class BrowserPerformanceClient extends PerformanceClient implements IPerf
         }
 
         const currentTime = window.performance.now();
-        const queueTime = super.calculateQueuedTime(preQueueTime, currentTime);
+        const resQueueTime = queueTime || super.calculateQueuedTime(preQueueTime, currentTime);
 
-        return super.addQueueMeasurement(eventName, correlationId, queueTime);
+        return super.addQueueMeasurement(eventName, correlationId, resQueueTime, manuallyCompleted);
     }
 }

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -103,7 +103,7 @@ export { ServerTelemetryRequest } from "./telemetry/server/ServerTelemetryReques
 export { IPerformanceClient, PerformanceCallbackFunction, InProgressPerformanceEvent, QueueMeasurement } from "./telemetry/performance/IPerformanceClient";
 export { Counters, IntFields, PerformanceEvent, PerformanceEvents, PerformanceEventStatus, StaticFields, SubMeasurement } from "./telemetry/performance/PerformanceEvent";
 export { IPerformanceMeasurement } from "./telemetry/performance/IPerformanceMeasurement";
-export { PerformanceClient } from "./telemetry/performance/PerformanceClient";
+export { PerformanceClient, PreQueueEvent } from "./telemetry/performance/PerformanceClient";
 export { StubPerformanceClient } from "./telemetry/performance/StubPerformanceClient";
 
 export { PopTokenGenerator } from "./crypto/PopTokenGenerator";

--- a/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
@@ -32,7 +32,7 @@ export interface IPerformanceClient {
     startPerformanceMeasurement(measureName: string, correlationId: string): IPerformanceMeasurement;
     generateId(): string;
     calculateQueuedTime(preQueueTime: number, currentTime: number): number;
-    addQueueMeasurement(eventName: PerformanceEvents, correlationId?: string, queueTime?: number): void;
+    addQueueMeasurement(eventName: PerformanceEvents, correlationId?: string, queueTime?: number, manuallyCompleted?: boolean): void;
     setPreQueueTime(eventName: PerformanceEvents, correlationId?: string): void;
 }
 
@@ -48,5 +48,10 @@ export type QueueMeasurement = {
     /**
      * Time spent in JS queue
      */
-    queueTime: number
+    queueTime: number,
+
+    /**
+     * Incomplete pre-queue events are instrumentation bugs that should be fixed.
+     */
+    manuallyCompleted?: boolean;
 };

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -330,6 +330,18 @@ export type StaticFields = {
 export type Counters = {
     visibilityChangeCount?: number;
     incompleteSubsCount?: number;
+    /**
+     * Amount of times queued in the JS event queue.
+     *
+     * @type {?number}
+     */
+    queuedCount?: number
+    /**
+     * Amount of manually completed queue events.
+     *
+     * @type {?number}
+     */
+    queuedManuallyCompletedCount?: number;
 };
 
 export type SubMeasurement = {
@@ -486,13 +498,6 @@ export type PerformanceEvent = StaticFields & Counters & {
      * @type {?number}
      */
     queuedTimeMs?: number,
-
-    /**
-     * Amount of times queued in the JS event queue.
-     *
-     * @type {?number}
-     */
-    queuedCount?: number
 
     /**
      * Sub-measurements for internal use. To be deleted before flushing.


### PR DESCRIPTION
Changes:
- Reduce `preQueueTimeByCorrelationId` RAM footprint. Maintain only the latest pre-queue event instead of the whole stack.
- Capture number of manually completed queue events.

Notes:
- We don't need to cache timestamps for all pre-queue events. Once new event comes in - we can safely remove the previous one from `preQueueTimeByCorrelationId` map as already processed.