### PR TITLE
Remove null from acquireTokenSilent response type

### DIFF
--- a/change/@azure-msal-node-e3a7afee-3776-4ab2-856c-80f283f134a8.json
+++ b/change/@azure-msal-node-e3a7afee-3776-4ab2-856c-80f283f134a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove `null` from `acquireTokenSilent` return type #5912",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -255,7 +255,7 @@ export abstract class ClientApplication {
      */
     async acquireTokenSilent(
         request: SilentFlowRequest
-    ): Promise<AuthenticationResult | null> {
+    ): Promise<AuthenticationResult> {
         const validRequest: CommonSilentFlowRequest = {
             ...request,
             ...(await this.initializeBaseRequest(request)),

--- a/lib/msal-node/src/client/IPublicClientApplication.ts
+++ b/lib/msal-node/src/client/IPublicClientApplication.ts
@@ -35,7 +35,7 @@ export interface IPublicClientApplication {
     /** Acquires a token silently when a user specifies the account the token is requested for */
     acquireTokenSilent(
         request: SilentFlowRequest
-    ): Promise<AuthenticationResult | null>;
+    ): Promise<AuthenticationResult>;
 
     /** Acquires a token by exchanging the refresh token provided for a new set of tokens */
     acquireTokenByRefreshToken(

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -215,7 +215,7 @@ export class PublicClientApplication
      */
     async acquireTokenSilent(
         request: SilentFlowRequest
-    ): Promise<AuthenticationResult | null> {
+    ): Promise<AuthenticationResult> {
         const correlationId =
             request.correlationId || this.cryptoProvider.createNewGuid();
         this.logger.trace("acquireTokenSilent called", correlationId);


### PR DESCRIPTION
`acquireTokenSilent` does not return anything other than `AuthenticationResult`. This PR updates the return type to reflect that.