### PR TITLE
Expose `BrowserPerformanceClient` and `BrowserPerformanceMeasurement` artifacts as public

### DIFF
--- a/change/@azure-msal-browser-9fab06a6-c09b-4f99-bf79-117daa948101.json
+++ b/change/@azure-msal-browser-9fab06a6-c09b-4f99-bf79-117daa948101.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose `BrowserPerformanceClient` and `BrowserPerformanceMeasurement` artifacts as public #6273",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/docs/configuration.md
+++ b/lib/msal-browser/docs/configuration.md
@@ -132,9 +132,10 @@ See [Caching in MSAL](./caching.md) for more.
 
 ### Telemetry Config Options
 
-| Option        | Description                                      | Format                              | Default Value                       |
-| ------------- | ------------------------------------------------ | ----------------------------------- | ----------------------------------- |
-| `application` | Telemetry options for applications using MSAL.js | See [below](#application-telemetry) | See [below](#application-telemetry) |
+| Option        | Description                                      | Format                                                                                  | Default Value                                                                                 |
+|---------------|--------------------------------------------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `application` | Telemetry options for applications using MSAL.js | See [below](#application-telemetry)                                                     | See [below](#application-telemetry)                                                           |
+| `client`      | Telemetry performance client instance            | [IPerformanceClient](../../msal-common/src/telemetry/performance/IPerformanceClient.ts) | [StubPerformanceClient](../../msal-common/src/telemetry/performance/StubPerformanceClient.ts) |
 
 #### Application Telemetry
 

--- a/lib/msal-browser/docs/performance.md
+++ b/lib/msal-browser/docs/performance.md
@@ -5,10 +5,39 @@ Please refer to [msal-common/performance](../../msal-common/docs/performance.md)
 ## Measuring performance
 
 Applications that want to measure the performance of authentication flows in MSAL.js can do so manually, or consume the performance measures taken by the library itself.
+Consuming performance measurements requires setting performance client in [telemetry configuration options](./configuration.md#telemetry-config-options) and adding performance callback.
 
-### addPerformanceCallback
+### Set telemetry performance client
 
-Since version `@azure/msal-browser@2.23.0`, applications can register a callback to receive performance measurements taken by the library. These measurement will include end-to-end measurements for top-level APIs, as well as measurements for important internal APIs.
+```javascript
+import { PublicClientApplication } from "@azure/msal-browser";
+
+const msalConfig = {
+    auth: {
+        ...
+    },
+    cache: {
+        ...
+    },
+    system: {
+        ...
+    }
+}
+
+const msalInstance = new PublicClientApplication({
+    ...msalConfig,
+    telemetry: {
+        client: new BrowserPerformanceClient(msalConfig)
+    }
+});
+msalInstance.initialize();
+```
+
+**Note**: You can pass your own performance telemetry client that implements [IPerformanceClient](../../msal-common/src/telemetry/performance/IPerformanceClient.ts) to customize telemetry management.
+
+### Add performance callback
+
+Applications can register a callback to receive performance measurements taken by the library. These measurement will include end-to-end measurements for top-level APIs, as well as measurements for important internal APIs.
 
 **Note for MSFT first-party applications**: We will be publishing an internal build of `@azure/msal-browser` that is already instrumented to capture this telemetry. Contact us for more details.
 

--- a/lib/msal-browser/docs/performance.md
+++ b/lib/msal-browser/docs/performance.md
@@ -10,7 +10,7 @@ Consuming performance measurements requires setting performance client in [telem
 ### Set telemetry performance client
 
 ```javascript
-import { PublicClientApplication } from "@azure/msal-browser";
+import { PublicClientApplication, BrowserPerformanceClient } from "@azure/msal-browser";
 
 const msalConfig = {
     auth: {

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -89,6 +89,10 @@ export {
 
 export { PopupWindowAttributes } from "./request/PopupWindowAttributes";
 
+// Telemetry
+export { BrowserPerformanceClient } from "./telemetry/BrowserPerformanceClient";
+export { BrowserPerformanceMeasurement } from "./telemetry/BrowserPerformanceMeasurement";
+
 // Common Object Formats
 export {
     AuthenticationScheme,

--- a/lib/msal-browser/src/internals.ts
+++ b/lib/msal-browser/src/internals.ts
@@ -38,10 +38,6 @@ export { CryptoOps } from "./crypto/CryptoOps";
 // Browser Errors
 export { NativeAuthError } from "./error/NativeAuthError";
 
-// Telemetry
-export { BrowserPerformanceClient } from "./telemetry/BrowserPerformanceClient";
-export { BrowserPerformanceMeasurement } from "./telemetry/BrowserPerformanceMeasurement";
-
 // Native request and response
 export { NativeTokenRequest } from "./broker/nativeBroker/NativeRequest";
 export { NativeResponse, MATS } from "./broker/nativeBroker/NativeResponse";

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
@@ -30,28 +30,18 @@ export class BrowserPerformanceClient
 
     constructor(
         configuration: Configuration,
-        logger?: Logger,
-        libraryName?: string,
-        libraryVersion?: string,
         intFields?: Set<string>
     ) {
-        const libName = libraryName || name;
-        const libVersion = libraryVersion || version;
         super(
             configuration.auth.clientId,
             configuration.auth.authority || `${Constants.DEFAULT_AUTHORITY}`,
-            logger ||
-                new Logger(
-                    configuration.system?.loggerOptions || {},
-                    libName,
-                    libVersion
-                ),
-            libName,
-            libVersion,
-            configuration.telemetry?.application || {
-                appName: "",
-                appVersion: "",
-            },
+            new Logger(
+                configuration.system?.loggerOptions || {},
+                name,
+                version),
+            name,
+            version,
+            configuration.telemetry?.application || { appName: '', appVersion: '' },
             intFields
         );
         this.browserCrypto = new BrowserCrypto(this.logger);

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
@@ -28,20 +28,21 @@ export class BrowserPerformanceClient
     private browserCrypto: BrowserCrypto;
     private guidGenerator: GuidGenerator;
 
-    constructor(
-        configuration: Configuration,
-        intFields?: Set<string>
-    ) {
+    constructor(configuration: Configuration, intFields?: Set<string>) {
         super(
             configuration.auth.clientId,
             configuration.auth.authority || `${Constants.DEFAULT_AUTHORITY}`,
             new Logger(
                 configuration.system?.loggerOptions || {},
                 name,
-                version),
+                version
+            ),
             name,
             version,
-            configuration.telemetry?.application || { appName: '', appVersion: '' },
+            configuration.telemetry?.application || {
+                appName: "",
+                appVersion: "",
+            },
             intFields
         );
         this.browserCrypto = new BrowserCrypto(this.logger);


### PR DESCRIPTION
- Expose `BrowserPerformanceClient` and `BrowserPerformanceMeasurement` artifacts as public.
- Remove redundant `BrowserPerformanceClient` params.
- Update docs.