### PR TITLE
Fix token audience handling for a legacy authority

### DIFF
--- a/change/@azure-msal-common-f7548aca-eb73-4890-aed5-6c0b955ff1f1.json
+++ b/change/@azure-msal-common-f7548aca-eb73-4890-aed5-6c0b955ff1f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: dSTS Token dummy aud claim value for requests with scope input by using v2.0 endpoint",
+  "packageName": "@azure/msal-common",
+  "email": "kapjain@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -311,7 +311,6 @@ export class Authority {
     protected get defaultOpenIdConfigurationEndpoint(): string {
         if (
             this.authorityType === AuthorityType.Adfs ||
-            this.authorityType === AuthorityType.Dsts ||
             this.protocolMode === ProtocolMode.OIDC
         ) {
             return `${this.canonicalAuthority}.well-known/openid-configuration`;

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -1880,7 +1880,7 @@ describe("Authority.ts Class Unit Tests", () => {
             );
         });
 
-        it("DSTS authority uses v1 well-known endpoint with common y", async () => {
+        it("DSTS authority uses v2 well-known endpoint with common y", async () => {
             const authorityUrl =
                 "https://login.microsoftonline.com/dstsv2/common/";
             let endpoint = "";
@@ -1902,11 +1902,11 @@ describe("Authority.ts Class Unit Tests", () => {
 
             await authority.resolveEndpointsAsync();
             expect(endpoint).toBe(
-                `${authorityUrl}.well-known/openid-configuration`
+                `${authorityUrl}v2.0/.well-known/openid-configuration`
             );
         });
 
-        it("DSTS authority uses v1 well-known  with tenanted authority", async () => {
+        it("DSTS authority uses v2 well-known  with tenanted authority", async () => {
             const authorityUrl = `https://login.microsoftonline.com/dstsv2/${TEST_CONFIG.TENANT}/`;
             let endpoint = "";
             authority = new Authority(
@@ -1927,7 +1927,7 @@ describe("Authority.ts Class Unit Tests", () => {
 
             await authority.resolveEndpointsAsync();
             expect(endpoint).toBe(
-                `${authorityUrl}.well-known/openid-configuration`
+                `${authorityUrl}v2.0/.well-known/openid-configuration`
             );
         });
 


### PR DESCRIPTION
Fixes token audience handling for requests to a legacy authority by using the v2.0 endpoint.