### PR TITLE
remove ppe in msal-core samples

### DIFF
--- a/samples/msal-core-samples/VanillaJSTestApp/app/adfs/authConfig.js
+++ b/samples/msal-core-samples/VanillaJSTestApp/app/adfs/authConfig.js
@@ -1,9 +1,9 @@
 // Config object to be passed to Msal on creation
 const msalConfig = {
     auth: {
-        clientId: "57448aa1-9515-4176-a106-5cb9be8550e1",
-        authority: "https://fs.msidlab8.com/adfs/",
-        knownAuthorities: ["fs.msidlab8.com"]
+        clientId: "ENTER_CLIENT_ID_HERE",
+        authority: "ENTER_ADFS_AUTHORITY_HERE",
+        knownAuthorities: ["ENTER_ADFS_DOMAIN_HERE"]
     },
     cache: {
         cacheLocation: "localStorage", // This configures where your cache will be stored

--- a/samples/msal-core-samples/VanillaJSTestApp/app/default/authConfig.js
+++ b/samples/msal-core-samples/VanillaJSTestApp/app/default/authConfig.js
@@ -7,9 +7,9 @@ const msalLogger = new Msal.Logger((level, message, pii) => {
 
 const msalConfig = {
     auth: {
-        clientId: "8fcb9fc1-d8f9-49c0-b80e-a8a8a201d051",
+        clientId: "ENTER_CLIENT_ID_HERE",
+        authority: "https://login.microsoftonline.com/ENTER_TENANT_INFO_HERE",
         redirectUri: "http://localhost:30662/",
-        authority: "https://login.windows-ppe.net/common"
     },
     cache: {
         cacheLocation: "localStorage", // This configures where your cache will be stored

--- a/samples/msal-core-samples/VanillaJSTestApp/app/default/graphConfig.js
+++ b/samples/msal-core-samples/VanillaJSTestApp/app/default/graphConfig.js
@@ -1,7 +1,7 @@
 // Add here the endpoints for MS Graph API services you would like to use.
 const graphConfig = {
-    graphMeEndpoint: "https://graph.microsoft-ppe.com/v1.0/me",
-    graphMailEndpoint: "https://graph.microsoft-ppe.com/v1.0/me/messages"
+    graphMeEndpoint: "https://graph.microsoft.com/v1.0/me",
+    graphMailEndpoint: "https://graph.microsoft.com/v1.0/me/messages"
 };
 
 // Add here scopes for access token to be used at MS Graph API endpoints.

--- a/samples/msal-core-samples/VanillaJSTestApp/app/default/test/browser.spec.ts
+++ b/samples/msal-core-samples/VanillaJSTestApp/app/default/test/browser.spec.ts
@@ -1,13 +1,18 @@
-import * as Mocha from "mocha";
+import path from "path"
 import puppeteer from "puppeteer";
 import { expect } from "chai";
 import fs from "fs";
 import { LabClient, ILabApiParams } from "../../../e2eTests/LabClient";
+import { StringReplacer } from "../../../../../e2eTestUtils/ConfigUtils";
+
+const stringReplacer = new StringReplacer(path.join(__dirname, "../authConfig.js"));
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
 let SCREENSHOT_NUM = 0;
 let username = "";
 let accountPwd = "";
+let clientID: string;
+let tenantID: string;
 
 function setupScreenshotDir() {
     if (!fs.existsSync(`${SCREENSHOT_BASE_FOLDER_NAME}`)) {
@@ -17,15 +22,25 @@ function setupScreenshotDir() {
 
 async function setupCredentials() {
     const testCreds = new LabClient();
-    const userParams: ILabApiParams = {azureEnvironment: "azureppe"};
+    const userParams: ILabApiParams = {
+        azureEnvironment: "azurecloud",
+        userType: "cloud",
+        appPlatform: "spa",
+    };
     const envResponse = await testCreds.getUserVarsByCloudEnvironment(userParams);
+
     const testEnv = envResponse[0];
     if (testEnv.upn) {
         username = testEnv.upn;
     }
+    if (testEnv.tenantID) {
+        tenantID = testEnv.tenantID;
+    }
+    if (testEnv.appId) {
+        clientID = testEnv.appId;
+    }
 
     const testPwdSecret = await testCreds.getSecret(testEnv.labName);
-
     accountPwd = testPwdSecret.value;
 }
 
@@ -47,6 +62,14 @@ async function enterCredentials(page: puppeteer.Page, testName: string): Promise
     await takeScreenshot(page, testName, "pwdInputPage");
     await page.type("#i0118", accountPwd);
     await page.click("#idSIButton9");
+    await page.waitForSelector('input#KmsiCheckboxField', {timeout: 1000});
+    await page.waitForSelector("input#idSIButton9");
+    await Promise.all([
+        page.waitForResponse((response) => response.url().startsWith("http://localhost")),
+        page.click('input#idSIButton9')
+    ]).catch(async (e) => {
+        throw e;
+    });
 }
 
 describe("Browser tests", function () {
@@ -56,7 +79,13 @@ describe("Browser tests", function () {
     let browser: puppeteer.Browser;
     before(async () => {
         setupScreenshotDir();
-        setupCredentials();
+        await setupCredentials();
+
+        stringReplacer.replace({
+            "ENTER_CLIENT_ID_HERE": clientID,
+            "ENTER_TENANT_INFO_HERE": tenantID,
+        });
+
         browser = await puppeteer.launch({
             headless: true,
             ignoreDefaultArgs: ["--no-sandbox", "–disable-setuid-sandbox"]
@@ -79,6 +108,7 @@ describe("Browser tests", function () {
     after(async () => {
         await context.close();
         await browser.close();
+        stringReplacer.restore();
     });
 
     it("Performs loginRedirect", async () => {
@@ -93,9 +123,9 @@ describe("Browser tests", function () {
         // Enter credentials
         await enterCredentials(page, testName);
         // Wait for return to page
-        await page.waitForNavigation({ waitUntil: "networkidle0"});
+        await page.waitForNavigation({ waitUntil: "networkidle0" });
         await takeScreenshot(page, testName, "samplePageLoggedIn");
-        const localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        const localStorage = await page.evaluate(() => Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(5);
     });
 
@@ -116,7 +146,7 @@ describe("Browser tests", function () {
         // Wait until popup window closes and see that we are logged in
         await popupWindowClosed;
         await takeScreenshot(page, testName, "samplePageLoggedIn");
-        const localStorage = await page.evaluate(() =>  Object.assign({}, window.localStorage));
+        const localStorage = await page.evaluate(() => Object.assign({}, window.localStorage));
         expect(Object.keys(localStorage).length).to.be.eq(5);
         expect(popupPage.isClosed()).to.be.true;
     });

--- a/samples/msal-core-samples/VanillaJSTestApp/app/get_access_token_interactively/authConfig.js
+++ b/samples/msal-core-samples/VanillaJSTestApp/app/get_access_token_interactively/authConfig.js
@@ -1,10 +1,10 @@
 // Config object to be passed to Msal on creation
 const msalConfig = {
     auth: {
-        clientId: "8fcb9fc1-d8f9-49c0-b80e-a8a8a201d051",
+        clientId: "ENTER_CLIENT_ID_HERE",
+        authority: "https://login.microsoftonline.com/ENTER_TENANT_INFO_HERE",
         redirectUri: "http://localhost:30662/",
         navigateToLoginRequestUrl: true,
-        authority: "https://login.windows-ppe.net/common"
     },
     cache: {
         cacheLocation: "localStorage", // This configures where your cache will be stored

--- a/samples/msal-core-samples/VanillaJSTestApp/app/get_access_token_interactively/graph.js
+++ b/samples/msal-core-samples/VanillaJSTestApp/app/get_access_token_interactively/graph.js
@@ -1,6 +1,6 @@
 // Add here the endpoints for MS Graph API services you would like to use.
 const graphConfig = {
-    graphMeEndpoint: "https://graph.microsoft-ppe.com/v1.0/me"
+    graphMeEndpoint: "https://graph.microsoft.com/v1.0/me"
 };
 
 // Helper function to call MS Graph API endpoint

--- a/samples/msal-core-samples/VanillaJSTestApp/e2eTests/LabClient.ts
+++ b/samples/msal-core-samples/VanillaJSTestApp/e2eTests/LabClient.ts
@@ -7,7 +7,8 @@ export interface ILabApiParams {
     azureEnvironment?: string,
     userType?: string,
     b2cProvider?: string,
-    federationProvider?: string
+    federationProvider?: string,
+    appPlatform?: string,
 };
 
 export class LabClient {
@@ -15,7 +16,7 @@ export class LabClient {
     private credentials: ClientSecretCredential;
     private currentToken: AccessToken;
     constructor() {
-        this.credentials = new ClientSecretCredential(process.env["AZURE_TENANT_ID"], process.env["AZURE_CLIENT_ID"], process.env["AZURE_CLIENT_SECRET"]);   
+        this.credentials = new ClientSecretCredential(process.env["AZURE_TENANT_ID"], process.env["AZURE_CLIENT_ID"], process.env["AZURE_CLIENT_SECRET"]);
     }
 
     private async getCurrentToken(): Promise<string> {
@@ -39,7 +40,7 @@ export class LabClient {
         } catch (e) {
             console.error(e);
         }
-    
+
         return null;
     }
 
@@ -61,6 +62,9 @@ export class LabClient {
         }
         if (apiParams.federationProvider) {
             queryParams.push(`federationprovider=${apiParams.federationProvider}`);
+        }
+        if (apiParams.appPlatform) {
+            queryParams.push(`appPlatform=${apiParams.appPlatform}`);
         }
 
         if (queryParams.length <= 0) {


### PR DESCRIPTION
This PR removes hardcoded IDs in msal-core samples and replaces ppe endpoints with prod endpoints. 

See also #5688 