### PR TITLE
Remove no account error in removeAccount

### DIFF
--- a/change/@azure-msal-common-92b7da9a-b20b-4d76-9b47-96c5160333de.json
+++ b/change/@azure-msal-common-92b7da9a-b20b-4d76-9b47-96c5160333de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "`removeAccount` does not throw if account does not exist in cache #5911",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -709,7 +709,7 @@ export abstract class CacheManager implements ICacheManager {
     async removeAccount(accountKey: string): Promise<void> {
         const account = this.getAccount(accountKey);
         if (!account) {
-            throw ClientAuthError.createNoAccountFoundError();
+            return;
         }
         await this.removeAccountContext(account);
         this.removeItem(accountKey);

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -3112,7 +3112,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             );
         });
 
-        it.skip("includes the requestId in the result when received in server response", async () => {
+        it("includes the requestId in the result when received in server response", async () => {
             sinon
                 .stub(
                     Authority.prototype,
@@ -3179,7 +3179,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             );
         });
 
-        it.skip("does not include the requestId in the result when none in server response", async () => {
+        it("does not include the requestId in the result when none in server response", async () => {
             sinon
                 .stub(
                     Authority.prototype,
@@ -3243,7 +3243,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(authenticationResult.requestId).toEqual("");
         });
 
-        it.skip("includes the http version in Authorization code client measurement(AT) when received in server response", async () => {
+        it("includes the http version in Authorization code client measurement(AT) when received in server response", async () => {
             sinon
                 .stub(
                     Authority.prototype,
@@ -3320,7 +3320,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             });
         });
 
-        it.skip("does not add http version to the measurement when not received in server response", async () => {
+        it("does not add http version to the measurement when not received in server response", async () => {
             sinon
                 .stub(
                     Authority.prototype,


### PR DESCRIPTION
- Removes no account error from `removeAccount` as this should not be a failure case
- Re-enables tests that were skipped