### PR TITLE
Add special npmrc write/delete in local directory for msal-angular

### DIFF
--- a/.pipelines/custom-templates/publish-template.yml
+++ b/.pipelines/custom-templates/publish-template.yml
@@ -69,6 +69,14 @@ jobs:
           # Write NPM authToken
           - bash: echo $NPM_TOKEN > .npmrc
             displayName: Write npm authToken
+            condition: not(eq('${{ parameters.libName }}', 'msal-angular'))
+            env:
+                NPM_TOKEN: $(MSALJSNPMTOKEN)
+          # Write NPM authToken (Angular only)
+          - bash: echo $NPM_TOKEN > .npmrc
+            displayName: Write npm authToken
+            workingDirectory: "${{ parameters.path }}/${{ parameters.libName }}"
+            condition: eq('${{ parameters.libName }}', 'msal-angular')
             env:
                 NPM_TOKEN: $(MSALJSNPMTOKEN)
 
@@ -109,8 +117,15 @@ jobs:
           # Remove .npmrc file
           - task: DeleteFiles@1
             displayName: Remove .npmrc file
+            condition: not(eq('${{ parameters.libName }}', 'msal-angular'))
             inputs:
                 Contents: /.npmrc
+          # Remove .npmrc file (Angular only)
+          - task: DeleteFiles@1
+            displayName: Remove .npmrc file
+            condition: eq('${{ parameters.libName }}', 'msal-angular')
+            inputs:
+                Contents: ${{ parameters.path }}/${{ parameters.libName }}/.npmrc
 
           # Install Release Scripts dependencies
           - task: Npm@1


### PR DESCRIPTION
This PR:
- Fixes an issue with the release pipeline where npm can't find the auth token in the root of the repo since the msal-angular deploy step has the --workspaces=false flag on by creating the npmrc directly in the msal-angular subdirectory