### PR TITLE
fix: msal-node now references the right path for module index

### DIFF
--- a/change/@azure-msal-node-91151471-3461-48a0-8707-8f9afdb4381b.json
+++ b/change/@azure-msal-node-91151471-3461-48a0-8707-8f9afdb4381b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: msal-node now references the right index.esm.ja",
+  "packageName": "@azure/msal-node",
+  "email": "joshua.head@envoryat.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -47,7 +47,7 @@
       "major"
     ]
   },
-  "module": "dist/msal-node.esm.js",
+  "module": "dist/index.esm.js",
   "devDependencies": {
     "@microsoft/api-extractor": "^7.19.4",
     "@rollup/plugin-node-resolve": "^15.0.1",


### PR DESCRIPTION
fixes #6189

This is currently blocking a prototype for an electron app, so if it's possible to get this prioritized and a new beta candidate released that would be amazing