### PR TITLE
Expose controller artifacts for 1p lib

### DIFF
--- a/change/@azure-msal-browser-eb932933-12ec-4b2c-a269-8052222fbee8.json
+++ b/change/@azure-msal-browser-eb932933-12ec-4b2c-a269-8052222fbee8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose controller artifacts for 1p lib #5794",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -26,7 +26,7 @@ import { StandardOperatingContext } from "../operatingcontext/StandardOperatingC
  */
 export class PublicClientApplication implements IPublicClientApplication {
 
-    private controller: IController;
+    protected controller: IController;
 
     public static async createPublicClientApplication(configuration: Configuration): Promise<IPublicClientApplication> {
 

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IPublicClientApplication } from "../app/IPublicClientApplication";
-
 import {
     AuthenticationResult,
     AccountInfo,

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -31,50 +31,96 @@ import { SilentIframeClient } from "../interaction_client/SilentIframeClient";
 
 export interface IController {
     initialize(): Promise<void>;
+
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
+
     acquireTokenRedirect(request: RedirectRequest): Promise<void>;
+
     acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
+
     acquireTokenByCode(request: AuthorizationCodeRequest): Promise<AuthenticationResult>;
+
     acquireTokenNative(request: PopupRequest | SilentRequest | SsoSilentRequest, apiId: ApiId, accountId?: string): Promise<AuthenticationResult>;
+
     acquireTokenByRefreshToken(commonRequest: CommonSilentFlowRequest, silentRequest: SilentRequest): Promise<AuthenticationResult>;
+
     addEventCallback(callback: Function): string | null;
+
     removeEventCallback(callbackId: string): void;
+
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
+
     removePerformanceCallback(callbackId: string): boolean;
+
     enableAccountStorageEvents(): void;
+
     disableAccountStorageEvents(): void;
+
     getAccountByHomeId(homeAccountId: string): AccountInfo | null;
+
     getAccountByLocalId(localId: string): AccountInfo | null;
+
     getAccountByUsername(userName: string): AccountInfo | null;
+
     getAllAccounts(): AccountInfo[];
+
     handleRedirectPromise(hash?: string): Promise<AuthenticationResult | null>;
+
     loginPopup(request?: PopupRequest): Promise<AuthenticationResult>;
+
     loginRedirect(request?: RedirectRequest): Promise<void>;
+
     logout(logoutRequest?: EndSessionRequest): Promise<void>;
+
     logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void>;
+
     logoutPopup(logoutRequest?: EndSessionPopupRequest): Promise<void>;
+
     ssoSilent(request: SsoSilentRequest): Promise<AuthenticationResult>;
+
     getTokenCache(): ITokenCache;
+
     getLogger(): Logger;
+
     setLogger(logger: Logger): void;
+
     setActiveAccount(account: AccountInfo | null): void;
+
     getActiveAccount(): AccountInfo | null;
+
     initializeWrapperLibrary(sku: WrapperSKU, version: string): void;
+
     setNavigationClient(navigationClient: INavigationClient): void;
+
     getConfiguration(): BrowserConfiguration;
+
     isBrowserEnv(): boolean;
+
     getBrowserStorage(): BrowserCacheManager;
+
     getNativeInternalStorage(): BrowserCacheManager;
+
     getBrowserCrypto(): ICrypto;
+
     getPerformanceClient(): IPerformanceClient;
+
     getNativeExtensionProvider(): NativeMessageHandler | undefined;
+
     setNativeExtensionProvider(provider: NativeMessageHandler | undefined): void;
+
     getNativeAccountId(request: RedirectRequest | PopupRequest | SsoSilentRequest): string;
+
     getEventHandler(): EventHandler;
+
     getNavigationClient(): INavigationClient;
+
     getRedirectResponse(): Map<string, Promise<AuthenticationResult | null>>;
+
     preflightBrowserEnvironmentCheck(interactionType: InteractionType, setInteractionInProgress?: boolean): void;
+
     canUseNative(request: RedirectRequest | PopupRequest | SsoSilentRequest, accountId?: string): boolean;
+
     createPopupClient(correlationId?: string): PopupClient;
+
     createSilentIframeClient(correlationId?: string): SilentIframeClient;
 }

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -5,4 +5,78 @@
 
 import { IPublicClientApplication } from "../app/IPublicClientApplication";
 
-export type IController = IPublicClientApplication;
+import {
+    AuthenticationResult,
+    AccountInfo,
+    Logger,
+    PerformanceCallbackFunction,
+    IPerformanceClient,
+    ICrypto,
+    CommonSilentFlowRequest
+} from "@azure/msal-common";
+import { RedirectRequest } from "../request/RedirectRequest";
+import { PopupRequest } from "../request/PopupRequest";
+import { SilentRequest } from "../request/SilentRequest";
+import { SsoSilentRequest } from "../request/SsoSilentRequest";
+import { EndSessionRequest } from "../request/EndSessionRequest";
+import { ApiId, InteractionType, WrapperSKU } from "../utils/BrowserConstants";
+import { INavigationClient } from "../navigation/INavigationClient";
+import { EndSessionPopupRequest } from "../request/EndSessionPopupRequest";
+import { ITokenCache } from "../cache/ITokenCache";
+import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
+import { BrowserConfiguration } from "../config/Configuration";
+import { BrowserCacheManager } from "../cache/BrowserCacheManager";
+import { NativeMessageHandler } from "../broker/nativeBroker/NativeMessageHandler";
+import { EventHandler } from "../event/EventHandler";
+import { PopupClient } from "../interaction_client/PopupClient";
+import { SilentIframeClient } from "../interaction_client/SilentIframeClient";
+
+export interface IController {
+    initialize(): Promise<void>;
+    acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
+    acquireTokenRedirect(request: RedirectRequest): Promise<void>;
+    acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
+    acquireTokenByCode(request: AuthorizationCodeRequest): Promise<AuthenticationResult>;
+    acquireTokenNative(request: PopupRequest | SilentRequest | SsoSilentRequest, apiId: ApiId, accountId?: string): Promise<AuthenticationResult>;
+    acquireTokenByRefreshToken(commonRequest: CommonSilentFlowRequest, silentRequest: SilentRequest): Promise<AuthenticationResult>;
+    addEventCallback(callback: Function): string | null;
+    removeEventCallback(callbackId: string): void;
+    addPerformanceCallback(callback: PerformanceCallbackFunction): string;
+    removePerformanceCallback(callbackId: string): boolean;
+    enableAccountStorageEvents(): void;
+    disableAccountStorageEvents(): void;
+    getAccountByHomeId(homeAccountId: string): AccountInfo | null;
+    getAccountByLocalId(localId: string): AccountInfo | null;
+    getAccountByUsername(userName: string): AccountInfo | null;
+    getAllAccounts(): AccountInfo[];
+    handleRedirectPromise(hash?: string): Promise<AuthenticationResult | null>;
+    loginPopup(request?: PopupRequest): Promise<AuthenticationResult>;
+    loginRedirect(request?: RedirectRequest): Promise<void>;
+    logout(logoutRequest?: EndSessionRequest): Promise<void>;
+    logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void>;
+    logoutPopup(logoutRequest?: EndSessionPopupRequest): Promise<void>;
+    ssoSilent(request: SsoSilentRequest): Promise<AuthenticationResult>;
+    getTokenCache(): ITokenCache;
+    getLogger(): Logger;
+    setLogger(logger: Logger): void;
+    setActiveAccount(account: AccountInfo | null): void;
+    getActiveAccount(): AccountInfo | null;
+    initializeWrapperLibrary(sku: WrapperSKU, version: string): void;
+    setNavigationClient(navigationClient: INavigationClient): void;
+    getConfiguration(): BrowserConfiguration;
+    isBrowserEnv(): boolean;
+    getBrowserStorage(): BrowserCacheManager;
+    getNativeInternalStorage(): BrowserCacheManager;
+    getBrowserCrypto(): ICrypto;
+    getPerformanceClient(): IPerformanceClient;
+    getNativeExtensionProvider(): NativeMessageHandler | undefined;
+    setNativeExtensionProvider(provider: NativeMessageHandler | undefined): void;
+    getNativeAccountId(request: RedirectRequest | PopupRequest | SsoSilentRequest): string;
+    getEventHandler(): EventHandler;
+    getNavigationClient(): INavigationClient;
+    getRedirectResponse(): Map<string, Promise<AuthenticationResult | null>>;
+    preflightBrowserEnvironmentCheck(interactionType: InteractionType, setInteractionInProgress?: boolean): void;
+    canUseNative(request: RedirectRequest | PopupRequest | SsoSilentRequest, accountId?: string): boolean;
+    createPopupClient(correlationId?: string): PopupClient;
+    createSilentIframeClient(correlationId?: string): SilentIframeClient;
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1113,39 +1113,73 @@ export class StandardController implements IController {
         return this.config;
     }
 
+    /**
+     * Returns the performance client
+     */
     public getPerformanceClient(): IPerformanceClient {
         return this.performanceClient;
     }
 
+    /**
+     * Returns the browser storage
+     */
     public getBrowserStorage(): BrowserCacheManager  {
         return this.browserStorage;
     }
 
+    /**
+     * Returns the native internal storage
+     */
     public getNativeInternalStorage(): BrowserCacheManager  {
         return this.nativeInternalStorage;
     }
 
+    /**
+     * Returns the instance of interface for crypto functions
+     */
     public getBrowserCrypto(): ICrypto {
         return this.browserCrypto;
     }
 
+    /**
+     * Returns the browser env indicator
+     */
     public isBrowserEnv() : boolean {
         return this.isBrowserEnvironment;
     }
+
+    /**
+     * Returns the native message handler
+     */
     getNativeExtensionProvider(): NativeMessageHandler | undefined {
         return this.nativeExtensionProvider;
     }
 
+    /**
+     * Sets the native message handler
+     * @param provider {?NativeMessageHandler}
+     */
     setNativeExtensionProvider(provider: NativeMessageHandler | undefined): void {
         this.nativeExtensionProvider = provider;
     }
+
+    /**
+     * Returns the event handler
+     */
     getEventHandler(): EventHandler {
         return this.eventHandler;
     }
+
+    /**
+     * Returns the navigation client
+     */
     getNavigationClient(): INavigationClient {
         return this.navigationClient;
     }
 
+    /**
+     * Returns the redirect response map
+     */
     getRedirectResponse(): Map<string, Promise<AuthenticationResult | null>> {
         return this.redirectResponse;
     }

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -43,7 +43,7 @@ import { version, name } from "../packageMetadata";
 export class StandardController implements IController {
 
     // OperatingContext
-    protected operatingContext: StandardOperatingContext;
+    protected readonly operatingContext: StandardOperatingContext;
 
     // Crypto interface implementation
     protected readonly browserCrypto: ICrypto;
@@ -61,7 +61,7 @@ export class StandardController implements IController {
     protected navigationClient: INavigationClient;
 
     // Input configuration by developer/user
-    protected config: BrowserConfiguration;
+    protected readonly config: BrowserConfiguration;
 
     // Token cache implementation
     private tokenCache: TokenCache;
@@ -72,10 +72,10 @@ export class StandardController implements IController {
     // Flag to indicate if in browser environment
     protected isBrowserEnvironment: boolean;
 
-    protected eventHandler: EventHandler;
+    protected readonly eventHandler: EventHandler;
 
     // Redirect Response Object
-    protected redirectResponse: Map<string, Promise<AuthenticationResult | null>>;
+    protected readonly redirectResponse: Map<string, Promise<AuthenticationResult | null>>;
 
     // Native Extension Provider
     protected nativeExtensionProvider: NativeMessageHandler | undefined;
@@ -84,7 +84,7 @@ export class StandardController implements IController {
     private hybridAuthCodeResponses: Map<string, Promise<AuthenticationResult>>;
 
     // Performance telemetry client
-    protected performanceClient: IPerformanceClient;
+    protected readonly performanceClient: IPerformanceClient;
 
     // Flag representing whether or not the initialize API has been called and completed
     protected initialized: boolean;
@@ -686,7 +686,7 @@ export class StandardController implements IController {
      * @param silentRequest SilentRequest
      * @returns A promise that, when resolved, returns the access token
      */
-    protected async acquireTokenByRefreshToken(
+    public async acquireTokenByRefreshToken(
         commonRequest: CommonSilentFlowRequest,
         silentRequest: SilentRequest
     ): Promise<AuthenticationResult> {
@@ -867,7 +867,7 @@ export class StandardController implements IController {
      * @param {InteractionType} interactionType What kind of interaction is being used
      * @param {boolean} [setInteractionInProgress=true] Whether to set interaction in progress temp cache flag
      */
-    protected preflightBrowserEnvironmentCheck(interactionType: InteractionType, setInteractionInProgress: boolean = true): void {
+    public preflightBrowserEnvironmentCheck(interactionType: InteractionType, setInteractionInProgress: boolean = true): void {
         this.logger.verbose("preflightBrowserEnvironmentCheck started");
         // Block request if not in browser environment
         BrowserUtils.blockNonBrowserEnvironment(this.isBrowserEnvironment);
@@ -917,7 +917,7 @@ export class StandardController implements IController {
      * Acquire a token from native device (e.g. WAM)
      * @param request
      */
-    protected async acquireTokenNative(request: PopupRequest | SilentRequest | SsoSilentRequest, apiId: ApiId, accountId?: string): Promise<AuthenticationResult> {
+    public async acquireTokenNative(request: PopupRequest | SilentRequest | SsoSilentRequest, apiId: ApiId, accountId?: string): Promise<AuthenticationResult> {
         this.logger.trace("acquireTokenNative called");
         if (!this.nativeExtensionProvider) {
             throw BrowserAuthError.createNativeConnectionNotEstablishedError();
@@ -932,7 +932,7 @@ export class StandardController implements IController {
      * Returns boolean indicating if this request can use the native broker
      * @param request
      */
-    protected canUseNative(request: RedirectRequest | PopupRequest | SsoSilentRequest, accountId?: string): boolean {
+    public canUseNative(request: RedirectRequest | PopupRequest | SsoSilentRequest, accountId?: string): boolean {
         this.logger.trace("canUseNative called");
         if (!NativeMessageHandler.isNativeAvailable(this.config, this.logger, this.nativeExtensionProvider, request.authenticationScheme)) {
             this.logger.trace("canUseNative: isNativeAvailable returned false, returning false");
@@ -965,7 +965,7 @@ export class StandardController implements IController {
      * @param request
      * @returns
      */
-    protected getNativeAccountId(request: RedirectRequest | PopupRequest | SsoSilentRequest): string {
+    public getNativeAccountId(request: RedirectRequest | PopupRequest | SsoSilentRequest): string {
         const account = request.account || this.browserStorage.getAccountInfoByHints(request.loginHint, request.sid) || this.getActiveAccount();
 
         return account && account.nativeAccountId || "";
@@ -975,7 +975,7 @@ export class StandardController implements IController {
      * Returns new instance of the Popup Interaction Client
      * @param correlationId
      */
-    protected createPopupClient(correlationId?: string): PopupClient {
+    public createPopupClient(correlationId?: string): PopupClient {
         return new PopupClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, this.performanceClient, this.nativeInternalStorage, this.nativeExtensionProvider, correlationId);
     }
 
@@ -991,7 +991,7 @@ export class StandardController implements IController {
      * Returns new instance of the Silent Iframe Interaction Client
      * @param correlationId
      */
-    protected createSilentIframeClient(correlationId?: string): SilentIframeClient {
+    public createSilentIframeClient(correlationId?: string): SilentIframeClient {
         return new SilentIframeClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, ApiId.ssoSilent, this.performanceClient, this.nativeInternalStorage, this.nativeExtensionProvider, correlationId);
     }
 
@@ -1076,7 +1076,7 @@ export class StandardController implements IController {
     /**
      * Returns the logger instance
      */
-    getLogger(): Logger {
+    public getLogger(): Logger {
         return this.logger;
     }
 
@@ -1109,8 +1109,45 @@ export class StandardController implements IController {
     /**
      * Returns the configuration object
      */
-    getConfiguration(): BrowserConfiguration {
+    public getConfiguration(): BrowserConfiguration {
         return this.config;
+    }
+
+    public getPerformanceClient(): IPerformanceClient {
+        return this.performanceClient;
+    }
+
+    public getBrowserStorage(): BrowserCacheManager  {
+        return this.browserStorage;
+    }
+
+    public getNativeInternalStorage(): BrowserCacheManager  {
+        return this.nativeInternalStorage;
+    }
+
+    public getBrowserCrypto(): ICrypto {
+        return this.browserCrypto;
+    }
+
+    public isBrowserEnv() : boolean {
+        return this.isBrowserEnvironment;
+    }
+    getNativeExtensionProvider(): NativeMessageHandler | undefined {
+        return this.nativeExtensionProvider;
+    }
+
+    setNativeExtensionProvider(provider: NativeMessageHandler | undefined): void {
+        this.nativeExtensionProvider = provider;
+    }
+    getEventHandler(): EventHandler {
+        return this.eventHandler;
+    }
+    getNavigationClient(): INavigationClient {
+        return this.navigationClient;
+    }
+
+    getRedirectResponse(): Map<string, Promise<AuthenticationResult | null>> {
+        return this.redirectResponse;
     }
 
     /**

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -12,10 +12,9 @@
  * Warning: This set of exports is purely intended to be used by other MSAL libraries, and should be considered potentially unstable. We strongly discourage using them directly, you do so at your own risk.
  * Breaking changes to these APIs will be shipped under a minor version, instead of a major version.
  */
-/*
- * import * as internals from "./internals";
- * export { internals };
- */
+
+import * as internals from "./internals";
+export { internals };
 
 export { PublicClientApplication } from "./app/PublicClientApplication";
 export { Configuration, BrowserAuthOptions, CacheOptions, BrowserSystemOptions, BrowserConfiguration, DEFAULT_IFRAME_TIMEOUT_MS } from "./config/Configuration";


### PR DESCRIPTION
- Export `msal-browser` internals for 1p lib.
- Expose controller artifacts for 1p lib.
- Make eligible fields `readonly` for `StandardController`.

Note: controller artifacts exposed by this PR are required for 1p.