### PR TITLE
changes to package.json, rollup config and tsconfig

### DIFF
--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -1,74 +1,75 @@
 {
-  "name": "@azure/msal-node",
-  "version": "1.17.0",
-  "author": {
-    "name": "Microsoft",
-    "email": "nugetaad@microsoft.com",
-    "url": "https://www.microsoft.com"
-  },
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
-  },
-  "description": "Microsoft Authentication Library for Node",
-  "keywords": [
-    "js",
-    "ts",
-    "node",
-    "AAD",
-    "msal",
-    "oauth"
-  ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "rollup -c --strictDeprecations --bundleConfigAsCjs",
-    "build:watch": "rollup -c --watch --strictDeprecations --bundleConfigAsCjs",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage",
-    "lint": "cd ../../ && npm run lint:node",
-    "lint:fix": "npm run lint -- -- --fix",
-    "build:all": "npm run build",
-    "prepack": "npm run build:all",
-    "format:check": "npx prettier --ignore-path .gitignore --check src test",
-    "format:fix": "npx prettier --ignore-path .gitignore --write src test"
-  },
-  "beachball": {
-    "disallowedChangeTypes": []
-  },
-  "module": "dist/msal-node.esm.js",
-  "devDependencies": {
-    "@microsoft/api-extractor": "^7.19.4",
-    "@rollup/plugin-node-resolve": "^15.0.1",
-    "@rollup/plugin-typescript": "^11.0.0",
-    "@types/jest": "^25.2.3",
-    "@types/jsonwebtoken": "^8.5.5",
-    "@types/node": "^13.13.4",
-    "@types/sinon": "^7.5.0",
-    "@types/uuid": "^7.0.0",
-    "husky": "^4.2.3",
-    "jest": "^29.5.0",
-    "prettier": "2.8.7",
-    "rollup": "^3.20.1",
-    "sinon": "^7.5.0",
-    "ts-jest": "^29.0.5",
-    "tslib": "^1.10.0",
-    "typescript": "^4.9.5",
-    "yargs": "^17.3.1"
-  },
-  "dependencies": {
-    "jsonwebtoken": "^9.0.0",
-    "uuid": "^8.3.0"
-  },
-  "bundledDependencies": [
-    "@azure/msal-common"
-  ],
-  "engines": {
-    "node": "16 || 18"
-  }
+    "name": "@azure/msal-node",
+    "version": "1.17.0",
+    "author": {
+        "name": "Microsoft",
+        "email": "nugetaad@microsoft.com",
+        "url": "https://www.microsoft.com"
+    },
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
+    },
+    "description": "Microsoft Authentication Library for Node",
+    "keywords": [
+        "js",
+        "ts",
+        "node",
+        "AAD",
+        "msal",
+        "oauth"
+    ],
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "rollup -c --strictDeprecations --bundleConfigAsCjs",
+        "build:watch": "rollup -c --watch --strictDeprecations --bundleConfigAsCjs",
+        "test": "jest",
+        "test:watch": "jest --watch",
+        "test:coverage": "jest --coverage",
+        "lint": "cd ../../ && npm run lint:node",
+        "lint:fix": "npm run lint -- -- --fix",
+        "build:all": "npm run build",
+        "prepack": "npm run build:all",
+        "format:check": "npx prettier --ignore-path .gitignore --check src test",
+        "format:fix": "npx prettier --ignore-path .gitignore --write src test"
+    },
+    "beachball": {
+        "disallowedChangeTypes": []
+    },
+    "module": "dist/msal-node.esm.js",
+    "devDependencies": {
+        "@microsoft/api-extractor": "^7.19.4",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "@types/jest": "^25.2.3",
+        "@types/jsonwebtoken": "^8.5.5",
+        "@types/node": "^13.13.4",
+        "@types/sinon": "^7.5.0",
+        "@types/uuid": "^7.0.0",
+        "husky": "^4.2.3",
+        "jest": "^29.5.0",
+        "prettier": "2.8.7",
+        "rollup": "^3.20.1",
+        "sinon": "^7.5.0",
+        "ts-jest": "^29.0.5",
+        "tslib": "^1.10.0",
+        "typescript": "^4.9.5",
+        "yargs": "^17.3.1"
+    },
+    "dependencies": {
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0",
+        "@azure/msal-common": "file:../msal-common"
+    },
+    "bundledDependencies": [
+        "@azure/msal-common"
+    ],
+    "engines": {
+        "node": "16 || 18"
+    }
 }

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -64,7 +64,7 @@
     "dependencies": {
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0",
-        "@azure/msal-common": "file:../msal-common"
+        "@azure/msal-common": "@azure/msal-common"
     },
     "bundledDependencies": [
         "@azure/msal-common"

--- a/lib/msal-node/rollup.config.js
+++ b/lib/msal-node/rollup.config.js
@@ -14,9 +14,9 @@ const fileHeader = `${libraryHeader}\n${useStrictHeader}`;
 export default [
     {
         // for cjs build
-        input: ["src/index.ts", "../msal-common/src/index.ts"],
+        input: "src/index.ts",
         output: {
-            dir: "dist",
+            dir: "lib",
             format: "cjs",
             preserveModules: true,
             preserveModulesRoot: "src",
@@ -34,14 +34,15 @@ export default [
         plugins: [
             typescript( {
                 typescript: require("typescript"),
-                tsconfig: "tsconfig.build.json"
+                tsconfig: "tsconfig.build.json",
+                compilerOptions: {outDir: "./lib"}
             }),
             nodeResolve()
         ]
     },
     {
         // for esm build
-        input: ["src/index.ts", "../msal-common/src/index.ts"],
+        input: "src/index.ts",
         output: {
             dir: "dist",
             format: "esm",

--- a/lib/msal-node/tsconfig.build.json
+++ b/lib/msal-node/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "rootDir": ".."
+        "rootDir": "./src"
     },
-    "include": ["src", "../msal-common/src"]
+    "include": ["src"]
 }

--- a/lib/msal-node/tsconfig.json
+++ b/lib/msal-node/tsconfig.json
@@ -1,43 +1,35 @@
 {
-  "include": ["src", "test"],
-  "exclude": ["node_modules"],
-  "compilerOptions": {
-    "target": "es2020",
-    "module": "esnext",
-    "declaration": true,
-    "declarationMap": true,
-    "lib": ["dom", "esnext"],
-    "importHelpers": true,
-    "sourceMap": true,
-    "rootDir": "./",
-    "outDir": "./dist",
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": false,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": false,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "node",
-    "jsx": "react",
-    "esModuleInterop": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "experimentalDecorators": true,
-    "baseUrl": "./",
-    "paths": {
-      "@azure/msal-common": ["../msal-common/src"]
-    }
-  },
-  "compileOnSave": false,
-  "buildOnSave": false,
-  "references": [
-    {
-      "path": "../msal-common"
-    }
-  ]
+    "include": ["src", "test"],
+    "exclude": ["node_modules"],
+    "compilerOptions": {
+        "target": "es2020",
+        "module": "esnext",
+        "declaration": true,
+        "declarationMap": true,
+        "lib": ["dom", "esnext"],
+        "importHelpers": true,
+        "sourceMap": true,
+        "rootDir": "./",
+        "outDir": "./dist",
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "strictPropertyInitialization": false,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "resolveJsonModule": true,
+        "moduleResolution": "node",
+        "jsx": "react",
+        "esModuleInterop": true,
+        "suppressImplicitAnyIndexErrors": true,
+        "experimentalDecorators": true,
+        "baseUrl": "./"
+    },
+    "compileOnSave": false,
+    "buildOnSave": false
 }


### PR DESCRIPTION
- Added dev dependency on msal-common via file path
- Added msal-common to bundleDependencies (bundledDependencies - also would work I believe)
- Modified rollup config to create separate UMD and ES6 output
- NOTE: I haven't changed the package json to reflect the 2 new output locations.... we should probably look at package exports for this... i use the legacy approach in msal-browser currently.