### PR TITLE
Multiple msal instances support for SSO

### DIFF
--- a/change/@azure-msal-browser-4da3caf5-9d27-405d-9f0c-0dfec8e09bb2.json
+++ b/change/@azure-msal-browser-4da3caf5-9d27-405d-9f0c-0dfec8e09bb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "When RT is not found in cache, attempts SSO #6217",
+  "packageName": "@azure/msal-browser",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-2bb3b803-2f00-4ee6-ad5d-7f01c90eb997.json
+++ b/change/@azure-msal-common-2bb3b803-2f00-4ee6-ad5d-7f01c90eb997.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Install @types/node in common",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/FAQ.md
+++ b/lib/msal-browser/FAQ.md
@@ -23,6 +23,7 @@
 
 1. [How to get single sign-on in my application with MSAL.js?](#how-to-get-single-sign-on-in-my-application-with-msaljs)
 1. [How can my application recognize a user after sign-in? How do I correlate users between applications?](#how-can-my-application-recognize-a-user-after-sign-in-how-do-i-correlate-users-between-applications)
+1. [How can I SSO when I have multiple MSAL instances running?](#how-can-i-sso-when-i-have-multiple-msal-instances-running)
 
 **[Accounts](#Accounts)**
 
@@ -211,6 +212,23 @@ loginPopup().then((response) => {
     const uniqueID = response.account.homeAccountId;
 })
 ```
+
+## How can I SSO when I have multiple MSAL instances running?
+
+For use cases where applications run multiple msal instances in a single window and expect SSO, please enable `attemptSSO: true` in authOptions in the Configuration. 
+
+```javascript
+const config = {
+    auth: {
+        clientId: "your-client-id",
+        authority: "https://yourApp.b2clogin.com/yourApp.onmicrosoft.com/your_policy",
+        attemptSSO: true;
+    }
+}
+const pca = new PublicClientApplication(config);
+```
+
+Please note that this will be default to `true` in v3 and applications that do not want SSO attempted can set the cache policies accordingly.
 
 # Accounts
 

--- a/lib/msal-browser/FAQ.md
+++ b/lib/msal-browser/FAQ.md
@@ -23,7 +23,7 @@
 
 1. [How to get single sign-on in my application with MSAL.js?](#how-to-get-single-sign-on-in-my-application-with-msaljs)
 1. [How can my application recognize a user after sign-in? How do I correlate users between applications?](#how-can-my-application-recognize-a-user-after-sign-in-how-do-i-correlate-users-between-applications)
-1. [How can I SSO when I have multiple MSAL instances running?](#how-can-i-sso-when-i-have-multiple-msal-instances-running)
+1. [Is SSO enabled when I have multiple MSAL instances running?](#is-sso-enabled-when-i-have-multiple-msal-instances-running)
 
 **[Accounts](#Accounts)**
 
@@ -213,22 +213,10 @@ loginPopup().then((response) => {
 })
 ```
 
-## How can I SSO when I have multiple MSAL instances running?
+## Is SSO enabled when I have multiple MSAL instances running?
 
-For use cases where applications run multiple msal instances in a single window and expect SSO, please enable `attemptSSO: true` in authOptions in the Configuration. 
+Yes. We try to SSO by default unless the cache policies say otherwise.
 
-```javascript
-const config = {
-    auth: {
-        clientId: "your-client-id",
-        authority: "https://yourApp.b2clogin.com/yourApp.onmicrosoft.com/your_policy",
-        attemptSSO: true;
-    }
-}
-const pca = new PublicClientApplication(config);
-```
-
-Please note that this will be default to `true` in v3 and applications that do not want SSO attempted can set the cache policies accordingly.
 
 # Accounts
 

--- a/lib/msal-browser/FAQ.md
+++ b/lib/msal-browser/FAQ.md
@@ -23,7 +23,6 @@
 
 1. [How to get single sign-on in my application with MSAL.js?](#how-to-get-single-sign-on-in-my-application-with-msaljs)
 1. [How can my application recognize a user after sign-in? How do I correlate users between applications?](#how-can-my-application-recognize-a-user-after-sign-in-how-do-i-correlate-users-between-applications)
-1. [Is SSO enabled when I have multiple MSAL instances running?](#is-sso-enabled-when-i-have-multiple-msal-instances-running)
 
 **[Accounts](#Accounts)**
 
@@ -212,12 +211,6 @@ loginPopup().then((response) => {
     const uniqueID = response.account.homeAccountId;
 })
 ```
-
-## Is SSO enabled when I have multiple MSAL instances running?
-
-Yes. We try to SSO by default unless the cache policies say otherwise.
-
-
 # Accounts
 
 ## In what scenarios will `getAllAccounts` return multiple accounts?

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -251,8 +251,6 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                         && (requestWithCLP.cacheLookupPolicy !== CacheLookupPolicy.Skip)
                         && !attemptSsoRTNotFound
                     ) {
-                        // eslint-disable-next-line no-console
-                        console.log("acquireTokenSilentAsync: retrieving refresh token failed.");
                         throw refreshTokenError;
                     }
 

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -240,7 +240,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                 return this.acquireTokenByRefreshToken(silentRequest, requestWithCLP).catch((refreshTokenError: AuthError) => {
                     const isServerError = refreshTokenError instanceof ServerError;
                     const isInteractionRequiredError = refreshTokenError instanceof InteractionRequiredAuthError;
-                    const attemptSsoRTNotFound = (refreshTokenError.errorCode === BrowserConstants.NO_TOKENS_FOUND_ERROR);
+                    const rtNotFound = (refreshTokenError.errorCode === BrowserConstants.NO_TOKENS_FOUND_ERROR);
                     const isInvalidGrantError = (refreshTokenError.errorCode === BrowserConstants.INVALID_GRANT_ERROR);
 
                     if ((!isServerError ||
@@ -249,7 +249,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                             requestWithCLP.cacheLookupPolicy === CacheLookupPolicy.AccessTokenAndRefreshToken ||
                             requestWithCLP.cacheLookupPolicy === CacheLookupPolicy.RefreshToken)
                         && (requestWithCLP.cacheLookupPolicy !== CacheLookupPolicy.Skip)
-                        && !attemptSsoRTNotFound
+                        && !rtNotFound
                     ) {
                         throw refreshTokenError;
                     }

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AccountInfo, AuthenticationResult, Constants, RequestThumbprint, AuthError, PerformanceEvents, ServerError, InteractionRequiredAuthError, InProgressPerformanceEvent } from "@azure/msal-common";
+import { AccountInfo, AuthenticationResult, Constants, RequestThumbprint, AuthError, PerformanceEvents, ServerError, InteractionRequiredAuthError, InProgressPerformanceEvent, InteractionRequiredAuthErrorMessage } from "@azure/msal-common";
 import { Configuration } from "../config/Configuration";
 import { DEFAULT_REQUEST, InteractionType, ApiId, CacheLookupPolicy, BrowserConstants } from "../utils/BrowserConstants";
 import { IPublicClientApplication } from "./IPublicClientApplication";
@@ -240,7 +240,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                 return this.acquireTokenByRefreshToken(silentRequest, requestWithCLP).catch((refreshTokenError: AuthError) => {
                     const isServerError = refreshTokenError instanceof ServerError;
                     const isInteractionRequiredError = refreshTokenError instanceof InteractionRequiredAuthError;
-                    const rtNotFound = (refreshTokenError.errorCode === BrowserConstants.NO_TOKENS_FOUND_ERROR);
+                    const rtNotFound = (refreshTokenError.errorCode === InteractionRequiredAuthErrorMessage.noTokensFoundError.code);
                     const isInvalidGrantError = (refreshTokenError.errorCode === BrowserConstants.INVALID_GRANT_ERROR);
 
                     if ((!isServerError ||

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -240,16 +240,19 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                 return this.acquireTokenByRefreshToken(silentRequest, requestWithCLP).catch((refreshTokenError: AuthError) => {
                     const isServerError = refreshTokenError instanceof ServerError;
                     const isInteractionRequiredError = refreshTokenError instanceof InteractionRequiredAuthError;
+                    const attemptSsoRTNotFound = (refreshTokenError.errorCode === BrowserConstants.NO_TOKENS_FOUND_ERROR) && this.config.auth.attemptSSO;
                     const isInvalidGrantError = (refreshTokenError.errorCode === BrowserConstants.INVALID_GRANT_ERROR);
 
                     if ((!isServerError ||
                             !isInvalidGrantError ||
                             isInteractionRequiredError ||
-                            this.config.auth.attemptSSO ||
                             requestWithCLP.cacheLookupPolicy === CacheLookupPolicy.AccessTokenAndRefreshToken ||
                             requestWithCLP.cacheLookupPolicy === CacheLookupPolicy.RefreshToken)
                         && (requestWithCLP.cacheLookupPolicy !== CacheLookupPolicy.Skip)
+                        && !attemptSsoRTNotFound
                     ) {
+                        // eslint-disable-next-line no-console
+                        console.log("acquireTokenSilentAsync: retrieving refresh token failed.");
                         throw refreshTokenError;
                     }
 

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -240,7 +240,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                 return this.acquireTokenByRefreshToken(silentRequest, requestWithCLP).catch((refreshTokenError: AuthError) => {
                     const isServerError = refreshTokenError instanceof ServerError;
                     const isInteractionRequiredError = refreshTokenError instanceof InteractionRequiredAuthError;
-                    const attemptSsoRTNotFound = (refreshTokenError.errorCode === BrowserConstants.NO_TOKENS_FOUND_ERROR) && this.config.auth.attemptSSO;
+                    const attemptSsoRTNotFound = (refreshTokenError.errorCode === BrowserConstants.NO_TOKENS_FOUND_ERROR);
                     const isInvalidGrantError = (refreshTokenError.errorCode === BrowserConstants.INVALID_GRANT_ERROR);
 
                     if ((!isServerError ||

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -245,6 +245,7 @@ export class PublicClientApplication extends ClientApplication implements IPubli
                     if ((!isServerError ||
                             !isInvalidGrantError ||
                             isInteractionRequiredError ||
+                            this.config.auth.attemptSSO ||
                             requestWithCLP.cacheLookupPolicy === CacheLookupPolicy.AccessTokenAndRefreshToken ||
                             requestWithCLP.cacheLookupPolicy === CacheLookupPolicy.RefreshToken)
                         && (requestWithCLP.cacheLookupPolicy !== CacheLookupPolicy.Skip)

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -67,10 +67,6 @@ export type BrowserAuthOptions = {
      * Flag of whether to use the local metadata cache
      */
     skipAuthorityMetadataCache?: boolean;
-    /**
-     * Flag to attempt SSOSilent when tokens not found for ATSilent
-     */
-    attemptSSO?: boolean;
 };
 
 /**
@@ -245,8 +241,7 @@ export function buildConfiguration({ auth: userInputAuth, cache: userInputCache,
             azureCloudInstance: AzureCloudInstance.None,
             tenant: Constants.EMPTY_STRING
         },
-        skipAuthorityMetadataCache: false,
-        attemptSSO: false
+        skipAuthorityMetadataCache: false,  
     };
 
     // Default cache options for browser

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -67,6 +67,10 @@ export type BrowserAuthOptions = {
      * Flag of whether to use the local metadata cache
      */
     skipAuthorityMetadataCache?: boolean;
+    /**
+     * Flag to attempt SSOSilent when tokens not found for ATSilent
+     */
+    attemptSSO?: boolean;
 };
 
 /**
@@ -242,6 +246,7 @@ export function buildConfiguration({ auth: userInputAuth, cache: userInputCache,
             tenant: Constants.EMPTY_STRING
         },
         skipAuthorityMetadataCache: false,
+        attemptSSO: false
     };
 
     // Default cache options for browser

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -20,10 +20,6 @@ export const BrowserConstants = {
      */
     INVALID_GRANT_ERROR: "invalid_grant",
     /**
-     * No tokens found error code
-     */
-    NO_TOKENS_FOUND_ERROR: "no_tokens_found",
-    /**
      * Default popup window width
      */
     POPUP_WIDTH: 483,

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -20,6 +20,10 @@ export const BrowserConstants = {
      */
     INVALID_GRANT_ERROR: "invalid_grant",
     /**
+     * No tokens found error code
+     */
+    NO_TOKENS_FOUND_ERROR: "no_tokens_found",
+    /**
      * Default popup window width
      */
     POPUP_WIDTH: 483,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -2404,7 +2404,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
         it("Calls SilentIframeClient.acquireToken and returns its response if cache lookup throws and refresh token is not found in cache", async () => {
 
-            pca.getConfiguration().auth.attemptSSO = true;
             const testAccount: AccountInfo = {
                 homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
                 localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -2402,6 +2402,44 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentIframeSpy.calledOnce).toBe(true);
         });
 
+        it("Calls SilentIframeClient.acquireToken and returns its response if cache lookup throws and refresh token is not found in cache", async () => {
+
+            pca.getConfiguration().auth.attemptSSO = true;
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com"
+            };
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: new Date(Date.now() + 3600000),
+                account: testAccount,
+                tokenType: AuthenticationScheme.BEARER
+            };
+
+            const refreshRequiredRTNotFoundError = InteractionRequiredAuthError.createNoTokensFoundError()
+
+            const silentCacheSpy = sinon.stub(SilentCacheClient.prototype, "acquireToken").rejects("Expired");
+            const silentRefreshSpy = sinon.stub(SilentRefreshClient.prototype, "acquireToken").rejects(refreshRequiredRTNotFoundError);
+            const silentIframeSpy = sinon.stub(SilentIframeClient.prototype, "acquireToken").resolves(testTokenResponse);
+
+            const response = await pca.acquireTokenSilent({scopes: ["openid"], account: testAccount});
+            expect(response).toEqual(testTokenResponse);
+            expect(silentCacheSpy.calledOnce).toBe(true);
+            expect(silentRefreshSpy.calledOnce).toBe(true);
+            expect(silentIframeSpy.calledOnce).toBe(true);
+        })
+
         it("makes one network request with multiple parallel silent requests with same request", async () => {
             const testServerTokenResponse = {
                 token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,

--- a/lib/msal-common/package-lock.json
+++ b/lib/msal-common/package-lock.json
@@ -2383,9 +2383,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.0.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "18.16.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
+      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -8930,7 +8931,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.3",
+      "version": "18.16.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
+      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
       "dev": true
     },
     "@types/normalize-package-data": {


### PR DESCRIPTION
When apps run multiple msal instances, attempt to SSO is not made for certain instances as there is not pre-fetched RT in the cache. Though this can be circumvented by setting appropriate cache policy or calling `ssoSilent` instead of `acquireTokenSilent`,  certain apps cannot afford the perf hit needed to determine the right API.

This fix will have MSAL JS attempt `sso` when RT is not found in the cache.