### PR TITLE
Update Issue Management Bot Actions

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -46,18 +46,6 @@ configuration:
       - hourly:
           hour: 12
       filters:
-      - not: isOpen
-      - noActivitySince:
-          days: 7
-      - isIssue
-      - isUnlocked
-      actions:
-      - lockIssue
-    - description: 
-      frequencies:
-      - hourly:
-          hour: 12
-      filters:
       - isOpen
       - isIssue
       - hasLabel:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -242,12 +242,12 @@ configuration:
       - isActivitySender:
           issueAuthor: true
       - hasLabel:
-            label: 'Needs: Author Feedback'
+          label: 'Needs: Author Feedback'
       then:
         - removeLabel:
-          label: 'Needs: Author Feedback'
+            label: 'Needs: Author Feedback'
         - addLabel:
-          label: 'Needs: Attention :wave:'
+            label: 'Needs: Attention :wave:'
       description: "Removes the 'Needs: Author Feedback' label and adds the 'Needs: Attention :wave:' label when the issue author comments on an issue"
     - if:
       - payloadType: Issue_Comment
@@ -256,7 +256,7 @@ configuration:
           issueAuthor: true
       then:
         - addLabel:
-          label: 'Needs: Attention :wave:'
+            label: 'Needs: Attention :wave:'
         - reopenIssue
       description: "If author comments on closed issue, reopen"
 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -46,6 +46,18 @@ configuration:
       - hourly:
           hour: 12
       filters:
+      - not: isOpen
+      - noActivitySince:
+          days: 7
+      - isIssue
+      - isUnlocked
+      actions:
+      - lockIssue
+    - description: 
+      frequencies:
+      - hourly:
+          hour: 12
+      filters:
       - isOpen
       - isIssue
       - hasLabel:
@@ -223,5 +235,42 @@ configuration:
           primary: True
           secondary: False
       description: 
+    - if:
+      - payloadType: Issue_Comment
+      - isOpen
+      - activitySenderHasAssociation:
+          association: Member
+      - hasLabel:
+          label: 'Needs: Attention :wave:'
+      then:
+        - removeLabel:
+            label: 'Needs: Attention :wave:'
+        - addLabel:
+            label: 'Needs: Author Feedback'
+      description: "Removes the 'Needs: Attention :wave:' label and adds the 'Needs: Author Feedback' label when a team member comments on an issue"
+    - if:
+      - payloadType: Issue_Comment
+      - isOpen
+      - isActivitySender:
+          issueAuthor: true
+      - hasLabel:
+            label: 'Needs: Author Feedback'
+      then:
+        - removeLabel:
+          label: 'Needs: Author Feedback'
+        - addLabel:
+          label: 'Needs: Attention :wave:'
+      description: "Removes the 'Needs: Author Feedback' label and adds the 'Needs: Attention :wave:' label when the issue author comments on an issue"
+    - if:
+      - payloadType: Issue_Comment
+      - not: isOpen
+      - isActivitySender:
+          issueAuthor: true
+      then:
+        - addLabel:
+          label: 'Needs: Attention :wave:'
+        - reopenIssue
+      description: "If author comments on closed issue, reopen"
+
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -59,24 +59,19 @@ configuration:
       frequencies:
       - weekday:
           day: Monday
-          time: 8:0
+          time: 8:00
       filters:
       - isOpen
       - isNotDraftPullRequest
       - isPullRequest
       - noActivitySince:
-          days: 7
+          days: 14
       - isNotLabeledWith:
           label: 'Needs: Attention :wave:'
       actions:
       - addReply:
           reply: >-
-            Reminder: The next release is scheduled for next week and this PR appears to be stale :( 
-
-
-            If changes have been requested please address feedback. 
-
-            If this PR is still a work in progress please mark as draft.
+            Reminder: This PR appears to be stale. If this PR is still a work in progress please mark as draft.
       - addLabel:
           label: 'Needs: Attention :wave:'
     eventResponderTasks:


### PR DESCRIPTION
The new issue bot doesn't seem to be able to create conditions based on the current date. This means every Monday it's commenting on stale PRs stating the next release is next week. This PR contains a few small updates to reduce confusion and spam

- Update the stale message to no longer mention the release
- Increase the number of days to be considered stale from 7 to 14

In addition, this PR restores the issue label management (Needs Attention and Needs Author Feedback labels)