### PR TITLE
fixing get account entity from cache using native account id

### DIFF
--- a/change/@azure-msal-common-ac79c211-9b36-4a75-9361-2af37685251f.json
+++ b/change/@azure-msal-common-ac79c211-9b36-4a75-9361-2af37685251f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing get account entity from cache using native account id",
+  "packageName": "@azure/msal-common",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-ac79c211-9b36-4a75-9361-2af37685251f.json
+++ b/change/@azure-msal-common-ac79c211-9b36-4a75-9361-2af37685251f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fixing get account entity from cache using native account id",
+  "comment": "fixing get account entity from cache using native account id #5695",
   "packageName": "@azure/msal-common",
   "email": "lalimasharda@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -706,7 +706,7 @@ export abstract class CacheManager implements ICacheManager {
             throw ClientAuthError.createMultipleMatchingAccountsInCacheError();
         }
 
-        return accountCache[0];
+        return accounts[0];
     }
 
     /**

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -874,7 +874,7 @@ describe("CacheManager.ts test cases", () => {
     });
 
     it("readAccountFromCacheWithNativeAccountId", () => {
-        const account = mockCache.cacheManager.readAccountFromCache(CACHE_MOCKS.MOCK_ACCOUNT_INFO_WITH_NATIVE_ACCOUNT_ID) as AccountEntity;
+        const account = mockCache.cacheManager.readAccountFromCacheWithNativeAccountId(CACHE_MOCKS.MOCK_ACCOUNT_INFO_WITH_NATIVE_ACCOUNT_ID.nativeAccountId) as AccountEntity;
         if (!account) {
             throw TestError.createTestSetupError("account does not have a value");
         }


### PR DESCRIPTION
Fixed:
- readAccountFromCacheWithNativeAccountId() not returning correct AccountEntity object.
- Unit test for readAccountFromCacheWithNativeAccountId() to call the correct method.