### PR TITLE
Extend proactive token refresh to obo

### DIFF
--- a/change/@azure-msal-node-72c6549c-c7bd-4a75-9c27-04564afb7fe2.json
+++ b/change/@azure-msal-node-72c6549c-c7bd-4a75-9c27-04564afb7fe2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Extend proactive token refresh to obo",
+  "packageName": "@azure/msal-node",
+  "email": "rgins16@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-72c6549c-c7bd-4a75-9c27-04564afb7fe2.json
+++ b/change/@azure-msal-node-72c6549c-c7bd-4a75-9c27-04564afb7fe2.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Extend proactive token refresh to obo",
   "packageName": "@azure/msal-node",
-  "email": "rgins16@gmail.com",
+  "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -123,7 +123,7 @@ export class OnBehalfOfClient extends BaseClient {
                 CacheOutcome.REFRESH_CACHED_ACCESS_TOKEN
             );
             this.logger.info(
-                "ClientCredentialClient:getCachedAuthenticationResult - Cached access token's refreshOn property has been exceeded'."
+                "OnbehalfofFlow:getCachedAuthenticationResult - Cached access token's refreshOn property has been exceeded'."
             );
             throw ClientAuthError.createRefreshRequiredError();
         }

--- a/lib/msal-node/test/client/OnBehalfOfClient.spec.ts
+++ b/lib/msal-node/test/client/OnBehalfOfClient.spec.ts
@@ -425,7 +425,7 @@ describe("OnBehalfOf unit tests", () => {
             );
         });
 
-        it("acquireToken fails because the cached token's refreshOn value is expired", async () => {
+        it("re-acquires a token via a network request, because the cached token's refreshOn value is expired", async () => {
             const testAccessTokenEntityWithExpiredRefreshOn = testAccessTokenEntity;
             testAccessTokenEntityWithExpiredRefreshOn.refreshOn = (TimeUtils.nowSeconds() - 4600).toString();
 


### PR DESCRIPTION
MSAL is expected to refresh the token when the refresh_in value expires. This is already implemented for AcquireTokenSilent but is not implemented for obo. This PR implements refresh_in for obo.