### PR TITLE
Move node clients from `msal-common` to `msal-node`

### DIFF
--- a/change/@azure-msal-angular-106836f3-95e1-45b0-b4c7-526d344a6261.json
+++ b/change/@azure-msal-angular-106836f3-95e1-45b0-b4c7-526d344a6261.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix package-lock.json #5788",
+  "packageName": "@azure/msal-angular",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-ca8797d8-0198-4c2b-88f6-946a39135c32.json
+++ b/change/@azure-msal-common-ca8797d8-0198-4c2b-88f6-946a39135c32.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Move node clients from msal-common to msal-node #5788",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-c301f1eb-3614-4839-b273-4c4bb34514ac.json
+++ b/change/@azure-msal-node-c301f1eb-3614-4839-b273-4c4bb34514ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Move node clients from msal-common to msal-node #5788",
+  "packageName": "@azure/msal-node",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/package-lock.json
+++ b/lib/msal-angular/package-lock.json
@@ -35,7 +35,7 @@
         "rxjs": "^7.0.0",
         "ts-node": "~8.3.0",
         "tslib": "^2.0.0",
-        "typescript": "^4.8.4",
+        "typescript": "~4.8.4",
         "zone.js": "~0.11.8"
       },
       "peerDependencies": {
@@ -11428,9 +11428,10 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19890,7 +19891,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/lib/msal-common/docs/Response.md
+++ b/lib/msal-common/docs/Response.md
@@ -3,7 +3,4 @@ MSAL will return an `AuthenticationResult.ts` object as a response to all acquir
 #### `msal-browser` public APIs for token acquisition:
 `loginPopup`, `acquireTokenPopup`, `acquireTokenSilent` or `handleRedirectPromise`
 
-#### `msal-node` public APIs for token acquisition:
-`acquireTokenByCode`, `acquireTokenSilent`, `acquireTokenByRefreshToken`, `acquireTokenByDeviceCode`
-
 Reference docs for `AuthenticationResult` expanding on each parameter can be found [here](https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-common/classes/_src_response_authenticationresult_.authenticationresult.html).

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -138,7 +138,7 @@ export abstract class CacheManager implements ICacheManager {
      * @param throttlingCacheKey
      * @param throttlingCache
      */
-    abstract setThrottlingCache(throttlingCacheKey: string, throttlingCache: ThrottlingEntity): void;;
+    abstract setThrottlingCache(throttlingCacheKey: string, throttlingCache: ThrottlingEntity): void;
 
     /**
      * Function to remove an item from cache given its key.

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -9,12 +9,8 @@
  */
 
 export { AuthorizationCodeClient} from "./client/AuthorizationCodeClient";
-export { DeviceCodeClient } from "./client/DeviceCodeClient";
 export { RefreshTokenClient } from "./client/RefreshTokenClient";
-export { ClientCredentialClient } from "./client/ClientCredentialClient";
-export { OnBehalfOfClient } from "./client/OnBehalfOfClient";
 export { SilentFlowClient } from "./client/SilentFlowClient";
-export { UsernamePasswordClient } from "./client/UsernamePasswordClient";
 export { AuthOptions, SystemOptions, LoggerOptions, DEFAULT_SYSTEM_OPTIONS, AzureCloudOptions, ApplicationTelemetry } from "./config/ClientConfiguration";
 export { IAppTokenProvider, AppTokenProviderParameters, AppTokenProviderResult } from "./config/AppTokenProvider";
 export { ClientConfiguration } from "./config/ClientConfiguration";

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -11,6 +11,7 @@
 export { AuthorizationCodeClient} from "./client/AuthorizationCodeClient";
 export { RefreshTokenClient } from "./client/RefreshTokenClient";
 export { SilentFlowClient } from "./client/SilentFlowClient";
+export { BaseClient } from "./client/BaseClient";
 export { AuthOptions, SystemOptions, LoggerOptions, DEFAULT_SYSTEM_OPTIONS, AzureCloudOptions, ApplicationTelemetry } from "./config/ClientConfiguration";
 export { IAppTokenProvider, AppTokenProviderParameters, AppTokenProviderResult } from "./config/AppTokenProvider";
 export { ClientConfiguration } from "./config/ClientConfiguration";
@@ -32,7 +33,7 @@ export { ProtocolMode } from "./authority/ProtocolMode";
 export { INativeBrokerPlugin } from "./broker/nativeBroker/INativeBrokerPlugin";
 // Cache
 export { CacheManager, DefaultStorageClass } from "./cache/CacheManager";
-export { AccountCache, AccessTokenCache, IdTokenCache, RefreshTokenCache, AppMetadataCache, ValidCacheType, ValidCredentialType } from "./cache/utils/CacheTypes";
+export { AccountCache, AccessTokenCache, IdTokenCache, RefreshTokenCache, AppMetadataCache, CredentialCache, CredentialFilter, ValidCacheType, ValidCredentialType } from "./cache/utils/CacheTypes";
 export { CacheRecord } from "./cache/entities/CacheRecord";
 export { CredentialEntity } from "./cache/entities/CredentialEntity";
 export { AppMetadataEntity } from "./cache/entities/AppMetadataEntity";
@@ -71,6 +72,7 @@ export { CommonEndSessionRequest } from "./request/CommonEndSessionRequest";
 export { CommonUsernamePasswordRequest } from "./request/CommonUsernamePasswordRequest";
 export { NativeRequest } from "./request/NativeRequest";
 export { NativeSignOutRequest } from "./request/NativeSignOutRequest";
+export { RequestParameterBuilder } from "./request/RequestParameterBuilder";
 // Response
 export { AzureRegion } from "./authority/AzureRegion";
 export { AzureRegionConfiguration } from "./authority/AzureRegionConfiguration";
@@ -79,7 +81,8 @@ export { AuthorizationCodePayload } from "./response/AuthorizationCodePayload";
 export { ServerAuthorizationCodeResponse } from "./response/ServerAuthorizationCodeResponse";
 export { ServerAuthorizationTokenResponse } from "./response/ServerAuthorizationTokenResponse";
 export { ExternalTokenResponse } from "./response/ExternalTokenResponse";
-export { DeviceCodeResponse } from "./response/DeviceCodeResponse";
+export { DeviceCodeResponse, ServerDeviceCodeResponse } from "./response/DeviceCodeResponse";
+export { ResponseHandler } from "./response/ResponseHandler";
 export { ScopeSet } from "./request/ScopeSet";
 export { AuthenticationHeaderParser } from "./request/AuthenticationHeaderParser";
 // Logger Callback
@@ -91,7 +94,7 @@ export { ServerError } from "./error/ServerError";
 export { ClientAuthError, ClientAuthErrorMessage } from "./error/ClientAuthError";
 export { ClientConfigurationError, ClientConfigurationErrorMessage } from "./error/ClientConfigurationError";
 // Constants and Utils
-export { Constants, OIDC_DEFAULT_SCOPES, PromptValue, PersistentCacheKeys, ResponseMode, CacheSchemaType, CredentialType, CacheType, CacheAccountType, AuthenticationScheme, CodeChallengeMethodValues, SSOTypes, PasswordGrantConstants, ThrottlingConstants, ClaimsRequestKeys, HeaderNames, AADServerParamKeys, Errors, THE_FAMILY_ID, ONE_DAY_IN_MS } from "./utils/Constants";
+export { Constants, OIDC_DEFAULT_SCOPES, PromptValue, PersistentCacheKeys, ResponseMode, CacheOutcome, CacheSchemaType, CredentialType, CacheType, CacheAccountType, AuthenticationScheme, CodeChallengeMethodValues, SSOTypes, PasswordGrantConstants, ThrottlingConstants, ClaimsRequestKeys, HeaderNames, AADServerParamKeys, Errors, THE_FAMILY_ID, ONE_DAY_IN_MS, GrantType } from "./utils/Constants";
 export { StringUtils } from "./utils/StringUtils";
 export { StringDict } from "./utils/MsalTypes";
 export { ProtocolUtils, RequestStateObject, LibraryStateObject } from "./utils/ProtocolUtils";

--- a/lib/msal-node/docs/configuration.md
+++ b/lib/msal-node/docs/configuration.md
@@ -2,7 +2,7 @@
 
 Before you start here, make sure you understand how to [initialize an app object](./initialize-public-client-application.md).
 
-The MSAL library has a set of configuration options that can be used to customize the behavior of your authentication flows. These options can be set either in the constructor of the [PublicClientApplication](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.publicclientapplication.html) object or as part of the [request APIs](../../msal-common/docs/request.md). Here we describe the configuration object that can be passed into the [PublicClientApplication](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.publicclientapplication.html) constructor.
+The MSAL library has a set of configuration options that can be used to customize the behavior of your authentication flows. These options can be set either in the constructor of the [PublicClientApplication](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.publicclientapplication.html) object or as part of the [request APIs](request.md). Here we describe the configuration object that can be passed into the [PublicClientApplication](https://azuread.github.io/microsoft-authentication-library-for-js/ref/classes/_azure_msal_node.publicclientapplication.html) constructor.
 
 In this document:
 - [Usage](#usage)
@@ -109,4 +109,4 @@ const msalInstance = new PublicClientApplication(msalConfig);
 | `appVersion` | Version of the application using MSAL | string | Empty string "" |
 
 ## Next Steps
-Proceed to understand the public APIs provided by `msal-node` for acquiring tokens [here](../../msal-common/docs/request.md)
+Proceed to understand the public APIs provided by `msal-node` for acquiring tokens [here](request.md)

--- a/lib/msal-node/docs/initialize-confidential-client-application.md
+++ b/lib/msal-node/docs/initialize-confidential-client-application.md
@@ -62,4 +62,4 @@ For more information on authority, please refer to: [Authority in MSAL](../../ms
 [Configuration](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_node.html#configuration) has more options which are documented [here](./configuration.md).
 
 ## Next Steps
-Proceed to understand the public APIs provided by `msal-node` for acquiring tokens [here](../../msal-common/docs/request.md)
+Proceed to understand the public APIs provided by `msal-node` for acquiring tokens [here](request.md)

--- a/lib/msal-node/docs/initialize-public-client-application.md
+++ b/lib/msal-node/docs/initialize-public-client-application.md
@@ -73,4 +73,4 @@ For more information on authority, please refer to: [Authority in MSAL](../../ms
 [Configuration](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_node.html#configuration) has more options which are documented [here](./configuration.md).
 
 ## Next Steps
-Proceed to understand the public APIs provided by `msal-node` for acquiring tokens [here](../../msal-common/docs/request.md)
+Proceed to understand the public APIs provided by `msal-node` for acquiring tokens [here](request.md)

--- a/lib/msal-node/docs/request.md
+++ b/lib/msal-node/docs/request.md
@@ -220,4 +220,4 @@ Please look at the On Behalf Of flow [sample](https://github.com/AzureAD/microso
 * [WebApp](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-node-samples/on-behalf-of/web-app/index.js) sample code
 
 ## Next Steps
-Proceed to understand the public APIs provided by `msal-node` for acquiring tokens [here](./Response.md)
+Proceed to understand the public APIs provided by `msal-node` for acquiring tokens [here](response.md)

--- a/lib/msal-node/docs/response.md
+++ b/lib/msal-node/docs/response.md
@@ -1,3 +1,5 @@
+# Response
+
 MSAL will return an `AuthenticationResult.ts` object as a response to all acquire token APIs:
 
 #### `msal-browser` public APIs for token acquisition:

--- a/lib/msal-node/docs/response.md
+++ b/lib/msal-node/docs/response.md
@@ -1,0 +1,6 @@
+MSAL will return an `AuthenticationResult.ts` object as a response to all acquire token APIs:
+
+#### `msal-browser` public APIs for token acquisition:
+`loginPopup`, `acquireTokenPopup`, `acquireTokenSilent` or `handleRedirectPromise`
+
+Reference docs for `AuthenticationResult` expanding on each parameter can be found [here](https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-common/classes/_src_response_authenticationresult_.authenticationresult.html).

--- a/lib/msal-node/package-lock.json
+++ b/lib/msal-node/package-lock.json
@@ -20,10 +20,12 @@
         "@types/jest": "^25.2.3",
         "@types/jsonwebtoken": "^8.5.5",
         "@types/node": "^13.13.4",
+        "@types/sinon": "^7.5.0",
         "@types/uuid": "^7.0.0",
         "husky": "^4.2.3",
         "jest": "^29.5.0",
         "rollup": "^3.20.1",
+        "sinon": "^7.5.0",
         "ts-jest": "^29.0.5",
         "tslib": "^1.10.0",
         "typescript": "^4.9.5",
@@ -1181,6 +1183,51 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "node_modules/@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "node_modules/@sinonjs/formatio/node_modules/@sinonjs/commons": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "dev": true,
@@ -1294,6 +1341,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/sinon": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+      "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
+      "dev": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "dev": true,
@@ -1387,6 +1440,12 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.5.0",
@@ -1767,6 +1826,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2239,6 +2307,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3244,6 +3318,12 @@
         "npm": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "license": "MIT",
@@ -3311,6 +3391,12 @@
       "version": "4.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3399,6 +3485,37 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/commons": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/nise/node_modules/lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -3562,6 +3679,15 @@
       "version": "1.0.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -3912,6 +4038,51 @@
       "version": "3.0.7",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/commons": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -50,13 +50,15 @@
     "@types/jsonwebtoken": "^8.5.5",
     "@types/node": "^13.13.4",
     "@types/uuid": "^7.0.0",
+    "@types/sinon": "^7.5.0",
     "husky": "^4.2.3",
     "jest": "^29.5.0",
     "rollup": "^3.20.1",
     "ts-jest": "^29.0.5",
     "tslib": "^1.10.0",
     "typescript": "^4.9.5",
-    "yargs": "^17.3.1"
+    "yargs": "^17.3.1",
+    "sinon": "^7.5.0"
   },
   "dependencies": {
     "@azure/msal-common": "^10.0.0",

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -20,7 +20,6 @@ import {
     CommonAuthorizationCodeRequest,
     CommonAuthorizationUrlRequest,
     CommonUsernamePasswordRequest,
-    UsernamePasswordClient,
     AuthenticationScheme,
     ResponseMode,
     AuthorityOptions,
@@ -45,6 +44,7 @@ import { SilentFlowRequest } from "../request/SilentFlowRequest";
 import { version, name } from "../packageMetadata";
 import { UsernamePasswordRequest } from "../request/UsernamePasswordRequest";
 import { NodeAuthError } from "../error/NodeAuthError";
+import { UsernamePasswordClient } from "./UsernamePasswordClient";
 
 /**
  * Base abstract class for all ClientApplications - public and confidential

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -3,24 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
-import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
-import { Authority } from "@azure/msal-common/src/authority/Authority";
-import { RequestParameterBuilder } from "@azure/msal-common/src/request/RequestParameterBuilder";
-import { ScopeSet } from "@azure/msal-common/src/request/ScopeSet";
-import { GrantType , CredentialType, CacheOutcome, Constants, AuthenticationScheme } from "@azure/msal-common/src/utils/Constants";
-import { ResponseHandler } from "@azure/msal-common/src/response/ResponseHandler";
-import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
-import { CommonClientCredentialRequest } from "@azure/msal-common/src/request/CommonClientCredentialRequest";
-import { CredentialFilter, CredentialCache } from "@azure/msal-common/src/cache/utils/CacheTypes";
-import { AccessTokenEntity } from "@azure/msal-common/src/cache/entities/AccessTokenEntity";
-import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
-import { StringUtils } from "@azure/msal-common/src/utils/StringUtils";
-import { RequestThumbprint } from "@azure/msal-common/src/network/RequestThumbprint";
-import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
-import { ServerAuthorizationTokenResponse } from "@azure/msal-common/src/response/ServerAuthorizationTokenResponse";
-import { IAppTokenProvider } from "@azure/msal-common/src/config/AppTokenProvider";
-import { UrlString } from "@azure/msal-common/src/url/UrlString";
+import {
+    AccessTokenEntity,
+    AuthenticationResult, AuthenticationScheme, Authority, BaseClient, CacheOutcome, ClientAuthError,
+    ClientConfiguration,
+    CommonClientCredentialRequest, Constants, CredentialCache, CredentialFilter, CredentialType, GrantType,
+    IAppTokenProvider, RequestParameterBuilder, RequestThumbprint, ResponseHandler,
+    ScopeSet, ServerAuthorizationTokenResponse, StringUtils, TimeUtils, UrlString
+} from "@azure/msal-common";
 
 /**
  * OAuth2.0 client credential grant
@@ -138,7 +128,7 @@ export class ClientCredentialClient extends BaseClient {
                 access_token: appTokenProviderResult.accessToken,
                 expires_in: appTokenProviderResult.expiresInSeconds,
                 refresh_in: appTokenProviderResult.refreshInSeconds,
-                token_type : AuthenticationScheme.BEARER
+                token_type: AuthenticationScheme.BEARER
             };
         } else {
             const queryParametersString = this.createTokenQueryParameters(request);

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -3,24 +3,24 @@
  * Licensed under the MIT License.
  */
 
-import { ClientConfiguration } from "../config/ClientConfiguration";
-import { BaseClient } from "./BaseClient";
-import { Authority } from "../authority/Authority";
-import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { ScopeSet } from "../request/ScopeSet";
-import { GrantType , CredentialType, CacheOutcome, Constants, AuthenticationScheme } from "../utils/Constants";
-import { ResponseHandler } from "../response/ResponseHandler";
-import { AuthenticationResult } from "../response/AuthenticationResult";
-import { CommonClientCredentialRequest } from "../request/CommonClientCredentialRequest";
-import { CredentialFilter, CredentialCache } from "../cache/utils/CacheTypes";
-import { AccessTokenEntity } from "../cache/entities/AccessTokenEntity";
-import { TimeUtils } from "../utils/TimeUtils";
-import { StringUtils } from "../utils/StringUtils";
-import { RequestThumbprint } from "../network/RequestThumbprint";
-import { ClientAuthError } from "../error/ClientAuthError";
-import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
-import { IAppTokenProvider } from "../config/AppTokenProvider";
-import { UrlString } from "../url/UrlString";
+import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
+import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
+import { Authority } from "@azure/msal-common/src/authority/Authority";
+import { RequestParameterBuilder } from "@azure/msal-common/src/request/RequestParameterBuilder";
+import { ScopeSet } from "@azure/msal-common/src/request/ScopeSet";
+import { GrantType , CredentialType, CacheOutcome, Constants, AuthenticationScheme } from "@azure/msal-common/src/utils/Constants";
+import { ResponseHandler } from "@azure/msal-common/src/response/ResponseHandler";
+import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
+import { CommonClientCredentialRequest } from "@azure/msal-common/src/request/CommonClientCredentialRequest";
+import { CredentialFilter, CredentialCache } from "@azure/msal-common/src/cache/utils/CacheTypes";
+import { AccessTokenEntity } from "@azure/msal-common/src/cache/entities/AccessTokenEntity";
+import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
+import { StringUtils } from "@azure/msal-common/src/utils/StringUtils";
+import { RequestThumbprint } from "@azure/msal-common/src/network/RequestThumbprint";
+import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
+import { ServerAuthorizationTokenResponse } from "@azure/msal-common/src/response/ServerAuthorizationTokenResponse";
+import { IAppTokenProvider } from "@azure/msal-common/src/config/AppTokenProvider";
+import { UrlString } from "@azure/msal-common/src/url/UrlString";
 
 /**
  * OAuth2.0 client credential grant
@@ -59,7 +59,7 @@ export class ClientCredentialClient extends BaseClient {
      * looks up cache if the tokens are cached already
      */
     private async getCachedAuthenticationResult(request: CommonClientCredentialRequest): Promise<AuthenticationResult | null> {
-        
+
         const cachedAccessToken = this.readAccessTokenFromCache();
 
         if (!cachedAccessToken) {
@@ -117,7 +117,7 @@ export class ClientCredentialClient extends BaseClient {
      */
     private async executeTokenRequest(request: CommonClientCredentialRequest, authority: Authority)
         : Promise<AuthenticationResult | null> {
-        
+
         let serverTokenResponse: ServerAuthorizationTokenResponse;
         let reqTimestamp: number;
 
@@ -135,7 +135,7 @@ export class ClientCredentialClient extends BaseClient {
             const appTokenProviderResult = await this.appTokenProvider(appTokenPropviderParameters);
 
             serverTokenResponse = {
-                access_token: appTokenProviderResult.accessToken, 
+                access_token: appTokenProviderResult.accessToken,
                 expires_in: appTokenProviderResult.expiresInSeconds,
                 refresh_in: appTokenProviderResult.refreshInSeconds,
                 token_type : AuthenticationScheme.BEARER
@@ -156,7 +156,7 @@ export class ClientCredentialClient extends BaseClient {
                 shrClaims: request.shrClaims,
                 sshKid: request.sshKid
             };
-    
+
             reqTimestamp = TimeUtils.nowSeconds();
             const response = await this.executePostToTokenEndpoint(endpoint, requestBody, headers, thumbprint);
             serverTokenResponse = response.body;
@@ -172,7 +172,7 @@ export class ClientCredentialClient extends BaseClient {
         );
 
         responseHandler.validateTokenResponse(serverTokenResponse);
-       
+
         const tokenResponse = await responseHandler.handleServerTokenResponse(
             serverTokenResponse,
             this.authority,
@@ -200,7 +200,7 @@ export class ClientCredentialClient extends BaseClient {
         parameterBuilder.addApplicationTelemetry(this.config.telemetry.application);
 
         parameterBuilder.addThrottling();
-        
+
         if (this.serverTelemetryManager) {
             parameterBuilder.addServerTelemetry(this.serverTelemetryManager);
         }

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -5,11 +5,28 @@
 
 import {
     AccessTokenEntity,
-    AuthenticationResult, AuthenticationScheme, Authority, BaseClient, CacheOutcome, ClientAuthError,
+    AuthenticationResult,
+    AuthenticationScheme,
+    Authority,
+    BaseClient,
+    CacheOutcome,
+    ClientAuthError,
     ClientConfiguration,
-    CommonClientCredentialRequest, Constants, CredentialCache, CredentialFilter, CredentialType, GrantType,
-    IAppTokenProvider, RequestParameterBuilder, RequestThumbprint, ResponseHandler,
-    ScopeSet, ServerAuthorizationTokenResponse, StringUtils, TimeUtils, UrlString
+    CommonClientCredentialRequest,
+    Constants,
+    CredentialCache,
+    CredentialFilter,
+    CredentialType,
+    GrantType,
+    IAppTokenProvider,
+    RequestParameterBuilder,
+    RequestThumbprint,
+    ResponseHandler,
+    ScopeSet,
+    ServerAuthorizationTokenResponse,
+    StringUtils,
+    TimeUtils,
+    UrlString
 } from "@azure/msal-common";
 
 /**

--- a/lib/msal-node/src/client/ConfidentialClientApplication.ts
+++ b/lib/msal-node/src/client/ConfidentialClientApplication.ts
@@ -8,8 +8,6 @@ import { Configuration } from "../config/Configuration";
 import { ClientAssertion } from "./ClientAssertion";
 import { Constants as NodeConstants, ApiId, REGION_ENVIRONMENT_VARIABLE } from "../utils/Constants";
 import {
-    ClientCredentialClient,
-    OnBehalfOfClient,
     CommonClientCredentialRequest,
     CommonOnBehalfOfRequest,
     AuthenticationResult,
@@ -24,6 +22,8 @@ import {
 import { IConfidentialClientApplication } from "./IConfidentialClientApplication";
 import { OnBehalfOfRequest } from "../request/OnBehalfOfRequest";
 import { ClientCredentialRequest } from "../request/ClientCredentialRequest";
+import { ClientCredentialClient } from "./ClientCredentialClient";
+import { OnBehalfOfClient } from "./OnBehalfOfClient";
 
 /**
  *  This class is to be used to acquire tokens for confidential client applications (webApp, webAPI). Confidential client applications

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import { DeviceCodeResponse, ServerDeviceCodeResponse } from "../response/DeviceCodeResponse";
-import { BaseClient } from "./BaseClient";
-import { CommonDeviceCodeRequest } from "../request/CommonDeviceCodeRequest";
-import { ClientAuthError } from "../error/ClientAuthError";
-import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { Constants, GrantType } from "../utils/Constants";
-import { ClientConfiguration } from "../config/ClientConfiguration";
-import { TimeUtils } from "../utils/TimeUtils";
-import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
-import { ResponseHandler } from "../response/ResponseHandler";
-import { AuthenticationResult } from "../response/AuthenticationResult";
-import { StringUtils } from "../utils/StringUtils";
-import { RequestThumbprint } from "../network/RequestThumbprint";
-import { ServerError } from "../error/ServerError";
-import { UrlString } from "../url/UrlString";
+import { DeviceCodeResponse, ServerDeviceCodeResponse } from "@azure/msal-common/src/response/DeviceCodeResponse";
+import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
+import { CommonDeviceCodeRequest } from "@azure/msal-common/src/request/CommonDeviceCodeRequest";
+import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
+import { RequestParameterBuilder } from "@azure/msal-common/src/request/RequestParameterBuilder";
+import { Constants, GrantType } from "@azure/msal-common/src/utils/Constants";
+import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
+import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
+import { ServerAuthorizationTokenResponse } from "@azure/msal-common/src/response/ServerAuthorizationTokenResponse";
+import { ResponseHandler } from "@azure/msal-common/src/response/ResponseHandler";
+import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
+import { StringUtils } from "@azure/msal-common/src/utils/StringUtils";
+import { RequestThumbprint } from "@azure/msal-common/src/network/RequestThumbprint";
+import { ServerError } from "@azure/msal-common/src/error/ServerError";
+import { UrlString } from "@azure/msal-common/src/url/UrlString";
 
 /**
  * OAuth2.0 Device code client

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -3,21 +3,25 @@
  * Licensed under the MIT License.
  */
 
-import { DeviceCodeResponse, ServerDeviceCodeResponse } from "@azure/msal-common/src/response/DeviceCodeResponse";
-import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
-import { CommonDeviceCodeRequest } from "@azure/msal-common/src/request/CommonDeviceCodeRequest";
-import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
-import { RequestParameterBuilder } from "@azure/msal-common/src/request/RequestParameterBuilder";
-import { Constants, GrantType } from "@azure/msal-common/src/utils/Constants";
-import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
-import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
-import { ServerAuthorizationTokenResponse } from "@azure/msal-common/src/response/ServerAuthorizationTokenResponse";
-import { ResponseHandler } from "@azure/msal-common/src/response/ResponseHandler";
-import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
-import { StringUtils } from "@azure/msal-common/src/utils/StringUtils";
-import { RequestThumbprint } from "@azure/msal-common/src/network/RequestThumbprint";
-import { ServerError } from "@azure/msal-common/src/error/ServerError";
-import { UrlString } from "@azure/msal-common/src/url/UrlString";
+import {
+    AuthenticationResult,
+    BaseClient,
+    ClientAuthError,
+    ClientConfiguration,
+    CommonDeviceCodeRequest,
+    Constants,
+    DeviceCodeResponse,
+    GrantType,
+    RequestParameterBuilder,
+    RequestThumbprint,
+    ResponseHandler,
+    ServerAuthorizationTokenResponse,
+    ServerDeviceCodeResponse,
+    ServerError,
+    StringUtils,
+    TimeUtils,
+    UrlString
+} from "@azure/msal-common";
 
 /**
  * OAuth2.0 Device code client

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -3,25 +3,32 @@
  * Licensed under the MIT License.
  */
 
-import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
-import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
-import { Authority } from "@azure/msal-common/src/authority/Authority";
-import { RequestParameterBuilder } from "@azure/msal-common/src/request/RequestParameterBuilder";
-import { ScopeSet } from "@azure/msal-common/src/request/ScopeSet";
-import { GrantType, AADServerParamKeys , CredentialType, Constants, CacheOutcome, AuthenticationScheme } from "@azure/msal-common/src/utils/Constants";
-import { ResponseHandler } from "@azure/msal-common/src/response/ResponseHandler";
-import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
-import { CommonOnBehalfOfRequest } from "@azure/msal-common/src/request/CommonOnBehalfOfRequest";
-import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
-import { CredentialFilter, CredentialCache } from "@azure/msal-common/src/cache/utils/CacheTypes";
-import { AccessTokenEntity } from "@azure/msal-common/src/cache/entities/AccessTokenEntity";
-import { IdTokenEntity } from "@azure/msal-common/src/cache/entities/IdTokenEntity";
-import { AccountEntity } from "@azure/msal-common/src/cache/entities/AccountEntity";
-import { AuthToken } from "@azure/msal-common/src/account/AuthToken";
-import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
-import { RequestThumbprint } from "@azure/msal-common/src/network/RequestThumbprint";
-import { AccountInfo } from "@azure/msal-common/src/account/AccountInfo";
-import { UrlString } from "@azure/msal-common/src/url/UrlString";
+import {
+    AADServerParamKeys,
+    AccessTokenEntity,
+    AccountEntity,
+    AccountInfo,
+    AuthenticationResult,
+    AuthenticationScheme,
+    Authority,
+    AuthToken,
+    BaseClient,
+    CacheOutcome,
+    ClientAuthError,
+    ClientConfiguration,
+    CommonOnBehalfOfRequest,
+    Constants,
+    CredentialCache,
+    CredentialFilter,
+    CredentialType, GrantType,
+    IdTokenEntity,
+    RequestParameterBuilder,
+    RequestThumbprint,
+    ResponseHandler,
+    ScopeSet,
+    TimeUtils,
+    UrlString
+} from "@azure/msal-common";
 
 /**
  * On-Behalf-Of client
@@ -82,7 +89,7 @@ export class OnBehalfOfClient extends BaseClient {
         }
 
         // fetch the idToken from cache
-        const cachedIdToken = this.readIdTokenFromCacheForOBO(request, cachedAccessToken.homeAccountId);
+        const cachedIdToken = this.readIdTokenFromCacheForOBO(cachedAccessToken.homeAccountId);
         let idTokenObject: AuthToken | undefined;
         let cachedAccount: AccountEntity | null = null;
         if (cachedIdToken) {
@@ -122,9 +129,9 @@ export class OnBehalfOfClient extends BaseClient {
     /**
      * read idtoken from cache, this is a specific implementation for OBO as the requirements differ from a generic lookup in the cacheManager
      * Certain use cases of OBO flow do not expect an idToken in the cache/or from the service
-     * @param request
+     * @param atHomeAccountId {string}
      */
-    private readIdTokenFromCacheForOBO(request: CommonOnBehalfOfRequest, atHomeAccountId: string): IdTokenEntity | null {
+    private readIdTokenFromCacheForOBO(atHomeAccountId: string): IdTokenEntity | null {
 
         const idTokenFilter: CredentialFilter = {
             homeAccountId: atHomeAccountId,

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -3,25 +3,25 @@
  * Licensed under the MIT License.
  */
 
-import { ClientConfiguration } from "../config/ClientConfiguration";
-import { BaseClient } from "./BaseClient";
-import { Authority } from "../authority/Authority";
-import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { ScopeSet } from "../request/ScopeSet";
-import { GrantType, AADServerParamKeys , CredentialType, Constants, CacheOutcome, AuthenticationScheme } from "../utils/Constants";
-import { ResponseHandler } from "../response/ResponseHandler";
-import { AuthenticationResult } from "../response/AuthenticationResult";
-import { CommonOnBehalfOfRequest } from "../request/CommonOnBehalfOfRequest";
-import { TimeUtils } from "../utils/TimeUtils";
-import { CredentialFilter, CredentialCache } from "../cache/utils/CacheTypes";
-import { AccessTokenEntity } from "../cache/entities/AccessTokenEntity";
-import { IdTokenEntity } from "../cache/entities/IdTokenEntity";
-import { AccountEntity } from "../cache/entities/AccountEntity";
-import { AuthToken } from "../account/AuthToken";
-import { ClientAuthError } from "../error/ClientAuthError";
-import { RequestThumbprint } from "../network/RequestThumbprint";
-import { AccountInfo } from "../account/AccountInfo";
-import { UrlString } from "../url/UrlString";
+import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
+import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
+import { Authority } from "@azure/msal-common/src/authority/Authority";
+import { RequestParameterBuilder } from "@azure/msal-common/src/request/RequestParameterBuilder";
+import { ScopeSet } from "@azure/msal-common/src/request/ScopeSet";
+import { GrantType, AADServerParamKeys , CredentialType, Constants, CacheOutcome, AuthenticationScheme } from "@azure/msal-common/src/utils/Constants";
+import { ResponseHandler } from "@azure/msal-common/src/response/ResponseHandler";
+import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
+import { CommonOnBehalfOfRequest } from "@azure/msal-common/src/request/CommonOnBehalfOfRequest";
+import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
+import { CredentialFilter, CredentialCache } from "@azure/msal-common/src/cache/utils/CacheTypes";
+import { AccessTokenEntity } from "@azure/msal-common/src/cache/entities/AccessTokenEntity";
+import { IdTokenEntity } from "@azure/msal-common/src/cache/entities/IdTokenEntity";
+import { AccountEntity } from "@azure/msal-common/src/cache/entities/AccountEntity";
+import { AuthToken } from "@azure/msal-common/src/account/AuthToken";
+import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
+import { RequestThumbprint } from "@azure/msal-common/src/network/RequestThumbprint";
+import { AccountInfo } from "@azure/msal-common/src/account/AccountInfo";
+import { UrlString } from "@azure/msal-common/src/url/UrlString";
 
 /**
  * On-Behalf-Of client
@@ -272,7 +272,7 @@ export class OnBehalfOfClient extends BaseClient {
         if (request.claims || (this.config.authOptions.clientCapabilities && this.config.authOptions.clientCapabilities.length > 0)) {
             parameterBuilder.addClaims(request.claims, this.config.authOptions.clientCapabilities);
         }
-       
+
         return parameterBuilder.createQueryString();
     }
 }

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -5,7 +5,6 @@
 
 import { ApiId } from "../utils/Constants";
 import {
-    DeviceCodeClient,
     AuthenticationResult,
     CommonDeviceCodeRequest,
     AuthError,
@@ -25,6 +24,7 @@ import { InteractiveRequest } from "../request/InteractiveRequest";
 import { NodeAuthError } from "../error/NodeAuthError";
 import { LoopbackClient } from "../network/LoopbackClient";
 import { ILoopbackClient } from "../network/ILoopbackClient";
+import { DeviceCodeClient } from "./DeviceCodeClient";
 
 /**
  * This class is to be used to acquire tokens for public client applications (desktop, mobile). Public client applications

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -3,21 +3,24 @@
  * Licensed under the MIT License.
  */
 
-import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
-import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
-import { CommonUsernamePasswordRequest } from "@azure/msal-common/src/request/CommonUsernamePasswordRequest";
-import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
-import { ResponseHandler } from "@azure/msal-common/src/response/ResponseHandler";
-import { Authority } from "@azure/msal-common/src/authority/Authority";
-import { NetworkResponse } from "@azure/msal-common/src/network/NetworkManager";
-import { ServerAuthorizationTokenResponse } from "@azure/msal-common/src/response/ServerAuthorizationTokenResponse";
-import { RequestParameterBuilder } from "@azure/msal-common/src/request/RequestParameterBuilder";
-import { GrantType, HeaderNames } from "@azure/msal-common/src/utils/Constants";
-import { StringUtils } from "@azure/msal-common/src/utils/StringUtils";
-import { RequestThumbprint } from "@azure/msal-common/src/network/RequestThumbprint";
-import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
-import { CcsCredentialType } from "@azure/msal-common/src/account/CcsCredential";
-import { UrlString } from "@azure/msal-common/src/url/UrlString";
+import {
+    AuthenticationResult,
+    Authority,
+    BaseClient,
+    CcsCredentialType,
+    ClientConfiguration,
+    CommonUsernamePasswordRequest,
+    GrantType,
+    HeaderNames,
+    NetworkResponse,
+    RequestParameterBuilder,
+    RequestThumbprint,
+    ResponseHandler,
+    ServerAuthorizationTokenResponse,
+    StringUtils,
+    TimeUtils,
+    UrlString
+} from "@azure/msal-common";
 
 /**
  * Oauth2.0 Password grant client

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import { BaseClient } from "./BaseClient";
-import { ClientConfiguration } from "../config/ClientConfiguration";
-import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePasswordRequest";
-import { AuthenticationResult } from "../response/AuthenticationResult";
-import { ResponseHandler } from "../response/ResponseHandler";
-import { Authority } from "../authority/Authority";
-import { NetworkResponse } from "../network/NetworkManager";
-import { ServerAuthorizationTokenResponse } from "../response/ServerAuthorizationTokenResponse";
-import { RequestParameterBuilder } from "../request/RequestParameterBuilder";
-import { GrantType, HeaderNames } from "../utils/Constants";
-import { StringUtils } from "../utils/StringUtils";
-import { RequestThumbprint } from "../network/RequestThumbprint";
-import { TimeUtils } from "../utils/TimeUtils";
-import { CcsCredentialType } from "../account/CcsCredential";
-import { UrlString } from "../url/UrlString";
+import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
+import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
+import { CommonUsernamePasswordRequest } from "@azure/msal-common/src/request/CommonUsernamePasswordRequest";
+import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
+import { ResponseHandler } from "@azure/msal-common/src/response/ResponseHandler";
+import { Authority } from "@azure/msal-common/src/authority/Authority";
+import { NetworkResponse } from "@azure/msal-common/src/network/NetworkManager";
+import { ServerAuthorizationTokenResponse } from "@azure/msal-common/src/response/ServerAuthorizationTokenResponse";
+import { RequestParameterBuilder } from "@azure/msal-common/src/request/RequestParameterBuilder";
+import { GrantType, HeaderNames } from "@azure/msal-common/src/utils/Constants";
+import { StringUtils } from "@azure/msal-common/src/utils/StringUtils";
+import { RequestThumbprint } from "@azure/msal-common/src/network/RequestThumbprint";
+import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
+import { CcsCredentialType } from "@azure/msal-common/src/account/CcsCredential";
+import { UrlString } from "@azure/msal-common/src/url/UrlString";
 
 /**
  * Oauth2.0 Password grant client
@@ -46,7 +46,7 @@ export class UsernamePasswordClient extends BaseClient {
         atsMeasurement?.addStaticFields({
             httpVerToken
         });
-    
+
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,
             this.cacheManager,

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -20,6 +20,11 @@ export { ILoopbackClient } from "./network/ILoopbackClient";
 export { PublicClientApplication } from "./client/PublicClientApplication";
 export { ConfidentialClientApplication } from "./client/ConfidentialClientApplication";
 export { ClientApplication } from "./client/ClientApplication";
+export { ClientCredentialClient } from "./client/ClientCredentialClient";
+export { DeviceCodeClient } from "./client/DeviceCodeClient";
+export { OnBehalfOfClient } from "./client/OnBehalfOfClient";
+export { UsernamePasswordClient } from "./client/UsernamePasswordClient";
+
 export { Configuration, buildAppConfiguration, NodeAuthOptions, NodeSystemOptions, CacheOptions } from "./config/Configuration";
 export { ClientAssertion } from "./client/ClientAssertion";
 

--- a/lib/msal-node/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-node/test/client/ClientCredentialClient.spec.ts
@@ -9,22 +9,22 @@ import {
     DSTS_CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT,
     AUTHENTICATION_RESULT_DEFAULT_SCOPES,
     ID_TOKEN_CLAIMS
-} from "../test_kit/StringConstants";
-import { BaseClient } from "../../src/client/BaseClient";
-import { AADServerParamKeys, GrantType, Constants, AuthenticationScheme, ThrottlingConstants } from "../../src/utils/Constants";
-import { ClientTestUtils, mockCrypto } from "./ClientTestUtils";
-import { Authority } from "../../src/authority/Authority";
+} from "@azure/msal-common/test/test_kit/StringConstants";
+import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
+import { AADServerParamKeys, GrantType, Constants, AuthenticationScheme, ThrottlingConstants } from "@azure/msal-common/src/utils/Constants";
+import { ClientTestUtils, mockCrypto } from "@azure/msal-common/test/client/ClientTestUtils";
+import { Authority } from "@azure/msal-common/src/authority/Authority";
 import { ClientCredentialClient } from "../../src/client/ClientCredentialClient";
-import { CommonClientCredentialRequest } from "../../src/request/CommonClientCredentialRequest";
+import { CommonClientCredentialRequest } from "@azure/msal-common/src/request/CommonClientCredentialRequest";
 import { UsernamePasswordClient } from "../../src/client/UsernamePasswordClient";
-import { CommonUsernamePasswordRequest } from "../../src/request/CommonUsernamePasswordRequest";
-import { AccessTokenEntity } from "../../src/cache/entities/AccessTokenEntity"
-import { TimeUtils } from "../../src/utils/TimeUtils";
-import { CredentialCache } from "../../src/cache/utils/CacheTypes";
-import { CacheManager } from "../../src/cache/CacheManager";
-import { ClientAuthError } from "../../src/error/ClientAuthError";
-import { AuthenticationResult } from "../../src/response/AuthenticationResult";
-import { AppTokenProviderResult, AuthToken, ClientConfiguration, IAppTokenProvider, InteractionRequiredAuthError } from "../../src";
+import { CommonUsernamePasswordRequest } from "@azure/msal-common/src/request/CommonUsernamePasswordRequest";
+import { AccessTokenEntity } from "@azure/msal-common/src/cache/entities/AccessTokenEntity"
+import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
+import { CredentialCache } from "@azure/msal-common/src/cache/utils/CacheTypes";
+import { CacheManager } from "@azure/msal-common/src/cache/CacheManager";
+import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
+import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
+import { AppTokenProviderResult, AuthToken, ClientConfiguration, IAppTokenProvider, InteractionRequiredAuthError } from "@azure/msal-common/src";
 
 describe("ClientCredentialClient unit tests", () => {
     let config: ClientConfiguration;
@@ -47,7 +47,7 @@ describe("ClientCredentialClient unit tests", () => {
             expect(client instanceof BaseClient).toBe(true);
         });
     });
-    
+
     it("acquires a token", async () => {
         sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
         sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").resolves(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT);
@@ -110,7 +110,7 @@ describe("ClientCredentialClient unit tests", () => {
             // Catch errors thrown after the function call this test is testing
         });
     });
-    
+
     it("acquireToken's interactionRequiredAuthError error contains claims", async () => {
         const errorResponse = {
             error: "interaction_required",
@@ -153,7 +153,7 @@ describe("ClientCredentialClient unit tests", () => {
     it("Multiple access tokens would match, but one of them has a Home Account ID of \"\"", async () => {
         sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
         sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").resolves(CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT);
-        
+
         const authenticationScopes = AUTHENTICATION_RESULT_DEFAULT_SCOPES;
         authenticationScopes.body.scope = "https://graph.microsoft.com/.default";
         sinon.stub(UsernamePasswordClient.prototype, <any>"executePostToTokenEndpoint").resolves(authenticationScopes);
@@ -441,7 +441,7 @@ describe("ClientCredentialClient unit tests", () => {
 
         const expectedAtEntity: AccessTokenEntity = AccessTokenEntity.createAccessTokenEntity(
             "", "login.microsoftonline.com", "an_access_token", config.authOptions.clientId, TEST_CONFIG.TENANT, TEST_CONFIG.DEFAULT_GRAPH_SCOPE.toString(), 4600, 4600, mockCrypto, undefined, AuthenticationScheme.BEARER);
-            
+
         sinon.stub(ClientCredentialClient.prototype, <any>"readAccessTokenFromCache").returns(expectedAtEntity);
         sinon.stub(TimeUtils, <any>"isTokenExpired").returns(false);
 
@@ -492,16 +492,16 @@ describe("ClientCredentialClient unit tests", () => {
 
     it("Multiple access tokens matched, exception thrown", async () => {
         sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
-        
+
         // mock access token
         const mockedAtEntity: AccessTokenEntity = AccessTokenEntity.createAccessTokenEntity(
             "", "login.microsoftonline.com", "an_access_token", config.authOptions.clientId, TEST_CONFIG.TENANT, TEST_CONFIG.DEFAULT_GRAPH_SCOPE.toString(), 4600, 4600, mockCrypto, undefined, AuthenticationScheme.BEARER, TEST_TOKENS.ACCESS_TOKEN);
-            
+
         const mockedAtEntity2: AccessTokenEntity = AccessTokenEntity.createAccessTokenEntity(
             "", "login.microsoftonline.com", "an_access_token", config.authOptions.clientId, TEST_CONFIG.TENANT, TEST_CONFIG.DEFAULT_GRAPH_SCOPE.toString(), 4600, 4600, mockCrypto, undefined, AuthenticationScheme.BEARER, TEST_TOKENS.ACCESS_TOKEN);
-            
+
         const mockedCredentialCache: CredentialCache = {
-            accessTokens: { 
+            accessTokens: {
                 "key1": mockedAtEntity,
                 "key2": mockedAtEntity2
             },
@@ -539,20 +539,20 @@ describe("ClientCredentialClient unit tests", () => {
         let callbackedCalledCount = 0;
 
         const appTokenProvider: IAppTokenProvider =  (appTokenProviderParameters) => {
-            
+
             callbackedCalledCount++;
 
             expect(appTokenProviderParameters.scopes).toEqual(expectedScopes);
             expect(appTokenProviderParameters.tenantId).toEqual("common");
             expect(appTokenProviderParameters.correlationId).toEqual(TEST_CONFIG.CORRELATION_ID);
             expect(appTokenProviderParameters.claims).toBeUndefined();
-                
+
             return new Promise<AppTokenProviderResult>(
-                (resolve) => resolve(appTokenProviderResult));                        
+                (resolve) => resolve(appTokenProviderResult));
         };
-    
+
         // client credentials not needed
-        config.clientCredentials = undefined;    
+        config.clientCredentials = undefined;
 
         const client = new ClientCredentialClient(config, appTokenProvider);
         const clientCredentialRequest: CommonClientCredentialRequest = {

--- a/lib/msal-node/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-node/test/client/ClientCredentialClient.spec.ts
@@ -1,30 +1,39 @@
 import sinon from "sinon";
 import {
-    CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT,
-    DEFAULT_OPENID_CONFIG_RESPONSE,
-    TEST_CONFIG,
-    TEST_TOKENS,
-    CORS_SIMPLE_REQUEST_HEADERS,
-    DSTS_OPENID_CONFIG_RESPONSE,
-    DSTS_CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT,
+    AADServerParamKeys,
+    AccessTokenEntity,
+    AppTokenProviderResult,
+    AuthenticationResult,
+    AuthenticationScheme,
+    Authority, AuthToken,
+    BaseClient,
+    CacheManager,
+    ClientAuthError,
+    ClientConfiguration,
+    CommonClientCredentialRequest,
+    CommonUsernamePasswordRequest,
+    Constants,
+    CredentialCache,
+    GrantType,
+    IAppTokenProvider, InteractionRequiredAuthError,
+    ThrottlingConstants,
+    TimeUtils
+} from "@azure/msal-common";
+import { ClientCredentialClient, UsernamePasswordClient } from "../../src";
+import {
     AUTHENTICATION_RESULT_DEFAULT_SCOPES,
-    ID_TOKEN_CLAIMS
-} from "@azure/msal-common/test/test_kit/StringConstants";
-import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
-import { AADServerParamKeys, GrantType, Constants, AuthenticationScheme, ThrottlingConstants } from "@azure/msal-common/src/utils/Constants";
-import { ClientTestUtils, mockCrypto } from "@azure/msal-common/test/client/ClientTestUtils";
-import { Authority } from "@azure/msal-common/src/authority/Authority";
-import { ClientCredentialClient } from "../../src/client/ClientCredentialClient";
-import { CommonClientCredentialRequest } from "@azure/msal-common/src/request/CommonClientCredentialRequest";
-import { UsernamePasswordClient } from "../../src/client/UsernamePasswordClient";
-import { CommonUsernamePasswordRequest } from "@azure/msal-common/src/request/CommonUsernamePasswordRequest";
-import { AccessTokenEntity } from "@azure/msal-common/src/cache/entities/AccessTokenEntity"
-import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
-import { CredentialCache } from "@azure/msal-common/src/cache/utils/CacheTypes";
-import { CacheManager } from "@azure/msal-common/src/cache/CacheManager";
-import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
-import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
-import { AppTokenProviderResult, AuthToken, ClientConfiguration, IAppTokenProvider, InteractionRequiredAuthError } from "@azure/msal-common/src";
+    CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT,
+    CORS_SIMPLE_REQUEST_HEADERS,
+    DEFAULT_OPENID_CONFIG_RESPONSE,
+    DSTS_CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT,
+    DSTS_OPENID_CONFIG_RESPONSE,
+    ID_TOKEN_CLAIMS,
+    TEST_CONFIG,
+    TEST_TOKENS
+} from "../test_kit/StringConstants";
+import { ClientTestUtils, mockCrypto } from "./ClientTestUtils";
+
+
 
 describe("ClientCredentialClient unit tests", () => {
     let config: ClientConfiguration;
@@ -106,7 +115,7 @@ describe("ClientCredentialClient unit tests", () => {
         };
 
         const client = new ClientCredentialClient(config);
-        client.acquireToken(clientCredentialRequest).catch((error) => {
+        client.acquireToken(clientCredentialRequest).catch(() => {
             // Catch errors thrown after the function call this test is testing
         });
     });
@@ -414,6 +423,7 @@ describe("ClientCredentialClient unit tests", () => {
         // For more information about this test see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
         let stubCalled = false;
         sinon.stub(Authority.prototype, <any>"getEndpointMetadataFromNetwork").resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+        // @ts-ignore
         sinon.stub(ClientCredentialClient.prototype, <any>"executePostToTokenEndpoint").callsFake((tokenEndpoint: string, queryString: string, headers: Record<string, string>) => {
             const headerNames = Object.keys(headers);
             headerNames.forEach((name) => {

--- a/lib/msal-node/test/client/ClientTestUtils.ts
+++ b/lib/msal-node/test/client/ClientTestUtils.ts
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    ServerTelemetryEntity,
+    CacheManager,
+    ClientConfiguration,
+    Constants,
+    PkceCodes,
+    ClientAuthError,
+    AccountEntity,
+    CredentialEntity,
+    AppMetadataEntity,
+    ThrottlingEntity,
+    IdTokenEntity,
+    AccessTokenEntity,
+    RefreshTokenEntity,
+    CredentialType,
+    ProtocolMode,
+    AuthorityFactory,
+    AuthorityOptions,
+    AuthorityMetadataEntity,
+    ValidCredentialType,
+    Logger,
+    LogLevel
+} from "@azure/msal-common";
+import {
+    AUTHENTICATION_RESULT,
+    ID_TOKEN_CLAIMS,
+    RANDOM_TEST_GUID,
+    TEST_CONFIG,
+    TEST_CRYPTO_VALUES,
+    TEST_POP_VALUES,
+    TEST_TOKENS
+} from "../test_kit/StringConstants";
+
+export class MockStorageClass extends CacheManager {
+    store = {};
+
+    // Accounts
+    getAccount(key: string): AccountEntity | null {
+        const account: AccountEntity = this.store[key] as AccountEntity;
+        if (AccountEntity.isAccountEntity(account)) {
+            return account;
+        }
+        return null;
+    }
+
+    setAccount(value: AccountEntity): void {
+        const key = value.generateAccountKey();
+        this.store[key] = value;
+    }
+
+    // Credentials (idtokens)
+    getIdTokenCredential(key: string): IdTokenEntity | null {
+        const credType = CredentialEntity.getCredentialType(key);
+        if (credType === CredentialType.ID_TOKEN) {
+            return this.store[key] as IdTokenEntity;
+        }
+        return null;
+    }
+
+    setIdTokenCredential(value: IdTokenEntity): void {
+        const key = value.generateCredentialKey();
+        this.store[key] = value;
+    }
+
+    // Credentials (accesstokens)
+    getAccessTokenCredential(key: string): AccessTokenEntity | null {
+        const credType = CredentialEntity.getCredentialType(key);
+        if (credType === CredentialType.ACCESS_TOKEN || credType === CredentialType.ACCESS_TOKEN_WITH_AUTH_SCHEME) {
+            return this.store[key] as AccessTokenEntity;
+        }
+        return null;
+    }
+
+    setAccessTokenCredential(value: AccessTokenEntity): void {
+        const key = value.generateCredentialKey();
+        this.store[key] = value;
+    }
+
+    // Credentials (accesstokens)
+    getRefreshTokenCredential(key: string): RefreshTokenEntity | null {
+        const credType = CredentialEntity.getCredentialType(key);
+        if (credType === CredentialType.REFRESH_TOKEN) {
+            return this.store[key] as RefreshTokenEntity;
+        }
+        return null;
+    }
+
+    setRefreshTokenCredential(value: RefreshTokenEntity): void {
+        const key = value.generateCredentialKey();
+        this.store[key] = value;
+    }
+
+    // AppMetadata
+    getAppMetadata(key: string): AppMetadataEntity | null {
+        return this.store[key] as AppMetadataEntity;
+    }
+
+    setAppMetadata(value: AppMetadataEntity): void {
+        const key = value.generateAppMetadataKey();
+        this.store[key] = value;
+    }
+
+    // Telemetry cache
+    getServerTelemetry(key: string): ServerTelemetryEntity | null {
+        return this.store[key] as ServerTelemetryEntity;
+    }
+
+    setServerTelemetry(key: string, value: ServerTelemetryEntity): void {
+        this.store[key] = value;
+    }
+
+    // Authority Metadata Cache
+    getAuthorityMetadata(key: string): AuthorityMetadataEntity | null {
+        return this.store[key] as AuthorityMetadataEntity;
+    }
+
+    setAuthorityMetadata(key: string, value: AuthorityMetadataEntity): void {
+        this.store[key] = value;
+    }
+
+    // Throttling cache
+    getThrottlingCache(key: string): ThrottlingEntity | null {
+        return this.store[key] as ThrottlingEntity;
+    }
+
+    setThrottlingCache(key: string, value: ThrottlingEntity): void {
+        this.store[key] = value;
+    }
+
+    removeItem(key: string): boolean {
+        let result: boolean = false;
+        if (!!this.store[key]) {
+            delete this.store[key];
+            result = true;
+        }
+        return result;
+    }
+
+    containsKey(key: string): boolean {
+        return !!this.store[key];
+    }
+
+    getKeys(): string[] {
+        return Object.keys(this.store);
+    }
+
+    getAuthorityMetadataKeys(): string[] {
+        return this.getKeys();
+    }
+
+    async clear(): Promise<void> {
+        this.store = {};
+    }
+
+    updateCredentialCacheKey(currentCacheKey: string, credential: ValidCredentialType): string {
+        const updatedCacheKey = credential.generateCredentialKey();
+
+        if (currentCacheKey !== updatedCacheKey) {
+            const cacheItem = this.store[currentCacheKey];
+            if (cacheItem) {
+                this.removeItem(currentCacheKey);
+                this.store[updatedCacheKey] = cacheItem;
+                return updatedCacheKey;
+            }
+        }
+
+        return currentCacheKey;
+    }
+}
+
+export const mockCrypto = {
+    createNewGuid(): string {
+        return RANDOM_TEST_GUID;
+    },
+    base64Decode(input: string): string {
+        if (AUTHENTICATION_RESULT.body.id_token.includes(input)) {
+            return JSON.stringify(ID_TOKEN_CLAIMS);
+        }
+        switch (input) {
+            case TEST_POP_VALUES.ENCODED_REQ_CNF:
+                return TEST_POP_VALUES.DECODED_REQ_CNF;
+            case TEST_TOKENS.POP_TOKEN_PAYLOAD:
+                return TEST_TOKENS.DECODED_POP_TOKEN_PAYLOAD;
+            default:
+                return input;
+        }
+    },
+    base64Encode(input: string): string {
+        switch (input) {
+            case TEST_POP_VALUES.DECODED_REQ_CNF:
+                return TEST_POP_VALUES.ENCODED_REQ_CNF;
+            default:
+                return input;
+        }
+    },
+    async generatePkceCodes(): Promise<PkceCodes> {
+        return {
+            challenge: TEST_CONFIG.TEST_CHALLENGE,
+            verifier: TEST_CONFIG.TEST_VERIFIER,
+        };
+    },
+    async getPublicKeyThumbprint(): Promise<string> {
+        return TEST_POP_VALUES.KID;
+    },
+    // @ts-ignore
+    async removeTokenBindingKey(keyId: string): Promise<boolean> {
+        return Promise.resolve(true);
+    },
+    async signJwt(): Promise<string> {
+        return "";
+    },
+    async clearKeystore(): Promise<boolean> {
+        return Promise.resolve(true);
+    },
+    async hashString(): Promise<string> {
+        return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
+    }
+};
+
+export class ClientTestUtils {
+
+    static async createTestClientConfiguration(): Promise<ClientConfiguration> {
+        const mockStorage = new MockStorageClass(TEST_CONFIG.MSAL_CLIENT_ID, mockCrypto);
+
+        const testLoggerCallback = (): void => {
+            return;
+        };
+
+        const mockHttpClient = {
+            sendGetRequestAsync<T>(): T {
+                return {} as T;
+            },
+            sendPostRequestAsync<T>(): T {
+                return {} as T;
+            }
+        };
+
+        const authorityOptions: AuthorityOptions = {
+            protocolMode: ProtocolMode.AAD,
+            knownAuthorities: [TEST_CONFIG.validAuthority],
+            cloudDiscoveryMetadata: "",
+            authorityMetadata: ""
+        };
+
+        const loggerOptions = {
+            loggerCallback: (): void => {
+            },
+            piiLoggingEnabled: true,
+            logLevel: LogLevel.Verbose
+        };
+        const logger = new Logger(loggerOptions);
+
+        const authority = AuthorityFactory.createInstance(TEST_CONFIG.validAuthority, mockHttpClient, mockStorage, authorityOptions, logger);
+
+        await authority.resolveEndpointsAsync().catch(error => {
+            throw ClientAuthError.createEndpointDiscoveryIncompleteError(error);
+        });
+
+        return {
+            authOptions: {
+                clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                authority: authority
+            },
+            storageInterface: mockStorage,
+            networkInterface: mockHttpClient,
+            cryptoInterface: mockCrypto,
+            loggerOptions: {
+                loggerCallback: testLoggerCallback,
+            },
+            systemOptions: {
+                tokenRenewalOffsetSeconds: TEST_CONFIG.DEFAULT_TOKEN_RENEWAL_OFFSET
+            },
+            clientCredentials: {
+                clientSecret: TEST_CONFIG.MSAL_CLIENT_SECRET,
+            },
+            libraryInfo: {
+                sku: Constants.SKU,
+                version: TEST_CONFIG.TEST_VERSION,
+                os: TEST_CONFIG.TEST_OS,
+                cpu: TEST_CONFIG.TEST_CPU,
+            },
+            telemetry: {
+                application: {
+                    appName: TEST_CONFIG.applicationName,
+                    appVersion: TEST_CONFIG.applicationVersion
+                }
+            }
+        };
+    }
+}

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -1,18 +1,34 @@
-import { ConfidentialClientApplication } from './../../src/client/ConfidentialClientApplication';
-import { ClientConfiguration, AuthorizationCodeClient, RefreshTokenClient, AuthenticationResult, ClientCredentialClient, OnBehalfOfClient, UsernamePasswordClient } from '@azure/msal-common';
+import {
+    AuthError,
+    ConfidentialClientApplication,
+    OnBehalfOfRequest,
+    UsernamePasswordRequest
+} from '../../src';
+import {
+    ClientConfiguration,
+    AuthorizationCodeClient,
+    RefreshTokenClient,
+    AuthenticationResult,
+    OIDC_DEFAULT_SCOPES
+} from '@azure/msal-common';
 import { TEST_CONSTANTS } from '../utils/TestConstants';
-import { Configuration } from "../../src/config/Configuration";
-import { AuthorizationCodeRequest } from "../../src/request/AuthorizationCodeRequest";
-import { UsernamePasswordRequest } from '../../src';
-import { RefreshTokenRequest } from "../../src/request/RefreshTokenRequest";
+import {
+    ClientCredentialRequest,
+    Configuration,
+    AuthorizationCodeRequest,
+    ClientCredentialClient,
+    RefreshTokenRequest
+} from "../../src";
 import { fakeAuthority, setupAuthorityFactory_createDiscoveredInstance_mock } from './test-fixtures';
 
-import { ClientCredentialRequest } from '../../src/request/ClientCredentialRequest';
-import { OnBehalfOfRequest } from '../../src';
+import * as msalNode from '../../src';
 import { getMsalCommonAutoMock, MSALCommonModule } from '../utils/MockUtils';
-import { AuthError, OIDC_DEFAULT_SCOPES } from "@azure/msal-common";
 
 const msalCommon: MSALCommonModule = jest.requireActual('@azure/msal-common');
+
+jest.mock('../../src/client/ClientCredentialClient');
+jest.mock('../../src/client/OnBehalfOfClient');
+jest.mock('../../src/client/UsernamePasswordClient');
 
 describe('ConfidentialClientApplication', () => {
     let appConfig: Configuration = {
@@ -73,7 +89,7 @@ describe('ConfidentialClientApplication', () => {
         setupAuthorityFactory_createDiscoveredInstance_mock();
 
 
-        const { RefreshTokenClient: mockRefreshTokenClient } = getMsalCommonAutoMock();
+        const {RefreshTokenClient: mockRefreshTokenClient} = getMsalCommonAutoMock();
 
 
         jest.spyOn(msalCommon, 'RefreshTokenClient')
@@ -101,7 +117,8 @@ describe('ConfidentialClientApplication', () => {
                     accessToken: "accessToken",
                     expiresInSeconds: 3601,
                     refreshInSeconds: 1801,
-                }))};
+                }))
+        };
 
         const configWithExtensibility: Configuration = {
             auth: {
@@ -116,10 +133,6 @@ describe('ConfidentialClientApplication', () => {
             skipCache: false
         };
         setupAuthorityFactory_createDiscoveredInstance_mock();
-        const MockClientCredentialClient = getMsalCommonAutoMock().ClientCredentialClient;
-
-        jest.spyOn(msalCommon, 'ClientCredentialClient')
-            .mockImplementation((conf) => new MockClientCredentialClient(conf));
 
         const authApp = new ConfidentialClientApplication(configWithExtensibility);
         authApp.SetAppTokenProvider(testProvider);
@@ -135,13 +148,8 @@ describe('ConfidentialClientApplication', () => {
             clientAssertion: "testAssertion"
         };
         setupAuthorityFactory_createDiscoveredInstance_mock();
-        const MockClientCredentialClient = getMsalCommonAutoMock().ClientCredentialClient;
 
-        jest.spyOn(msalCommon, 'ClientCredentialClient')
-            .mockImplementation((conf) => new MockClientCredentialClient(conf));
-
-        // @ts-ignore
-        MockClientCredentialClient.prototype.acquireToken = jest.fn((request: msalCommon.CommonClientCredentialRequest) => {
+        ClientCredentialClient.prototype.acquireToken = jest.fn((request: ClientCredentialRequest) => {
             expect(request.clientAssertion).not.toBe(undefined);
             expect(request.clientAssertion?.assertion).toBe("testAssertion");
             expect(request.clientAssertion?.assertionType).toBe("urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
@@ -153,7 +161,6 @@ describe('ConfidentialClientApplication', () => {
     });
 
 
-
     test('acquireTokenOnBehalfOf', async () => {
         const request: OnBehalfOfRequest = {
             scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
@@ -162,18 +169,15 @@ describe('ConfidentialClientApplication', () => {
 
         setupAuthorityFactory_createDiscoveredInstance_mock();
 
-        const { OnBehalfOfClient: MockOnBehalfOfClient } = getMsalCommonAutoMock();
-
-        jest.spyOn(msalCommon, 'OnBehalfOfClient').mockImplementation((conf) => new MockOnBehalfOfClient(conf));
+        const onBehalfOfClientSpy = jest.spyOn(msalNode, 'OnBehalfOfClient');
 
         const authApp = new ConfidentialClientApplication(appConfig);
         await authApp.acquireTokenOnBehalfOf(request);
-        expect(OnBehalfOfClient).toHaveBeenCalledTimes(1);
-        expect(OnBehalfOfClient).toHaveBeenCalledWith(
+        expect(onBehalfOfClientSpy).toHaveBeenCalledTimes(1);
+        expect(onBehalfOfClientSpy).toHaveBeenCalledWith(
             expect.objectContaining(expectedConfig)
         );
     });
-
 
 
     test('acquireTokenByUsernamePassword', async () => {
@@ -185,14 +189,12 @@ describe('ConfidentialClientApplication', () => {
 
         setupAuthorityFactory_createDiscoveredInstance_mock();
 
-        const { UsernamePasswordClient: MockUsernamePasswordClient } = getMsalCommonAutoMock();
-
-        jest.spyOn(msalCommon, 'UsernamePasswordClient').mockImplementation((conf) => new MockUsernamePasswordClient(conf));
+        const usernamePasswordClientSpy = jest.spyOn(msalNode, 'UsernamePasswordClient')
 
         const authApp = new ConfidentialClientApplication(appConfig);
         await authApp.acquireTokenByUsernamePassword(request);
-        expect(UsernamePasswordClient).toHaveBeenCalledTimes(1);
-        expect(UsernamePasswordClient).toHaveBeenCalledWith(
+        expect(usernamePasswordClientSpy).toHaveBeenCalledTimes(1);
+        expect(usernamePasswordClientSpy).toHaveBeenCalledWith(
             expect.objectContaining(expectedConfig)
         );
     });
@@ -204,18 +206,13 @@ describe('ConfidentialClientApplication', () => {
         };
 
         setupAuthorityFactory_createDiscoveredInstance_mock();
-        const MockClientCredentialClient = getMsalCommonAutoMock().ClientCredentialClient;
-
-        jest.spyOn(msalCommon, 'ClientCredentialClient')
-            .mockImplementation((conf) => new MockClientCredentialClient(conf));
 
         jest.spyOn(AuthError.prototype, 'setCorrelationId');
 
-        jest.spyOn(MockClientCredentialClient.prototype, 'acquireToken')
+        jest.spyOn(ClientCredentialClient.prototype, 'acquireToken')
             .mockImplementation(() => {
                 throw new AuthError();
             });
-
 
         try {
             const authApp = new ConfidentialClientApplication(appConfig);
@@ -233,13 +230,9 @@ describe('ConfidentialClientApplication', () => {
         };
 
         setupAuthorityFactory_createDiscoveredInstance_mock();
-        const MockClientCredentialClient = getMsalCommonAutoMock().ClientCredentialClient;
 
-        jest.spyOn(msalCommon, 'ClientCredentialClient')
-            .mockImplementation((conf) => new MockClientCredentialClient(conf));
-
-        // @ts-ignore
-        MockClientCredentialClient.prototype.acquireToken = jest.fn((request: msalCommon.CommonClientCredentialRequest) => {
+        jest.spyOn(ClientCredentialClient.prototype, 'acquireToken')
+            .mockImplementation((request: ClientCredentialRequest) => {
             OIDC_DEFAULT_SCOPES.forEach((scope: string) => {
                 expect(request.scopes).not.toContain(scope);
             });

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -1,10 +1,4 @@
 import {
-    AuthError,
-    ConfidentialClientApplication,
-    OnBehalfOfRequest,
-    UsernamePasswordRequest
-} from '../../src';
-import {
     ClientConfiguration,
     AuthorizationCodeClient,
     RefreshTokenClient,
@@ -14,6 +8,10 @@ import {
 } from '@azure/msal-common';
 import { TEST_CONSTANTS } from '../utils/TestConstants';
 import {
+    AuthError,
+    ConfidentialClientApplication,
+    OnBehalfOfRequest,
+    UsernamePasswordRequest,
     ClientCredentialRequest,
     Configuration,
     AuthorizationCodeRequest,

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -9,7 +9,7 @@ import {
     AuthorizationCodeClient,
     RefreshTokenClient,
     AuthenticationResult,
-    OIDC_DEFAULT_SCOPES
+    OIDC_DEFAULT_SCOPES, CommonClientCredentialRequest
 } from '@azure/msal-common';
 import { TEST_CONSTANTS } from '../utils/TestConstants';
 import {
@@ -149,7 +149,7 @@ describe('ConfidentialClientApplication', () => {
         };
         setupAuthorityFactory_createDiscoveredInstance_mock();
 
-        ClientCredentialClient.prototype.acquireToken = jest.fn((request: ClientCredentialRequest) => {
+        ClientCredentialClient.prototype.acquireToken = jest.fn((request: CommonClientCredentialRequest) => {
             expect(request.clientAssertion).not.toBe(undefined);
             expect(request.clientAssertion?.assertion).toBe("testAssertion");
             expect(request.clientAssertion?.assertionType).toBe("urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
@@ -232,7 +232,7 @@ describe('ConfidentialClientApplication', () => {
         setupAuthorityFactory_createDiscoveredInstance_mock();
 
         jest.spyOn(ClientCredentialClient.prototype, 'acquireToken')
-            .mockImplementation((request: ClientCredentialRequest) => {
+            .mockImplementation((request: CommonClientCredentialRequest) => {
             OIDC_DEFAULT_SCOPES.forEach((scope: string) => {
                 expect(request.scopes).not.toContain(scope);
             });

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -9,7 +9,8 @@ import {
     AuthorizationCodeClient,
     RefreshTokenClient,
     AuthenticationResult,
-    OIDC_DEFAULT_SCOPES, CommonClientCredentialRequest
+    OIDC_DEFAULT_SCOPES,
+    CommonClientCredentialRequest
 } from '@azure/msal-common';
 import { TEST_CONSTANTS } from '../utils/TestConstants';
 import {

--- a/lib/msal-node/test/client/DeviceCodeClient.spec.ts
+++ b/lib/msal-node/test/client/DeviceCodeClient.spec.ts
@@ -11,17 +11,17 @@ import {
     CORS_SIMPLE_REQUEST_HEADERS,
     RANDOM_TEST_GUID,
     SERVER_UNEXPECTED_ERROR
-} from "../test_kit/StringConstants";
-import { BaseClient } from "../../src/client/BaseClient";
-import { AADServerParamKeys, GrantType, ThrottlingConstants, Constants } from "../../src/utils/Constants";
-import { ClientTestUtils } from "./ClientTestUtils";
-import { ClientConfiguration } from "../../src/config/ClientConfiguration";
-import { Authority } from "../../src/authority/Authority";
-import { AuthToken } from "../../src/account/AuthToken";
+} from "@azure/msal-common/test/test_kit/StringConstants";
+import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
+import { AADServerParamKeys, GrantType, ThrottlingConstants, Constants } from "@azure/msal-common/src/utils/Constants";
+import { ClientTestUtils } from "@azure/msal-common/test/client/ClientTestUtils";
+import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
+import { Authority } from "@azure/msal-common/src/authority/Authority";
+import { AuthToken } from "@azure/msal-common/src/account/AuthToken";
 import { DeviceCodeClient } from "../../src/client/DeviceCodeClient";
-import { CommonDeviceCodeRequest } from "../../src/request/CommonDeviceCodeRequest";
-import { ClientAuthError } from "../../src/error/ClientAuthError";
-import { AuthError } from "../../src";
+import { CommonDeviceCodeRequest } from "@azure/msal-common/src/request/CommonDeviceCodeRequest";
+import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
+import { AuthError } from "@azure/msal-common/src";
 
 describe("DeviceCodeClient unit tests", () => {
     let config: ClientConfiguration;
@@ -104,7 +104,7 @@ describe("DeviceCodeClient unit tests", () => {
                 headerNames.forEach((name) => {
                     expect(CORS_SIMPLE_REQUEST_HEADERS).toEqual(expect.arrayContaining([name.toLowerCase()]));
                 });
-    
+
                 done();
                 return AUTHENTICATION_RESULT;
             });
@@ -181,7 +181,7 @@ describe("DeviceCodeClient unit tests", () => {
                     done(error);
                 }
             });
-    
+
             // let deviceCodeResponse = null;
             const deviceCodeRequest: CommonDeviceCodeRequest = {
                 authority: TEST_CONFIG.validAuthority,
@@ -194,7 +194,7 @@ describe("DeviceCodeClient unit tests", () => {
                 },
                 deviceCodeCallback: () => {},
             };
-    
+
             const client = new DeviceCodeClient(config);
             client.acquireToken(deviceCodeRequest).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
@@ -348,7 +348,7 @@ describe("DeviceCodeClient unit tests", () => {
                 correlationId: "test-correlationId",
                 scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE, ...TEST_CONFIG.DEFAULT_SCOPES],
                 deviceCodeCallback: () => {},
-                timeout: DEVICE_CODE_RESPONSE.interval - 1, // Setting a timeout equal to the interval polling time minus one to allow for one call to the token endpoint 
+                timeout: DEVICE_CODE_RESPONSE.interval - 1, // Setting a timeout equal to the interval polling time minus one to allow for one call to the token endpoint
             };
 
             const client = new DeviceCodeClient(config);

--- a/lib/msal-node/test/client/DeviceCodeClient.spec.ts
+++ b/lib/msal-node/test/client/DeviceCodeClient.spec.ts
@@ -1,6 +1,20 @@
 import sinon from "sinon";
 import {
-    AUTHENTICATION_RESULT, AUTHORIZATION_PENDING_RESPONSE,
+    AADServerParamKeys,
+    AuthError,
+    Authority,
+    AuthToken,
+    BaseClient,
+    ClientAuthError,
+    ClientConfiguration,
+    CommonDeviceCodeRequest,
+    Constants,
+    GrantType,
+    ThrottlingConstants
+} from "@azure/msal-common";
+import {
+    AUTHENTICATION_RESULT,
+    AUTHORIZATION_PENDING_RESPONSE,
     DEFAULT_OPENID_CONFIG_RESPONSE,
     DEVICE_CODE_EXPIRED_RESPONSE,
     DEVICE_CODE_RESPONSE,
@@ -11,17 +25,9 @@ import {
     CORS_SIMPLE_REQUEST_HEADERS,
     RANDOM_TEST_GUID,
     SERVER_UNEXPECTED_ERROR
-} from "@azure/msal-common/test/test_kit/StringConstants";
-import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
-import { AADServerParamKeys, GrantType, ThrottlingConstants, Constants } from "@azure/msal-common/src/utils/Constants";
-import { ClientTestUtils } from "@azure/msal-common/test/client/ClientTestUtils";
-import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
-import { Authority } from "@azure/msal-common/src/authority/Authority";
-import { AuthToken } from "@azure/msal-common/src/account/AuthToken";
-import { DeviceCodeClient } from "../../src/client/DeviceCodeClient";
-import { CommonDeviceCodeRequest } from "@azure/msal-common/src/request/CommonDeviceCodeRequest";
-import { ClientAuthError } from "@azure/msal-common/src/error/ClientAuthError";
-import { AuthError } from "@azure/msal-common/src";
+} from "../test_kit/StringConstants";
+import { ClientTestUtils } from "./ClientTestUtils";
+import { DeviceCodeClient } from "../../src";
 
 describe("DeviceCodeClient unit tests", () => {
     let config: ClientConfiguration;
@@ -99,6 +105,7 @@ describe("DeviceCodeClient unit tests", () => {
             jest.setTimeout(6000);
             // For more information about this test see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
             sinon.stub(DeviceCodeClient.prototype, <any>"executePostRequestToDeviceCodeEndpoint").resolves(DEVICE_CODE_RESPONSE);
+            // @ts-ignore
             sinon.stub(BaseClient.prototype, <any>"executePostToTokenEndpoint").callsFake((tokenEndpoint: string, queryString: string, headers: Record<string, string>) => {
                 const headerNames = Object.keys(headers);
                 headerNames.forEach((name) => {
@@ -196,7 +203,7 @@ describe("DeviceCodeClient unit tests", () => {
             };
 
             const client = new DeviceCodeClient(config);
-            client.acquireToken(deviceCodeRequest).catch((error) => {
+            client.acquireToken(deviceCodeRequest).catch(() => {
                 // Catch errors thrown after the function call this test is testing
             });
         });

--- a/lib/msal-node/test/client/OnBehalfOfClient.spec.ts
+++ b/lib/msal-node/test/client/OnBehalfOfClient.spec.ts
@@ -5,34 +5,34 @@
 
 import sinon from "sinon";
 import {
+    AADServerParamKeys,
+    AccessTokenEntity,
+    AccountEntity,
+    AuthenticationScheme,
+    Authority,
+    AuthToken,
+    BaseClient,
+    CacheManager,
+    ClientConfiguration,
+    CommonOnBehalfOfRequest,
+    Constants,
+    CredentialType,
+    IdTokenEntity, ScopeSet,
+    ThrottlingConstants,
+    TimeUtils
+} from "@azure/msal-common";
+import { AuthenticationResult, OnBehalfOfClient } from "../../src";
+import {
+    AUTHENTICATION_RESULT,
+    DEFAULT_OPENID_CONFIG_RESPONSE,
     TEST_CONFIG,
     TEST_DATA_CLIENT_INFO,
-    TEST_URIS,
-    ID_TOKEN_CLAIMS,
-    DEFAULT_OPENID_CONFIG_RESPONSE,
     TEST_TOKENS,
-    AUTHENTICATION_RESULT,
-} from "@azure/msal-common/test/test_kit/StringConstants";
-import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
-import { ClientTestUtils } from "@azure/msal-common/test/client/ClientTestUtils";
-import { OnBehalfOfClient } from "../../src/client/OnBehalfOfClient";
-import { CommonOnBehalfOfRequest } from "@azure/msal-common/src/request/CommonOnBehalfOfRequest";
-import { AuthToken } from "@azure/msal-common/src/account/AuthToken";
-import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
-import { Authority } from "@azure/msal-common/src/authority/Authority";
-import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
-import { AuthenticationResult, IdTokenEntity } from "@azure/msal-common/src";
-import { AccessTokenEntity } from "@azure/msal-common/src/cache/entities/AccessTokenEntity";
-import { AccountEntity } from "@azure/msal-common/src/cache/entities/AccountEntity";
-import {
-    AuthenticationScheme,
-    CredentialType,
-    AADServerParamKeys,
-    Constants,
-    ThrottlingConstants,
-} from "@azure/msal-common/src/utils/Constants";
-import { CacheManager } from "@azure/msal-common/src/cache/CacheManager";
-import { ScopeSet } from "@azure/msal-common/src/request/ScopeSet";
+    TEST_URIS
+} from "../test_kit/StringConstants";
+import { ID_TOKEN_CLAIMS } from "../utils/TestConstants";
+import { ClientTestUtils } from "./ClientTestUtils";
+
 
 const testAccountEntity: AccountEntity = new AccountEntity();
 testAccountEntity.homeAccountId = `${TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID}`;
@@ -193,7 +193,7 @@ describe("OnBehalfOf unit tests", () => {
                 },
             };
 
-            client.acquireToken(oboRequest).catch((error) => {
+            client.acquireToken(oboRequest).catch(() => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -258,7 +258,7 @@ describe("OnBehalfOf unit tests", () => {
             });
 
             const authResult = await client.acquireToken(oboRequest) as AuthenticationResult;
-            expect(mockIdTokenCached.calledWith(oboRequest)).toBe(true);
+            expect(mockIdTokenCached.calledWith('home_account_id')).toBe(true);
             expect(authResult.scopes).toEqual(ScopeSet.fromString(testAccessTokenEntity.target).asArray());
             expect(authResult.idToken).toEqual(testIdToken.secret);
             expect(authResult.accessToken).toEqual(testAccessTokenEntity.secret);

--- a/lib/msal-node/test/client/OnBehalfOfClient.spec.ts
+++ b/lib/msal-node/test/client/OnBehalfOfClient.spec.ts
@@ -12,27 +12,27 @@ import {
     DEFAULT_OPENID_CONFIG_RESPONSE,
     TEST_TOKENS,
     AUTHENTICATION_RESULT,
-} from "../test_kit/StringConstants";
-import { BaseClient } from "../../src/client/BaseClient";
-import { ClientTestUtils } from "./ClientTestUtils";
+} from "@azure/msal-common/test/test_kit/StringConstants";
+import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
+import { ClientTestUtils } from "@azure/msal-common/test/client/ClientTestUtils";
 import { OnBehalfOfClient } from "../../src/client/OnBehalfOfClient";
-import { CommonOnBehalfOfRequest } from "../../src/request/CommonOnBehalfOfRequest";
-import { AuthToken } from "../../src/account/AuthToken";
-import { TimeUtils } from "../../src/utils/TimeUtils";
-import { Authority } from "../../src/authority/Authority";
-import { ClientConfiguration } from "../../src/config/ClientConfiguration";
-import { AuthenticationResult, IdTokenEntity } from "../../src";
-import { AccessTokenEntity } from "../../src/cache/entities/AccessTokenEntity";
-import { AccountEntity } from "../../src/cache/entities/AccountEntity";
+import { CommonOnBehalfOfRequest } from "@azure/msal-common/src/request/CommonOnBehalfOfRequest";
+import { AuthToken } from "@azure/msal-common/src/account/AuthToken";
+import { TimeUtils } from "@azure/msal-common/src/utils/TimeUtils";
+import { Authority } from "@azure/msal-common/src/authority/Authority";
+import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
+import { AuthenticationResult, IdTokenEntity } from "@azure/msal-common/src";
+import { AccessTokenEntity } from "@azure/msal-common/src/cache/entities/AccessTokenEntity";
+import { AccountEntity } from "@azure/msal-common/src/cache/entities/AccountEntity";
 import {
     AuthenticationScheme,
     CredentialType,
     AADServerParamKeys,
     Constants,
     ThrottlingConstants,
-} from "../../src/utils/Constants";
-import { CacheManager } from "../../src/cache/CacheManager";
-import { ScopeSet } from "../../src/request/ScopeSet";
+} from "@azure/msal-common/src/utils/Constants";
+import { CacheManager } from "@azure/msal-common/src/cache/CacheManager";
+import { ScopeSet } from "@azure/msal-common/src/request/ScopeSet";
 
 const testAccountEntity: AccountEntity = new AccountEntity();
 testAccountEntity.homeAccountId = `${TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID}`;
@@ -135,7 +135,7 @@ describe("OnBehalfOf unit tests", () => {
 
             const createTokenRequestBodySpy = sinon.spy(OnBehalfOfClient.prototype, <any>"createTokenRequestBody");
 
-            let config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration(); 
+            let config: ClientConfiguration = await ClientTestUtils.createTestClientConfiguration();
             const client = new OnBehalfOfClient(config);
             const oboRequest: CommonOnBehalfOfRequest = {
                 scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE],
@@ -148,7 +148,7 @@ describe("OnBehalfOf unit tests", () => {
 
             const authResult = await client.acquireToken(oboRequest) as AuthenticationResult;
             const returnVal = await createTokenRequestBodySpy.returnValues[0] as string;
-        
+
             expect(authResult.accessToken).toEqual(AUTHENTICATION_RESULT.body.access_token);
             expect(authResult.state).toBe("");
             expect(authResult.fromCache).toBe(false);
@@ -177,7 +177,7 @@ describe("OnBehalfOf unit tests", () => {
                     done(error);
                 }
             });
-    
+
             const client = new OnBehalfOfClient(config);
             const oboRequest: CommonOnBehalfOfRequest = {
                 scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE],
@@ -192,7 +192,7 @@ describe("OnBehalfOf unit tests", () => {
                     testParam3: "testValue3",
                 },
             };
-    
+
             client.acquireToken(oboRequest).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -14,13 +14,15 @@ import {
     AccountInfo,
     ServerAuthorizationCodeResponse
 } from '@azure/msal-common';
-import { CryptoProvider } from '../../src';
-import { DeviceCodeRequest } from '../../src';
-import { AuthorizationCodeRequest } from '../../src';
-import { RefreshTokenRequest } from '../../src';
-import { AuthorizationUrlRequest } from "../../src";
-import { UsernamePasswordRequest } from '../../src';
-import { SilentFlowRequest } from '../../src';
+import {
+    CryptoProvider,
+    DeviceCodeRequest,
+    AuthorizationCodeRequest,
+    RefreshTokenRequest,
+    AuthorizationUrlRequest,
+    UsernamePasswordRequest,
+    SilentFlowRequest
+} from '../../src';
 import { HttpClient } from '../../src/network/HttpClient';
 import http from "http";
 

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -1,27 +1,42 @@
-import { PublicClientApplication } from './../../src/client/PublicClientApplication';
-import { Configuration, ILoopbackClient, InteractiveRequest } from './../../src/index';
+import { PublicClientApplication } from '../../src';
+import { Configuration, DeviceCodeClient, ILoopbackClient, InteractiveRequest } from '../../src';
 import { ID_TOKEN_CLAIMS, mockAuthenticationResult, TEST_CONSTANTS, TEST_DATA_CLIENT_INFO } from '../utils/TestConstants';
 import {
-    ClientConfiguration, AuthenticationResult, AuthorizationCodeClient, RefreshTokenClient, UsernamePasswordClient,
-    SilentFlowClient, ProtocolMode, Logger, LogLevel, ClientAuthError, AccountInfo, ServerAuthorizationCodeResponse
+    ClientConfiguration,
+    AuthenticationResult,
+    AuthorizationCodeClient,
+    RefreshTokenClient,
+    SilentFlowClient,
+    ProtocolMode,
+    Logger,
+    LogLevel,
+    ClientAuthError,
+    AccountInfo,
+    ServerAuthorizationCodeResponse
 } from '@azure/msal-common';
-import { CryptoProvider } from '../../src/crypto/CryptoProvider';
-import { DeviceCodeRequest } from '../../src/request/DeviceCodeRequest';
-import { AuthorizationCodeRequest } from '../../src/request/AuthorizationCodeRequest';
-import { RefreshTokenRequest } from '../../src/request/RefreshTokenRequest';
-import { AuthorizationUrlRequest } from "../../src/request/AuthorizationUrlRequest";
-import { UsernamePasswordRequest } from '../../src/request/UsernamePasswordRequest';
-import { SilentFlowRequest } from '../../src/request/SilentFlowRequest';
+import { CryptoProvider } from '../../src';
+import { DeviceCodeRequest } from '../../src';
+import { AuthorizationCodeRequest } from '../../src';
+import { RefreshTokenRequest } from '../../src';
+import { AuthorizationUrlRequest } from "../../src";
+import { UsernamePasswordRequest } from '../../src';
+import { SilentFlowRequest } from '../../src';
 import { HttpClient } from '../../src/network/HttpClient';
 import http from "http";
 
+import * as msalNode from '../../src';
 import { fakeAuthority, setupAuthorityFactory_createDiscoveredInstance_mock, setupServerTelemetryManagerMock } from './test-fixtures';
 import { getMsalCommonAutoMock, MSALCommonModule } from '../utils/MockUtils';
 
-import { NodeStorage } from '../../src/cache/NodeStorage'
+import { NodeStorage } from '../../src'
 import { version, name } from '../../package.json'
 
 const msalCommon: MSALCommonModule = jest.requireActual('@azure/msal-common');
+
+jest.mock('../../src/client/DeviceCodeClient');
+jest.mock('../../src/client/ClientCredentialClient');
+jest.mock('../../src/client/OnBehalfOfClient');
+jest.mock('../../src/client/UsernamePasswordClient');
 
 describe('PublicClientApplication', () => {
 
@@ -74,20 +89,15 @@ describe('PublicClientApplication', () => {
             scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
         };
 
-
-        const MockDeviceCodeClient2 = getMsalCommonAutoMock().DeviceCodeClient;
-
-        jest.spyOn(msalCommon, 'DeviceCodeClient')
-            .mockImplementation((conf) => new MockDeviceCodeClient2(conf));
-
+        const deviceCodeClientSpy = jest.spyOn(msalNode, 'DeviceCodeClient');
         const fakeAuthResult = { "foo": "bar" }
-        jest.spyOn(MockDeviceCodeClient2.prototype, 'acquireToken')
+        jest.spyOn(DeviceCodeClient.prototype, 'acquireToken')
             .mockImplementation(() => Promise.resolve(fakeAuthResult as unknown as AuthenticationResult));
 
         const authApp = new PublicClientApplication(appConfig);
         const result = await authApp.acquireTokenByDeviceCode(request);
-        expect(MockDeviceCodeClient2).toHaveBeenCalledTimes(1);
-        expect(MockDeviceCodeClient2).toHaveBeenCalledWith(
+        expect(deviceCodeClientSpy).toHaveBeenCalledTimes(1);
+        expect(deviceCodeClientSpy).toHaveBeenCalledWith(
             expect.objectContaining(expectedConfig)
         );
         expect(result).toEqual(fakeAuthResult);
@@ -373,14 +383,12 @@ describe('PublicClientApplication', () => {
             password: TEST_CONSTANTS.PASSWORD
         };
 
-        const mockUsernamePasswordClient = getMsalCommonAutoMock().UsernamePasswordClient;
-        jest.spyOn(msalCommon, 'UsernamePasswordClient')
-            .mockImplementation((config) => new mockUsernamePasswordClient(config));
+        const usernamePasswordClientSpy = jest.spyOn(msalNode, 'UsernamePasswordClient');
 
         const authApp = new PublicClientApplication(appConfig);
         await authApp.acquireTokenByUsernamePassword(request);
-        expect(UsernamePasswordClient).toHaveBeenCalledTimes(1);
-        expect(UsernamePasswordClient).toHaveBeenCalledWith(
+        expect(usernamePasswordClientSpy).toHaveBeenCalledTimes(1);
+        expect(usernamePasswordClientSpy).toHaveBeenCalledWith(
             expect.objectContaining(expectedConfig)
         );
     });

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -1,5 +1,3 @@
-import { PublicClientApplication } from '../../src';
-import { Configuration, DeviceCodeClient, ILoopbackClient, InteractiveRequest } from '../../src';
 import { ID_TOKEN_CLAIMS, mockAuthenticationResult, TEST_CONSTANTS, TEST_DATA_CLIENT_INFO } from '../utils/TestConstants';
 import {
     ClientConfiguration,
@@ -15,13 +13,19 @@ import {
     ServerAuthorizationCodeResponse
 } from '@azure/msal-common';
 import {
+    Configuration,
+    DeviceCodeClient,
+    ILoopbackClient,
+    InteractiveRequest,
+    PublicClientApplication,
     CryptoProvider,
     DeviceCodeRequest,
     AuthorizationCodeRequest,
     RefreshTokenRequest,
     AuthorizationUrlRequest,
     UsernamePasswordRequest,
-    SilentFlowRequest
+    SilentFlowRequest,
+    NodeStorage
 } from '../../src';
 import { HttpClient } from '../../src/network/HttpClient';
 import http from "http";
@@ -30,7 +34,6 @@ import * as msalNode from '../../src';
 import { fakeAuthority, setupAuthorityFactory_createDiscoveredInstance_mock, setupServerTelemetryManagerMock } from './test-fixtures';
 import { getMsalCommonAutoMock, MSALCommonModule } from '../utils/MockUtils';
 
-import { NodeStorage } from '../../src'
 import { version, name } from '../../package.json'
 
 const msalCommon: MSALCommonModule = jest.requireActual('@azure/msal-common');

--- a/lib/msal-node/test/client/UsernamePasswordClient.spec.ts
+++ b/lib/msal-node/test/client/UsernamePasswordClient.spec.ts
@@ -5,22 +5,28 @@
 
 import sinon from "sinon";
 import {
+    AADServerParamKeys,
+    AuthenticationResult,
+    Authority,
+    AuthToken,
+    BaseClient,
+    ClientConfiguration,
+    CommonUsernamePasswordRequest,
+    Constants,
+    GrantType,
+    PasswordGrantConstants,
+    ThrottlingConstants
+} from "@azure/msal-common";
+import {
     AUTHENTICATION_RESULT_DEFAULT_SCOPES,
     DEFAULT_OPENID_CONFIG_RESPONSE,
+    RANDOM_TEST_GUID,
     TEST_CONFIG,
     TEST_DATA_CLIENT_INFO,
-    TEST_URIS,
-    RANDOM_TEST_GUID
-} from "@azure/msal-common/test/test_kit/StringConstants";
-import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
-import { AADServerParamKeys, GrantType, Constants, PasswordGrantConstants, ThrottlingConstants } from "@azure/msal-common/src/utils/Constants";
-import { ClientTestUtils } from "@azure/msal-common/test/client/ClientTestUtils";
-import { Authority } from "@azure/msal-common/src/authority/Authority";
-import { UsernamePasswordClient } from "../../src/client/UsernamePasswordClient";
-import { CommonUsernamePasswordRequest } from "@azure/msal-common/src/request/CommonUsernamePasswordRequest";
-import { AuthToken } from "@azure/msal-common/src/account/AuthToken";
-import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
-import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
+    TEST_URIS
+} from "../test_kit/StringConstants";
+import { UsernamePasswordClient } from "../../src";
+import { ClientTestUtils } from "./ClientTestUtils";
 
 describe("Username Password unit tests", () => {
     let config: ClientConfiguration;
@@ -152,7 +158,7 @@ describe("Username Password unit tests", () => {
             },
         };
 
-        client.acquireToken(usernamePasswordRequest).catch((error) => {
+        client.acquireToken(usernamePasswordRequest).catch(() => {
             // Catch errors thrown after the function call this test is testing
         });
     });

--- a/lib/msal-node/test/client/UsernamePasswordClient.spec.ts
+++ b/lib/msal-node/test/client/UsernamePasswordClient.spec.ts
@@ -11,16 +11,16 @@ import {
     TEST_DATA_CLIENT_INFO,
     TEST_URIS,
     RANDOM_TEST_GUID
-} from "../test_kit/StringConstants";
-import { BaseClient } from "../../src/client/BaseClient";
-import { AADServerParamKeys, GrantType, Constants, PasswordGrantConstants, ThrottlingConstants } from "../../src/utils/Constants";
-import { ClientTestUtils } from "./ClientTestUtils";
-import { Authority } from "../../src/authority/Authority";
+} from "@azure/msal-common/test/test_kit/StringConstants";
+import { BaseClient } from "@azure/msal-common/src/client/BaseClient";
+import { AADServerParamKeys, GrantType, Constants, PasswordGrantConstants, ThrottlingConstants } from "@azure/msal-common/src/utils/Constants";
+import { ClientTestUtils } from "@azure/msal-common/test/client/ClientTestUtils";
+import { Authority } from "@azure/msal-common/src/authority/Authority";
 import { UsernamePasswordClient } from "../../src/client/UsernamePasswordClient";
-import { CommonUsernamePasswordRequest } from "../../src/request/CommonUsernamePasswordRequest";
-import { AuthToken } from "../../src/account/AuthToken";
-import { ClientConfiguration } from "../../src/config/ClientConfiguration";
-import { AuthenticationResult } from "../../src/response/AuthenticationResult";
+import { CommonUsernamePasswordRequest } from "@azure/msal-common/src/request/CommonUsernamePasswordRequest";
+import { AuthToken } from "@azure/msal-common/src/account/AuthToken";
+import { ClientConfiguration } from "@azure/msal-common/src/config/ClientConfiguration";
+import { AuthenticationResult } from "@azure/msal-common/src/response/AuthenticationResult";
 
 describe("Username Password unit tests", () => {
     let config: ClientConfiguration;

--- a/lib/msal-node/test/test_kit/StringConstants.ts
+++ b/lib/msal-node/test/test_kit/StringConstants.ts
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    AuthenticationScheme,
+    Constants,
+    ONE_DAY_IN_MS
+} from "@azure/msal-common";
+
+// This file contains the string constants used by the test classes.
+
+// Test Tokens
+export const TEST_TOKENS = {
+    /*
+     * idTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
+     * accessTokens referenced from MSFT docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
+     */
+    IDTOKEN_V1: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjdfWnVmMXR2a3dMeFlhSFMzcTZsVWpVWUlHdyIsImtpZCI6IjdfWnVmMXR2a3dMeFlhSFMzcTZsVWpVWUlHdyJ9.eyJhdWQiOiJiMTRhNzUwNS05NmU5LTQ5MjctOTFlOC0wNjAxZDBmYzljYWEiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9mYTE1ZDY5Mi1lOWM3LTQ0NjAtYTc0My0yOWYyOTU2ZmQ0MjkvIiwiaWF0IjoxNTM2Mjc1MTI0LCJuYmYiOjE1MzYyNzUxMjQsImV4cCI6MTUzNjI3OTAyNCwiYWlvIjoiQVhRQWkvOElBQUFBcXhzdUIrUjREMnJGUXFPRVRPNFlkWGJMRDlrWjh4ZlhhZGVBTTBRMk5rTlQ1aXpmZzN1d2JXU1hodVNTajZVVDVoeTJENldxQXBCNWpLQTZaZ1o5ay9TVTI3dVY5Y2V0WGZMT3RwTnR0Z2s1RGNCdGsrTExzdHovSmcrZ1lSbXY5YlVVNFhscGhUYzZDODZKbWoxRkN3PT0iLCJhbXIiOlsicnNhIl0sImVtYWlsIjoiYWJlbGlAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiTGluY29sbiIsImdpdmVuX25hbWUiOiJBYmUiLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaXBhZGRyIjoiMTMxLjEwNy4yMjIuMjIiLCJuYW1lIjoiYWJlbGkiLCJub25jZSI6IjEyMzUyMyIsIm9pZCI6IjA1ODMzYjZiLWFhMWQtNDJkNC05ZWMwLTFiMmJiOTE5NDQzOCIsInJoIjoiSSIsInN1YiI6IjVfSjlyU3NzOC1qdnRfSWN1NnVlUk5MOHhYYjhMRjRGc2dfS29vQzJSSlEiLCJ0aWQiOiJmYTE1ZDY5Mi1lOWM3LTQ0NjAtYTc0My0yOWYyOTU2ZmQ0MjkiLCJ1bmlxdWVfbmFtZSI6IkFiZUxpQG1pY3Jvc29mdC5jb20iLCJ1dGkiOiJMeGVfNDZHcVRrT3BHU2ZUbG40RUFBIiwidmVyIjoiMS4wIn0=.UJQrCA6qn2bXq57qzGX_-D3HcPHqBMOKDPx4su1yKRLNErVD8xkxJLNLVRdASHqEcpyDctbdHccu6DPpkq5f0ibcaQFhejQNcABidJCTz0Bb2AbdUCTqAzdt9pdgQvMBnVH1xk3SCM6d4BbT4BkLLj10ZLasX7vRknaSjE_C5DI7Fg4WrZPwOhII1dB0HEZ_qpNaYXEiy-o94UJ94zCr07GgrqMsfYQqFR7kn-mn68AjvLcgwSfZvyR_yIK75S_K37vC3QryQ7cNoafDe9upql_6pB2ybMVlgWPs_DmbJ8g0om-sPlwyn74Cc1tW3ze-Xptw_2uVdPgWyqfuWAfq6Q",
+    IDTOKEN_V2: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
+    IDTOKEN_V2_NEWCLAIM: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.ewogICJ2ZXIiOiAiMi4wIiwKICAiaXNzIjogImh0dHBzOi8vbG9naW4ubWljcm9zb2Z0b25saW5lLmNvbS85MTg4MDQwZC02YzY3LTRjNWItYjExMi0zNmEzMDRiNjZkYWQvdjIuMCIsCiAgInN1YiI6ICJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwKICAiYXVkIjogIjZjYjA0MDE4LWEzZjUtNDZhNy1iOTk1LTk0MGM3OGY1YWVmMyIsCiAgImV4cCI6IDE1MzYzNjE0MTEsCiAgImlhdCI6IDE1MzYyNzQ3MTEsCiAgIm5iZiI6IDE1MzYyNzQ3MTEsCiAgIm5hbWUiOiAiQWJlIExpbmNvbG4iLAogICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiQWJlTGlAbWljcm9zb2Z0LmNvbSIsCiAgIm9pZCI6ICIwMDAwMDAwMC0wMDAwLTAwMDAtNjZmMy0zMzMyZWNhN2VhODEiLAogICJlbWFpbCI6ICJBYmVMaUBtaWNyb3NvZnQuY29tIiwKICAidGlkIjogIjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsCiAgIm5vbmNlIjogIjEyMzUyMyIsCiAgImFpbyI6ICJEZjJVVlhMMWl4IWxNQ1dNU09KQmNGYXR6Y0dmdkZHaGpLdjhxNWcweDczMmRSNU1CNUJpc3ZHUU83WVdCeWpkOGlRRExxIWVHYklEYWt5cDVtbk9yY2RxSGVZU25sdGVwUW1ScDZBSVo4alkiCn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
+    LOGIN_AT_STRING: "O35pBcPgsXxS0K54JcJ2bO2lPQzy59r98BM3TLUNV5lJfzLYv5ZL2c8i3IODbS9qx93DzmpKlOgdQLrFDctgSbutgFXUKLdNIeR1ZvzCSEbwtV4zOe0EJU0CkVaWo1Vg8iKrdJdGtEqOtOB3Pbqe2zMg0cuMXW4B6xtbDy5gYO78McdjKWiljdltJqPTZkb1ESbGOGM2",
+    ACCESS_TOKEN: "thisIs.an.accessT0ken",
+    POP_TOKEN: "eyJ0eXAiOiJKV1QiLCJub25jZSI6InFMZmZKT255c2dnVnhhdGxSbVhvR0dnYkx3NDV5LTdsWkswaHJWSm9zeDQiLCJhbGciOiJSUzI1NiIsIng1dCI6InZhcF9pdmtIdHRMRmNubm9CWEF3SjVIWDBLNCIsImtpZCI6InZhcF9pdmtIdHRMRmNubm9CWEF3SjVIWDBLNCJ9.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTAwMDAtYzAwMC0wMDAwMDAwMDAwMDAiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvMTllZWEyZjgtZTE3YS00NzBmLTk1NGQtZDg5N2M0N2YzMTFjLyIsImlhdCI6MTYxODAwNzU2MCwibmJmIjoxNjE4MDA3NTYwLCJleHAiOjE2MTgwMTE0NjAsImFjY3QiOjAsImFjciI6IjEiLCJhY3JzIjpbInVybjp1c2VyOnJlZ2lzdGVyc2VjdXJpdHlpbmZvIiwidXJuOm1pY3Jvc29mdDpyZXExIiwidXJuOm1pY3Jvc29mdDpyZXEyIiwidXJuOm1pY3Jvc29mdDpyZXEzIiwiYzEiLCJjMiIsImMzIiwiYzQiLCJjNSIsImM2IiwiYzciLCJjOCIsImM5IiwiYzEwIiwiYzExIiwiYzEyIiwiYzEzIiwiYzE0IiwiYzE1IiwiYzE2IiwiYzE3IiwiYzE4IiwiYzE5IiwiYzIwIiwiYzIxIiwiYzIyIiwiYzIzIiwiYzI0IiwiYzI1Il0sImFpbyI6IkUyTmdZRGo3Y0dVWEczT1p4OXhXSjVNRWg5MXU2NVFTZnAzVXYycVpLSHByaHRtVkY2d0EiLCJhbXIiOlsicHdkIl0sImFwcF9kaXNwbGF5bmFtZSI6IlBLLU1TQUxUZXN0Mi4wIiwiYXBwaWQiOiIzZmJhNTU2ZS01ZDRhLTQ4ZTMtOGUxYS1mZDU3YzEyY2I4MmUiLCJhcHBpZGFjciI6IjAiLCJjbmYiOnsia2lkIjoiVjZOX0hNUGFnTnBZU193eE0xNFg3M3EzZVd6YlRyOVozMVJ5SGtJY04wWSIsInhtc19rc2wiOiJzdyJ9LCJmYW1pbHlfbmFtZSI6IkJhc2ljIFVzZXIiLCJnaXZlbl9uYW1lIjoiQ2xvdWQgSURMQUIiLCJpZHR5cCI6InVzZXIiLCJpcGFkZHIiOiIyNC4xNy4yNDYuMjA5IiwibmFtZSI6IkNsb3VkIElETEFCIEJhc2ljIFVzZXIiLCJvaWQiOiJiZTA2NGMzNy0yNjE3LTQ2OGMtYjYyNy0yNWI0ZTQ4MTdhZGYiLCJwbGF0ZiI6IjMiLCJwdWlkIjoiMTAwMzQwMDAwMDU0NzdCQSIsInJoIjoiMC5BQUFBLUtMdUdYcmhEMGVWVGRpWHhIOHhIRzVWdWo5S1hlTklqaHI5VjhFc3VDNEJBTmsuIiwic2NwIjoiRmlsZXMuUmVhZCBNYWlsLlJlYWQgb3BlbmlkIHByb2ZpbGUgVXNlci5SZWFkIGVtYWlsIiwic2lnbmluX3N0YXRlIjpbImttc2kiXSwic3ViIjoidExjaFl1bUczSXZZT1VrQlprU0EzbWhnOEVfYnNGZDhuU2licUlOX0UxVSIsInRpZCI6IjE5ZWVhMmY4LWUxN2EtNDcwZi05NTRkLWQ4OTdjNDdmMzExYyIsInVuaXF1ZV9uYW1lIjoiSURMQUJAbXNpZGxhYjAuY2NzY3RwLm5ldCIsInVwbiI6IklETEFCQG1zaWRsYWIwLmNjc2N0cC5uZXQiLCJ1dGkiOiJ5a2tPd3dyTkFVT1k5SUVXejRITEFBIiwidmVyIjoiMS4wIiwid2lkcyI6WyJiNzlmYmY0ZC0zZWY5LTQ2ODktODE0My03NmIxOTRlODU1MDkiXSwieG1zX3N0Ijp7InN1YiI6Imx2QnRkdmVkdDRkT1pyeGZvQjdjbV9UTkU3THFucG5lcGFHc3EtUmZkS2MifSwieG1zX3RjZHQiOjE1NDQ1NzQzNjN9.VPBqUrMDc-H1T4paZoSbGaec0lBoJqSiu13chxJmgee1lDxUFr2pM52tqzPPH6N_Yk-VQ0_AKTyvfnbAQw4mryhp3SJytZbU7FedrXX7oq2laLh9s0K_Hz1EZSj5xg3SSUxXmKEjdePN6d0_5MLlt1P-LcL2PAGgkEEBhUfDm6pAxyTMO8Mw1DUYbq7kr_IzyQ71V-kuoYHDjazghSIwOkidoWMCPP-HIENVbFEKUDKFGDiOzU76IagUBAYUQ4JD1bC9hHA-OO6AV8xLK7UoPyx9UH7fLbiImzhARBxMkmAQu9v2kwn5Hl9hoBEBhlu48YOYOr4O3GxwKisff87R9Q",
+    POP_TOKEN_PAYLOAD: "eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTAwMDAtYzAwMC0wMDAwMDAwMDAwMDAiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvMTllZWEyZjgtZTE3YS00NzBmLTk1NGQtZDg5N2M0N2YzMTFjLyIsImlhdCI6MTYxODAwNzU2MCwibmJmIjoxNjE4MDA3NTYwLCJleHAiOjE2MTgwMTE0NjAsImFjY3QiOjAsImFjciI6IjEiLCJhY3JzIjpbInVybjp1c2VyOnJlZ2lzdGVyc2VjdXJpdHlpbmZvIiwidXJuOm1pY3Jvc29mdDpyZXExIiwidXJuOm1pY3Jvc29mdDpyZXEyIiwidXJuOm1pY3Jvc29mdDpyZXEzIiwiYzEiLCJjMiIsImMzIiwiYzQiLCJjNSIsImM2IiwiYzciLCJjOCIsImM5IiwiYzEwIiwiYzExIiwiYzEyIiwiYzEzIiwiYzE0IiwiYzE1IiwiYzE2IiwiYzE3IiwiYzE4IiwiYzE5IiwiYzIwIiwiYzIxIiwiYzIyIiwiYzIzIiwiYzI0IiwiYzI1Il0sImFpbyI6IkUyTmdZRGo3Y0dVWEczT1p4OXhXSjVNRWg5MXU2NVFTZnAzVXYycVpLSHByaHRtVkY2d0EiLCJhbXIiOlsicHdkIl0sImFwcF9kaXNwbGF5bmFtZSI6IlBLLU1TQUxUZXN0Mi4wIiwiYXBwaWQiOiIzZmJhNTU2ZS01ZDRhLTQ4ZTMtOGUxYS1mZDU3YzEyY2I4MmUiLCJhcHBpZGFjciI6IjAiLCJjbmYiOnsia2lkIjoiVjZOX0hNUGFnTnBZU193eE0xNFg3M3EzZVd6YlRyOVozMVJ5SGtJY04wWSIsInhtc19rc2wiOiJzdyJ9LCJmYW1pbHlfbmFtZSI6IkJhc2ljIFVzZXIiLCJnaXZlbl9uYW1lIjoiQ2xvdWQgSURMQUIiLCJpZHR5cCI6InVzZXIiLCJpcGFkZHIiOiIyNC4xNy4yNDYuMjA5IiwibmFtZSI6IkNsb3VkIElETEFCIEJhc2ljIFVzZXIiLCJvaWQiOiJiZTA2NGMzNy0yNjE3LTQ2OGMtYjYyNy0yNWI0ZTQ4MTdhZGYiLCJwbGF0ZiI6IjMiLCJwdWlkIjoiMTAwMzQwMDAwMDU0NzdCQSIsInJoIjoiMC5BQUFBLUtMdUdYcmhEMGVWVGRpWHhIOHhIRzVWdWo5S1hlTklqaHI5VjhFc3VDNEJBTmsuIiwic2NwIjoiRmlsZXMuUmVhZCBNYWlsLlJlYWQgb3BlbmlkIHByb2ZpbGUgVXNlci5SZWFkIGVtYWlsIiwic2lnbmluX3N0YXRlIjpbImttc2kiXSwic3ViIjoidExjaFl1bUczSXZZT1VrQlprU0EzbWhnOEVfYnNGZDhuU2licUlOX0UxVSIsInRpZCI6IjE5ZWVhMmY4LWUxN2EtNDcwZi05NTRkLWQ4OTdjNDdmMzExYyIsInVuaXF1ZV9uYW1lIjoiSURMQUJAbXNpZGxhYjAuY2NzY3RwLm5ldCIsInVwbiI6IklETEFCQG1zaWRsYWIwLmNjc2N0cC5uZXQiLCJ1dGkiOiJ5a2tPd3dyTkFVT1k5SUVXejRITEFBIiwidmVyIjoiMS4wIiwid2lkcyI6WyJiNzlmYmY0ZC0zZWY5LTQ2ODktODE0My03NmIxOTRlODU1MDkiXSwieG1zX3N0Ijp7InN1YiI6Imx2QnRkdmVkdDRkT1pyeGZvQjdjbV9UTkU3THFucG5lcGFHc3EtUmZkS2MifSwieG1zX3RjZHQiOjE1NDQ1NzQzNjN9",
+    DECODED_POP_TOKEN_PAYLOAD: `{
+        "cnf": {
+            "kid": "V6N_HMPagNpYS_wxM14X73q3eWzbTr9Z31RyHkIcN0Y",
+            "xms_ksl": "sw"
+        }
+      }`,
+    SSH_CERTIFICATE: "AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgrk+wGrNoM6ZcU8/aVc+O9nMQArnTpgQcN2nDOojq3LwAAAADAQABAAABAQCiPcGP8PriIUKC1EAiepduIitPFswHDoPpAUJqbzgKNLdTdy86OoGFpY9yKo9kVgCTdPj/v8cO76/+I1vlHk1p7Q9DeFe333LefRnBUT8tDiFC4wtYJDxhpCcuOsEIlHVhYPp33ZQZePomb9rzTCatzFnrP9b62FRpx0Y3pjk/lstOr50Bh/3ZlDFPH36chXwEDSOcW3QX+0y4FT6x5zxna9KrwpCOWVaBdqsHpoqruDhGwkCAaoL6RXCyQTZatcqJNWCcD6a8GFHAkTZMxh2LR0xPZ4JkIDofKbauP/s9FPlAJN+VhY+HthrduVzgRP3ELxqSCE8xmNV8R/AVv1OxAAAAAAAAAAAAAAABAAAASTE4ZmRhY2MyLThkMWEtNDMzOC04NWM4LTAwMjY1ZmI2NWVmNkA3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcAAAAZAAAAFWhlbW9yYWxAbWljcm9zb2Z0LmNvbQAAAABhcFyFAAAAAGFwa8EAAAAAAAABTAAAACBkaXNwbGF5bmFtZUBzc2hzZXJ2aWNlLmF6dXJlLm5ldAAAABIAAAAOSGVjdG9yIE1vcmFsZXMAAAAYb2lkQHNzaHNlcnZpY2UuYXp1cmUubmV0AAAAKAAAACQxOGZkYWNjMi04ZDFhLTQzMzgtODVjOC0wMDI2NWZiNjVlZjYAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAGHRpZEBzc2hzZXJ2aWNlLmF6dXJlLm5ldAAAACgAAAAkNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3AAAAAAAAARcAAAAHc3NoLXJzYQAAAAMBAAEAAAEBALH7FzF1rjvnZ4i2iBC2tz8qs/WP61n3/wFawgJxUnTx2vP/z5pG7f8qvumd7taOII0aSlp648SIfMw59WdUUtup5CnDYOcX1sUdivAj20m2PIDK6f+KWZ+7YKxJqCzJMH4GGlQvuDIhRKNT9oHfZgnYCCAmjXmJBtWyD052qqrkzOSn0/e9TKbjlTnTNcrIno3XDQ7xG+79vOD2GZMNopsKogWNxUdLFRu44ClKLRb4Xe00eVrANtBkv+mSJFFJS1Gxv611hpdGI2S0v1H+KvB26O7vuzGhZ/AevRemGhXQ5V5vwNEqXnVRVkBRszLKeN/+rxM436xQyVQGJMG+sVEAAAEUAAAADHJzYS1zaGEyLTI1NgAAAQBlbiFgkvtKprsj96PD2uIJ7ZypzE/t/iba7/eDvXXc3ixI8fBns2bSuNx7LF3i2vlAUgz6UHe4xW0voc+jmZKEI8jXj91C84npo7J4kCxAkfO4GmdwGhQMjNRoN+pZliPNtj5jQLsuVxgXoJARAEP8nSp372i2bn7iFzolXWPiWkF1MVFV9BLwL3uPDeqTZqurYcpXJnSX30owMyC9qf913MGvWujN2AKNyoX1OIm19EKUSVLMM7S65A5nuuOMrkaajumdEgCgiVQSgHjqD5gDix+EZy7w6L6b8nKqT2mu481dM2yMqejAWxgife4oPI07sGXf1kIOn8kTuZAHkiSH",
+    REFRESH_TOKEN: "thisIsARefreshT0ken",
+    AUTHORIZATION_CODE: "0.ASgAqPq4kJXMDkamGO53C-4XWVm3ypmrKgtCkdhePY1PBjsoAJg.AQABAAIAAAAm-06blBE1TpVMil8KPQ41DOje1jDj1oK3KxTXGKg89VjLYJi71gx_npOoxVfC7X49MqOX7IltTJOilUId-IAHndHXlfWzoSGq3GUmwAOLMisftceBRtq3YBsvHX7giiuSZXJgpgu03uf3V2h5Z3GJNpnSXT1f7iVFuRvGh1-jqjWxKs2un8AS5rhti1ym1zxkeicKT43va5jQeHVUlTQo69llnwQJ3iKmKLDVq_Q25Au4EQjYaeEx6TP5IZSqPPm7x0bynmjE8cqR5r4ySP4wH8fjnxlLySrUEZObk2VgREB1AdH6-xKIa04EnJEj9dUgTwiFvQumkuHHetFOgH7ep_9diFOdAOQLUK8C9N4Prlj0JiOcgn6l0xYd5Q9691Ylw8UfifLwq_B7f30mMLN64_XgoBY9K9CR1L4EC1kPPwIhVv3m6xmbhXZ3efx-A-bbV2SYcO4D4ZlnQztHzie_GUlredtsdEMAOE3-jaMJs7i2yYMuIEEtRcHIjV_WscVooCDdKmVncHOObWhNUSdULAejBr3pFs0v3QO_xZ269eLu5Z0qHzCZ_EPg2aL-ERz-rpgdclQ_H_KnEtMsC4F1RgAnDjVmSRKJZZdnNLfKSX_Wd40t_nuo4kjN2cSt8QzzeL533zIZ4CxthOsC4HH2RcUZDIgHdLDLT2ukg-Osc6J9URpZP-IUpdjXg_uwbkHEjrXDMBMo2pmCqaWbMJKo5Lr7CrystifnDITXzZmmOah8HV83Xyb6EP8Gno6JRuaG80j8BKDWyb1Yof4rnLI1kZ59n_t2d0LnRBXz50PdWCWX6vtkg-kAV-bGJQr45XDSKBSv0Q_fVsdLMk24NacUZcF5ujUtqv__Bv-wATzCHWlbUDGHC8nHEi84PcYAjSsgAA",
+    SAMPLE_JWT_HEADER: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+    SAMPLE_JWT_PAYLOAD: "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
+    SAMPLE_JWT_SIG: "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    SAMPLE_MALFORMED_JWT: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
+    CACHE_IDTOKEN: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Imk2bEdrM0ZaenhSY1ViMkMzbkVRN3N5SEpsWSIsImtpZCI6Imk2bEdrM0ZaenhSY1ViMkMzbkVRN3N5SEpsWSJ9.eyJvaWQiOiAib2JqZWN0MTIzNCIsICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiSm9obiBEb2UiLCAic3ViIjogInN1YiJ9.D3H6pMUtQnoJAGq6AHd"
+};
+
+export const ID_TOKEN_CLAIMS = {
+    ver: "2.0",
+    iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+    sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+    aud: "6cb04018-a3f5-46a7-b995-940c78f5aef3",
+    exp: 1536361411,
+    iat: 1536274711,
+    nbf: 1536274711,
+    name: "Abe Lincoln",
+    preferred_username: "AbeLi@microsoft.com",
+    oid: "00000000-0000-0000-66f3-3332eca7ea81",
+    tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+    nonce: "123523",
+    aio: "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY",
+    auth_time: Date.now() - (ONE_DAY_IN_MS * 2)
+};
+
+// Test Expiration Vals
+export const TEST_TOKEN_LIFETIMES = {
+    DEFAULT_EXPIRES_IN: 3599,
+    TEST_ID_TOKEN_EXP: 1536361411,
+    TEST_ACCESS_TOKEN_EXP: 1537234948
+};
+
+// Test CLIENT_INFO
+export const TEST_DATA_CLIENT_INFO = {
+    TEST_UID: "123-test-uid",
+    TEST_UTID: "456-test-utid",
+    TEST_DECODED_CLIENT_INFO: "{\"uid\":\"123-test-uid\",\"utid\":\"456-test-utid\"}",
+    TEST_INVALID_JSON_CLIENT_INFO: "{\"uid\":\"123-test-uid\"\"utid\":\"456-test-utid\"}",
+    TEST_RAW_CLIENT_INFO: "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9",
+    TEST_CLIENT_INFO_B64ENCODED: "eyJ1aWQiOiIxMjM0NSIsInV0aWQiOiI2Nzg5MCJ9",
+    TEST_ENCODED_HOME_ACCOUNT_ID: "MTIzLXRlc3QtdWlk.NDU2LXRlc3QtdXRpZA==",
+    TEST_DECODED_HOME_ACCOUNT_ID: "123-test-uid.456-test-utid",
+    TEST_LOCAL_ACCOUNT_ID: "00000000-0000-0000-66f3-3332eca7ea81s",
+    TEST_CACHE_RAW_CLIENT_INFO: "eyJ1aWQiOiJ1aWQiLCAidXRpZCI6InV0aWQifQ==",
+    TEST_CACHE_DECODED_CLIENT_INFO: "{\"uid\":\"uid\", \"utid\":\"utid\"}",
+    TEST_RAW_CLIENT_INFO_GUIDS: "eyJ1aWQiOiIwMDAwMDAwMC0wMDAwLTAwMDAtNjZmMy0zMzMyZWNhN2VhODEiLCJ1dGlkIjoiMzMzODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkIn0=",
+    TEST_CACHE_DECODED_CLIENT_INFO_GUIDS: "{\"uid\":\"00000000-0000-0000-66f3-3332eca7ea81\",\"utid\":\"3338040d-6c67-4c5b-b112-36a304b66dad\"}"
+};
+
+// Test Hashes
+export const TEST_HASHES = {
+    TEST_SUCCESS_ID_TOKEN_HASH: `#id_token=${TEST_TOKENS.IDTOKEN_V2}&client_info=${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}&state=RANDOM-GUID-HERE|`,
+    TEST_SUCCESS_ACCESS_TOKEN_HASH: `#access_token=${TEST_TOKENS.ACCESS_TOKEN}&id_token=${TEST_TOKENS.IDTOKEN_V2}&scope=test&expiresIn=${TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN}&client_info=${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}&state=RANDOM-GUID-HERE|`,
+    TEST_SUCCESS_CODE_HASH: `#code=thisIsATestCode&client_info=${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}&state=RANDOM-GUID-HERE|testState`,
+    TEST_ERROR_HASH: "#error=error_code&error_description=msal+error+description&state=RANDOM-GUID-HERE|",
+    TEST_INTERACTION_REQ_ERROR_HASH1: "#error=interaction_required&error_description=msal+error+description&state=RANDOM-GUID-HERE|",
+    TEST_INTERACTION_REQ_ERROR_HASH2: "#error=interaction_required&error_description=msal+error+description+interaction_required&state=RANDOM-GUID-HERE|",
+    TEST_LOGIN_REQ_ERROR_HASH1: "#error=login_required&error_description=msal+error+description&state=RANDOM-GUID-HERE|",
+    TEST_LOGIN_REQ_ERROR_HASH2: "#error=login_required&error_description=msal+error+description+login_required&state=RANDOM-GUID-HERE|",
+    TEST_CONSENT_REQ_ERROR_HASH1: "#error=consent_required&error_description=msal+error+description&state=RANDOM-GUID-HERE|",
+    TEST_CONSENT_REQ_ERROR_HASH2: "#error=consent_required&error_description=msal+error+description+consent_required&state=RANDOM-GUID-HERE|"
+};
+
+// Test URIs
+export const TEST_URIS = {
+    DEFAULT_INSTANCE: "https://login.microsoftonline.com/",
+    ALTERNATE_INSTANCE: "https://login.windows.net/",
+    TEST_REDIR_URI: "https://localhost:8081/index.html",
+    TEST_LOGOUT_URI: "https://localhost:8081/logout.html",
+    TEST_AUTH_ENDPT: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    TEST_AUTH_ENDPT_ORGS: "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize",
+    TEST_AUTH_ENDPT_TENANT_ID: "https://login.microsoftonline.com/sample-tenantID/oauth2/v2.0/authorize",
+    TEST_AUTH_ENDPT_WITH_PARAMS1: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?param1=value1",
+    TEST_AUTH_ENDPT_WITH_PARAMS2: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?param1=value1&param2=value2",
+    TEST_RESOURCE_ENDPT_WITH_PARAMS: "https://localhost:8081/endpoint?param1=value1&param2=value2",
+    TEST_REDIRECT_URI_LOCALHOST: "https://localhost:3000"
+};
+
+// Test Crypto Values
+export const TEST_CRYPTO_VALUES = {
+    TEST_SHA256_HASH: "vdluSPGh34Y-nFDCbX7CudVKZIXRG1rquljNBbn7xuE",
+    TEST_USER_ASSERTION_HASH: "nFDCbX7CudvdluSPGh34Y-VKZIXRG1rquljNBbn7xuE"
+};
+
+// Test MSAL config params
+export const TEST_CONFIG = {
+    TENANT: "common",
+    MSAL_CLIENT_ID: "0813e1d1-ad72-46a9-8665-399bba48c201",
+    MSAL_CLIENT_SECRET: "ThisIsASecret",
+    MSAL_TENANT_ID: "3338040d-6c67-4c5b-b112-36a304b66dad",
+    validAuthority: TEST_URIS.DEFAULT_INSTANCE + "common",
+    alternateValidAuthority: TEST_URIS.ALTERNATE_INSTANCE + "common",
+    ADFS_VALID_AUTHORITY: "https://on.prem/adfs",
+    DSTS_VALID_AUTHORITY: "https://domain.dsts.subdomain/dstsv2/tenant",
+    b2cValidAuthority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
+    applicationName: "msal.js-tests",
+    applicationVersion: "msal.js-tests.1.0.fake",
+    STATE: "1234",
+    NONCE: "a1b2c3",
+    TEST_VERIFIER: "Y5LnOOlAWK0kt370Bjm0ZcrW9Sc2pMXR1slip9TFZXoyUV8Y8lCn0WHXyyQ1QcTnALMbrUAj85dC7WIe6gYqc8o8jsHCezP3xiUNB143A5IfwtSfO6Kb8oy7pNqcT9vN",
+    TEST_CHALLENGE: "JsjesZmxJwehdhNY9kvyr0QOeSMEvryY_EHZo3BKrqg",
+    CODE_CHALLENGE_METHOD: "S256",
+    TOKEN_TYPE_BEARER: "Bearer",
+    DEFAULT_SCOPES: ["openid", "profile", "offline_access"],
+    DSTS_TEST_SCOPE: ["https://testserviceprincipalname-6df5cfbb-2ff9-45bb-b27a-595f48f4c7e4/.default"],
+    DEFAULT_GRAPH_SCOPE: ["User.Read"],
+    LOGIN_HINT: "user@test.com",
+    DOMAIN_HINT: "test.com",
+    SID: "session-id",
+    CORRELATION_ID: "7821e1d3-ad52-42t9-8666-399gea483401",
+    CLAIMS: "{\"access_token\":{\"example_claim\":{\"values\":[\"example_value\"]}}}",
+    TEST_SKU: "test.sku",
+    TEST_VERSION: "1.1.0",
+    TEST_OS: "win32",
+    TEST_CPU: "x86",
+    TEST_APP_NAME: "MSAL.js Unit Test",
+    TEST_APP_VER: "1.0.0",
+    TEST_ASSERTION_TYPE: "jwt_bearer",
+    THE_FAMILY_ID: "1",
+    DEFAULT_TOKEN_RENEWAL_OFFSET: 300,
+    TEST_CONFIG_ASSERTION: "DefaultAssertion",
+    TEST_REQUEST_ASSERTION: "RequestAssertion"
+};
+
+export const RANDOM_TEST_GUID = "11553a9b-7116-48b1-9d48-f6d4a8ff8371";
+
+export const TEST_POP_VALUES = {
+    CLIENT_CLAIMS: "{\"customClaim\":\"CustomClaimValue\",\"anotherClaim\":\"AnotherValue\"}",
+    KID: "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+    ENCODED_REQ_CNF: "eyJraWQiOiJOemJMc1hoOHVEQ2NkLTZNTndYRjRXXzdub1dYRlpBZkhreFpzUkdDOVhzIiwieG1zX2tzbCI6InN3In0=",
+    DECODED_REQ_CNF: "{\"kid\":\"NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs\",\"xms_ksl\":\"sw\"}",
+    SAMPLE_POP_AT: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJjbmYiOnsia2lkIjoiTnpiTHNYaDh1RENjZC02TU53WEY0V183bm9XWEZaQWZIa3hac1JHQzlYcyJ9fQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    SAMPLE_POP_AT_PAYLOAD_ENCODED: "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJjbmYiOnsia2lkIjoiTnpiTHNYaDh1RENjZC02TU53WEY0V183bm9XWEZaQWZIa3hac1JHQzlYcyJ9fQ",
+    SAMPLE_POP_AT_PAYLOAD_DECODED: "{\"sub\":\"1234567890\",\"name\":\"John Doe\",\"iat\":1516239022,\"cnf\":{\"kid\":\"NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs\"}}",
+    SHR_NONCE: "eyJhbGciOiJIUzI1NiIsImtpZCI6IktJRCIsInR5cCI6IkpXVCJ9.eyJ0cyI6IjE2MjU2NzI1MjkifQ.rA5ho63Lbdwo8eqZ_gUtQxY3HaseL0InIVwdgf7L_fc"
+};
+
+export const TEST_SSH_VALUES = {
+    SSH_JWK: "{\"kty\":\"RSA\",\"n\":\"wDJwv083ZhGGkpMPVcBMwtSBNLu7qhT2VmKv7AyPEz_dWb8GQzNEnWT1niNjFI0isDMFWQ7X2O-dhTL9J1QguQ==\",\"e\":\"AQAB\"}",
+    ENCODED_SSH_JWK: "%7B%22kty%22%3A%22RSA%22%2C%22n%22%3A%22wDJwv083ZhGGkpMPVcBMwtSBNLu7qhT2VmKv7AyPEz_dWb8GQzNEnWT1niNjFI0isDMFWQ7X2O-dhTL9J1QguQ%3D%3D%22%2C%22e%22%3A%22AQAB%22%7D",
+    SSH_KID: "TestSSHKeyId",
+    ALTERNATE_SSH_JWK: "{\"p\":\"zN8SHQ_QsbEMNwrA3ZpKn2ulmKGZfAfrOnouojvUIzuH13y-sWUfiDADgei4MG3j5fJHFPuMdKE5zdYKgsC3eyImeAzNd10ZDRUaMXubg1fyyvlf7hE4cvrwaQ0MftXsvlCLi1nkK_DjnPjAonqvbRMOS6YyUXAZBZyfLaZ76cU\",\"kty\":\"RSA\",\"q\":\"yrsb5PwGF5Lvtx1CCSX6j0fhNDjwK7LkKvfE1qhrGgv3Cu9HBUb90qoj0qewA1prPQBN3cjrKv19zIrIV2ac3-p_j6jKotd7o2-t0jXpSW7wlGFpArIf2nxDyJo1KeimDi697hbESb_gPYGeno0TJTdmIyYWB8_JHm06cGkU3P0\",\"d\":\"U4A5WR4L4cqActlO0PALdBF9_Myc4Zzk401Uo3bufsI3AGw9EFkARIq7U2T4PAnPbhUr-mT3zIYsLD6Ck1-PNE9gJbeQXgBRHJWCZe6s90FoeQZl1k2ADjjwOWjf5MyTxTSmdH7ENIABLzsukz3EQnsEZIGM4bnpaC-5wfZ5THI8FFEIMh-sEro1BbI_roohwKoDiOmzpthrxbqoFXq7YfEOjZ9i_H8mvCunMuQQ0CZLZfGTKoKN5ZcQkQSdy4wAVzln5eXtm-lxWFXrB-EL8qgDUrsx9HAxKxjACKNoTdgttGy3G434OJqh7QB5iGtHaXVb5wEvUeJXXa_N44Sd4Q\",\"e\":\"AQAB\",\"use\":\"enc\",\"kid\":\"40890f08-6b55-450f-9443-a6d5cef8b6d0\",\"qi\":\"OQ2Ku_syiEvUEvixOyyBSuq5UuoQLwaecExggwUaJZF-zpRv76fsxxaKYZiTZU-80cLMIOfsYbxMU1_p_VI4gKOr8vnY10VSCBSge8UX6InuLzVGdx8UoMb-q0rhmStw2hhfFzLzrZSYvooxMX_PQQTkmyhyVck9Pp-5hVPg3hI","dp":"XMccndqeqQnDvV16UCDicGXAfWmZZ2jypu3UFpY_kKER-I0-knl4GSWdQQSR_SSW03ivphnw1pR45_VplyMNNI8XmsA5gDfB84G99fDDUWzPwAnE3rwfszpfC0Pkh7_7UYiKWVYhFaEmgtzH6AzlSuEZVTrziJvaSQdPss21Sf0\",\"dq\":\"MqBTMPW218A72LCXww0W6xz6Ij5ty5va2tgQ8cIRLOn8AWELjUfTLv6J_5scm1nDGfKvf0kjYRL4jVHDAgCAAHLg9BEkuVGycHf9IleQMGRh88v3m1K8HaWWj8viptqQTU5i48gPsJMX_oQWBmYYd9zDxtdF_SFoig6g311-dkk","n":"oj3Bj_D64iFCgtRAInqXbiIrTxbMBw6D6QFCam84CjS3U3cvOjqBhaWPciqPZFYAk3T4_7_HDu-v_iNb5R5Nae0PQ3hXt99y3n0ZwVE_LQ4hQuMLWCQ8YaQnLjrBCJR1YWD6d92UGXj6Jm_a80wmrcxZ6z_W-thUacdGN6Y5P5bLTq-dAYf92ZQxTx9-nIV8BA0jnFt0F_tMuBU-sec8Z2vSq8KQjllWgXarB6aKq7g4RsJAgGqC-kVwskE2WrXKiTVgnA-mvBhRwJE2TMYdi0dMT2eCZCA6Hym2rj_7PRT5QCTflYWPh7Ya3blc4ET9xC8akghPMZjVfEfwFb9TsQ\"}",
+    ALTERNATE_ENCODED_SSH_JWK: "%7B%22p%22%3A%22zN8SHQ_QsbEMNwrA3ZpKn2ulmKGZfAfrOnouojvUIzuH13y-sWUfiDADgei4MG3j5fJHFPuMdKE5zdYKgsC3eyImeAzNd10ZDRUaMXubg1fyyvlf7hE4cvrwaQ0MftXsvlCLi1nkK_DjnPjAonqvbRMOS6YyUXAZBZyfLaZ76cU%22%2C%22kty%22%3A%22RSA%22%2C%22q%22%3A%22yrsb5PwGF5Lvtx1CCSX6j0fhNDjwK7LkKvfE1qhrGgv3Cu9HBUb90qoj0qewA1prPQBN3cjrKv19zIrIV2ac3-p_j6jKotd7o2-t0jXpSW7wlGFpArIf2nxDyJo1KeimDi697hbESb_gPYGeno0TJTdmIyYWB8_JHm06cGkU3P0%22%2C%22d%22%3A%22U4A5WR4L4cqActlO0PALdBF9_Myc4Zzk401Uo3bufsI3AGw9EFkARIq7U2T4PAnPbhUr-mT3zIYsLD6Ck1-PNE9gJbeQXgBRHJWCZe6s90FoeQZl1k2ADjjwOWjf5MyTxTSmdH7ENIABLzsukz3EQnsEZIGM4bnpaC-5wfZ5THI8FFEIMh-sEro1BbI_roohwKoDiOmzpthrxbqoFXq7YfEOjZ9i_H8mvCunMuQQ0CZLZfGTKoKN5ZcQkQSdy4wAVzln5eXtm-lxWFXrB-EL8qgDUrsx9HAxKxjACKNoTdgttGy3G434OJqh7QB5iGtHaXVb5wEvUeJXXa_N44Sd4Q%22%2C%22e%22%3A%22AQAB%22%2C%22use%22%3A%22enc%22%2C%22kid%22%3A%2240890f08-6b55-450f-9443-a6d5cef8b6d0%22%2C%22qi%22%3A%22OQ2Ku_syiEvUEvixOyyBSuq5UuoQLwaecExggwUaJZF-zpRv76fsxxaKYZiTZU-80cLMIOfsYbxMU1_p_VI4gKOr8vnY10VSCBSge8UX6InuLzVGdx8UoMb-q0rhmStw2hhfFzLzrZSYvooxMX_PQQTkmyhyVck9Pp-5hVPg3hI%22%2C%22dp%22%3A%22XMccndqeqQnDvV16UCDicGXAfWmZZ2jypu3UFpY_kKER-I0-knl4GSWdQQSR_SSW03ivphnw1pR45_VplyMNNI8XmsA5gDfB84G99fDDUWzPwAnE3rwfszpfC0Pkh7_7UYiKWVYhFaEmgtzH6AzlSuEZVTrziJvaSQdPss21Sf0%22%2C%22dq%22%3A%22MqBTMPW218A72LCXww0W6xz6Ij5ty5va2tgQ8cIRLOn8AWELjUfTLv6J_5scm1nDGfKvf0kjYRL4jVHDAgCAAHLg9BEkuVGycHf9IleQMGRh88v3m1K8HaWWj8viptqQTU5i48gPsJMX_oQWBmYYd9zDxtdF_SFoig6g311-dkk%22%2C%22n%22%3A%22oj3Bj_D64iFCgtRAInqXbiIrTxbMBw6D6QFCam84CjS3U3cvOjqBhaWPciqPZFYAk3T4_7_HDu-v_iNb5R5Nae0PQ3hXt99y3n0ZwVE_LQ4hQuMLWCQ8YaQnLjrBCJR1YWD6d92UGXj6Jm_a80wmrcxZ6z_W-thUacdGN6Y5P5bLTq-dAYf92ZQxTx9-nIV8BA0jnFt0F_tMuBU-sec8Z2vSq8KQjllWgXarB6aKq7g4RsJAgGqC-kVwskE2WrXKiTVgnA-mvBhRwJE2TMYdi0dMT2eCZCA6Hym2rj_7PRT5QCTflYWPh7Ya3blc4ET9xC8akghPMZjVfEfwFb9TsQ%22%7D",
+    ALTERNATE_SSH_KID: "AlternateSSHKeyId"
+};
+
+export const TEST_STATE_VALUES = {
+    USER_STATE: "userState",
+    TEST_TIMESTAMP: 1592846482,
+    DECODED_LIB_STATE: `{"id":"${RANDOM_TEST_GUID}","ts":1592846482}`,
+    ENCODED_LIB_STATE: "eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ==",
+    URI_ENCODED_LIB_STATE: "eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ%3D%3D",
+    TEST_STATE: `eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ==${Constants.RESOURCE_DELIM}userState`
+};
+export const DEFAULT_TENANT_DISCOVERY_RESPONSE = {
+    body: {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+            {
+                "preferred_network": "login.windows.net",
+                "preferred_cache": "sts.windows.net",
+                "aliases": ["login.microsoftonline.com","login.windows.net","login.microsoft.com","sts.windows.net"]
+            }
+        ]
+    }
+};
+
+export const DSTS_OPENID_CONFIG_RESPONSE = {
+    body: {
+        "token_endpoint": "https://login.microsoftonline.com/dstsv2/{tenant}/oauth2/v2.0/token",
+    }
+}
+export const DEFAULT_OPENID_CONFIG_RESPONSE = {
+    body: {
+        "token_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_post",
+            "private_key_jwt",
+            "client_secret_basic"
+        ],
+        "jwks_uri": "https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys",
+        "response_modes_supported": [
+            "query",
+            "fragment",
+            "form_post"
+        ],
+        "subject_types_supported": ["pairwise"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "response_types_supported": ["code", "id_token", "code id_token", "id_token token"],
+        "scopes_supported": ["openid", "profile", "email", "offline_access"],
+        "issuer": "https://login.microsoftonline.com/{tenant}/v2.0",
+        "request_uri_parameter_supported": false,
+        "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+        "authorization_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize",
+        "http_logout_supported": true,
+        "frontchannel_logout_supported": true,
+        "end_session_endpoint": "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/logout",
+        "claims_supported": ["sub", "iss", "cloud_instance_name", "cloud_instance_host_name", "cloud_graph_host_name", "msgraph_host", "aud", "exp", "iat", "auth_time", "acr", "nonce", "preferred_username", "name", "tid", "ver", "at_hash", "c_hash", "email"],
+        "tenant_region_scope": null,
+        "cloud_instance_name": "microsoftonline.com",
+        "cloud_graph_host_name": "graph.windows.net",
+        "msgraph_host": "graph.microsoft.com",
+        "rbac_url": "https://pas.windows.net"
+    }
+};
+
+export const AUTHENTICATION_RESULT = {
+    status: 200,
+    body: {
+        "token_type": AuthenticationScheme.BEARER,
+        "scope": "openid profile User.Read email",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "thisIs.an.accessT0ken",
+        "refresh_token": "thisIsARefreshT0ken",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
+        "client_info": `${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}`
+    }
+};
+
+export const AUTHENTICATION_RESULT_DEFAULT_SCOPES = {
+    status: 200,
+    body: {
+        "token_type": AuthenticationScheme.BEARER,
+        "scope": "openid profile offline_access User.Read",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "thisIs.an.accessT0ken",
+        "refresh_token": "thisIsARefreshT0ken",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw",
+        "client_info": `${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}`
+    }
+};
+
+export const CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT = {
+    status: 200,
+    body: {
+        "token_type": AuthenticationScheme.BEARER,
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "thisIs.an.accessT0ken",
+    }
+};
+
+export const DSTS_CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT = {
+    status: 200,
+    body: {
+        "token_type": AuthenticationScheme.BEARER,
+        "expires_in": 86396,
+        "ext_expires_in": 86396,
+        "refresh_in": 43198,
+        "access_token":"thisIs.a.dsts.accessT0ken"
+    }
+}
+export const DEVICE_CODE_RESPONSE = {
+    "userCode": "FRWQDE7YL",
+    "deviceCode": "FAQABAAEAAAAm-06blBE1TpVMil8KPQ414yBCo3ZKuMDP8Rw0c8_mKXKdJEpKINnjC1jRfwa_uuF-yqKFw100qeiQDNGuRnS8FxCKeWCybjEPf2KoptmHGa3MEL5MXGl9yEDtaMRGBYpJNx_ssI2zYJP1uXqejSj1Kns69bdClF4BZxRpmJ1rcssZuY1-tTLw0vngmHYqRp0gAA",
+    "verificationUri": "https://microsoft.com/devicelogin",
+    "expiresIn": 900,
+    "interval": 5,
+    "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code FRWQDE7YL to authenticate.",
+};
+
+export const DEVICE_CODE_EXPIRED_RESPONSE = {
+    "userCode": "FRWQDE7YL",
+    "deviceCode": "FAQABAAEAAAAm-06blBE1TpVMil8KPQ414yBCo3ZKuMDP8Rw0c8_mKXKdJEpKINnjC1jRfwa_uuF-yqKFw100qeiQDNGuRnS8FxCKeWCybjEPf2KoptmHGa3MEL5MXGl9yEDtaMRGBYpJNx_ssI2zYJP1uXqejSj1Kns69bdClF4BZxRpmJ1rcssZuY1-tTLw0vngmHYqRp0gAA",
+    "verificationUri": "https://microsoft.com/devicelogin",
+    "expiresIn": 0,
+    "interval": 5,
+    "message": "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code FRWQDE7YL to authenticate.",
+    "client_info": `${TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO}`
+};
+
+export const AUTHORIZATION_PENDING_RESPONSE = {
+    body: {
+        error: "authorization_pending",
+        error_description: "AADSTS70016: OAuth 2.0 device flow error. Authorization is pending. Continue polling." +
+            "Trace ID: 01707a0c-640b-4049-8cbb-ee2304dc0700" +
+            "Correlation ID: 78b0fdfc-dd0e-4dfb-b13a-d316333783f6" +
+            "Timestamp: 2020-03-26 22:54:14Z",
+        error_codes: [70016],
+        timestamp: "2020-03-26 22:54:14Z",
+        trace_id: "01707a0c-640b-4049-8cbb-ee2304dc0700",
+        correlation_id: "78b0fdfc-dd0e-4dfb-b13a-d316333783f6",
+        error_uri: "https://login.microsoftonline.com/error?code=70016"
+    }
+};
+
+export const SERVER_UNEXPECTED_ERROR = {
+    status: 503,
+    body: {
+        error: "Service Unavailable"
+    }
+};
+
+export const DEFAULT_NETWORK_IMPLEMENTATION = {
+    sendGetRequestAsync: async (): Promise<any> => {
+        return { test: "test" };
+    },
+    sendPostRequestAsync: async (): Promise<any> => {
+        return { test: "test" };
+    }
+};
+
+export const CORS_SIMPLE_REQUEST_HEADERS = [
+    "connection",
+    "user-agent",
+    "accept",
+    "accept-language",
+    "content-language",
+    "content-type"
+];


### PR DESCRIPTION
1. Move 4 clients used only by `msal-node` from `msal-common` to `msal-node`.
    - ClientCredentialClient
    - DeviceCodeClient
    - OnBehalfOfClient
    - UsernamePasswordClient
2. Move `request` and part of `response` docs from `msal-common` to `msal-node`.
3. Update references.
