### PR TITLE
Updates to msal-node's custom-INetworkModule-and-network-tracing sample

### DIFF
--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientAxios.ts
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/HttpClientAxios.ts
@@ -40,7 +40,7 @@ export class HttpClientAxios implements INetworkModule {
 
         const response = await axios(request);
         return {
-            headers: response.headers,
+            headers: response.headers as Record<string, string>,
             body: response.data as T,
             status: response.status,
         };
@@ -70,7 +70,7 @@ export class HttpClientAxios implements INetworkModule {
 
         const response = await axios(request);
         return {
-            headers: response.headers,
+            headers: response.headers as Record<string, string>,
             body: response.data as T,
             status: response.status,
         };

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/package.json
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/msal-node": "^2.0.0-beta.0",
+    "@azure/msal-node": "^2.0.1",
     "express": "^4.18.2",
     "url": "^0.11.0"
   },

--- a/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/tsconfig.json
+++ b/samples/msal-node-samples/custom-INetworkModule-and-network-tracing/tsconfig.json
@@ -4,7 +4,13 @@
     "target": "es6",
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": [
+      "node",
+      "express"
+    ]
   },
-  "lib": ["es2015"]
+  "lib": [
+    "es2015"
+  ]
 }


### PR DESCRIPTION
The sample was not compiling with msal-node v2.0.0+. These updates allow the sample to compile and run to completion.