### PR TITLE
Add library docs as includes for cross repo referencing

### DIFF
--- a/lib/msal-browser/docs/includes/acquire-token.md
+++ b/lib/msal-browser/docs/includes/acquire-token.md
@@ -1,0 +1,124 @@
+---
+author: Dickson-Mwendia
+ms.service: active-directory
+ms.topic: include
+ms.date: 04/12/2023
+ms.author: dmwendia
+---
+
+# Acquiring and using an access token
+
+> :information_source: Before you start here, make sure you understand how to [initialize the application object](./initialization.md). It is also crucial to understand the relationship between [access tokens and resources](./resources-and-scopes.md).
+
+In MSAL, you can get access tokens for the APIs your app needs to call using the `acquireToken*` methods provided by the library. The `acquireToken*` methods abstract away the 2 steps involved in acquiring tokens with the [OAuth 2.0 authorization code flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow):
+
+1. make a request to Azure AD to obtain an `authorization code`
+1. exchange that code for an [access token](https://docs.microsoft.com/azure/active-directory/develop/access-tokens) containing the user consented scopes
+
+You can read more about access tokens [here](https://docs.microsoft.com/azure/active-directory/develop/access-tokens).
+
+## Acquiring an Access Token
+
+### Choose an Interaction Type
+
+See [here](./initialization.md#choosing-an-interaction-type) if you are uncertain about the differences between `acquireTokenRedirect` and `acquireTokenPopup`.
+
+### Prepare the request object
+
+You must pass a request object to the `acquireToken*` APIs. This object allows you to use different parameters in the request. See [here](./request-response-object.md) for more information on the request object parameters. Scopes are required for all `acquireToken*` calls.
+
+### Check the cache
+
+MSAL uses a [cache](./caching.md) to store tokens based on specific parameters including scopes, resource and authority, and will retrieve the token from the cache when needed. It also can perform silent renewal of those tokens when they have expired. MSAL exposes this functionality through the `acquireTokenSilent` method.
+
+After you've logged in with one of the `ssoSilent` or `login*` APIs the cache will contain a set of ID, access and refresh tokens. Every time you need an access token you should call `acquireTokenSilent` and if this fails call an interactive API instead. `acquireTokenSilent` will look for a valid token in the cache, and if it is close to expiring or does not exist, will automatically try to refresh it for you using the cached refresh token. You can read more about using `acquireTokenSilent` [here](./token-lifetimes.md#token-renewal).
+
+#### Popup
+
+```javascript
+var request = {
+    scopes: ["User.Read"],
+};
+
+msalInstance.acquireTokenSilent(request).then(tokenResponse => {
+    // Do something with the tokenResponse
+}).catch(async (error) => {
+    if (error instanceof InteractionRequiredAuthError) {
+        // fallback to interaction when silent call fails
+        return msalInstance.acquireTokenPopup(request);
+    }
+
+    // handle other errors
+})
+```
+
+#### Redirect
+
+```javascript
+var request = {
+    scopes: ["User.Read"],
+};
+
+msalInstance.acquireTokenSilent(request).then(tokenResponse => {
+    // Do something with the tokenResponse
+}).catch(error => {
+    if (error instanceof InteractionRequiredAuthError) {
+        // fallback to interaction when silent call fails
+        return msalInstance.acquireTokenRedirect(request)
+    }
+
+    // handle other errors
+});
+```
+
+## Using the Access Token
+
+Once you have retrieved the access token, you must include it in the `Authorization` header as a [bearer token](https://www.rfc-editor.org/rfc/rfc6750) for the request to the resource you obtained the token for, as shown below:
+
+```JavaScript
+var headers = new Headers();
+var bearer = "Bearer " + tokenResponse.accessToken;
+headers.append("Authorization", bearer);
+var options = {
+        method: "GET",
+        headers: headers
+};
+var graphEndpoint = "https://graph.microsoft.com/v1.0/me";
+
+fetch(graphEndpoint, options)
+    .then(resp => {
+        //do something with response
+    });
+```
+
+## MSAL token acquisition best practices
+
+The following are best practices to acquire tokens with MSAL for avoiding errors, performance hits and usability issues. Certain scenarios may provide exceptions to these.
+
+### Use a single PublicClientApplication instance
+
+Instantiate one `PublicClientApplication` per application and use the same instance throughout your app. This ensures that there is a single source of truth for what MSAL is performing at any given time (see: [MSAL events](events.md)) and eliminates the chance of distinct app objects making parallel interactive requests or potential cache conflicts, which might break apps, reduce performance or hinder user experience.
+
+### Always wait for promises to resolve
+
+All MSAL `acquireToken*` as well as `login*` APIs perform asynchronous operations and return promises. You should always wait for these promises to resolve before doing any other tasks that depend on authentication state or tokens, such as rendering user information, calling a protected API or calling other MSAL APIs.
+
+### Attempt silent request first, then interactive
+
+When requesting tokens, always use `acquireTokenSilent` first, falling back to interactive token acquisition if needed (e.g., when the `InteractionRequiredAuthError` is thrown).
+
+Concurrent silent requests are permitted. If two or more silent requests are made concurrently, only one would go to the network (if needed), but all would receive the response, as long as those requests are for the same request parameters (e.g. scopes).
+
+Concurrent interactive requests are **not** permitted. If two or more interactive requests are made concurrently, only the first one will start an interaction, while the rest will fail with [interaction_in_progress](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/errors.md#interaction_in_progress) error. We recommend getting familiar with this error and possible remedies to avoid running into it in your applications.
+
+### Make one token request per resource
+
+You can only request access tokens for one resource at a time (see [resources and scopes](resources-and-scopes.md)). If needed, you can ask user consent to scopes (permissions) required by more than one resource by using the `extraScopesToConsent` parameter in the request object. Access tokens for previously consented scopes can be acquired silently.
+
+## Next Steps
+
+- [Token lifetimes, expiration and renewal](./token-lifetimes.md).
+- [Caching in MSAL](./caching.md)
+- [Handling errors](./errors.md)
+- [Working with B2C](./working-with-b2c.md)
+- [Throttling](../../msal-common/docs/Throttling.md)

--- a/lib/msal-browser/docs/includes/initialization.md
+++ b/lib/msal-browser/docs/includes/initialization.md
@@ -1,0 +1,178 @@
+---
+author: Dickson-Mwendia
+ms.service: active-directory
+ms.topic: include
+ms.date: 04/12/2023
+ms.author: dmwendia
+---
+
+# Initialization of MSAL
+
+Before you get started, please ensure you have completed all the [prerequisites](../README.md#prerequisites).
+
+In this document:
+
+- [Initialization of MSAL](#initialization-of-msal)
+  - [Initializing the PublicClientApplication object](#initializing-the-publicclientapplication-object)
+  - [(Optional) Configure Authority](#optional-configure-authority)
+  - [(Optional) Configure Redirect URI](#optional-configure-redirect-uri)
+  - [(Optional) Additional Configuration](#optional-additional-configuration)
+  - [Choosing an Interaction Type](#choosing-an-interaction-type)
+    - [Popup APIs](#popup-apis)
+    - [Redirect APIs](#redirect-apis)
+- [Next Steps](#next-steps)
+
+## Initializing the PublicClientApplication object
+
+In order to use MSAL.js, you need to instantiate a `PublicClientApplication` object. You must provide the `client id` (`appId`) of your application.
+
+### Option 1
+
+Instantiate a `PublicClientApplication` object and initialize it afterwards. The `initialize` function is asynchronous and must resolve before invoking other MSAL.js APIs.
+
+```javascript
+import * as msal from "@azure/msal-browser";
+
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id'
+    }
+};
+
+const msalInstance = new msal.PublicClientApplication(msalConfig);
+await msalInstance.initialize();
+```
+
+### Option 2
+
+Invoke the `createPublicClientApplication` static method which returns an initialized `PublicClientApplication` object. Note that this function is asynchronous.
+
+```javascript
+import * as msal from "@azure/msal-browser";
+
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id'
+    }
+};
+
+const msalInstance = await msal.PublicClientApplication.createPublicClientApplication(msalConfig);
+```
+
+## (Optional) Configure Authority
+
+By default, MSAL is configured with the `common` tenant, which is used for multi-tenant applications and applications allowing personal accounts (not B2C).
+
+```javascript
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id',
+        authority: 'https://login.microsoftonline.com/common/'
+    }
+};
+```
+
+If your application audience is a single tenant, you must provide an authority with your tenant id like below:
+
+```javascript
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id',
+        authority: 'https://login.microsoftonline.com/{your_tenant_id}'
+    }
+};
+```
+
+If your application is using a separate OIDC-compliant authority like `"https://login.live.com"` or an IdentityServer, you will need to provide it in the `knownAuthorities` field and set your `protocolMode` to `"OIDC"`.
+
+```javascript
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id',
+        authority: 'https://login.live.com',
+        knownAuthorities: ["login.live.com"],
+        protocolMode: "OIDC"
+    }
+};
+```
+
+**Note**: The `protocolMode` configuration option, which tells MSAL whether to enable AAD-specific quirks, changes the following behavior:
+
+- Authority metadata (since `v2.4.0`):
+  - When set to `OIDC`, the library will not include `/v2.0/` in the authority path when fetching authority metadata.
+  - When set to `AAD` (the default value), the library will include `/v2.0/` in the authority path when fetching authority metadata.
+
+For more information on authority, please refer to: [Authority in MSAL](../../msal-common/docs/authority.md).
+
+## (Optional) Configure Redirect URI
+
+By default, MSAL is configured to set the redirect URI to the current page that it is running on. If you would like to receive the authorization code on a different page than the one running MSAL, you can set this in the configuration:
+
+```javascript
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id',
+        authority: 'https://login.microsoftonline.com/{your_tenant_id}',
+        redirectUri: 'https://contoso.com'
+    }
+};
+```
+
+Any redirect URI used must be configured in the portal registration. You can also set the redirect URI per request using the [login](./login-user.md) and [request APIs](./acquire-token.md).
+
+## (Optional) Additional Configuration
+
+MSAL has additional configuration options which you can review [here](./configuration.md).
+
+## Choosing an Interaction Type
+
+In the browser, there are two ways you can present the login screen to your users from your application:
+
+- [presenting a popup window from the current page](#popup-apis)
+- [redirecting the browser window to the login server](#redirect-apis)
+
+### Popup APIs
+
+- `loginPopup`
+- `acquireTokenPopup`
+
+The popup APIs use ES6 Promises that resolve when the authentication flow in the popup concludes and returns to the redirect URI specified, or reject if there are issues in the code or the popup is blocked.
+
+#### RedirectUri Considerations
+
+When using popup APIs we recommend setting the `redirectUri` to a blank page or a page that does not implement MSAL. This will help prevent potential issues as well as improve performance. If your application is only using popup and silent APIs you can set this on the `PublicClientApplication` config. If your application also needs to support redirect APIs you can set the `redirectUri` on a per request basis:
+
+```javascript
+msalInstance.loginPopup({
+    redirectUri: "http://localhost:3000/blank.html"
+});
+```
+
+### Redirect APIs
+
+- `loginRedirect`
+- `acquireTokenRedirect`
+
+Note: If you are using `msal-angular` or `msal-react`, redirects are handled differently, and you should see the [`msal-angular` redirect doc](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/v2-docs/redirects.md) and [`msal-react` FAQ](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-react/FAQ.md#how-do-i-handle-the-redirect-flow-in-a-react-app) for more details.
+
+The redirect APIs are asynchronous (i.e. return a promise) `void` functions which redirect the browser window after caching some basic info. If you choose to use the redirect APIs, be aware that **you MUST call `handleRedirectPromise()` to correctly handle the API**. You can use the following function to perform an action when this token exchange is completed:
+
+```javascript
+msalInstance.handleRedirectPromise().then((tokenResponse) => {
+    // Check if the tokenResponse is null
+    // If the tokenResponse !== null, then you are coming back from a successful authentication redirect.
+    // If the tokenResponse === null, you are not coming back from an auth redirect.
+}).catch((error) => {
+    // handle error, either in the library or coming back from the server
+});
+```
+
+This will also allow you to retrieve tokens on page reload. See the [onPageLoad sample](../../../samples/msal-browser-samples/VanillaJSTestApp2.0/app/onPageLoad/) for more information on usage.
+
+It is not recommended to use both interaction types in a single application.
+
+**Note:** `handleRedirectPromise` will optionally accept a hash value to be processed, defaulting to the current value of `window.location.hash`. This parameter only needs to be provided in scenarios where the current value of `window.location.hash` does not contain the redirect response that needs to be processed. **For almost all scenarios, applications should not need to provide this parameter explicitly.**
+
+# Next Steps
+
+You are ready to perform a [login](./login-user.md)!

--- a/lib/msal-browser/docs/includes/login-user.md
+++ b/lib/msal-browser/docs/includes/login-user.md
@@ -1,0 +1,180 @@
+---
+author: Dickson-Mwendia
+ms.service: active-directory
+ms.topic: include
+ms.date: 04/12/2023
+ms.author: dmwendia
+---
+# Login User
+
+Before you start here, make sure you understand how to [initialize the application object](./initialization.md).
+
+The login APIs in MSAL retrieve an `authorization code` which can be exchanged for an [ID token](https://docs.microsoft.com/azure/active-directory/develop/id-tokens) for a signed in user, while consenting scopes for an additional resource, and an [access token](https://docs.microsoft.com/azure/active-directory/develop/access-tokens) containing the user consented scopes to allow your app to securely call the API.
+
+You can read more about ID tokens on our [Azure Docs pages](https://docs.microsoft.com/azure/active-directory/develop/id-tokens).
+
+## Choosing an Interaction Type
+
+See [here](./initialization.md#choosing-an-interaction-type) if you are uncertain about the differences between `loginRedirect` and `loginPopup`.
+
+## Login the user
+
+You must pass a request object to the login APIs. This object allows you to use different parameters in the request. See [here](./request-response-object.md) for more information on the request object parameters.
+
+For login requests, all parameters are optional, so you can just send an empty object.
+
+- Popup
+
+```javascript
+try {
+    const loginResponse = await msalInstance.loginPopup({});
+} catch (err) {
+    // handle error
+}
+```
+
+- Redirect
+
+```javascript
+try {
+    msalInstance.loginRedirect({});
+} catch (err) {
+    // handle error
+}
+```
+
+Or you can send a set of [scopes](./request-response-object.md#scopes) to pre-consent to:
+
+- Popup
+
+```javascript
+var loginRequest = {
+    scopes: ["user.read", "mail.send"] // optional Array<string>
+};
+
+try {
+    const loginResponse = await msalInstance.loginPopup(loginRequest);
+} catch (err) {
+    // handle error
+}
+```
+
+- Redirect
+
+```javascript
+var loginRequest = {
+    scopes: ["user.read", "mail.send"] // optional Array<string>
+};
+
+try {
+    msalInstance.loginRedirect(loginRequest);
+} catch (err) {
+    // handle error
+}
+```
+
+## Account APIs
+
+When a login call has succeeded, you can use the `getAllAccounts()` function to retrieve information about currently signed in users.
+
+```javascript
+const myAccounts: AccountInfo[] = msalInstance.getAllAccounts();
+```
+
+If you know the account information, you can also retrieve the account information by using the `getAccountByUsername()` or `getAccountByHomeId()` APIs:
+
+```javascript
+const username = "test@contoso.com";
+const myAccount: AccountInfo = msalInstance.getAccountByUsername(username);
+
+const homeAccountId = "userid.hometenantid"; // Best to retrieve the homeAccountId from an account object previously obtained through msal
+const myAccount: AccountInfo = maslInstance.getAccountByHomeId(homeAccountId);
+```
+
+**Note:** `getAccountByUsername()` is provided for convenience and should be considered less reliable than `getAccountByHomeId()`. When possible use `getAccountByHomeId()`.
+
+In B2C scenarios your B2C tenant will need to be configured to return the `emails` claim on `idTokens` in order to use the `getAccountByUsername()` API.
+
+These APIs will return an account object or an array of account objects with the following signature:
+
+```javascript
+{
+    // home account identifier for this account object
+    homeAccountId: string;
+    // Entity who issued the token represented as a full host of it (e.g. login.microsoftonline.com)
+    environment: string;
+    // Full tenant or organizational id that this account belongs to
+    tenantId: string;
+    // preferred_username claim of the id_token that represents this account.
+    username: string;
+};
+```
+
+## Silent login with ssoSilent()
+
+If you already have a session that exists with the authentication server, you can use the ssoSilent() API to make requests for tokens without interaction.
+
+### With User Hint
+
+If you already have the user's sign-in information, you can pass this into the API to improve performance and ensure that the authorization server will look for the correct account session. You can pass one of the following into the request object in order to successfully obtain a token silently.
+
+It is recommended to leverage the [`login_hint` optional ID token claim](https://docs.microsoft.com/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set) (provided to `ssoSilent` as `loginHint`), as it is the most reliable account hint of silent (and interactive) requests.
+
+- `account` (which can be retrieved using on of the [account APIs](./accounts.md))
+- `sid` (which can be retrieved from the `idTokenClaims` of an `account` object)
+- `login_hint` (which can be retrieved from either the account object `login_hint` ID token claim, `username` property, or the `upn` ID token claim)
+
+Passing an account will look for the `login_hint` optional ID token claim (preferred), then the `sid` optional id token claim, then fall back to `loginHint` (if provided) or account username.
+
+```javascript
+const silentRequest = {
+    scopes: ["User.Read", "Mail.Read"],
+    loginHint: "user@contoso.com"
+};
+
+try {
+    const loginResponse = await msalInstance.ssoSilent(silentRequest);
+} catch (err) {
+    if (err instanceof InteractionRequiredAuthError) {
+        const loginResponse = await msalInstance.loginPopup(silentRequest).catch(error => {
+            // handle error
+        });
+    } else {
+        // handle error
+    }
+}
+```
+
+### Without User Hint
+
+If there is not enough information available about the user, you can attempt to use the `ssoSilent` API **without** passing an `account`, `sid` or `login_hint`.
+
+```javascript
+const silentRequest = {
+    scopes: ["User.Read", "Mail.Read"]
+};
+```
+
+However, be aware that if your application has code paths for multiple users in a single browser session, or if the user has multiple accounts for that single browser session, then there is a higher likelihood of silent sign-in errors. You may see the following error show up in the event of multiple account sessions found by the authorization server:
+
+```txt
+InteractionRequiredAuthError: interaction_required: AADSTS16000: Either multiple user identities are available for the current request or selected account is not supported for the scenario.
+```
+
+This indicates that the server could not determine which account to sign into, and will require either one of the parameters above (`account`, `login_hint`, `sid`) or an interactive sign-in to choose the account.
+
+## RedirectUri Considerations
+
+When using popup and silent APIs we recommend setting the `redirectUri` to a blank page or a page that does not implement MSAL. This will help prevent potential issues as well as improve performance. If your application is only using popup and silent APIs you can set this on the `PublicClientApplication` config. If your application also needs to support redirect APIs you can set the `redirectUri` on a per request basis:
+
+Note: This does not apply for `loginRedirect` or `acquireTokenRedirect`. When using those APIs please see the directions on handling redirects [here](./initialization#redirect-apis)
+
+```javascript
+msalInstance.loginPopup({
+    redirectUri: "http://localhost:3000/blank.html"
+});
+```
+
+# Next Steps
+
+Learn how to [acquire and use an access token](./acquire-token.md)!

--- a/lib/msal-browser/docs/includes/v1-migration.md
+++ b/lib/msal-browser/docs/includes/v1-migration.md
@@ -1,0 +1,136 @@
+---
+author: Dickson-Mwendia
+ms.service: active-directory
+ms.topic: include
+ms.date: 04/12/2023
+ms.author: dmwendia
+---
+
+# Migrating from MSAL 1.x to MSAL 2.x
+
+If you are new to MSAL, you should start [here](./initialization.md).
+
+If you are coming from [MSAL v1.x](../../msal-common/), you can follow this guide to update your code to use [MSAL v2.x](../../msal-browser/).
+
+## 1. Update application registration
+
+Go to the Azure AD portal for your tenant and review the App Registrations. You can create a [new registration](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#create-the-app-registration) for MSAL 2.x or you can [update your existing registration](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow) for the registration that you are using for MSAL 1.x.
+
+## 2. Add the msal-browser package to your project
+
+See the [installation section of the README](../README.md#installation).
+
+## 3. Update your code
+
+In MSAL 1.x, you created an application instance as below:
+
+```javascript
+import * as msal from "msal";
+
+const msalInstance = new msal.UserAgentApplication(config);
+```
+
+In MSAL 2.x, you can update this to use the new `PublicClientApplication` object.
+
+```javascript
+import * as msal from "@azure/msal-browser";
+
+const msalInstance = new msal.PublicClientApplication(config);
+```
+
+There may be some small differences in the configuration object that is passed in. If you are passing a more advanced configuration to the `UserAgentApplication` object, see [here](./configuration.md) for more information on new app object configuration options.
+
+Request and response object signatures have changed - `acquireTokenSilent` now has a separate object signature from the interactive APIs. Please see [here](./request-response-object.md) for more information on configuring the request APIs.
+
+Most APIs from MSAL 1.x have been carried forward to MSAL 2.x without change. Some functions have been removed:
+
+- `handleRedirectCallback`
+- `urlContainsHash`
+- `getCurrentConfiguration`
+- `getLoginInProgress`
+- `getAccount`
+- `getAccountState`
+- `isCallback`
+
+In MSAL 2.x, handling the response from the hash is an asynchronous operation, as MSAL will perform a token exchange as soon as it parses the authorization code from the response. Because of this, when performing redirect calls, MSAL provides the `handleRedirectPromise` function which will return a promise that resolves when the redirect has been fully handled by MSAL. When using a redirect method, the page used as the `redirectUri` must implement  `handleRedirectPromise` to ensure the response is handled and tokens are cached when returning from the redirect.
+
+```javascript
+const myMSALObj = new msal.PublicClientApplication(msalConfig); 
+
+// Register Callbacks for Redirect flow
+myMSALObj.handleRedirectPromise().then((tokenResponse) => {
+    let accountObj = null;
+    if (tokenResponse !== null) {
+        accountObj = tokenResponse.account;
+        const id_token = tokenResponse.idToken;
+        const access_token = tokenResponse.accessToken;
+    } else {
+        const currentAccounts = myMSALObj.getAllAccounts();
+        if (!currentAccounts || currentAccounts.length === 0) {
+            // No user signed in
+            return;
+        } else if (currentAccounts.length > 1) {
+            // More than one user signed in, find desired user with getAccountByUsername(username)
+        } else {
+            accountObj = currentAccounts[0];
+        }
+    }
+    
+    const username = accountObj.username;
+   
+}).catch((error) => {
+    handleError(error);
+});
+
+function signIn() {
+    myMSALObj.loginRedirect(loginRequest);
+}
+
+async function getTokenRedirect(request) {
+    return await myMSALObj.acquireTokenSilent(request).catch(error => {
+        this.logger.info("silent token acquisition fails. acquiring token using redirect");
+        // fallback to interaction when silent call fails
+        return myMSALObj.acquireTokenRedirect(request)
+    });
+}
+```
+
+During `loginPopup`, `acquireTokenPopup`, or `acquireTokenSilent` calls, you can wait for the promise to resolve.
+
+```javascript
+const myMSALObj = new msal.PublicClientApplication(msalConfig); 
+
+async function signIn(method) {
+    try {
+        const loginResponse = await myMSALObj.loginPopup(loginRequest);
+    } catch (err) {
+        handleError(error);
+    }
+
+    const currentAccounts = myMSALObj.getAllAccounts();
+    if (!currentAccounts || currentAccounts.length === 0) {
+        // No user signed in
+        return;
+    } else if (currentAccounts.length > 1) {
+        // More than one user signed in, find desired user with getAccountByUsername(username)
+    } else {
+        accountObj = currentAccounts[0];
+    }
+}
+
+async function getTokenPopup(request) {
+    return await myMSALObj.acquireTokenSilent(request).catch(async (error) => {
+        this.logger.info("silent token acquisition fails. acquiring token using popup");
+        // fallback to interaction when silent call fails
+        return await myMSALObj.acquireTokenPopup(request).catch(error => {
+            handleError(error);
+        });
+    });
+}
+```
+
+Please see the [login](./login-user.md) and [acquire token](./acquire-token.md) docs for more detailed information on usage.
+
+Refresh tokens are now returned as part of the token responses, and are used by the library to renew access tokens without interaction or the use of iframes. See the [token lifetimes docs](./token-lifetimes.md) for more information on renewing tokens.
+
+All other APIs should work as before. It is recommended to take a look at the [default sample](../../../samples/msal-browser-samples/VanillaJSTestApp2.0) to see a working example of MSAL 2.0.

--- a/lib/msal-browser/docs/includes/v2-migration.md
+++ b/lib/msal-browser/docs/includes/v2-migration.md
@@ -1,0 +1,89 @@
+---
+author: Dickson-Mwendia
+ms.service: active-directory
+ms.topic: include
+ms.date: 04/12/2023
+ms.author: dmwendia
+---
+
+# Migrating from MSAL 2.x to MSAL 3.x
+
+If you are new to MSAL, you should start [here](initialization.md).
+
+If you are coming from [MSAL v1.x](../../msal-core/), you should check [this guide](v1-migration.md) first to migrate to [MSAL v2.x](../../msal-browser/) and then follow next steps.
+
+If you are coming from [MSAL v2.x](../../msal-browser/), you can follow this guide to update your code to use [MSAL v3.x](../../msal-browser/).
+
+## Update your code
+
+In MSAL v2.x, you created an application instance as below:
+
+```javascript
+import * as msal from "@azure/msal-browser";
+
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id'
+    }
+};
+
+const msalInstance = new msal.PublicClientApplication(msalConfig);
+```
+
+In MSAL v3.x, you must initialize the application object as well. There are several options at your disposal:
+
+### Option 1
+
+Instantiate a `PublicClientApplication` object and initialize it afterwards. The `initialize` function is asynchronous and must resolve before invoking other MSAL.js APIs.
+
+```javascript
+import * as msal from "@azure/msal-browser";
+
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id'
+    }
+};
+
+const msalInstance = new msal.PublicClientApplication(msalConfig);
+await msalInstance.initialize();
+```
+
+### Option 2
+
+Invoke the `createPublicClientApplication` static method which returns an initialized `PublicClientApplication` object. Note that this function is asynchronous.
+
+```javascript
+import * as msal from "@azure/msal-browser";
+
+const msalConfig = {
+    auth: {
+        clientId: 'your_client_id'
+    }
+};
+
+const msalInstance = await msal.PublicClientApplication.createPublicClientApplication(msalConfig);
+```
+
+All other APIs are backward compatible with [MSAL v2.x](../../msal-browser/). It is recommended to take a look at the [default sample](../../../samples/msal-browser-samples/VanillaJSTestApp2.0) to see a working example of MSAL v3.0.
+
+## Key changes
+
+### Browser support
+
+MSAL.js no longer supports the following browsers:
+
+- IE 11
+- Edge (Legacy)
+
+### Package dependencies
+
+Typescript version was bumped from `3.8.3` to `4.9.5`.
+
+### Compiler options
+
+Module/target versions were bumped from `es6`/`es5` to `es2020`/`es2020` respectively.
+
+### CDN
+
+MSAL.js is no longer hosted on a CDN. Check [this doc](cdn-usage.md) for more details.


### PR DESCRIPTION
This PR sets up a couple of msal-browser docs as includes, since the library repo is used as a dependent repository by the docs repo. 

Cc: @EmLauber 