### PR TITLE
Capture WAM bridge telemetry data points

### DIFF
--- a/change/@azure-msal-browser-f55044ef-6dc4-4b0c-8422-39efb069b33a.json
+++ b/change/@azure-msal-browser-f55044ef-6dc4-4b0c-8422-39efb069b33a.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Capture WAM bridge telemetry data points #5698",
+  "comment": "Capture native bridge telemetry data points #5698",
   "packageName": "@azure/msal-browser",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-f55044ef-6dc4-4b0c-8422-39efb069b33a.json
+++ b/change/@azure-msal-browser-f55044ef-6dc4-4b0c-8422-39efb069b33a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Capture WAM bridge telemetry data points #5698",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-5c1774a8-030d-4ab4-a67e-bb8ed28e77b2.json
+++ b/change/@azure-msal-common-5c1774a8-030d-4ab4-a67e-bb8ed28e77b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Capture WAM bridge telemetry data points #5698",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-5c1774a8-030d-4ab4-a67e-bb8ed28e77b2.json
+++ b/change/@azure-msal-common-5c1774a8-030d-4ab4-a67e-bb8ed28e77b2.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Capture WAM bridge telemetry data points #5698",
+  "comment": "Capture native bridge telemetry data points #5698",
   "packageName": "@azure/msal-common",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -185,7 +185,7 @@ export abstract class ClientApplication {
         this.initialized = true;
         this.eventHandler.emitEvent(EventType.INITIALIZE_END);
 
-        initMeasurement.endMeasurement({wamAllowed: allowNativeBroker, success: true});
+        initMeasurement.endMeasurement({allowNativeBroker, success: true});
     }
 
     // #region Redirect Flow

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -170,16 +170,23 @@ export abstract class ClientApplication {
             this.logger.info("initialize has already been called, exiting early.");
             return;
         }
+
+        const allowNativeBroker = this.config.system.allowNativeBroker;
+        const initMeasurement = this.performanceClient.startMeasurement(PerformanceEvents.InitializeClientApplication);
         this.eventHandler.emitEvent(EventType.INITIALIZE_START);
-        if (this.config.system.allowNativeBroker) {
+
+        if (allowNativeBroker) {
             try {
-                this.nativeExtensionProvider = await NativeMessageHandler.createProvider(this.logger, this.config.system.nativeBrokerHandshakeTimeout);
+                this.nativeExtensionProvider = await NativeMessageHandler.createProvider(this.logger, this.config.system.nativeBrokerHandshakeTimeout, this.performanceClient);
             } catch (e) {
                 this.logger.verbose(e);
             }
         }
         this.initialized = true;
         this.eventHandler.emitEvent(EventType.INITIALIZE_END);
+
+        initMeasurement.endMeasurement({wamAllowed: allowNativeBroker, success: true});
+        initMeasurement.flushMeasurement();
     }
 
     // #region Redirect Flow

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -186,7 +186,6 @@ export abstract class ClientApplication {
         this.eventHandler.emitEvent(EventType.INITIALIZE_END);
 
         initMeasurement.endMeasurement({wamAllowed: allowNativeBroker, success: true});
-        initMeasurement.flushMeasurement();
     }
 
     // #region Redirect Flow

--- a/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
@@ -4,7 +4,14 @@
  */
 
 import { NativeConstants, NativeExtensionMethod } from "../../utils/BrowserConstants";
-import { Logger, AuthError, AuthenticationScheme } from "@azure/msal-common";
+import {
+    Logger,
+    AuthError,
+    AuthenticationScheme,
+    InProgressPerformanceEvent,
+    PerformanceEvents,
+    IPerformanceClient
+} from "@azure/msal-common";
 import { NativeExtensionRequest, NativeExtensionRequestBody } from "./NativeRequest";
 import { NativeAuthError } from "../../error/NativeAuthError";
 import { BrowserAuthError } from "../../error/BrowserAuthError";
@@ -19,15 +26,17 @@ export class NativeMessageHandler {
     private extensionId: string | undefined;
     private extensionVersion: string | undefined;
     private logger: Logger;
-    private handshakeTimeoutMs: number;
+    private readonly handshakeTimeoutMs: number;
     private responseId: number;
     private timeoutId: number | undefined;
     private resolvers: Map<number, ResponseResolvers<object>>;
     private handshakeResolvers: Map<number, ResponseResolvers<void>>;
     private messageChannel: MessageChannel;
-    private windowListener: (event: MessageEvent) => void;
+    private readonly windowListener: (event: MessageEvent) => void;
+    private readonly performanceClient: IPerformanceClient;
+    private readonly handshakeEvent: InProgressPerformanceEvent;
 
-    constructor(logger: Logger, handshakeTimeoutMs: number, extensionId?: string) {
+    constructor(logger: Logger, handshakeTimeoutMs: number, performanceClient: IPerformanceClient, extensionId?: string) {
         this.logger = logger;
         this.handshakeTimeoutMs = handshakeTimeoutMs;
         this.extensionId = extensionId;
@@ -36,11 +45,13 @@ export class NativeMessageHandler {
         this.responseId = 0;
         this.messageChannel = new MessageChannel();
         this.windowListener = this.onWindowMessage.bind(this); // Window event callback doesn't have access to 'this' unless it's bound
+        this.performanceClient = performanceClient;
+        this.handshakeEvent = performanceClient.startMeasurement(PerformanceEvents.NativeMessageHandlerHandshake);
     }
 
     /**
      * Sends a given message to the extension and resolves with the extension response
-     * @param body 
+     * @param body
      */
     async sendMessage(body: NativeExtensionRequestBody): Promise<object> {
         this.logger.trace("NativeMessageHandler - sendMessage called.");
@@ -62,18 +73,19 @@ export class NativeMessageHandler {
 
     /**
      * Returns an instance of the MessageHandler that has successfully established a connection with an extension
-     * @param logger 
-     * @param handshakeTimeoutMs
+     * @param {Logger} logger
+     * @param {number} handshakeTimeoutMs
+     * @param {IPerformanceClient} performanceClient
      */
-    static async createProvider(logger: Logger, handshakeTimeoutMs: number): Promise<NativeMessageHandler> {
+    static async createProvider(logger: Logger, handshakeTimeoutMs: number, performanceClient: IPerformanceClient): Promise<NativeMessageHandler> {
         logger.trace("NativeMessageHandler - createProvider called.");
         try {
-            const preferredProvider = new NativeMessageHandler(logger, handshakeTimeoutMs, NativeConstants.PREFERRED_EXTENSION_ID);
+            const preferredProvider = new NativeMessageHandler(logger, handshakeTimeoutMs, performanceClient, NativeConstants.PREFERRED_EXTENSION_ID);
             await preferredProvider.sendHandshakeRequest();
             return preferredProvider;
         } catch (e) {
             // If preferred extension fails for whatever reason, fallback to using any installed extension
-            const backupProvider = new NativeMessageHandler(logger, handshakeTimeoutMs);
+            const backupProvider = new NativeMessageHandler(logger, handshakeTimeoutMs, performanceClient);
             await backupProvider.sendHandshakeRequest();
             return backupProvider;
         }
@@ -91,11 +103,15 @@ export class NativeMessageHandler {
             channel: NativeConstants.CHANNEL_ID,
             extensionId: this.extensionId,
             responseId: this.responseId++,
-
             body: {
                 method: NativeExtensionMethod.HandshakeRequest
             }
         };
+        this.handshakeEvent.addStaticFields({
+            wamChannel: NativeConstants.CHANNEL_ID,
+            wamExtensionId: this.extensionId,
+            wamTimeoutMs: this.handshakeTimeoutMs
+        });
 
         this.messageChannel.port1.onmessage = (event) => {
             this.onChannelMessage(event);
@@ -113,6 +129,8 @@ export class NativeMessageHandler {
                 window.removeEventListener("message", this.windowListener, false);
                 this.messageChannel.port1.close();
                 this.messageChannel.port2.close();
+                this.handshakeEvent.endMeasurement({wamTimedOut: true, success: false});
+                this.handshakeEvent.flushMeasurement();
                 reject(BrowserAuthError.createNativeHandshakeTimeoutError());
                 this.handshakeResolvers.delete(req.responseId);
             }, this.handshakeTimeoutMs); // Use a reasonable timeout in milliseconds here
@@ -121,7 +139,7 @@ export class NativeMessageHandler {
 
     /**
      * Invoked when a message is posted to the window. If a handshake request is received it means the extension is not installed.
-     * @param event 
+     * @param event
      */
     private onWindowMessage(event: MessageEvent): void {
         this.logger.trace("NativeMessageHandler - onWindowMessage called");
@@ -149,6 +167,8 @@ export class NativeMessageHandler {
             window.removeEventListener("message", this.windowListener, false);
             const handshakeResolver = this.handshakeResolvers.get(request.responseId);
             if (handshakeResolver) {
+                this.handshakeEvent.endMeasurement({success: false, wamExtensionInstalled: false});
+                this.handshakeEvent.flushMeasurement();
                 handshakeResolver.reject(BrowserAuthError.createNativeExtensionNotInstalledError());
             }
         }
@@ -156,18 +176,18 @@ export class NativeMessageHandler {
 
     /**
      * Invoked when a message is received from the extension on the MessageChannel port
-     * @param event 
+     * @param event
      */
     private onChannelMessage(event: MessageEvent): void {
         this.logger.trace("NativeMessageHandler - onChannelMessage called.");
         const request = event.data;
-        
+
         const resolver = this.resolvers.get(request.responseId);
         const handshakeResolver = this.handshakeResolvers.get(request.responseId);
 
         try {
             const method = request.body.method;
-            
+
             if (method === NativeExtensionMethod.Response) {
                 if (!resolver) {
                     return;
@@ -196,10 +216,12 @@ export class NativeMessageHandler {
                 this.extensionId = request.extensionId;
                 this.extensionVersion = request.body.version;
                 this.logger.verbose(`NativeMessageHandler - Received HandshakeResponse from extension: ${this.extensionId}`);
+                this.handshakeEvent.endMeasurement({wamExtensionInstalled: true, success: true});
+                this.handshakeEvent.flushMeasurement();
 
                 handshakeResolver.resolve();
                 this.handshakeResolvers.delete(request.responseId);
-            } 
+            }
             // Do nothing if method is not Response or HandshakeResponse
         } catch (err) {
             this.logger.error("Error parsing response from WAM Extension");
@@ -216,7 +238,7 @@ export class NativeMessageHandler {
 
     /**
      * Returns the Id for the browser extension this handler is communicating with
-     * @returns 
+     * @returns
      */
     getExtensionId(): string | undefined {
         return this.extensionId;
@@ -224,18 +246,18 @@ export class NativeMessageHandler {
 
     /**
      * Returns the version for the browser extension this handler is communicating with
-     * @returns 
+     * @returns
      */
     getExtensionVersion(): string | undefined {
         return this.extensionVersion;
     }
-    
+
     /**
      * Returns boolean indicating whether or not the request should attempt to use native broker
      * @param logger
      * @param config
      * @param nativeExtensionProvider
-     * @param authenticationScheme 
+     * @param authenticationScheme
      */
     static isNativeAvailable(config: BrowserConfiguration, logger: Logger, nativeExtensionProvider?: NativeMessageHandler, authenticationScheme?: AuthenticationScheme): boolean {
         logger.trace("isNativeAvailable called");
@@ -265,4 +287,4 @@ export class NativeMessageHandler {
 
         return true;
     }
-} 
+}

--- a/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
@@ -108,7 +108,6 @@ export class NativeMessageHandler {
             }
         };
         this.handshakeEvent.addStaticFields({
-            extensionChannel: NativeConstants.CHANNEL_ID,
             extensionId: this.extensionId,
             extensionHandshakeTimeoutMs: this.handshakeTimeoutMs
         });

--- a/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
@@ -130,7 +130,6 @@ export class NativeMessageHandler {
                 this.messageChannel.port1.close();
                 this.messageChannel.port2.close();
                 this.handshakeEvent.endMeasurement({wamTimedOut: true, success: false});
-                this.handshakeEvent.flushMeasurement();
                 reject(BrowserAuthError.createNativeHandshakeTimeoutError());
                 this.handshakeResolvers.delete(req.responseId);
             }, this.handshakeTimeoutMs); // Use a reasonable timeout in milliseconds here
@@ -168,7 +167,6 @@ export class NativeMessageHandler {
             const handshakeResolver = this.handshakeResolvers.get(request.responseId);
             if (handshakeResolver) {
                 this.handshakeEvent.endMeasurement({success: false, wamExtensionInstalled: false});
-                this.handshakeEvent.flushMeasurement();
                 handshakeResolver.reject(BrowserAuthError.createNativeExtensionNotInstalledError());
             }
         }
@@ -217,7 +215,6 @@ export class NativeMessageHandler {
                 this.extensionVersion = request.body.version;
                 this.logger.verbose(`NativeMessageHandler - Received HandshakeResponse from extension: ${this.extensionId}`);
                 this.handshakeEvent.endMeasurement({wamExtensionInstalled: true, success: true});
-                this.handshakeEvent.flushMeasurement();
 
                 handshakeResolver.resolve();
                 this.handshakeResolvers.delete(request.responseId);

--- a/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
@@ -108,9 +108,9 @@ export class NativeMessageHandler {
             }
         };
         this.handshakeEvent.addStaticFields({
-            wamChannel: NativeConstants.CHANNEL_ID,
-            wamExtensionId: this.extensionId,
-            wamTimeoutMs: this.handshakeTimeoutMs
+            extensionChannel: NativeConstants.CHANNEL_ID,
+            extensionId: this.extensionId,
+            extensionHandshakeTimeoutMs: this.handshakeTimeoutMs
         });
 
         this.messageChannel.port1.onmessage = (event) => {
@@ -129,7 +129,7 @@ export class NativeMessageHandler {
                 window.removeEventListener("message", this.windowListener, false);
                 this.messageChannel.port1.close();
                 this.messageChannel.port2.close();
-                this.handshakeEvent.endMeasurement({wamTimedOut: true, success: false});
+                this.handshakeEvent.endMeasurement({extensionHandshakeTimedOut: true, success: false});
                 reject(BrowserAuthError.createNativeHandshakeTimeoutError());
                 this.handshakeResolvers.delete(req.responseId);
             }, this.handshakeTimeoutMs); // Use a reasonable timeout in milliseconds here
@@ -166,7 +166,7 @@ export class NativeMessageHandler {
             window.removeEventListener("message", this.windowListener, false);
             const handshakeResolver = this.handshakeResolvers.get(request.responseId);
             if (handshakeResolver) {
-                this.handshakeEvent.endMeasurement({success: false, wamExtensionInstalled: false});
+                this.handshakeEvent.endMeasurement({success: false, extensionInstalled: false});
                 handshakeResolver.reject(BrowserAuthError.createNativeExtensionNotInstalledError());
             }
         }
@@ -214,7 +214,7 @@ export class NativeMessageHandler {
                 this.extensionId = request.extensionId;
                 this.extensionVersion = request.body.version;
                 this.logger.verbose(`NativeMessageHandler - Received HandshakeResponse from extension: ${this.extensionId}`);
-                this.handshakeEvent.endMeasurement({wamExtensionInstalled: true, success: true});
+                this.handshakeEvent.endMeasurement({extensionInstalled: true, success: true});
 
                 handshakeResolver.resolve();
                 this.handshakeResolvers.delete(request.responseId);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -568,7 +568,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(events.length).toBe(1);
                 const event = events[0];
                 expect(event.success).toBeTruthy();
-                expect(event.wamAllowed).toBeTruthy();
+                expect(event.allowNativeBroker).toBeTruthy();
                 pca.removePerformanceCallback(callbackId);
                 done();
             }));

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -75,7 +75,6 @@ let testAppConfig = {
     }
 };
 
-
 jest.mock("../../src/telemetry/BrowserPerformanceMeasurement", () => {
     return {
         BrowserPerformanceMeasurement: jest.fn().mockImplementation(() => {
@@ -87,6 +86,14 @@ jest.mock("../../src/telemetry/BrowserPerformanceMeasurement", () => {
         })
     }
 });
+
+function stubProvider(pca: PublicClientApplication) {
+    // @ts-ignore
+    const perfClient = pca.performanceClient;
+    return sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
+        return new NativeMessageHandler(pca.getLogger(), 2000, perfClient, "test-extensionId");
+    });
+}
 
 describe("PublicClientApplication.ts Class Unit Tests", () => {
     globalThis.MessageChannel = require("worker_threads").MessageChannel; // jsdom does not include an implementation for MessageChannel
@@ -123,9 +130,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
     describe("intialize tests", () => {
         it("creates extension provider if allowNativeBroker is true", async () => {
-            const createProviderSpy = sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
             pca = new PublicClientApplication({
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID
@@ -134,6 +138,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     allowNativeBroker: true
                 }
             });
+            const createProviderSpy = stubProvider(pca);
             await pca.initialize();
             expect(createProviderSpy.called).toBeTruthy();
             // @ts-ignore
@@ -270,9 +275,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     loginSuccessFired = true;
                 }
             });
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const response = await pca.handleRedirectPromise();
             expect(response).toEqual(testTokenResponse);
@@ -534,9 +537,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 nativeAccountId: "test-nativeAccountId"
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireTokenRedirect").callsFake(async () => {
                 return;
@@ -551,6 +552,29 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             expect(nativeAcquireTokenSpy.calledOnce).toBeTruthy();
             expect(redirectSpy.calledOnce).toBeFalsy();
+        });
+
+        it("captures telemetry data points during initialization", (done) => {
+            pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID
+                },
+                system: {
+                    allowNativeBroker: true
+                }
+            });
+
+            const callbackId = pca.addPerformanceCallback((events => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                expect(event.success).toBeTruthy();
+                expect(event.wamAllowed).toBeTruthy();
+                pca.removePerformanceCallback(callbackId);
+                done();
+            }));
+
+            stubProvider(pca);
+            pca.initialize();
         });
 
         it("falls back to web flow if prompt is select_account", async () => {
@@ -572,9 +596,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 nativeAccountId: "test-nativeAccountId"
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.spy(NativeInteractionClient.prototype, "acquireTokenRedirect");
             const redirectSpy = sinon.stub(RedirectClient.prototype, "acquireToken").callsFake(async () => {
@@ -609,9 +631,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 nativeAccountId: "test-nativeAccountId"
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireTokenRedirect").callsFake(async () => {
                 throw new NativeAuthError("ContentError", "error in extension");
@@ -647,9 +667,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 nativeAccountId: "test-nativeAccountId"
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireTokenRedirect").callsFake(async () => {
                 throw InteractionRequiredAuthError.createNativeAccountUnavailableError();
@@ -685,9 +703,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 nativeAccountId: "test-nativeAccountId"
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireTokenRedirect").callsFake(async () => {
                 throw new Error("testError");
@@ -982,9 +998,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 return testTokenResponse;
@@ -1035,9 +1049,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.spy(NativeInteractionClient.prototype, "acquireToken");
             const popupSpy = sinon.stub(PopupClient.prototype, "acquireToken").callsFake(async () => {
@@ -1087,9 +1099,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw new NativeAuthError("ContentError", "error in extension");
@@ -1140,9 +1150,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw InteractionRequiredAuthError.createNativeAccountUnavailableError();
@@ -1179,9 +1187,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 nativeAccountId: "test-nativeAccountId"
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw new Error("testError");
@@ -1457,9 +1463,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 return testTokenResponse;
@@ -1510,9 +1514,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw new NativeAuthError("ContentError", "error in extension");
@@ -1549,9 +1551,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 nativeAccountId: "test-nativeAccountId"
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw new Error("testError");
@@ -1777,9 +1777,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 return testTokenResponse;
@@ -1803,9 +1801,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 }
             });
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw new NativeAuthError("ContentError", "something went wrong in the extension");
@@ -2183,9 +2179,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 return testTokenResponse;
@@ -2236,9 +2230,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw new NativeAuthError("ContentError", "error in extension");
@@ -2275,9 +2267,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 nativeAccountId: "test-nativeAccountId"
             };
 
-            sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-                return new NativeMessageHandler(pca.getLogger(), 2000, "test-extensionId");
-            });
+            stubProvider(pca);
             await pca.initialize();
             const nativeAcquireTokenSpy = sinon.stub(NativeInteractionClient.prototype, "acquireToken").callsFake(async () => {
                 throw new Error("testError");

--- a/lib/msal-browser/test/broker/NativeMessageHandler.spec.ts
+++ b/lib/msal-browser/test/broker/NativeMessageHandler.spec.ts
@@ -97,11 +97,11 @@ describe("NativeMessageHandler Tests", () => {
             const callbackId = performanceClient.addPerformanceCallback((events => {
                 expect(events.length).toBe(1);
                 const event = events[0];
-                expect(event.wamTimeoutMs).toEqual(2000);
-                expect(event.wamChannel).toEqual("53ee284d-920a-4b59-9d30-a60315b26836");
-                expect(event.wamExtensionId).toEqual("ppnbnpeolgkicgegkbkbjmhlideopiji");
-                expect(event.wamExtensionInstalled).toBeTruthy();
-                expect(event.wamTimedOut).toBeUndefined();
+                expect(event.extensionHandshakeTimeoutMs).toEqual(2000);
+                expect(event.extensionChannel).toEqual("53ee284d-920a-4b59-9d30-a60315b26836");
+                expect(event.extensionId).toEqual("ppnbnpeolgkicgegkbkbjmhlideopiji");
+                expect(event.extensionInstalled).toBeTruthy();
+                expect(event.extensionHandshakeTimedOut).toBeUndefined();
                 expect(event.success).toBeTruthy();
                 performanceClient.removePerformanceCallback(callbackId);
                 done();
@@ -178,11 +178,11 @@ describe("NativeMessageHandler Tests", () => {
             const callbackId = performanceClient.addPerformanceCallback((events => {
                 expect(events.length).toBe(1);
                 const event = events[0];
-                expect(event.wamTimeoutMs).toEqual(2000);
-                expect(event.wamChannel).toEqual("53ee284d-920a-4b59-9d30-a60315b26836");
-                expect(event.wamExtensionId).toEqual("ppnbnpeolgkicgegkbkbjmhlideopiji");
-                expect(event.wamExtensionInstalled).toBeFalsy();
-                expect(event.wamTimedOut).toBeUndefined();
+                expect(event.extensionHandshakeTimeoutMs).toEqual(2000);
+                expect(event.extensionChannel).toEqual("53ee284d-920a-4b59-9d30-a60315b26836");
+                expect(event.extensionId).toEqual("ppnbnpeolgkicgegkbkbjmhlideopiji");
+                expect(event.extensionInstalled).toBeFalsy();
+                expect(event.extensionHandshakeTimedOut).toBeUndefined();
                 expect(event.success).toBeFalsy();
                 performanceClient.removePerformanceCallback(callbackId);
                 callbackDone = true;

--- a/lib/msal-browser/test/broker/NativeMessageHandler.spec.ts
+++ b/lib/msal-browser/test/broker/NativeMessageHandler.spec.ts
@@ -98,7 +98,6 @@ describe("NativeMessageHandler Tests", () => {
                 expect(events.length).toBe(1);
                 const event = events[0];
                 expect(event.extensionHandshakeTimeoutMs).toEqual(2000);
-                expect(event.extensionChannel).toEqual("53ee284d-920a-4b59-9d30-a60315b26836");
                 expect(event.extensionId).toEqual("ppnbnpeolgkicgegkbkbjmhlideopiji");
                 expect(event.extensionInstalled).toBeTruthy();
                 expect(event.extensionHandshakeTimedOut).toBeUndefined();
@@ -179,7 +178,6 @@ describe("NativeMessageHandler Tests", () => {
                 expect(events.length).toBe(1);
                 const event = events[0];
                 expect(event.extensionHandshakeTimeoutMs).toEqual(2000);
-                expect(event.extensionChannel).toEqual("53ee284d-920a-4b59-9d30-a60315b26836");
                 expect(event.extensionId).toEqual("ppnbnpeolgkicgegkbkbjmhlideopiji");
                 expect(event.extensionInstalled).toBeFalsy();
                 expect(event.extensionHandshakeTimedOut).toBeUndefined();

--- a/lib/msal-browser/test/broker/NativeMessageHandler.spec.ts
+++ b/lib/msal-browser/test/broker/NativeMessageHandler.spec.ts
@@ -3,12 +3,27 @@
  * Licensed under the MIT License.
  */
 
-import { Logger, AuthError, AuthErrorMessage } from "@azure/msal-common";
+import { Logger, AuthError, AuthErrorMessage, IPerformanceClient } from "@azure/msal-common";
 import sinon from "sinon";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
-import { BrowserAuthError, BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
+import { BrowserAuthError, BrowserAuthErrorMessage } from "../../src";
 import { NativeExtensionMethod } from "../../src/utils/BrowserConstants";
 import { NativeAuthError } from "../../src/error/NativeAuthError";
+import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
+
+let performanceClient: IPerformanceClient;
+
+jest.mock("../../src/telemetry/BrowserPerformanceMeasurement", () => {
+    return {
+        BrowserPerformanceMeasurement: jest.fn().mockImplementation(() => {
+            return {
+                startMeasurement: () => {},
+                endMeasurement: () => {},
+                flushMeasurement: () => 50
+            }
+        })
+    }
+});
 
 describe("NativeMessageHandler Tests", () => {
     let postMessageSpy: sinon.SinonSpy;
@@ -18,6 +33,7 @@ describe("NativeMessageHandler Tests", () => {
     beforeEach(() => {
         postMessageSpy = sinon.spy(window, "postMessage");
         sinon.stub(MessageEvent.prototype, "source").get(() => window); // source property not set by jsdom window messaging APIs
+        performanceClient = getDefaultPerformanceClient();
     });
 
     afterEach(() => {
@@ -49,10 +65,52 @@ describe("NativeMessageHandler Tests", () => {
 
             window.addEventListener("message", eventHandler, true);
 
-            const wamMessageHandler = await NativeMessageHandler.createProvider(new Logger({}), 2000);
+            const wamMessageHandler = await NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient);
             expect(wamMessageHandler).toBeInstanceOf(NativeMessageHandler);
 
             window.removeEventListener("message", eventHandler, true);
+        });
+
+        it("Emits event during handshake request to preferred extension which responds", (done) => {
+            const eventHandler = function (event: MessageEvent) {
+                event.stopImmediatePropagation();
+                const request = event.data;
+                const req  = {
+                    channel: "53ee284d-920a-4b59-9d30-a60315b26836",
+                    extensionId: "test-ext-id",
+                    responseId: request.responseId,
+                    body: {
+                        method: "HandshakeResponse",
+                        version: 3
+                    }
+                };
+
+                mcPort = postMessageSpy.args[0][2][0];
+                if (!mcPort) {
+                    throw new Error("MessageChannel port was not transferred");
+                }
+                mcPort.postMessage(req);
+            };
+
+            window.addEventListener("message", eventHandler, true);
+
+            const callbackId = performanceClient.addPerformanceCallback((events => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                expect(event.wamTimeoutMs).toEqual(2000);
+                expect(event.wamChannel).toEqual("53ee284d-920a-4b59-9d30-a60315b26836");
+                expect(event.wamExtensionId).toEqual("ppnbnpeolgkicgegkbkbjmhlideopiji");
+                expect(event.wamExtensionInstalled).toBeTruthy();
+                expect(event.wamTimedOut).toBeUndefined();
+                expect(event.success).toBeTruthy();
+                performanceClient.removePerformanceCallback(callbackId);
+                done();
+            }));
+
+            NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient)
+                .then(() => {
+                    window.removeEventListener("message", eventHandler, true);
+                });
         });
 
         it("Sends handshake to any extension if preferred extension is not installed", async () => {
@@ -83,14 +141,14 @@ describe("NativeMessageHandler Tests", () => {
 
             window.addEventListener("message", eventHandler, true);
 
-            const wamMessageHandler = await NativeMessageHandler.createProvider(new Logger({}), 2000);
+            const wamMessageHandler = await NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient);
             expect(wamMessageHandler).toBeInstanceOf(NativeMessageHandler);
 
             window.removeEventListener("message", eventHandler, true);
         });
 
         it("Throws if no extension is installed", (done) => {
-            NativeMessageHandler.createProvider(new Logger({}), 2000).catch((e) => {
+            NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient).catch((e) => {
                 expect(e).toBeInstanceOf(BrowserAuthError);
                 expect(e.errorCode).toBe(BrowserAuthErrorMessage.nativeExtensionNotInstalled.code);
                 expect(e.errorMessage).toBe(BrowserAuthErrorMessage.nativeExtensionNotInstalled.desc);
@@ -105,7 +163,7 @@ describe("NativeMessageHandler Tests", () => {
 
             window.addEventListener("message", eventHandler, true);
 
-            NativeMessageHandler.createProvider(new Logger({}), 2000).catch((e) => {
+            NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient).catch((e) => {
                 expect(e).toBeInstanceOf(BrowserAuthError);
                 expect(e.errorCode).toBe(BrowserAuthErrorMessage.nativeHandshakeTimeout.code);
                 expect(e.errorMessage).toBe(BrowserAuthErrorMessage.nativeHandshakeTimeout.desc);
@@ -113,6 +171,29 @@ describe("NativeMessageHandler Tests", () => {
             }).finally(() => {
                 window.removeEventListener("message", eventHandler, true);
             });
+        });
+
+        it("Emits event if no extension responds to handshake", (done) => {
+            let callbackDone = false;
+            const callbackId = performanceClient.addPerformanceCallback((events => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                expect(event.wamTimeoutMs).toEqual(2000);
+                expect(event.wamChannel).toEqual("53ee284d-920a-4b59-9d30-a60315b26836");
+                expect(event.wamExtensionId).toEqual("ppnbnpeolgkicgegkbkbjmhlideopiji");
+                expect(event.wamExtensionInstalled).toBeFalsy();
+                expect(event.wamTimedOut).toBeUndefined();
+                expect(event.success).toBeFalsy();
+                performanceClient.removePerformanceCallback(callbackId);
+                callbackDone = true;
+            }));
+
+            NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient)
+                .catch(() => {
+                    if (callbackDone) {
+                        done();
+                    }
+                });
         });
     });
 
@@ -158,7 +239,7 @@ describe("NativeMessageHandler Tests", () => {
 
             window.addEventListener("message", eventHandler, true);
 
-            const wamMessageHandler = await NativeMessageHandler.createProvider(new Logger({}), 2000);
+            const wamMessageHandler = await NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient);
             expect(wamMessageHandler).toBeInstanceOf(NativeMessageHandler);
 
             const response = await wamMessageHandler.sendMessage({method: NativeExtensionMethod.GetToken});
@@ -207,7 +288,7 @@ describe("NativeMessageHandler Tests", () => {
 
             window.addEventListener("message", eventHandler, true);
 
-            NativeMessageHandler.createProvider(new Logger({}), 2000).then((wamMessageHandler) => {
+            NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient).then((wamMessageHandler) => {
                 wamMessageHandler.sendMessage({method: NativeExtensionMethod.GetToken}).catch((e) => {
                     expect(e).toBeInstanceOf(NativeAuthError);
                     expect(e.errorCode).toEqual(testResponse.code);
@@ -261,7 +342,7 @@ describe("NativeMessageHandler Tests", () => {
 
             window.addEventListener("message", eventHandler, true);
 
-            NativeMessageHandler.createProvider(new Logger({}), 2000).then((wamMessageHandler) => {
+            NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient).then((wamMessageHandler) => {
                 wamMessageHandler.sendMessage({method: NativeExtensionMethod.GetToken}).catch((e) => {
                     expect(e).toBeInstanceOf(NativeAuthError);
                     expect(e.errorCode).toEqual(testResponse.result.code);
@@ -311,7 +392,7 @@ describe("NativeMessageHandler Tests", () => {
 
             window.addEventListener("message", eventHandler, true);
 
-            NativeMessageHandler.createProvider(new Logger({}), 2000).then((wamMessageHandler) => {
+            NativeMessageHandler.createProvider(new Logger({}), 2000, performanceClient).then((wamMessageHandler) => {
                 wamMessageHandler.sendMessage({method: NativeExtensionMethod.GetToken}).catch((e) => {
                     expect(e).toBeInstanceOf(AuthError);
                     expect(e.errorCode).toEqual(AuthErrorMessage.unexpectedError.code);

--- a/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
@@ -15,6 +15,7 @@ import { BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
 import { NativeAuthError, NativeAuthErrorMessage } from "../../src/error/NativeAuthError";
 import { SilentCacheClient } from "../../src/interaction_client/SilentCacheClient";
 import { NativeExtensionRequestBody } from "../../src/broker/nativeBroker/NativeRequest";
+import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
 
 const networkInterface = {
     sendGetRequestAsync<T>(): T {
@@ -65,7 +66,7 @@ describe("NativeInteractionClient Tests", () => {
             clientId: TEST_CONFIG.MSAL_CLIENT_ID
         }
     });
-    const wamProvider = new NativeMessageHandler(pca.getLogger(), 2000);
+    const wamProvider = new NativeMessageHandler(pca.getLogger(), 2000, getDefaultPerformanceClient());
     // @ts-ignore
     const nativeInteractionClient = new NativeInteractionClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.getLogger(), pca.eventHandler, pca.navigationClient, ApiId.acquireTokenRedirect, pca.performanceClient, wamProvider, "nativeAccountId", pca.nativeInternalStorage, RANDOM_TEST_GUID);
     let postMessageSpy: sinon.SinonSpy;

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -17,6 +17,7 @@ import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessag
 import { BrowserAuthError, BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
 import { FetchClient } from "../../src/network/FetchClient";
 import { InteractionHandler } from "../../src/interaction_handler/InteractionHandler";
+import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
 
 const testPopupWondowDefaults = {
     height: BrowserConstants.POPUP_HEIGHT,
@@ -232,7 +233,7 @@ describe("PopupClient", () => {
             });
             sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
             // @ts-ignore
-            const nativeMessageHandler = new NativeMessageHandler(pca.logger);
+            const nativeMessageHandler = new NativeMessageHandler(pca.logger, 2000, getDefaultPerformanceClient());
             //@ts-ignore
             popupClient = new PopupClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient, pca.performanceClient, pca.nativeInternalStorage, nativeMessageHandler);
             const tokenResp = await popupClient.acquireToken({

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -23,6 +23,7 @@ import { EventHandler } from "../../src/event/EventHandler";
 import { EventType } from "../../src/event/EventType";
 import { NativeInteractionClient } from "../../src/interaction_client/NativeInteractionClient";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
+import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
 
 const cacheConfig = {
     cacheLocation: BrowserCacheLocation.SessionStorage,
@@ -250,7 +251,7 @@ describe("RedirectClient", () => {
                 }
             });
             // @ts-ignore
-            const nativeMessageHandler = new NativeMessageHandler(pca.logger);
+            const nativeMessageHandler = new NativeMessageHandler(pca.logger, 2000, getDefaultPerformanceClient());
             // @ts-ignore
             redirectClient = new RedirectClient(pca.config, browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient, pca.performanceClient, pca.nativeInternalStorage, nativeMessageHandler);
             const b64Encode = new Base64Encode();

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -15,6 +15,7 @@ import { BrowserCacheManager } from "../../src/cache/BrowserCacheManager";
 import { ApiId } from "../../src";
 import { NativeInteractionClient } from "../../src/interaction_client/NativeInteractionClient";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
+import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
 
 describe("SilentIframeClient", () => {
     globalThis.MessageChannel = require("worker_threads").MessageChannel; // jsdom does not include an implementation for MessageChannel
@@ -231,7 +232,7 @@ describe("SilentIframeClient", () => {
                 }
             });
             // @ts-ignore
-            const nativeMessageHandler = new NativeMessageHandler(pca.logger);
+            const nativeMessageHandler = new NativeMessageHandler(pca.logger, 2000, getDefaultPerformanceClient());
             // @ts-ignore
             silentIframeClient = new SilentIframeClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient, ApiId.acquireTokenSilent_authCode, pca.performanceClient, pca.nativeInternalStorage, nativeMessageHandler);
             const testServerTokenResponse = {

--- a/lib/msal-browser/test/utils/TelemetryUtils.ts
+++ b/lib/msal-browser/test/utils/TelemetryUtils.ts
@@ -1,0 +1,19 @@
+import { Logger, ApplicationTelemetry, IPerformanceClient } from "@azure/msal-common";
+import { name, version } from "../../src/packageMetadata";
+import { BrowserPerformanceClient } from "../../src/telemetry/BrowserPerformanceClient";
+
+const clientId = "test-client-id";
+const authority = "https://login.microsoftonline.com";
+const logger = new Logger({});
+const applicationTelemetry: ApplicationTelemetry = {
+    appName: "Test App",
+    appVersion: "1.0.0-test.0"
+}
+const cryptoOptions = {
+    useMsrCrypto: false,
+    entropy: undefined
+}
+
+export function getDefaultPerformanceClient(): IPerformanceClient {
+    return new BrowserPerformanceClient(clientId, authority, logger, name, version, applicationTelemetry, cryptoOptions);
+}

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -158,6 +158,8 @@ export enum PerformanceEvents {
      */
     InitializeSilentRequest = "initializeSilentRequest",
 
+    InitializeClientApplication = "initializeClientApplication",
+
     /**
      * Helper function in SilentIframeClient class (msal-browser).
      */
@@ -238,6 +240,7 @@ export enum PerformanceEvents {
 
     UsernamePasswordClientAcquireToken = "usernamePasswordClientAcquireToken",
 
+    NativeMessageHandlerHandshake = "nativeMessageHandlerHandshake",
 }
 
 /**
@@ -322,6 +325,16 @@ export type StaticFields = {
     matsHttpEventCount?: number;
     httpVerToken?: string;
     httpVerAuthority?: string;
+
+    /**
+     * WAM bridge flags
+     */
+    wamAllowed?: boolean;
+    wamChannel?: string;
+    wamExtensionInstalled?: boolean;
+    wamExtensionId?: string;
+    wamTimeoutMs?: number;
+    wamTimedOut?: boolean;
 };
 
 /**

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -330,7 +330,6 @@ export type StaticFields = {
      * Native broker fields
      */
     allowNativeBroker?: boolean;
-    extensionChannel?: string;
     extensionInstalled?: boolean;
     extensionHandshakeTimeoutMs?: number;
     extensionHandshakeTimedOut?: boolean;

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -327,14 +327,13 @@ export type StaticFields = {
     httpVerAuthority?: string;
 
     /**
-     * WAM bridge flags
+     * Native broker fields
      */
-    wamAllowed?: boolean;
-    wamChannel?: string;
-    wamExtensionInstalled?: boolean;
-    wamExtensionId?: string;
-    wamTimeoutMs?: number;
-    wamTimedOut?: boolean;
+    allowNativeBroker?: boolean;
+    extensionChannel?: string;
+    extensionInstalled?: boolean;
+    extensionHandshakeTimeoutMs?: number;
+    extensionHandshakeTimedOut?: boolean;
 };
 
 /**


### PR DESCRIPTION
- Add `performanceClient` param to `NativeMessageHandler`.
- Capture WAM bridge telemetry data points.
- Remove repetitive `NativeMessageHandler` stubbing in unit tests.
- Add `TelemetryUtils` to `msal-browser` test package to seamlessly mock telemetry client.

Note: Since `NativeMessageHandler` constructor is not invoked directly in 1p there won't be any breaking changes.