### PR TITLE
Support tenant switching for tenant domain names

### DIFF
--- a/change/@azure-msal-common-f0736a66-3f12-4680-a218-fe4a3d9b97de.json
+++ b/change/@azure-msal-common-f0736a66-3f12-4680-a218-fe4a3d9b97de.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support tenant switching for tenant domain names #6011",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -59,7 +59,13 @@ export class Authority {
     // Correlation Id
     protected correlationId: string | undefined;
     // Reserved tenant domain names that will not be replaced with tenant id
-    private static reservedTenantDomains: Set<string> = new Set([Constants.DEFAULT_COMMON_TENANT, "{tenant}", "{tenantid}"]);
+    private static reservedTenantDomains: Set<string> = new Set([
+        Constants.DEFAULT_COMMON_TENANT,
+        "{tenant}",
+        "{tenantid}",
+        "consumers",
+        "organizations"
+    ]);
 
     constructor(
         authority: string,
@@ -235,11 +241,11 @@ export class Authority {
     }
 
     /**
-     * Returns a flag indicating that authority {@link IUri} type is AAD
+     * Returns a flag indicating that tenant name can be replaced in authority {@link IUri}
      * @param authorityUri {@link IUri}
      * @private
      */
-    private isAADAuthority(authorityUri: IUri): boolean {
+    private canReplaceTenant(authorityUri: IUri): boolean {
         return authorityUri.PathSegments.length === 1
             && !Authority.reservedTenantDomains.has(authorityUri.PathSegments[0])
             && this.getAuthorityType(authorityUri) === AuthorityType.Default
@@ -267,7 +273,7 @@ export class Authority {
 
         currentAuthorityParts.forEach((currentPart, index) => {
             let cachedPart = cachedAuthorityParts[index];
-            if (index === 0 && this.isAADAuthority(cachedAuthorityUrlComponents))
+            if (index === 0 && this.canReplaceTenant(cachedAuthorityUrlComponents))
             {
                 const tenantId = (new UrlString(this.metadata.authorization_endpoint)).getUrlComponents().PathSegments[0];
                 /**

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -9,7 +9,7 @@ import { UrlString } from "../url/UrlString";
 import { IUri } from "../url/IUri";
 import { ClientAuthError } from "../error/ClientAuthError";
 import { INetworkModule } from "../network/INetworkModule";
-import { AuthorityMetadataSource, Constants, RegionDiscoveryOutcomes } from "../utils/Constants";
+import { AADAuthorityConstants, AuthorityMetadataSource, Constants, RegionDiscoveryOutcomes } from "../utils/Constants";
 import { EndpointMetadata, InstanceDiscoveryMetadata } from "./AuthorityMetadata";
 import { ClientConfigurationError } from "../error/ClientConfigurationError";
 import { ProtocolMode } from "./ProtocolMode";
@@ -59,13 +59,14 @@ export class Authority {
     // Correlation Id
     protected correlationId: string | undefined;
     // Reserved tenant domain names that will not be replaced with tenant id
-    private static reservedTenantDomains: Set<string> = new Set([
-        Constants.DEFAULT_COMMON_TENANT,
+    private static reservedTenantDomains: Set<string> = (new Set([
         "{tenant}",
         "{tenantid}",
-        "consumers",
-        "organizations"
-    ]);
+        AADAuthorityConstants.COMMON,
+        AADAuthorityConstants.CONSUMERS,
+        AADAuthorityConstants.ORGANIZATIONS
+    ]));
+
 
     constructor(
         authority: string,

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -67,7 +67,6 @@ export class Authority {
         AADAuthorityConstants.ORGANIZATIONS
     ]));
 
-
     constructor(
         authority: string,
         networkInterface: INetworkModule,

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -240,7 +240,7 @@ describe("Authority.ts Class Unit Tests", () => {
             it("Returns correct endpoint when cached canonical endpoint contains tenant name", async () => {
                 jest.spyOn(Authority.prototype, <any>"getEndpointMetadataFromNetwork").mockResolvedValue(response);
 
-                const tenantDomain = "tenant.domain.name.com";
+                const tenantDomain = "test.tenant.domain.name.onmicrosoft.com";
                 const customAuthority = new Authority(`https://login.microsoftonline.com/${tenantDomain}/`, networkInterface, mockStorage, authorityOptions, logger);
                 await customAuthority.resolveEndpointsAsync();
 

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -207,10 +207,13 @@ describe("Authority.ts Class Unit Tests", () => {
             });
         });
 
-        describe("Swap tenants", () => {
+        describe("Switch tenants", () => {
             const tenant = "51db77ae-2865-4010-bc5d-8f99097f494b";
             const newTenant = "1d56e21e-b696-410b-83a0-bc2d775d0b39";
-            const response = {...DEFAULT_OPENID_CONFIG_RESPONSE.body};
+            const tenantDomain = "tenant.domain.onmicrosoft.com";
+            const newTenantDomain = "new.tenant.domain.onmicrosoft.com";
+            const response = { ...DEFAULT_OPENID_CONFIG_RESPONSE.body };
+            const b2cResponse = { ...B2C_OPENID_CONFIG_RESPONSE.body };
             for (const [key, value] of Object.entries(response)) {
                 if (typeof response[key] === "string") {
                     // @ts-ignore
@@ -218,7 +221,7 @@ describe("Authority.ts Class Unit Tests", () => {
                 }
             }
 
-            it("Returns correct endpoint", async () => {
+            it("Returns correct endpoint for AAD", async () => {
                 jest.spyOn(Authority.prototype, <any>"getEndpointMetadataFromNetwork").mockResolvedValue(response);
 
                 const authority = new Authority(Constants.DEFAULT_AUTHORITY, networkInterface, mockStorage, authorityOptions, logger);
@@ -237,10 +240,33 @@ describe("Authority.ts Class Unit Tests", () => {
                 expect(authority.authorizationEndpoint).toBe(response.authorization_endpoint.replace(tenant, newTenant));
             });
 
-            it("Returns correct endpoint when cached canonical endpoint contains tenant name", async () => {
+            it("Returns correct endpoint for B2C", async () => {
+                jest.spyOn(Authority.prototype, <any>"getEndpointMetadataFromNetwork").mockResolvedValue(b2cResponse);
+
+                const baseAuthority = `https://msidlabb2c.b2clogin.com/tfp/${tenantDomain}/`;
+                const customAuthority = new Authority(baseAuthority, networkInterface, mockStorage, {
+                    ...authorityOptions,
+                    knownAuthorities: ["msidlabb2c.b2clogin.com"],
+                }, logger);
+                await customAuthority.resolveEndpointsAsync();
+
+                expect(customAuthority.authorizationEndpoint).toBe(b2cResponse.authorization_endpoint);
+
+                const newAuthorityEndpoint = b2cResponse.authorization_endpoint.replace(tenantDomain, newTenantDomain);
+                const urlComponents = new UrlString(newAuthorityEndpoint).getUrlComponents();
+
+                // Mimic tenant switching
+                // @ts-ignore
+                customAuthority.metadata.authorization_endpoint = newAuthorityEndpoint;
+                jest.spyOn(Authority.prototype, <any>"canonicalAuthorityUrlComponents", "get").mockReturnValue(urlComponents);
+
+                expect(customAuthority.authorizationEndpoint).toBe(b2cResponse.authorization_endpoint.replace(tenantDomain, newTenantDomain));
+            });
+
+            it("Returns correct endpoint when AAD cached canonical endpoint contains tenant name", async () => {
                 jest.spyOn(Authority.prototype, <any>"getEndpointMetadataFromNetwork").mockResolvedValue(response);
 
-                const tenantDomain = "test.tenant.domain.name.onmicrosoft.com";
+
                 const customAuthority = new Authority(`https://login.microsoftonline.com/${tenantDomain}/`, networkInterface, mockStorage, authorityOptions, logger);
                 await customAuthority.resolveEndpointsAsync();
 
@@ -1006,7 +1032,7 @@ describe("Authority.ts Class Unit Tests", () => {
                 };
                 jest.spyOn(Authority.prototype, <any>"updateEndpointMetadata").mockResolvedValue("cache");
                 authority = new Authority(Constants.DEFAULT_AUTHORITY, networkInterface, mockStorage, authorityOptions, logger);
-                
+
                 await authority.resolveEndpointsAsync();
                 expect(authority.isAlias("login.microsoftonline.com")).toBe(true);
             });


### PR DESCRIPTION
- Support tenant switching for tenant domain names.
- Move `replaceTenant()` into `replacePath()`.