### PR TITLE
Update `msa-common` bundling config for `msal-node-extensions`

### DIFF
--- a/change/@azure-msal-node-extensions-ca924dfd-858f-4987-9710-8cb55033be6d.json
+++ b/change/@azure-msal-node-extensions-ca924dfd-858f-4987-9710-8cb55033be6d.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Update `msa-common` bundling config for `msal-node-extensions` #5943",
+  "comment": "Update `msal-common` bundling config for `msal-node-extensions` #5943",
   "packageName": "@azure/msal-node-extensions",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "none"

--- a/change/@azure-msal-node-extensions-ca924dfd-858f-4987-9710-8cb55033be6d.json
+++ b/change/@azure-msal-node-extensions-ca924dfd-858f-4987-9710-8cb55033be6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update `msa-common` bundling config for `msal-node-extensions` #5943",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/extensions/msal-node-extensions/package-lock.json
+++ b/extensions/msal-node-extensions/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "@azure/msal-common": "file:../../lib/msal-common",
         "@azure/msal-node-runtime": "^0.13.6-alpha.0",
         "@types/jest": "^29.5.0",
         "keytar": "^7.8.0",
@@ -31,6 +32,39 @@
         "node": ">=10"
       }
     },
+    "../../lib/msal-common": {
+      "name": "@azure/msal-common",
+      "version": "12.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.7.2",
+        "@babel/plugin-proposal-class-properties": "^7.7.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+        "@babel/preset-env": "^7.7.1",
+        "@babel/preset-typescript": "^7.7.2",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "@types/debug": "^4.1.5",
+        "@types/jest": "^27.0.0",
+        "@types/lodash": "^4.14.182",
+        "@types/sinon": "^7.5.0",
+        "husky": "^3.0.9",
+        "jest": "^27.0.4",
+        "lodash": "^4.17.21",
+        "prettier": "2.8.7",
+        "rimraf": "^3.0.2",
+        "rollup": "^3.14.0",
+        "shx": "^0.3.2",
+        "sinon": "^7.5.0",
+        "ts-jest": "^27.1.5",
+        "tslib": "^1.10.0",
+        "tslint": "^5.20.0",
+        "typescript": "^4.9.5",
+        "yargs": "^17.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -43,6 +77,10 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@azure/msal-common": {
+      "resolved": "../../lib/msal-common",
+      "link": true
     },
     "node_modules/@azure/msal-node-runtime": {
       "version": "0.13.6-alpha.0",
@@ -4063,6 +4101,34 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@azure/msal-common": {
+      "version": "file:../../lib/msal-common",
+      "requires": {
+        "@babel/core": "^7.7.2",
+        "@babel/plugin-proposal-class-properties": "^7.7.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+        "@babel/preset-env": "^7.7.1",
+        "@babel/preset-typescript": "^7.7.2",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "@types/debug": "^4.1.5",
+        "@types/jest": "^27.0.0",
+        "@types/lodash": "^4.14.182",
+        "@types/sinon": "^7.5.0",
+        "husky": "^3.0.9",
+        "jest": "^27.0.4",
+        "lodash": "^4.17.21",
+        "prettier": "2.8.7",
+        "rimraf": "^3.0.2",
+        "rollup": "^3.14.0",
+        "shx": "^0.3.2",
+        "sinon": "^7.5.0",
+        "ts-jest": "^27.1.5",
+        "tslib": "^1.10.0",
+        "tslint": "^5.20.0",
+        "typescript": "^4.9.5",
+        "yargs": "^17.5.1"
       }
     },
     "@azure/msal-node-runtime": {

--- a/extensions/msal-node-extensions/package.json
+++ b/extensions/msal-node-extensions/package.json
@@ -33,7 +33,8 @@
     "test:coverage": "jest --coverage",
     "lint": "cd ../../ && npm run lint:node:extensions",
     "lint:fix": "npm run lint -- -- --fix",
-    "prepack": "npm run build:all"
+    "prepare": "npm install ../../lib/msal-common",
+    "prepack": "cd ../../lib/msal-common && npm install --production && cd ../../extensions/msal-node-extensions && npm run build:all"
   },
   "author": {
     "name": "Microsoft",
@@ -49,6 +50,7 @@
     ]
   },
   "dependencies": {
+    "@azure/msal-common": "file:../../lib/msal-common",
     "@azure/msal-node-runtime": "^0.13.6-alpha.0",
     "@types/jest": "^29.5.0",
     "keytar": "^7.8.0",

--- a/extensions/msal-node-extensions/rollup.config.js
+++ b/extensions/msal-node-extensions/rollup.config.js
@@ -14,7 +14,7 @@ const fileHeader = `${libraryHeader}\n${useStrictHeader}`;
 export default [
     {
         // for cjs build
-        input: ["src/index.ts", "../../lib/msal-common/src/index.ts"],
+        input: "src/index.ts",
         output: {
             dir: "dist",
             format: "cjs",
@@ -42,7 +42,7 @@ export default [
     },
     {
         // for esm build
-        input: ["src/index.ts", "../../lib/msal-common/src/index.ts"],
+        input: "src/index.ts",
         output: {
             dir: "dist",
             format: "esm",

--- a/extensions/msal-node-extensions/test/performance-test/LockAndWriteToStorageScript.js
+++ b/extensions/msal-node-extensions/test/performance-test/LockAndWriteToStorageScript.js
@@ -7,7 +7,7 @@ const process = require("process");
 const extensions = require("../../dist/index");
 const fs = require("fs");
 const path = require("path");
-const msalCommon = require("../../dist/lib/msal-common/src/index");
+const msalCommon = require("@azure/msal-common");
 
 // Expect: node_path, path_to_file, filename, retryNumber, retryDelay
 if (process.argv.length < 5) {

--- a/extensions/msal-node-extensions/tsconfig.build.json
+++ b/extensions/msal-node-extensions/tsconfig.build.json
@@ -1,13 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "rootDirs": [
-            "./src",
-            "../../lib/msal-common/src"
-        ],
-        "paths": {
-            "@azure/msal-common": ["../../lib/msal-common/src"]
-        }
+        "rootDir": "./src"
     },
     "include": ["src"]
 }

--- a/extensions/msal-node-extensions/tsconfig.json
+++ b/extensions/msal-node-extensions/tsconfig.json
@@ -15,10 +15,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "rootDirs": [
-      "./",
-      "../../lib/msal-common"
-    ],
+    "rootDir": "./",
     "outDir": "./dist",
     "noUnusedLocals": true,
     "baseUrl": "./",
@@ -27,8 +24,7 @@
         "src/*",
         "node_modules/*",
         "build/"
-      ],
-      "@azure/msal-common": ["../../lib/msal-common/src"]
+      ]
     },
     "jsx": "react",
     "esModuleInterop": true


### PR DESCRIPTION
- Set `msal-common` as bundled dependency.
- Add `prepare` step to make lerna bootstrap local `msal-common` package.
- Update `prepack` step to filter out `msal-common` devDeps before publishing.
- Update tsconfig.

**_NOTE:_** `msal-common` is bundled under `node_modules` in tar file.