### PR TITLE
Remove deprecated telemetry event `flushMeasurement()` function

### DIFF
--- a/change/@azure-msal-browser-50b46906-3657-41b7-a4de-ea307d9dd5b1.json
+++ b/change/@azure-msal-browser-50b46906-3657-41b7-a4de-ea307d9dd5b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove deprecated telemetry `flushMeasurements()` function from unit tests #5718",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-a9377ff1-3683-40b4-bd59-78b4d576ea0e.json
+++ b/change/@azure-msal-common-a9377ff1-3683-40b4-bd59-78b4d576ea0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Remove deprecated telemetry event \"flushMeasurement()\" function #5718",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -116,7 +116,6 @@ const performanceClient = {
     startMeasurement: jest.fn(),
     endMeasurement: jest.fn(),
     addStaticFields: jest.fn(),
-    flushMeasurements: jest.fn(),
     discardMeasurements: jest.fn(),
     removePerformanceCallback: jest.fn(),
     addPerformanceCallback: jest.fn(),
@@ -242,7 +241,7 @@ describe("InteractionHandler.ts Unit Tests", () => {
             browserStorage.setTemporaryCache(browserStorage.generateStateKey(TEST_STATE_VALUES.TEST_STATE_REDIRECT), TEST_STATE_VALUES.TEST_STATE_REDIRECT);
             browserStorage.setTemporaryCache(browserStorage.generateNonceKey(TEST_STATE_VALUES.TEST_STATE_REDIRECT), idTokenClaims.nonce);
             browserStorage.setTemporaryCache(TemporaryCacheKeys.CCS_CREDENTIAL, JSON.stringify(CcsCredentialType));
-            
+
             sinon.stub(Authority.prototype, "isAlias").returns(false);
             const authorityOptions: AuthorityOptions = {
                 protocolMode: ProtocolMode.AAD,
@@ -275,7 +274,7 @@ describe("InteractionHandler.ts Unit Tests", () => {
             //@ts-ignore
             expect(interactionHandler.handleCodeResponseFromHash(null, "", authorityInstance, authConfig.networkInterface)).rejects.toMatchObject(BrowserAuthError.createEmptyHashError(null));
         });
-        
+
         // TODO: Need to improve these tests
         it("successfully uses a new authority if cloud_instance_host_name is different", async () => {
             const idTokenClaims = {

--- a/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
@@ -54,7 +54,7 @@ describe("RedirectHandler.ts Unit Tests", () => {
     let browserRequestLogger: Logger;
     let browserStorage: BrowserCacheManager;
     let performanceClient: IPerformanceClient;
-    
+
     beforeEach(() => {
         const appConfig: Configuration = {
             auth: {
@@ -137,7 +137,6 @@ describe("RedirectHandler.ts Unit Tests", () => {
             startMeasurement: jest.fn(),
             endMeasurement: jest.fn(),
             addStaticFields: jest.fn(),
-            flushMeasurements: jest.fn(),
             discardMeasurements: jest.fn(),
             removePerformanceCallback: jest.fn(),
             addPerformanceCallback: jest.fn(),
@@ -231,7 +230,7 @@ describe("RedirectHandler.ts Unit Tests", () => {
             sinon.stub(DatabaseStorage.prototype, "open").callsFake(async (): Promise<void> => {
                 dbStorage = {};
             });
-            
+
             const navigationClient = new NavigationClient();
             navigationClient.navigateExternal = (requestUrl, options): Promise<boolean> => {
                 expect(requestUrl).toEqual(TEST_URIS.TEST_ALTERNATE_REDIR_URI);

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -50,7 +50,7 @@ describe("SilentHandler.ts Unit Tests", () => {
     let browserRequestLogger: Logger;
     let browserStorage: BrowserCacheManager;
     let performanceClient: IPerformanceClient;
-    
+
     beforeEach(() => {
         const appConfig: Configuration = {
             auth: {
@@ -127,7 +127,6 @@ describe("SilentHandler.ts Unit Tests", () => {
             startMeasurement: jest.fn(),
             endMeasurement: jest.fn(),
             addStaticFields: jest.fn(),
-            flushMeasurements: jest.fn(),
             discardMeasurements: jest.fn(),
             removePerformanceCallback: jest.fn(),
             addPerformanceCallback: jest.fn(),

--- a/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
@@ -20,8 +20,6 @@ export type InProgressPerformanceEvent = {
 export interface IPerformanceClient {
     startMeasurement(measureName: PerformanceEvents, correlationId?: string): InProgressPerformanceEvent;
     endMeasurement(event: PerformanceEvent): PerformanceEvent | null;
-    // @deprecated use "endMeasurement" instead
-    flushMeasurements(measureName: PerformanceEvents, correlationId?: string): void;
     discardMeasurements(correlationId: string): void;
     addStaticFields(staticFields: StaticFields, correlationId: string): void;
     removePerformanceCallback(callbackId: string): boolean;

--- a/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
@@ -9,8 +9,7 @@ import { IPerformanceMeasurement } from "./IPerformanceMeasurement";
 export type PerformanceCallbackFunction = (events: PerformanceEvent[]) => void;
 
 export type InProgressPerformanceEvent = {
-    endMeasurement: (event?: Partial<PerformanceEvent>) => PerformanceEvent | null
-    flushMeasurement: () => void,
+    endMeasurement: (event?: Partial<PerformanceEvent>) => PerformanceEvent | null,
     discardMeasurement: () => void,
     addStaticFields: (staticFields: StaticFields) => void,
     increment: (counters: Counters) => void,

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -269,10 +269,6 @@ export abstract class PerformanceClient implements IPerformanceClient {
                 },
                 performanceMeasurement);
             },
-            // @deprecated use "endMeasurement" instead
-            flushMeasurement: () => {
-                return this.flushMeasurements(inProgressEvent.name, inProgressEvent.correlationId);
-            },
             discardMeasurement: () => {
                 return this.discardMeasurements(inProgressEvent.correlationId);
             },

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -433,17 +433,6 @@ export abstract class PerformanceClient implements IPerformanceClient {
     }
 
     /**
-     * Gathers and emits performance events for measurements taked for the given top-level API and correlation ID.
-     * @deprecated use "endMeasurement" instead
-     *
-     * @param {PerformanceEvents} measureName
-     * @param {string} correlationId
-     */
-    flushMeasurements(measureName: PerformanceEvents, correlationId: string): void {
-        this.logger.trace(`PerformanceClient: Performance measurements flushed for ${measureName}`, correlationId);
-    }
-
-    /**
      * Removes measurements for a given correlation id.
      *
      * @param {string} correlationId

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -644,9 +644,9 @@ describe("AuthorizationCodeClient unit tests", () => {
 
         it("Throws error if null code request is passed", async () => {
             sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
-            
+
             const client = new AuthorizationCodeClient(config);
-            
+
             // @ts-ignore
             await expect(client.acquireToken(null, null)).rejects.toMatchObject(ClientAuthError.createTokenRequestCannotBeMadeError());
             // @ts-ignore
@@ -657,12 +657,12 @@ describe("AuthorizationCodeClient unit tests", () => {
 
         it("Throws error if code response does not contain authorization code", async () => {
             sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
-            
+
             if (!config.storageInterface) {
                 throw TestError.createTestSetupError("configuration storageInterface not initialized correctly.");
             }
             const client = new AuthorizationCodeClient(config);
-            
+
             const codeRequest: CommonAuthorizationCodeRequest = {
                 redirectUri: TEST_URIS.TEST_REDIR_URI,
                 scopes: ["scope"],
@@ -1309,7 +1309,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                     done(error);
                 }
             });
-    
+
             const client = new AuthorizationCodeClient(config);
             const authorizationCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
@@ -1326,7 +1326,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                     testParam3: "testValue3",
                 },
             };
-    
+
             client.acquireToken(authorizationCodeRequest).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
@@ -1999,7 +1999,7 @@ describe("AuthorizationCodeClient unit tests", () => {
         it.skip('includes the http version in Authorization code client measurement(AT) when received in server response', async () => {
             sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
             sinon.stub(AuthorizationCodeClient.prototype, <any>"executeTokenRequest").resolves(AUTHENTICATION_RESULT_WITH_HEADERS);
-            
+
             if (!config.cryptoInterface) {
                 throw TestError.createTestSetupError("configuration cryptoInterface not initialized correctly.");
             }
@@ -2021,7 +2021,6 @@ describe("AuthorizationCodeClient unit tests", () => {
                 endMeasurement: jest.fn(),
                 addStaticFields: jest.fn(),
                 incrementCounters: jest.fn(),
-                flushMeasurements: jest.fn(),
                 discardMeasurements: jest.fn(),
                 removePerformanceCallback: jest.fn(),
                 addPerformanceCallback: jest.fn(),
@@ -2058,7 +2057,7 @@ describe("AuthorizationCodeClient unit tests", () => {
         it.skip('does not add http version to the measurement when not received in server response', async () => {
             sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
             sinon.stub(AuthorizationCodeClient.prototype, <any>"executeTokenRequest").resolves(AUTHENTICATION_RESULT);
-            
+
             if (!config.cryptoInterface) {
                 throw TestError.createTestSetupError("configuration cryptoInterface not initialized correctly.");
             }
@@ -2080,7 +2079,6 @@ describe("AuthorizationCodeClient unit tests", () => {
                 endMeasurement: jest.fn(),
                 addStaticFields: jest.fn(),
                 incrementCounters: jest.fn(),
-                flushMeasurements: jest.fn(),
                 discardMeasurements: jest.fn(),
                 removePerformanceCallback: jest.fn(),
                 addPerformanceCallback: jest.fn(),

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -309,7 +309,7 @@ describe("RefreshTokenClient unit tests", () => {
                     done(error);
                 }
             });
-    
+
             const client = new RefreshTokenClient(config, stubPerformanceClient);
             const refreshTokenRequest: CommonRefreshTokenRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
@@ -324,7 +324,7 @@ describe("RefreshTokenClient unit tests", () => {
                     testParam3: "testValue3",
                 },
             };
-    
+
             client.acquireToken(refreshTokenRequest).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
@@ -531,7 +531,6 @@ describe("RefreshTokenClient unit tests", () => {
                 endMeasurement: jest.fn(),
                 addStaticFields: jest.fn(),
                 incrementCounters: jest.fn(),
-                flushMeasurements: jest.fn(),
                 discardMeasurements: jest.fn(),
                 removePerformanceCallback: jest.fn(),
                 addPerformanceCallback: jest.fn(),
@@ -568,7 +567,6 @@ describe("RefreshTokenClient unit tests", () => {
                 endMeasurement: jest.fn(),
                 addStaticFields: jest.fn(),
                 incrementCounters: jest.fn(),
-                flushMeasurements: jest.fn(),
                 discardMeasurements: jest.fn(),
                 removePerformanceCallback: jest.fn(),
                 addPerformanceCallback: jest.fn(),


### PR DESCRIPTION
Changes:
- Remove deprecated telemetry `flushMeasurements()` function.
- Remove deprecated telemetry event `flushMeasurement()` function

Note: All references to `event.flushMeasurement()` are removed in both 3p and 1p repos.