### PR TITLE
Pick up broker extra query params

### DIFF
--- a/change/@azure-msal-browser-718f1e87-756c-454f-9a93-2a1de87c68ed.json
+++ b/change/@azure-msal-browser-718f1e87-756c-454f-9a93-2a1de87c68ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Pick up broker extra query params #6286",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-f8fb5a1d-b4f3-40a0-baaa-3456f35f58b7.json
+++ b/change/@azure-msal-common-f8fb5a1d-b4f3-40a0-baaa-3456f35f58b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Pick up broker extra query params #6286",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
@@ -1004,15 +1004,11 @@ describe("NativeInteractionClient Tests", () => {
                 });
 
             expect(nativeRequest.clientId).toEqual(TEST_CONFIG.MSAL_CLIENT_ID);
+            expect(nativeRequest.extraParameters!["child_client_id"]).toEqual(
+                "parent_client_id"
+            );
             expect(
-                nativeRequest.extraParameters![
-                    AADServerParamKeys.CHILD_CLIENT_ID
-                ]
-            ).toEqual("parent_client_id");
-            expect(
-                nativeRequest.extraParameters![
-                    AADServerParamKeys.CHILD_REDIRECT_URI
-                ]
+                nativeRequest.extraParameters!["child_redirect_uri"]
             ).toEqual("localhost");
             expect(nativeRequest.redirectUri).toEqual(
                 "https://broker_redirect_uri.com"

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -501,7 +501,10 @@ export class AuthorizationCodeClient extends BaseClient {
 
         const parameterBuilder = new RequestParameterBuilder();
 
-        parameterBuilder.addClientId(this.config.authOptions.clientId);
+        parameterBuilder.addClientId(
+            request.extraQueryParameters?.[AADServerParamKeys.CLIENT_ID] ||
+                this.config.authOptions.clientId
+        );
 
         const requestScopes = [
             ...(request.scopes || []),

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -328,7 +328,10 @@ export class AuthorizationCodeClient extends BaseClient {
 
         const parameterBuilder = new RequestParameterBuilder();
 
-        parameterBuilder.addClientId(this.config.authOptions.clientId);
+        parameterBuilder.addClientId(
+            request.tokenBodyParameters?.[AADServerParamKeys.CLIENT_ID] ||
+                this.config.authOptions.clientId
+        );
 
         /*
          * For hybrid spa flow, there will be a code but no verifier

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -164,6 +164,8 @@ export const AADServerParamKeys = {
     RETURN_SPA_CODE: "return_spa_code",
     NATIVE_BROKER: "nativebroker",
     LOGOUT_HINT: "logout_hint",
+    CHILD_CLIENT_ID: "child_client_id",
+    CHILD_REDIRECT_URI: "child_redirect_uri",
 } as const;
 export type AADServerParamKeys =
     (typeof AADServerParamKeys)[keyof typeof AADServerParamKeys];

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -164,8 +164,6 @@ export const AADServerParamKeys = {
     RETURN_SPA_CODE: "return_spa_code",
     NATIVE_BROKER: "nativebroker",
     LOGOUT_HINT: "logout_hint",
-    CHILD_CLIENT_ID: "child_client_id",
-    CHILD_REDIRECT_URI: "child_redirect_uri",
 } as const;
 export type AADServerParamKeys =
     (typeof AADServerParamKeys)[keyof typeof AADServerParamKeys];

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -3707,4 +3707,43 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(logoutUri).toBe(testLogoutUriWithParams);
         });
     });
+
+    describe("createAuthCodeUrlQueryString tests", () => {
+        it("pick up default client_id", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createAuthCodeUrlQueryString({
+                    scopes: ["User.Read"],
+                    prompt: PromptValue.LOGIN,
+                    redirectUri: "localhost",
+                });
+
+            expect(queryString).toContain(
+                `client_id=${TEST_CONFIG.MSAL_CLIENT_ID}`
+            );
+        });
+
+        it("pick up extra query client_id param", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createAuthCodeUrlQueryString({
+                    scopes: ["User.Read"],
+                    prompt: PromptValue.LOGIN,
+                    redirectUri: "localhost",
+                    extraQueryParameters: {
+                        client_id: "child_client_id",
+                    },
+                });
+
+            expect(queryString).toContain(`client_id=child_client_id`);
+        });
+    });
 });

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -3746,4 +3746,41 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(queryString).toContain(`client_id=child_client_id`);
         });
     });
+
+    describe("createTokenRequestBody tests", () => {
+        it("pick up default client_id", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                });
+
+            expect(queryString).toContain(
+                `client_id=${TEST_CONFIG.MSAL_CLIENT_ID}`
+            );
+        });
+
+        it("pick up extra query client_id param", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    tokenBodyParameters: {
+                        client_id: "child_client_id",
+                    },
+                });
+
+            expect(queryString).toContain(`client_id=child_client_id`);
+        });
+    });
 });


### PR DESCRIPTION
- Add "child_client_id" and "child_redirect_uri" query params.
- Manage "client_id" based on extra query params for web flow.
- Manage child query params based on extra query params for native flow.