### PR TITLE
remove hardcoded params in msal-react samples

### DIFF
--- a/samples/msal-react-samples/gatsby-sample/jest.config.js
+++ b/samples/msal-react-samples/gatsby-sample/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
     displayName: "Gatsby",
     globals: {
         __PORT__: 3001,
-        __STARTCMD__: "npm run develop -- -p 3001"
+        __STARTCMD__: "NODE_ENV=development npm run develop -- -p 3001"
     },
     preset: "../../e2eTestUtils/jest-puppeteer-utils/jest-preset.js"
 };

--- a/samples/msal-react-samples/gatsby-sample/jest.config.js
+++ b/samples/msal-react-samples/gatsby-sample/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
     displayName: "Gatsby",
     globals: {
         __PORT__: 3001,
-        __STARTCMD__: "npm run serve -- -p 3001"
+        __STARTCMD__: "npm run develop -- -p 3001"
     },
     preset: "../../e2eTestUtils/jest-puppeteer-utils/jest-preset.js"
 };

--- a/samples/msal-react-samples/gatsby-sample/package.json
+++ b/samples/msal-react-samples/gatsby-sample/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "gatsby build",
     "build:package": "cd ../../../lib/msal-react && npm run build:all",
-    "develop": "gatsby develop -p 3000",
-    "start": "gatsby serve -p 3000",
+    "develop": "gatsby develop",
+    "start": "gatsby serve",
     "serve": "gatsby serve",
     "test": "jest --runInBand",
     "clean": "gatsby clean",

--- a/samples/msal-react-samples/gatsby-sample/package.json
+++ b/samples/msal-react-samples/gatsby-sample/package.json
@@ -9,7 +9,7 @@
     "develop": "gatsby develop -p 3000",
     "start": "gatsby serve -p 3000",
     "serve": "gatsby serve",
-    "test": "jest",
+    "test": "jest --runInBand",
     "clean": "gatsby clean",
     "install:local": "npm install ../../../lib/msal-react ../../../lib/msal-react/node_modules/react ../../../lib/msal-react/node_modules/react-dom ../../../lib/msal-browser",
     "install:published": "npm install @azure/msal-browser@latest @azure/msal-react@latest react@^18 react-dom@^18"

--- a/samples/msal-react-samples/gatsby-sample/src/authConfig.js
+++ b/samples/msal-react-samples/gatsby-sample/src/authConfig.js
@@ -1,8 +1,8 @@
 // Config object to be passed to Msal on creation
 export const msalConfig = {
     auth: {
-        clientId: "3fba556e-5d4a-48e3-8e1a-fd57c12cb82e",
-        authority: "https://login.windows-ppe.net/common",
+        clientId: "ENTER_CLIENT_ID_HERE",
+        authority: "https://login.microsoftonline.com/ENTER_TENANT_INFO_HERE",
         redirectUri: "/",
         postLogoutRedirectUri: "/"
     }
@@ -15,5 +15,5 @@ export const loginRequest = {
 
 // Add here the endpoints for MS Graph API services you would like to use.
 export const graphConfig = {
-    graphMeEndpoint: "https://graph.microsoft-ppe.com/v1.0/me"
+    graphMeEndpoint: "https://graph.microsoft.com/v1.0/me"
 };

--- a/samples/msal-react-samples/gatsby-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/gatsby-sample/test/home.spec.ts
@@ -1,11 +1,15 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, UserTypes, AppPlatforms } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/home-tests`;
+
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.js"));
 
 async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
@@ -24,6 +28,8 @@ describe('/ (Home Page)', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -35,14 +41,26 @@ describe('/ (Home Page)', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {

--- a/samples/msal-react-samples/nextjs-sample/jest.config.js
+++ b/samples/msal-react-samples/nextjs-sample/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
     displayName: "Next.js",
     globals: {
         __PORT__: 3200,
-        __STARTCMD__: "npm run start -- -p 3200"
+        __STARTCMD__: "npm run dev -- -p 3200"
     },
     preset: "../../e2eTestUtils/jest-puppeteer-utils/jest-preset.js"
 };

--- a/samples/msal-react-samples/nextjs-sample/package.json
+++ b/samples/msal-react-samples/nextjs-sample/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "test": "jest",
+    "test": "jest --runInBand",
     "build": "next build",
     "build:package": "cd ../../../lib/msal-react && npm run build:all",
     "start": "next start",

--- a/samples/msal-react-samples/nextjs-sample/src/authConfig.js
+++ b/samples/msal-react-samples/nextjs-sample/src/authConfig.js
@@ -1,8 +1,8 @@
 // Config object to be passed to Msal on creation
 export const msalConfig = {
     auth: {
-        clientId: "3fba556e-5d4a-48e3-8e1a-fd57c12cb82e",
-        authority: "https://login.windows-ppe.net/common",
+        clientId: "ENTER_CLIENT_ID_HERE",
+        authority: "https://login.microsoftonline.com/ENTER_TENANT_INFO_HERE",
         redirectUri: "/",
         postLogoutRedirectUri: "/"
     }
@@ -15,5 +15,5 @@ export const loginRequest = {
 
 // Add here the endpoints for MS Graph API services you would like to use.
 export const graphConfig = {
-    graphMeEndpoint: "https://graph.microsoft-ppe.com/v1.0/me"
+    graphMeEndpoint: "https://graph.microsoft.com/v1.0/me"
 };

--- a/samples/msal-react-samples/nextjs-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/nextjs-sample/test/home.spec.ts
@@ -1,11 +1,15 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, UserTypes, AppPlatforms } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/home-tests`;
+
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.js"));
 
 async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
@@ -24,6 +28,8 @@ describe('/ (Home Page)', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -35,14 +41,26 @@ describe('/ (Home Page)', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {

--- a/samples/msal-react-samples/nextjs-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/nextjs-sample/test/profile.spec.ts
@@ -1,13 +1,17 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, UserTypes, AppPlatforms } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/profile-tests`;
 
-async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.js"));
+
+async function verifyTokenStore(BrowserCache: BrowserCacheUtils, clientID: string, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
     expect(tokenStore.idTokens.length).toBe(1);
     expect(tokenStore.accessTokens.length).toBe(1);
@@ -16,7 +20,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
     expect(Object.keys(storage).length).toBe(7);
-    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
+    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry(clientID);
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry["cacheHits"]).toBe(1);
 }
@@ -27,6 +31,8 @@ describe('/profile', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -38,14 +44,26 @@ describe('/profile', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {
@@ -87,7 +105,7 @@ describe('/profile', () => {
         await screenshot.takeScreenshot(page, "App signed in");
 
         // Verify tokens are in cache
-        await verifyTokenStore(BrowserCache, ["User.Read"]);
+        await verifyTokenStore(BrowserCache, clientID, ["User.Read"]);
     });
 
     it("MsalAuthenticationTemplate - renders children without invoking login if user is already signed in", async () => {
@@ -125,7 +143,7 @@ describe('/profile', () => {
         await page.waitForXPath("//div/ul/li[contains(., 'Name')]");
         await screenshot.takeScreenshot(page, "Graph data acquired");
         // Verify tokens are in cache
-        await verifyTokenStore(BrowserCache, ["User.Read"]);
+        await verifyTokenStore(BrowserCache, clientID, ["User.Read"]);
     });
   }
 );

--- a/samples/msal-react-samples/react-router-sample/package.json
+++ b/samples/msal-react-samples/react-router-sample/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "test": "jest",
+    "test": "jest --runInBand",
     "build": "react-scripts build",
     "build:package": "cd ../../../lib/msal-react & npm run build:all",
     "eject": "react-scripts eject",

--- a/samples/msal-react-samples/react-router-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react-router-sample/src/authConfig.js
@@ -14,8 +14,8 @@ const isFirefox = firefox > 0; // Only needed if you need to support the redirec
 // Config object to be passed to Msal on creation
 export const msalConfig = {
     auth: {
-        clientId: "3fba556e-5d4a-48e3-8e1a-fd57c12cb82e",
-        authority: "https://login.windows-ppe.net/common",
+        clientId: "ENTER_CLIENT_ID_HERE",
+        authority: "https://login.microsoftonline.com/ENTER_TENANT_INFO_HERE",
         redirectUri: "/",
         postLogoutRedirectUri: "/"
     },
@@ -26,22 +26,22 @@ export const msalConfig = {
     system: {
         loggerOptions: {
             loggerCallback: (level, message, containsPii) => {
-                if (containsPii) {	
-                    return;	
+                if (containsPii) {
+                    return;
                 }
-                switch (level) {	
-                    case LogLevel.Error:	
-                        console.error(message);	
-                        return;	
-                    case LogLevel.Info:	
-                        console.info(message);	
-                        return;	
-                    case LogLevel.Verbose:	
-                        console.debug(message);	
-                        return;	
-                    case LogLevel.Warning:	
-                        console.warn(message);	
-                        return;	
+                switch (level) {
+                    case LogLevel.Error:
+                        console.error(message);
+                        return;
+                    case LogLevel.Info:
+                        console.info(message);
+                        return;
+                    case LogLevel.Verbose:
+                        console.debug(message);
+                        return;
+                    case LogLevel.Warning:
+                        console.warn(message);
+                        return;
                     default:
                         return;
                 }
@@ -57,5 +57,5 @@ export const loginRequest = {
 
 // Add here the endpoints for MS Graph API services you would like to use.
 export const graphConfig = {
-    graphMeEndpoint: "https://graph.microsoft-ppe.com/v1.0/me"
+    graphMeEndpoint: "https://graph.microsoft.com/v1.0/me"
 };

--- a/samples/msal-react-samples/react-router-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/home.spec.ts
@@ -1,11 +1,15 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, UserTypes, AppPlatforms } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/home-tests`;
+
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.js"));
 
 async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
@@ -24,6 +28,8 @@ describe('/ (Home Page)', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -35,14 +41,26 @@ describe('/ (Home Page)', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {

--- a/samples/msal-react-samples/react-router-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profile.spec.ts
@@ -1,13 +1,17 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, UserTypes, AppPlatforms } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/profile-tests`;
 
-async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.js"));
+
+async function verifyTokenStore(BrowserCache: BrowserCacheUtils, clientID: string, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
     expect(tokenStore.idTokens.length).toBe(1);
     expect(tokenStore.accessTokens.length).toBe(1);
@@ -16,7 +20,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
     expect(Object.keys(storage).length).toBe(7);
-    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
+    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry(clientID);
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry["cacheHits"]).toBe(1);
 }
@@ -27,6 +31,8 @@ describe('/profile', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -38,14 +44,26 @@ describe('/profile', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {
@@ -89,7 +107,7 @@ describe('/profile', () => {
         await screenshot.takeScreenshot(page, "App signed in");
 
         // Verify tokens are in cache
-        await verifyTokenStore(BrowserCache, ["User.Read"]);
+        await verifyTokenStore(BrowserCache, clientID, ["User.Read"]);
     });
 
     it("MsalAuthenticationTemplate - renders children without invoking login if user is already signed in", async () => {
@@ -126,7 +144,7 @@ describe('/profile', () => {
         await page.waitForXPath("//div/ul/li[contains(., 'Name')]", {timeout: 5000});
         await screenshot.takeScreenshot(page, "Graph data acquired");
         // Verify tokens are in cache
-        await verifyTokenStore(BrowserCache, ["User.Read"]);
+        await verifyTokenStore(BrowserCache, clientID, ["User.Read"]);
     });
 
     it("MsalAuthenticationTemplate - renders loading component when popup is open, then error component when loginPopup is cancelled", async () => {

--- a/samples/msal-react-samples/react-router-sample/test/profileRawContext.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profileRawContext.spec.ts
@@ -1,13 +1,17 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, UserTypes, AppPlatforms } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/profileRawContext-tests`;
 
-async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.js"));
+
+async function verifyTokenStore(BrowserCache: BrowserCacheUtils, clientID: string, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
     expect(tokenStore.idTokens.length).toBe(1);
     expect(tokenStore.accessTokens.length).toBe(1);
@@ -16,7 +20,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
     expect(Object.keys(storage).length).toBe(7);
-    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
+    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry(clientID);
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry["cacheHits"]).toBe(1);
 }
@@ -27,6 +31,8 @@ describe('/profileRawContext', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -38,14 +44,26 @@ describe('/profileRawContext', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {
@@ -81,7 +99,7 @@ describe('/profileRawContext', () => {
         await screenshot.takeScreenshot(page, "Graph data acquired");
 
         // Verify tokens are in cache
-        await verifyTokenStore(BrowserCache, ["User.Read"]);
+        await verifyTokenStore(BrowserCache, clientID, ["User.Read"]);
     });
   }
 );

--- a/samples/msal-react-samples/react-router-sample/test/profileWithMsal.spec.ts
+++ b/samples/msal-react-samples/react-router-sample/test/profileWithMsal.spec.ts
@@ -1,13 +1,17 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, UserTypes, AppPlatforms } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/profileWithMsal-tests`;
 
-async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.js"));
+
+async function verifyTokenStore(BrowserCache: BrowserCacheUtils, clientID: string, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
     expect(tokenStore.idTokens.length).toBe(1);
     expect(tokenStore.accessTokens.length).toBe(1);
@@ -16,7 +20,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
     expect(Object.keys(storage).length).toBe(7);
-    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
+    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry(clientID);
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry["cacheHits"]).toBe(1);
 }
@@ -27,6 +31,8 @@ describe('/profileWithMsal', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -38,14 +44,26 @@ describe('/profileWithMsal', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {
@@ -77,7 +95,7 @@ describe('/profileWithMsal', () => {
         await screenshot.takeScreenshot(page, "Graph data acquired");
 
         // Verify tokens are in cache
-        await verifyTokenStore(BrowserCache, ["User.Read"]);
+        await verifyTokenStore(BrowserCache, clientID, ["User.Read"]);
     });
   }
 );

--- a/samples/msal-react-samples/typescript-sample/package.json
+++ b/samples/msal-react-samples/typescript-sample/package.json
@@ -23,7 +23,7 @@
         "start": "react-scripts start",
         "build": "react-scripts build",
         "build:package": "cd ../../../lib/msal-react && npm run build:all",
-        "test": "jest",
+        "test": "jest --runInBand",
         "eject": "react-scripts eject",
         "install:local": "npm install ../../../lib/msal-react ../../../lib/msal-react/node_modules/react ../../../lib/msal-react/node_modules/react-dom ../../../lib/msal-browser",
         "install:published": "npm install @azure/msal-browser@latest @azure/msal-react@latest react@^18 react-dom@^18"

--- a/samples/msal-react-samples/typescript-sample/src/authConfig.ts
+++ b/samples/msal-react-samples/typescript-sample/src/authConfig.ts
@@ -3,8 +3,8 @@ import { Configuration, PopupRequest } from "@azure/msal-browser";
 // Config object to be passed to Msal on creation
 export const msalConfig: Configuration = {
     auth: {
-        clientId: "3fba556e-5d4a-48e3-8e1a-fd57c12cb82e",
-        authority: "https://login.windows-ppe.net/common",
+        clientId: "ENTER_CLIENT_ID_HERE",
+        authority: "https://login.microsoftonline.com/ENTER_TENANT_INFO_HERE",
         redirectUri: "/",
         postLogoutRedirectUri: "/"
     }
@@ -17,5 +17,5 @@ export const loginRequest: PopupRequest = {
 
 // Add here the endpoints for MS Graph API services you would like to use.
 export const graphConfig = {
-    graphMeEndpoint: "https://graph.microsoft-ppe.com/v1.0/me"
+    graphMeEndpoint: "https://graph.microsoft.com/v1.0/me"
 };

--- a/samples/msal-react-samples/typescript-sample/test/home.spec.ts
+++ b/samples/msal-react-samples/typescript-sample/test/home.spec.ts
@@ -1,11 +1,15 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, AppPlatforms, UserTypes } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/home-tests`;
+
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.ts"));
 
 async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
@@ -24,6 +28,8 @@ describe('/ (Home Page)', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -35,14 +41,26 @@ describe('/ (Home Page)', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {

--- a/samples/msal-react-samples/typescript-sample/test/profile.spec.ts
+++ b/samples/msal-react-samples/typescript-sample/test/profile.spec.ts
@@ -1,13 +1,17 @@
+import path from "path";
 import puppeteer from "puppeteer";
-import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES} from "../../../e2eTestUtils/TestUtils";
+import {Screenshot, setupCredentials, enterCredentials, RETRY_TIMES, retrieveAppConfiguration} from "../../../e2eTestUtils/TestUtils";
 import { LabClient } from "../../../e2eTestUtils/LabClient";
 import { LabApiQueryParams } from "../../../e2eTestUtils/LabApiQueryParams";
-import { AzureEnvironments, AppTypes } from "../../../e2eTestUtils/Constants";
+import { AzureEnvironments, AppTypes, UserTypes, AppPlatforms } from "../../../e2eTestUtils/Constants";
 import { BrowserCacheUtils } from "../../../e2eTestUtils/BrowserCacheTestUtils";
+import { StringReplacer } from "../../../e2eTestUtils/ConfigUtils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/profile-tests`;
 
-async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[]): Promise<void> {
+const stringReplacer = new StringReplacer(path.join(__dirname, "../src/authConfig.ts"));
+
+async function verifyTokenStore(BrowserCache: BrowserCacheUtils, clientID: string, scopes: string[]): Promise<void> {
     const tokenStore = await BrowserCache.getTokens();
     expect(tokenStore.idTokens.length).toBe(1);
     expect(tokenStore.accessTokens.length).toBe(1);
@@ -16,7 +20,7 @@ async function verifyTokenStore(BrowserCache: BrowserCacheUtils, scopes: string[
     expect(await BrowserCache.accessTokenForScopesExists(tokenStore.accessTokens, scopes)).toBeTruthy;
     const storage = await BrowserCache.getWindowStorage();
     expect(Object.keys(storage).length).toBe(7);
-    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry("3fba556e-5d4a-48e3-8e1a-fd57c12cb82e");
+    const telemetryCacheEntry = await BrowserCache.getTelemetryCacheEntry(clientID);
     expect(telemetryCacheEntry).not.toBeNull;
     expect(telemetryCacheEntry!.cacheHits).toBe(1);
 }
@@ -27,6 +31,8 @@ describe('/profile', () => {
     let context: puppeteer.BrowserContext;
     let page: puppeteer.Page;
     let port: number;
+    let clientID: string;
+    let authority: string;
     let username: string;
     let accountPwd: string;
     let BrowserCache: BrowserCacheUtils;
@@ -38,14 +44,26 @@ describe('/profile', () => {
         port = global.__PORT__;
 
         const labApiParams: LabApiQueryParams = {
-            azureEnvironment: AzureEnvironments.PPE,
-            appType: AppTypes.CLOUD
+            azureEnvironment: AzureEnvironments.CLOUD,
+            appType: AppTypes.CLOUD,
+            userType: UserTypes.CLOUD,
+            appPlatform: AppPlatforms.SPA,
         };
 
         const labClient = new LabClient();
         const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
         [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+        [clientID, , authority] = await retrieveAppConfiguration(envResponse[0], labClient, false);
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": authority.split("/")[3],
+        });
+    });
+
+    afterAll(async () => {
+        stringReplacer.restore();
     });
 
     beforeEach(async () => {
@@ -85,7 +103,7 @@ describe('/profile', () => {
         await screenshot.takeScreenshot(page, "App signed in");
 
         // Verify tokens are in cache
-        await verifyTokenStore(BrowserCache, ["User.Read"]);
+        await verifyTokenStore(BrowserCache, clientID, ["User.Read"]);
     });
 
     it("MsalAuthenticationTemplate - renders children without invoking login if user is already signed in", async () => {
@@ -122,7 +140,7 @@ describe('/profile', () => {
         await page.waitForXPath("//div/ul/li[contains(., 'Name')]", {timeout: 5000});
         await screenshot.takeScreenshot(page, "Graph data acquired");
         // Verify tokens are in cache
-        await verifyTokenStore(BrowserCache, ["User.Read"]);
+        await verifyTokenStore(BrowserCache, clientID, ["User.Read"]);
     });
   }
 );


### PR DESCRIPTION
This PR removes hardcoded IDs in msal-react samples and replaces ppe endpoints with prod endpoints. 

See also #5687 #5688 