### PR TITLE
Remove unused params in msal-common

### DIFF
--- a/change/@azure-msal-common-88c5a75c-383e-4f9b-946d-7348934522f9.json
+++ b/change/@azure-msal-common-88c5a75c-383e-4f9b-946d-7348934522f9.json
@@ -3,5 +3,5 @@
   "comment": "Remove unused params in msal-common #6122",
   "packageName": "@azure/msal-common",
   "email": "kshabelko@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@azure-msal-common-88c5a75c-383e-4f9b-946d-7348934522f9.json
+++ b/change/@azure-msal-common-88c5a75c-383e-4f9b-946d-7348934522f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unused params in msal-common #6122",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/request/RequestValidator.ts
+++ b/lib/msal-common/src/request/RequestValidator.ts
@@ -101,7 +101,7 @@ export class RequestValidator {
 
         // remove empty string parameters
         return Object.fromEntries(
-            Object.entries(eQParams).filter(([key, value]) => value !== "") // eslint-disable-line @typescript-eslint/no-unused-vars
+            Object.entries(eQParams).filter(kv => kv[1] !== "")
         );
     }
 }

--- a/lib/msal-common/src/telemetry/performance/StubPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/StubPerformanceClient.ts
@@ -6,16 +6,11 @@
 import { IPerformanceClient } from "./IPerformanceClient";
 import { IPerformanceMeasurement } from "./IPerformanceMeasurement";
 import { PerformanceClient } from "./PerformanceClient";
-import { PerformanceEvents } from "./PerformanceEvent";
 
 export class StubPerformanceMeasurement implements IPerformanceMeasurement {
-    /* eslint-disable-next-line @typescript-eslint/no-empty-function */
-    startMeasurement(): void {}
-    /* eslint-disable-next-line @typescript-eslint/no-empty-function */
-    endMeasurement(): void {}
-    flushMeasurement(): number | null {
-        return null;
-    }
+    startMeasurement(): void { return; }
+    endMeasurement(): void { return; }
+    flushMeasurement(): number | null { return null; }
 }
 
 export class StubPerformanceClient
@@ -30,23 +25,11 @@ export class StubPerformanceClient
         return new StubPerformanceMeasurement();
     }
 
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    calculateQueuedTime(preQueueTime: number, currentTime: number): number {
+    calculateQueuedTime(): number {
         return 0;
     }
 
-    addQueueMeasurement(
-        eventName: PerformanceEvents, // eslint-disable-line @typescript-eslint/no-unused-vars
-        correlationId: string, // eslint-disable-line @typescript-eslint/no-unused-vars
-        queueTime: number // eslint-disable-line @typescript-eslint/no-unused-vars
-    ): void {
-        return;
-    }
+    addQueueMeasurement(): void { return; }
 
-    setPreQueueTime(
-        eventName: PerformanceEvents, // eslint-disable-line @typescript-eslint/no-unused-vars
-        correlationId?: string | undefined // eslint-disable-line @typescript-eslint/no-unused-vars
-    ): void {
-        return;
-    }
+    setPreQueueTime(): void { return; }
 }

--- a/lib/msal-common/tsconfig.json
+++ b/lib/msal-common/tsconfig.json
@@ -17,7 +17,7 @@
             "strictPropertyInitialization": false,
             "noImplicitThis": true,
             "noUnusedLocals": true,
-            "noUnusedParameters": false,
+            "noUnusedParameters": true,
             "noImplicitAny": false,
             "noFallthroughCasesInSwitch": true
         }


### PR DESCRIPTION
- Remove unused params in msal-common.
- Enable "noUnusedParameters" in tsconfig.json.