### PR TITLE
Update "PerformanceClient" for better usability/extendibility

### DIFF
--- a/change/@azure-msal-browser-f70d917e-2030-4905-a4bd-2217c249f54c.json
+++ b/change/@azure-msal-browser-f70d917e-2030-4905-a4bd-2217c249f54c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update \"PerformanceClient\" for better usability/extendibility #6270",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-86bf26c1-44bd-4abe-a5ba-3d3b9b98c4fe.json
+++ b/change/@azure-msal-common-86bf26c1-44bd-4abe-a5ba-3d3b9b98c4fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update \"PerformanceClient\" for better usability/extendibility #6270",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-df3f7be8-bae2-4df4-a99b-2bb011e41371.json
+++ b/change/@azure-msal-node-df3f7be8-bae2-4df4-a99b-2bb011e41371.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update \"PerformanceClient\" for better usability/extendibility #6270",
+  "packageName": "@azure/msal-node",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/NativeMessageHandler.ts
@@ -149,7 +149,7 @@ export class NativeMessageHandler {
                 method: NativeExtensionMethod.HandshakeRequest,
             },
         };
-        this.handshakeEvent.addStaticFields({
+        this.handshakeEvent.add({
             extensionId: this.extensionId,
             extensionHandshakeTimeoutMs: this.handshakeTimeoutMs,
         });
@@ -174,7 +174,7 @@ export class NativeMessageHandler {
                 );
                 this.messageChannel.port1.close();
                 this.messageChannel.port2.close();
-                this.handshakeEvent.endMeasurement({
+                this.handshakeEvent.end({
                     extensionHandshakeTimedOut: true,
                     success: false,
                 });
@@ -231,7 +231,7 @@ export class NativeMessageHandler {
             this.messageChannel.port1.close();
             this.messageChannel.port2.close();
             window.removeEventListener("message", this.windowListener, false);
-            this.handshakeEvent.endMeasurement({
+            this.handshakeEvent.end({
                 success: false,
                 extensionInstalled: false,
             });
@@ -316,7 +316,7 @@ export class NativeMessageHandler {
                 this.logger.verbose(
                     `NativeMessageHandler - Received HandshakeResponse from extension: ${this.extensionId}`
                 );
-                this.handshakeEvent.endMeasurement({
+                this.handshakeEvent.end({
                     extensionInstalled: true,
                     success: true,
                 });

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -180,23 +180,7 @@ export class StandardController implements IController {
         this.hybridAuthCodeResponses = new Map();
 
         // Initialize performance client
-        this.performanceClient = this.isBrowserEnvironment
-            ? new BrowserPerformanceClient(
-                  this.config.auth.clientId,
-                  this.config.auth.authority,
-                  this.logger,
-                  name,
-                  version,
-                  this.config.telemetry.application
-              )
-            : new StubPerformanceClient(
-                  this.config.auth.clientId,
-                  this.config.auth.authority,
-                  this.logger,
-                  name,
-                  version,
-                  this.config.telemetry.application
-              );
+        this.performanceClient = this.config.telemetry.client;
 
         // Initialize the crypto class.
         this.browserCrypto = this.isBrowserEnvironment
@@ -304,7 +288,7 @@ export class StandardController implements IController {
         this.initialized = true;
         this.eventHandler.emitEvent(EventType.INITIALIZE_END);
 
-        initMeasurement.endMeasurement({ allowNativeBroker, success: true });
+        initMeasurement.end({ allowNativeBroker, success: true });
     }
 
     // #region Redirect Flow
@@ -619,7 +603,7 @@ export class StandardController implements IController {
             result = this.acquireTokenNative(request, ApiId.acquireTokenPopup)
                 .then((response) => {
                     this.browserStorage.setInteractionInProgress(false);
-                    atPopupMeasurement.endMeasurement({
+                    atPopupMeasurement.end({
                         success: true,
                         isNativeBroker: true,
                         requestId: response.requestId,
@@ -671,11 +655,11 @@ export class StandardController implements IController {
                     );
                 }
 
-                atPopupMeasurement.addStaticFields({
+                atPopupMeasurement.add({
                     accessTokenSize: result.accessToken.length,
                     idTokenSize: result.idToken.length,
                 });
-                atPopupMeasurement.endMeasurement({
+                atPopupMeasurement.end({
                     success: true,
                     requestId: result.requestId,
                 });
@@ -698,7 +682,7 @@ export class StandardController implements IController {
                     );
                 }
 
-                atPopupMeasurement.endMeasurement({
+                atPopupMeasurement.end({
                     errorCode: e.errorCode,
                     subErrorCode: e.subError,
                     success: false,
@@ -801,11 +785,11 @@ export class StandardController implements IController {
                     InteractionType.Silent,
                     response
                 );
-                this.ssoSilentMeasurement?.addStaticFields({
+                this.ssoSilentMeasurement?.add({
                     accessTokenSize: response.accessToken.length,
                     idTokenSize: response.idToken.length,
                 });
-                this.ssoSilentMeasurement?.endMeasurement({
+                this.ssoSilentMeasurement?.end({
                     success: true,
                     isNativeBroker: response.fromNativeBroker,
                     requestId: response.requestId,
@@ -819,7 +803,7 @@ export class StandardController implements IController {
                     null,
                     e
                 );
-                this.ssoSilentMeasurement?.endMeasurement({
+                this.ssoSilentMeasurement?.end({
                     errorCode: e.errorCode,
                     subErrorCode: e.subError,
                     success: false,
@@ -883,11 +867,11 @@ export class StandardController implements IController {
                                 result
                             );
                             this.hybridAuthCodeResponses.delete(hybridAuthCode);
-                            atbcMeasurement.addStaticFields({
+                            atbcMeasurement.add({
                                 accessTokenSize: result.accessToken.length,
                                 idTokenSize: result.idToken.length,
                             });
-                            atbcMeasurement.endMeasurement({
+                            atbcMeasurement.end({
                                 success: true,
                                 isNativeBroker: result.fromNativeBroker,
                                 requestId: result.requestId,
@@ -902,7 +886,7 @@ export class StandardController implements IController {
                                 null,
                                 error
                             );
-                            atbcMeasurement.endMeasurement({
+                            atbcMeasurement.end({
                                 errorCode: error.errorCode,
                                 subErrorCode: error.subError,
                                 success: false,
@@ -915,7 +899,7 @@ export class StandardController implements IController {
                         "Existing acquireTokenByCode request found",
                         request.correlationId
                     );
-                    atbcMeasurement.discardMeasurement();
+                    atbcMeasurement.discard();
                 }
                 return response;
             } else if (request.nativeAccountId) {
@@ -944,7 +928,7 @@ export class StandardController implements IController {
                 null,
                 e as EventError
             );
-            atbcMeasurement.endMeasurement({
+            atbcMeasurement.end({
                 errorCode: (e instanceof AuthError && e.errorCode) || undefined,
                 subErrorCode:
                     (e instanceof AuthError && e.subError) || undefined,
@@ -984,7 +968,7 @@ export class StandardController implements IController {
         const silentTokenResult = await silentAuthCodeClient
             .acquireToken(request)
             .then((response) => {
-                this.acquireTokenByCodeAsyncMeasurement?.endMeasurement({
+                this.acquireTokenByCodeAsyncMeasurement?.end({
                     success: true,
                     fromCache: response.fromCache,
                     isNativeBroker: response.fromNativeBroker,
@@ -993,7 +977,7 @@ export class StandardController implements IController {
                 return response;
             })
             .catch((tokenRenewalError: AuthError) => {
-                this.acquireTokenByCodeAsyncMeasurement?.endMeasurement({
+                this.acquireTokenByCodeAsyncMeasurement?.end({
                     errorCode: tokenRenewalError.errorCode,
                     subErrorCode: tokenRenewalError.subError,
                     success: false,
@@ -1815,7 +1799,7 @@ export class StandardController implements IController {
             PerformanceEvents.AcquireTokenSilent,
             correlationId
         );
-        atsMeasurement.addStaticFields({
+        atsMeasurement.add({
             cacheLookupPolicy: request.cacheLookupPolicy,
         });
 
@@ -1862,11 +1846,11 @@ export class StandardController implements IController {
             )
                 .then((result) => {
                     this.activeSilentTokenRequests.delete(silentRequestKey);
-                    atsMeasurement.addStaticFields({
+                    atsMeasurement.add({
                         accessTokenSize: result.accessToken.length,
                         idTokenSize: result.idToken.length,
                     });
-                    atsMeasurement.endMeasurement({
+                    atsMeasurement.end({
                         success: true,
                         fromCache: result.fromCache,
                         isNativeBroker: result.fromNativeBroker,
@@ -1877,7 +1861,7 @@ export class StandardController implements IController {
                 })
                 .catch((error: AuthError) => {
                     this.activeSilentTokenRequests.delete(silentRequestKey);
-                    atsMeasurement.endMeasurement({
+                    atsMeasurement.end({
                         errorCode: error.errorCode,
                         subErrorCode: error.subError,
                         success: false,
@@ -1892,7 +1876,7 @@ export class StandardController implements IController {
                 correlationId
             );
             // Discard measurements for memoized calls, as they are usually only a couple of ms and will artificially deflate metrics
-            atsMeasurement.discardMeasurement();
+            atsMeasurement.discard();
             return cachedResponse;
         }
     }
@@ -2062,7 +2046,7 @@ export class StandardController implements IController {
                     InteractionType.Silent,
                     response
                 );
-                this.atsAsyncMeasurement?.endMeasurement({
+                this.atsAsyncMeasurement?.end({
                     success: true,
                     fromCache: response.fromCache,
                     isNativeBroker: response.fromNativeBroker,
@@ -2077,7 +2061,7 @@ export class StandardController implements IController {
                     null,
                     tokenRenewalError
                 );
-                this.atsAsyncMeasurement?.endMeasurement({
+                this.atsAsyncMeasurement?.end({
                     errorCode: tokenRenewalError.errorCode,
                     subErrorCode: tokenRenewalError.subError,
                     success: false,

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -16,7 +16,6 @@ import {
     AuthError,
     PerformanceEvents,
     PerformanceCallbackFunction,
-    StubPerformanceClient,
     IPerformanceClient,
     BaseAuthRequest,
     PromptValue,
@@ -68,10 +67,8 @@ import { SilentAuthCodeClient } from "../interaction_client/SilentAuthCodeClient
 import { BrowserAuthError } from "../error/BrowserAuthError";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { NativeTokenRequest } from "../broker/nativeBroker/NativeRequest";
-import { BrowserPerformanceClient } from "../telemetry/BrowserPerformanceClient";
 import { StandardOperatingContext } from "../operatingcontext/StandardOperatingContext";
 import { BaseOperatingContext } from "../operatingcontext/BaseOperatingContext";
-import { version, name } from "../packageMetadata";
 import { IController } from "./IController";
 import { AuthenticationResult } from "../response/AuthenticationResult";
 

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -148,7 +148,7 @@ export class CryptoOps implements ICrypto {
         });
 
         if (publicKeyThumbMeasurement) {
-            publicKeyThumbMeasurement.endMeasurement({
+            publicKeyThumbMeasurement.end({
                 success: true,
             });
         }
@@ -236,7 +236,7 @@ export class CryptoOps implements ICrypto {
         const signedJwt = `${tokenString}.${encodedSignature}`;
 
         if (signJwtMeasurement) {
-            signJwtMeasurement.endMeasurement({
+            signJwtMeasurement.end({
                 success: true,
             });
         }

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -129,7 +129,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
                 this.accountId,
                 nativeRequest
             );
-            nativeATMeasurement.endMeasurement({
+            nativeATMeasurement.end({
                 success: true,
                 isNativeBroker: false, // Should be true only when the result is coming directly from the broker
                 fromCache: true,
@@ -160,7 +160,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             reqTimestamp
         )
             .then((result: AuthenticationResult) => {
-                nativeATMeasurement.endMeasurement({
+                nativeATMeasurement.end({
                     success: true,
                     isNativeBroker: true,
                     requestId: result.requestId,
@@ -168,7 +168,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
                 return result;
             })
             .catch((error: AuthError) => {
-                nativeATMeasurement.endMeasurement({
+                nativeATMeasurement.end({
                     success: false,
                     errorCode: error.errorCode,
                     subErrorCode: error.subError,
@@ -699,7 +699,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             return null;
         }
 
-        this.performanceClient.addStaticFields(
+        this.performanceClient.addFields(
             {
                 extensionId: this.nativeMessageHandler.getExtensionId(),
                 extensionVersion:

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -310,7 +310,7 @@ export class PopupClient extends StandardInteractionClient {
                 );
                 // end measurement for server call with native brokering enabled
                 if (fetchNativeAccountIdMeasurement) {
-                    fetchNativeAccountIdMeasurement.endMeasurement({
+                    fetchNativeAccountIdMeasurement.end({
                         success: true,
                         isNativeBroker: true,
                     });
@@ -420,7 +420,7 @@ export class PopupClient extends StandardInteractionClient {
             } catch {
                 if (validRequest.account?.homeAccountId && validRequest.postLogoutRedirectUri && authClient.authority.protocolMode === ProtocolMode.OIDC){
                     this.browserStorage.removeAccount(validRequest.account?.homeAccountId);
-                    
+
                     this.eventHandler.emitEvent(
                         EventType.LOGOUT_SUCCESS,
                         InteractionType.Popup,
@@ -872,7 +872,7 @@ export class PopupClient extends StandardInteractionClient {
         return `${BrowserConstants.POPUP_NAME_PREFIX}.${this.config.auth.clientId}.${homeAccountId}.${this.correlationId}`;
     }
 
-    /** 
+    /**
      * Extracts the server response from the popup window
      */
     extractServerResponseStringFromPopup(

--- a/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
@@ -50,7 +50,7 @@ export class SilentCacheClient extends StandardInteractionClient {
                 silentRequest
             ) as AuthenticationResult;
 
-            acquireTokenMeasurement.endMeasurement({
+            acquireTokenMeasurement.end({
                 success: true,
                 fromCache: true,
             });
@@ -65,7 +65,7 @@ export class SilentCacheClient extends StandardInteractionClient {
                     "Signing keypair for bound access token not found. Refreshing bound access token and generating a new crypto keypair."
                 );
             }
-            acquireTokenMeasurement.endMeasurement({
+            acquireTokenMeasurement.end({
                 errorCode:
                     (error instanceof AuthError && error.errorCode) ||
                     undefined,

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -97,7 +97,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             request.prompt !== PromptValue.NONE &&
             request.prompt !== PromptValue.NO_SESSION
         ) {
-            acquireTokenMeasurement.endMeasurement({
+            acquireTokenMeasurement.end({
                 success: false,
             });
             throw BrowserAuthError.createSilentPromptValueError(request.prompt);
@@ -148,7 +148,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             );
             return await this.silentTokenHelper(authClient, silentRequest).then(
                 (result: AuthenticationResult) => {
-                    acquireTokenMeasurement.endMeasurement({
+                    acquireTokenMeasurement.end({
                         success: true,
                         fromCache: false,
                         requestId: result.requestId,
@@ -162,7 +162,7 @@ export class SilentIframeClient extends StandardInteractionClient {
                 serverTelemetryManager.cacheFailedRequest(e);
             }
             this.browserStorage.cleanRequestByState(silentRequest.state);
-            acquireTokenMeasurement.endMeasurement({
+            acquireTokenMeasurement.end({
                 errorCode: (e instanceof AuthError && e.errorCode) || undefined,
                 subErrorCode:
                     (e instanceof AuthError && e.subError) || undefined,

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -60,7 +60,7 @@ export class SilentRefreshClient extends StandardInteractionClient {
             .acquireTokenByRefreshToken(silentRequest)
             .then((result) => result as AuthenticationResult)
             .then((result: AuthenticationResult) => {
-                acquireTokenMeasurement.endMeasurement({
+                acquireTokenMeasurement.end({
                     success: true,
                     fromCache: result.fromCache,
                     requestId: result.requestId,
@@ -71,7 +71,7 @@ export class SilentRefreshClient extends StandardInteractionClient {
             .catch((e: AuthError) => {
                 (e as AuthError).setCorrelationId(this.correlationId);
                 serverTelemetryManager.cacheFailedRequest(e);
-                acquireTokenMeasurement.endMeasurement({
+                acquireTokenMeasurement.end({
                     errorCode: e.errorCode,
                     subErrorCode: e.subError,
                     success: false,

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -390,14 +390,14 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
             this.correlationId
         )
             .then((result: Authority) => {
-                getAuthorityMeasurement.endMeasurement({
+                getAuthorityMeasurement.end({
                     success: true,
                 });
 
                 return result;
             })
             .catch((error: AuthError) => {
-                getAuthorityMeasurement.endMeasurement({
+                getAuthorityMeasurement.end({
                     errorCode: error.errorCode,
                     subErrorCode: error.subError,
                     success: false,

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
@@ -32,7 +32,8 @@ export class BrowserPerformanceClient
         logger: Logger,
         libraryName: string,
         libraryVersion: string,
-        applicationTelemetry: ApplicationTelemetry
+        applicationTelemetry: ApplicationTelemetry,
+        intFields?: Set<string>
     ) {
         super(
             clientId,
@@ -40,7 +41,8 @@ export class BrowserPerformanceClient
             logger,
             libraryName,
             libraryVersion,
-            applicationTelemetry
+            applicationTelemetry,
+            intFields
         );
         this.browserCrypto = new BrowserCrypto(this.logger);
         this.guidGenerator = new GuidGenerator(this.browserCrypto);
@@ -114,10 +116,10 @@ export class BrowserPerformanceClient
 
         return {
             ...inProgressEvent,
-            endMeasurement: (
+            end: (
                 event?: Partial<PerformanceEvent>
             ): PerformanceEvent | null => {
-                const res = inProgressEvent.endMeasurement({
+                const res = inProgressEvent.end({
                     startPageVisibility,
                     endPageVisibility: this.getPageVisibility(),
                     ...event,
@@ -126,8 +128,8 @@ export class BrowserPerformanceClient
 
                 return res;
             },
-            discardMeasurement: () => {
-                inProgressEvent.discardMeasurement();
+            discard: () => {
+                inProgressEvent.discard();
                 this.deleteIncompleteSubMeasurements(inProgressEvent);
                 inProgressEvent.measurement.flushMeasurement();
             },

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
@@ -11,13 +11,15 @@ import {
     PerformanceClient,
     IPerformanceMeasurement,
     InProgressPerformanceEvent,
-    ApplicationTelemetry,
     SubMeasurement,
     PreQueueEvent,
+    Constants,
 } from "@azure/msal-common";
 import { BrowserCrypto } from "../crypto/BrowserCrypto";
 import { GuidGenerator } from "../crypto/GuidGenerator";
 import { BrowserPerformanceMeasurement } from "./BrowserPerformanceMeasurement";
+import { Configuration } from "../config/Configuration";
+import { name, version } from "../packageMetadata";
 
 export class BrowserPerformanceClient
     extends PerformanceClient
@@ -27,21 +29,24 @@ export class BrowserPerformanceClient
     private guidGenerator: GuidGenerator;
 
     constructor(
-        clientId: string,
-        authority: string,
-        logger: Logger,
-        libraryName: string,
-        libraryVersion: string,
-        applicationTelemetry: ApplicationTelemetry,
+        configuration: Configuration,
+        logger?: Logger,
+        libraryName?: string,
+        libraryVersion?: string,
         intFields?: Set<string>
     ) {
+        const libName = libraryName || name;
+        const libVersion = libraryVersion || version;
         super(
-            clientId,
-            authority,
-            logger,
-            libraryName,
-            libraryVersion,
-            applicationTelemetry,
+            configuration.auth.clientId,
+            configuration.auth.authority || `${Constants.DEFAULT_AUTHORITY}`,
+            logger || new Logger(
+                configuration.system?.loggerOptions || {},
+                libName,
+                libVersion),
+            libName,
+            libVersion,
+            configuration.telemetry?.application || { appName: '', appVersion: '' },
             intFields
         );
         this.browserCrypto = new BrowserCrypto(this.logger);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -49,7 +49,6 @@ import {
     AuthError,
     ProtocolMode,
     ServerResponseType,
-    ApplicationTelemetry
 } from "@azure/msal-common";
 import {
     ApiId,
@@ -98,9 +97,7 @@ import { NativeAuthError } from "../../src/error/NativeAuthError";
 import { StandardController } from "../../src/controllers/StandardController";
 import { BrowserPerformanceMeasurement } from "../../src/telemetry/BrowserPerformanceMeasurement";
 import { AuthenticationResult } from "../../src/response/AuthenticationResult";
-import { UrlString } from "@azure/msal-common";
 import { BrowserPerformanceClient } from "../../src/telemetry/BrowserPerformanceClient";
-import { name } from "../../src/packageMetadata";
 
 const cacheConfig = {
     temporaryCacheLocation: BrowserCacheLocation.SessionStorage,
@@ -109,14 +106,6 @@ const cacheConfig = {
     secureCookies: false,
     cacheMigrationEnabled: false,
     claimsBasedCachingEnabled: false,
-};
-
-const clientId = "test-client-id";
-const authority = "https://login.microsoftonline.com";
-const logger = new Logger({});
-const applicationTelemetry: ApplicationTelemetry = {
-    appName: "Test App",
-    appVersion: "1.0.0-test.0",
 };
 
 let testAppConfig = {
@@ -166,14 +155,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
             },
             telemetry: {
-                client: new BrowserPerformanceClient(
-                    clientId,
-                    authority,
-                    logger,
-                    name,
-                    version,
-                    applicationTelemetry
-                ),
+                client: new BrowserPerformanceClient(testAppConfig),
                 application: {
                     appName: TEST_CONFIG.applicationName,
                     appVersion: TEST_CONFIG.applicationVersion,
@@ -1029,14 +1011,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     allowNativeBroker: true,
                 },
                 telemetry: {
-                    client: new BrowserPerformanceClient(
-                        clientId,
-                        authority,
-                        logger,
-                        name,
-                        version,
-                        applicationTelemetry
-                    )
+                    client: new BrowserPerformanceClient(testAppConfig),
                 }
             });
 

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -49,6 +49,7 @@ import {
     AuthError,
     ProtocolMode,
     ServerResponseType,
+    ApplicationTelemetry
 } from "@azure/msal-common";
 import {
     ApiId,
@@ -85,6 +86,7 @@ import {
     AuthorizationCodeRequest,
     BrowserConfigurationAuthError,
     EndSessionRequest,
+    version,
 } from "../../src";
 import { RedirectHandler } from "../../src/interaction_handler/RedirectHandler";
 import { SilentAuthCodeClient } from "../../src/interaction_client/SilentAuthCodeClient";
@@ -97,6 +99,8 @@ import { StandardController } from "../../src/controllers/StandardController";
 import { BrowserPerformanceMeasurement } from "../../src/telemetry/BrowserPerformanceMeasurement";
 import { AuthenticationResult } from "../../src/response/AuthenticationResult";
 import { UrlString } from "@azure/msal-common";
+import { BrowserPerformanceClient } from "../../src/telemetry/BrowserPerformanceClient";
+import { name } from "../../src/packageMetadata";
 
 const cacheConfig = {
     temporaryCacheLocation: BrowserCacheLocation.SessionStorage,
@@ -105,6 +109,14 @@ const cacheConfig = {
     secureCookies: false,
     cacheMigrationEnabled: false,
     claimsBasedCachingEnabled: false,
+};
+
+const clientId = "test-client-id";
+const authority = "https://login.microsoftonline.com";
+const logger = new Logger({});
+const applicationTelemetry: ApplicationTelemetry = {
+    appName: "Test App",
+    appVersion: "1.0.0-test.0",
 };
 
 let testAppConfig = {
@@ -154,6 +166,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
             },
             telemetry: {
+                client: new BrowserPerformanceClient(
+                    clientId,
+                    authority,
+                    logger,
+                    name,
+                    version,
+                    applicationTelemetry
+                ),
                 application: {
                     appName: TEST_CONFIG.applicationName,
                     appVersion: TEST_CONFIG.applicationVersion,
@@ -1008,6 +1028,16 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 system: {
                     allowNativeBroker: true,
                 },
+                telemetry: {
+                    client: new BrowserPerformanceClient(
+                        clientId,
+                        authority,
+                        logger,
+                        name,
+                        version,
+                        applicationTelemetry
+                    )
+                }
             });
 
             const callbackId = pca.addPerformanceCallback((events) => {

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -150,7 +150,6 @@ const cryptoInterface = {
 const performanceClient = {
     startMeasurement: jest.fn(),
     endMeasurement: jest.fn(),
-    addStaticFields: jest.fn(),
     discardMeasurements: jest.fn(),
     removePerformanceCallback: jest.fn(),
     addPerformanceCallback: jest.fn(),
@@ -160,6 +159,8 @@ const performanceClient = {
     calculateQueuedTime: jest.fn(),
     addQueueMeasurement: jest.fn(),
     setPreQueueTime: jest.fn(),
+    addFields: jest.fn(),
+    incrementFields: jest.fn(),
 };
 
 let authorityInstance: Authority;

--- a/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
@@ -184,7 +184,6 @@ describe("RedirectHandler.ts Unit Tests", () => {
         performanceClient = {
             startMeasurement: jest.fn(),
             endMeasurement: jest.fn(),
-            addStaticFields: jest.fn(),
             discardMeasurements: jest.fn(),
             removePerformanceCallback: jest.fn(),
             addPerformanceCallback: jest.fn(),
@@ -194,6 +193,8 @@ describe("RedirectHandler.ts Unit Tests", () => {
             calculateQueuedTime: jest.fn(),
             addQueueMeasurement: jest.fn(),
             setPreQueueTime: jest.fn(),
+            addFields: jest.fn(),
+            incrementFields: jest.fn(),
         };
     });
 

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -164,7 +164,6 @@ describe("SilentHandler.ts Unit Tests", () => {
         performanceClient = {
             startMeasurement: jest.fn(),
             endMeasurement: jest.fn(),
-            addStaticFields: jest.fn(),
             discardMeasurements: jest.fn(),
             removePerformanceCallback: jest.fn(),
             addPerformanceCallback: jest.fn(),
@@ -174,6 +173,8 @@ describe("SilentHandler.ts Unit Tests", () => {
             calculateQueuedTime: jest.fn(),
             addQueueMeasurement: jest.fn(),
             setPreQueueTime: jest.fn(),
+            addFields: jest.fn(),
+            incrementFields: jest.fn(),
         };
     });
 

--- a/lib/msal-browser/test/telemetry/BrowserPerformanceClient.spec.ts
+++ b/lib/msal-browser/test/telemetry/BrowserPerformanceClient.spec.ts
@@ -93,7 +93,7 @@ describe("BrowserPerformanceClient.ts", () => {
                 correlationId
             );
 
-            const result = measurement.endMeasurement();
+            const result = measurement.end();
 
             expect(result?.durationMs).toBe(50);
         });
@@ -117,7 +117,7 @@ describe("BrowserPerformanceClient.ts", () => {
                 correlationId
             );
 
-            const result = measurement.endMeasurement();
+            const result = measurement.end();
 
             expect(result?.startPageVisibility).toBe("visible");
             expect(result?.endPageVisibility).toBe("visible");

--- a/lib/msal-browser/test/telemetry/BrowserPerformanceClient.spec.ts
+++ b/lib/msal-browser/test/telemetry/BrowserPerformanceClient.spec.ts
@@ -1,22 +1,15 @@
 import {
-    ApplicationTelemetry,
-    Logger,
     PerformanceEvents,
 } from "@azure/msal-common";
-import { name, version } from "../../src/packageMetadata";
 import { BrowserPerformanceClient } from "../../src/telemetry/BrowserPerformanceClient";
+import { TEST_CONFIG } from "../utils/StringConstants";
 
-const clientId = "test-client-id";
-const authority = "https://login.microsoftonline.com";
-const logger = new Logger({});
 const correlationId = "correlation-id";
-const applicationTelemetry: ApplicationTelemetry = {
-    appName: "Test App",
-    appVersion: "1.0.0-test.0",
-};
-const cryptoOptions = {
-    useMsrCrypto: false,
-    entropy: undefined,
+
+let testAppConfig = {
+    auth: {
+        clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+    },
 };
 
 jest.mock("../../src/telemetry/BrowserPerformanceMeasurement", () => {
@@ -39,12 +32,7 @@ describe("BrowserPerformanceClient.ts", () => {
 
     it("sets pre-queue time", () => {
         const browserPerfClient = new BrowserPerformanceClient(
-            clientId,
-            authority,
-            logger,
-            name,
-            version,
-            applicationTelemetry
+            testAppConfig
         );
         const eventName = PerformanceEvents.AcquireTokenSilent;
         const correlationId = "test-correlation-id";
@@ -66,12 +54,7 @@ describe("BrowserPerformanceClient.ts", () => {
     describe("generateId", () => {
         it("returns a string", () => {
             const browserPerfClient = new BrowserPerformanceClient(
-                clientId,
-                authority,
-                logger,
-                name,
-                version,
-                applicationTelemetry
+                testAppConfig
             );
 
             expect(typeof browserPerfClient.generateId()).toBe("string");
@@ -80,12 +63,7 @@ describe("BrowserPerformanceClient.ts", () => {
     describe("startPerformanceMeasurement", () => {
         it("calculate performance duration", () => {
             const browserPerfClient = new BrowserPerformanceClient(
-                clientId,
-                authority,
-                logger,
-                name,
-                version,
-                applicationTelemetry
+                testAppConfig
             );
 
             const measurement = browserPerfClient.startMeasurement(
@@ -104,12 +82,7 @@ describe("BrowserPerformanceClient.ts", () => {
                 .mockReturnValue("visible");
 
             const browserPerfClient = new BrowserPerformanceClient(
-                clientId,
-                authority,
-                logger,
-                name,
-                version,
-                applicationTelemetry
+                testAppConfig
             );
 
             const measurement = browserPerfClient.startMeasurement(
@@ -128,12 +101,7 @@ describe("BrowserPerformanceClient.ts", () => {
 
     it("supportsBrowserPerformanceNow returns false if window.performance not present", () => {
         const browserPerfClient = new BrowserPerformanceClient(
-            clientId,
-            authority,
-            logger,
-            name,
-            version,
-            applicationTelemetry
+            testAppConfig
         );
 
         // @ts-ignore

--- a/lib/msal-browser/test/utils/TelemetryUtils.ts
+++ b/lib/msal-browser/test/utils/TelemetryUtils.ts
@@ -4,28 +4,17 @@
  */
 
 import {
-    Logger,
-    ApplicationTelemetry,
     IPerformanceClient,
 } from "@azure/msal-common";
-import { name, version } from "../../src/packageMetadata";
 import { BrowserPerformanceClient } from "../../src/telemetry/BrowserPerformanceClient";
-
-const clientId = "test-client-id";
-const authority = "https://login.microsoftonline.com";
-const logger = new Logger({});
-const applicationTelemetry: ApplicationTelemetry = {
-    appName: "Test App",
-    appVersion: "1.0.0-test.0",
-};
+import { TEST_CONFIG } from "./StringConstants";
 
 export function getDefaultPerformanceClient(): IPerformanceClient {
     return new BrowserPerformanceClient(
-        clientId,
-        authority,
-        logger,
-        name,
-        version,
-        applicationTelemetry
+        {
+            auth: {
+                clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+            },
+        }
     );
 }

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -614,10 +614,10 @@ export class Authority {
                 );
             const isValidResponse = isOpenIdConfigResponse(response.body);
             if (isValidResponse) {
-                perfEvent?.endMeasurement({ success: true });
+                perfEvent?.end({ success: true });
                 return response.body;
             } else {
-                perfEvent?.endMeasurement({
+                perfEvent?.end({
                     success: false,
                     errorCode: "invalid_response",
                 });
@@ -627,7 +627,7 @@ export class Authority {
                 return null;
             }
         } catch (e) {
-            perfEvent?.endMeasurement({
+            perfEvent?.end({
                 success: false,
                 errorCode: "request_failure",
             });

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -69,8 +69,8 @@ export class AuthorizationCodeClient extends BaseClient {
      */
     async getAuthCodeUrl(
         request: CommonAuthorizationUrlRequest
-    ): 
-        
+    ):
+
         Promise<string> {
         this.performanceClient?.addQueueMeasurement(
             PerformanceEvents.GetAuthCodeUrl,
@@ -129,7 +129,7 @@ export class AuthorizationCodeClient extends BaseClient {
         const httpVerAuthority =
             response.headers?.[HeaderNames.X_MS_HTTP_VERSION];
         if (httpVerAuthority) {
-            atsMeasurement?.addStaticFields({
+            atsMeasurement?.add({
                 httpVerAuthority,
             });
         }
@@ -163,7 +163,7 @@ export class AuthorizationCodeClient extends BaseClient {
                 requestId
             )
             .then((result: AuthenticationResult) => {
-                atsMeasurement?.endMeasurement({
+                atsMeasurement?.end({
                     success: true,
                 });
                 return result;
@@ -173,7 +173,7 @@ export class AuthorizationCodeClient extends BaseClient {
                     "Error in fetching token in ACC",
                     request.correlationId
                 );
-                atsMeasurement?.endMeasurement({
+                atsMeasurement?.end({
                     errorCode: error.errorCode,
                     subErrorCode: error.subError,
                     success: false,

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -71,11 +71,11 @@ export class RefreshTokenClient extends BaseClient {
             this.authority
         );
         const httpVerToken = response.headers?.[HeaderNames.X_MS_HTTP_VERSION];
-        atsMeasurement?.addStaticFields({
+        atsMeasurement?.add({
             refreshTokenSize: response.body.refresh_token?.length || 0,
         });
         if (httpVerToken) {
-            atsMeasurement?.addStaticFields({
+            atsMeasurement?.add({
                 httpVerToken,
             });
         }
@@ -109,7 +109,7 @@ export class RefreshTokenClient extends BaseClient {
                 requestId
             )
             .then((result: AuthenticationResult) => {
-                atsMeasurement?.endMeasurement({
+                atsMeasurement?.end({
                     success: true,
                 });
                 return result;
@@ -119,7 +119,7 @@ export class RefreshTokenClient extends BaseClient {
                     "Error in fetching refresh token",
                     request.correlationId
                 );
-                atsMeasurement?.endMeasurement({
+                atsMeasurement?.end({
                     errorCode: error.errorCode,
                     subErrorCode: error.subError,
                     success: false,
@@ -227,11 +227,11 @@ export class RefreshTokenClient extends BaseClient {
         );
 
         if (!refreshToken) {
-            atsMeasurement?.discardMeasurement();
+            atsMeasurement?.discard();
             throw InteractionRequiredAuthError.createNoTokensFoundError();
         }
         // attach cached RT size to the current measurement
-        atsMeasurement?.endMeasurement({
+        atsMeasurement?.end({
             success: true,
         });
 
@@ -305,13 +305,13 @@ export class RefreshTokenClient extends BaseClient {
             thumbprint
         )
             .then((result) => {
-                acquireTokenMeasurement?.endMeasurement({
+                acquireTokenMeasurement?.end({
                     success: true,
                 });
                 return result;
             })
             .catch((error) => {
-                acquireTokenMeasurement?.endMeasurement({
+                acquireTokenMeasurement?.end({
                     success: false,
                 });
                 throw error;
@@ -391,7 +391,7 @@ export class RefreshTokenClient extends BaseClient {
             if (request.sshJwk) {
                 parameterBuilder.addSshJwk(request.sshJwk);
             } else {
-                acquireTokenMeasurement?.endMeasurement({
+                acquireTokenMeasurement?.end({
                     success: false,
                 });
                 throw ClientConfigurationError.createMissingSshJwkError();
@@ -434,7 +434,7 @@ export class RefreshTokenClient extends BaseClient {
                     break;
             }
         }
-        acquireTokenMeasurement?.endMeasurement({
+        acquireTokenMeasurement?.end({
             success: true,
         });
         return parameterBuilder.createQueryString();

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -194,12 +194,10 @@ export {
     QueueMeasurement,
 } from "./telemetry/performance/IPerformanceClient";
 export {
-    Counters,
     IntFields,
     PerformanceEvent,
     PerformanceEvents,
     PerformanceEventStatus,
-    StaticFields,
     SubMeasurement,
 } from "./telemetry/performance/PerformanceEvent";
 export { IPerformanceMeasurement } from "./telemetry/performance/IPerformanceMeasurement";

--- a/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
@@ -17,7 +17,7 @@ export type InProgressPerformanceEvent = {
     ) => PerformanceEvent | null;
     discard: () => void;
     add: (fields: { [key: string]: {} | undefined; }) => void;
-    increment: (fields: { [key: string]: {} | undefined; }) => void;
+    increment: (fields: { [key: string]: number | undefined; }) => void;
     event: PerformanceEvent;
     measurement: IPerformanceMeasurement;
 };
@@ -30,7 +30,7 @@ export interface IPerformanceClient {
     endMeasurement(event: PerformanceEvent): PerformanceEvent | null;
     discardMeasurements(correlationId: string): void;
     addFields(fields: { [key: string]: {} | undefined }, correlationId: string): void;
-    incrementFields(fields: { [key: string]: {} | undefined }, correlationId: string): void;
+    incrementFields(fields: { [key: string]: number | undefined }, correlationId: string): void;
     removePerformanceCallback(callbackId: string): boolean;
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
     emitEvents(events: PerformanceEvent[], correlationId: string): void;

--- a/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
@@ -4,34 +4,33 @@
  */
 
 import {
-    Counters,
     PerformanceEvent,
-    PerformanceEvents,
-    StaticFields,
+    PerformanceEvents
 } from "./PerformanceEvent";
 import { IPerformanceMeasurement } from "./IPerformanceMeasurement";
 
 export type PerformanceCallbackFunction = (events: PerformanceEvent[]) => void;
 
 export type InProgressPerformanceEvent = {
-    endMeasurement: (
+    end: (
         event?: Partial<PerformanceEvent>
     ) => PerformanceEvent | null;
-    discardMeasurement: () => void;
-    addStaticFields: (staticFields: StaticFields) => void;
-    increment: (counters: Counters) => void;
+    discard: () => void;
+    add: (fields: { [key: string]: {} | undefined; }) => void;
+    increment: (fields: { [key: string]: {} | undefined; }) => void;
     event: PerformanceEvent;
     measurement: IPerformanceMeasurement;
 };
 
 export interface IPerformanceClient {
     startMeasurement(
-        measureName: PerformanceEvents,
+        measureName: string,
         correlationId?: string
     ): InProgressPerformanceEvent;
     endMeasurement(event: PerformanceEvent): PerformanceEvent | null;
     discardMeasurements(correlationId: string): void;
-    addStaticFields(staticFields: StaticFields, correlationId: string): void;
+    addFields(fields: { [key: string]: {} | undefined }, correlationId: string): void;
+    incrementFields(fields: { [key: string]: {} | undefined }, correlationId: string): void;
     removePerformanceCallback(callbackId: string): boolean;
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
     emitEvents(events: PerformanceEvent[], correlationId: string): void;

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -442,7 +442,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @param fields {string[]}
      * @param correlationId {string} correlation identifier
      */
-    incrementFields(fields: { [key: string]: {} | undefined; }, correlationId: string): void {
+    incrementFields(fields: { [key: string]: number | undefined; }, correlationId: string): void {
         this.logger.trace("PerformanceClient: Updating counters");
         const event = this.eventsByCorrelationId.get(correlationId);
         if (event) {

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -322,7 +322,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
                     inProgressEvent.correlationId
                 );
             },
-            increment: (fields: { [key: string]: {} | undefined; }) => {
+            increment: (fields: { [key: string]: number | undefined; }) => {
                 return this.incrementFields(fields, inProgressEvent.correlationId);
             },
             measurement: performanceMeasurement,

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -13,12 +13,10 @@ import {
 } from "./IPerformanceClient";
 import { IPerformanceMeasurement } from "./IPerformanceMeasurement";
 import {
-    Counters,
     IntFields,
     PerformanceEvent,
     PerformanceEvents,
-    PerformanceEventStatus,
-    StaticFields,
+    PerformanceEventStatus
 } from "./PerformanceEvent";
 
 export interface PreQueueEvent {
@@ -58,6 +56,8 @@ export abstract class PerformanceClient implements IPerformanceClient {
      */
     protected queueMeasurements: Map<string, Array<QueueMeasurement>>;
 
+    protected intFields: Set<string>;
+
     /**
      * Creates an instance of PerformanceClient,
      * an abstract class containing core performance telemetry logic.
@@ -68,6 +68,8 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @param {Logger} logger Logger used by the application
      * @param {string} libraryName Name of the library
      * @param {string} libraryVersion Version of the library
+     * @param {ApplicationTelemetry} applicationTelemetry application name and version
+     * @param {Set<String>} intFields integer fields to be truncated
      */
     constructor(
         clientId: string,
@@ -75,7 +77,8 @@ export abstract class PerformanceClient implements IPerformanceClient {
         logger: Logger,
         libraryName: string,
         libraryVersion: string,
-        applicationTelemetry: ApplicationTelemetry
+        applicationTelemetry: ApplicationTelemetry,
+        intFields?: Set<string>
     ) {
         this.authority = authority;
         this.libraryName = libraryName;
@@ -87,6 +90,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
         this.eventsByCorrelationId = new Map();
         this.queueMeasurements = new Map();
         this.preQueueTimeByCorrelationId = new Map();
+        this.intFields = intFields || new Set();
+        for (const item of IntFields) {
+            this.intFields.add(item);
+        }
     }
 
     /**
@@ -124,14 +131,6 @@ export abstract class PerformanceClient implements IPerformanceClient {
         eventName: PerformanceEvents,
         correlationId?: string
     ): void;
-
-    /**
-     * Get integral fields.
-     * Override to change the set.
-     */
-    getIntFields(): ReadonlySet<string> {
-        return IntFields;
-    }
 
     /**
      * Gets map of pre-queue times by correlation Id
@@ -260,7 +259,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @returns {InProgressPerformanceEvent}
      */
     startMeasurement(
-        measureName: PerformanceEvents,
+        measureName: string,
         correlationId?: string
     ): InProgressPerformanceEvent {
         // Generate a placeholder correlation if the request does not provide one
@@ -301,7 +300,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
 
         // Return the event and functions the caller can use to properly end/flush the measurement
         return {
-            endMeasurement: (
+            end: (
                 event?: Partial<PerformanceEvent>
             ): PerformanceEvent | null => {
                 return this.endMeasurement(
@@ -314,17 +313,17 @@ export abstract class PerformanceClient implements IPerformanceClient {
                     performanceMeasurement
                 );
             },
-            discardMeasurement: () => {
+            discard: () => {
                 return this.discardMeasurements(inProgressEvent.correlationId);
             },
-            addStaticFields: (fields: StaticFields) => {
-                return this.addStaticFields(
+            add: (fields: { [key: string]: {} | undefined; }) => {
+                return this.addFields(
                     fields,
                     inProgressEvent.correlationId
                 );
             },
-            increment: (counters: Counters) => {
-                return this.increment(counters, inProgressEvent.correlationId);
+            increment: (fields: { [key: string]: {} | undefined; }) => {
+                return this.incrementFields(fields, inProgressEvent.correlationId);
             },
             measurement: performanceMeasurement,
             event: inProgressEvent,
@@ -411,7 +410,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
             status: PerformanceEventStatus.Completed,
             incompleteSubsCount,
         };
-        this.truncateIntegralFields(finalEvent, this.getIntFields());
+        this.truncateIntegralFields(finalEvent);
         this.emitEvents([finalEvent], event.correlationId);
 
         return finalEvent;
@@ -422,7 +421,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @param fields
      * @param correlationId
      */
-    addStaticFields(fields: StaticFields, correlationId: string): void {
+    addFields(fields: { [key: string]: {} | undefined; }, correlationId: string): void {
         this.logger.trace("PerformanceClient: Updating static fields");
         const event = this.eventsByCorrelationId.get(correlationId);
         if (event) {
@@ -440,18 +439,20 @@ export abstract class PerformanceClient implements IPerformanceClient {
 
     /**
      * Increment counters to be emitted when the measurements are flushed
-     * @param counters {Counters}
+     * @param fields {string[]}
      * @param correlationId {string} correlation identifier
      */
-    increment(counters: Counters, correlationId: string): void {
+    incrementFields(fields: { [key: string]: {} | undefined; }, correlationId: string): void {
         this.logger.trace("PerformanceClient: Updating counters");
         const event = this.eventsByCorrelationId.get(correlationId);
         if (event) {
-            for (const counter in counters) {
+            for (const counter in fields) {
                 if (!event.hasOwnProperty(counter)) {
                     event[counter] = 0;
+                } else if (isNaN(Number(event[counter]))) {
+                    return;
                 }
-                event[counter] += counters[counter];
+                event[counter] += fields[counter];
             }
         } else {
             this.logger.trace(
@@ -470,7 +471,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @private
      * @param {PerformanceEvent} event
      */
-    private cacheEventByCorrelationId(event: PerformanceEvent) {
+    protected cacheEventByCorrelationId(event: PerformanceEvent): void {
         const rootEvent = this.eventsByCorrelationId.get(event.correlationId);
         if (rootEvent) {
             this.logger.trace(
@@ -622,10 +623,9 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @param {Set<string>} intFields integral fields.
      */
     private truncateIntegralFields(
-        event: PerformanceEvent,
-        intFields: ReadonlySet<string>
+        event: PerformanceEvent
     ): void {
-        intFields.forEach((key) => {
+        this.intFields.forEach((key) => {
             if (key in event && typeof event[key] === "number") {
                 event[key] = Math.floor(event[key]);
             }

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -240,6 +240,8 @@ export const PerformanceEvents = {
     UsernamePasswordClientAcquireToken: "usernamePasswordClientAcquireToken",
 
     NativeMessageHandlerHandshake: "nativeMessageHandlerHandshake",
+
+    NativeGenerateAuthResult: "nativeGenerateAuthResult"
 } as const;
 export type PerformanceEvents = typeof PerformanceEvents[keyof typeof PerformanceEvents];
 
@@ -256,108 +258,8 @@ export const PerformanceEventStatus = {
 } as const;
 export type PerformanceEventStatus = typeof PerformanceEventStatus[keyof typeof PerformanceEventStatus];
 
-/**
- * Fields whose value will not change throughout a request
- */
-export type StaticFields = {
-    /**
-     * The Silent Token Cache Lookup Policy
-     *
-     * @type {?(number | undefined)}
-     */
-    cacheLookupPolicy?: number | undefined;
-
-    /**
-     * Size of the id token
-     *
-     * @type {number}
-     */
-    idTokenSize?: number;
-
-    /**
-     *
-     * Size of the access token
-     *
-     * @type {number}
-     */
-
-    accessTokenSize?: number;
-
-    /**
-     *
-     * Size of the refresh token
-     *
-     * @type {number}
-     */
-
-    refreshTokenSize?: number | undefined;
-
-    /**
-     * Application name as specified by the app.
-     *
-     * @type {?string}
-     */
-    appName?: string;
-
-    /**
-     * Application version as specified by the app.
-     *
-     * @type {?string}
-     */
-    appVersion?: string;
-
-    /**
-     * The following are fields that may be emitted in native broker scenarios
-     */
-    extensionId?: string;
-    extensionVersion?: string;
-    matsBrokerVersion?: string;
-    matsAccountJoinOnStart?: string;
-    matsAccountJoinOnEnd?: string;
-    matsDeviceJoin?: string;
-    matsPromptBehavior?: string;
-    matsApiErrorCode?: number;
-    matsUiVisible?: boolean;
-    matsSilentCode?: number;
-    matsSilentBiSubCode?: number;
-    matsSilentMessage?: string;
-    matsSilentStatus?: number;
-    matsHttpStatus?: number;
-    matsHttpEventCount?: number;
-    httpVerToken?: string;
-    httpVerAuthority?: string;
-
-    /**
-     * Native broker fields
-     */
-    allowNativeBroker?: boolean;
-    extensionInstalled?: boolean;
-    extensionHandshakeTimeoutMs?: number;
-    extensionHandshakeTimedOut?: boolean;
-};
-
-/**
- * Fields whose value may change throughout a request
- */
-export type Counters = {
-    visibilityChangeCount?: number;
-    incompleteSubsCount?: number;
-    /**
-     * Amount of times queued in the JS event queue.
-     *
-     * @type {?number}
-     */
-    queuedCount?: number;
-    /**
-     * Amount of manually completed queue events.
-     *
-     * @type {?number}
-     */
-    queuedManuallyCompletedCount?: number;
-};
-
 export type SubMeasurement = {
-    name: PerformanceEvents;
+    name: string;
     startTimeMs: number;
 };
 
@@ -367,8 +269,7 @@ export type SubMeasurement = {
  * @export
  * @typedef {PerformanceEvent}
  */
-export type PerformanceEvent = StaticFields &
-    Counters & {
+export type PerformanceEvent = {
         /**
          * Unique id for the event
          *
@@ -430,9 +331,9 @@ export type PerformanceEvent = StaticFields &
         /**
          * Event name (usually in the form of classNameFunctionName)
          *
-         * @type {PerformanceEvents}
+         * @type {string}
          */
-        name: PerformanceEvents;
+        name: string;
 
         /**
          * Visibility of the page when the event completed.
@@ -516,6 +417,89 @@ export type PerformanceEvent = StaticFields &
          * Sub-measurements for internal use. To be deleted before flushing.
          */
         incompleteSubMeasurements?: Map<string, SubMeasurement>;
+
+        visibilityChangeCount?: number;
+        incompleteSubsCount?: number;
+        /**
+         * Amount of times queued in the JS event queue.
+         *
+         * @type {?number}
+         */
+        queuedCount?: number;
+        /**
+         * Amount of manually completed queue events.
+         *
+         * @type {?number}
+         */
+        queuedManuallyCompletedCount?: number;
+
+        /**
+         * Size of the id token
+         *
+         * @type {number}
+         */
+        idTokenSize?: number;
+
+        /**
+         *
+         * Size of the access token
+         *
+         * @type {number}
+         */
+
+        accessTokenSize?: number;
+
+        /**
+         *
+         * Size of the refresh token
+         *
+         * @type {number}
+         */
+
+        refreshTokenSize?: number | undefined;
+
+        /**
+         * Application name as specified by the app.
+         *
+         * @type {?string}
+         */
+        appName?: string;
+
+        /**
+         * Application version as specified by the app.
+         *
+         * @type {?string}
+         */
+        appVersion?: string;
+
+        /**
+         * The following are fields that may be emitted in native broker scenarios
+         */
+        extensionId?: string;
+        extensionVersion?: string;
+        matsBrokerVersion?: string;
+        matsAccountJoinOnStart?: string;
+        matsAccountJoinOnEnd?: string;
+        matsDeviceJoin?: string;
+        matsPromptBehavior?: string;
+        matsApiErrorCode?: number;
+        matsUiVisible?: boolean;
+        matsSilentCode?: number;
+        matsSilentBiSubCode?: number;
+        matsSilentMessage?: string;
+        matsSilentStatus?: number;
+        matsHttpStatus?: number;
+        matsHttpEventCount?: number;
+        httpVerToken?: string;
+        httpVerAuthority?: string;
+
+        /**
+         * Native broker fields
+         */
+        allowNativeBroker?: boolean;
+        extensionInstalled?: boolean;
+        extensionHandshakeTimeoutMs?: number;
+        extensionHandshakeTimedOut?: boolean;
     };
 
 export const IntFields: ReadonlySet<string> = new Set([

--- a/lib/msal-common/src/telemetry/performance/StubPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/StubPerformanceClient.ts
@@ -6,6 +6,7 @@
 import { IPerformanceClient } from "./IPerformanceClient";
 import { IPerformanceMeasurement } from "./IPerformanceMeasurement";
 import { PerformanceClient } from "./PerformanceClient";
+import { PerformanceEvent } from "./PerformanceEvent";
 
 export class StubPerformanceMeasurement implements IPerformanceMeasurement {
     startMeasurement(): void { return; }
@@ -13,23 +14,23 @@ export class StubPerformanceMeasurement implements IPerformanceMeasurement {
     flushMeasurement(): number | null { return null; }
 }
 
+const stubPerformanceMeasurement = new StubPerformanceMeasurement();
+
 export class StubPerformanceClient
     extends PerformanceClient
     implements IPerformanceClient
 {
-    generateId(): string {
-        return "callback-id";
-    }
-
-    startPerformanceMeasurement(): IPerformanceMeasurement {
-        return new StubPerformanceMeasurement();
-    }
-
-    calculateQueuedTime(): number {
-        return 0;
-    }
-
+    endMeasurement(): PerformanceEvent | null { return null; }
+    discardMeasurements(): void { return; }
+    removePerformanceCallback(): boolean { return true; };
+    addPerformanceCallback(): string { return ''; }
+    emitEvents(): void { return; }
+    startPerformanceMeasurement(): IPerformanceMeasurement { return stubPerformanceMeasurement }
+    generateId(): string { return "callback-id"; }
+    calculateQueuedTime(): number { return 0; }
     addQueueMeasurement(): void { return; }
-
     setPreQueueTime(): void { return; }
+    addFields(): void { return; }
+    incrementFields(): void { return; }
+    cacheEventByCorrelationId(): void { return; }
 }

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -3278,8 +3278,8 @@ describe("AuthorizationCodeClient unit tests", () => {
             const performanceClient = {
                 startMeasurement: jest.fn(),
                 endMeasurement: jest.fn(),
-                addStaticFields: jest.fn(),
-                incrementCounters: jest.fn(),
+                addFields: jest.fn(),
+                incrementFields: jest.fn(),
                 discardMeasurements: jest.fn(),
                 removePerformanceCallback: jest.fn(),
                 addPerformanceCallback: jest.fn(),
@@ -3291,7 +3291,11 @@ describe("AuthorizationCodeClient unit tests", () => {
                 setPreQueueTime: jest.fn(),
             };
             performanceClient.startMeasurement.mockImplementation(() => {
-                return performanceClient;
+                return {
+                    add: (fields: { [key: string]: {} | undefined; }) => performanceClient.addFields(fields, TEST_CONFIG.CORRELATION_ID),
+                    increment: jest.fn(),
+                    end: jest.fn(),
+                }
             });
             const client = new AuthorizationCodeClient(
                 config,
@@ -3315,9 +3319,9 @@ describe("AuthorizationCodeClient unit tests", () => {
                 nonce: idTokenClaims.nonce,
             });
 
-            expect(performanceClient.addStaticFields).toBeCalledWith({
-                httpVerAuthority: "xMsHttpVer",
-            });
+            expect(performanceClient.addFields).toBeCalledWith({
+                httpVerAuthority: "xMsHttpVer"
+            }, TEST_CONFIG.CORRELATION_ID);
         });
 
         it("does not add http version to the measurement when not received in server response", async () => {
@@ -3355,8 +3359,8 @@ describe("AuthorizationCodeClient unit tests", () => {
             const performanceClient = {
                 startMeasurement: jest.fn(),
                 endMeasurement: jest.fn(),
-                addStaticFields: jest.fn(),
-                incrementCounters: jest.fn(),
+                addFields: jest.fn(),
+                incrementFields: jest.fn(),
                 discardMeasurements: jest.fn(),
                 removePerformanceCallback: jest.fn(),
                 addPerformanceCallback: jest.fn(),
@@ -3368,7 +3372,11 @@ describe("AuthorizationCodeClient unit tests", () => {
                 setPreQueueTime: jest.fn(),
             };
             performanceClient.startMeasurement.mockImplementation(() => {
-                return performanceClient;
+                return {
+                    add: (fields: { [key: string]: {} | undefined; }) => performanceClient.addFields(fields, TEST_CONFIG.CORRELATION_ID),
+                    increment: jest.fn(),
+                    end: jest.fn(),
+                }
             });
             const client = new AuthorizationCodeClient(
                 config,
@@ -3392,7 +3400,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 nonce: idTokenClaims.nonce,
             });
 
-            expect(performanceClient.addStaticFields).not.toHaveBeenCalled();
+            expect(performanceClient.addFields).not.toHaveBeenCalled();
         });
     });
 

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -204,8 +204,8 @@ describe("RefreshTokenClient unit tests", () => {
             expect(spy).toHaveBeenCalled();
         });
 
-        it("Checks whether performance telemetry addStaticFields method is called", async () => {
-            const spy = jest.spyOn(stubPerformanceClient, "addStaticFields");
+        it("Checks whether performance telemetry add method is called", async () => {
+            const spy: any = jest.spyOn(stubPerformanceClient, "addFields");
 
             const client = new RefreshTokenClient(
                 config,
@@ -233,8 +233,8 @@ describe("RefreshTokenClient unit tests", () => {
             expect(refreshTokenSize).toBe(19);
         });
 
-        it("Checks whether performance telemetry addStaticFields method is called- no rt", async () => {
-            const spy = jest.spyOn(stubPerformanceClient, "addStaticFields");
+        it("Checks whether performance telemetry add method is called- no rt", async () => {
+            const spy: any = jest.spyOn(stubPerformanceClient, "addFields");
 
             const client = new RefreshTokenClient(
                 config,
@@ -934,8 +934,6 @@ describe("RefreshTokenClient unit tests", () => {
             const performanceClient = {
                 startMeasurement: jest.fn(),
                 endMeasurement: jest.fn(),
-                addStaticFields: jest.fn(),
-                incrementCounters: jest.fn(),
                 discardMeasurements: jest.fn(),
                 removePerformanceCallback: jest.fn(),
                 addPerformanceCallback: jest.fn(),
@@ -945,9 +943,15 @@ describe("RefreshTokenClient unit tests", () => {
                 calculateQueuedTime: jest.fn(),
                 addQueueMeasurement: jest.fn(),
                 setPreQueueTime: jest.fn(),
+                addFields: jest.fn(),
+                incrementFields: jest.fn(),
             };
             performanceClient.startMeasurement.mockImplementation(() => {
-                return performanceClient;
+                return {
+                    add: (fields: { [key: string]: {} | undefined; }) => performanceClient.addFields(fields, TEST_CONFIG.CORRELATION_ID),
+                    increment: jest.fn(),
+                    end: jest.fn(),
+                }
             });
             const client = new RefreshTokenClient(config, performanceClient);
             const refreshTokenRequest: CommonRefreshTokenRequest = {
@@ -961,10 +965,10 @@ describe("RefreshTokenClient unit tests", () => {
             };
             await client.acquireToken(refreshTokenRequest);
 
-            expect(performanceClient.addStaticFields).toBeCalledTimes(2);
-            expect(performanceClient.addStaticFields).toBeCalledWith({
-                httpVerToken: "xMsHttpVer",
-            });
+            expect(performanceClient.addFields).toBeCalledTimes(2);
+            expect(performanceClient.addFields).toBeCalledWith({
+                httpVerToken: "xMsHttpVer"
+            }, TEST_CONFIG.CORRELATION_ID);
         });
 
         it("does not add http version to the measurement when not received in server response", async () => {
@@ -974,8 +978,6 @@ describe("RefreshTokenClient unit tests", () => {
             const performanceClient = {
                 startMeasurement: jest.fn(),
                 endMeasurement: jest.fn(),
-                addStaticFields: jest.fn(),
-                incrementCounters: jest.fn(),
                 discardMeasurements: jest.fn(),
                 removePerformanceCallback: jest.fn(),
                 addPerformanceCallback: jest.fn(),
@@ -985,9 +987,15 @@ describe("RefreshTokenClient unit tests", () => {
                 calculateQueuedTime: jest.fn(),
                 addQueueMeasurement: jest.fn(),
                 setPreQueueTime: jest.fn(),
+                addFields: jest.fn(),
+                incrementFields: jest.fn(),
             };
             performanceClient.startMeasurement.mockImplementation(() => {
-                return performanceClient;
+                return {
+                    add: (fields: { [key: string]: {} | undefined; }) => performanceClient.addFields(fields, TEST_CONFIG.CORRELATION_ID),
+                    increment: jest.fn(),
+                    end: jest.fn(),
+                }
             });
             const client = new RefreshTokenClient(config, performanceClient);
             const refreshTokenRequest: CommonRefreshTokenRequest = {
@@ -1001,8 +1009,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
             await client.acquireToken(refreshTokenRequest);
 
-            expect(performanceClient.addStaticFields).toBeCalledTimes(1);
-            expect(performanceClient.addStaticFields).not.toBeCalledWith({
+            expect(performanceClient.addFields).toBeCalledTimes(1);
+            expect(performanceClient.addFields).not.toBeCalledWith({
                 httpVerToken: "xMsHttpVer",
             });
         });

--- a/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
+++ b/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
@@ -151,16 +151,16 @@ describe("PerformanceClient.spec.ts", () => {
             PerformanceEvents.AcquireTokenSilentAsync,
             correlationId
         );
-        subMeasurement.endMeasurement({
+        subMeasurement.end({
             success: true,
         });
 
-        topLevelEvent.endMeasurement({
+        topLevelEvent.end({
             success: true,
         });
     });
 
-    it("adds static fields", (done) => {
+    it("adds fields", (done) => {
         const mockPerfClient = new MockPerformanceClient();
 
         const correlationId = "test-correlation-id";
@@ -179,16 +179,16 @@ describe("PerformanceClient.spec.ts", () => {
             PerformanceEvents.AcquireTokenSilent,
             correlationId
         );
-        topLevelEvent.addStaticFields({
+        topLevelEvent.add({
             httpVerAuthority: authority,
             extensionId: extensionId,
         });
-        topLevelEvent.endMeasurement({
+        topLevelEvent.end({
             success: true,
         });
     });
 
-    it("increments counters", (done) => {
+    it("increments", (done) => {
         const mockPerfClient = new MockPerformanceClient();
 
         const correlationId = "test-correlation-id";
@@ -207,7 +207,7 @@ describe("PerformanceClient.spec.ts", () => {
         );
         topLevelEvent.increment({ visibilityChangeCount: 5 });
         topLevelEvent.increment({ visibilityChangeCount: 3 });
-        topLevelEvent.endMeasurement({
+        topLevelEvent.end({
             success: true,
         });
     });
@@ -241,16 +241,16 @@ describe("PerformanceClient.spec.ts", () => {
                 PerformanceEvents.AcquireTokenSilentAsync,
                 correlationId
             )
-            .endMeasurement({ status: PerformanceEventStatus.Completed });
+            .end({ status: PerformanceEventStatus.Completed });
         mockPerfClient
             .startMeasurement(
                 PerformanceEvents.SilentIframeClientAcquireToken,
                 correlationId
             )
-            .endMeasurement({ status: PerformanceEventStatus.Completed });
+            .end({ status: PerformanceEventStatus.Completed });
 
         // End top level event without ending submeasurement
-        topLevelEvent.endMeasurement({
+        topLevelEvent.end({
             success: true,
         });
     });
@@ -289,14 +289,14 @@ describe("PerformanceClient.spec.ts", () => {
                 PerformanceEvents.SilentIframeClientAcquireToken,
                 correlationId
             )
-            .endMeasurement({ status: PerformanceEventStatus.Completed });
+            .end({ status: PerformanceEventStatus.Completed });
         mockPerfClient.startMeasurement(
             PerformanceEvents.SilentCacheClientAcquireToken,
             correlationId
         );
 
         // End top level event without ending submeasurement
-        topLevelEvent.endMeasurement({
+        topLevelEvent.end({
             success: true,
         });
     });
@@ -327,7 +327,7 @@ describe("PerformanceClient.spec.ts", () => {
             PerformanceEvents.AcquireTokenSilentAsync,
             correlationId
         );
-        subMeasure1.endMeasurement({
+        subMeasure1.end({
             success: true,
         });
 
@@ -335,12 +335,12 @@ describe("PerformanceClient.spec.ts", () => {
             PerformanceEvents.AcquireTokenSilentAsync,
             correlationId
         );
-        subMeasure2.endMeasurement({
+        subMeasure2.end({
             success: true,
             durationMs: 1,
         });
 
-        topLevelEvent.endMeasurement({
+        topLevelEvent.end({
             success: true,
         });
     });
@@ -359,7 +359,7 @@ describe("PerformanceClient.spec.ts", () => {
             PerformanceEvents.AcquireTokenSilent,
             correlationId
         );
-        const result = measure.endMeasurement({
+        const result = measure.end({
             success: true,
         });
 
@@ -394,11 +394,11 @@ describe("PerformanceClient.spec.ts", () => {
             correlationId
         );
 
-        topLevelEvent2.endMeasurement({
+        topLevelEvent2.end({
             success: true,
             startTimeMs: topLevelEvent1.event.startTimeMs + 5,
         });
-        topLevelEvent1.endMeasurement({
+        topLevelEvent1.end({
             success: false,
         });
     });
@@ -431,12 +431,12 @@ describe("PerformanceClient.spec.ts", () => {
             PerformanceEvents.AcquireTokenSilent,
             correlationId
         );
-        topLevelEvent.addStaticFields({
+        topLevelEvent.add({
             accessTokenSize,
             refreshTokenSize,
             idTokenSize,
         });
-        topLevelEvent.endMeasurement({
+        topLevelEvent.end({
             success: true,
         });
     });
@@ -484,7 +484,7 @@ describe("PerformanceClient.spec.ts", () => {
             true
         );
 
-        topLevelEvent.endMeasurement({
+        topLevelEvent.end({
             success: true,
         });
     });

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -11,7 +11,6 @@ import {
     ClientConfiguration,
     CommonUsernamePasswordRequest,
     GrantType,
-    HeaderNames,
     NetworkResponse,
     RequestParameterBuilder,
     RequestThumbprint,
@@ -39,11 +38,6 @@ export class UsernamePasswordClient extends BaseClient {
     async acquireToken(
         request: CommonUsernamePasswordRequest
     ): Promise<AuthenticationResult | null> {
-        const atsMeasurement = this.performanceClient?.startMeasurement(
-            // @ts-ignore
-            "UsernamePasswordClientAcquireToken",
-            request.correlationId
-        );
         this.logger.info("in acquireToken call in username-password client");
 
         const reqTimestamp = TimeUtils.nowSeconds();
@@ -51,11 +45,6 @@ export class UsernamePasswordClient extends BaseClient {
             this.authority,
             request
         );
-
-        const httpVerToken = response.headers?.[HeaderNames.X_MS_HTTP_VERSION];
-        atsMeasurement?.add({
-            httpVerToken,
-        });
 
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -53,7 +53,7 @@ export class UsernamePasswordClient extends BaseClient {
         );
 
         const httpVerToken = response.headers?.[HeaderNames.X_MS_HTTP_VERSION];
-        atsMeasurement?.addStaticFields({
+        atsMeasurement?.add({
             httpVerToken,
         });
 


### PR DESCRIPTION
- Make measurement name param a string.
- Make measurement payload type a string.
- Merge telemetry "Counters" and "StaticFields" into "PerformanceEvent". 
- Simplify "InProgressPerformanceEvent" method names.
- Make "int fields" a parameter of "PerformanceClient" constructor.
- Make "performance client" a parameter of "PublicClientApplication" constructor.
- Stub "PublicClientApplication.performanceClient" by default to eliminate telemetry instrumentation overhead.