### PR TITLE
Make claims-based caching configurable [LTS]

### DIFF
--- a/change/@azure-msal-browser-8cb83615-34d8-486c-b6a6-9178b80d4bab.json
+++ b/change/@azure-msal-browser-8cb83615-34d8-486c-b6a6-9178b80d4bab.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make claims-based caching configurable [LTS] #6187",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-ded9565d-3378-446d-bf01-d9d20399d3f3.json
+++ b/change/@azure-msal-common-ded9565d-3378-446d-bf01-d9d20399d3f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make claims-based caching configurable [LTS] #6187",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-21c04757-0868-4338-b181-b039b1b73f10.json
+++ b/change/@azure-msal-node-21c04757-0868-4338-b181-b039b1b73f10.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make claims-based caching configurable [LTS] #6187",
+  "packageName": "@azure/msal-node",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/docs/configuration.md
+++ b/lib/msal-browser/docs/configuration.md
@@ -24,7 +24,8 @@ const msalConfig = {
         cacheLocation: "sessionStorage",
         temporaryCacheLocation: "sessionStorage",
         storeAuthStateInCookie: false,
-        secureCookies: false
+        secureCookies: false,
+        claimsBasedCachingEnabled: true,
     },
     system: {
         loggerOptions: {
@@ -93,6 +94,7 @@ const msalInstance = new PublicClientApplication(msalConfig);
 | `storeAuthStateInCookie` | If true, stores cache items in cookies as well as browser cache. Should be set to true for use cases using IE. | boolean | `false` |
 | `secureCookies` | If true and `storeAuthStateInCookies` is also enabled, MSAL adds the `Secure` flag to the browser cookie so it can only be sent over HTTPS. | boolean | `false` |
 | `cacheMigrationEnabled` | If true, cache entries from older versions of MSAL will be updated to conform to the latest cache schema on startup. If your application has not been recently updated to a new version of MSAL.js you can safely turn this off. In the event old cache entries are not migrated it may result in a cache miss when attempting to retrieve accounts or tokens and affected users may need to re-authenticate to get up to date. | boolean | `true` when using `localStorage`, `false` otherwise |
+| `claimsBasedCachingEnabled` | If `true`, access tokens will be cached under a key containing the hash of the requested claims string, resulting in a cache miss and new network token request when the same token request is made with different or missing claims. If set to `false`, tokens will be cached without claims, but all requests containing claims will go to the network and overwrite any previously cached token with the same scopes. | boolean | `true` |
 
 See [Caching in MSAL](./caching.md) for more.
 

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -153,7 +153,8 @@ export abstract class ClientApplication {
             temporaryCacheLocation: BrowserCacheLocation.MemoryStorage,
             storeAuthStateInCookie: false,
             secureCookies: false,
-            cacheMigrationEnabled: false
+            cacheMigrationEnabled: false,
+            claimsBasedCachingEnabled: true
         };
         this.nativeInternalStorage = new BrowserCacheManager(this.config.auth.clientId, nativeCacheOptions, this.browserCrypto, this.logger);
 

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1392,7 +1392,8 @@ export const DEFAULT_BROWSER_CACHE_MANAGER = (clientId: string, logger: Logger):
         temporaryCacheLocation: BrowserCacheLocation.MemoryStorage,
         storeAuthStateInCookie: false,
         secureCookies: false,
-        cacheMigrationEnabled: false
+        cacheMigrationEnabled: false,
+        claimsBasedCachingEnabled: true
     };
     return new BrowserCacheManager(clientId, cacheOptions, DEFAULT_CRYPTO_IMPLEMENTATION, logger);
 };

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -93,6 +93,10 @@ export type CacheOptions = {
      * If set, MSAL will attempt to migrate cache entries from older versions on initialization. By default this flag is set to true if cacheLocation is localStorage, otherwise false.
      */
     cacheMigrationEnabled?: boolean;
+    /**
+     * Flag that determines whether access tokens are stored based on requested claims
+     */
+    claimsBasedCachingEnabled?: boolean;
 };
 
 export type BrowserSystemOptions = SystemOptions & {
@@ -247,7 +251,8 @@ export function buildConfiguration({ auth: userInputAuth, cache: userInputCache,
         storeAuthStateInCookie: false,
         secureCookies: false,
         // Default cache migration to true if cache location is localStorage since entries are preserved across tabs/windows. Migration has little to no benefit in sessionStorage and memoryStorage
-        cacheMigrationEnabled: userInputCache && userInputCache.cacheLocation === BrowserCacheLocation.LocalStorage ? true : false
+        cacheMigrationEnabled: userInputCache && userInputCache.cacheLocation === BrowserCacheLocation.LocalStorage ? true : false,
+        claimsBasedCachingEnabled: true
     };
 
     // Default logger options for browser

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -111,8 +111,8 @@ export abstract class BaseInteractionClient {
             this.logger.verbose(`Authentication Scheme set to "${validatedRequest.authenticationScheme}" as configured in Auth request`);
         }
 
-        // Set requested claims hash if claims were requested
-        if (request.claims && !StringUtils.isEmpty(request.claims)) {
+        // Set requested claims hash if claims were requested and claims-based caching is enabled
+        if (this.config.cache.claimsBasedCachingEnabled && request.claims && !StringUtils.isEmptyObj(request.claims)) {
             validatedRequest.requestedClaimsHash = await this.browserCrypto.hashString(request.claims);
         }
 

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -163,6 +163,9 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
                 logLevel: logger.logLevel,
                 correlationId: this.correlationId
             },
+            cacheOptions: {
+                claimsBasedCachingEnabled: this.config.cache.claimsBasedCachingEnabled
+            },
             cryptoInterface: this.browserCrypto,
             networkInterface: this.networkClient,
             storageInterface: this.browserStorage,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -64,7 +64,8 @@ const cacheConfig = {
     cacheLocation: BrowserCacheLocation.SessionStorage,
     storeAuthStateInCookie: false,
     secureCookies: false,
-    cacheMigrationEnabled: false
+    cacheMigrationEnabled: false,
+    claimsBasedCachingEnabled: true
 };
 
 let testAppConfig = {

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -25,7 +25,8 @@ describe("BrowserCacheManager tests", () => {
             cacheLocation: BrowserCacheLocation.SessionStorage,
             storeAuthStateInCookie: false,
             secureCookies: false,
-            cacheMigrationEnabled: false
+            cacheMigrationEnabled: false,
+            claimsBasedCachingEnabled: true
         };
         logger = new Logger({
             loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => { },
@@ -117,13 +118,13 @@ describe("BrowserCacheManager tests", () => {
             window.localStorage.setItem(testRefreshToken.generateCredentialKey(), JSON.stringify(testRefreshToken));
 
             // Validate that tokens are not added to token key map when cacheMigration is false
-            const initialStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: false}, browserCrypto, logger);
+            const initialStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: false, claimsBasedCachingEnabled: true}, browserCrypto, logger);
             expect(initialStorage.getTokenKeys().idToken.length).toBe(0);
             expect(initialStorage.getTokenKeys().accessToken.length).toBe(0);
             expect(initialStorage.getTokenKeys().refreshToken.length).toBe(0);
 
             // Validate that tokens are added to token key map when cacheMigration is true
-            const migrationStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: true}, browserCrypto, logger);
+            const migrationStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: true, claimsBasedCachingEnabled: true}, browserCrypto, logger);
             expect(migrationStorage.getTokenKeys().idToken.length).toBe(1);
             expect(migrationStorage.getTokenKeys().accessToken.length).toBe(1);
             expect(migrationStorage.getTokenKeys().refreshToken.length).toBe(1);
@@ -139,7 +140,7 @@ describe("BrowserCacheManager tests", () => {
             window.localStorage.setItem(testRefreshToken.generateCredentialKey(), JSON.stringify(testRefreshToken));
 
             // Validate that tokens are added to token key map when cacheMigration is true
-            const migrationStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: true}, browserCrypto, logger);
+            const migrationStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: true, claimsBasedCachingEnabled: true}, browserCrypto, logger);
             expect(migrationStorage.getTokenKeys().idToken.length).toBe(0);
             expect(migrationStorage.getTokenKeys().accessToken.length).toBe(0);
             expect(migrationStorage.getTokenKeys().refreshToken.length).toBe(0);
@@ -151,11 +152,11 @@ describe("BrowserCacheManager tests", () => {
             window.localStorage.setItem(testAccount.generateAccountKey(), JSON.stringify(testAccount));
 
             // Validate that accounts are not added to account key map when cacheMigration is false
-            const initialStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: false}, browserCrypto, logger);
+            const initialStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: false, claimsBasedCachingEnabled: true}, browserCrypto, logger);
             expect(initialStorage.getAccountKeys().length).toBe(0);
 
             // Validate that accounts are added to account key map when cacheMigration is true
-            const migrationStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: true}, browserCrypto, logger);
+            const migrationStorage = new BrowserCacheManager(TEST_CONFIG.MSAL_CLIENT_ID, {cacheLocation: BrowserCacheLocation.LocalStorage, temporaryCacheLocation: BrowserCacheLocation.LocalStorage, storeAuthStateInCookie: false, secureCookies: false, cacheMigrationEnabled: true, claimsBasedCachingEnabled: true}, browserCrypto, logger);
             expect(migrationStorage.getAccountKeys().length).toBe(1);
         });
     });
@@ -1739,7 +1740,8 @@ describe("BrowserCacheManager tests", () => {
                 cacheLocation: BrowserCacheLocation.SessionStorage,
                 storeAuthStateInCookie: false,
                 secureCookies: false,
-                cacheMigrationEnabled: false
+                cacheMigrationEnabled: false,
+                claimsBasedCachingEnabled: true
             };
             logger = new Logger({
                 loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => { },
@@ -1869,7 +1871,8 @@ describe("BrowserCacheManager tests", () => {
                 cacheLocation: BrowserCacheLocation.SessionStorage,
                 storeAuthStateInCookie: false,
                 secureCookies: false,
-                cacheMigrationEnabled: false
+                cacheMigrationEnabled: false,
+                claimsBasedCachingEnabled: true
             };
             logger = new Logger({
                 loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => { },

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -32,7 +32,8 @@ describe("TokenCache tests", () => {
             cacheLocation: BrowserCacheLocation.SessionStorage,
             storeAuthStateInCookie: false,
             secureCookies: false,
-            cacheMigrationEnabled: false
+            cacheMigrationEnabled: false,
+            claimsBasedCachingEnabled: true
         };
         logger = new Logger({
             loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {},

--- a/lib/msal-browser/test/config/Configuration.spec.ts
+++ b/lib/msal-browser/test/config/Configuration.spec.ts
@@ -33,6 +33,7 @@ describe("Configuration.ts Class Unit Tests", () => {
         expect(emptyConfig.cache?.storeAuthStateInCookie).toBeDefined();
         expect(emptyConfig.cache?.storeAuthStateInCookie).toBe(false);
         expect(emptyConfig.cache?.secureCookies).toBe(false);
+        expect(emptyConfig.cache?.claimsBasedCachingEnabled).toBe(true);
         // System config checks
         expect(emptyConfig.system).toBeDefined();
         expect(emptyConfig.system?.loggerOptions).toBeDefined();
@@ -161,7 +162,8 @@ describe("Configuration.ts Class Unit Tests", () => {
             cache: {
                 cacheLocation: BrowserCacheLocation.LocalStorage,
                 storeAuthStateInCookie: true,
-                secureCookies: true
+                secureCookies: true,
+                claimsBasedCachingEnabled: false
             },
             system: {
                 windowHashTimeout: TEST_POPUP_TIMEOUT_MS,
@@ -187,6 +189,7 @@ describe("Configuration.ts Class Unit Tests", () => {
         expect(newConfig.cache?.storeAuthStateInCookie).not.toBeNull();
         expect(newConfig.cache?.storeAuthStateInCookie).toBe(true);
         expect(newConfig.cache?.secureCookies).toBe(true);
+        expect(newConfig.cache?.claimsBasedCachingEnabled).toBe(false);
         // System config checks
         expect(newConfig.system).not.toBeNull();
         expect(newConfig.system?.windowHashTimeout).not.toBeNull();

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -30,7 +30,8 @@ const cacheConfig = {
     temporaryCacheLocation: BrowserCacheLocation.SessionStorage,
     storeAuthStateInCookie: false,
     secureCookies: false,
-    cacheMigrationEnabled: false
+    cacheMigrationEnabled: false,
+    claimsBasedCachingEnabled: true
 };
 
 const loggerOptions = {

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -29,6 +29,7 @@ const DEFAULT_TOKEN_RENEWAL_OFFSET_SEC = 300;
  * - libraryInfo                - Library metadata
  * - telemetry                  - Telemetry options and data
  * - loggerOptions              - Logging for application
+ * - cacheOptions               - Cache options for application
  * - networkInterface           - Network implementation
  * - storageInterface           - Storage implementation
  * - systemOptions              - Additional library options
@@ -38,6 +39,7 @@ export type ClientConfiguration = {
     authOptions: AuthOptions,
     systemOptions?: SystemOptions,
     loggerOptions?: LoggerOptions,
+    cacheOptions?: CacheOptions,
     storageInterface?: CacheManager,
     networkInterface?: INetworkModule,
     cryptoInterface?: ICrypto,
@@ -53,6 +55,7 @@ export type CommonClientConfiguration = {
     authOptions: Required<AuthOptions>,
     systemOptions: Required<SystemOptions>,
     loggerOptions : Required<LoggerOptions>,
+    cacheOptions: Required<CacheOptions>,
     storageInterface: CacheManager,
     networkInterface : INetworkModule,
     cryptoInterface : Required<ICrypto>,
@@ -109,6 +112,15 @@ export type LoggerOptions = {
 };
 
 /**
+ *  Use this to configure credential cache preferences in the ClientConfiguration object
+ *
+ * - claimsBasedCachingEnabled   - Sets whether tokens should be cached based on the claims hash. Default is true.
+ */
+export type CacheOptions = {
+    claimsBasedCachingEnabled?: boolean;
+};
+
+/**
  * Library-specific options
  */
 export type LibraryInfo = {
@@ -155,6 +167,10 @@ const DEFAULT_LOGGER_IMPLEMENTATION: Required<LoggerOptions> = {
     piiLoggingEnabled: false,
     logLevel: LogLevel.Info,
     correlationId: Constants.EMPTY_STRING
+};
+
+const DEFAULT_CACHE_OPTIONS: Required<CacheOptions> = {
+    claimsBasedCachingEnabled: true
 };
 
 const DEFAULT_NETWORK_IMPLEMENTATION: INetworkModule = {
@@ -204,6 +220,7 @@ export function buildClientConfiguration(
         authOptions: userAuthOptions,
         systemOptions: userSystemOptions,
         loggerOptions: userLoggerOption,
+        cacheOptions: userCacheOptions,
         storageInterface: storageImplementation,
         networkInterface: networkImplementation,
         cryptoInterface: cryptoImplementation,
@@ -221,6 +238,7 @@ export function buildClientConfiguration(
         authOptions: buildAuthOptions(userAuthOptions),
         systemOptions: { ...DEFAULT_SYSTEM_OPTIONS, ...userSystemOptions },
         loggerOptions: loggerOptions,
+        cacheOptions: {...DEFAULT_CACHE_OPTIONS, ...userCacheOptions },
         storageInterface: storageImplementation || new DefaultStorageClass(userAuthOptions.clientId, DEFAULT_CRYPTO_IMPLEMENTATION, new Logger(loggerOptions)),
         networkInterface: networkImplementation || DEFAULT_NETWORK_IMPLEMENTATION,
         cryptoInterface: cryptoImplementation || DEFAULT_CRYPTO_IMPLEMENTATION,

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -15,7 +15,7 @@ export { ClientCredentialClient } from "./client/ClientCredentialClient";
 export { OnBehalfOfClient } from "./client/OnBehalfOfClient";
 export { SilentFlowClient } from "./client/SilentFlowClient";
 export { UsernamePasswordClient } from "./client/UsernamePasswordClient";
-export { AuthOptions, SystemOptions, LoggerOptions, DEFAULT_SYSTEM_OPTIONS, AzureCloudOptions, ApplicationTelemetry } from "./config/ClientConfiguration";
+export { AuthOptions, SystemOptions, LoggerOptions, CacheOptions, DEFAULT_SYSTEM_OPTIONS, AzureCloudOptions, ApplicationTelemetry } from "./config/ClientConfiguration";
 export { IAppTokenProvider, AppTokenProviderParameters, AppTokenProviderResult } from "./config/AppTokenProvider";
 export { ClientConfiguration } from "./config/ClientConfiguration";
 // Account

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -380,7 +380,8 @@ export enum CacheOutcome {
     FORCE_REFRESH = "1",
     NO_CACHED_ACCESS_TOKEN = "2",
     CACHED_ACCESS_TOKEN_EXPIRED = "3",
-    REFRESH_CACHED_ACCESS_TOKEN = "4"
+    REFRESH_CACHED_ACCESS_TOKEN = "4",
+    CLAIMS_REQUESTED_CACHE_SKIPPED = "5"
 }
 
 export enum JsonTypes {

--- a/lib/msal-common/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-common/test/config/ClientConfiguration.spec.ts
@@ -72,6 +72,9 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
         // Logger options checks
         expect(emptyConfig.loggerOptions).not.toBeNull();
         expect(emptyConfig.loggerOptions.piiLoggingEnabled).toBe(false);
+        // Cache options checks
+        expect(emptyConfig.cacheOptions).not.toBeNull();
+        expect(emptyConfig.cacheOptions.claimsBasedCachingEnabled).toBe(true);
         // Client info checks
         expect(emptyConfig.libraryInfo.sku).toBe(Constants.SKU);
         expect(emptyConfig.libraryInfo.version).toBe(version);
@@ -143,6 +146,9 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
                 loggerCallback: (level: LogLevel, message: string, containsPii: boolean): void => {},
                 piiLoggingEnabled: true
             },
+            cacheOptions: {
+                claimsBasedCachingEnabled: false
+            },
             libraryInfo: {
                 sku: TEST_CONFIG.TEST_SKU,
                 version: TEST_CONFIG.TEST_VERSION,
@@ -193,6 +199,9 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
         expect(newConfig.loggerOptions).not.toBeNull();
         expect(newConfig.loggerOptions.loggerCallback).not.toBeNull();
         expect(newConfig.loggerOptions.piiLoggingEnabled).toBe(true);
+        // Cache option tests
+        expect(newConfig.cacheOptions).not.toBeNull();
+        expect(newConfig.cacheOptions.claimsBasedCachingEnabled).toBe(false);
         // Client info tests
         expect(newConfig.libraryInfo.sku).toBe(TEST_CONFIG.TEST_SKU);
         expect(newConfig.libraryInfo.version).toBe(TEST_CONFIG.TEST_VERSION);

--- a/lib/msal-node/docs/configuration.md
+++ b/lib/msal-node/docs/configuration.md
@@ -45,7 +45,8 @@ const msalConfig = {
         }
     },
     cache: {
-        cachePlugin // your implementation of cache plugin
+        cachePlugin // your implementation of cache plugin,
+        claimsBasedCachingEnabled: true
     },
     system: {
         loggerOptions: {
@@ -81,7 +82,8 @@ const msalInstance = new PublicClientApplication(msalConfig);
 ### Cache Config Options
 | Option | Description | Format | Default Value |
 | ------ | ----------- | ------ | ------------- |
-| `cachePlugin` | Cache plugin with call backs to reading and writing into the cache persistence (see also: [caching](caching.md)) | [ICachePlugin](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_node.html#icacheplugin) | null
+| `cachePlugin` | Cache plugin with call backs to reading and writing into the cache persistence (see also: [caching](caching.md)) | [ICachePlugin](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_node.html#icacheplugin) | null |
+| `claimsBasedCachingEnabled` | If `true`, access tokens will be cached under a key containing the hash of the requested claims string, resulting in a cache miss and new network token request when the same token request is made with different or missing claims. If set to `false`, tokens will be cached without claims, but all requests containing claims will go to the network and overwrite any previously cached token with the same scopes. | boolean | `true` |
 
 ### System Config Options
 | Option | Description | Format | Default Value |

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -358,6 +358,9 @@ export abstract class ClientApplication {
                 piiLoggingEnabled: this.config.system.loggerOptions.piiLoggingEnabled ,
                 correlationId: requestCorrelationId
             },
+            cacheOptions: {
+                claimsBasedCachingEnabled: this.config.cache.claimsBasedCachingEnabled,
+            },
             cryptoInterface: this.cryptoProvider,
             networkInterface: this.config.system.networkClient,
             storageInterface: this.storage,
@@ -400,8 +403,11 @@ export abstract class ClientApplication {
 
         authRequest.authenticationScheme = AuthenticationScheme.BEARER;
 
-        // Set requested claims hash if claims were requested
-        if (authRequest.claims && !StringUtils.isEmpty(authRequest.claims)) {
+        // Set requested claims hash if claims-based caching is enabled and claims were requested
+        if (this.config.cache.claimsBasedCachingEnabled &&
+            authRequest.claims &&
+            // Checks for empty stringified object "{}" which doesn't qualify as requested claims
+            !StringUtils.isEmptyObj(authRequest.claims)) {
             authRequest.requestedClaimsHash = await this.cryptoProvider.hashString(authRequest.claims);
         }
 

--- a/lib/msal-node/src/config/Configuration.ts
+++ b/lib/msal-node/src/config/Configuration.ts
@@ -53,10 +53,12 @@ export type NodeAuthOptions = {
  * Use this to configure the below cache configuration options:
  *
  * - cachePlugin   - Plugin for reading and writing token cache to disk.
+ * - claimsBasedCachingEnabled - Flag to enable/disable claims based caching. Set to true by default.
  * @public
  */
 export type CacheOptions = {
     cachePlugin?: ICachePlugin;
+    claimsBasedCachingEnabled?: boolean;
 };
 
 /**
@@ -128,7 +130,9 @@ const DEFAULT_AUTH_OPTIONS: Required<NodeAuthOptions> = {
     skipAuthorityMetadataCache: false,
 };
 
-const DEFAULT_CACHE_OPTIONS: CacheOptions = {};
+const DEFAULT_CACHE_OPTIONS: CacheOptions = {
+    claimsBasedCachingEnabled: true
+};
 
 const DEFAULT_LOGGER_OPTIONS: LoggerOptions = {
     loggerCallback: (): void => {

--- a/lib/msal-node/test/utils/TestConstants.ts
+++ b/lib/msal-node/test/utils/TestConstants.ts
@@ -42,7 +42,7 @@ line3
 line4
 -----END CERTIFICATE-----
     `,
-    CLAIMS: 'claim1 claim2',
+    CLAIMS: "{\"access_token\":{\"acrs\":{\"essential\":true,\"value\":\"c1\"}}}",
     SNI_CERTIFICATE:
         `-----BEGIN PRIVATE KEY-----\r
 line1\r
@@ -196,7 +196,7 @@ export const TEST_DATA_CLIENT_INFO = {
 // Test Crypto Values
 export const TEST_CRYPTO_VALUES = {
     TEST_SHA256_HASH: "vdluSPGh34Y-nFDCbX7CudVKZIXRG1rquljNBbn7xuE"
-}
+};
 
 export const mockAuthenticationResult: AuthenticationResult = {
     authority: TEST_CONSTANTS.DEFAULT_AUTHORITY,
@@ -217,11 +217,11 @@ export const mockAuthenticationResult: AuthenticationResult = {
     expiresOn: new Date(),
     tokenType: "BEARER",
     correlationId: "test-correlationId"
-}
+};
 
 export type MockedMetadataResponse = {
     tenant_discovery_endpoint: string,
     token_endpoint: string,
     authorization_endpoint: string,
     device_authorization_endpoint: string
-}
+};


### PR DESCRIPTION
This PR:

- Sets ability to cache based on requested claims as a configurable option under CacheOptions.claimsBasedCachinEnabled
- Sets (keeps) default behavior so in `msal-browser@v2.x` and `msal-node@v1.x` claims-based caching is on by default and any request containing claims will try the cache before going to the network (avoids a breaking change)
- Provides a mitigation to the issue where requesting different claims results in a cache miss and a cached token accumulation with no practical way to clear unused tokens