### PR TITLE
Replaces `multiple matched tokens error` with a log message, removing matching tokens from cache

### DIFF
--- a/change/@azure-msal-common-cf7a4773-c584-4d15-a4dd-6ab3bc567fa4.json
+++ b/change/@azure-msal-common-cf7a4773-c584-4d15-a4dd-6ab3bc567fa4.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "- Replaces `multiple matched tokens error` with a log message, removing matching tokens from cache.",
+  "comment": "Replaces `multiple matched tokens error` with a log message, removing matching tokens from cache #6311",
   "packageName": "@azure/msal-common",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-cf7a4773-c584-4d15-a4dd-6ab3bc567fa4.json
+++ b/change/@azure-msal-common-cf7a4773-c584-4d15-a4dd-6ab3bc567fa4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "- Replaces `multiple matched tokens error` with a log message, removing matching tokens from cache.",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -882,7 +882,13 @@ export abstract class CacheManager implements ICacheManager {
             this.commonLogger.info("CacheManager:getIdToken - No token found");
             return null;
         } else if (numIdTokens > 1) {
-            throw ClientAuthError.createMultipleMatchingTokensInCacheError();
+            this.commonLogger.info(
+                "CacheManager:getIdToken - Multiple id tokens found, clearing them"
+            );
+            idTokens.forEach((idToken) => {
+                this.removeIdToken(idToken.generateCredentialKey());
+            });
+            return null;
         }
 
         this.commonLogger.info("CacheManager:getIdToken - Returning id token");
@@ -1033,7 +1039,13 @@ export abstract class CacheManager implements ICacheManager {
             );
             return null;
         } else if (numAccessTokens > 1) {
-            throw ClientAuthError.createMultipleMatchingTokensInCacheError();
+            this.commonLogger.info(
+                "CacheManager:getAccessToken - Multiple access tokens found, clearing them"
+            );
+            accessTokens.forEach((accessToken) => {
+                this.removeAccessToken(accessToken.generateCredentialKey());
+            });
+            return null;
         }
 
         this.commonLogger.info(

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -168,6 +168,17 @@ export class MockStorageClass extends CacheManager {
     removeItem(key: string): void {
         if (!!this.store[key]) {
             delete this.store[key];
+            // Update token keys
+            const tokenKeys = this.store[TOKEN_KEYS];
+            if (tokenKeys?.accessToken.includes(key)) {
+                const index = tokenKeys?.accessToken.indexOf(key);
+                tokenKeys.accessToken.splice(index, 1);
+            }
+            if (tokenKeys?.idToken.includes(key)) {
+                const index = tokenKeys?.idToken.indexOf(key);
+                tokenKeys.idToken.splice(index, 1);
+            }
+            this.store[TOKEN_KEYS] = tokenKeys;
         }
     }
     containsKey(key: string): boolean {


### PR DESCRIPTION
Replaces `multiple matched tokens error` with a log message, removing matching tokens from cache.