### PR TITLE
Remove sample dependency on msal-common

### DIFF
--- a/change/@azure-msal-browser-1fe30015-5db8-41ae-988f-d27fa55e15e3.json
+++ b/change/@azure-msal-browser-1fe30015-5db8-41ae-988f-d27fa55e15e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Export IdTokenClaims & PromptValue types",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-5b1b3e16-c8e5-47fb-847f-9faada5ce08e.json
+++ b/change/@azure-msal-node-5b1b3e16-c8e5-47fb-847f-9faada5ce08e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Export IdTokenClaims & ServerAuthorizationCodeResponse types",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -96,6 +96,7 @@ export {
     AccountEntity,
     // Response
     AuthenticationResult,
+    IdTokenClaims,
     // Error
     AuthError,
     AuthErrorMessage,
@@ -116,6 +117,7 @@ export {
     LogLevel,
     // Protocol Mode
     ProtocolMode,
+    PromptValue,
     // Server Response
     ExternalTokenResponse,
     // Utils

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -79,6 +79,8 @@ export {
     AuthorizationCodePayload,
     // Response
     AuthenticationResult,
+    ServerAuthorizationCodeResponse,
+    IdTokenClaims,
     // Cache
     AccountInfo,
     ValidCacheType,

--- a/samples/msal-angular-v3-samples/angular-b2c-sample-app/src/app/app.component.ts
+++ b/samples/msal-angular-v3-samples/angular-b2c-sample-app/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Inject, OnDestroy } from '@angular/core';
 import { MsalService, MsalBroadcastService, MSAL_GUARD_CONFIG, MsalGuardConfiguration } from '@azure/msal-angular';
-import { AuthenticationResult, InteractionStatus, PopupRequest, RedirectRequest, EventMessage, EventType, InteractionType, AccountInfo, SsoSilentRequest } from '@azure/msal-browser';
-import { IdTokenClaims, PromptValue } from '@azure/msal-common'
+import { AuthenticationResult, InteractionStatus, PopupRequest, RedirectRequest, EventMessage, EventType, InteractionType, AccountInfo, SsoSilentRequest, IdTokenClaims, PromptValue } from '@azure/msal-browser';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 

--- a/samples/msal-node-samples/ElectronSystemBrowserTestApp/package.json
+++ b/samples/msal-node-samples/ElectronSystemBrowserTestApp/package.json
@@ -53,7 +53,6 @@
         "typescript": "~4.5.4"
     },
     "dependencies": {
-        "@azure/msal-common": "file:../../../lib/msal-common",
         "@azure/msal-node": "file:../../../lib/msal-node",
         "axios": "^1.1.3",
         "bootstrap": "^5.2.3",

--- a/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/CustomLoopbackClient.ts
+++ b/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/CustomLoopbackClient.ts
@@ -185,7 +185,7 @@ export class CustomLoopbackClient implements ILoopbackClient {
      * @param query
      */
     static queryStringToObject(query: string): ServerAuthorizationCodeResponse {
-        const obj: ServerAuthorizationCodeResponse = {};
+        const obj: {[key:string]:string} = {};
         const params = query.split("&");
         const decode = (s: string) => decodeURIComponent(s.replace(/\+/g, " "));
         params.forEach((pair) => {
@@ -196,6 +196,6 @@ export class CustomLoopbackClient implements ILoopbackClient {
                 }
             }
         });
-        return obj;
+        return obj as ServerAuthorizationCodeResponse;
     }
 }

--- a/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/CustomLoopbackClient.ts
+++ b/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/CustomLoopbackClient.ts
@@ -4,8 +4,7 @@
  */
 
 import { createServer, IncomingMessage, Server, ServerResponse } from "http";
-import { Constants as CommonConstants, UrlString, ServerAuthorizationCodeResponse } from "@azure/msal-common";
-import { ILoopbackClient } from "@azure/msal-node";
+import { ILoopbackClient, ServerAuthorizationCodeResponse } from "@azure/msal-node";
 
 /**
  * Implements ILoopbackClient interface to listen for authZ code response.
@@ -59,12 +58,12 @@ export class CustomLoopbackClient implements ILoopbackClient {
                     res.end(errorTemplate || "Error occurred loading redirectUrl");
                     reject(new Error('Loopback server callback was invoked without a url. This is unexpected.'));
                     return;
-                } else if (url === CommonConstants.FORWARD_SLASH) {
+                } else if (url === "/") {
                     res.end(successTemplate || "Auth code was successfully acquired. You can close this window now.");
                     return;
                 }
 
-                const authCodeResponse = UrlString.getDeserializedQueryString(url);
+                const authCodeResponse = CustomLoopbackClient.getDeserializedQueryString(url);
                 if (authCodeResponse.code) {
                     const redirectUri = await this.getRedirectUri();
                     res.writeHead(302, { location: redirectUri }); // Prevent auth code from being saved in the browser history
@@ -139,5 +138,64 @@ export class CustomLoopbackClient implements ILoopbackClient {
                     resolve(false);
                 });
         });
+    }
+
+    /**
+     * Returns URL query string as server auth code response object.
+     */
+    static getDeserializedQueryString(
+        query: string
+    ): ServerAuthorizationCodeResponse {
+        // Check if given query is empty
+        if (!query) {
+            return {};
+        }
+        // Strip the ? symbol if present
+        const parsedQueryString = this.parseQueryString(query);
+        // If ? symbol was not present, above will return empty string, so give original query value
+        const deserializedQueryString: ServerAuthorizationCodeResponse =
+            this.queryStringToObject(
+                parsedQueryString || query
+            );
+        // Check if deserialization didn't work
+        if (!deserializedQueryString) {
+            throw "Unable to deserialize query string";
+        }
+        return deserializedQueryString;
+    }
+
+    /**
+     * Parses query string from given string. Returns empty string if no query symbol is found.
+     * @param queryString
+     */
+    static parseQueryString(queryString: string): string {
+        const queryIndex1 = queryString.indexOf("?");
+        const queryIndex2 = queryString.indexOf("/?");
+        if (queryIndex2 > -1) {
+            return queryString.substring(queryIndex2 + 2);
+        } else if (queryIndex1 > -1) {
+            return queryString.substring(queryIndex1 + 1);
+        }
+        return "";
+    }
+
+    /**
+     * Parses string into an object.
+     *
+     * @param query
+     */
+    static queryStringToObject(query: string): ServerAuthorizationCodeResponse {
+        const obj: ServerAuthorizationCodeResponse = {};
+        const params = query.split("&");
+        const decode = (s: string) => decodeURIComponent(s.replace(/\+/g, " "));
+        params.forEach((pair) => {
+            if (pair.trim()) {
+                const [key, value] = pair.split(/=(.+)/g, 2); // Split on the first occurence of the '=' character
+                if (key && value) {
+                    obj[decode(key)] = decode(value);
+                }
+            }
+        });
+        return obj;
     }
 }

--- a/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/app/components/NavigationBar.tsx
+++ b/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/app/components/NavigationBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AccountInfo } from "@azure/msal-common";
+import { AccountInfo } from "@azure/msal-node";
 import { Navbar, Button, DropdownButton, Dropdown } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { IpcMessages } from "../../Constants";

--- a/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/app/components/PageLayout.tsx
+++ b/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/app/components/PageLayout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AccountInfo } from "@azure/msal-common";
+import { AccountInfo } from "@azure/msal-node";
 import { NavigationBar } from "./NavigationBar";
 
 type PageLayoutProps = {

--- a/samples/msal-node-samples/ExpressTestApp/src/AuthProvider.ts
+++ b/samples/msal-node-samples/ExpressTestApp/src/AuthProvider.ts
@@ -11,9 +11,8 @@ import {
 
 import {
     InteractionRequiredAuthError,
-    OIDC_DEFAULT_SCOPES,
     PromptValue
-} from '@azure/msal-common';
+} from '@azure/msal-node';
 
 import {
     ConfidentialClientApplication,
@@ -133,7 +132,7 @@ export class AuthProvider {
 
         const params: AuthCodeParams = {
             authority: this.msalConfig.auth.authority,
-            scopes: OIDC_DEFAULT_SCOPES,
+            scopes: ["openid", "profile"],
             state: state,
             redirect: this.appSettings.settings.redirectUri,
             prompt: PromptValue.SELECT_ACCOUNT,
@@ -200,7 +199,7 @@ export class AuthProvider {
                                  * establishing a session. If this does not apply, the application won't benefit from validating
                                  * the token. For more information, visit: https://learn.microsoft.com/azure/active-directory/develop/access-tokens#validate-tokens
                                  */
-                                const isIdTokenValid = await this.tokenValidator.validateIdToken(tokenResponse.idToken);
+                                const isIdTokenValid = await this.tokenValidator.validateIdToken(tokenResponse.idToken, tokenResponse.idTokenClaims);
 
                                 if (isIdTokenValid) {
 

--- a/samples/msal-node-samples/ExpressTestApp/src/TokenValidator.ts
+++ b/samples/msal-node-samples/ExpressTestApp/src/TokenValidator.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { TokenClaims, TimeUtils, AuthToken } from "@azure/msal-common";
-import { CryptoProvider } from "@azure/msal-node";
+import { CryptoProvider, IdTokenClaims } from "@azure/msal-node";
 import { AuthorityConstants, AuthorityStrings } from "./Constants";
 import { AppSettings } from "./Types";
 
@@ -47,7 +46,7 @@ export class TokenValidator {
      * @param {string} rawIdToken: raw Id token
      * @returns {Promise}
      */
-    async validateIdToken(rawIdToken: string): Promise<boolean> {
+    async validateIdToken(rawIdToken: string, idTokenClaims: IdTokenClaims): Promise<boolean> {
 
         /**
          * A JWT token validation is a 2-step process comprising of: (1) signature validation, (2) claims validation
@@ -61,8 +60,7 @@ export class TokenValidator {
                 return false;
             }
 
-            const decodedIdTokenPayload = new AuthToken(rawIdToken, this.cryptoProvider).claims;
-            return this.validateIdTokenClaims(decodedIdTokenPayload);
+            return this.validateIdTokenClaims(idTokenClaims);
         } catch (error) {
             console.log(error);
             return false;
@@ -74,8 +72,8 @@ export class TokenValidator {
      * @param {IdTokenClaims} idTokenClaims: decoded id token claims
      * @returns {boolean}
      */
-    validateIdTokenClaims(idTokenClaims: TokenClaims): boolean {
-        const now = TimeUtils.nowSeconds(); // current time in seconds
+    validateIdTokenClaims(idTokenClaims: IdTokenClaims): boolean {
+        const now = Math.round(new Date().getTime() / 1000.0); // current time in seconds
 
         /**
          * if a multi-tenant application only allows sign-in from specific tenants who have signed up

--- a/samples/msal-node-samples/ExpressTestApp/src/Types.ts
+++ b/samples/msal-node-samples/ExpressTestApp/src/Types.ts
@@ -2,9 +2,6 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import {
-    TokenClaims
-} from "@azure/msal-common";
 
 import {
     AccountInfo,

--- a/samples/msal-node-samples/client-credentials-distributed-cache/src/CustomCachePlugin.ts
+++ b/samples/msal-node-samples/client-credentials-distributed-cache/src/CustomCachePlugin.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICachePlugin, TokenCacheContext } from "@azure/msal-common";
-import { ICacheClient } from "@azure/msal-node";
+import { ICacheClient, ICachePlugin, TokenCacheContext } from "@azure/msal-node";
 import { performance } from "perf_hooks";
 
 /**

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientAxios.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientAxios.ts
@@ -7,7 +7,7 @@ import {
     INetworkModule,
     NetworkRequestOptions,
     NetworkResponse,
-} from "@azure/msal-common";
+} from "@azure/msal-node";
 import axios, { AxiosRequestConfig } from "axios";
 
 enum HttpMethod {

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientCurrent.ts
@@ -7,7 +7,7 @@ import {
     INetworkModule,
     NetworkRequestOptions,
     NetworkResponse
-} from "@azure/msal-common";
+} from "@azure/msal-node";
 
 import http from "http";
 import https from "https";

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/app.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/app.ts
@@ -1,5 +1,5 @@
 import * as msal from "@azure/msal-node";
-// import { INetworkModule, } from "@azure/msal-common";
+// import { INetworkModule, } from "@azure/msal-node";
 /**
  * After "npx tsc" is executed via the "npm run start" script, app.ts and HttpClientCurrent.ts are compiled to .js and stored in the /dist folder
  * The app is run via "node dist/app.js", hence the .js import of the HttpClientCurrent

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/express.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/express.ts
@@ -1,5 +1,5 @@
 import * as msal from "@azure/msal-node";
-// import { INetworkModule, } from "@azure/msal-common";
+// import { INetworkModule, } from "@azure/msal-node";
 import express from "express";
 /**
  * After "npx tsc" is executed via the "npm run start" script, app.ts and HttpClientCurrent.ts are compiled to .js and stored in the /dist folder

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/package.json
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/package.json
@@ -15,7 +15,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/msal-common": "^10.0.0",
     "@azure/msal-node": "^1.15.0",
     "express": "^4.18.2",
     "url": "^0.11.0"

--- a/samples/msal-node-samples/on-behalf-of-distributed-cache/src/CustomCachePlugin.ts
+++ b/samples/msal-node-samples/on-behalf-of-distributed-cache/src/CustomCachePlugin.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICachePlugin, TokenCacheContext } from "@azure/msal-common";
-import { ICacheClient } from "@azure/msal-node";
+import { ICacheClient, ICachePlugin, TokenCacheContext } from "@azure/msal-node";
 import { performance } from "perf_hooks";
 
 /**


### PR DESCRIPTION
Some of our samples are taking direct dependency on msal-common. This PR refactors these samples to use exports from msal-browser/msal-node instead & adds additional exports to those libraries where needed.