### PR TITLE
Add CIAM support for v3

### DIFF
--- a/change/@azure-msal-common-a41521ad-cf75-4f37-bc79-d009688b83cb.json
+++ b/change/@azure-msal-common-a41521ad-cf75-4f37-bc79-d009688b83cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add CIAM support for v3(#5915)",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/docs/authority.md
+++ b/lib/msal-common/docs/authority.md
@@ -109,6 +109,22 @@ const cca = new ConfidentialClientApplication({
 
 > *Note: dSTS supports both Public and Confidential Client applications.*
 
+### CIAM 
+
+Azure Active Directory (Azure AD) is adding support to customer identity access management (CIAM) solution that lets you create secure, customized sign-in experiences for your customer-facing apps and services. With these built-in CIAM features, Azure AD can serve as the identity provider and access management service for your customer scenarios.
+
+The CIAM authority format is still in the process of standardization. It is determined to be split from AAD and currently supported in the below formats:
+- https://tenantName.ciamlogin.com/tenant
+- https://tenantName.ciamlogin.com
+
+Where `tenant` would mean:
+
+- tenantName.microsoft.com
+- GUID (tenantId)
+- a verified domain for the tenant
+
+Note: MSAL JS currently is previeing the `CIAM` support. This is an emerging space and there could be some changes to the support until we GA the feature.
+
 ### Other OIDC-compliant IdPs
 
 MSAL can be configured to acquire tokens from any OIDC-compliant IdP. See [initialization](../../msal-browser/docs/initialization.md#optional-configure-authority) for more.

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -691,7 +691,6 @@ export class Authority {
      */
     private getCloudDiscoveryMetadataFromConfig(): CloudDiscoveryMetadata | null {
 
-
         // CIAM does not support cloud discovery metadata
         if (this.authorityType === AuthorityType.Ciam) {
             this.logger.verbose("CIAM authorities do not support cloud discovery metadata, generate the aliases from authority host.");
@@ -1049,6 +1048,7 @@ export class Authority {
      * @param authority 
      */
     static transformCIAMAuthority(authority: string): string {
+        
         let ciamAuthority = authority.endsWith(Constants.FORWARD_SLASH) ? authority : `${authority}${Constants.FORWARD_SLASH}`;
         const authorityUrl = new UrlString(authority);
         const authorityUrlComponents = authorityUrl.getUrlComponents();

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -104,6 +104,12 @@ export class Authority {
     // See above for AuthorityType
     public get authorityType(): AuthorityType {
         const pathSegments = this.canonicalAuthorityUrlComponents.PathSegments;
+
+        // CIAM auth url pattern is being standardized as: <tenant>.ciamlogin.com
+        if (this.canonicalAuthorityUrlComponents.HostNameAndPort.endsWith(Constants.CIAM_AUTH_URL)) {
+            return AuthorityType.Ciam;
+        }
+
         if (pathSegments.length) {
             switch (pathSegments[0].toLowerCase()) {
                 case Constants.ADFS:
@@ -400,7 +406,6 @@ export class Authority {
             return AuthorityMetadataSource.CACHE;
         }
 
-        let harcodedMetadata = this.getEndpointMetadataFromHardcodedValues();
         this.performanceClient?.setPreQueueTime(
             PerformanceEvents.AuthorityGetEndpointMetadataFromNetwork,
             this.correlationId
@@ -422,6 +427,7 @@ export class Authority {
             return AuthorityMetadataSource.NETWORK;
         }
 
+        let harcodedMetadata = this.getEndpointMetadataFromHardcodedValues();
         if (
             harcodedMetadata &&
             !this.authorityOptions.skipAuthorityMetadataCache
@@ -585,8 +591,8 @@ export class Authority {
     /**
      * Updates the AuthorityMetadataEntity with new aliases, preferred_network and preferred_cache
      * and returns where the information was retrieved from
-     * @param cachedMetadata
-     * @param newMetadata
+     * @param metadataEntity 
+     * @returns AuthorityMetadataSource
      */
     private async updateCloudDiscoveryMetadata(
         metadataEntity: AuthorityMetadataEntity
@@ -684,6 +690,14 @@ export class Authority {
      * Parse cloudDiscoveryMetadata config or check knownAuthorities
      */
     private getCloudDiscoveryMetadataFromConfig(): CloudDiscoveryMetadata | null {
+
+
+        // CIAM does not support cloud discovery metadata
+        if (this.authorityType === AuthorityType.Ciam) {
+            this.logger.verbose("CIAM authorities do not support cloud discovery metadata, generate the aliases from authority host.");
+            return Authority.createCloudDiscoveryMetadataFromHost(this.hostnameAndPort);
+        }
+
         // Check if network response was provided in config
         if (this.authorityOptions.cloudDiscoveryMetadata) {
             this.logger.verbose(
@@ -1023,5 +1037,28 @@ export class Authority {
         }
 
         return metadata;
+    }
+
+    /**
+     * Transform CIAM_AUTHORIY as per the below rules:
+     * If no path segments found and it is a CIAM authority (hostname ends with .ciamlogin.com), then transform it
+     * 
+     * NOTE: The transformation path should go away once STS supports CIAM with the format: `tenantIdorDomain.ciamlogin.com`
+     * `ciamlogin.com` can also change in the future and we should accommodate the same
+     * 
+     * @param authority 
+     */
+    static transformCIAMAuthority(authority: string): string {
+        let ciamAuthority = authority.endsWith(Constants.FORWARD_SLASH) ? authority : `${authority}${Constants.FORWARD_SLASH}`;
+        const authorityUrl = new UrlString(authority);
+        const authorityUrlComponents = authorityUrl.getUrlComponents();
+
+        // check if transformation is needed
+        if (authorityUrlComponents.PathSegments.length === 0 && (authorityUrlComponents.HostNameAndPort.endsWith(Constants.CIAM_AUTH_URL))){
+            const tenantIdOrDomain = authorityUrlComponents.HostNameAndPort.split(".")[0];
+            ciamAuthority = `${ciamAuthority}${tenantIdOrDomain}${Constants.AAD_TENANT_DOMAIN_SUFFIX}`;
+        }
+
+        return ciamAuthority;
     }
 }

--- a/lib/msal-common/src/authority/AuthorityFactory.ts
+++ b/lib/msal-common/src/authority/AuthorityFactory.ts
@@ -39,10 +39,12 @@ export class AuthorityFactory {
             correlationId
         );
 
+        const authorityUriFinal = Authority.transformCIAMAuthority(authorityUri);
+
         // Initialize authority and perform discovery endpoint check.
         const acquireTokenAuthority: Authority =
             AuthorityFactory.createInstance(
-                authorityUri,
+                authorityUriFinal,
                 networkClient,
                 cacheManager,
                 authorityOptions,

--- a/lib/msal-common/src/authority/AuthorityType.ts
+++ b/lib/msal-common/src/authority/AuthorityType.ts
@@ -10,4 +10,5 @@ export enum AuthorityType {
     Default,
     Adfs,
     Dsts,
+    Ciam
 }

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -18,6 +18,9 @@ export const Constants = {
     // Default AAD Instance Discovery Endpoint
     AAD_INSTANCE_DISCOVERY_ENDPT:
         "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=",
+    // CIAM URL
+    CIAM_AUTH_URL: ".ciamlogin.com",
+    AAD_TENANT_DOMAIN_SUFFIX: ".onmicrosoft.com",
     // Resource delimiter - used for certain cache entries
     RESOURCE_DELIM: "|",
     // Placeholder for non-existent account ids/objects

--- a/lib/msal-common/test/authority/AuthorityFactory.spec.ts
+++ b/lib/msal-common/test/authority/AuthorityFactory.spec.ts
@@ -215,4 +215,50 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
             done();
         });
     });
+
+    it("createDiscoveredInstance transforms CIAM authority", async () => {
+        const resolveEndpointsStub = jest.spyOn(Authority.prototype, "resolveEndpointsAsync").mockResolvedValue();
+        const authorityInstance = await AuthorityFactory.createDiscoveredInstance("https://test.ciamlogin.com/", networkInterface, mockStorage, authorityOptions, logger);
+        expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
+        expect(authorityInstance.canonicalAuthority).toBe("https://test.ciamlogin.com/test.onmicrosoft.com/");
+        expect(authorityInstance instanceof Authority);
+        expect(resolveEndpointsStub).toHaveBeenCalledTimes(1);
+    });
+
+    it("createDiscoveredInstance transforms CIAM authority when a `/` is missing", async () => {
+        const resolveEndpointsStub = jest.spyOn(Authority.prototype, "resolveEndpointsAsync").mockResolvedValue();
+        const authorityInstance = await AuthorityFactory.createDiscoveredInstance("https://test.ciamlogin.com", networkInterface, mockStorage, authorityOptions, logger);
+        expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
+        expect(authorityInstance.canonicalAuthority).toBe("https://test.ciamlogin.com/test.onmicrosoft.com/");
+        expect(authorityInstance instanceof Authority);
+        expect(resolveEndpointsStub).toHaveBeenCalledTimes(1);
+    });
+
+
+    it("createDiscoveredInstance does not transform when there is a PATH", async () => {
+        const resolveEndpointsStub = jest.spyOn(Authority.prototype, "resolveEndpointsAsync").mockResolvedValue();
+        const authorityInstance = await AuthorityFactory.createDiscoveredInstance("https://test.ciamlogin.com/tenant/", networkInterface, mockStorage, authorityOptions, logger);
+        expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
+        expect(authorityInstance.canonicalAuthority).toBe("https://test.ciamlogin.com/tenant/");
+        expect(authorityInstance instanceof Authority);
+        expect(resolveEndpointsStub).toHaveBeenCalledTimes(1);
+    });
+
+    it("createDiscoveredInstance does not transform when there is a PATH adds a trailing `slash` if not provided", async () => {
+        const resolveEndpointsStub = jest.spyOn(Authority.prototype, "resolveEndpointsAsync").mockResolvedValue();
+        const authorityInstance = await AuthorityFactory.createDiscoveredInstance("https://test.ciamlogin.com/tenant", networkInterface, mockStorage, authorityOptions, logger);
+        expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
+        expect(authorityInstance.canonicalAuthority).toBe("https://test.ciamlogin.com/tenant/");
+        expect(authorityInstance instanceof Authority);
+        expect(resolveEndpointsStub).toHaveBeenCalledTimes(1);
+    })
+
+    it("createDiscoveredInstance does not tranform CIAM authority when there is a PATH & accounts for existing trailing `slash`", async () => {
+        const resolveEndpointsStub = jest.spyOn(Authority.prototype, "resolveEndpointsAsync").mockResolvedValue();
+        const authorityInstance = await AuthorityFactory.createDiscoveredInstance("https://test.ciamlogin.com/e458a5d7-3227-49a6-a1f1-8e5317c8a790/", networkInterface, mockStorage, authorityOptions, logger);
+        expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
+        expect(authorityInstance.canonicalAuthority).toBe("https://test.ciamlogin.com/e458a5d7-3227-49a6-a1f1-8e5317c8a790/");
+        expect(authorityInstance instanceof Authority);
+        expect(resolveEndpointsStub).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
Ported PR #5865 to mainline!

**Add CIAM support in MSAL JS**

Azure Active Directory (Azure AD) is adding support to customer identity access management (CIAM) solution that lets you create secure, customized sign-in experiences for your customer-facing apps and services. With these built-in CIAM features, Azure AD can serve as the identity provider and access management service for your customer scenarios.

> The CIAM authority format is still in the process of standardization. It is determined to be split from AAD and currently supported in the below formats:

* `https://tenantName.ciamlogin.com/tenant` 
* `https://tenantName.ciamlogin.com`

> All MSALs have currently agreed to add two rules for CIAM Authority:

1. Add a new `CIAM` authority type
2. If the i/p CIAM  authority does not have a path, append `"tenant.onmicrosoft.com"` to the PATH as a temporary measure to support the STS endpoints. 

The second part of this support eventually will go away.

> Please also note that this is an emerging space and the endpoints may change eventually before productization. More details about CIAM can be found here: [CIAM previews](https://github.com/microsoft/entra-previews)

**_Completed :_**
- Code changes: Added `AuthorityType: Ciam` and the path tranformation logic stated above
- Unit tests
- Docs updates
- Samples tested
