### PR TITLE
exposing missing token claims parameters

### DIFF
--- a/change/@azure-msal-common-b2950ef2-9358-44e2-97f2-603bdbf45686.json
+++ b/change/@azure-msal-common-b2950ef2-9358-44e2-97f2-603bdbf45686.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added tenant_region_scope and tenant_region_sub_scope to TokenClaims #5789",
+  "packageName": "@azure/msal-common",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/account/TokenClaims.ts
+++ b/lib/msal-common/src/account/TokenClaims.ts
@@ -62,4 +62,6 @@ export type TokenClaims = {
     amr?: string[],
     idp?: string,
     auth_time?: number,
+    tenant_region_scope?: string,
+    tenant_region_sub_scope?: string
 };

--- a/lib/msal-common/src/account/TokenClaims.ts
+++ b/lib/msal-common/src/account/TokenClaims.ts
@@ -62,6 +62,9 @@ export type TokenClaims = {
     amr?: string[],
     idp?: string,
     auth_time?: number,
+    /**
+     * 	Region of the resource tenant
+     */
     tenant_region_scope?: string,
     tenant_region_sub_scope?: string
 };

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -373,7 +373,9 @@ describe("AuthorizationCodeClient unit tests", () => {
                 oid: "00000000-0000-0000-66f3-3332eca7ea81",
                 tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
                 nonce: "123523",
-                sid: "testSid"
+                sid: "testSid",
+                tenant_region_scope: "test_tenant_region_scope",
+                tenant_region_sub_scope: "test_tenant_region_sub_scope"
             };
 
             const authCodeUrlRequest: CommonAuthorizationUrlRequest = {
@@ -411,7 +413,9 @@ describe("AuthorizationCodeClient unit tests", () => {
                 preferred_username: "AbeLi@microsoft.com",
                 oid: "00000000-0000-0000-66f3-3332eca7ea81",
                 tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
-                nonce: "123523"
+                nonce: "123523",
+                tenant_region_scope: "test_tenant_region_scope",
+                tenant_region_sub_scope: "test_tenant_region_sub_scope"
             };
 
             const authCodeUrlRequest: CommonAuthorizationUrlRequest = {


### PR DESCRIPTION
Bug fix:
- Added missing `tenant_region_scope` and `tenant_region_sub_scope` claims from Token Claims