### PR TITLE
Randomize native extension response identifiers to facilitate concurrency

### DIFF
--- a/change/@azure-msal-browser-3eb1c367-abda-4451-b5e0-c6d2f2277136.json
+++ b/change/@azure-msal-browser-3eb1c367-abda-4451-b5e0-c6d2f2277136.json
@@ -1,5 +1,5 @@
 {
-  "type": "major",
+  "type": "minor",
   "comment": "Randomize native extension response identifiers to facilitate concurrency #5903",
   "packageName": "@azure/msal-browser",
   "email": "kshabelko@microsoft.com",

--- a/change/@azure-msal-browser-3eb1c367-abda-4451-b5e0-c6d2f2277136.json
+++ b/change/@azure-msal-browser-3eb1c367-abda-4451-b5e0-c6d2f2277136.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Randomize native extension response identifiers to facilitate concurrency #5903",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
@@ -212,8 +212,10 @@ export class NativeMessageHandler {
             const handshakeResolver = this.handshakeResolvers.get(
                 request.responseId
             );
-            // Filter out responses with no matched resolvers sooner to keep channel ports open while waiting for
-            // the proper response.
+            /*
+             * Filter out responses with no matched resolvers sooner to keep channel ports open while waiting for
+             * the proper response.
+             */
             if (!handshakeResolver) {
                 this.logger.trace(`NativeMessageHandler.onWindowMessage - resolver can't be found for request ${request.responseId}`);
                 return;

--- a/lib/msal-browser/src/broker/nativeBroker/NativeRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeRequest.ts
@@ -45,7 +45,7 @@ export type NativeExtensionRequestBody = {
  */
 export type NativeExtensionRequest = {
     channel: string;
-    responseId: number;
+    responseId: string;
     extensionId?: string;
     body: NativeExtensionRequestBody;
 };

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -296,7 +296,8 @@ export class StandardController implements IController {
                     await NativeMessageHandler.createProvider(
                         this.logger,
                         this.config.system.nativeBrokerHandshakeTimeout,
-                        this.performanceClient
+                        this.performanceClient,
+                        this.browserCrypto
                     );
             } catch (e) {
                 this.logger.verbose(e as string);

--- a/lib/msal-browser/test/broker/NativeMessageHandler.spec.ts
+++ b/lib/msal-browser/test/broker/NativeMessageHandler.spec.ts
@@ -15,6 +15,7 @@ import { BrowserAuthError, BrowserAuthErrorMessage } from "../../src";
 import { NativeExtensionMethod } from "../../src/utils/BrowserConstants";
 import { NativeAuthError } from "../../src/error/NativeAuthError";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
+import { CryptoOps } from "../../src/crypto/CryptoOps";
 
 let performanceClient: IPerformanceClient;
 
@@ -33,12 +34,14 @@ jest.mock("../../src/telemetry/BrowserPerformanceMeasurement", () => {
 describe("NativeMessageHandler Tests", () => {
     let postMessageSpy: sinon.SinonSpy;
     let mcPort: MessagePort;
+    let cryptoInterface: CryptoOps;
     globalThis.MessageChannel = require("worker_threads").MessageChannel; // jsdom does not include an implementation for MessageChannel
 
     beforeEach(() => {
         postMessageSpy = sinon.spy(window, "postMessage");
         sinon.stub(MessageEvent.prototype, "source").get(() => window); // source property not set by jsdom window messaging APIs
         performanceClient = getDefaultPerformanceClient();
+        cryptoInterface = new CryptoOps(new Logger({}));
     });
 
     afterEach(() => {
@@ -73,7 +76,8 @@ describe("NativeMessageHandler Tests", () => {
             const wamMessageHandler = await NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             );
             expect(wamMessageHandler).toBeInstanceOf(NativeMessageHandler);
 
@@ -122,7 +126,8 @@ describe("NativeMessageHandler Tests", () => {
             NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             ).then(() => {
                 window.removeEventListener("message", eventHandler, true);
             });
@@ -159,7 +164,8 @@ describe("NativeMessageHandler Tests", () => {
             const wamMessageHandler = await NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             );
             expect(wamMessageHandler).toBeInstanceOf(NativeMessageHandler);
 
@@ -170,7 +176,8 @@ describe("NativeMessageHandler Tests", () => {
             NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             ).catch((e) => {
                 expect(e).toBeInstanceOf(BrowserAuthError);
                 expect(e.errorCode).toBe(
@@ -193,7 +200,8 @@ describe("NativeMessageHandler Tests", () => {
             NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             )
                 .catch((e) => {
                     expect(e).toBeInstanceOf(BrowserAuthError);
@@ -231,7 +239,8 @@ describe("NativeMessageHandler Tests", () => {
             NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             ).catch(() => {
                 if (callbackDone) {
                     done();
@@ -287,7 +296,8 @@ describe("NativeMessageHandler Tests", () => {
             const wamMessageHandler = await NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             );
             expect(wamMessageHandler).toBeInstanceOf(NativeMessageHandler);
 
@@ -344,7 +354,8 @@ describe("NativeMessageHandler Tests", () => {
             NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             )
                 .then((wamMessageHandler) => {
                     wamMessageHandler
@@ -410,7 +421,8 @@ describe("NativeMessageHandler Tests", () => {
             NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             )
                 .then((wamMessageHandler) => {
                     wamMessageHandler
@@ -474,7 +486,8 @@ describe("NativeMessageHandler Tests", () => {
             NativeMessageHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                cryptoInterface
             )
                 .then((wamMessageHandler) => {
                     wamMessageHandler

--- a/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
@@ -14,6 +14,7 @@ import {
     CredentialType,
     TimeUtils,
     CacheManager,
+    Logger
 } from "@azure/msal-common";
 import sinon from "sinon";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
@@ -36,6 +37,7 @@ import {
 import { SilentCacheClient } from "../../src/interaction_client/SilentCacheClient";
 import { NativeExtensionRequestBody } from "../../src/broker/nativeBroker/NativeRequest";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
+import { CryptoOps } from "../../src/crypto/CryptoOps";
 
 const networkInterface = {
     sendGetRequestAsync<T>(): T {
@@ -95,7 +97,8 @@ describe("NativeInteractionClient Tests", () => {
     const wamProvider = new NativeMessageHandler(
         pca.getLogger(),
         2000,
-        getDefaultPerformanceClient()
+        getDefaultPerformanceClient(),
+        new CryptoOps(new Logger({}))
     );
     // @ts-ignore
     const nativeInteractionClient = new NativeInteractionClient(

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -36,6 +36,7 @@ import {
     Authority,
     CommonAuthorizationCodeRequest,
     AuthError,
+    Logger
 } from "@azure/msal-common";
 import {
     TemporaryCacheKeys,
@@ -372,7 +373,8 @@ describe("PopupClient", () => {
                 //@ts-ignore
                 pca.logger,
                 2000,
-                getDefaultPerformanceClient()
+                getDefaultPerformanceClient(),
+                new CryptoOps(new Logger({}))
             );
             //@ts-ignore
             popupClient = new PopupClient(


### PR DESCRIPTION
- Randomize native extension `responseId` to facilitate concurrency.
- Update window message handler to filter out responses with no matched resolvers sooner.
- Add unit tests to make sure concurrent calls to `app.initialize()` do not interfere with each other.