### PR TITLE
passport-azure-ad update node-jose dependency

### DIFF
--- a/maintenance/passport-azure-ad/package.json
+++ b/maintenance/passport-azure-ad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-azure-ad",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "license": "MIT",
   "keywords": [
     "azure active directory",

--- a/maintenance/passport-azure-ad/package.json
+++ b/maintenance/passport-azure-ad/package.json
@@ -42,7 +42,7 @@
     "https-proxy-agent": "^5.0.0",
     "jws": "^3.1.3",
     "lodash": "^4.11.2",
-    "node-jose": "^2.0.0",
+    "node-jose": "^2.2.0",
     "oauth": "0.9.15",
     "passport": "^0.6.0",
     "valid-url": "^1.0.6"


### PR DESCRIPTION
Updates node-jose dependency to 2.2.0+ to address vulnerability with versions < 2.2.0