### PR TITLE
Fix SHR typ header to pop value

### DIFF
--- a/change/@azure-msal-common-20e84402-2671-45dd-9953-9453d8a310bc.json
+++ b/change/@azure-msal-common-20e84402-2671-45dd-9953-9453d8a310bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix SHR typ header to pop value #5751",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/crypto/JoseHeader.ts
+++ b/lib/msal-common/src/crypto/JoseHeader.ts
@@ -43,8 +43,8 @@ export class JoseHeader {
         }
 
         const shrHeader = new JoseHeader({
-            // Access Token PoP headers must have type JWT, but the type header can be overriden for special cases
-            typ: shrHeaderOptions.typ || JsonTypes.Jwt,
+            // Access Token PoP headers must have type pop, but the type header can be overriden for special cases
+            typ: shrHeaderOptions.typ || JsonTypes.Pop,
             kid: shrHeaderOptions.kid,
             alg: shrHeaderOptions.alg
         });

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -406,7 +406,8 @@ export enum CacheOutcome {
 
 export enum JsonTypes {
     Jwt = "JWT",
-    Jwk = "JWK"
+    Jwk = "JWK",
+    Pop = "pop"
 }
 
 export const ONE_DAY_IN_MS = 86400000;

--- a/lib/msal-common/test/crypto/JoseHeader.spec.ts
+++ b/lib/msal-common/test/crypto/JoseHeader.spec.ts
@@ -11,7 +11,7 @@ describe("JoseHeader.ts Unit Tests", () => {
 				kid: TEST_POP_VALUES.KID
 			});
 
-			expect(shrHeaderString).toBe(`{"typ":"${JsonTypes.Jwt}","alg":"${TEST_CRYPTO_ALGORITHMS.rsa}","kid":"${TEST_POP_VALUES.KID}"}`);
+			expect(shrHeaderString).toBe(`{"typ":"${JsonTypes.Pop}","alg":"${TEST_CRYPTO_ALGORITHMS.rsa}","kid":"${TEST_POP_VALUES.KID}"}`);
 		});
 
 		it("should throw if kid header is missing", () => {


### PR DESCRIPTION
This PR replaces the default value of the typ header in SHRs from "JWT" to "pop" to match the SHR specification.