### PR TITLE
fix: fix lexical declaration in case clause, type of acquireToken, ad…

### DIFF
--- a/samples/msal-browser-samples/vue3-sample-app/src/composition-api/useMsalAuthentication.ts
+++ b/samples/msal-browser-samples/vue3-sample-app/src/composition-api/useMsalAuthentication.ts
@@ -3,7 +3,7 @@ import { Ref, ref, watch } from "vue";
 import { useMsal } from "./useMsal";
 
 export type MsalAuthenticationResult = {
-    acquireToken: Function;
+    acquireToken: (requestOverride?: PopupRequest|RedirectRequest|SilentRequest) => Promise<void>;
     result: Ref<AuthenticationResult|null>;
     error: Ref<AuthError|null>;
     inProgress: Ref<boolean>;
@@ -65,7 +65,7 @@ export function useMsalAuthentication(interactionType: InteractionType, request:
     }
 
     const stopWatcher = watch(inProgress, () => {
-        if (!result && !error) {
+        if (!result.value && !error.value) {
             acquireToken();
         } else {
             stopWatcher();
@@ -73,7 +73,7 @@ export function useMsalAuthentication(interactionType: InteractionType, request:
     });
 
     acquireToken();
-    
+
     return {
         acquireToken,
         result,

--- a/samples/msal-browser-samples/vue3-sample-app/src/plugins/msalPlugin.ts
+++ b/samples/msal-browser-samples/vue3-sample-app/src/plugins/msalPlugin.ts
@@ -1,13 +1,20 @@
-import { App, reactive } from "vue";
-import { EventMessage, EventMessageUtils, EventType, InteractionStatus, PublicClientApplication, AccountInfo } from "@azure/msal-browser";
+import {App, reactive} from "vue";
+import {
+    EventMessage,
+    EventMessageUtils,
+    EventType,
+    InteractionStatus,
+    PublicClientApplication,
+    AccountInfo
+} from "@azure/msal-browser";
 
-type AccountIdentifiers = Partial<Pick<AccountInfo, "homeAccountId"|"localAccountId"|"username">>;
+type AccountIdentifiers = Partial<Pick<AccountInfo, "homeAccountId" | "localAccountId" | "username">>;
 
 /**
  * Helper function to determine whether 2 arrays are equal
  * Used to avoid unnecessary state updates
- * @param arrayA 
- * @param arrayB 
+ * @param arrayA
+ * @param arrayB
  */
 function accountArraysAreEqual(arrayA: Array<AccountIdentifiers>, arrayB: Array<AccountIdentifiers>): boolean {
     if (arrayA.length !== arrayB.length) {
@@ -22,9 +29,9 @@ function accountArraysAreEqual(arrayA: Array<AccountIdentifiers>, arrayB: Array<
             return false;
         }
 
-        return (elementA.homeAccountId === elementB.homeAccountId) && 
-               (elementA.localAccountId === elementB.localAccountId) &&
-               (elementA.username === elementB.username);
+        return (elementA.homeAccountId === elementB.homeAccountId) &&
+            (elementA.localAccountId === elementB.localAccountId) &&
+            (elementA.username === elementB.username);
     });
 }
 
@@ -53,14 +60,15 @@ export const msalPlugin = {
                 case EventType.SSO_SILENT_FAILURE:
                 case EventType.LOGOUT_END:
                 case EventType.ACQUIRE_TOKEN_SUCCESS:
-                case EventType.ACQUIRE_TOKEN_FAILURE:
+                case EventType.ACQUIRE_TOKEN_FAILURE: {
                     const currentAccounts = msalInstance.getAllAccounts();
                     if (!accountArraysAreEqual(currentAccounts, state.accounts)) {
                         state.accounts = currentAccounts;
                     }
                     break;
+                }
             }
-            
+
             const status = EventMessageUtils.getInteractionStatusFromEvent(message, state.inProgress);
             if (status !== null) {
                 state.inProgress = status;


### PR DESCRIPTION
Hello!
I have searched the [issues](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues) of this repository and believe that this is not a duplicate.

Version 
@azure/msal-browser
2.30.0

Environment
vue
3.2.37

1. plugins/msalPlugin.ts
String 63: There is a lexical declaration in the "case" clause. It can be a problem because the lexical declaration is visible in the entire switch block but it only gets initialized when it is assigned, which will only happen if the case where it is defined is reached.
I suggest adding a block in this "case":

```
case EventType.ACQUIRE_TOKEN_FAILURE: {
                    const currentAccounts = msalInstance.getAllAccounts();
                    if (!accountArraysAreEqual(currentAccounts, state.accounts)) {
                        state.accounts = currentAccounts;
                    }
                    break;
                }
```
2. composition-api/useMsalAuthentication.ts
String 6: `acquireToken: Function`
The `Function` type accepts any function-like value
I suggest explicitly define the function shape
`acquireToken: (requestOverride?: PopupRequest|RedirectRequest|SilentRequest) => Promise<void>;`

3. composition-api/useMsalAuthentication.ts
String 68:  ` if (!result && !error) {`
`result` and `error` are Refs, and to access the values we should use `result.value, error.value`
I suggest: `if (!result.value && !error.value) {`

Thanks! Happy coding!
