### PR TITLE
Update native flow reqcnf format (msal-lts)

### DIFF
--- a/change/@azure-msal-browser-f8ddc69f-f2dd-412d-84ec-74ae8fe2c11d.json
+++ b/change/@azure-msal-browser-f8ddc69f-f2dd-412d-84ec-74ae8fe2c11d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update req-cnf to short form for native flows #6095",
+  "packageName": "@azure/msal-browser",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-41766894-2b51-448b-ac3c-ec932bd81924.json
+++ b/change/@azure-msal-common-41766894-2b51-448b-ac3c-ec932bd81924.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update req-cnf to short form for native flow #6095",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -611,8 +611,8 @@ export class NativeInteractionClient extends BaseInteractionClient {
             const popTokenGenerator = new PopTokenGenerator(this.browserCrypto);
             const reqCnfData = await popTokenGenerator.generateCnf(shrParameters);
 
-            // to reduce the URL length, it is recommended to send the hash of the req_cnf instead of the whole string
-            validatedRequest.reqCnf = reqCnfData.reqCnfHash;
+            // to reduce the URL length, it is recommended to send the short form of the req_cnf 
+            validatedRequest.reqCnf = reqCnfData.reqCnfString;
             validatedRequest.keyId = reqCnfData.kid;
         }
 

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -468,9 +468,9 @@ export class AuthorizationCodeClient extends BaseClient {
             // pass the req_cnf for POP
             if (request.authenticationScheme === AuthenticationScheme.POP) {
                 const popTokenGenerator = new PopTokenGenerator(this.cryptoUtils);
-                // to reduce the URL length, it is recommended to send the hash of the req_cnf instead of the whole string
+                // to reduce the URL length, it is recommended to send the short form of the req_cnf
                 const reqCnfData = await popTokenGenerator.generateCnf(request);
-                parameterBuilder.addPopToken(reqCnfData.reqCnfHash);
+                parameterBuilder.addPopToken(reqCnfData.reqCnfString);
             }
         }
 

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -641,8 +641,6 @@ describe("AuthorizationCodeClient unit tests", () => {
         });
     });
 
-    });
-
     describe("handleFragmentResponse()", () => {
 
         it("returns valid server code response", async () => {

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -583,6 +583,64 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(loginUrl.includes(`${AADServerParamKeys.CODE_CHALLENGE}=${encodeURIComponent(TEST_CONFIG.TEST_CHALLENGE)}`)).toBe(true);
             expect(loginUrl.includes(`${AADServerParamKeys.CODE_CHALLENGE_METHOD}=${encodeURIComponent(Constants.S256_CODE_CHALLENGE_METHOD)}`)).toBe(true);
         });
+
+        it("Adds req-cnf as needed", async () => {
+            // Override with alternate authority openid_config
+            sinon
+                .stub(
+                    Authority.prototype,
+                    <any>"getEndpointMetadataFromNetwork"
+                )
+                .resolves(DEFAULT_OPENID_CONFIG_RESPONSE.body);
+
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            if (!config.cryptoInterface) {
+                throw TestError.createTestSetupError(
+                    "configuration cryptoInterface not initialized correctly."
+                );
+            }
+
+            const authCodeUrlRequest: CommonAuthorizationUrlRequest = {
+                redirectUri: TEST_URIS.TEST_REDIRECT_URI_LOCALHOST,
+                scopes: [
+                    ...TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                    ...TEST_CONFIG.DEFAULT_SCOPES,
+                ],
+                authority: TEST_CONFIG.validAuthority,
+                responseMode: ResponseMode.FORM_POST,
+                codeChallenge: TEST_CONFIG.TEST_CHALLENGE,
+                codeChallengeMethod: TEST_CONFIG.CODE_CHALLENGE_METHOD,
+                state: TEST_CONFIG.STATE,
+                prompt: PromptValue.LOGIN,
+                loginHint: TEST_CONFIG.LOGIN_HINT,
+                domainHint: TEST_CONFIG.DOMAIN_HINT,
+                claims: TEST_CONFIG.CLAIMS,
+                nonce: TEST_CONFIG.NONCE,
+                correlationId: RANDOM_TEST_GUID,
+                authenticationScheme: AuthenticationScheme.POP,
+                nativeBroker: true,
+            };
+            const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
+            expect(
+                loginUrl.includes(
+                    `${AADServerParamKeys.NATIVE_BROKER}=${encodeURIComponent(
+                        "1"
+                    )}`
+                )
+            ).toBe(true);
+            expect(
+                loginUrl.includes(
+                    `${AADServerParamKeys.REQ_CNF}=${encodeURIComponent(
+                        TEST_POP_VALUES.ENCODED_REQ_CNF
+                    )}`
+                )
+            ).toBe(true);
+        });
+    });
+
     });
 
     describe("handleFragmentResponse()", () => {


### PR DESCRIPTION
The req-cnf format is expected to be a short-form with base64 encoding for native flows for POP to work.