### PR TITLE
Add logging to `Authority.getEndpointMetadataFromNetwork()`

### DIFF
--- a/change/@azure-msal-common-cca6bc06-23ce-46fb-ac98-853c9c2a8ae9.json
+++ b/change/@azure-msal-common-cca6bc06-23ce-46fb-ac98-853c9c2a8ae9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add logging to Authority.getEndpointMetadataFromNetwork() #5973",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -500,6 +500,7 @@ export class Authority {
             this.correlationId
         );
 
+        const perfEvent = this.performanceClient?.startMeasurement(PerformanceEvents.AuthorityGetEndpointMetadataFromNetwork, this.correlationId);
         const options: ImdsOptions = {};
 
         /*
@@ -518,12 +519,15 @@ export class Authority {
                 );
             const isValidResponse = isOpenIdConfigResponse(response.body);
             if (isValidResponse) {
+                perfEvent?.endMeasurement({ success: true });
                 return response.body;
             } else {
+                perfEvent?.endMeasurement({ success: false, errorCode: "invalid_response" });
                 this.logger.verbose(`Authority.getEndpointMetadataFromNetwork: could not parse response as OpenID configuration`);
                 return null;
             }
         } catch (e) {
+            perfEvent?.endMeasurement({ success: false, errorCode: "request_failure" });
             this.logger.verbose(`Authority.getEndpointMetadataFromNetwork: ${e}`);
             return null;
         }

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -507,14 +507,24 @@ export class Authority {
          * hardcoded list of metadata
          */
 
+        const openIdConfigurationEndpoint = this.defaultOpenIdConfigurationEndpoint;
+        this.logger.verbose(`Authority.getEndpointMetadataFromNetwork: attempting to retrieve OAuth endpoints from ${openIdConfigurationEndpoint}`);
+
         try {
             const response =
                 await this.networkInterface.sendGetRequestAsync<OpenIdConfigResponse>(
-                    this.defaultOpenIdConfigurationEndpoint,
+                    openIdConfigurationEndpoint,
                     options
                 );
-            return isOpenIdConfigResponse(response.body) ? response.body : null;
+            const isValidResponse = isOpenIdConfigResponse(response.body);
+            if (isValidResponse) {
+                return response.body;
+            } else {
+                this.logger.verbose(`Authority.getEndpointMetadataFromNetwork: could not parse response as OpenID configuration`);
+                return null;
+            }
         } catch (e) {
+            this.logger.verbose(`Authority.getEndpointMetadataFromNetwork: ${e}`);
             return null;
         }
     }
@@ -590,7 +600,7 @@ export class Authority {
     /**
      * Updates the AuthorityMetadataEntity with new aliases, preferred_network and preferred_cache
      * and returns where the information was retrieved from
-     * @param metadataEntity 
+     * @param metadataEntity
      * @returns AuthorityMetadataSource
      */
     private async updateCloudDiscoveryMetadata(
@@ -1040,14 +1050,14 @@ export class Authority {
     /**
      * Transform CIAM_AUTHORIY as per the below rules:
      * If no path segments found and it is a CIAM authority (hostname ends with .ciamlogin.com), then transform it
-     * 
+     *
      * NOTE: The transformation path should go away once STS supports CIAM with the format: `tenantIdorDomain.ciamlogin.com`
      * `ciamlogin.com` can also change in the future and we should accommodate the same
-     * 
-     * @param authority 
+     *
+     * @param authority
      */
     static transformCIAMAuthority(authority: string): string {
-        
+
         let ciamAuthority = authority.endsWith(Constants.FORWARD_SLASH) ? authority : `${authority}${Constants.FORWARD_SLASH}`;
         const authorityUrl = new UrlString(authority);
         const authorityUrlComponents = authorityUrl.getUrlComponents();


### PR DESCRIPTION
- Add verbose logs to `Authority.getEndpointMetadataFromNetwork()` to capture HTTP/parsing failures.
- Add telemetry.