### PR TITLE
Mitigate jsonwebtoken vulnerability in samples

### DIFF
--- a/samples/msal-node-samples/on-behalf-of/web-api/package.json
+++ b/samples/msal-node-samples/on-behalf-of/web-api/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@azure/msal-node": "file:../../../../lib/msal-node",
     "express": "^4.17.1",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^1.8.1",
     "uuid": "^8.3.1"
   }

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -19,7 +19,7 @@
                 "dotenv": "^8.2.0",
                 "find-process": "^1.4.4",
                 "jest": "^27.1.1",
-                "playwright-core": "~1.28.1",
+                "playwright-core": "^1.28.1",
                 "puppeteer": "^19.2.0",
                 "ts-jest": "^27.0.5"
             }
@@ -240,9 +240,9 @@
             }
         },
         "node_modules/@azure/identity": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-3.1.2.tgz",
-            "integrity": "sha512-UCuxhM3q3ODH62oOChEOS57uMc/CFTtoO7NyrDv0nx9IIfbiAaEVztDLXkpVWLw90Dw+t39MDL+I1MQLOWLT9g==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-3.1.3.tgz",
+            "integrity": "sha512-y0jFjSfHsVPwXSwi3KaSPtOZtJZqhiqAhWUXfFYBUd/+twUBovZRXspBwLrF5rJe0r5NyvmScpQjL+TYDTQVvw==",
             "dev": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
@@ -252,9 +252,9 @@
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/core-util": "^1.0.0",
                 "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^2.32.0",
-                "@azure/msal-common": "^9.0.0",
-                "@azure/msal-node": "^1.14.4",
+                "@azure/msal-browser": "^2.32.2",
+                "@azure/msal-common": "^9.0.2",
+                "@azure/msal-node": "^1.14.6",
                 "events": "^3.0.0",
                 "jws": "^4.0.0",
                 "open": "^8.0.0",
@@ -310,38 +310,56 @@
             }
         },
         "node_modules/@azure/msal-browser": {
-            "version": "2.32.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.32.1.tgz",
-            "integrity": "sha512-2G3B12ZEIpiimi6/Yqq7KLk4ud1zZWoHvVd2kJ2VthN1HjMsZjdMUxeHkwMWaQ6RzO6mv9rZiuKmRX64xkXW9g==",
+            "version": "2.33.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.33.0.tgz",
+            "integrity": "sha512-c7CVh1tfUfxiWkEIhoIb11hL4PGo4hz0M+gMy34ATagAKdLK7qyEu/5AXJWAf5lz5eE+vQhm7+LKiuETrcXXGw==",
             "dev": true,
             "dependencies": {
-                "@azure/msal-common": "^9.0.1"
+                "@azure/msal-common": "^10.0.0"
             },
             "engines": {
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-10.0.0.tgz",
+            "integrity": "sha512-/LghpT93jsZLy55QzTsRZWMx6R1Mjc1Aktwps8sKSGE3WbrGwbSsh2uhDlpl6FMcKChYjJ0ochThWwwOodrQNg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/@azure/msal-common": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.0.1.tgz",
-            "integrity": "sha512-eNNHIW/cwPTZDWs9KtYgb1X6gtQ+cC+FGX2YN+t4AUVsBdUbqlMTnUs6/c/VBxC2AAGIhgLREuNnO3F66AN2zQ==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+            "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw==",
             "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
-            "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.15.0.tgz",
+            "integrity": "sha512-fwC5M0c8pxOAzmScPbpx7j28YVTDebUaizlVF7bR0xvlU0r3VWW5OobCcr9ybqKS6wGyO7u4EhXJS9rjRWAuwA==",
             "dev": true,
             "dependencies": {
-                "@azure/msal-common": "^9.0.1",
-                "jsonwebtoken": "^8.5.1",
+                "@azure/msal-common": "^10.0.0",
+                "jsonwebtoken": "^9.0.0",
                 "uuid": "^8.3.0"
             },
             "engines": {
                 "node": "10 || 12 || 14 || 16 || 18"
+            }
+        },
+        "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-10.0.0.tgz",
+            "integrity": "sha512-/LghpT93jsZLy55QzTsRZWMx6R1Mjc1Aktwps8sKSGE3WbrGwbSsh2uhDlpl6FMcKChYjJ0ochThWwwOodrQNg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -3657,25 +3675,19 @@
             }
         },
         "node_modules/jsonwebtoken": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+            "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
             "dev": true,
             "dependencies": {
                 "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
+                "lodash": "^4.17.21",
                 "ms": "^2.1.1",
-                "semver": "^5.6.0"
+                "semver": "^7.3.8"
             },
             "engines": {
-                "node": ">=4",
-                "npm": ">=1.4.28"
+                "node": ">=12",
+                "npm": ">=6"
             }
         },
         "node_modules/jsonwebtoken/node_modules/jwa": {
@@ -3700,12 +3712,18 @@
             }
         },
         "node_modules/jsonwebtoken/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
             "bin": {
-                "semver": "bin/semver"
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/jwa": {
@@ -3784,52 +3802,10 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
-        "node_modules/lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-            "dev": true
-        },
-        "node_modules/lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "dev": true
-        },
-        "node_modules/lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-            "dev": true
-        },
-        "node_modules/lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-            "dev": true
-        },
-        "node_modules/lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "dev": true
-        },
-        "node_modules/lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "dev": true
-        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-            "dev": true
-        },
-        "node_modules/lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "dev": true
         },
         "node_modules/lru-cache": {
@@ -5524,9 +5500,9 @@
             }
         },
         "@azure/identity": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-3.1.2.tgz",
-            "integrity": "sha512-UCuxhM3q3ODH62oOChEOS57uMc/CFTtoO7NyrDv0nx9IIfbiAaEVztDLXkpVWLw90Dw+t39MDL+I1MQLOWLT9g==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-3.1.3.tgz",
+            "integrity": "sha512-y0jFjSfHsVPwXSwi3KaSPtOZtJZqhiqAhWUXfFYBUd/+twUBovZRXspBwLrF5rJe0r5NyvmScpQjL+TYDTQVvw==",
             "dev": true,
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
@@ -5536,9 +5512,9 @@
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/core-util": "^1.0.0",
                 "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^2.32.0",
-                "@azure/msal-common": "^9.0.0",
-                "@azure/msal-node": "^1.14.4",
+                "@azure/msal-browser": "^2.32.2",
+                "@azure/msal-common": "^9.0.2",
+                "@azure/msal-node": "^1.14.6",
                 "events": "^3.0.0",
                 "jws": "^4.0.0",
                 "open": "^8.0.0",
@@ -5584,29 +5560,45 @@
             }
         },
         "@azure/msal-browser": {
-            "version": "2.32.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.32.1.tgz",
-            "integrity": "sha512-2G3B12ZEIpiimi6/Yqq7KLk4ud1zZWoHvVd2kJ2VthN1HjMsZjdMUxeHkwMWaQ6RzO6mv9rZiuKmRX64xkXW9g==",
+            "version": "2.33.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.33.0.tgz",
+            "integrity": "sha512-c7CVh1tfUfxiWkEIhoIb11hL4PGo4hz0M+gMy34ATagAKdLK7qyEu/5AXJWAf5lz5eE+vQhm7+LKiuETrcXXGw==",
             "dev": true,
             "requires": {
-                "@azure/msal-common": "^9.0.1"
+                "@azure/msal-common": "^10.0.0"
+            },
+            "dependencies": {
+                "@azure/msal-common": {
+                    "version": "10.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-10.0.0.tgz",
+                    "integrity": "sha512-/LghpT93jsZLy55QzTsRZWMx6R1Mjc1Aktwps8sKSGE3WbrGwbSsh2uhDlpl6FMcKChYjJ0ochThWwwOodrQNg==",
+                    "dev": true
+                }
             }
         },
         "@azure/msal-common": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.0.1.tgz",
-            "integrity": "sha512-eNNHIW/cwPTZDWs9KtYgb1X6gtQ+cC+FGX2YN+t4AUVsBdUbqlMTnUs6/c/VBxC2AAGIhgLREuNnO3F66AN2zQ==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+            "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw==",
             "dev": true
         },
         "@azure/msal-node": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
-            "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.15.0.tgz",
+            "integrity": "sha512-fwC5M0c8pxOAzmScPbpx7j28YVTDebUaizlVF7bR0xvlU0r3VWW5OobCcr9ybqKS6wGyO7u4EhXJS9rjRWAuwA==",
             "dev": true,
             "requires": {
-                "@azure/msal-common": "^9.0.1",
-                "jsonwebtoken": "^8.5.1",
+                "@azure/msal-common": "^10.0.0",
+                "jsonwebtoken": "^9.0.0",
                 "uuid": "^8.3.0"
+            },
+            "dependencies": {
+                "@azure/msal-common": {
+                    "version": "10.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-10.0.0.tgz",
+                    "integrity": "sha512-/LghpT93jsZLy55QzTsRZWMx6R1Mjc1Aktwps8sKSGE3WbrGwbSsh2uhDlpl6FMcKChYjJ0ochThWwwOodrQNg==",
+                    "dev": true
+                }
             }
         },
         "@babel/code-frame": {
@@ -8152,21 +8144,15 @@
             "dev": true
         },
         "jsonwebtoken": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+            "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
             "dev": true,
             "requires": {
                 "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
+                "lodash": "^4.17.21",
                 "ms": "^2.1.1",
-                "semver": "^5.6.0"
+                "semver": "^7.3.8"
             },
             "dependencies": {
                 "jwa": {
@@ -8191,10 +8177,13 @@
                     }
                 },
                 "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
                 }
             }
         },
@@ -8262,52 +8251,10 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
-        "lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-            "dev": true
-        },
-        "lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "dev": true
-        },
-        "lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-            "dev": true
-        },
-        "lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-            "dev": true
-        },
-        "lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "dev": true
-        },
-        "lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "dev": true
-        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-            "dev": true
-        },
-        "lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "dev": true
         },
         "lru-cache": {


### PR DESCRIPTION
This PR:

- Updates the MSALs' versions in @azure/identity in the samples/ package-lock to mitigate the jsonwebtoken vulnerability before verison 9.0.0
- Updates the MSAL Node OBO sample's package.json to use version ^9.0.0 of jsonwebtoken as well