### PR TITLE
Fix prepack hook

### DIFF
--- a/change/@azure-msal-browser-fe2d4c6f-b59e-4528-839d-a5dd76a6f8d9.json
+++ b/change/@azure-msal-browser-fe2d4c6f-b59e-4528-839d-a5dd76a6f8d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix prepack hook #5967",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-45890e91-dc92-4a2f-a01d-23a946e715b3.json
+++ b/change/@azure-msal-node-45890e91-dc92-4a2f-a01d-23a946e715b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix prepack hook #5967",
+  "packageName": "@azure/msal-node",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-extensions-323c0b24-2e71-431f-9331-0b7b2b684b6c.json
+++ b/change/@azure-msal-node-extensions-323c0b24-2e71-431f-9331-0b7b2b684b6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix prepack hook #5967",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/extensions/msal-node-extensions/package.json
+++ b/extensions/msal-node-extensions/package.json
@@ -34,7 +34,7 @@
     "lint": "cd ../../ && npm run lint:node:extensions",
     "lint:fix": "npm run lint -- -- --fix",
     "prepare": "npm install ../../lib/msal-common",
-    "prepack": "cd ../../lib/msal-common && npm install --production && cd ../../extensions/msal-node-extensions && npm run build:all"
+    "prepack": "npm run build:all && cd ../../lib/msal-common && npm install --production && cd ../../extensions/msal-node-extensions"
   },
   "author": {
     "name": "Microsoft",

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -57,7 +57,7 @@
     "build:modules:watch": "rollup -cw --bundleConfigAsCjs",
     "build": "npm run clean && npm run build:modules",
     "prepare": "npm install ../msal-common",
-    "prepack": "cd ../msal-common && npm install --production && cd ../msal-browser && npm run build:all",
+    "prepack": "npm run build:all && cd ../msal-common && npm install --production && cd ../msal-browser",
     "format:check": "npx prettier --ignore-path .gitignore --check src test",
     "format:fix": "npx prettier --ignore-path .gitignore --write src test"
   },

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -36,7 +36,7 @@
     "build:all": "npm run build:common && npm run build",
     "build:common": "cd ../msal-common && npm run build",
     "prepare": "npm install ../msal-common",
-    "prepack": "cd ../msal-common && npm install --production && cd ../msal-node && npm run build:all",
+    "prepack": "npm run build:all && cd ../msal-common && npm install --production && cd ../msal-node",
     "format:check": "npx prettier --ignore-path .gitignore --check src test",
     "format:fix": "npx prettier --ignore-path .gitignore --write src test"
   },


### PR DESCRIPTION
- Fix prepack hook by building `msal-common` package before removing its non-production dependencies.