### PR TITLE
Fix authority endpoint version for B2C authorities

### DIFF
--- a/change/@azure-msal-common-3abce29b-a58c-4c6c-9755-0fb366da41d2.json
+++ b/change/@azure-msal-common-3abce29b-a58c-4c6c-9755-0fb366da41d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix authority endpoint version for B2C authorities #6342",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -356,7 +356,7 @@ export class Authority {
         const canonicalAuthorityHost = this.hostnameAndPort;
         if (
             this.authorityType === AuthorityType.Adfs ||
-            (this.protocolMode === ProtocolMode.OIDC &&
+            (this.protocolMode !== ProtocolMode.AAD &&
                 !this.isAliasOfKnownMicrosoftAuthority(canonicalAuthorityHost))
         ) {
             return `${this.canonicalAuthority}.well-known/openid-configuration`;

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -356,7 +356,8 @@ export class Authority {
         const canonicalAuthorityHost = this.hostnameAndPort;
         if (
             this.authorityType === AuthorityType.Adfs ||
-            !this.isAliasOfKnownMicrosoftAuthority(canonicalAuthorityHost)
+            (this.protocolMode === ProtocolMode.OIDC &&
+                !this.isAliasOfKnownMicrosoftAuthority(canonicalAuthorityHost))
         ) {
             return `${this.canonicalAuthority}.well-known/openid-configuration`;
         }

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -2518,6 +2518,31 @@ describe("Authority.ts Class Unit Tests", () => {
             );
         });
 
+        it("Arbitrary B2C (non-microsoft known authority) authority uses v2 well-known endpoint", async () => {
+            const authorityUrl = TEST_CONFIG.b2cValidAuthority;
+            let endpoint = "";
+            authority = new Authority(
+                authorityUrl,
+                networkInterface,
+                mockStorage,
+                { ...authorityOptions, knownAuthorities: [authorityUrl] },
+                logger
+            );
+            jest.spyOn(
+                networkInterface,
+                <any>"sendGetRequestAsync"
+            ).mockImplementation((openIdConfigEndpoint) => {
+                // @ts-ignore
+                endpoint = openIdConfigEndpoint;
+                return DEFAULT_OPENID_CONFIG_RESPONSE;
+            });
+
+            await authority.resolveEndpointsAsync();
+            expect(endpoint).toBe(
+                `${authorityUrl}/v2.0/.well-known/openid-configuration`
+            );
+        });
+
         it("DSTS authority uses v2 well-known endpoint with common authority", async () => {
             const authorityUrl =
                 "https://login.microsoftonline.com/dstsv2/common/";


### PR DESCRIPTION
This PR:

- Fixes a bug where B2C authority URLs were not having /v2 appended because they were not in the list of known Microsoft authorities