### PR TITLE
Make account info mandatory for AuthenticationResult and CacheRecord types.

### DIFF
--- a/change/@azure-msal-browser-327c8ac5-8041-4c9b-9b4c-fa7ca85e713f.json
+++ b/change/@azure-msal-browser-327c8ac5-8041-4c9b-9b4c-fa7ca85e713f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make account info mandatory for AuthenticationResult and CacheRecord types #6156",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-327c8ac5-8041-4c9b-9b4c-fa7ca85e713f.json
+++ b/change/@azure-msal-browser-327c8ac5-8041-4c9b-9b4c-fa7ca85e713f.json
@@ -3,5 +3,5 @@
   "comment": "Make account info mandatory for AuthenticationResult and CacheRecord types #6156",
   "packageName": "@azure/msal-browser",
   "email": "kshabelko@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    AuthenticationResult,
     AccountInfo,
     Logger,
     PerformanceCallbackFunction,
@@ -21,6 +20,7 @@ import { EndSessionPopupRequest } from "../request/EndSessionPopupRequest";
 import { ITokenCache } from "../cache/ITokenCache";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { BrowserConfiguration } from "../config/Configuration";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export interface IPublicClientApplication {
     initialize(): Promise<void>;

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -13,7 +13,6 @@ import { WrapperSKU } from "../utils/BrowserConstants";
 import { IPublicClientApplication } from "./IPublicClientApplication";
 import { IController } from "../controllers/IController";
 import {
-    AuthenticationResult,
     PerformanceCallbackFunction,
     AccountInfo,
     Logger,
@@ -24,6 +23,7 @@ import { ControllerFactory } from "../controllers/ControllerFactory";
 import { StandardController } from "../controllers/StandardController";
 import { BrowserConfiguration, Configuration } from "../config/Configuration";
 import { StandardOperatingContext } from "../operatingcontext/StandardOperatingContext";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 /**
  * The PublicClientApplication class is the object exposed by the library to perform authentication and authorization functions in Single Page Applications

--- a/lib/msal-browser/src/cache/ITokenCache.ts
+++ b/lib/msal-browser/src/cache/ITokenCache.ts
@@ -4,11 +4,11 @@
  */
 
 import {
-    ExternalTokenResponse,
-    AuthenticationResult,
+    ExternalTokenResponse
 } from "@azure/msal-common";
 import { SilentRequest } from "../request/SilentRequest";
 import { LoadTokenOptions } from "./TokenCache";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export interface ITokenCache {
     /**

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -16,8 +16,6 @@ import {
     AuthToken,
     RefreshTokenEntity,
     AuthorityType,
-    CacheRecord,
-    AuthenticationResult,
     Constants,
 } from "@azure/msal-common";
 import { BrowserConfiguration } from "../config/Configuration";
@@ -25,6 +23,8 @@ import { SilentRequest } from "../request/SilentRequest";
 import { BrowserCacheManager } from "./BrowserCacheManager";
 import { ITokenCache } from "./ITokenCache";
 import { BrowserAuthError } from "../error/BrowserAuthError";
+import { AuthenticationResult } from "../response/AuthenticationResult";
+import { CacheRecord } from "./entities/CacheRecord";
 
 export type LoadTokenOptions = {
     clientInfo?: string;
@@ -84,7 +84,7 @@ export class TokenCache implements ITokenCache {
 
         const idToken = new AuthToken(response.id_token, this.cryptoObj);
 
-        let cacheRecord: CacheRecord | undefined;
+        let cacheRecord: CacheRecord;
         let authority: Authority | undefined;
 
         if (request.account) {
@@ -435,7 +435,7 @@ export class TokenCache implements ITokenCache {
     private generateAuthenticationResult(
         request: SilentRequest,
         idTokenObj: AuthToken,
-        cacheRecord?: CacheRecord,
+        cacheRecord: CacheRecord,
         authority?: Authority
     ): AuthenticationResult {
         let accessToken: string = Constants.EMPTY_STRING;
@@ -469,9 +469,7 @@ export class TokenCache implements ITokenCache {
             uniqueId: uid,
             tenantId: tid,
             scopes: responseScopes,
-            account: cacheRecord?.account
-                ? cacheRecord.account.getAccountInfo()
-                : null,
+            account: cacheRecord.account.getAccountInfo(),
             idToken: idTokenObj ? idTokenObj.rawToken : Constants.EMPTY_STRING,
             idTokenClaims: idTokenObj ? idTokenObj.claims : {},
             accessToken: accessToken,

--- a/lib/msal-browser/src/cache/entities/CacheRecord.ts
+++ b/lib/msal-browser/src/cache/entities/CacheRecord.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    AccessTokenEntity,
+    AccountEntity,
+    AppMetadataEntity,
+    CacheRecord as CommonCacheRecord,
+    IdTokenEntity,
+    RefreshTokenEntity
+} from "@azure/msal-common";
+
+export class CacheRecord extends CommonCacheRecord {
+    account: AccountEntity;
+
+    constructor(
+        accountEntity: AccountEntity,
+        idTokenEntity?: IdTokenEntity | null,
+        accessTokenEntity?: AccessTokenEntity | null,
+        refreshTokenEntity?: RefreshTokenEntity | null,
+        appMetadataEntity?: AppMetadataEntity | null
+    ) {
+        super(accountEntity, idTokenEntity, accessTokenEntity, refreshTokenEntity, appMetadataEntity);
+        this.account = accountEntity;
+    }
+}

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    AuthenticationResult,
     AccountInfo,
     Logger,
     PerformanceCallbackFunction,
@@ -28,6 +27,7 @@ import { NativeMessageHandler } from "../broker/nativeBroker/NativeMessageHandle
 import { EventHandler } from "../event/EventHandler";
 import { PopupClient } from "../interaction_client/PopupClient";
 import { SilentIframeClient } from "../interaction_client/SilentIframeClient";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export interface IController {
     initialize(): Promise<void>;

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -9,7 +9,6 @@ import {
     AccountInfo,
     Constants,
     INetworkModule,
-    AuthenticationResult,
     Logger,
     CommonSilentFlowRequest,
     ICrypto,
@@ -72,6 +71,7 @@ import { StandardOperatingContext } from "../operatingcontext/StandardOperatingC
 import { BaseOperatingContext } from "../operatingcontext/BaseOperatingContext";
 import { version, name } from "../packageMetadata";
 import { IController } from "./IController";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export class StandardController implements IController {
     // OperatingContext

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    AuthenticationResult,
     AuthError,
     AccountInfo,
 } from "@azure/msal-common";
@@ -16,6 +15,7 @@ import {
     SilentRequest,
     SsoSilentRequest,
     EndSessionRequest,
+    AuthenticationResult,
 } from "..";
 
 export type EventMessage = {

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -66,6 +66,7 @@ export { EndSessionRequest } from "./request/EndSessionRequest";
 export { EndSessionPopupRequest } from "./request/EndSessionPopupRequest";
 export { AuthorizationUrlRequest } from "./request/AuthorizationUrlRequest";
 export { AuthorizationCodeRequest } from "./request/AuthorizationCodeRequest";
+export { AuthenticationResult } from "./response/AuthenticationResult";
 
 // Cache
 export { LoadTokenOptions } from "./cache/TokenCache";
@@ -94,8 +95,6 @@ export {
     // Account
     AccountInfo,
     AccountEntity,
-    // Response
-    AuthenticationResult,
     IdTokenClaims,
     // Error
     AuthError,

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -7,7 +7,6 @@ import {
     ICrypto,
     INetworkModule,
     Logger,
-    AuthenticationResult,
     AccountInfo,
     AccountEntity,
     BaseAuthRequest,
@@ -35,6 +34,7 @@ import { BrowserConstants } from "../utils/BrowserConstants";
 import { BrowserUtils } from "../utils/BrowserUtils";
 import { INavigationClient } from "../navigation/INavigationClient";
 import { NativeMessageHandler } from "../broker/nativeBroker/NativeMessageHandler";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export abstract class BaseInteractionClient {
     protected config: BrowserConfiguration;
@@ -207,12 +207,12 @@ export abstract class BaseInteractionClient {
     }
 
     /*
-     * If authority provided in the request does not match environment/authority specified 
+     * If authority provided in the request does not match environment/authority specified
      * in the account or MSAL config, we throw an error.
      */
     async validateRequestAuthority(authority: string, account: AccountInfo): Promise<void> {
         const discoveredAuthority = await this.getDiscoveredAuthority(authority);
-        
+
         if(!discoveredAuthority.isAlias(account.environment)) {
             throw ClientConfigurationError.createAuthorityMismatchError();
         }

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    AuthenticationResult,
     Logger,
     ICrypto,
     PromptValue,
@@ -27,7 +26,6 @@ import {
     AuthError,
     CommonSilentFlowRequest,
     AccountInfo,
-    CacheRecord,
 } from "@azure/msal-common";
 import { BaseInteractionClient } from "./BaseInteractionClient";
 import { BrowserConfiguration } from "../config/Configuration";
@@ -54,6 +52,8 @@ import { NavigationOptions } from "../navigation/NavigationOptions";
 import { INavigationClient } from "../navigation/INavigationClient";
 import { BrowserAuthError } from "../error/BrowserAuthError";
 import { SilentCacheClient } from "./SilentCacheClient";
+import { AuthenticationResult } from "../response/AuthenticationResult";
+import { CacheRecord } from "../cache/entities/CacheRecord";
 
 export class NativeInteractionClient extends BaseInteractionClient {
     protected apiId: ApiId;

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    AuthenticationResult,
     CommonAuthorizationCodeRequest,
     AuthorizationCodeClient,
     ThrottlingUtils,
@@ -45,6 +44,7 @@ import {
 } from "../interaction_handler/InteractionHandler";
 import { PopupWindowAttributes } from "../request/PopupWindowAttributes";
 import { EventError } from "../event/EventMessage";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export type PopupParams = InteractionParams & {
     popup?: Window | null;

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    AuthenticationResult,
     CommonAuthorizationCodeRequest,
     AuthorizationCodeClient,
     UrlString,
@@ -39,6 +38,7 @@ import { BrowserCacheManager } from "../cache/BrowserCacheManager";
 import { EventHandler } from "../event/EventHandler";
 import { INavigationClient } from "../navigation/INavigationClient";
 import { EventError } from "../event/EventMessage";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export class RedirectClient extends StandardInteractionClient {
     protected nativeStorage: BrowserCacheManager;

--- a/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    AuthenticationResult,
     ICrypto,
     Logger,
     CommonAuthorizationCodeRequest,
@@ -25,6 +24,7 @@ import { SilentHandler } from "../interaction_handler/SilentHandler";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { HybridSpaAuthorizationCodeClient } from "./HybridSpaAuthorizationCodeClient";
 import { NativeMessageHandler } from "../broker/nativeBroker/NativeMessageHandler";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export class SilentAuthCodeClient extends StandardInteractionClient {
     private apiId: ApiId;

--- a/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
@@ -6,7 +6,6 @@
 import { StandardInteractionClient } from "./StandardInteractionClient";
 import {
     CommonSilentFlowRequest,
-    AuthenticationResult,
     SilentFlowClient,
     ServerTelemetryManager,
     AccountInfo,
@@ -20,6 +19,7 @@ import {
     BrowserAuthError,
     BrowserAuthErrorMessage,
 } from "../error/BrowserAuthError";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export class SilentCacheClient extends StandardInteractionClient {
     /**
@@ -48,7 +48,7 @@ export class SilentCacheClient extends StandardInteractionClient {
         try {
             const cachedToken = await silentAuthClient.acquireCachedToken(
                 silentRequest
-            );
+            ) as AuthenticationResult;
 
             acquireTokenMeasurement.endMeasurement({
                 success: true,

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-    AuthenticationResult,
     ICrypto,
     Logger,
     StringUtils,
@@ -31,6 +30,7 @@ import { SilentHandler } from "../interaction_handler/SilentHandler";
 import { SsoSilentRequest } from "../request/SsoSilentRequest";
 import { NativeMessageHandler } from "../broker/nativeBroker/NativeMessageHandler";
 import { NativeInteractionClient } from "./NativeInteractionClient";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export class SilentIframeClient extends StandardInteractionClient {
     protected apiId: ApiId;

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -6,7 +6,6 @@
 import { StandardInteractionClient } from "./StandardInteractionClient";
 import {
     CommonSilentFlowRequest,
-    AuthenticationResult,
     ServerTelemetryManager,
     RefreshTokenClient,
     AuthError,
@@ -15,6 +14,7 @@ import {
 } from "@azure/msal-common";
 import { ApiId } from "../utils/BrowserConstants";
 import { BrowserAuthError } from "../error/BrowserAuthError";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export class SilentRefreshClient extends StandardInteractionClient {
     /**
@@ -58,6 +58,7 @@ export class SilentRefreshClient extends StandardInteractionClient {
         );
         return refreshTokenClient
             .acquireTokenByRefreshToken(silentRequest)
+            .then((result) => result as AuthenticationResult)
             .then((result: AuthenticationResult) => {
                 acquireTokenMeasurement.endMeasurement({
                     success: true,

--- a/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
@@ -7,7 +7,6 @@ import {
     AuthorizationCodePayload,
     StringUtils,
     CommonAuthorizationCodeRequest,
-    AuthenticationResult,
     AuthorizationCodeClient,
     AuthorityFactory,
     Authority,
@@ -26,6 +25,7 @@ import {
     BrowserAuthErrorMessage,
 } from "../error/BrowserAuthError";
 import { TemporaryCacheKeys } from "../utils/BrowserConstants";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export type InteractionParams = {};
 
@@ -185,7 +185,7 @@ export class InteractionHandler {
         const tokenResponse = await this.authModule.acquireToken(
             this.authCodeRequest,
             authCodeResponse
-        );
+        ) as AuthenticationResult;
         this.browserStorage.cleanRequestByState(state);
         return tokenResponse;
     }

--- a/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/RedirectHandler.ts
@@ -8,7 +8,6 @@ import {
     StringUtils,
     CommonAuthorizationCodeRequest,
     ICrypto,
-    AuthenticationResult,
     Authority,
     INetworkModule,
     ClientAuthError,
@@ -25,6 +24,7 @@ import { BrowserCacheManager } from "../cache/BrowserCacheManager";
 import { InteractionHandler, InteractionParams } from "./InteractionHandler";
 import { INavigationClient } from "../navigation/INavigationClient";
 import { NavigationOptions } from "../navigation/NavigationOptions";
+import { AuthenticationResult } from "../response/AuthenticationResult";
 
 export type RedirectParams = InteractionParams & {
     navigationClient: INavigationClient;
@@ -217,7 +217,7 @@ export class RedirectHandler extends InteractionHandler {
         const tokenResponse = await this.authModule.acquireToken(
             this.authCodeRequest,
             authCodeResponse
-        );
+        ) as AuthenticationResult;
 
         this.browserStorage.cleanRequestByState(state);
         return tokenResponse;

--- a/lib/msal-browser/src/internals.ts
+++ b/lib/msal-browser/src/internals.ts
@@ -11,6 +11,9 @@
 // Cache Manager
 export { BrowserCacheManager } from "./cache/BrowserCacheManager";
 
+// Cache entities
+export { CacheRecord } from "./cache/entities/CacheRecord";
+
 // Clients
 export { StandardInteractionClient } from "./interaction_client/StandardInteractionClient";
 export { RedirectClient } from "./interaction_client/RedirectClient";

--- a/lib/msal-browser/src/response/AuthenticationResult.ts
+++ b/lib/msal-browser/src/response/AuthenticationResult.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AccountInfo, AuthenticationResult as CommonAuthenticationResult } from "@azure/msal-common";
+
+export type AuthenticationResult = CommonAuthenticationResult & {
+    account: AccountInfo;
+};

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -28,7 +28,6 @@ import {
     Constants,
     AccountInfo,
     TokenClaims,
-    AuthenticationResult,
     CommonAuthorizationUrlRequest,
     AuthorizationCodeClient,
     ResponseMode,
@@ -94,6 +93,7 @@ import { NativeTokenRequest } from "../../src/broker/nativeBroker/NativeRequest"
 import { NativeAuthError } from "../../src/error/NativeAuthError";
 import { StandardController } from "../../src/controllers/StandardController";
 import { BrowserPerformanceMeasurement } from "../../src/telemetry/BrowserPerformanceMeasurement";
+import { AuthenticationResult } from "../../src";
 
 const cacheConfig = {
     temporaryCacheLocation: BrowserCacheLocation.SessionStorage,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -93,7 +93,7 @@ import { NativeTokenRequest } from "../../src/broker/nativeBroker/NativeRequest"
 import { NativeAuthError } from "../../src/error/NativeAuthError";
 import { StandardController } from "../../src/controllers/StandardController";
 import { BrowserPerformanceMeasurement } from "../../src/telemetry/BrowserPerformanceMeasurement";
-import { AuthenticationResult } from "../../src";
+import { AuthenticationResult } from "../../src/response/AuthenticationResult";
 
 const cacheConfig = {
     temporaryCacheLocation: BrowserCacheLocation.SessionStorage,

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -55,7 +55,7 @@ import {
 import { FetchClient } from "../../src/network/FetchClient";
 import { InteractionHandler } from "../../src/interaction_handler/InteractionHandler";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
-import { AuthenticationResult } from "../../src";
+import { AuthenticationResult } from "../../src/response/AuthenticationResult";
 
 const testPopupWondowDefaults = {
     height: BrowserConstants.POPUP_HEIGHT,

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -23,7 +23,6 @@ import {
     Constants,
     AccountInfo,
     TokenClaims,
-    AuthenticationResult,
     CommonAuthorizationUrlRequest,
     AuthorizationCodeClient,
     ResponseMode,
@@ -56,6 +55,7 @@ import {
 import { FetchClient } from "../../src/network/FetchClient";
 import { InteractionHandler } from "../../src/interaction_handler/InteractionHandler";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
+import { AuthenticationResult } from "../../src";
 
 const testPopupWondowDefaults = {
     height: BrowserConstants.POPUP_HEIGHT,

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -71,7 +71,7 @@ import { EventType } from "../../src/event/EventType";
 import { NativeInteractionClient } from "../../src/interaction_client/NativeInteractionClient";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
-import { AuthenticationResult } from "../../src";
+import { AuthenticationResult } from "../../src/response/AuthenticationResult";
 
 const cacheConfig = {
     cacheLocation: BrowserCacheLocation.SessionStorage,

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -25,7 +25,6 @@ import {
     Constants,
     AccountInfo,
     TokenClaims,
-    AuthenticationResult,
     CommonAuthorizationCodeRequest,
     CommonAuthorizationUrlRequest,
     AuthToken,
@@ -72,6 +71,7 @@ import { EventType } from "../../src/event/EventType";
 import { NativeInteractionClient } from "../../src/interaction_client/NativeInteractionClient";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";
+import { AuthenticationResult } from "../../src";
 
 const cacheConfig = {
     cacheLocation: BrowserCacheLocation.SessionStorage,

--- a/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
@@ -17,7 +17,6 @@ import {
 import {
     AccountInfo,
     TokenClaims,
-    AuthenticationResult,
     AuthorizationCodeClient,
     AuthenticationScheme,
 } from "@azure/msal-common";
@@ -25,7 +24,7 @@ import { BrowserAuthError } from "../../src/error/BrowserAuthError";
 import { SilentHandler } from "../../src/interaction_handler/SilentHandler";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { SilentAuthCodeClient } from "../../src/interaction_client/SilentAuthCodeClient";
-import { ApiId, AuthorizationCodeRequest } from "../../src";
+import { ApiId, AuthorizationCodeRequest, AuthenticationResult } from "../../src";
 
 describe("SilentAuthCodeClient", () => {
     let silentAuthCodeClient: SilentAuthCodeClient;

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -19,7 +19,6 @@ import {
     AccountInfo,
     TokenClaims,
     PromptValue,
-    AuthenticationResult,
     CommonAuthorizationUrlRequest,
     AuthorizationCodeClient,
     ResponseMode,
@@ -34,7 +33,7 @@ import { SilentHandler } from "../../src/interaction_handler/SilentHandler";
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import { SilentIframeClient } from "../../src/interaction_client/SilentIframeClient";
 import { BrowserCacheManager } from "../../src/cache/BrowserCacheManager";
-import { ApiId } from "../../src";
+import { ApiId, AuthenticationResult } from "../../src";
 import { NativeInteractionClient } from "../../src/interaction_client/NativeInteractionClient";
 import { NativeMessageHandler } from "../../src/broker/nativeBroker/NativeMessageHandler";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils";


### PR DESCRIPTION
- Make account info mandatory for `AuthenticationResult` type.
- Make account info mandatory for `CacheRecord` type.

FYI: 1p will be updated thereafter.