### PR TITLE
Remove expression syntax in job conditional

### DIFF
--- a/.github/workflows/ci-template.yml
+++ b/.github/workflows/ci-template.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build-test:
-    if: ${{ inputs.should-run }}}
+    if: inputs.should-run
     runs-on: ${{ inputs.os }}
 
     steps:


### PR DESCRIPTION
Apparently Github Actions has [a bug](https://github.com/actions/runner/issues/1173) where the usage of expression syntax in an if conditional can result in false positives. The expression syntax is [implicit in if conditionals](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif) anyway so this PR removes it to address false positives in our own pipelines.