### PR TITLE
Bundle msal-common into platform library source-code

### DIFF
--- a/lib/msal-browser/.gitignore
+++ b/lib/msal-browser/.gitignore
@@ -263,3 +263,4 @@ typings/
 lib/
 dist/
 ref/
+msal-common/

--- a/lib/msal-browser/package-lock.json
+++ b/lib/msal-browser/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@azure/msal-browser",
       "version": "2.35.0",
       "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "^12.0.0"
-      },
       "devDependencies": {
         "@azure/storage-blob": "^12.2.1",
         "@babel/core": "^7.7.2",
@@ -43,6 +40,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "../msal-common/dist": {
+      "extraneous": true
+    },
+    "../msal-common/index.ts": {
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -219,14 +222,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
-    },
-    "node_modules/@azure/msal-common": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-12.0.0.tgz",
-      "integrity": "sha512-SvQl4JWy1yZnxyq0xng/urf103wz68UJG0K9Dq2NM2to7ePA+R1hMisKnXELJvZrEGYANGbh/Hc0T9piGqOteQ==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/@azure/storage-blob": {
       "version": "12.14.0",

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -52,7 +52,7 @@
     "test:coverage": "jest --coverage",
     "test:coverage:only": "npm run clean:coverage && npm run test:coverage",
     "build:all": "npm run build:common && npm run build",
-    "build:common": "cd ../msal-common && npm run build",
+    "build:common": "shx cp -r ../msal-common/src ./msal-common/",
     "build:modules": "rollup -c --strictDeprecations --bundleConfigAsCjs",
     "build:modules:watch": "rollup -cw --bundleConfigAsCjs",
     "build": "npm run clean && npm run build:modules",
@@ -89,8 +89,5 @@
     "tslib": "^1.10.0",
     "tslint": "^5.20.0",
     "typescript": "^4.9.5"
-  },
-  "dependencies": {
-    "@azure/msal-common": "^12.0.0"
   }
 }

--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -8,7 +8,7 @@ import {
     AccountInfo,
     Logger,
     PerformanceCallbackFunction,
-} from "@azure/msal-common";
+} from "../../msal-common";
 import { RedirectRequest } from "../request/RedirectRequest";
 import { PopupRequest } from "../request/PopupRequest";
 import { SilentRequest } from "../request/SilentRequest";

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -17,7 +17,7 @@ import {
     PerformanceCallbackFunction,
     AccountInfo,
     Logger,
-} from "@azure/msal-common";
+} from "../../msal-common";
 import { EndSessionRequest } from "../request/EndSessionRequest";
 import { SsoSilentRequest } from "../request/SsoSilentRequest";
 import { ControllerFactory } from "../controllers/ControllerFactory";

--- a/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
@@ -14,7 +14,7 @@ import {
     InProgressPerformanceEvent,
     PerformanceEvents,
     IPerformanceClient,
-} from "@azure/msal-common";
+} from "../../../msal-common";
 import {
     NativeExtensionRequest,
     NativeExtensionRequestBody,

--- a/lib/msal-browser/src/controllers/ControllerFactory.ts
+++ b/lib/msal-browser/src/controllers/ControllerFactory.ts
@@ -6,7 +6,7 @@
 import { TeamsAppOperatingContext } from "../operatingcontext/TeamsAppOperatingContext";
 import { StandardOperatingContext } from "../operatingcontext/StandardOperatingContext";
 import { IController } from "./IController";
-import { Logger } from "@azure/msal-common";
+import { Logger } from "../..//msal-common";
 import { Configuration } from "../config/Configuration";
 import { version, name } from "../packageMetadata";
 

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -12,7 +12,7 @@ import {
     PkceCodes,
     SignedHttpRequest,
     SignedHttpRequestParameters,
-} from "@azure/msal-common";
+} from "../..//msal-common";
 import { GuidGenerator } from "./GuidGenerator";
 import { Base64Encode } from "../encode/Base64Encode";
 import { Base64Decode } from "../encode/Base64Decode";

--- a/lib/msal-browser/src/error/BrowserAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserAuthError.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthError, StringUtils } from "@azure/msal-common";
+import { AuthError, StringUtils } from "../../msal-common";
 
 /**
  * BrowserAuthErrorMessage class containing string constants used by error codes and messages.

--- a/lib/msal-browser/src/error/BrowserConfigurationAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserConfigurationAuthError.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthError } from "@azure/msal-common";
+import { AuthError } from "../../msal-common";
 
 /**
  * BrowserAuthErrorMessage class containing string constants used by error codes and messages.

--- a/lib/msal-browser/src/operatingcontext/BaseOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/BaseOperatingContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Logger } from "@azure/msal-common";
+import { Logger } from "../../msal-common";
 import {
     BrowserConfiguration,
     buildConfiguration,

--- a/lib/msal-browser/test/app/IPublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/IPublicClientApplication.spec.ts
@@ -5,7 +5,7 @@
 
 import { stubbedPublicClientApplication } from "../../src/app/IPublicClientApplication";
 import { BrowserConfigurationAuthErrorMessage } from "../../src/error/BrowserConfigurationAuthError";
-import { BrowserAuthError } from "../../lib";
+import { BrowserAuthError } from "../../src/";
 
 describe("IPublicClientApplication.ts Class Unit Tests", () => {
     describe("stubbedPublicClientApplication tests", () => {

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -48,7 +48,7 @@ import {
     PersistentCacheKeys,
     Authority,
     AuthError,
-} from "@azure/msal-common";
+} from "../..//msal-common";
 import {
     ApiId,
     InteractionType,
@@ -81,6 +81,8 @@ import {
     AuthorizationCodeRequest,
     BrowserConfigurationAuthError,
     EndSessionRequest,
+    RedirectRequest,
+    PopupRequest
 } from "../../src";
 import { RedirectHandler } from "../../src/interaction_handler/RedirectHandler";
 import { SilentAuthCodeClient } from "../../src/interaction_client/SilentAuthCodeClient";
@@ -636,7 +638,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
     describe("loginRedirect", () => {
         it("doesnt mutate request correlation id", async () => {
-            const request: SilentRequest = {
+            const request: RedirectRequest = {
                 scopes: [],
             };
 
@@ -933,7 +935,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         });
 
         it("doesnt mutate request correlation id", async () => {
-            const request: SilentRequest = {
+            const request: RedirectRequest = {
                 scopes: [],
             };
 
@@ -1158,7 +1160,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         });
 
         it("doesnt mutate request correlation id", async () => {
-            const request: SilentRequest = {
+            const request: PopupRequest = {
                 scopes: [],
             };
 
@@ -1526,7 +1528,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         });
 
         it("doesnt mutate request correlation id", async () => {
-            const request: SilentRequest = {
+            const request: PopupRequest = {
                 scopes: [],
             };
 

--- a/lib/msal-browser/tsconfig.json
+++ b/lib/msal-browser/tsconfig.json
@@ -20,7 +20,11 @@
             "path": "../msal-common"
         }
     ],
-    "include": ["src", "test"],
+    "include": [
+        "src",
+        "test",
+        "msal-common"
+    ],
     "exclude": [
         "node_modules"
     ],


### PR DESCRIPTION
This PR:
- Updates msal-browser `build:common` script to bundle common code into msal-browser source code and updates import statements.