### PR TITLE
Allow major change types for v3 updates

### DIFF
--- a/.github/workflows/beachball-check.yml
+++ b/.github/workflows/beachball-check.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:  
       - dev
+      - msal-browser-v3
 
 concurrency:
   group: beachball-${{github.ref}}

--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,4 @@ lib/msal-node/temp
 ref/
 .server.pid
 *.pem
+tsconfig.build.tsbuildinfo

--- a/change/@azure-msal-angular-b22f1221-0db0-4702-8649-d48cab3146fe.json
+++ b/change/@azure-msal-angular-b22f1221-0db0-4702-8649-d48cab3146fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v3 updates #5746",
+  "packageName": "@azure/msal-angular",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-common-6b5a3278-c9dd-41b0-ba53-cceb111ff50a.json
+++ b/change/@azure-msal-common-6b5a3278-c9dd-41b0-ba53-cceb111ff50a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v3 updates #5746",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-node-b32fe37e-5d14-4afb-b707-95fcb8c3cba1.json
+++ b/change/@azure-msal-node-b32fe37e-5d14-4afb-b707-95fcb8c3cba1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v3 updates #5746",
+  "packageName": "@azure/msal-node",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-react-aeb41d54-85af-4781-9d82-f03be8885e39.json
+++ b/change/@azure-msal-react-aeb41d54-85af-4781-9d82-f03be8885e39.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v3 updates #5746",
+  "packageName": "@azure/msal-react",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -33,9 +33,7 @@
   "main": "./dist/bundles/azure-msal-angular.umd.js",
   "typings": "./dist/azure-msal-angular.d.ts",
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1102.11",

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -29,9 +29,7 @@
     "node": ">=0.8.0"
   },
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "directories": {
     "test": "test"

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -40,9 +40,7 @@
     "prepack": "npm run build:all"
   },
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "module": "dist/msal-node.esm.js",
   "devDependencies": {

--- a/lib/msal-react/package.json
+++ b/lib/msal-react/package.json
@@ -21,9 +21,7 @@
     "node": ">=10"
   },
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "scripts": {
     "start": "tsdx watch",


### PR DESCRIPTION
This PR:

- Removes major change restriction from beachball configuration for msal-browser, angular, react and node
- Updates .gitignore to include no tsconfig.build.tsbuildinfo autogenerated files.