### PR TITLE
Remove googleapi fonts from Angular samples

### DIFF
--- a/samples/msal-angular-v2-samples/angular-b2c-sample-app/src/index.html
+++ b/samples/msal-angular-v2-samples/angular-b2c-sample-app/src/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Angular 14 B2C Sample</title>
@@ -7,11 +8,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body class="mat-typography">
   <app-root></app-root>
   <app-redirect></app-redirect>
 </body>
+
 </html>

--- a/samples/msal-angular-v2-samples/angular11-sample-app/src/index.html
+++ b/samples/msal-angular-v2-samples/angular11-sample-app/src/index.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Angular11SampleApp</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body class="mat-typography">
   <app-root></app-root>
   <app-redirect></app-redirect>
 </body>
+
 </html>

--- a/samples/msal-angular-v2-samples/angular12-sample-app/src/index.html
+++ b/samples/msal-angular-v2-samples/angular12-sample-app/src/index.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Angular12SampleApp</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body class="mat-typography">
   <app-root></app-root>
   <app-redirect></app-redirect>
 </body>
+
 </html>

--- a/samples/msal-angular-v2-samples/angular13-rxjs6-sample-app/src/index.html
+++ b/samples/msal-angular-v2-samples/angular13-rxjs6-sample-app/src/index.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Angular13RxJS6SampleApp</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body class="mat-typography">
   <app-root></app-root>
   <app-redirect></app-redirect>
 </body>
+
 </html>

--- a/samples/msal-angular-v2-samples/angular13-rxjs7-sample-app/src/index.html
+++ b/samples/msal-angular-v2-samples/angular13-rxjs7-sample-app/src/index.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Angular13RxJS7SampleApp</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body class="mat-typography">
   <app-root></app-root>
   <app-redirect></app-redirect>
 </body>
+
 </html>

--- a/samples/msal-angular-v2-samples/angular14-rxjs6-sample-app/src/index.html
+++ b/samples/msal-angular-v2-samples/angular14-rxjs6-sample-app/src/index.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Angular14RxJS6SampleApp</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body class="mat-typography">
   <app-root></app-root>
   <app-redirect></app-redirect>
 </body>
+
 </html>

--- a/samples/msal-angular-v2-samples/angular14-rxjs7-sample-app/src/index.html
+++ b/samples/msal-angular-v2-samples/angular14-rxjs7-sample-app/src/index.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Angular14RxJS7SampleApp</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body class="mat-typography">
   <app-root></app-root>
   <app-redirect></app-redirect>
 </body>
+
 </html>

--- a/samples/msal-angular-v3-samples/angular15-sample-app/src/index.html
+++ b/samples/msal-angular-v3-samples/angular15-sample-app/src/index.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Angular 15 Sample App</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body class="mat-typography">
   <app-root></app-root>
   <app-redirect></app-redirect>
 </body>
+
 </html>


### PR DESCRIPTION
This PR removes `font.googleapi` stylesheets that were added as part of initial Angular application bootstrapping.