### PR TITLE
Fix silent cache bugs in native flow (msal-lts)

### DIFF
--- a/change/@azure-msal-browser-5440d5ab-ae17-4b42-b054-7512c6cb9358.json
+++ b/change/@azure-msal-browser-5440d5ab-ae17-4b42-b054-7512c6cb9358.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix silent cache bugs in native flow #6096",
+  "packageName": "@azure/msal-browser",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -229,7 +229,7 @@ export class RedirectClient extends StandardInteractionClient {
             if (!this.nativeMessageHandler) {
                 throw BrowserAuthError.createNativeConnectionNotEstablishedError();
             }
-            const nativeInteractionClient = new NativeInteractionClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, ApiId.acquireTokenPopup, this.performanceClient, this.nativeMessageHandler, serverParams.accountId, this.browserStorage, cachedRequest.correlationId);
+            const nativeInteractionClient = new NativeInteractionClient(this.config, this.browserStorage, this.browserCrypto, this.logger, this.eventHandler, this.navigationClient, ApiId.acquireTokenPopup, this.performanceClient, this.nativeMessageHandler, serverParams.accountId, this.nativeStorage, cachedRequest.correlationId);
             const { userRequestState } = ProtocolUtils.parseRequestState(this.browserCrypto, state);
             return nativeInteractionClient.acquireToken({
                 ...cachedRequest,

--- a/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthenticationScheme, AccountInfo, PromptValue, AuthenticationResult, AccountEntity, IdTokenEntity, AccessTokenEntity, CredentialType, TimeUtils, CacheManager} from "@azure/msal-common";
+import { AuthenticationScheme, AccountInfo, PromptValue, AuthenticationResult, AccountEntity, IdTokenEntity, AccessTokenEntity, CredentialType, TimeUtils, CacheManager, CacheRecord} from "@azure/msal-common";
 import sinon from "sinon";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
 import { ApiId } from "../../src/utils/BrowserConstants";
@@ -58,6 +58,14 @@ testAccessTokenEntity.expiresOn = `${TimeUtils.nowSeconds() + TEST_CONFIG.TOKEN_
 testAccessTokenEntity.cachedAt = `${TimeUtils.nowSeconds()}`;
 testAccessTokenEntity.tokenType = AuthenticationScheme.BEARER;
 
+const testCacheRecord: CacheRecord = {
+    account: testAccountEntity,
+    idToken: testIdToken,
+    accessToken: testAccessTokenEntity,
+    refreshToken: null,
+    appMetadata: null,
+};
+
 describe("NativeInteractionClient Tests", () => {
     globalThis.MessageChannel = require("worker_threads").MessageChannel; // jsdom does not include an implementation for MessageChannel
 
@@ -102,7 +110,7 @@ describe("NativeInteractionClient Tests", () => {
         };
 
         sinon.stub(CacheManager.prototype, "getAccountInfoFilteredBy").returns(testAccountInfo);
-        sinon.stub(SilentCacheClient.prototype, "acquireToken").callsFake(() => { return Promise.resolve(response); });
+        sinon.stub(CacheManager.prototype, "readCacheRecord").returns(testCacheRecord);
 
         it("Tokens found in cache", async () => {
             const response = await nativeInteractionClient.acquireToken({ scopes: TEST_CONFIG.DEFAULT_SCOPES });


### PR DESCRIPTION
This PR fixes two bugs:

Fix a typo that is passing browserStorage instead of nativeStorage in RedirectClient for native flows.
Rewrite cache look ups based on cache optimization to perform correct look ups in silent cases.