### PR TITLE
Bundle `msal-common` into `msal-node`

### DIFF
--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -65,8 +65,8 @@ jobs:
       if: steps.lib-cache.outputs.cache-hit != 'true'
       run: npm ci --ignore-scripts
 
-    - name: Link local packages
-      run: npx lerna --scope @azure/msal-node --scope @azure/msal-common bootstrap
+    - name: Bootstrap msal-node
+      run: npx lerna --scope @azure/msal-node bootstrap
 
     - name: Build Package
       working-directory: samples/msal-node-samples
@@ -158,6 +158,9 @@ jobs:
     - name: Clean Install
       if: steps.lib-cache.outputs.cache-hit != 'true'
       run: npm ci
+
+    - name: Bootstrap msal-node
+      run: npx lerna --scope @azure/msal-node bootstrap
 
     - name: Build Package
       working-directory: samples/msal-node-samples

--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -65,6 +65,9 @@ jobs:
       if: steps.lib-cache.outputs.cache-hit != 'true'
       run: npm ci --ignore-scripts
 
+    - name: Bootstrap msal-common
+      run: npx lerna --scope @azure/msal-common bootstrap
+
     - name: Bootstrap msal-node
       run: npx lerna --scope @azure/msal-node bootstrap
 
@@ -158,6 +161,9 @@ jobs:
     - name: Clean Install
       if: steps.lib-cache.outputs.cache-hit != 'true'
       run: npm ci
+
+    - name: Bootstrap msal-common
+      run: npx lerna --scope @azure/msal-common bootstrap
 
     - name: Bootstrap msal-node
       run: npx lerna --scope @azure/msal-node bootstrap

--- a/change/@azure-msal-node-a4b7a984-e70f-4541-84cc-982bd29d190a.json
+++ b/change/@azure-msal-node-a4b7a984-e70f-4541-84cc-982bd29d190a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Bundle msal-common into msal-node #5942",
+  "packageName": "@azure/msal-node",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/package-lock.json
+++ b/lib/msal-node/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "../msal-common",
+        "@azure/msal-common": "file:../msal-common",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },

--- a/lib/msal-node/package-lock.json
+++ b/lib/msal-node/package-lock.json
@@ -7,9 +7,12 @@
     "": {
       "name": "@azure/msal-node",
       "version": "1.17.0",
+      "bundleDependencies": [
+        "@azure/msal-common"
+      ],
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "^12.0.0",
+        "@azure/msal-common": "../msal-common",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -36,6 +36,7 @@
     "build:all": "npm run build:common && npm run build",
     "build:common": "cd ../msal-common && npm run build",
     "prepack": "npm run build:all",
+    "prepare": "npm install ../msal-common",
     "format:check": "npx prettier --ignore-path .gitignore --check src test",
     "format:fix": "npx prettier --ignore-path .gitignore --write src test"
   },
@@ -63,7 +64,7 @@
     "yargs": "^17.3.1"
   },
   "dependencies": {
-    "@azure/msal-common": "../msal-common",
+    "@azure/msal-common": "file:../msal-common",
     "jsonwebtoken": "^9.0.0",
     "uuid": "^8.3.0"
   },

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -36,7 +36,7 @@
     "build:all": "npm run build:common && npm run build",
     "build:common": "cd ../msal-common && npm run build",
     "prepack": "npm run build:all",
-    "prepare": "npm install ../msal-common",
+    "prepare": "cd ../msal-common && npm install --production && cd ../msal-node && npm install ../msal-common",
     "format:check": "npx prettier --ignore-path .gitignore --check src test",
     "format:fix": "npx prettier --ignore-path .gitignore --write src test"
   },

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -35,7 +35,6 @@
     "lint:fix": "npm run lint -- -- --fix",
     "build:all": "npm run build:common && npm run build",
     "build:common": "cd ../msal-common && npm run build",
-    "link:localDeps": "npx lerna bootstrap --scope @azure/msal-common --scope @azure/msal-node",
     "prepack": "npm run build:all",
     "format:check": "npx prettier --ignore-path .gitignore --check src test",
     "format:fix": "npx prettier --ignore-path .gitignore --write src test"
@@ -64,10 +63,13 @@
     "yargs": "^17.3.1"
   },
   "dependencies": {
-    "@azure/msal-common": "^12.0.0",
+    "@azure/msal-common": "../msal-common",
     "jsonwebtoken": "^9.0.0",
     "uuid": "^8.3.0"
   },
+  "bundledDependencies": [
+    "@azure/msal-common"
+  ],
   "engines": {
     "node": "16 || 18"
   }

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -35,8 +35,8 @@
     "lint:fix": "npm run lint -- -- --fix",
     "build:all": "npm run build:common && npm run build",
     "build:common": "cd ../msal-common && npm run build",
-    "prepack": "npm run build:all",
-    "prepare": "cd ../msal-common && npm install --production && cd ../msal-node && npm install ../msal-common",
+    "prepare": "npm install ../msal-common",
+    "prepack": "cd ../msal-common && npm install --production && cd ../msal-node && npm run build:all",
     "format:check": "npx prettier --ignore-path .gitignore --check src test",
     "format:fix": "npx prettier --ignore-path .gitignore --write src test"
   },

--- a/lib/msal-node/test/network/HttpClient.spec.ts
+++ b/lib/msal-node/test/network/HttpClient.spec.ts
@@ -3,7 +3,7 @@ import {
     NetworkResponse,
     NetworkRequestOptions,
     UrlToHttpRequestOptions,
-} from "../../../msal-common";
+} from "@azure/msal-common";
 import { MockedMetadataResponse } from "../utils/TestConstants";
 
 import http from "http";


### PR DESCRIPTION
- Declare `msal-common` as bundled dependency.
- Update msal-node-e2e workflow.
- Add `prepare` step to make lerna bootstrap local `msal-common` package.
- Update `prepack` step to filter out `msal-common` devDeps before publishing.

**_NOTE:_** `msal-common` is bundled under `node_modules` in tar file.