### PR TITLE
Fix error on homepage of Facebook sample app

### DIFF
--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/facebook-sample/index.html
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/facebook-sample/index.html
@@ -29,7 +29,7 @@
     </div>
   </nav>
   <br>
-  <h5 class="card-header text-center">Vanilla JavaScript SPA calling Vanilla Graph API with MSAL.JS</h5>
+  <h5 class="card-header text-center">Vanilla JavaScript SPA calling Facebook Graph API with MSAL.JS</h5>
   <br>
   <div class="row" style="margin:auto">
     <div id="card-div" class="col-md-3" style="display:none">

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/facebook-sample/index.html
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/facebook-sample/index.html
@@ -29,7 +29,7 @@
     </div>
   </nav>
   <br>
-  <h5 class="card-header text-center">Vanilla JavaScript SPA calling MS Graph API with MSAL.JS</h5>
+  <h5 class="card-header text-center">Vanilla JavaScript SPA calling Vanilla Graph API with MSAL.JS</h5>
   <br>
   <div class="row" style="margin:auto">
     <div id="card-div" class="col-md-3" style="display:none">


### PR DESCRIPTION
This PR fixes the wording on the homepage of the Facebook sample app to clarify that the app is calling the Facebook Graph API instead of the MS Graph API.