### PR TITLE
lock node version in build-test-pr workflow

### DIFF
--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -88,6 +88,8 @@ jobs:
 
     - name: Use Node.js
       uses: actions/setup-node@v3
+      with:
+        node-version: 16
 
     - name: Restore node_modules
       uses: actions/cache@v3


### PR DESCRIPTION
Angular CI is also failing similar to #5721. Should we add an if clause to do this only for msal-angular?