### PR TITLE
Update maintained node versions to fix tsdx optional chaining

### DIFF
--- a/change/@azure-msal-node-d1847685-48e5-4547-9b0b-83c286a6c4b4.json
+++ b/change/@azure-msal-node-d1847685-48e5-4547-9b0b-83c286a6c4b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update maintained node versions to fix tsdx optional chaining #6014",
+  "packageName": "@azure/msal-node",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-core/CHANGELOG.json
+++ b/lib/msal-core/CHANGELOG.json
@@ -11,7 +11,7 @@
             "author": "sameera.gajjarapu@microsoft.com",
             "package": "msal",
             "commit": "9fc8ec7d5318f6da827f755b7f7132bbddbf4a28",
-            "comment": "Update polycheck version, rename Blacklist params (#5901)"
+            "comment": "Update polycheck version, rename Blocklist params (#5901)"
           }
         ]
       }

--- a/lib/msal-core/CHANGELOG.md
+++ b/lib/msal-core/CHANGELOG.md
@@ -10,7 +10,7 @@ Mon, 01 May 2023 20:47:42 GMT
 
 ### Patches
 
-- Update polycheck version, rename Blacklist params (#5901) (sameera.gajjarapu@microsoft.com)
+- Update polycheck version, rename Blocklist params (#5901) (sameera.gajjarapu@microsoft.com)
 
 ## 1.4.17
 
@@ -192,7 +192,7 @@ Tue, 25 Aug 2020 00:40:45 GMT
 * Add onRedirectNavigate callback to stop navigatation and get redirect url. (#1691)
 * Allow applications to bypass network request for OpenID configuration. (#1578)
 * Extend acquireTokenSilent Instrumentation. (#1629)
-* Add performance instrumentation to TelemetryManager events. (#1643) 
+* Add performance instrumentation to TelemetryManager events. (#1643)
 
 # 1.3.1
 

--- a/lib/msal-node/.browserslistrc
+++ b/lib/msal-node/.browserslistrc
@@ -1,1 +1,6 @@
+node 10
+node 12
+node 14
+node 16
+node 18
 maintained node versions


### PR DESCRIPTION
- Update maintained node versions to fix `tsdx` optional chaining.
- Address Guardian pipeline errors.