### PR TITLE
Fixed bug in msal-node's httpClient

### DIFF
--- a/change/@azure-msal-common-0d8dacd8-a045-4b09-8edd-86afeaa945d3.json
+++ b/change/@azure-msal-common-0d8dacd8-a045-4b09-8edd-86afeaa945d3.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
-  "comment": "Added new UrlToHttpRequestOptions type",
+  "comment": "Fixed bug in msal-node's httpClient #5722",
   "packageName": "@azure/msal-common",
-  "email": "rgins16@gmail.com",
+  "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@azure-msal-common-0d8dacd8-a045-4b09-8edd-86afeaa945d3.json
+++ b/change/@azure-msal-common-0d8dacd8-a045-4b09-8edd-86afeaa945d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added new UrlToHttpRequestOptions type",
+  "packageName": "@azure/msal-common",
+  "email": "rgins16@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-bb4bf07d-017e-4646-b8f7-caf97e35551b.json
+++ b/change/@azure-msal-node-bb4bf07d-017e-4646-b8f7-caf97e35551b.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
-  "comment": "Fixed bug in msal-node's httpClient",
+  "comment": "Fixed bug in msal-node's httpClient #5722",
   "packageName": "@azure/msal-node",
-  "email": "rgins16@gmail.com",
+  "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@azure-msal-node-bb4bf07d-017e-4646-b8f7-caf97e35551b.json
+++ b/change/@azure-msal-node-bb4bf07d-017e-4646-b8f7-caf97e35551b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug in msal-node's httpClient",
+  "packageName": "@azure/msal-node",
+  "email": "rgins16@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -52,7 +52,7 @@ export { TokenCacheContext } from "./cache/persistence/TokenCacheContext";
 export { ISerializableTokenCache } from "./cache/interface/ISerializableTokenCache";
 // Network Interface
 export { INetworkModule, NetworkRequestOptions, StubbedNetworkModule } from "./network/INetworkModule";
-export { NetworkManager, NetworkResponse } from "./network/NetworkManager";
+export { NetworkManager, NetworkResponse, UrlToHttpRequestOptions } from "./network/NetworkManager";
 export { ThrottlingUtils } from "./network/ThrottlingUtils";
 export { RequestThumbprint } from "./network/RequestThumbprint";
 export { IUri } from "./url/IUri";

--- a/lib/msal-common/src/network/NetworkManager.ts
+++ b/lib/msal-common/src/network/NetworkManager.ts
@@ -16,6 +16,18 @@ export type NetworkResponse<T> = {
     status: number;
 };
 
+export type UrlToHttpRequestOptions = {
+    protocol: string;
+    hostname: string;
+    hash: string;
+    search: string;
+    pathname: string;
+    path: string;
+    href: string;
+    port?: number;
+    auth?: string;
+};
+
 export class NetworkManager {
     private networkClient: INetworkModule;
     private cacheManager: CacheManager;

--- a/lib/msal-node/src/network/HttpClient.ts
+++ b/lib/msal-node/src/network/HttpClient.ts
@@ -8,6 +8,7 @@ import { HttpMethod, Constants, HttpStatus, ProxyStatus } from "../utils/Constan
 import { NetworkUtils } from "../utils/NetworkUtils";
 import http from "http";
 import https from "https";
+import { urlToHttpOptions } from "node:url";
 
 /**
  * This class implements the API for network requests.
@@ -224,16 +225,12 @@ const networkRequestViaHttps = <T>(
     const body: string = options?.body || "";
 
     const url = new URL(urlString);
-    const emptyHeaders: Record<string, string> = {};
+    const headers = options?.headers || {} as Record<string, string>;
     const customOptions: https.RequestOptions = {
-        hostname: url.hostname,
-        path: url.pathname,
         method: httpMethod,
-        headers: options?.headers || emptyHeaders,
+        headers: headers,
+        ...urlToHttpOptions(url),
     };
-    if (url.search) {
-        customOptions.path += url.search;
-    }
 
     if (timeout) {
         customOptions.timeout = timeout;

--- a/lib/msal-node/src/network/HttpClient.ts
+++ b/lib/msal-node/src/network/HttpClient.ts
@@ -8,7 +8,6 @@ import { HttpMethod, Constants, HttpStatus, ProxyStatus } from "../utils/Constan
 import { NetworkUtils } from "../utils/NetworkUtils";
 import http from "http";
 import https from "https";
-import { urlToHttpOptions } from "node:url";
 
 /**
  * This class implements the API for network requests.
@@ -229,7 +228,7 @@ const networkRequestViaHttps = <T>(
     const customOptions: https.RequestOptions = {
         method: httpMethod,
         headers: headers,
-        ...urlToHttpOptions(url),
+        ...NetworkUtils.urlToHttpOptions(url),
     };
 
     if (timeout) {

--- a/lib/msal-node/src/network/HttpClient.ts
+++ b/lib/msal-node/src/network/HttpClient.ts
@@ -78,9 +78,6 @@ const networkRequestViaProxy = <T>(
         path: destinationUrl.hostname,
         headers: headers,
     };
-    if (destinationUrl.searchParams) {
-        tunnelRequestOptions.path += `?${destinationUrl.searchParams}`;
-    }
 
     if (timeout) {
         tunnelRequestOptions.timeout = timeout;
@@ -234,8 +231,8 @@ const networkRequestViaHttps = <T>(
         method: httpMethod,
         headers: options?.headers || emptyHeaders,
     };
-    if (url.searchParams) {
-        customOptions.path += `?${url.searchParams}`;
+    if (url.search) {
+        customOptions.path += url.search;
     }
 
     if (timeout) {

--- a/lib/msal-node/src/utils/NetworkUtils.ts
+++ b/lib/msal-node/src/utils/NetworkUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { NetworkResponse } from "@azure/msal-common";
+import { NetworkResponse, UrlToHttpRequestOptions } from "@azure/msal-common";
 
 export class NetworkUtils {
     static getNetworkResponse<T>(headers: Record<string, string>, body: T, statusCode: number): NetworkResponse<T> {
@@ -12,5 +12,31 @@ export class NetworkUtils {
             body: body,
             status: statusCode,
         };
+    }
+
+    /*
+     * Utility function that converts a URL object into an ordinary options object as expected by the
+     * http.request and https.request APIs.
+     * https://github.com/nodejs/node/blob/main/lib/internal/url.js#L1090
+     */
+    static urlToHttpOptions(url: URL): UrlToHttpRequestOptions {
+        const options: UrlToHttpRequestOptions = {
+            protocol: url.protocol,
+            hostname: url.hostname && url.hostname.startsWith("[") ?
+                url.hostname.slice(1, -1) :
+                url.hostname,
+            hash: url.hash,
+            search: url.search,
+            pathname: url.pathname,
+            path: `${url.pathname || ""}${url.search || ""}`,
+            href: url.href,
+        };
+        if (url.port !== "") {
+            options.port = Number(url.port);
+        }
+        if (url.username || url.password) {
+            options.auth = `${decodeURIComponent(url.username)}:${decodeURIComponent(url.password)}`;
+        }
+        return options;
     }
 }

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
@@ -11,6 +11,7 @@ import {
 
 import http from "http";
 import https from "https";
+import { urlToHttpOptions } from "node:url";
 
 enum HttpMethod {
     GET = "get",
@@ -265,17 +266,13 @@ const networkRequestViaHttps = <T>(
     const body: string = options?.body || "";
 
     const url = new URL(urlString);
-    const emptyHeaders: Record<string, string> = {};
-    const customOptions: https.RequestOptions = {
-        hostname: url.hostname,
-        path: url.pathname,
+    const headers = options?.headers || {} as Record<string, string>;
+    let customOptions: https.RequestOptions = {
         method: httpMethod,
-        headers: options?.headers || emptyHeaders,
+        headers: headers,
+        ...urlToHttpOptions(url),
     };
-    if (url.search) {
-        customOptions.path += url.search;
-    }
-
+    
     if (timeout) {
         customOptions.timeout = timeout;
     }

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
@@ -11,7 +11,6 @@ import {
 
 import http from "http";
 import https from "https";
-import { urlToHttpOptions } from "node:url";
 
 enum HttpMethod {
     GET = "get",
@@ -48,6 +47,31 @@ class NetworkUtils {
             body: body,
             status: statusCode,
         };
+    }
+
+    /*
+     * Utility function that converts a URL object into an ordinary options object as expected by the
+     * http.request and https.request APIs.
+     */
+    static urlToHttpOptions(url: URL): https.RequestOptions {
+        const options: https.RequestOptions & Partial<Omit<URL, "port">> = {
+            protocol: url.protocol,
+            hostname: url.hostname && url.hostname.startsWith("[") ?
+                url.hostname.slice(1, -1) :
+                url.hostname,
+            hash: url.hash,
+            search: url.search,
+            pathname: url.pathname,
+            path: `${url.pathname || ""}${url.search || ""}`,
+            href: url.href,
+        };
+        if (url.port !== "") {
+            options.port = Number(url.port);
+        }
+        if (url.username || url.password) {
+            options.auth = `${decodeURIComponent(url.username)}:${decodeURIComponent(url.password)}`;
+        }
+        return options;
     }
 }
 
@@ -270,7 +294,7 @@ const networkRequestViaHttps = <T>(
     let customOptions: https.RequestOptions = {
         method: httpMethod,
         headers: headers,
-        ...urlToHttpOptions(url),
+        ...NetworkUtils.urlToHttpOptions(url),
     };
     
     if (timeout) {

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
@@ -100,18 +100,18 @@ export class HttpClientCurrent implements INetworkModule {
 }
 
 const networkRequestViaProxy = <T>(
-    url: string,
+    destinationUrlString: string,
     proxyUrlString: string,
     httpMethod: string,
     options: NetworkRequestOptions,
     agentOptions?: http.AgentOptions,
     timeout?: number,
 ): Promise<NetworkResponse<T>> => {
-    const headers = options?.headers || {} as Record<string, string>;
+    const destinationUrl = new URL(destinationUrlString);
     const proxyUrl = new URL(proxyUrlString);
-    const destinationUrl = new URL(url);
 
     // "method: connect" must be used to establish a connection to the proxy
+    const headers = options?.headers || {} as Record<string, string>;
     const tunnelRequestOptions: https.RequestOptions = {
         host: proxyUrl.hostname,
         port: proxyUrl.port,
@@ -119,6 +119,9 @@ const networkRequestViaProxy = <T>(
         path: destinationUrl.hostname,
         headers: headers,
     };
+    if (destinationUrl.searchParams) {
+        tunnelRequestOptions.path += `?${destinationUrl.searchParams}`;
+    }
 
     if (timeout) {
         tunnelRequestOptions.timeout = timeout;
@@ -255,7 +258,7 @@ const networkRequestViaProxy = <T>(
 };
 
 const networkRequestViaHttps = <T>(
-    url: string,
+    urlString: string,
     httpMethod: string,
     options?: NetworkRequestOptions,
     agentOptions?: https.AgentOptions,
@@ -264,11 +267,17 @@ const networkRequestViaHttps = <T>(
     const isPostRequest = httpMethod === HttpMethod.POST;
     const body: string = options?.body || "";
 
+    const url = new URL(urlString);
     const emptyHeaders: Record<string, string> = {};
     const customOptions: https.RequestOptions = {
+        hostname: url.hostname,
+        path: url.pathname,
         method: httpMethod,
         headers: options?.headers || emptyHeaders,
     };
+    if (url.searchParams) {
+        customOptions.path += `?${url.searchParams}`;
+    }
 
     if (timeout) {
         customOptions.timeout = timeout;
@@ -287,7 +296,7 @@ const networkRequestViaHttps = <T>(
     }
 
     return new Promise<NetworkResponse<T>>((resolve, reject) => {
-        const request = https.request(url, customOptions);
+        const request = https.request(customOptions);
 
         if (timeout) {
             request.on("timeout", () => {

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
@@ -119,9 +119,6 @@ const networkRequestViaProxy = <T>(
         path: destinationUrl.hostname,
         headers: headers,
     };
-    if (destinationUrl.searchParams) {
-        tunnelRequestOptions.path += `?${destinationUrl.searchParams}`;
-    }
 
     if (timeout) {
         tunnelRequestOptions.timeout = timeout;
@@ -275,8 +272,8 @@ const networkRequestViaHttps = <T>(
         method: httpMethod,
         headers: options?.headers || emptyHeaders,
     };
-    if (url.searchParams) {
-        customOptions.path += `?${url.searchParams}`;
+    if (url.search) {
+        customOptions.path += url.search;
     }
 
     if (timeout) {

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/app.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/app.ts
@@ -34,6 +34,7 @@ const clientConfig: msal.Configuration = {
          * console.log()'s can be added to help the developer debug network issues
          */
         // networkClient: new HttpClientCurrent,
+        // networkClient: new HttpClientCurrent(<proxyUrl>, <customHttp(s)AgentOptions>),
         // networkClient: new HttpClientAxios,
 
         /**


### PR DESCRIPTION
We've been receiving reports of users receiving the error:

`Error: TypeError
Error Description: The "listener" argument must be of type function. Received an instance of Object - []`

I wasn't able to reproduce the issue from any user reports, however, a fellow Microsoft employee who works on the VSCode team received the same error in a VSCode extension she was building. She walked me through the build steps for her VSCode extension and reproduction steps, and then I was finally able to reproduce the issue.

As it relates to msal-node's HttpClient: I'm not sure why this error was being thrown, because the nodejs code where the error occurs adheres to the documentation on NodeJS's website. Specifically, I'm talking about [https.request](https://nodejs.org/docs/latest-v16.x/api/http.html#httprequesturl-options-callback).

The relevant code in msal-node's code base is [located here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/src/network/HttpClient.ts#L249). According to the docs, we can make a https request this way:
 ```https.request(url, options)```.

However, I needed to change that linked code to the following to resolve the error:
```
const customOptions: https.RequestOptions = {
        hostname: url.hostname, // <-- new code
        path: url.pathname, // <-- new code
        method: httpMethod,
        headers: options?.headers || emptyHeaders,
    };
...
https.request(customOptions)
```

Update: I have been looking into this for a while, and the only conclusion I can draw is that maybe the NodeJS docs are incorrect, or this is a NodeJS bug.