### PR TITLE
Revert to common as a regular dependency

### DIFF
--- a/.github/workflows/msal-node-e2e.yml
+++ b/.github/workflows/msal-node-e2e.yml
@@ -65,11 +65,8 @@ jobs:
       if: steps.lib-cache.outputs.cache-hit != 'true'
       run: npm ci --ignore-scripts
 
-    - name: Bootstrap msal-common
-      run: npx lerna --scope @azure/msal-common bootstrap
-
-    - name: Bootstrap msal-node
-      run: npx lerna --scope @azure/msal-node bootstrap
+    - name: Link local packages
+      run: npx lerna --scope @azure/msal-node --scope @azure/msal-common bootstrap
 
     - name: Build Package
       working-directory: samples/msal-node-samples
@@ -161,12 +158,6 @@ jobs:
     - name: Clean Install
       if: steps.lib-cache.outputs.cache-hit != 'true'
       run: npm ci
-
-    - name: Bootstrap msal-common
-      run: npx lerna --scope @azure/msal-common bootstrap
-
-    - name: Bootstrap msal-node
-      run: npx lerna --scope @azure/msal-node bootstrap
 
     - name: Build Package
       working-directory: samples/msal-node-samples

--- a/change/@azure-msal-browser-df6d8ea5-8684-44a4-9547-0487de81f182.json
+++ b/change/@azure-msal-browser-df6d8ea5-8684-44a4-9547-0487de81f182.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert to common as a regular dependency #5985",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-0c2121f3-a61a-42a3-bd5d-7902f0489ede.json
+++ b/change/@azure-msal-node-0c2121f3-a61a-42a3-bd5d-7902f0489ede.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert to common as a regular dependency #5985",
+  "packageName": "@azure/msal-node",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-extensions-1bd78778-5660-49b0-bb88-62c5839ed327.json
+++ b/change/@azure-msal-node-extensions-1bd78778-5660-49b0-bb88-62c5839ed327.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert to common as a regular dependency #5985",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/package-lock.json
+++ b/extensions/msal-node-extensions/package-lock.json
@@ -7,12 +7,9 @@
     "": {
       "name": "@azure/msal-node-extensions",
       "version": "1.0.0-alpha.34",
-      "bundleDependencies": [
-        "@azure/msal-common"
-      ],
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "file:../../lib/msal-common",
+        "@azure/msal-common": "14.0.0",
         "@azure/msal-node-runtime": "^0.13.6-alpha.0",
         "@types/jest": "^29.5.0",
         "keytar": "^7.8.0",

--- a/extensions/msal-node-extensions/package.json
+++ b/extensions/msal-node-extensions/package.json
@@ -33,8 +33,7 @@
     "test:coverage": "jest --coverage",
     "lint": "cd ../../ && npm run lint:node:extensions",
     "lint:fix": "npm run lint -- -- --fix",
-    "prepare": "npm install ../../lib/msal-common",
-    "prepack": "npm run build:all && cd ../../lib/msal-common && npm install --production && cd ../../extensions/msal-node-extensions"
+    "prepack": "npm run build:all"
   },
   "author": {
     "name": "Microsoft",
@@ -50,7 +49,7 @@
     ]
   },
   "dependencies": {
-    "@azure/msal-common": "file:../../lib/msal-common",
+    "@azure/msal-common": "14.0.0",
     "@azure/msal-node-runtime": "^0.13.6-alpha.0",
     "@types/jest": "^29.5.0",
     "keytar": "^7.8.0",
@@ -65,8 +64,5 @@
     "ts-jest": "^29.1.0",
     "tslib": "^2.0.0",
     "typescript": "^4.9.5"
-  },
-  "bundleDependencies": [
-    "@azure/msal-common"
-  ]
+  }
 }

--- a/lib/msal-browser/package-lock.json
+++ b/lib/msal-browser/package-lock.json
@@ -7,12 +7,9 @@
     "": {
       "name": "@azure/msal-browser",
       "version": "3.0.0-alpha.0",
-      "bundleDependencies": [
-        "@azure/msal-common"
-      ],
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "file:../msal-common"
+        "@azure/msal-common": "14.0.0"
       },
       "devDependencies": {
         "@azure/storage-blob": "^12.2.1",

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -56,8 +56,8 @@
     "build:modules": "rollup -c --strictDeprecations --bundleConfigAsCjs",
     "build:modules:watch": "rollup -cw --bundleConfigAsCjs",
     "build": "npm run clean && npm run build:modules",
-    "prepare": "npm install ../msal-common",
-    "prepack": "npm run build:all && cd ../msal-common && npm install --production && cd ../msal-browser",
+    "link:localDeps": "npx lerna bootstrap --scope @azure/msal-common --scope @azure/msal-browser",
+    "prepack": "npm run build:all",
     "format:check": "npx prettier --ignore-path .gitignore --check src test",
     "format:fix": "npx prettier --ignore-path .gitignore --write src test"
   },
@@ -91,9 +91,6 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@azure/msal-common": "file:../msal-common"
-  },
-  "bundleDependencies": [
-    "@azure/msal-common"
-  ]
+    "@azure/msal-common": "14.0.0"
+  }
 }

--- a/lib/msal-common/CHANGELOG.json
+++ b/lib/msal-common/CHANGELOG.json
@@ -2,6 +2,59 @@
   "name": "@azure/msal-common",
   "entries": [
     {
+      "date": "Tue, 02 May 2023 23:14:26 GMT",
+      "tag": "@azure/msal-common_v14.0.0",
+      "version": "14.0.0",
+      "comments": {
+        "major": [
+          {
+            "author": "sameera.gajjarapu@microsoft.com",
+            "package": "@azure/msal-common",
+            "commit": "4ba37f441c75bb5e0638dbc2c4df04adbda2eb02",
+            "comment": "Add CIAM Authority Support(#5865)"
+          }
+        ],
+        "patch": [
+          {
+            "author": "sameera.gajjarapu@microsoft.com",
+            "package": "@azure/msal-common",
+            "commit": "38c29bdb23f75989f9b1efcdd038e28586370fb0",
+            "comment": "Fix bugs in CIAM Authority Support (#5917)"
+          },
+          {
+            "author": "sameera.gajjarapu@microsoft.com",
+            "package": "@azure/msal-common",
+            "commit": "9fc8ec7d5318f6da827f755b7f7132bbddbf4a28",
+            "comment": "Update polycheck version (#5901)"
+          },
+          {
+            "author": "kapjain@microsoft.com",
+            "package": "@azure/msal-common",
+            "commit": "84a31a3476375782c63a1b558ea1fd1ec52efb40",
+            "comment": "Fix: dSTS Token dummy aud claim value for requests with scope input by using v2.0 endpoint"
+          },
+          {
+            "author": "rginsburg@microsoft.com",
+            "package": "@azure/msal-common",
+            "commit": "c0c956a1d31ca5fd4218e04616911a96eac37ba6",
+            "comment": "Exception is thrown in acquireTokenByClientCredential if tenantId is missing #5805"
+          },
+          {
+            "author": "thomas.norling@microsoft.com",
+            "package": "@azure/msal-common",
+            "commit": "4f26fba90f10fc62cc7a8774d1f079996e120d76",
+            "comment": "`removeAccount` does not throw if account does not exist in cache #5911"
+          },
+          {
+            "author": "thomas.norling@microsoft.com",
+            "package": "@azure/msal-common",
+            "commit": "629883fbfe597b56260483e4567bacd9ae9ba81d",
+            "comment": "Remove unused enum"
+          }
+        ]
+      }
+    },
+    {
       "date": "Mon, 01 May 2023 20:47:41 GMT",
       "tag": "@azure/msal-common_v13.0.0",
       "version": "13.0.0",

--- a/lib/msal-common/CHANGELOG.md
+++ b/lib/msal-common/CHANGELOG.md
@@ -4,6 +4,23 @@ This log was last generated on Tue, 02 May 2023 23:14:26 GMT and should not be m
 
 <!-- Start content -->
 
+## 14.0.0
+
+Tue, 02 May 2023 23:14:26 GMT
+
+### Major changes
+
+- Add CIAM Authority Support(#5865) (sameera.gajjarapu@microsoft.com)
+
+### Patches
+
+- Fix bugs in CIAM Authority Support (#5917) (sameera.gajjarapu@microsoft.com)
+- Update polycheck version (#5901) (sameera.gajjarapu@microsoft.com)
+- Fix: dSTS Token dummy aud claim value for requests with scope input by using v2.0 endpoint (kapjain@microsoft.com)
+- Exception is thrown in acquireTokenByClientCredential if tenantId is missing #5805 (rginsburg@microsoft.com)
+- `removeAccount` does not throw if account does not exist in cache #5911 (thomas.norling@microsoft.com)
+- Remove unused enum (thomas.norling@microsoft.com)
+
 ## 13.0.0
 
 Mon, 01 May 2023 20:47:41 GMT

--- a/lib/msal-node/package-lock.json
+++ b/lib/msal-node/package-lock.json
@@ -7,12 +7,9 @@
     "": {
       "name": "@azure/msal-node",
       "version": "2.0.0-alpha.0",
-      "bundleDependencies": [
-        "@azure/msal-common"
-      ],
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "file:../msal-common",
+        "@azure/msal-common": "14.0.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -35,8 +35,8 @@
     "lint:fix": "npm run lint -- -- --fix",
     "build:all": "npm run build:common && npm run build",
     "build:common": "cd ../msal-common && npm run build",
-    "prepare": "npm install ../msal-common",
-    "prepack": "npm run build:all && cd ../msal-common && npm install --production && cd ../msal-node",
+    "link:localDeps": "npx lerna bootstrap --scope @azure/msal-common --scope @azure/msal-node",
+    "prepack": "npm run build:all",
     "format:check": "npx prettier --ignore-path .gitignore --check src test",
     "format:fix": "npx prettier --ignore-path .gitignore --write src test"
   },
@@ -64,14 +64,11 @@
     "yargs": "^17.3.1"
   },
   "dependencies": {
-    "@azure/msal-common": "file:../msal-common",
+    "@azure/msal-common": "14.0.0",
     "jsonwebtoken": "^9.0.0",
     "uuid": "^8.3.0"
   },
   "engines": {
     "node": "18 || 20"
-  },
-  "bundleDependencies": [
-    "@azure/msal-common"
-  ]
+  }
 }


### PR DESCRIPTION
This PR:

- Reverts `msal-browser` dependency config to use `msal-common` as a regular dependency rather than a `bundleDependency`
- Restores MSAL Common change logs that were merged into msal-browser's
- Pins `msal-common` version