### PR TITLE
Update string conversion

### DIFF
--- a/change/@azure-msal-browser-86bd2ee6-1646-4c84-a3ae-0eb31623675e.json
+++ b/change/@azure-msal-browser-86bd2ee6-1646-4c84-a3ae-0eb31623675e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update string conversion function",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -224,7 +224,7 @@ export class CryptoOps implements ICrypto {
         const tokenString = `${encodedShrHeader}.${encodedPayload}`;
 
         // Sign token
-        const tokenBuffer = BrowserStringUtils.stringToArrayBuffer(tokenString);
+        const tokenBuffer = BrowserStringUtils.stringToUtf8Arr(tokenString);
         const signatureBuffer = await this.browserCrypto.sign(
             cachedKeyPair.privateKey,
             tokenBuffer

--- a/lib/msal-browser/src/utils/BrowserStringUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserStringUtils.ts
@@ -34,7 +34,7 @@ export class BrowserStringUtils {
                     ? 5
                     : 6;
         }
-
+        
         const aBytes = new Uint8Array(nArrLen);
 
         /* transcription... */
@@ -78,19 +78,6 @@ export class BrowserStringUtils {
         }
 
         return aBytes;
-    }
-
-    /**
-     * Converst string to ArrayBuffer
-     * @param dataString
-     */
-    static stringToArrayBuffer(dataString: string): ArrayBuffer {
-        const data = new ArrayBuffer(dataString.length);
-        const dataView = new Uint8Array(data);
-        for (let i: number = 0; i < dataString.length; i++) {
-            dataView[i] = dataString.charCodeAt(i);
-        }
-        return data;
     }
 
     /**


### PR DESCRIPTION
Node 20 now validates the type of input parameters for the `sign` API and our current implementation is throwing in our test environment as the buffer we are passing is the wrong type. This PR addresses this error.