### PR TITLE
Exclude .gyp files from git language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 *.json  linguist-language=JSON-with-Comments
+*.gyp -linguist-detectable


### PR DESCRIPTION
.gyp is being detected as python which is causing CodeQL to expect a python snapshot