### PR TITLE
added new ClientConfigurationError for invalid authority in request - v2

### DIFF
--- a/change/@azure-msal-browser-29886468-4240-4b78-af7b-3780b4fcc764.json
+++ b/change/@azure-msal-browser-29886468-4240-4b78-af7b-3780b4fcc764.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "added authority check for native flow",
+  "comment": "Added authority check for native and silent flows #6002",
   "packageName": "@azure/msal-browser",
   "email": "lalimasharda@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-29886468-4240-4b78-af7b-3780b4fcc764.json
+++ b/change/@azure-msal-browser-29886468-4240-4b78-af7b-3780b4fcc764.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added authority check for native flow",
+  "packageName": "@azure/msal-browser",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-0e8eab18-58d4-40bd-869e-aa2e9705cef2.json
+++ b/change/@azure-msal-common-0e8eab18-58d4-40bd-869e-aa2e9705cef2.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "Added new ClientConfigurationError type for authority mismatch in login request #6002",
   "packageName": "@azure/msal-common",
   "email": "lalimasharda@microsoft.com",

--- a/change/@azure-msal-common-0e8eab18-58d4-40bd-869e-aa2e9705cef2.json
+++ b/change/@azure-msal-common-0e8eab18-58d4-40bd-869e-aa2e9705cef2.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
-  "comment": " added new ClientAuthError type for environment mismatch in account #6002",
+  "comment": "Added new ClientConfigurationError type for authority mismatch in login request #6002",
   "packageName": "@azure/msal-common",
   "email": "lalimasharda@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/change/@azure-msal-common-0e8eab18-58d4-40bd-869e-aa2e9705cef2.json
+++ b/change/@azure-msal-common-0e8eab18-58d4-40bd-869e-aa2e9705cef2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": " added new ClientAuthError type for environment mismatch in account #6002",
+  "packageName": "@azure/msal-common",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-0e8eab18-58d4-40bd-869e-aa2e9705cef2.json
+++ b/change/@azure-msal-common-0e8eab18-58d4-40bd-869e-aa2e9705cef2.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Added new ClientConfigurationError type for authority mismatch in login request #6002",
   "packageName": "@azure/msal-common",
   "email": "lalimasharda@microsoft.com",
-  "dependentChangeType": "minor"
+  "dependentChangeType": "patch"
 }

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -138,9 +138,8 @@ export abstract class BaseInteractionClient {
      */
     async validateRequestAuthority(authority: string, account: AccountInfo): Promise<void> {
         const discoveredAuthority = await this.getDiscoveredAuthority(authority);
-        const validAuthority = discoveredAuthority.isAlias(account.environment) || discoveredAuthority.isAlias(this.config.auth.authority);
         
-        if(!validAuthority) {
+        if(!discoveredAuthority.isAlias(account.environment)) {
             throw ClientConfigurationError.createAuthorityMismatchError();
         }
     }

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -536,6 +536,11 @@ export class NativeInteractionClient extends BaseInteractionClient {
         this.logger.trace("NativeInteractionClient - initializeNativeRequest called");
 
         const authority = request.authority || this.config.auth.authority;
+
+        if (request.account) {
+            await this.validateRequestAuthority(authority, request.account);
+        }
+
         const canonicalAuthority = new UrlString(authority);
         canonicalAuthority.validateAsUri();
 

--- a/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
@@ -69,7 +69,7 @@ export class SilentCacheClient extends StandardInteractionClient {
         this.performanceClient.setPreQueueTime(PerformanceEvents.InitializeBaseRequest, this.correlationId);
         return {
             ...request,
-            ...await this.initializeBaseRequest(request),
+            ...await this.initializeBaseRequest(request, account),
             account: account,
             forceRefresh: request.forceRefresh || false
         };

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -19,7 +19,7 @@ export class SilentRefreshClient extends StandardInteractionClient {
         this.performanceClient.setPreQueueTime(PerformanceEvents.InitializeBaseRequest, request.correlationId);
         const silentRequest: CommonSilentFlowRequest = {
             ...request,
-            ...await this.initializeBaseRequest(request)
+            ...await this.initializeBaseRequest(request, request.account)
         };
         const acquireTokenMeasurement = this.performanceClient.startMeasurement(PerformanceEvents.SilentRefreshClientAcquireToken, silentRequest.correlationId);
         const serverTelemetryManager = this.initializeServerTelemetryManager(ApiId.acquireTokenSilent_silentFlow);

--- a/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
@@ -142,19 +142,7 @@ describe("BaseInteractionClient", () => {
                 username: testIdTokenClaims.preferred_username || ""
             };
 
-            const testAccount1: AccountEntity = new AccountEntity();
-            testAccount1.homeAccountId = testAccountInfo1.homeAccountId;
-            testAccount1.localAccountId = testAccountInfo1.localAccountId;
-            testAccount1.environment = testAccountInfo1.environment;
-            testAccount1.realm = testAccountInfo1.tenantId;
-            testAccount1.username = testAccountInfo1.username;
-            testAccount1.name = testAccountInfo1.name;
-            testAccount1.authorityType = "MSSTS";
-            testAccount1.clientInfo = TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
-
             pca.setActiveAccount(testAccountInfo1);
-            // @ts-ignore
-            pca.browserStorage.setAccount(testAccount1);
         });
 
         afterEach(() => {
@@ -164,30 +152,30 @@ describe("BaseInteractionClient", () => {
         it("Throw error when authority in request or MSAL config does not match with environment set for account", async () => {
             let loginRequest = {
                 authority: "https://login.windows-ppe.net/common",
-                account: pca.getActiveAccount()
+                account: testAccountInfo1
             };
 
-            if(loginRequest.account) {
-                await testClient.validateRequestAuthority(loginRequest.authority, loginRequest.account)
-                    .catch(error => {
-                        expect(error).toStrictEqual(ClientConfigurationError.createAuthorityMismatchError());
-                });
-            };
+            await testClient.validateRequestAuthority(loginRequest.authority, loginRequest.account)
+                .then(() => {
+                    throw "String unexpected";
+                })
+                .catch(error => {
+                    expect(error).toStrictEqual(ClientConfigurationError.createAuthorityMismatchError());
+            });
         });
 
-        it("Does not throw error when authority in request or MSAL config matches with environment set for account", async () => {
+        it("Does not throw error when authority in request or MSAL config matches with environment set for account", (done) => {
             let loginRequest = {
                 authority: "https://login.microsoftonline.com/common",
-                account: pca.getActiveAccount()
+                account: testAccountInfo1
             };
 
-            if(loginRequest.account) {
-                await testClient.validateRequestAuthority(loginRequest.authority, loginRequest.account)
-                    .then( error => {
-                        expect(error).toBe(undefined);
-                    }
-                );
-            };
+            testClient.validateRequestAuthority(loginRequest.authority, loginRequest.account)
+                .then(() => { 
+                    done();
+                }).catch(error => {
+                    done(error);
+            });
         });
     });
 });

--- a/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
@@ -157,7 +157,7 @@ describe("BaseInteractionClient", () => {
 
             await testClient.validateRequestAuthority(loginRequest.authority, loginRequest.account)
                 .then(() => {
-                    throw "String unexpected";
+                    throw "This is unexpected. This call should have failed.";
                 })
                 .catch(error => {
                     expect(error).toStrictEqual(ClientConfigurationError.createAuthorityMismatchError());

--- a/lib/msal-common/src/error/ClientAuthError.ts
+++ b/lib/msal-common/src/error/ClientAuthError.ts
@@ -211,6 +211,10 @@ export const ClientAuthErrorMessage = {
     userCanceledError: {
         code: "user_canceled",
         desc: "User canceled the flow."
+    },
+    environmentMismatch: {
+        code: "environment_mismatch",
+        desc: "Environment mismatch error. Environment provided in account should match with authority provided in login request or MSAL.js configuration options."
     }
 };
 
@@ -576,4 +580,8 @@ export class ClientAuthError extends AuthError {
     static createUserCanceledError(): ClientAuthError {
         return new ClientAuthError(ClientAuthErrorMessage.userCanceledError.code, ClientAuthErrorMessage.userCanceledError.desc);
     }
+
+    /**
+     * Create an error when the authority/environment provided in account does not match authority
+     */
 }

--- a/lib/msal-common/src/error/ClientAuthError.ts
+++ b/lib/msal-common/src/error/ClientAuthError.ts
@@ -582,6 +582,9 @@ export class ClientAuthError extends AuthError {
     }
 
     /**
-     * Create an error when the authority/environment provided in account does not match authority
+     * Create an error when the environment provided in account does not match authority provided in request or MSAL.js configuration.
      */
+    static createEnvironmentMismatchError(): ClientAuthError {
+        return new ClientAuthError(ClientAuthErrorMessage.environmentMismatch.code, ClientAuthErrorMessage.environmentMismatch.desc);
+    }
 }

--- a/lib/msal-common/src/error/ClientAuthError.ts
+++ b/lib/msal-common/src/error/ClientAuthError.ts
@@ -211,10 +211,6 @@ export const ClientAuthErrorMessage = {
     userCanceledError: {
         code: "user_canceled",
         desc: "User canceled the flow."
-    },
-    environmentMismatch: {
-        code: "environment_mismatch",
-        desc: "Environment mismatch error. Environment provided in account should match with authority provided in login request or MSAL.js configuration options."
     }
 };
 
@@ -579,12 +575,5 @@ export class ClientAuthError extends AuthError {
      */
     static createUserCanceledError(): ClientAuthError {
         return new ClientAuthError(ClientAuthErrorMessage.userCanceledError.code, ClientAuthErrorMessage.userCanceledError.desc);
-    }
-
-    /**
-     * Create an error when the environment provided in account does not match authority provided in request or MSAL.js configuration.
-     */
-    static createEnvironmentMismatchError(): ClientAuthError {
-        return new ClientAuthError(ClientAuthErrorMessage.environmentMismatch.code, ClientAuthErrorMessage.environmentMismatch.desc);
     }
 }

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -311,7 +311,7 @@ export class ClientConfigurationError extends ClientAuthError {
     /**
      * Create an error when the authority provided in request does not match authority provided in account or MSAL.js configuration.
      */
-    static createAuthorityMismatchError(): ClientAuthError {
-        return new ClientAuthError(ClientConfigurationErrorMessage.authorityMismatch.code, ClientConfigurationErrorMessage.authorityMismatch.desc);
+    static createAuthorityMismatchError(): ClientConfigurationError {
+        return new ClientConfigurationError(ClientConfigurationErrorMessage.authorityMismatch.code, ClientConfigurationErrorMessage.authorityMismatch.desc);
     }
 }

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -103,7 +103,7 @@ export const ClientConfigurationErrorMessage = {
     },
     authorityMismatch: {
         code: "authority_mismatch",
-        desc: "Authority mismatch error. Authority provided in login request should match with environment/authority provided in account or MSAL.js configuration options."
+        desc: "Authority mismatch error. Authority provided in login request does not match with environment/authority provided in account or MSAL.js configuration options. Please make an interactive request to login."
     }
 };
 

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -103,7 +103,7 @@ export const ClientConfigurationErrorMessage = {
     },
     authorityMismatch: {
         code: "authority_mismatch",
-        desc: "Authority mismatch error. Authority provided in login request does not match with environment/authority provided in account or MSAL.js configuration options. Please make an interactive request to login."
+        desc: "Authority mismatch error. Authority provided in login request or PublicClientApplication config does not match the environment of the provided account. Please use a matching account or make an interactive request to login to this authority."
     }
 };
 

--- a/lib/msal-common/src/error/ClientConfigurationError.ts
+++ b/lib/msal-common/src/error/ClientConfigurationError.ts
@@ -100,6 +100,10 @@ export const ClientConfigurationErrorMessage = {
     invalidAuthenticationHeader: {
         code: "invalid_authentication_header",
         desc: "Invalid authentication header provided"
+    },
+    authorityMismatch: {
+        code: "authority_mismatch",
+        desc: "Authority mismatch error. Authority provided in login request should match with environment/authority provided in account or MSAL.js configuration options."
     }
 };
 
@@ -302,5 +306,12 @@ export class ClientConfigurationError extends ClientAuthError {
     static createInvalidAuthenticationHeaderError(invalidHeaderName: string, details: string): ClientConfigurationError {
         return new ClientConfigurationError(ClientConfigurationErrorMessage.invalidAuthenticationHeader.code,
             `${ClientConfigurationErrorMessage.invalidAuthenticationHeader.desc}. Invalid header: ${invalidHeaderName}. Details: ${details}`);
+    }
+    
+    /**
+     * Create an error when the authority provided in request does not match authority provided in account or MSAL.js configuration.
+     */
+    static createAuthorityMismatchError(): ClientAuthError {
+        return new ClientAuthError(ClientConfigurationErrorMessage.authorityMismatch.code, ClientConfigurationErrorMessage.authorityMismatch.desc);
     }
 }

--- a/lib/msal-common/test/error/ClientConfigurationError.spec.ts
+++ b/lib/msal-common/test/error/ClientConfigurationError.spec.ts
@@ -190,4 +190,18 @@ describe("ClientConfigurationError.ts Class Unit Tests", () => {
         expect(err.name).toBe("ClientConfigurationError");
         expect(err.stack?.includes("ClientConfigurationError.spec.ts")).toBe(true);
     });
+
+    it("createAuthorityMismatchError creates a ClientConfigurationError object", () => {
+        const err: ClientConfigurationError = ClientConfigurationError.createAuthorityMismatchError();
+
+        expect(err instanceof ClientConfigurationError).toBe(true);
+        expect(err instanceof ClientAuthError).toBe(true);
+        expect(err instanceof AuthError).toBe(true);
+        expect(err instanceof Error).toBe(true);
+        expect(err.errorCode).toBe(ClientConfigurationErrorMessage.authorityMismatch.code);
+        expect(err.errorMessage.includes(ClientConfigurationErrorMessage.authorityMismatch.desc)).toBe(true);
+        expect(err.message.includes(ClientConfigurationErrorMessage.authorityMismatch.desc)).toBe(true);
+        expect(err.name).toBe("ClientConfigurationError");
+        expect(err.stack?.includes("ClientConfigurationError.spec.ts")).toBe(true);
+    });
 });


### PR DESCRIPTION
Throw authority mismatch error in the acquire token silent and native cases if the authority in request does not match environment specified in the account obj or MSAL config.