### PR TITLE
Include invalid_method as fatal WAM error

### DIFF
--- a/change/@azure-msal-browser-3ca69ce8-66f7-40dc-b81e-8a7c9742eecf.json
+++ b/change/@azure-msal-browser-3ca69ce8-66f7-40dc-b81e-8a7c9742eecf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Treat invalid_method as a fatal error for WAM #6094",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/error/NativeAuthError.ts
+++ b/lib/msal-browser/src/error/NativeAuthError.ts
@@ -7,12 +7,14 @@ import { AuthError, InteractionRequiredAuthError } from "@azure/msal-common";
 import { BrowserAuthError } from "./BrowserAuthError";
 
 export type OSError = {
-    error: number;
-    protocol_error: string;
-    properties: object;
-    status: string;
+    error?: number;
+    protocol_error?: string;
+    properties?: object;
+    status?: string;
     retryable?: boolean;
 };
+
+const INVALID_METHOD_ERROR = -2147186943;
 
 export const NativeStatusCode = {
     USER_INTERACTION_REQUIRED: "USER_INTERACTION_REQUIRED",
@@ -59,6 +61,14 @@ export class NativeAuthError extends AuthError {
             this.ext.status &&
             (this.ext.status === NativeStatusCode.PERSISTENT_ERROR ||
                 this.ext.status === NativeStatusCode.DISABLED)
+        ) {
+            return true;
+        }
+
+        if (
+            this.ext &&
+            this.ext.error &&
+            this.ext.error === INVALID_METHOD_ERROR
         ) {
             return true;
         }

--- a/lib/msal-browser/test/error/NativeAuthError.spec.ts
+++ b/lib/msal-browser/test/error/NativeAuthError.spec.ts
@@ -43,6 +43,15 @@ describe("NativeAuthError Unit Tests", () => {
                 expect(error.isFatal()).toBe(true);
             });
 
+            it("should return true for isFatal when WAM status is INVALID_METHOD_ERROR", () => {
+                const error = new NativeAuthError(
+                    "OSError",
+                    "Error processing request.",
+                    { error: -2147186943 }
+                );
+                expect(error.isFatal()).toBe(true);
+            });
+
             it("should return true for isFatal when extension throws an error", () => {
                 const error = new NativeAuthError(
                     NativeAuthErrorMessage.extensionError.code,


### PR DESCRIPTION
If the Windows Accounts extension returns the invalid_method error we should treat this as a "fatal" error and fallback to the standard flow. This can happen if the user is on an older version of Windows which does not yet support the GetToken API.