### PR TITLE
Remove beta tags from publish commands

### DIFF
--- a/.pipelines/custom-templates/publish-template.yml
+++ b/.pipelines/custom-templates/publish-template.yml
@@ -81,7 +81,7 @@ jobs:
             inputs:
                 command: "custom"
                 workingDir: "${{ parameters.path }}/${{ parameters.libName }}"
-                customCommand: "publish --tag beta" # Remove --tag beta when ready to GA
+                customCommand: "publish"
           - task: Npm@1
             displayName: Publish to npm - Test Mode
             condition: and(not(eq('${{ parameters.libName }}', 'msal-angular')), ${{ parameters.testMode }})
@@ -98,7 +98,7 @@ jobs:
             inputs:
                 command: "custom"
                 workingDir: "${{ parameters.path }}/${{ parameters.libName }}"
-                customCommand: "run deploy:beta" # Remove :beta when ready to GA"
+                customCommand: "run deploy"
           - task: Npm@1
             displayName: Deploy to npm (Angular only) - Test Mode
             condition: and(eq('${{ parameters.libName }}', 'msal-angular'), ${{ parameters.testMode }})


### PR DESCRIPTION
Remove beta tags from publish commands in publish_template.yml to prepare for stabel v3 release