### PR TITLE
Fix addEventCallback input parameter type

### DIFF
--- a/change/@azure-msal-browser-4f1d1231-b112-4ea4-8306-c0e8a48f4ef7.json
+++ b/change/@azure-msal-browser-4f1d1231-b112-4ea4-8306-c0e8a48f4ef7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix input parameter type for addEventCallback",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -21,6 +21,7 @@ import { ITokenCache } from "../cache/ITokenCache";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { BrowserConfiguration } from "../config/Configuration";
 import { AuthenticationResult } from "../response/AuthenticationResult";
+import { EventCallbackFunction } from "../event/EventMessage";
 
 export interface IPublicClientApplication {
     initialize(): Promise<void>;
@@ -32,7 +33,7 @@ export interface IPublicClientApplication {
     acquireTokenByCode(
         request: AuthorizationCodeRequest
     ): Promise<AuthenticationResult>;
-    addEventCallback(callback: Function): string | null;
+    addEventCallback(callback: EventCallbackFunction): string | null;
     removeEventCallback(callbackId: string): void;
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
     removePerformanceCallback(callbackId: string): boolean;

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -24,6 +24,7 @@ import { StandardController } from "../controllers/StandardController";
 import { BrowserConfiguration, Configuration } from "../config/Configuration";
 import { StandardOperatingContext } from "../operatingcontext/StandardOperatingContext";
 import { AuthenticationResult } from "../response/AuthenticationResult";
+import { EventCallbackFunction } from "../event/EventMessage";
 
 /**
  * The PublicClientApplication class is the object exposed by the library to perform authentication and authorization functions in Single Page Applications
@@ -140,7 +141,7 @@ export class PublicClientApplication implements IPublicClientApplication {
      * Adds event callbacks to array
      * @param callback
      */
-    addEventCallback(callback: Function): string | null {
+    addEventCallback(callback: EventCallbackFunction): string | null {
         return this.controller.addEventCallback(callback);
     }
 

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -28,6 +28,7 @@ import { EventHandler } from "../event/EventHandler";
 import { PopupClient } from "../interaction_client/PopupClient";
 import { SilentIframeClient } from "../interaction_client/SilentIframeClient";
 import { AuthenticationResult } from "../response/AuthenticationResult";
+import { EventCallbackFunction } from "../event/EventMessage";
 
 export interface IController {
     initialize(): Promise<void>;
@@ -55,7 +56,7 @@ export interface IController {
         silentRequest: SilentRequest
     ): Promise<AuthenticationResult>;
 
-    addEventCallback(callback: Function): string | null;
+    addEventCallback(callback: EventCallbackFunction): string | null;
 
     removeEventCallback(callbackId: string): void;
 


### PR DESCRIPTION
Fixes input parameter type for addEventCallback which broke when moving from v2 to v3

Addresses #6309 