### PR TITLE
Add Lab API param appPlatform to e2eTestUtils

### DIFF
--- a/samples/e2eTestUtils/Constants.ts
+++ b/samples/e2eTestUtils/Constants.ts
@@ -16,6 +16,7 @@ export const ParamKeys = {
     APP_TYPE: "apptype",
     SIGN_IN_AUDIENCE: "signInAudience",
     PUBLIC_CLIENT: "publicClient",
+    APP_PLATFORM: "appPlatform"
 };
 
 // Lab API Query Param Values
@@ -73,3 +74,7 @@ export const AppTypes = {
     ONPREM: "onprem"
 };
 
+export const AppPlatforms = {
+    SPA: "spa",
+    WEB: "web"
+};

--- a/samples/e2eTestUtils/LabApiQueryParams.ts
+++ b/samples/e2eTestUtils/LabApiQueryParams.ts
@@ -6,5 +6,6 @@ export type LabApiQueryParams = {
     homeDomain?: string,
     appType?: string,
     signInAudience?: string,
-    publicClient?: string
+    publicClient?: string,
+    appPlatform?: string,
 };

--- a/samples/e2eTestUtils/LabApiQueryParams.ts
+++ b/samples/e2eTestUtils/LabApiQueryParams.ts
@@ -1,3 +1,7 @@
+/**
+ * Query parameters for the lab API
+ * See: https://msidlab.com/swagger/v1/swagger.json
+ */
 export type LabApiQueryParams = {
     userType?: string,
     azureEnvironment?: string,

--- a/samples/e2eTestUtils/LabClient.ts
+++ b/samples/e2eTestUtils/LabClient.ts
@@ -47,7 +47,7 @@ export class LabClient {
         } catch (e) {
             console.error(e);
         }
-    
+
         return null;
     }
 
@@ -85,6 +85,10 @@ export class LabClient {
 
         if (labApiParams.publicClient) {
             apiParams.push(`${ParamKeys.PUBLIC_CLIENT}=${labApiParams.publicClient}`);
+        }
+
+        if (labApiParams.appPlatform) {
+            apiParams.push(`${ParamKeys.APP_PLATFORM}=${labApiParams.appPlatform}`);
         }
 
         if (apiParams.length <= 0) {

--- a/samples/e2eTestUtils/LabClient.ts
+++ b/samples/e2eTestUtils/LabClient.ts
@@ -51,6 +51,12 @@ export class LabClient {
         return null;
     }
 
+    /**
+     * Queries the lab API for an app environment based on the provided parameters
+     * See: https://docs.msidlab.com/labapi/intro.html
+     * @param labApiParams
+     * @returns
+     */
     async getVarsByCloudEnvironment(labApiParams: LabApiQueryParams): Promise<any> {
         const accessToken = await this.getCurrentToken();
         const apiParams: Array<string> = [];


### PR DESCRIPTION
MSIDLabs API supports the parameter `appPlatform`, which helps with querying apps supporting SPA redirect URI type. This PR updates the E2ETestUtils/LabClient to make use of the parameter.