### PR TITLE
Unit tests for NativeBrokerPlugin (msal-node-extensions) v3

### DIFF
--- a/change/@azure-msal-node-extensions-da951297-a9ec-4ff4-be0a-4b3b1a7429b9.json
+++ b/change/@azure-msal-node-extensions-da951297-a9ec-4ff4-be0a-4b3b1a7429b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix response expiresOn property",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/jest.config.js
+++ b/extensions/msal-node-extensions/jest.config.js
@@ -4,8 +4,8 @@
  */
 
 module.exports = {
-    transform: {
-        "^.+\\.(ts|tsx)$": "ts-jest",
-    },
+    preset: "ts-jest",
+    testEnvironment: "node",
+    collectCoverageFrom: ["src/**/*.ts"],
     coverageReporters: [["lcov", { "projectRoot": "../../" }]]
 };

--- a/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
+++ b/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
@@ -329,7 +329,7 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
     private getAuthenticationResult(request: NativeRequest, authResult: AuthResult): AuthenticationResult {
         this.logger.trace("NativeBrokerPlugin - getAuthenticationResult called", request.correlationId);
         
-        let fromCache: boolean;
+        let fromCache: boolean = false;
         try {
             const telemetryJSON = JSON.parse(authResult.telemetryData);
             fromCache = !!telemetryJSON["is_cache"];
@@ -356,7 +356,7 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
             idTokenClaims: idTokenClaims,
             accessToken: authResult.accessToken,
             fromCache: fromCache,
-            expiresOn: new Date(authResult.expiresOn * 1000),
+            expiresOn: new Date(authResult.expiresOn),
             tokenType: authResult.isPopAuthorization ? AuthenticationScheme.POP : AuthenticationScheme.BEARER,
             correlationId: request.correlationId,
             fromNativeBroker: true

--- a/extensions/msal-node-extensions/test/__mocks__/@azure/msal-node-runtime.js
+++ b/extensions/msal-node-extensions/test/__mocks__/@azure/msal-node-runtime.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const mock = jest.requireActual("@azure/msal-node-runtime");
+
+const asyncHandle = {
+    CancelAsyncOperation: () => { }
+}
+mock.msalNodeRuntime = {
+    ReadAccountByIdAsync: (accountId, correlationId, callback) => asyncHandle,
+    SignInAsync: (windowHandle, authParams, correlationId, accountHint, callback) => asyncHandle,
+    SignInSilentlyAsync: (authParams, correlationId, callback) => asyncHandle,
+    SignInInteractivelyAsync: (windowHandle, authParams, correlationId, accountHint, callback) => asyncHandle,
+    AcquireTokenSilentlyAsync: (authParams, correlationId, account, callback) => asyncHandle,
+    AcquireTokenInteractivelyAsync: (windowHandle, authParams, correlationId, account, callback) => asyncHandle,
+    SignOutSilentlyAsync: (clientId, correlationId, account, callback) => asyncHandle,
+    RegisterLogger: (callback, isPiiEnabled) => { },
+    DiscoverAccountsAsync: (clientId, correlationId, callback) => asyncHandle,
+    StartupError: undefined,
+    AuthParameters: mock.msalNodeRuntime.AuthParameters
+}
+
+module.exports = mock;

--- a/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
+++ b/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
@@ -1,0 +1,1320 @@
+import { NativeBrokerPlugin } from "../../src/broker/NativeBrokerPlugin";
+import { Account, AsyncHandle, AuthParameters, AuthResult, DiscoverAccountsResult, ErrorStatus, msalNodeRuntime, MsalRuntimeError, ReadAccountResult, SignOutResult } from "@azure/msal-node-runtime";
+import { AccountInfo, AuthenticationResult, ClientAuthError, ClientConfigurationError, InteractionRequiredAuthError, NativeRequest, NativeSignOutRequest, PromptValue, ServerError } from "@azure/msal-common";
+import { randomUUID } from "crypto";
+import { NativeAuthError } from "../../src/error/NativeAuthError";
+import { testMsalRuntimeAccount, testAccountInfo, msalRuntimeExampleError, getTestAuthenticationResult, TEST_CLIENT_ID, TEST_REDIRECTURI } from "../util/TestConstants";
+
+describe("NativeBrokerPlugin", () => {
+    const testNativeAuthError = new NativeAuthError(ErrorStatus[msalRuntimeExampleError.errorStatus], msalRuntimeExampleError.errorContext, msalRuntimeExampleError.errorCode, msalRuntimeExampleError.errorTag);
+
+    const generateCorrelationId = () => {
+        return randomUUID();
+    };
+
+    const asyncHandle: AsyncHandle = {
+        CancelAsyncOperation: () => {}
+    }
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("constructor tests", () => {
+        it("Sets isBrokerAvailable to true if the broker is available", () => {
+            jest.replaceProperty(msalNodeRuntime, 'StartupError', undefined);
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            expect(nativeBrokerPlugin.isBrokerAvailable).toBe(true);
+        });
+
+        it("Sets isBrokerAvailable to false if the broker is not available", () => {
+            jest.replaceProperty(msalNodeRuntime, 'StartupError', {
+                errorCode: 0,
+                errorStatus: ErrorStatus.Unexpected,
+                errorContext: "Test Startup Error",
+                errorTag: 0
+            });
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            expect(nativeBrokerPlugin.isBrokerAvailable).toBe(false);
+        });
+    });
+
+    describe("getAccountById tests", () => {
+        it("Returns account", async () => {
+            const testCorrelationId = generateCorrelationId();
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(accountId).toEqual(testMsalRuntimeAccount.accountId);
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const account = await nativeBrokerPlugin.getAccountById(testMsalRuntimeAccount.accountId, testCorrelationId);
+            expect(account).toStrictEqual<AccountInfo>(testAccountInfo);
+        });
+
+        it("Rejects with error if Msal-Node-Runtime ReadAccountByIdAsync API throws", (done) => {
+            const testCorrelationId = generateCorrelationId();
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation(() => {
+                throw msalRuntimeExampleError;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            nativeBrokerPlugin.getAccountById(testMsalRuntimeAccount.accountId, testCorrelationId).catch((error) => {
+                expect(error).toStrictEqual<NativeAuthError>(testNativeAuthError);
+                done();
+            });
+        });
+
+        it("Rejects with error if callback is invoked with error response", (done) => {
+            const testCorrelationId = generateCorrelationId();
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {
+                        throw msalRuntimeExampleError;
+                    },
+                    telemetryData: ""
+                };
+                expect(accountId).toEqual(testMsalRuntimeAccount.accountId);
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            nativeBrokerPlugin.getAccountById(testMsalRuntimeAccount.accountId, testCorrelationId).catch((error) => {
+                expect(error).toStrictEqual<NativeAuthError>(testNativeAuthError);
+                done();
+            });
+        });
+    });
+
+    describe("getAllAccounts tests", () => {
+        it("Returns accounts", async () => {
+            const testCorrelationId = generateCorrelationId();
+            jest.spyOn(msalNodeRuntime, "DiscoverAccountsAsync").mockImplementation((clientId: string, correlationId: string, callback: (result: DiscoverAccountsResult) => void) => {
+                const result: DiscoverAccountsResult = {
+                    accounts: [testMsalRuntimeAccount],
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(clientId).toEqual(TEST_CLIENT_ID);
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const accounts = await nativeBrokerPlugin.getAllAccounts(TEST_CLIENT_ID, testCorrelationId);
+            expect(accounts).toStrictEqual<AccountInfo[]>([testAccountInfo]);
+        });
+
+        it("Rejects with error if Msal-Node-Runtime DiscoverAccountsAsync API throws", (done) => {
+            const testCorrelationId = generateCorrelationId();
+            jest.spyOn(msalNodeRuntime, "DiscoverAccountsAsync").mockImplementation(() => {
+                throw msalRuntimeExampleError;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            nativeBrokerPlugin.getAllAccounts(TEST_CLIENT_ID, testCorrelationId).catch((error) => {
+                expect(error).toStrictEqual<NativeAuthError>(testNativeAuthError);
+                done();
+            });
+        });
+
+        it("Rejects with error if callback is invoked with error response", (done) => {
+            const testCorrelationId = generateCorrelationId();
+            jest.spyOn(msalNodeRuntime, "DiscoverAccountsAsync").mockImplementation((clientId: string, correlationId: string, callback: (result: DiscoverAccountsResult) => void) => {
+                const result: DiscoverAccountsResult = {
+                    accounts: [testMsalRuntimeAccount],
+                    CheckError: () => {
+                        throw msalRuntimeExampleError;
+                    },
+                    telemetryData: ""
+                };
+                expect(clientId).toEqual(TEST_CLIENT_ID);
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            nativeBrokerPlugin.getAllAccounts(TEST_CLIENT_ID, testCorrelationId).catch((error) => {
+                expect(error).toStrictEqual<NativeAuthError>(testNativeAuthError);
+                done();
+            });
+        });
+    });
+
+    describe("acquireTokenSilent tests", () => {
+        it("Signs user in and returns successful response", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI
+            }
+            const response = await nativeBrokerPlugin.acquireTokenSilent(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Returns successful response if user is already signed in", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "AcquireTokenSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, account: Account, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                expect(account).toStrictEqual<Account>(testMsalRuntimeAccount);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI,
+                accountId: testMsalRuntimeAccount.accountId
+            }
+            const response = await nativeBrokerPlugin.acquireTokenSilent(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Rejects with error if Msal-Node-Runtime AcquireTokenSilentlyAsync API throws", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "AcquireTokenSilentlyAsync").mockImplementation(() => {
+                throw msalRuntimeExampleError;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI,
+                accountId: testMsalRuntimeAccount.accountId
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toStrictEqual<NativeAuthError>(testNativeAuthError);
+                done();
+            });
+        });
+
+        it("Rejects with error if Msal-Node-Runtime SignInSilentlyAsync API throws", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation(() => {
+                throw msalRuntimeExampleError;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toStrictEqual<NativeAuthError>(testNativeAuthError);
+                done();
+            });
+        });
+
+        it("Rejects with error if callback is invoked with error response", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        throw msalRuntimeExampleError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toStrictEqual<NativeAuthError>(testNativeAuthError);
+                done();
+            });
+        });
+    });
+
+    describe("acquireTokenInteractive tests", () => {
+        it("Calls SignInAsync and returns successful response if user is not already signed in", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "SignInAsync").mockImplementation((windowHandle: Buffer, authParams: AuthParameters, correlationId: string, accountHint: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI
+            }
+            const response = await nativeBrokerPlugin.acquireTokenInteractive(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Calls AcquireTokenInteractivelyAsync and returns successful response if user is already signed in", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "AcquireTokenInteractivelyAsync").mockImplementation((windowHandle: Buffer, authParams: AuthParameters, correlationId: string, account: Account, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                expect(account).toStrictEqual(testMsalRuntimeAccount);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI,
+                accountId: testMsalRuntimeAccount.accountId
+            }
+            const response = await nativeBrokerPlugin.acquireTokenInteractive(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Calls AcquireTokenSilentlyAsync and returns successful response if prompt is set to none and user is signed-in", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "AcquireTokenSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, account: Account, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                expect(account).toStrictEqual(testMsalRuntimeAccount);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI,
+                prompt: PromptValue.NONE,
+                accountId: testMsalRuntimeAccount.accountId
+            }
+            const response = await nativeBrokerPlugin.acquireTokenInteractive(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Calls SignInSilentlyAsync and returns successful response if prompt is set to none and user is not signed-in", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI,
+                prompt: PromptValue.NONE
+            }
+            const response = await nativeBrokerPlugin.acquireTokenInteractive(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Calls SignInInteractivelyAsync and returns successful response if prompt is set to select_account", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "SignInInteractivelyAsync").mockImplementation((windowHandle: Buffer, authParams: AuthParameters, correlationId: string, accountHint: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI,
+                prompt: PromptValue.SELECT_ACCOUNT
+            }
+            const response = await nativeBrokerPlugin.acquireTokenInteractive(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Calls SignInInteractivelyAsync and returns successful response if prompt is set to login", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "SignInInteractivelyAsync").mockImplementation((windowHandle: Buffer, authParams: AuthParameters, correlationId: string, accountHint: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI,
+                prompt: PromptValue.LOGIN
+            }
+            const response = await nativeBrokerPlugin.acquireTokenInteractive(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Calls SignInInteractivelyAsync and returns successful response if prompt is set to create", async () => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "SignInInteractivelyAsync").mockImplementation((windowHandle: Buffer, authParams: AuthParameters, correlationId: string, accountHint: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI,
+                prompt: PromptValue.CREATE
+            }
+            const response = await nativeBrokerPlugin.acquireTokenInteractive(request);
+            expect(response).toStrictEqual<AuthenticationResult>(testAuthenticationResult);
+        });
+
+        it("Throws error if SignInInteractivelyAsync returns error", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInInteractivelyAsync").mockImplementation((windowHandle: Buffer, authParams: AuthParameters, correlationId: string, accountHint: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => { throw msalRuntimeExampleError; },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI,
+                prompt: PromptValue.CREATE
+            }
+            await expect(nativeBrokerPlugin.acquireTokenInteractive(request)).rejects.toThrowError(testNativeAuthError);
+        });
+
+        it("Throws error if AcquireTokenInteractivelyAsync returns error", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "AcquireTokenInteractivelyAsync").mockImplementation((windowHandle: Buffer, authParams: AuthParameters, correlationId: string, account: Account, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => { throw msalRuntimeExampleError; },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                expect(account).toEqual(testMsalRuntimeAccount);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI,
+                accountId: testAccountInfo.nativeAccountId
+            }
+            await expect(nativeBrokerPlugin.acquireTokenInteractive(request)).rejects.toThrowError(testNativeAuthError);
+        });
+
+        it("Throws error if SignInAsync returns error", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInAsync").mockImplementation((windowHandle: Buffer, authParams: AuthParameters, correlationId: string, accountHint: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => { throw msalRuntimeExampleError; },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            await expect(nativeBrokerPlugin.acquireTokenInteractive(request)).rejects.toThrowError(testNativeAuthError);
+        });
+
+        it("Throws error if AcquireTokenSilentlyAsync returns error", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "AcquireTokenSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, account: Account, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => { throw msalRuntimeExampleError; },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI,
+                prompt: PromptValue.NONE,
+                accountId: testAccountInfo.nativeAccountId
+            }
+            await expect(nativeBrokerPlugin.acquireTokenInteractive(request)).rejects.toThrowError(testNativeAuthError);
+        });
+
+        it("Throws error if SignInSilentlyAsync returns error", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => { throw msalRuntimeExampleError; },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI,
+                prompt: PromptValue.NONE
+            }
+            await expect(nativeBrokerPlugin.acquireTokenInteractive(request)).rejects.toThrowError(testNativeAuthError);
+        });
+
+        it("Throws error if MsalRuntime API throws", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInAsync").mockImplementation(() => {
+                throw msalRuntimeExampleError;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            await expect(nativeBrokerPlugin.acquireTokenInteractive(request)).rejects.toThrowError(testNativeAuthError);
+        })
+    });
+
+    describe("signOut tests", () => {
+        it("Calls SignOutSilentlyAsync and resolves promise successfully", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "SignOutSilentlyAsync").mockImplementation((clientId: string, correlationId: string, account: Account, callback: (result: SignOutResult) => void) => {
+                const result: SignOutResult = {
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                expect(account).toStrictEqual(testMsalRuntimeAccount);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeSignOutRequest = {
+                clientId: TEST_CLIENT_ID,
+                correlationId: testCorrelationId,
+                accountId: testAccountInfo.nativeAccountId
+            }
+            await nativeBrokerPlugin.signOut(request);
+        });
+
+        it("Throws error if account is not signed in", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: null,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeSignOutRequest = {
+                clientId: TEST_CLIENT_ID,
+                correlationId: testCorrelationId,
+                accountId: testAccountInfo.nativeAccountId
+            }
+
+            await expect(nativeBrokerPlugin.signOut(request)).rejects.toThrowError(ClientAuthError.createNoAccountFoundError());
+        });
+
+        it("Throws error if SignOutSilentlyAsync returns error", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "SignOutSilentlyAsync").mockImplementation((clientId: string, correlationId: string, account: Account, callback: (result: SignOutResult) => void) => {
+                const result: SignOutResult = {
+                    CheckError: () => { throw msalRuntimeExampleError; },
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeSignOutRequest = {
+                clientId: TEST_CLIENT_ID,
+                correlationId: testCorrelationId,
+                accountId: testAccountInfo.nativeAccountId
+            }
+            await expect(nativeBrokerPlugin.signOut(request)).rejects.toThrowError(testNativeAuthError);
+        });
+
+        it("Throws error if SignOutSilentlyAsync API throws", async () => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "ReadAccountByIdAsync").mockImplementation((accountId: string, correlationId: string, callback: (result: ReadAccountResult) => void) => {
+                const result: ReadAccountResult = {
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {},
+                    telemetryData: ""
+                };
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            jest.spyOn(msalNodeRuntime, "SignOutSilentlyAsync").mockImplementation(() => {
+                throw msalRuntimeExampleError;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeSignOutRequest = {
+                clientId: TEST_CLIENT_ID,
+                correlationId: testCorrelationId,
+                accountId: testAccountInfo.nativeAccountId
+            }
+            await expect(nativeBrokerPlugin.signOut(request)).rejects.toThrowError(testNativeAuthError);
+        });
+    });
+
+    describe("WrapError tests", () => {
+        it("Throws interaction_required error if MsalRuntime throws InteractionRequired Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.InteractionRequired,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toBeInstanceOf(InteractionRequiredAuthError);
+                done();
+            });
+        });
+
+        it("Throws interaction_required error if MsalRuntime throws AccountUnusable Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.AccountUnusable,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toBeInstanceOf(InteractionRequiredAuthError);
+                done();
+            });
+        });
+
+        it("Throws no_network_connectivity error if MsalRuntime throws NoNetwork Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.NoNetwork,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toStrictEqual(ClientAuthError.createNoNetworkConnectivityError());
+                done();
+            });
+        });
+
+        it("Throws no_network_connectivity error if MsalRuntime throws NetworkTemporarilyUnavailable Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.NetworkTemporarilyUnavailable,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toStrictEqual(ClientAuthError.createNoNetworkConnectivityError());
+                done();
+            });
+        });
+
+        it("Throws server_error if MsalRuntime throws ServerTemporarilyUnavailable Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.ServerTemporarilyUnavailable,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toBeInstanceOf(ServerError);
+                done();
+            });
+        });
+
+        it("Throw user_cancelled error if MsalRuntime throws UserCanceled Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.UserCanceled,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toStrictEqual(ClientAuthError.createUserCanceledError());
+                done();
+            });
+        });
+
+        it("Throw authority_untrusted error if MsalRuntime throws AuthorityUntrusted Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.AuthorityUntrusted,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toStrictEqual(ClientConfigurationError.createUntrustedAuthorityError());
+                done();
+            });
+        });
+
+        it("Does not throw error if MsalRuntime throws UserSwitched Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+            const testAuthenticationResult = getTestAuthenticationResult(testCorrelationId);
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: JSON.stringify(testAuthenticationResult.idTokenClaims),
+                    accessToken: testAuthenticationResult.accessToken,
+                    rawIdToken: testAuthenticationResult.idToken,
+                    grantedScopes: testAuthenticationResult.scopes.join(" "),
+                    expiresOn: testAuthenticationResult.expiresOn.getTime(),
+                    isPopAuthorization: false,
+                    account: testMsalRuntimeAccount,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.UserSwitched,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: testAuthenticationResult.scopes,
+                correlationId: testCorrelationId,
+                authority: testAuthenticationResult.authority,
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).then((response) => {
+                expect(response).toStrictEqual(testAuthenticationResult);
+                done();
+            });
+        });
+
+        it("Throws account_not_found error if MsalRuntime throws AccountNotFound Status", (done) => {
+            const testCorrelationId = generateCorrelationId();
+
+            jest.spyOn(msalNodeRuntime, "SignInSilentlyAsync").mockImplementation((authParams: AuthParameters, correlationId: string, callback: (result: AuthResult) => void) => {
+                const result: AuthResult = {
+                    idToken: "",
+                    accessToken: "",
+                    rawIdToken: "",
+                    grantedScopes: "",
+                    expiresOn: 0,
+                    isPopAuthorization: false,
+                    account: null,
+                    CheckError: () => {
+                        const testError: MsalRuntimeError = {
+                            errorCode: 0,
+                            errorStatus: ErrorStatus.AccountNotFound,
+                            errorContext: "",
+                            errorTag: 0
+                        }
+                        throw testError;
+                    },
+                    telemetryData: ""
+                };
+                expect(correlationId).toEqual(testCorrelationId);
+                callback(result);
+
+                return asyncHandle;
+            });
+
+            const nativeBrokerPlugin = new NativeBrokerPlugin();
+            const request: NativeRequest = {
+                clientId: TEST_CLIENT_ID,
+                scopes: [],
+                correlationId: testCorrelationId,
+                authority: "",
+                redirectUri: TEST_REDIRECTURI
+            }
+            nativeBrokerPlugin.acquireTokenSilent(request).catch((error) => {
+                expect(error).toStrictEqual(ClientAuthError.createNoAccountFoundError());
+                done();
+            });
+        });
+    });
+});

--- a/extensions/msal-node-extensions/test/lock/CrossPlatformLock.spec.ts
+++ b/extensions/msal-node-extensions/test/lock/CrossPlatformLock.spec.ts
@@ -85,7 +85,7 @@ describe('Test cross platform lock', () => {
         }, 2000);
 
         // expect lockfile to be present
-        await expect(async () => await lock.lock()).not.toThrow();
-        await expect(async () => await fs.access(lockFilePath)).not.toThrow();
+        await lock.lock();
+        await fs.access(lockFilePath);
     });
 });

--- a/extensions/msal-node-extensions/test/persistence/FilePersistence.spec.ts
+++ b/extensions/msal-node-extensions/test/persistence/FilePersistence.spec.ts
@@ -8,7 +8,7 @@ import { FileSystemUtils } from "../util/FileSystemUtils";
 
 describe('Test File Persistence', () => {
 
-    const filePath = "./test.json";
+    const filePath = "./file-persistence-test.json";
 
     afterEach(async () => {
         await FileSystemUtils.cleanUpFile(filePath);

--- a/extensions/msal-node-extensions/test/persistence/FilePersistenceWithDataProtection.spec.ts
+++ b/extensions/msal-node-extensions/test/persistence/FilePersistenceWithDataProtection.spec.ts
@@ -15,6 +15,7 @@ describe('Test File Persistence with data protection', () => {
 
     afterEach(async () => {
         await FileSystemUtils.cleanUpFile(filePath);
+        jest.restoreAllMocks();
     });
 
     test('exports a class', async () => {

--- a/extensions/msal-node-extensions/test/persistence/PersistenceCachePlugin.spec.ts
+++ b/extensions/msal-node-extensions/test/persistence/PersistenceCachePlugin.spec.ts
@@ -7,7 +7,7 @@ import { IPersistence, PersistenceCachePlugin } from "../../src";
 import { Logger, TokenCacheContext, ISerializableTokenCache } from "@azure/msal-common";
 
 describe('Test PersistenceCachePlugin', () => {
-    const filePath = "./test.json";
+    const filePath = "./cache-plugin-test.json";
     const mockCacheData = "mockCacheData";
 
     const mockPersistence: IPersistence = {

--- a/extensions/msal-node-extensions/test/persistence/PersistenceCreator.spec.ts
+++ b/extensions/msal-node-extensions/test/persistence/PersistenceCreator.spec.ts
@@ -19,11 +19,11 @@ import { FileSystemUtils } from '../util/FileSystemUtils';
 
 describe('Persistence Creator', () => {
     afterAll(() => {
-        FileSystemUtils.cleanUpFile("./test.json");
+        FileSystemUtils.cleanUpFile("./creator-test.json");
     });
 
     const persistenceConfig: IPersistenceConfiguration = {
-        cachePath: "./test.json",
+        cachePath: "./creator-test.json",
         dataProtectionScope: DataProtectionScope.CurrentUser,
         serviceName: "serviceName",
         accountName: "accountName",

--- a/extensions/msal-node-extensions/test/util/TestConstants.ts
+++ b/extensions/msal-node-extensions/test/util/TestConstants.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AccountInfo, AuthenticationResult } from "@azure/msal-common";
+import { Account, ErrorStatus, MsalRuntimeError } from "@azure/msal-node-runtime";
+
+export const testMsalRuntimeAccount: Account = {
+    accountId: "MTIzLXRlc3QtdWlk.NDU2LXRlc3QtdXRpZA==",
+    homeAccountId: "123-test-uid.456-test-utid",
+    environment: "login.windows.net",
+    realm: "456-test-utid",
+    localAccountId: "123-test-uid",
+    username: "JohnSmith@contoso.com",
+    givenName: "John",
+    familyName: "Smith",
+    middleName: "M",
+    displayName: "John Smith",
+    additionalFieldsJson: "",
+    homeEnvironment: "login.windows.net",
+    clientInfo: "eyJ1aWQiOiIxMjMtdGVzdC11aWQiLCJ1dGlkIjoiNDU2LXRlc3QtdXRpZCJ9"
+}
+
+export const testAccountInfo: AccountInfo = {
+    homeAccountId: testMsalRuntimeAccount.homeAccountId,
+    environment: testMsalRuntimeAccount.environment,
+    tenantId: testMsalRuntimeAccount.realm,
+    username: testMsalRuntimeAccount.username,
+    localAccountId: testMsalRuntimeAccount.localAccountId,
+    idTokenClaims: undefined,
+    name: testMsalRuntimeAccount.displayName,
+    nativeAccountId: testMsalRuntimeAccount.accountId
+};
+
+export const msalRuntimeExampleError: MsalRuntimeError = {
+    errorCode: 0,
+    errorStatus: ErrorStatus.Unexpected,
+    errorContext: "Test Error",
+    errorTag: 0
+};
+
+export const TEST_CLIENT_ID = "0813e1d1-ad72-46a9-8665-399bba48c201";
+
+export const TEST_ID_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFJa3pxRlZyU2FTYUZIeTc4MmJidGFRIiwiYXVkIjoiNmNiMDQwMTgtYTNmNS00NmE3LWI5OTUtOTQwYzc4ZjVhZWYzIiwiZXhwIjoxNTM2MzYxNDExLCJpYXQiOjE1MzYyNzQ3MTEsIm5iZiI6MTUzNjI3NDcxMSwibmFtZSI6IkFiZSBMaW5jb2xuIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiQWJlTGlAbWljcm9zb2Z0LmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC02NmYzLTMzMzJlY2E3ZWE4MSIsInRpZCI6IjMzMzgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsIm5vbmNlIjoiMTIzNTIzIiwiYWlvIjoiRGYyVVZYTDFpeCFsTUNXTVNPSkJjRmF0emNHZnZGR2hqS3Y4cTVnMHg3MzJkUjVNQjVCaXN2R1FPN1lXQnlqZDhpUURMcSFlR2JJRGFreXA1bW5PcmNkcUhlWVNubHRlcFFtUnA2QUlaOGpZIn0=.1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw";
+
+export const TEST_ID_TOKEN_CLAIMS = {
+    ver: "2.0",
+    iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+    sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+    aud: "6cb04018-a3f5-46a7-b995-940c78f5aef3",
+    exp: 1536361411,
+    iat: 1536274711,
+    nbf: 1536274711,
+    name: "Abe Lincoln",
+    preferred_username: "AbeLi@microsoft.com",
+    oid: "00000000-0000-0000-66f3-3332eca7ea81",
+    tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+    nonce: "123523",
+    aio: "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY"
+};
+
+export const TEST_ACCESS_TOKEN = "this.is.an.accesstoken";
+
+export const getTestAuthenticationResult = (correlationId: string): AuthenticationResult => {
+    return {
+        authority: "https://login.microsoftonline.com/common",
+        uniqueId: TEST_ID_TOKEN_CLAIMS.oid,
+        tenantId: TEST_ID_TOKEN_CLAIMS.tid,
+        scopes: ["User.Read", "openid", "profile"],
+        account: {...testAccountInfo,
+                  idTokenClaims: TEST_ID_TOKEN_CLAIMS
+                 },
+        idToken: TEST_ID_TOKEN,
+        idTokenClaims: TEST_ID_TOKEN_CLAIMS,
+        accessToken: TEST_ACCESS_TOKEN,
+        fromCache: false,
+        expiresOn: new Date(Date.now() + 3600 * 1000),
+        tokenType: "Bearer",
+        correlationId,
+        fromNativeBroker: true
+    }
+};
+
+export const TEST_REDIRECTURI = "http://localhost";


### PR DESCRIPTION
Same contents as #5855 but new target branch

- Adds unit tests for the NativeBrokerPlugin implementation in msal-node-extensions
- Fixes incorrect expiresOn property