### PR TITLE
Clear claims cache for apps that switched their cache preferences [LTS]

### DIFF
--- a/change/@azure-msal-browser-ed90fec9-e683-48e6-96db-249be8f4d921.json
+++ b/change/@azure-msal-browser-ed90fec9-e683-48e6-96db-249be8f4d921.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clear tokens and token keys for claims based ATs when `claimsBasedCachingEnabled` is set to `false` #6356",
+  "packageName": "@azure/msal-browser",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-36e9a23e-db9f-459d-86f4-02d265994ee3.json
+++ b/change/@azure-msal-common-36e9a23e-db9f-459d-86f4-02d265994ee3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Clean up claims cached in tokens when claimsclaimsBasedCachingEnabled is set to false #6356",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -188,7 +188,9 @@ export abstract class ClientApplication {
 
         if(!this.config.cache.claimsBasedCachingEnabled) {
             this.logger.verbose("Claims-based caching is disabled. Clearing the previous cache with claims");
+            const claimsTokensRemovalMeasurement = this.performanceClient.startMeasurement(PerformanceEvents.ClearTokensAndKeysWithClaims);
             await this.browserStorage.clearTokensAndKeysWithClaims();
+            claimsTokensRemovalMeasurement.endMeasurement(PerformanceEvents.ClearTokensAndKeysWithClaims);
         }
 
         this.initialized = true;

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -185,6 +185,12 @@ export abstract class ClientApplication {
                 this.logger.verbose(e);
             }
         }
+
+        if(!this.config.cache.claimsBasedCachingEnabled) {
+            this.logger.verbose("Claims-based caching is disabled. Clearing the previous cache with claims");
+            await this.browserStorage.clearTokensWithClaimsInCache();
+        }
+
         this.initialized = true;
         this.eventHandler.emitEvent(EventType.INITIALIZE_END);
 

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -188,7 +188,7 @@ export abstract class ClientApplication {
 
         if(!this.config.cache.claimsBasedCachingEnabled) {
             this.logger.verbose("Claims-based caching is disabled. Clearing the previous cache with claims");
-            await this.browserStorage.clearTokensWithClaimsInCache();
+            await this.browserStorage.clearTokensAndKeysWithClaims();
         }
 
         this.initialized = true;

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -190,7 +190,7 @@ export abstract class ClientApplication {
             this.logger.verbose("Claims-based caching is disabled. Clearing the previous cache with claims");
             const claimsTokensRemovalMeasurement = this.performanceClient.startMeasurement(PerformanceEvents.ClearTokensAndKeysWithClaims);
             await this.browserStorage.clearTokensAndKeysWithClaims();
-            claimsTokensRemovalMeasurement.endMeasurement(PerformanceEvents.ClearTokensAndKeysWithClaims);
+            claimsTokensRemovalMeasurement.endMeasurement({success: true});
         }
 
         this.initialized = true;

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -954,6 +954,26 @@ export class BrowserCacheManager extends CacheManager {
     }
 
     /**
+     * Clears all access tokes that have claims prior to saving the current one
+     * @param credential 
+     * @returns 
+     */
+    async clearTokensAndKeysWithClaims(): Promise<void> {
+
+        const tokenKeys = this.getTokenKeys();
+            
+        const removedAccessTokens: Array<Promise<void>> = [];
+        tokenKeys.accessToken.forEach((key: string) => {
+            // if the access token has claims in its key, remove the token key and the token
+            const credential = this.getAccessTokenCredential(key);
+            if(credential?.requestedClaimsHash && key.includes(credential.requestedClaimsHash)) {
+                removedAccessTokens.push(this.removeAccessToken(key));
+            }
+        });
+        await Promise.all(removedAccessTokens);
+    }
+
+    /**
      * Add value to cookies
      * @param cookieName
      * @param cookieValue

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -966,7 +966,7 @@ export class BrowserCacheManager extends CacheManager {
         tokenKeys.accessToken.forEach((key: string) => {
             // if the access token has claims in its key, remove the token key and the token
             const credential = this.getAccessTokenCredential(key);
-            if(credential?.requestedClaimsHash && key.includes(credential.requestedClaimsHash)) {
+            if(credential?.requestedClaimsHash && key.includes(credential.requestedClaimsHash.toLowerCase())) {
                 removedAccessTokens.push(this.removeAccessToken(key));
             }
         });

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -973,7 +973,7 @@ export class BrowserCacheManager extends CacheManager {
         });
         await Promise.all(removedAccessTokens);
 
-        // warn if tokens are removed
+        // warn if any access tokens are removed
         if(removedAccessTokens.length > 0) {
             this.logger.warning(`${removedAccessTokens.length} access tokens with claims in the cache keys have been removed from the cache.`);
         }

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -960,6 +960,7 @@ export class BrowserCacheManager extends CacheManager {
      */
     async clearTokensAndKeysWithClaims(): Promise<void> {
 
+        this.logger.trace("BrowserCacheManager.clearTokensAndKeysWithClaims called");
         const tokenKeys = this.getTokenKeys();
             
         const removedAccessTokens: Array<Promise<void>> = [];
@@ -971,6 +972,7 @@ export class BrowserCacheManager extends CacheManager {
             }
         });
         await Promise.all(removedAccessTokens);
+        this.logger.warning(`${removedAccessTokens.length} access tokens with claims in the cache keys have been removed from the cache.`);
     }
 
     /**

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -972,7 +972,11 @@ export class BrowserCacheManager extends CacheManager {
             }
         });
         await Promise.all(removedAccessTokens);
-        this.logger.warning(`${removedAccessTokens.length} access tokens with claims in the cache keys have been removed from the cache.`);
+
+        // warn if tokens are removed
+        if(removedAccessTokens.length > 0) {
+            this.logger.warning(`${removedAccessTokens.length} access tokens with claims in the cache keys have been removed from the cache.`);
+        }
     }
 
     /**

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -945,7 +945,7 @@ describe("BrowserCacheManager tests", () => {
                     }
                 )
 
-                it.only("clearTokensWithClaimsInCache clears all access tokens with claims in tokenKeys", () => {
+                it("clearTokensWithClaimsInCache clears all access tokens with claims in tokenKeys", () => {
                     const testAT1 = AccessTokenEntity.createAccessTokenEntity("homeAccountId1", "environment", "secret1", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion");
                     const testAT2 = AccessTokenEntity.createAccessTokenEntity("homeAccountId2", "environment", "secret2", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion", undefined, "claims", "claims-hash");
                     const testAT3 = AccessTokenEntity.createAccessTokenEntity("homeAccountId3", "environment", "secret3", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion", undefined, "claims");

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -949,6 +949,7 @@ describe("BrowserCacheManager tests", () => {
                     const testAT1 = AccessTokenEntity.createAccessTokenEntity("homeAccountId1", "environment", "secret1", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion");
                     const testAT2 = AccessTokenEntity.createAccessTokenEntity("homeAccountId2", "environment", "secret2", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion", undefined, "claims", "claims-hash");
                     const testAT3 = AccessTokenEntity.createAccessTokenEntity("homeAccountId3", "environment", "secret3", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion", undefined, "claims");
+                    const testAT4 = AccessTokenEntity.createAccessTokenEntity("homeAccountId4", "environment", "secret4", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion", undefined, "claims", "claims-Hash");
 
                     expect(browserLocalStorage.getTokenKeys()).toStrictEqual({
                         idToken: [],
@@ -968,21 +969,23 @@ describe("BrowserCacheManager tests", () => {
                     browserSessionStorage.setAccessTokenCredential(testAT2);
                     browserLocalStorage.setAccessTokenCredential(testAT3);
                     browserSessionStorage.setAccessTokenCredential(testAT3);
+                    browserLocalStorage.setAccessTokenCredential(testAT4);
+                    browserSessionStorage.setAccessTokenCredential(testAT4);
 
                     expect(browserLocalStorage.getTokenKeys()).toStrictEqual({
                         idToken: [],
-                        accessToken: [testAT1.generateCredentialKey(), testAT2.generateCredentialKey(), testAT3.generateCredentialKey()],
+                        accessToken: [testAT1.generateCredentialKey(), testAT2.generateCredentialKey(), testAT3.generateCredentialKey(), testAT4.generateCredentialKey()],
                         refreshToken: []
                     });
 
                     expect(browserSessionStorage.getTokenKeys()).toStrictEqual({
                         idToken: [],
-                        accessToken: [testAT1.generateCredentialKey(), testAT2.generateCredentialKey(), testAT3.generateCredentialKey()],
+                        accessToken: [testAT1.generateCredentialKey(), testAT2.generateCredentialKey(), testAT3.generateCredentialKey(), testAT4.generateCredentialKey()],
                         refreshToken: []
                     });
 
-                    expect(browserSessionStorage.getTokenKeys().accessToken.length).toBe(3);
-                    expect(browserLocalStorage.getTokenKeys().accessToken.length).toBe(3);
+                    expect(browserSessionStorage.getTokenKeys().accessToken.length).toBe(4);
+                    expect(browserLocalStorage.getTokenKeys().accessToken.length).toBe(4);
 
                     expect(browserSessionStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toEqual(testAT1);
                     expect(browserSessionStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);;
@@ -999,6 +1002,11 @@ describe("BrowserCacheManager tests", () => {
                     expect(browserLocalStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toEqual(testAT3);
                     expect(browserLocalStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
 
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT4.generateCredentialKey())).toEqual(testAT4);
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT4.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT4.generateCredentialKey())).toEqual(testAT4);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT4.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+
                     browserSessionStorage.clearTokensAndKeysWithClaims();
                     browserLocalStorage.clearTokensAndKeysWithClaims();
 
@@ -1014,6 +1022,9 @@ describe("BrowserCacheManager tests", () => {
                     expect(browserSessionStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
                     expect(browserLocalStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toEqual(testAT3);
                     expect(browserLocalStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT2.generateCredentialKey())).toBeNull(); 
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT2.generateCredentialKey())).toBeNull();
 
                     expect(browserLocalStorage.getTokenKeys()).toStrictEqual({
                         idToken: [],

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -944,6 +944,92 @@ describe("BrowserCacheManager tests", () => {
                         expect(browserLocalStorage.getAccessTokenCredential(testAccessTokenWithAuthScheme.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
                     }
                 )
+
+                it.only("clearTokensWithClaimsInCache clears all access tokens with claims in tokenKeys", () => {
+                    const testAT1 = AccessTokenEntity.createAccessTokenEntity("homeAccountId1", "environment", "secret1", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion");
+                    const testAT2 = AccessTokenEntity.createAccessTokenEntity("homeAccountId2", "environment", "secret2", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion", undefined, "claims", "claims-hash");
+                    const testAT3 = AccessTokenEntity.createAccessTokenEntity("homeAccountId3", "environment", "secret3", "client-id", "tenantId", "openid", 1000, 1000, browserCrypto, 500, AuthenticationScheme.BEARER, "oboAssertion", undefined, "claims");
+
+                    expect(browserLocalStorage.getTokenKeys()).toStrictEqual({
+                        idToken: [],
+                        accessToken: [],
+                        refreshToken: []
+                    });
+
+                    expect(browserSessionStorage.getTokenKeys()).toStrictEqual({
+                        idToken: [],
+                        accessToken: [],
+                        refreshToken: []
+                    });
+
+                    browserLocalStorage.setAccessTokenCredential(testAT1);
+                    browserSessionStorage.setAccessTokenCredential(testAT1);
+                    browserLocalStorage.setAccessTokenCredential(testAT2);
+                    browserSessionStorage.setAccessTokenCredential(testAT2);
+                    browserLocalStorage.setAccessTokenCredential(testAT3);
+                    browserSessionStorage.setAccessTokenCredential(testAT3);
+
+                    expect(browserLocalStorage.getTokenKeys()).toStrictEqual({
+                        idToken: [],
+                        accessToken: [testAT1.generateCredentialKey(), testAT2.generateCredentialKey(), testAT3.generateCredentialKey()],
+                        refreshToken: []
+                    });
+
+                    expect(browserSessionStorage.getTokenKeys()).toStrictEqual({
+                        idToken: [],
+                        accessToken: [testAT1.generateCredentialKey(), testAT2.generateCredentialKey(), testAT3.generateCredentialKey()],
+                        refreshToken: []
+                    });
+
+                    expect(browserSessionStorage.getTokenKeys().accessToken.length).toBe(3);
+                    expect(browserLocalStorage.getTokenKeys().accessToken.length).toBe(3);
+
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toEqual(testAT1);
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);;
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toEqual(testAT1);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT2.generateCredentialKey())).toEqual(testAT2);
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT2.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT2.generateCredentialKey())).toEqual(testAT2);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT2.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toEqual(testAT3);
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toEqual(testAT3);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+
+                    browserSessionStorage.clearTokensAndKeysWithClaims();
+                    browserLocalStorage.clearTokensAndKeysWithClaims();
+
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toEqual(testAT1);
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toEqual(testAT1);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT1.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT2.generateCredentialKey())).toBeNull(); 
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT2.generateCredentialKey())).toBeNull();
+
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toEqual(testAT3);
+                    expect(browserSessionStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toEqual(testAT3);
+                    expect(browserLocalStorage.getAccessTokenCredential(testAT3.generateCredentialKey())).toBeInstanceOf(AccessTokenEntity);
+
+                    expect(browserLocalStorage.getTokenKeys()).toStrictEqual({
+                        idToken: [],
+                        accessToken: [testAT1.generateCredentialKey(), testAT3.generateCredentialKey()],
+                        refreshToken: []
+                    });
+
+                    expect(browserSessionStorage.getTokenKeys()).toStrictEqual({
+                        idToken: [],
+                        accessToken: [testAT1.generateCredentialKey(), testAT3.generateCredentialKey()],
+                        refreshToken: []
+                    });
+
+                    expect(browserSessionStorage.getTokenKeys().accessToken.length).toBe(2);
+                    expect(browserLocalStorage.getTokenKeys().accessToken.length).toBe(2);
+                });
             });
 
             describe("RefreshTokenCredential", () => {

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -301,6 +301,26 @@ export abstract class CacheManager implements ICacheManager {
     }
 
     /**
+     * Clears all access tokes that have claims prior to saving the current one
+     * @param credential 
+     * @returns 
+     */
+    async clearTokensWithClaimsInCache(): Promise<void> {
+
+        const tokenKeys = this.getTokenKeys();
+        
+        const removedAccessTokens: Array<Promise<void>> = [];
+        tokenKeys.accessToken.forEach((key) => {
+            // if the access token has claims in its key, remove the token key and the token
+            const credential = this.getAccessTokenCredential(key);
+            if(credential?.requestedClaimsHash && key.includes(credential.requestedClaimsHash)) {
+                removedAccessTokens.push(this.removeAccessToken(key));
+            }
+        });
+        await Promise.all(removedAccessTokens);
+    }
+
+    /**
      * retrieve accounts matching all provided filters; if no filter is set, get all accounts
      * not checking for casing as keys are all generated in lower case, remember to convert to lower case if object properties are compared
      * @param homeAccountId

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -301,26 +301,6 @@ export abstract class CacheManager implements ICacheManager {
     }
 
     /**
-     * Clears all access tokes that have claims prior to saving the current one
-     * @param credential 
-     * @returns 
-     */
-    async clearTokensWithClaimsInCache(): Promise<void> {
-
-        const tokenKeys = this.getTokenKeys();
-        
-        const removedAccessTokens: Array<Promise<void>> = [];
-        tokenKeys.accessToken.forEach((key) => {
-            // if the access token has claims in its key, remove the token key and the token
-            const credential = this.getAccessTokenCredential(key);
-            if(credential?.requestedClaimsHash && key.includes(credential.requestedClaimsHash)) {
-                removedAccessTokens.push(this.removeAccessToken(key));
-            }
-        });
-        await Promise.all(removedAccessTokens);
-    }
-
-    /**
      * retrieve accounts matching all provided filters; if no filter is set, get all accounts
      * not checking for casing as keys are all generated in lower case, remember to convert to lower case if object properties are compared
      * @param homeAccountId

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -241,6 +241,11 @@ export enum PerformanceEvents {
     UsernamePasswordClientAcquireToken = "usernamePasswordClientAcquireToken",
 
     NativeMessageHandlerHandshake = "nativeMessageHandlerHandshake",
+
+    /**
+     * Cache operations
+     */
+    ClearTokensAndKeysWithClaims = "clearTokensAndKeysWithClaims",
 }
 
 /**


### PR DESCRIPTION
Some apps fetch tokens with high frequency and changing claims (new claim per request). Prior to #6187, these tokens over flowed the local cache. However, there is still the issue of stale tokens to be cleared when the `claimsBasedCachingEnabled`  feature is set to false, which is not addressed.

This PR adds a new utility function `clearTokensAndKeysWithClaims()` which will be triggered when the application is `initialized` to clear any old tokens cached with claims.

The initial choice is to clear the cache at token acquisition. However apps facing this issue will not be able to fetch tokens since the `tokenKeys` cache entry is already large and freezes the app. Hence the choice of adding this when the app is initialized and the extra requirement of any application on the msal v2 to specifically call `msal.initialize()` as a pre-requisite.

Applications are mandated to call `initialize()` for `msal v3` and we are defaulting to `claimsBasedCachingEnabled: false` in v3. Hoping both these settings will mitigate this issue from day one in the new version.

So here is the guidance:

`msal-browser v2`: App needs to explicitly set `claimsBasedCachingEnabled: false` and call `initialize()` to use msal to mitigate this issue.
`msal-browser v3`: MSAL JS should handle this in the back ground.

P.S: Currently this approach is in test and once approved will push the changes to v3.