### PR TITLE
Require application invoke initialize() function

### DIFF
--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -18,7 +18,6 @@ import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { BrowserConfiguration } from "../config/Configuration";
 
 export interface IPublicClientApplication {
-    initialize(): Promise<void>;
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
     acquireTokenRedirect(request: RedirectRequest): Promise<void>;
     acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
@@ -51,53 +50,50 @@ export interface IPublicClientApplication {
 }
 
 export const stubbedPublicClientApplication: IPublicClientApplication = {
-    initialize: () => {
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
-    },
     acquireTokenPopup: () => {
         return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
     },
-    acquireTokenRedirect: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
-    },	
-    acquireTokenSilent: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
+    acquireTokenRedirect: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
+    },
+    acquireTokenSilent: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
     },
     acquireTokenByCode: () => {
         return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
     },
     getAllAccounts: () => {
-        return [];	
-    },	
+        return [];
+    },
     getAccountByHomeId: () => {
         return null;
     },
-    getAccountByUsername: () => {	
-        return null;	
-    },	
+    getAccountByUsername: () => {
+        return null;
+    },
     getAccountByLocalId: () => {
         return null;
     },
-    handleRedirectPromise: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
-    },	
-    loginPopup: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
-    },	
-    loginRedirect: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
-    },	
-    logout: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
-    },	
-    logoutRedirect: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
+    handleRedirectPromise: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
     },
-    logoutPopup: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
+    loginPopup: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
     },
-    ssoSilent: () => {	
-        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());	
+    loginRedirect: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
+    },
+    logout: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
+    },
+    logoutRedirect: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
+    },
+    logoutPopup: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
+    },
+    ssoSilent: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
     },
     addEventCallback: () => {
         return null;

--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -18,6 +18,7 @@ import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { BrowserConfiguration } from "../config/Configuration";
 
 export interface IPublicClientApplication {
+    initialize(): Promise<void>;
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
     acquireTokenRedirect(request: RedirectRequest): Promise<void>;
     acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
@@ -50,6 +51,9 @@ export interface IPublicClientApplication {
 }
 
 export const stubbedPublicClientApplication: IPublicClientApplication = {
+    initialize: () => {
+        return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
+    },
     acquireTokenPopup: () => {
         return Promise.reject(BrowserConfigurationAuthError.createStubPcaInstanceCalledError());
     },

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -29,7 +29,21 @@ export class PublicClientApplication extends ClientApplication implements IPubli
 
     /**
      * @constructor
-     * Constructor for the PublicClientApplication used to instantiate the PublicClientApplication object
+     * Constructor for the PublicClientApplication used to instantiate the PublicClientApplication object. To be used
+     * internally within the class or any class that extends it but not externally
+     *
+     * @param configuration object for the MSAL PublicClientApplication instance
+     */
+    protected constructor(configuration: Configuration) {
+        super(configuration);
+
+        this.activeSilentTokenRequests = new Map();
+        // Register listener functions
+        this.trackPageVisibility = this.trackPageVisibility.bind(this);
+    }
+
+    /**
+     * Static method to instantiate the PublicClientApplication object
      *
      * Important attributes in the Configuration object for auth are:
      * - clientID: the application ID of your application. You can obtain one by registering your application with our Application registration portal : https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredAppsPreview
@@ -46,14 +60,12 @@ export class PublicClientApplication extends ClientApplication implements IPubli
      * In Azure B2C, authority is of the form https://{instance}/tfp/{tenant}/{policyName}/
      * Full B2C functionality will be available in this library in future versions.
      *
-     * @param configuration object for the MSAL PublicClientApplication instance
+     * @param configuration {Configuration}
      */
-    constructor(configuration: Configuration) {
-        super(configuration);
-
-        this.activeSilentTokenRequests = new Map();
-        // Register listener functions
-        this.trackPageVisibility = this.trackPageVisibility.bind(this);
+    public static async getInstance(configuration: Configuration): Promise<PublicClientApplication> {
+        const app: PublicClientApplication = new PublicClientApplication(configuration);
+        await app.initialize();
+        return app;
     }
 
     /**

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -29,21 +29,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
 
     /**
      * @constructor
-     * Constructor for the PublicClientApplication used to instantiate the PublicClientApplication object. To be used
-     * internally within the class or any class that extends it but not externally
-     *
-     * @param configuration object for the MSAL PublicClientApplication instance
-     */
-    protected constructor(configuration: Configuration) {
-        super(configuration);
-
-        this.activeSilentTokenRequests = new Map();
-        // Register listener functions
-        this.trackPageVisibility = this.trackPageVisibility.bind(this);
-    }
-
-    /**
-     * Static method to instantiate the PublicClientApplication object
+     * Constructor for the PublicClientApplication used to instantiate the PublicClientApplication object
      *
      * Important attributes in the Configuration object for auth are:
      * - clientID: the application ID of your application. You can obtain one by registering your application with our Application registration portal : https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredAppsPreview
@@ -60,9 +46,22 @@ export class PublicClientApplication extends ClientApplication implements IPubli
      * In Azure B2C, authority is of the form https://{instance}/tfp/{tenant}/{policyName}/
      * Full B2C functionality will be available in this library in future versions.
      *
+     * @param configuration object for the MSAL PublicClientApplication instance
+     */
+    constructor(configuration: Configuration) {
+        super(configuration);
+
+        this.activeSilentTokenRequests = new Map();
+        // Register listener functions
+        this.trackPageVisibility = this.trackPageVisibility.bind(this);
+    }
+
+    /**
+     * Static method to create the PublicClientApplication object. Performs startup tasks seamlessly.
+     *
      * @param configuration {Configuration}
      */
-    public static async getInstance(configuration: Configuration): Promise<PublicClientApplication> {
+    public static async createPublicClientApplication(configuration: Configuration): Promise<PublicClientApplication> {
         const app: PublicClientApplication = new PublicClientApplication(configuration);
         await app.initialize();
         return app;

--- a/lib/msal-browser/test/app/PCANonBrowser.spec.ts
+++ b/lib/msal-browser/test/app/PCANonBrowser.spec.ts
@@ -4,11 +4,12 @@
 import { TEST_CONFIG } from "../utils/StringConstants";
 import { PublicClientApplication } from "../../src/app/PublicClientApplication";
 import { BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError";
+import { getPublicClientApplication } from "../utils/PublicClientApplication";
 
 describe("Non-browser environment", () => {
 
-    it("Constructor doesnt throw if window is undefined", () => {
-        new PublicClientApplication({
+    it("Constructor doesnt throw if window is undefined", async () => {
+        await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
@@ -16,118 +17,118 @@ describe("Non-browser environment", () => {
     });
 
     it("acquireTokenSilent throws", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
+        }).then((instance) => {
+            instance.acquireTokenSilent({scopes: ["openid"], account: undefined})
+                .catch(error => {
+                    expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
+                    done();
+                });
         });
-
-        instance.acquireTokenSilent({scopes: ["openid"], account: undefined})
-            .catch(error => {
-                expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
-                done();
-            });
     });
 
     it("ssoSilent throws", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
+        }).then((instance) => {
+            instance.ssoSilent({})
+                .catch(error => {
+                    expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
+                    done();
+                });
         });
-
-        instance.ssoSilent({})
-            .catch(error => {
-                expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
-                done();
-            });
     });
 
     it("acquireTokenPopup throws", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
-        });
-
-        instance.acquireTokenPopup({scopes: ["openid"]}).catch((error) => {
-            expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
-            done();
+        }).then((instance) => {
+            instance.acquireTokenPopup({scopes: ["openid"]}).catch((error) => {
+                expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
+                done();
+            });
         });
     });
 
     it("acquireTokenRedirect throws", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
+        }).then((instance) => {
+            instance.acquireTokenRedirect({scopes: ["openid"]})
+                .catch(error => {
+                    expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
+                    done();
+                });
         });
-
-        instance.acquireTokenRedirect({scopes: ["openid"]})
-            .catch(error => {
-                expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
-                done();
-            });
     });
 
     it("loginPopup throws", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
+        }).then((instance) => {
+            instance.loginPopup({scopes: ["openid"]})
+                .catch(error => {
+                    expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
+                    done();
+                });
         });
-
-        instance.loginPopup({scopes: ["openid"]})
-            .catch(error => {
-                expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
-                done();
-            });
     });
 
     it("loginRedirect throws", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
+        }).then((instance) => {
+            instance.loginRedirect({scopes: ["openid"]})
+                .catch(error => {
+                    expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
+                    done();
+                });
         });
-
-        instance.loginRedirect({scopes: ["openid"]})
-            .catch(error => {
-                expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
-                done();
-            });
     });
 
     it("logoutRedirect throws", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
+        }).then((instance) => {
+            instance.logoutRedirect()
+                .catch(error => {
+                    expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
+                    done();
+                });
         });
-
-        instance.logoutRedirect()
-            .catch(error => {
-                expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
-                done();
-            });
     });
 
     it("logoutPopup throws", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
+        }).then((instance) => {
+            instance.logoutPopup()
+                .catch(error => {
+                    expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
+                    done();
+                });
         });
-
-        instance.logoutPopup()
-            .catch(error => {
-                expect(error.errorCode).toEqual(BrowserAuthErrorMessage.notInBrowserEnvironment.code);
-                done();
-            });
     });
 
-    it("getAllAccounts returns empty array", () => {
-        const instance = new PublicClientApplication({
+    it("getAllAccounts returns empty array", async () => {
+        const instance = await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
@@ -137,8 +138,8 @@ describe("Non-browser environment", () => {
         expect(accounts).toEqual([]);
     });
 
-    it("getAccountByUsername returns null", () => {
-        const instance = new PublicClientApplication({
+    it("getAccountByUsername returns null", async () => {
+        const instance = await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
@@ -149,29 +150,29 @@ describe("Non-browser environment", () => {
     });
 
     it("handleRedirectPromise returns null", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             },
             system: {
                 allowNativeBroker: false
             }
-        });
-
-        instance.handleRedirectPromise().then(result => {
-            expect(result).toBeNull();
-            done();
+        }).then((instance) => {
+            instance.handleRedirectPromise().then(result => {
+                expect(result).toBeNull();
+                done();
+            });
         });
     });
 
     it("addEventCallback does not throw", (done) => {
-        const instance = new PublicClientApplication({
+        getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
+        }).then((instance) => {
+            expect(() => instance.addEventCallback(() => {})).not.toThrow();
+            done();
         });
-
-        expect(() => instance.addEventCallback(() => {})).not.toThrow();
-        done();
     });
 });

--- a/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
@@ -8,6 +8,7 @@ import { AccountInfo, AccountEntity, TokenClaims } from "@azure/msal-common";
 import { TEST_DATA_CLIENT_INFO, TEST_CONFIG } from "../utils/StringConstants";
 import { BaseInteractionClient } from "../../src/interaction_client/BaseInteractionClient";
 import { EndSessionRequest, PublicClientApplication } from "../../src";
+import { getPublicClientApplication } from "../utils/PublicClientApplication";
 
 class testInteractionClient extends BaseInteractionClient {
     acquireToken(): Promise<void> {
@@ -22,8 +23,8 @@ class testInteractionClient extends BaseInteractionClient {
 describe("BaseInteractionClient", () => {
     let pca: PublicClientApplication;
     let testClient: testInteractionClient;
-    beforeEach(() => {
-        pca = new PublicClientApplication({
+    beforeEach(async () => {
+        pca = await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }

--- a/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
@@ -12,12 +12,13 @@ import { SilentHandler } from "../../src/interaction_handler/SilentHandler";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { SilentAuthCodeClient } from "../../src/interaction_client/SilentAuthCodeClient";
 import { ApiId, AuthorizationCodeRequest } from "../../src";
+import { getPublicClientApplication } from "../utils/PublicClientApplication";
 
 describe("SilentAuthCodeClient", () => {
     let silentAuthCodeClient: SilentAuthCodeClient;
 
-    beforeEach(() => {
-        const pca = new PublicClientApplication({
+    beforeEach(async () => {
+        const pca = await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
@@ -85,7 +86,7 @@ describe("SilentAuthCodeClient", () => {
             };
             sinon.stub(AuthorizationCodeClient.prototype, "getAuthCodeUrl").resolves(testNavUrl);
             const handleCodeSpy = sinon.stub(SilentHandler.prototype, "handleCodeResponseFromServer").resolves(testTokenResponse);
- 
+
             sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
 
             const request: AuthorizationCodeRequest = {
@@ -95,7 +96,7 @@ describe("SilentAuthCodeClient", () => {
             const tokenResp = await silentAuthCodeClient.acquireToken(request);
 
             expect(handleCodeSpy.calledWith({
-                code: "test-code", 
+                code: "test-code",
                 msgraph_host: request.msGraphHost,
                 cloud_graph_host_name: request.cloudGraphHostName,
                 cloud_instance_host_name: request.cloudInstanceHostName

--- a/lib/msal-browser/test/interaction_client/SilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentCacheClient.spec.ts
@@ -8,6 +8,7 @@ import { PublicClientApplication, BrowserAuthError } from "../../src";
 import { TEST_CONFIG, ID_TOKEN_CLAIMS, TEST_TOKENS, DEFAULT_OPENID_CONFIG_RESPONSE } from "../utils/StringConstants";
 import { SilentCacheClient } from "../../src/interaction_client/SilentCacheClient";
 import { AuthToken, CacheManager, IdTokenEntity, AccountEntity, AccessTokenEntity, CredentialType, AuthenticationScheme, RefreshTokenEntity, TimeUtils, AuthenticationResult, AccountInfo, Authority } from "@azure/msal-common";
+import { getPublicClientApplication } from "../utils/PublicClientApplication";
 
 const testAccountEntity: AccountEntity = new AccountEntity();
 testAccountEntity.homeAccountId = `${ID_TOKEN_CLAIMS.oid}.${ID_TOKEN_CLAIMS.tid}`;
@@ -60,8 +61,8 @@ const testAccount: AccountInfo = {
 describe("SilentCacheClient", () => {
     let silentCacheClient: SilentCacheClient;
 
-    beforeEach(() => {
-        const pca = new PublicClientApplication({
+    beforeEach(async () => {
+        const pca = await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
@@ -94,7 +95,7 @@ describe("SilentCacheClient", () => {
             await expect(silentCacheClient.acquireToken({
                 authority: TEST_CONFIG.validAuthority,
                 correlationId: "testCorrelationId",
-                account: testAccount, 
+                account: testAccount,
                 scopes: ["openid"],
                 forceRefresh: false
             })).resolves.toMatchObject(response);

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -16,14 +16,15 @@ import { ApiId } from "../../src";
 import { NativeInteractionClient } from "../../src/interaction_client/NativeInteractionClient";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
+import { getPublicClientApplication } from "../utils/PublicClientApplication";
 
 describe("SilentIframeClient", () => {
     globalThis.MessageChannel = require("worker_threads").MessageChannel; // jsdom does not include an implementation for MessageChannel
     let silentIframeClient: SilentIframeClient;
     let pca: PublicClientApplication;
 
-    beforeEach(() => {
-        pca = new PublicClientApplication({
+    beforeEach(async () => {
+        pca = await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }
@@ -223,7 +224,7 @@ describe("SilentIframeClient", () => {
         });
 
         it("successfully returns a token response from native broker", async () => {
-            pca = new PublicClientApplication({
+            pca = await getPublicClientApplication({
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID
                 },
@@ -295,72 +296,73 @@ describe("SilentIframeClient", () => {
         });
 
         it("throw if server returns accountId but extension communication has not been established", (done) => {
-            pca = new PublicClientApplication({
+            getPublicClientApplication({
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID
                 },
                 system: {
                     allowNativeBroker: true
                 }
-            });
-            // @ts-ignore
-            silentIframeClient = new SilentIframeClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient, ApiId.acquireTokenSilent_authCode, pca.performanceClient, pca.nativeInternalStorage);
-            const testServerTokenResponse = {
-                token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,
-                scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
-                expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
-                ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
-                access_token: TEST_TOKENS.ACCESS_TOKEN,
-                refresh_token: TEST_TOKENS.REFRESH_TOKEN,
-                id_token: TEST_TOKENS.IDTOKEN_V2
-            };
-            const testIdTokenClaims: TokenClaims = {
-                "ver": "2.0",
-                "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
-                "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-                "name": "Abe Lincoln",
-                "preferred_username": "AbeLi@microsoft.com",
-                "oid": "00000000-0000-0000-66f3-3332eca7ea81",
-                "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
-                "nonce": "123523",
-            };
-            const testAccount: AccountInfo = {
-                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
-                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
-                environment: "login.windows.net",
-                tenantId: testIdTokenClaims.tid || "",
-                username: testIdTokenClaims.preferred_username || "",
-                nativeAccountId: "test-nativeAccountId"
-            };
-            const testTokenResponse: AuthenticationResult = {
-                authority: TEST_CONFIG.validAuthority,
-                uniqueId: testIdTokenClaims.oid || "",
-                tenantId: testIdTokenClaims.tid || "",
-                scopes: TEST_CONFIG.DEFAULT_SCOPES,
-                idToken: testServerTokenResponse.id_token,
-                idTokenClaims: testIdTokenClaims,
-                accessToken: testServerTokenResponse.access_token,
-                fromCache: false,
-                correlationId: RANDOM_TEST_GUID,
-                expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
-                account: testAccount,
-                tokenType: AuthenticationScheme.BEARER
-            };
-            sinon.stub(AuthorizationCodeClient.prototype, "getAuthCodeUrl").resolves(testNavUrl);
-            sinon.spy(SilentHandler.prototype, <any>"loadFrameSync");
-            sinon.stub(SilentHandler.prototype, "monitorIframeForHash").resolves(TEST_HASHES.TEST_SUCCESS_NATIVE_ACCOUNT_ID_SILENT);
-            sinon.stub(NativeInteractionClient.prototype, "acquireToken").resolves(testTokenResponse);
-            sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
-                challenge: TEST_CONFIG.TEST_CHALLENGE,
-                verifier: TEST_CONFIG.TEST_VERIFIER
-            });
-            sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
-            silentIframeClient.acquireToken({
-                scopes: TEST_CONFIG.DEFAULT_SCOPES,
-            }).catch(e => {
-                expect(e.errorCode).toEqual(BrowserAuthErrorMessage.nativeConnectionNotEstablished.code);
-                expect(e.errorMessage).toEqual(BrowserAuthErrorMessage.nativeConnectionNotEstablished.desc);
-                done();
+            }).then((pca) => {
+                // @ts-ignore
+                silentIframeClient = new SilentIframeClient(pca.config, pca.browserStorage, pca.browserCrypto, pca.logger, pca.eventHandler, pca.navigationClient, ApiId.acquireTokenSilent_authCode, pca.performanceClient, pca.nativeInternalStorage);
+                const testServerTokenResponse = {
+                    token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,
+                    scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
+                    expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+                    ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+                    access_token: TEST_TOKENS.ACCESS_TOKEN,
+                    refresh_token: TEST_TOKENS.REFRESH_TOKEN,
+                    id_token: TEST_TOKENS.IDTOKEN_V2
+                };
+                const testIdTokenClaims: TokenClaims = {
+                    "ver": "2.0",
+                    "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                    "sub": "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                    "name": "Abe Lincoln",
+                    "preferred_username": "AbeLi@microsoft.com",
+                    "oid": "00000000-0000-0000-66f3-3332eca7ea81",
+                    "tid": "3338040d-6c67-4c5b-b112-36a304b66dad",
+                    "nonce": "123523",
+                };
+                const testAccount: AccountInfo = {
+                    homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                    localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                    environment: "login.windows.net",
+                    tenantId: testIdTokenClaims.tid || "",
+                    username: testIdTokenClaims.preferred_username || "",
+                    nativeAccountId: "test-nativeAccountId"
+                };
+                const testTokenResponse: AuthenticationResult = {
+                    authority: TEST_CONFIG.validAuthority,
+                    uniqueId: testIdTokenClaims.oid || "",
+                    tenantId: testIdTokenClaims.tid || "",
+                    scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                    idToken: testServerTokenResponse.id_token,
+                    idTokenClaims: testIdTokenClaims,
+                    accessToken: testServerTokenResponse.access_token,
+                    fromCache: false,
+                    correlationId: RANDOM_TEST_GUID,
+                    expiresOn: new Date(Date.now() + (testServerTokenResponse.expires_in * 1000)),
+                    account: testAccount,
+                    tokenType: AuthenticationScheme.BEARER
+                };
+                sinon.stub(AuthorizationCodeClient.prototype, "getAuthCodeUrl").resolves(testNavUrl);
+                sinon.spy(SilentHandler.prototype, <any>"loadFrameSync");
+                sinon.stub(SilentHandler.prototype, "monitorIframeForHash").resolves(TEST_HASHES.TEST_SUCCESS_NATIVE_ACCOUNT_ID_SILENT);
+                sinon.stub(NativeInteractionClient.prototype, "acquireToken").resolves(testTokenResponse);
+                sinon.stub(CryptoOps.prototype, "generatePkceCodes").resolves({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER
+                });
+                sinon.stub(CryptoOps.prototype, "createNewGuid").returns(RANDOM_TEST_GUID);
+                silentIframeClient.acquireToken({
+                    scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                }).catch(e => {
+                    expect(e.errorCode).toEqual(BrowserAuthErrorMessage.nativeConnectionNotEstablished.code);
+                    expect(e.errorMessage).toEqual(BrowserAuthErrorMessage.nativeConnectionNotEstablished.desc);
+                    done();
+                });
             });
         });
     });

--- a/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
@@ -10,12 +10,13 @@ import { Constants, AccountInfo, TokenClaims, AuthenticationResult, Authenticati
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { BrowserAuthError } from "../../src/error/BrowserAuthError";
 import { SilentRefreshClient } from "../../src/interaction_client/SilentRefreshClient";
+import { getPublicClientApplication } from "../utils/PublicClientApplication";
 
 describe("SilentRefreshClient", () => {
     let silentRefreshClient: SilentRefreshClient;
 
-    beforeEach(() => {
-        const pca = new PublicClientApplication({
+    beforeEach(async () => {
+        const pca = await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }

--- a/lib/msal-browser/test/interaction_client/StandardInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/StandardInteractionClient.spec.ts
@@ -12,6 +12,7 @@ import { TEST_CONFIG, TEST_STATE_VALUES, TEST_URIS, DEFAULT_TENANT_DISCOVERY_RES
 import { AuthorizationUrlRequest } from "../../src/request/AuthorizationUrlRequest";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { FetchClient } from "../../src/network/FetchClient";
+import { getPublicClientApplication } from "../utils/PublicClientApplication";
 
 class testStandardInteractionClient extends StandardInteractionClient {
     acquireToken(): Promise<void> {
@@ -35,8 +36,8 @@ describe("StandardInteractionClient", () => {
     let pca: PublicClientApplication;
     let testClient: testStandardInteractionClient;
 
-    beforeEach(() => {
-        pca = new PublicClientApplication({
+    beforeEach(async () => {
+        pca = await getPublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID
             }

--- a/lib/msal-browser/test/utils/PublicClientApplication.ts
+++ b/lib/msal-browser/test/utils/PublicClientApplication.ts
@@ -1,0 +1,24 @@
+import sinon from "sinon";
+import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
+import { Logger, PublicClientApplication } from "../../src";
+import { Configuration } from "../../lib";
+import { LoggerOptions } from "@azure/msal-common";
+
+const extensionId = "test-extensionId";
+
+export async function getPublicClientApplication(configuration: Configuration): Promise<PublicClientApplication> {
+    const loggerOptions: LoggerOptions = {
+        loggerCallback: (): void => {},
+        piiLoggingEnabled: true,
+    };
+    const logger: Logger = new Logger(loggerOptions);
+    const providerStub: sinon.SinonStub = sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
+        return new NativeMessageHandler(logger, 2000, extensionId);
+    });
+
+    try {
+        return PublicClientApplication.getInstance(configuration);
+    } finally {
+        providerStub.restore();
+    }
+}

--- a/lib/msal-browser/test/utils/PublicClientApplication.ts
+++ b/lib/msal-browser/test/utils/PublicClientApplication.ts
@@ -3,6 +3,7 @@ import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessag
 import { Logger, PublicClientApplication } from "../../src";
 import { Configuration } from "../../lib";
 import { LoggerOptions } from "@azure/msal-common";
+import { getDefaultPerformanceClient } from "./TelemetryUtils";
 
 const extensionId = "test-extensionId";
 
@@ -13,11 +14,11 @@ export async function getPublicClientApplication(configuration: Configuration): 
     };
     const logger: Logger = new Logger(loggerOptions);
     const providerStub: sinon.SinonStub = sinon.stub(NativeMessageHandler, "createProvider").callsFake(async () => {
-        return new NativeMessageHandler(logger, 2000, extensionId);
+        return new NativeMessageHandler(logger, 2000, getDefaultPerformanceClient(), extensionId);
     });
 
     try {
-        return PublicClientApplication.getInstance(configuration);
+        return PublicClientApplication.createPublicClientApplication(configuration);
     } finally {
         providerStub.restore();
     }


### PR DESCRIPTION
- Make `PublicClientApplication` constructor protected.
- Add `PublicClientApplication.getInstance()` as a constructor replacement to invoke `PublicClientApplication.initialize()` seamlessly.
- Remove `PublicClientApplication.initialized` as redundant.