### PR TITLE
Expose response handler and update attributes' access modifiers

### DIFF
--- a/change/@azure-msal-browser-d7f70ef6-a914-4d27-bc18-cc735b95263e.json
+++ b/change/@azure-msal-browser-d7f70ef6-a914-4d27-bc18-cc735b95263e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose response handler and update attributes' access modifiers #6284",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-26de7ca7-412f-44a9-b9e1-b87ab3e09344.json
+++ b/change/@azure-msal-common-26de7ca7-412f-44a9-b9e1-b87ab3e09344.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose response handler and update attributes' access modifiers #6284",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/internals.ts
+++ b/lib/msal-browser/src/internals.ts
@@ -8,8 +8,9 @@
  * Breaking changes to these APIs will be shipped under a minor version, instead of a major version.
  */
 
-// Cache Manager
+// Cache
 export { BrowserCacheManager } from "./cache/BrowserCacheManager";
+export { CacheRecord } from "@azure/msal-common";
 
 // Clients
 export { StandardInteractionClient } from "./interaction_client/StandardInteractionClient";
@@ -24,6 +25,7 @@ export { NativeInteractionClient } from "./interaction_client/NativeInteractionC
 export { RedirectHandler } from "./interaction_handler/RedirectHandler";
 export { EventHandler } from "./event/EventHandler";
 export { NativeMessageHandler } from "./broker/nativeBroker/NativeMessageHandler";
+export { ResponseHandler } from "@azure/msal-common";
 
 // Utilities
 export { BrowserStateObject } from "./utils/BrowserProtocolUtils";

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -42,14 +42,14 @@ import { PerformanceEvents } from "../telemetry/performance/PerformanceEvent";
  * Class that handles response parsing.
  */
 export class ResponseHandler {
-    private clientId: string;
-    private cacheStorage: CacheManager;
-    private cryptoObj: ICrypto;
-    private logger: Logger;
-    private homeAccountIdentifier: string;
-    private serializableCache: ISerializableTokenCache | null;
-    private persistencePlugin: ICachePlugin | null;
-    private performanceClient?: IPerformanceClient;
+    private readonly clientId: string;
+    protected readonly cacheStorage: CacheManager;
+    protected readonly cryptoObj: ICrypto;
+    protected readonly logger: Logger;
+    protected homeAccountIdentifier: string;
+    private readonly serializableCache: ISerializableTokenCache | null;
+    private readonly persistencePlugin: ICachePlugin | null;
+    private readonly performanceClient?: IPerformanceClient;
 
     constructor(
         clientId: string,
@@ -346,15 +346,21 @@ export class ResponseHandler {
      * @param serverTokenResponse
      * @param idTokenObj
      * @param authority
+     * @param reqTimestamp
+     * @param request
+     * @param userAssertionHash
+     * @param authCodePayload
+     * @param clientId
      */
-    private generateCacheRecord(
+    protected generateCacheRecord(
         serverTokenResponse: ServerAuthorizationTokenResponse,
         authority: Authority,
         reqTimestamp: number,
         request: BaseAuthRequest,
         idTokenObj?: AuthToken,
         userAssertionHash?: string,
-        authCodePayload?: AuthorizationCodePayload
+        authCodePayload?: AuthorizationCodePayload,
+        clientId?: string
     ): CacheRecord {
         const env = authority.getPreferredCache();
         if (StringUtils.isEmpty(env)) {
@@ -372,7 +378,7 @@ export class ResponseHandler {
                 this.homeAccountIdentifier,
                 env,
                 serverTokenResponse.id_token || Constants.EMPTY_STRING,
-                this.clientId,
+                clientId || this.clientId,
                 idTokenObj.claims.tid || Constants.EMPTY_STRING
             );
 
@@ -425,7 +431,7 @@ export class ResponseHandler {
                 this.homeAccountIdentifier,
                 env,
                 serverTokenResponse.access_token || Constants.EMPTY_STRING,
-                this.clientId,
+                clientId || this.clientId,
                 idTokenObj
                     ? idTokenObj.claims.tid || Constants.EMPTY_STRING
                     : authority.tenant,


### PR DESCRIPTION
- Make ResponseHandler attributes protected for extendability.
- Add optional "clientId" param to generateCacheRecord.
- Expose "CacheRecord" and "ResponseHandler" as part of msal-browser "internals".