### PR TITLE
bfcache bug fix for back button

### DIFF
--- a/change/@azure-msal-browser-fe9a5361-1c1d-4b36-b631-0aaa1e22e719.json
+++ b/change/@azure-msal-browser-fe9a5361-1c1d-4b36-b631-0aaa1e22e719.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix inProgress state reset when page restored from bfCache #6020",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -71,6 +71,7 @@ export class EventMessageUtils {
             case EventType.LOGIN_FAILURE:
             case EventType.ACQUIRE_TOKEN_SUCCESS:
             case EventType.ACQUIRE_TOKEN_FAILURE:
+            case EventType.RESTORE_FROM_BFCACHE:
                 if (message.interactionType === InteractionType.Redirect || message.interactionType === InteractionType.Popup) {
                     if (currentStatus && currentStatus !== InteractionStatus.Login && currentStatus !== InteractionStatus.AcquireToken) {
                         // Prevent this event from clearing any status other than login or acquireToken

--- a/lib/msal-browser/src/event/EventType.ts
+++ b/lib/msal-browser/src/event/EventType.ts
@@ -27,5 +27,6 @@ export enum EventType {
     LOGOUT_START = "msal:logoutStart",
     LOGOUT_SUCCESS = "msal:logoutSuccess",
     LOGOUT_FAILURE = "msal:logoutFailure",
-    LOGOUT_END = "msal:logoutEnd"
+    LOGOUT_END = "msal:logoutEnd",
+    RESTORE_FROM_BFCACHE = "msal:restoreFromBFCache"
 }

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -43,7 +43,7 @@ export class RedirectClient extends StandardInteractionClient {
             if (event.persisted) {
                 this.logger.verbose("Page was restored from back/forward cache. Clearing temporary cache.");
                 this.browserStorage.cleanRequestByState(validRequest.state);
-                this.eventHandler.emitEvent(EventType.RESTORE_FROM_BFCACHE);
+                this.eventHandler.emitEvent(EventType.RESTORE_FROM_BFCACHE, InteractionType.Redirect);
             }
         };
 

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -43,6 +43,7 @@ export class RedirectClient extends StandardInteractionClient {
             if (event.persisted) {
                 this.logger.verbose("Page was restored from back/forward cache. Clearing temporary cache.");
                 this.browserStorage.cleanRequestByState(validRequest.state);
+                this.eventHandler.emitEvent(EventType.RESTORE_FROM_BFCACHE);
             }
         };
 

--- a/lib/msal-browser/test/event/EventMessage.spec.ts
+++ b/lib/msal-browser/test/event/EventMessage.spec.ts
@@ -128,6 +128,17 @@ describe("EventMessage.ts Unit Tests", () => {
             expect(test2).toBe(InteractionStatus.None);
         });
 
+        it("returns status None with event type RESTORE_FROM_BFCACHE", () => {
+            TEST_EVENT_MESSAGE.eventType = EventType.RESTORE_FROM_BFCACHE;
+            TEST_EVENT_MESSAGE.interactionType = InteractionType.Redirect;
+
+            const test1 = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE, InteractionStatus.Login);
+            expect(test1).toBe(InteractionStatus.None);
+
+            const test2 = EventMessageUtils.getInteractionStatusFromEvent(TEST_EVENT_MESSAGE, InteractionStatus.AcquireToken);
+            expect(test2).toBe(InteractionStatus.None);
+        });
+
         it("returns null with event type ACQUIRE_TOKEN_SUCCESS if current interaction is not login or acquireToken", () => {
             TEST_EVENT_MESSAGE.eventType = EventType.ACQUIRE_TOKEN_SUCCESS;
             TEST_EVENT_MESSAGE.interactionType = InteractionType.Redirect;

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -1093,6 +1093,8 @@ describe("RedirectClient", () => {
                 verifier: TEST_CONFIG.TEST_VERIFIER
             });
 
+            const eventSpy = sinon.stub(EventHandler.prototype, "emitEvent");
+
             const testLogger = new Logger(loggerOptions);
             const browserCrypto = new CryptoOps(new Logger({}));
             const browserStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, cacheConfig, browserCrypto, testLogger);
@@ -1103,6 +1105,7 @@ describe("RedirectClient", () => {
                 expect(browserStorage.getTemporaryCache(browserStorage.generateNonceKey(TEST_STATE_VALUES.TEST_STATE_REDIRECT))).toEqual(RANDOM_TEST_GUID);
                 expect(browserStorage.getTemporaryCache(browserStorage.generateAuthorityKey(TEST_STATE_VALUES.TEST_STATE_REDIRECT))).toEqual(`${Constants.DEFAULT_AUTHORITY}`);
                 bfCacheCallback({ persisted: true });
+                expect(eventSpy.calledWith(EventType.RESTORE_FROM_BFCACHE, InteractionType.Redirect)).toBe(true);
                 expect(browserStorage.isInteractionInProgress()).toBe(false);
                 expect(browserStorage.getTemporaryCache(browserStorage.generateStateKey(TEST_STATE_VALUES.TEST_STATE_REDIRECT))).toEqual(null);
                 expect(browserStorage.getTemporaryCache(browserStorage.generateNonceKey(TEST_STATE_VALUES.TEST_STATE_REDIRECT))).toEqual(null);


### PR DESCRIPTION
When a page is restored from the browser bfCache, inProgress state in React/Angular won't be reset. This PR fixes this behavior.