### PR TITLE
Support missing slash in CIAM authority support

### DIFF
--- a/change/@azure-msal-common-c26c7676-d0d7-4113-877a-e56e36fb73eb.json
+++ b/change/@azure-msal-common-c26c7676-d0d7-4113-877a-e56e36fb73eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bugs in CIAM Authority Support (#5917)",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -797,7 +797,7 @@ export class Authority {
      * @param authority 
      */
     static transformCIAMAuthority(authority: string): string {
-        let ciamAuthority = authority;
+        let ciamAuthority = authority.endsWith(Constants.FORWARD_SLASH) ? authority : `${authority}${Constants.FORWARD_SLASH}`;
         const authorityUrl = new UrlString(authority);
         const authorityUrlComponents = authorityUrl.getUrlComponents();
 

--- a/lib/msal-common/test/authority/AuthorityFactory.spec.ts
+++ b/lib/msal-common/test/authority/AuthorityFactory.spec.ts
@@ -143,6 +143,15 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
         expect(resolveEndpointsStub).toHaveBeenCalledTimes(1);
     });
 
+    it("createDiscoveredInstance transforms CIAM authority when trailing slash is missing", async () => {
+        const resolveEndpointsStub = jest.spyOn(Authority.prototype, "resolveEndpointsAsync").mockResolvedValue();
+        const authorityInstance = await AuthorityFactory.createDiscoveredInstance("https://test.ciamlogin.com", networkInterface, mockStorage, authorityOptions, logger);
+        expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
+        expect(authorityInstance.canonicalAuthority).toBe("https://test.ciamlogin.com/test.onmicrosoft.com/");
+        expect(authorityInstance instanceof Authority);
+        expect(resolveEndpointsStub).toHaveBeenCalledTimes(1);
+    });
+
     it("createDiscoveredInstance does not transform when there is a PATH", async () => {
         const resolveEndpointsStub = jest.spyOn(Authority.prototype, "resolveEndpointsAsync").mockResolvedValue();
         const authorityInstance = await AuthorityFactory.createDiscoveredInstance("https://test.ciamlogin.com/tenant/", networkInterface, mockStorage, authorityOptions, logger);


### PR DESCRIPTION
This PR fixes a bug in CIAM support, a specific use case where the `authority` without `PATH` without a trailing slash is failing:

```
clientId: 'Enter_the_Application_Id_Here', 
authority: '[https://Enter_the_Tenant_Name_Here.ciamlogin.com']
```

This PR fixes the bug and also adds a test case to cover this use case.

cc @derisen 