### PR TITLE
Use matrix strategy for running browser e2e tests

### DIFF
--- a/.github/workflows/msal-browser-e2e.yml
+++ b/.github/workflows/msal-browser-e2e.yml
@@ -5,8 +5,8 @@ name: msal-browser E2E Tests
 
 on:
   pull_request:
-    paths: 
-      - 'lib/msal-browser/**/*' 
+    paths:
+      - 'lib/msal-browser/**/*'
       - 'lib/msal-common/**/*'
       - 'samples/msal-browser-samples/VanillaJSTestApp2.0/**/*'
       - 'samples/e2eTestUtils/**/*'
@@ -27,6 +27,18 @@ jobs:
   run-e2e:
     if: (github.repository == 'AzureAD/microsoft-authentication-library-for-js') && (github.actor != 'dependabot[bot]') && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'merge_group'))
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        sample:
+          - 'client-capabilities'
+          - 'multipleResources'
+          - 'onPageLoad'
+          - 'pop'
+          - 'customizable-e2e-test'
+
+    name: ${{ matrix.sample }}
 
     steps:
     - uses: actions/checkout@v3
@@ -52,7 +64,7 @@ jobs:
     - name: Restore node_modules for test tools
       uses: actions/cache@v3
       id: test-tools-cache
-      with: 
+      with:
         path: |
           samples/node_modules
           samples/.cache/puppeteer
@@ -66,7 +78,7 @@ jobs:
     - name: Restore node_modules for sample
       uses: actions/cache@v3
       id: sample-cache
-      with: 
+      with:
         path: samples/msal-browser-samples/VanillaJSTestApp2.0/node_modules
         key: ${{ runner.os }}-browser-sample-${{ hashFiles('samples/msal-browser-samples/VanillaJSTestApp2.0/package.json', 'samples/package-lock.json') }}
 
@@ -86,7 +98,7 @@ jobs:
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      run: npm run test:e2e
+      run: npm run test:e2e -- --sample=${{ matrix.sample }}
 
     - name: Upload E2E Test Screenshots
       uses: actions/upload-artifact@v3

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/jest.config.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/jest.config.js
@@ -3,17 +3,12 @@ const path = require("path");
 
 const APP_DIR = path.join(__dirname, 'app');
 
-let sampleFolders;
-
-if (process.argv.find((x) => x.startsWith('--sample'))) {
-    sampleFolders = [APP_DIR + '/' + process.argv.find((x) => x.startsWith('--sample')).split('=')[1]];
-} else {
-    sampleFolders = fs.readdirSync(APP_DIR, { withFileTypes: true }).filter(function(file) {
-        return file.isDirectory() && file.name !== "node_modules" && fs.existsSync(path.resolve(APP_DIR, file.name, "jest.config.js"));
-    }).map(function(file) {
-        return path.join(APP_DIR, file.name);
-    });
-}
+// if a sample is specified, only run tests for that sample
+const sampleFolders = process.argv.find(arg => arg.startsWith('--sample='))
+    ? [path.join(APP_DIR, process.argv.find(arg => arg.startsWith('--sample='))?.split('=')[1])]
+    : fs.readdirSync(APP_DIR, { withFileTypes: true })
+        .filter(file => file.isDirectory() && file.name !== "node_modules" && fs.existsSync(path.resolve(APP_DIR, file.name, "jest.config.js")))
+        .map(file => path.join(APP_DIR, file.name));
 
 module.exports = {
     projects: sampleFolders,

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/jest.config.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/jest.config.js
@@ -3,13 +3,19 @@ const path = require("path");
 
 const APP_DIR = path.join(__dirname, 'app');
 
-const sampleFolders = fs.readdirSync(APP_DIR, { withFileTypes: true }).filter(function(file) {
-    return file.isDirectory() && file.name !== "node_modules" && fs.existsSync(path.resolve(APP_DIR, file.name, "jest.config.js"));
-}).map(function(file) {
-    return path.join(APP_DIR, file.name);
-});
+let sampleFolders;
+
+if (process.argv.find((x) => x.startsWith('--sample'))) {
+    sampleFolders = [APP_DIR + '/' + process.argv.find((x) => x.startsWith('--sample')).split('=')[1]];
+} else {
+    sampleFolders = fs.readdirSync(APP_DIR, { withFileTypes: true }).filter(function(file) {
+        return file.isDirectory() && file.name !== "node_modules" && fs.existsSync(path.resolve(APP_DIR, file.name, "jest.config.js"));
+    }).map(function(file) {
+        return path.join(APP_DIR, file.name);
+    });
+}
 
 module.exports = {
-    projects : sampleFolders,
+    projects: sampleFolders,
     testTimeout: 30000
 };


### PR DESCRIPTION
Updates msal-browser-e2e workflow to use multiple jobs for running browser e2e tests. This gives better visibility to failed tests, ability to retry only the failed ones, and slightly improves run time.