### PR TITLE
Change relative import to extensioned variations for Node16 and NodeNext type support

### DIFF
--- a/change/@azure-msal-node-fd9abab4-f755-4c59-8e63-744eefaee29b.json
+++ b/change/@azure-msal-node-fd9abab4-f755-4c59-8e63-744eefaee29b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(msal-node): change all relative imports to .js",
+  "packageName": "@azure/msal-node",
+  "email": "22598347+datner@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/jest.config.cjs
+++ b/lib/msal-node/jest.config.cjs
@@ -5,19 +5,18 @@
 
 module.exports = {
     verbose: true,
-    moduleFileExtensions: [
-        "ts",
-        "tsx",
-        "js",
-        "json",
-        "jsx",
-        "node"
-    ],
-    testMatch: [
-        "<rootDir>/test/**/*.spec.ts"
-    ],
+    moduleFileExtensions: ["ts", "tsx", "js", "json", "jsx", "node"],
+    testMatch: ["<rootDir>/test/**/*.spec.ts"],
     transform: {
         "^.+\\.(ts|tsx)$": "ts-jest",
     },
-    coverageReporters: [["lcov", {"projectRoot": "../../"}]]
+    /**
+     * "Not a ts-jest issue" but a jest one. Consider vitest?
+     *  this morphs "./some/relative/path.js" to "./some/relative/path"
+     *  https://github.com/kulshekhar/ts-jest/issues/1057
+     */
+    moduleNameMapper: {
+        "^(\\.\\.?\\/.+)\\.js$": "$1",
+    },
+    coverageReporters: [["lcov", { projectRoot: "../../" }]],
 };

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/package.json",
   "name": "@azure/msal-node",
   "version": "2.0.2",
   "author": {

--- a/lib/msal-node/rollup.config.js
+++ b/lib/msal-node/rollup.config.js
@@ -5,68 +5,49 @@
 
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
+import { defineConfig } from "rollup";
 import pkg from "./package.json";
 
-const libraryHeader = `/*! ${pkg.name} v${pkg.version} ${new Date().toISOString().split("T")[0]} */`;
+const libraryHeader = `/*! ${pkg.name} v${pkg.version} ${
+    new Date().toISOString().split("T")[0]
+} */`;
 const useStrictHeader = "'use strict';";
 const fileHeader = `${libraryHeader}\n${useStrictHeader}`;
 
-export default [
-    {
-        // for cjs build
-        input: "src/index.ts",
-        output: {
+export default defineConfig({
+    input: "src/index.ts",
+    output: [
+        {
             dir: "dist",
             format: "cjs",
             entryFileNames: "[name].cjs",
             preserveModules: true,
             preserveModulesRoot: "src",
             banner: fileHeader,
-            sourcemap: true
+            sourcemap: true,
         },
-        treeshake: {
-            moduleSideEffects: false,
-            propertyReadSideEffects: false
-        },
-        external: [
-            ...Object.keys(pkg.dependencies || {}),
-            ...Object.keys(pkg.peerDependencies || {})
-        ],
-        plugins: [
-            typescript( {
-                typescript: require("typescript"),
-                tsconfig: "tsconfig.build.json"
-            }),
-            nodeResolve()
-        ]
-    },
-    {
-        // for esm build
-        input: "src/index.ts",
-        output: {
+        {
             dir: "dist",
             format: "es",
             entryFileNames: "[name].mjs",
             preserveModules: true,
             preserveModulesRoot: "src",
             banner: fileHeader,
-            sourcemap: true
+            sourcemap: true,
         },
-        treeshake: {
-            moduleSideEffects: false,
-            propertyReadSideEffects: false
-        },
-        external: [
-            ...Object.keys(pkg.dependencies || {}),
-            ...Object.keys(pkg.peerDependencies || {})
-        ],
-        plugins: [
-            typescript( {
-                typescript: require("typescript"),
-                tsconfig: "tsconfig.build.json"
-            }),
-            nodeResolve()
-        ]
-    }
-
-];
+    ],
+    treeshake: {
+        moduleSideEffects: false,
+        propertyReadSideEffects: false,
+    },
+    external: [
+        ...Object.keys(pkg.dependencies || {}),
+        ...Object.keys(pkg.peerDependencies || {}),
+    ],
+    plugins: [
+        typescript({
+            tsconfig: "tsconfig.build.json",
+        }),
+        nodeResolve(),
+    ],
+});

--- a/lib/msal-node/src/cache/NodeStorage.ts
+++ b/lib/msal-node/src/cache/NodeStorage.ts
@@ -20,13 +20,13 @@ import {
     ValidCredentialType,
 } from "@azure/msal-common";
 
-import { Deserializer } from "./serializer/Deserializer";
-import { Serializer } from "./serializer/Serializer";
+import { Deserializer } from "./serializer/Deserializer.js";
+import { Serializer } from "./serializer/Serializer.js";
 import {
     InMemoryCache,
     JsonCache,
     CacheKVStore,
-} from "./serializer/SerializerTypes";
+} from "./serializer/SerializerTypes.js";
 
 /**
  * This class implements Storage for node, reading cache from user specified storage location or an  extension library

--- a/lib/msal-node/src/cache/TokenCache.ts
+++ b/lib/msal-node/src/cache/TokenCache.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { NodeStorage } from "./NodeStorage";
+import { NodeStorage } from "./NodeStorage.js";
 import {
     StringUtils,
     AccountEntity,
@@ -22,10 +22,10 @@ import {
     SerializedIdTokenEntity,
     SerializedAppMetadataEntity,
     CacheKVStore,
-} from "./serializer/SerializerTypes";
-import { Deserializer } from "./serializer/Deserializer";
-import { Serializer } from "./serializer/Serializer";
-import { ITokenCache } from "./ITokenCache";
+} from "./serializer/SerializerTypes.js";
+import { Deserializer } from "./serializer/Deserializer.js";
+import { Serializer } from "./serializer/Serializer.js";
+import { ITokenCache } from "./ITokenCache.js";
 
 const defaultSerializedCache: JsonCache = {
     Account: {},

--- a/lib/msal-node/src/cache/distributed/DistributedCachePlugin.ts
+++ b/lib/msal-node/src/cache/distributed/DistributedCachePlugin.ts
@@ -8,9 +8,9 @@ import {
     ICachePlugin,
     TokenCacheContext,
 } from "@azure/msal-common";
-import { TokenCache } from "../TokenCache";
-import { IPartitionManager } from "./IPartitionManager";
-import { ICacheClient } from "./ICacheClient";
+import { TokenCache } from "../TokenCache.js";
+import { IPartitionManager } from "./IPartitionManager.js";
+import { ICacheClient } from "./ICacheClient.js";
 
 export class DistributedCachePlugin implements ICachePlugin {
     private client: ICacheClient;

--- a/lib/msal-node/src/cache/serializer/Deserializer.ts
+++ b/lib/msal-node/src/cache/serializer/Deserializer.ts
@@ -25,7 +25,7 @@ import {
     SerializedAccessTokenEntity,
     SerializedRefreshTokenEntity,
     SerializedAppMetadataEntity,
-} from "./SerializerTypes";
+} from "./SerializerTypes.js";
 
 /**
  * This class deserializes cache entities read from the file into in memory object types defined internally

--- a/lib/msal-node/src/cache/serializer/Serializer.ts
+++ b/lib/msal-node/src/cache/serializer/Serializer.ts
@@ -18,7 +18,7 @@ import {
     SerializedAccessTokenEntity,
     SerializedRefreshTokenEntity,
     SerializedAppMetadataEntity,
-} from "./SerializerTypes";
+} from "./SerializerTypes.js";
 
 export class Serializer {
     /**

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -36,20 +36,20 @@ import {
     Configuration,
     buildAppConfiguration,
     NodeConfiguration,
-} from "../config/Configuration";
-import { CryptoProvider } from "../crypto/CryptoProvider";
-import { NodeStorage } from "../cache/NodeStorage";
-import { Constants as NodeConstants, ApiId } from "../utils/Constants";
-import { TokenCache } from "../cache/TokenCache";
-import { ClientAssertion } from "./ClientAssertion";
-import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
-import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
-import { RefreshTokenRequest } from "../request/RefreshTokenRequest";
-import { SilentFlowRequest } from "../request/SilentFlowRequest";
-import { version, name } from "../packageMetadata";
-import { UsernamePasswordRequest } from "../request/UsernamePasswordRequest";
-import { NodeAuthError } from "../error/NodeAuthError";
-import { UsernamePasswordClient } from "./UsernamePasswordClient";
+} from "../config/Configuration.js";
+import { CryptoProvider } from "../crypto/CryptoProvider.js";
+import { NodeStorage } from "../cache/NodeStorage.js";
+import { Constants as NodeConstants, ApiId } from "../utils/Constants.js";
+import { TokenCache } from "../cache/TokenCache.js";
+import { ClientAssertion } from "./ClientAssertion.js";
+import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest.js";
+import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest.js";
+import { RefreshTokenRequest } from "../request/RefreshTokenRequest.js";
+import { SilentFlowRequest } from "../request/SilentFlowRequest.js";
+import { version, name } from "../packageMetadata.js";
+import { UsernamePasswordRequest } from "../request/UsernamePasswordRequest.js";
+import { NodeAuthError } from "../error/NodeAuthError.js";
+import { UsernamePasswordClient } from "./UsernamePasswordClient.js";
 
 /**
  * Base abstract class for all ClientApplications - public and confidential

--- a/lib/msal-node/src/client/ClientAssertion.ts
+++ b/lib/msal-node/src/client/ClientAssertion.ts
@@ -5,9 +5,9 @@
 
 import jwt from "jsonwebtoken";
 import { TimeUtils, ClientAuthError, Constants } from "@azure/msal-common";
-import { CryptoProvider } from "../crypto/CryptoProvider";
-import { EncodingUtils } from "../utils/EncodingUtils";
-import { JwtConstants } from "../utils/Constants";
+import { CryptoProvider } from "../crypto/CryptoProvider.js";
+import { EncodingUtils } from "../utils/EncodingUtils.js";
+import { JwtConstants } from "../utils/Constants.js";
 
 /**
  * Client assertion of type jwt-bearer used in confidential client flows

--- a/lib/msal-node/src/client/ConfidentialClientApplication.ts
+++ b/lib/msal-node/src/client/ConfidentialClientApplication.ts
@@ -5,14 +5,14 @@
 
 // AADAuthorityConstants
 
-import { ClientApplication } from "./ClientApplication";
-import { Configuration } from "../config/Configuration";
-import { ClientAssertion } from "./ClientAssertion";
+import { ClientApplication } from "./ClientApplication.js";
+import { Configuration } from "../config/Configuration.js";
+import { ClientAssertion } from "./ClientAssertion.js";
 import {
     Constants as NodeConstants,
     ApiId,
     REGION_ENVIRONMENT_VARIABLE,
-} from "../utils/Constants";
+} from "../utils/Constants.js";
 import {
     CommonClientCredentialRequest,
     CommonOnBehalfOfRequest,
@@ -27,11 +27,11 @@ import {
     UrlString,
     AADAuthorityConstants,
 } from "@azure/msal-common";
-import { IConfidentialClientApplication } from "./IConfidentialClientApplication";
-import { OnBehalfOfRequest } from "../request/OnBehalfOfRequest";
-import { ClientCredentialRequest } from "../request/ClientCredentialRequest";
-import { ClientCredentialClient } from "./ClientCredentialClient";
-import { OnBehalfOfClient } from "./OnBehalfOfClient";
+import { IConfidentialClientApplication } from "./IConfidentialClientApplication.js";
+import { OnBehalfOfRequest } from "../request/OnBehalfOfRequest.js";
+import { ClientCredentialRequest } from "../request/ClientCredentialRequest.js";
+import { ClientCredentialClient } from "./ClientCredentialClient.js";
+import { OnBehalfOfClient } from "./OnBehalfOfClient.js";
 
 /**
  *  This class is to be used to acquire tokens for confidential client applications (webApp, webAPI). Confidential client applications

--- a/lib/msal-node/src/client/IConfidentialClientApplication.ts
+++ b/lib/msal-node/src/client/IConfidentialClientApplication.ts
@@ -8,14 +8,14 @@ import {
     IAppTokenProvider,
     Logger,
 } from "@azure/msal-common";
-import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
-import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
-import { ClientCredentialRequest } from "../request/ClientCredentialRequest";
-import { OnBehalfOfRequest } from "../request/OnBehalfOfRequest";
-import { RefreshTokenRequest } from "../request/RefreshTokenRequest";
-import { SilentFlowRequest } from "../request/SilentFlowRequest";
-import { UsernamePasswordRequest } from "../request/UsernamePasswordRequest";
-import { TokenCache } from "../cache/TokenCache";
+import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest.js";
+import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest.js";
+import { ClientCredentialRequest } from "../request/ClientCredentialRequest.js";
+import { OnBehalfOfRequest } from "../request/OnBehalfOfRequest.js";
+import { RefreshTokenRequest } from "../request/RefreshTokenRequest.js";
+import { SilentFlowRequest } from "../request/SilentFlowRequest.js";
+import { UsernamePasswordRequest } from "../request/UsernamePasswordRequest.js";
+import { TokenCache } from "../cache/TokenCache.js";
 
 /**
  * Interface for the ConfidentialClientApplication class defining the public API signatures

--- a/lib/msal-node/src/client/IPublicClientApplication.ts
+++ b/lib/msal-node/src/client/IPublicClientApplication.ts
@@ -4,15 +4,15 @@
  */
 
 import { AccountInfo, AuthenticationResult, Logger } from "@azure/msal-common";
-import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
-import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
-import { DeviceCodeRequest } from "../request/DeviceCodeRequest";
-import { RefreshTokenRequest } from "../request/RefreshTokenRequest";
-import { SilentFlowRequest } from "../request/SilentFlowRequest";
-import { UsernamePasswordRequest } from "../request/UsernamePasswordRequest";
-import { TokenCache } from "../cache/TokenCache";
-import { InteractiveRequest } from "../request/InteractiveRequest";
-import { SignOutRequest } from "../request/SignOutRequest";
+import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest.js";
+import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest.js";
+import { DeviceCodeRequest } from "../request/DeviceCodeRequest.js";
+import { RefreshTokenRequest } from "../request/RefreshTokenRequest.js";
+import { SilentFlowRequest } from "../request/SilentFlowRequest.js";
+import { UsernamePasswordRequest } from "../request/UsernamePasswordRequest.js";
+import { TokenCache } from "../cache/TokenCache.js";
+import { InteractiveRequest } from "../request/InteractiveRequest.js";
+import { SignOutRequest } from "../request/SignOutRequest.js";
 
 /**
  * Interface for the PublicClientApplication class defining the public API signatures

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ApiId, Constants } from "../utils/Constants";
+import { ApiId, Constants } from "../utils/Constants.js";
 import {
     AuthenticationResult,
     CommonDeviceCodeRequest,
@@ -18,19 +18,19 @@ import {
     AccountInfo,
     INativeBrokerPlugin,
 } from "@azure/msal-common";
-import { Configuration } from "../config/Configuration";
-import { ClientApplication } from "./ClientApplication";
-import { IPublicClientApplication } from "./IPublicClientApplication";
-import { DeviceCodeRequest } from "../request/DeviceCodeRequest";
-import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
-import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
-import { InteractiveRequest } from "../request/InteractiveRequest";
-import { NodeAuthError } from "../error/NodeAuthError";
-import { LoopbackClient } from "../network/LoopbackClient";
-import { SilentFlowRequest } from "../request/SilentFlowRequest";
-import { SignOutRequest } from "../request/SignOutRequest";
-import { ILoopbackClient } from "../network/ILoopbackClient";
-import { DeviceCodeClient } from "./DeviceCodeClient";
+import { Configuration } from "../config/Configuration.js";
+import { ClientApplication } from "./ClientApplication.js";
+import { IPublicClientApplication } from "./IPublicClientApplication.js";
+import { DeviceCodeRequest } from "../request/DeviceCodeRequest.js";
+import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest.js";
+import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest.js";
+import { InteractiveRequest } from "../request/InteractiveRequest.js";
+import { NodeAuthError } from "../error/NodeAuthError.js";
+import { LoopbackClient } from "../network/LoopbackClient.js";
+import { SilentFlowRequest } from "../request/SilentFlowRequest.js";
+import { SignOutRequest } from "../request/SignOutRequest.js";
+import { ILoopbackClient } from "../network/ILoopbackClient.js";
+import { DeviceCodeClient } from "./DeviceCodeClient.js";
 
 /**
  * This class is to be used to acquire tokens for public client applications (desktop, mobile). Public client applications

--- a/lib/msal-node/src/config/Configuration.ts
+++ b/lib/msal-node/src/config/Configuration.ts
@@ -15,7 +15,7 @@ import {
     ApplicationTelemetry,
     INativeBrokerPlugin,
 } from "@azure/msal-common";
-import { HttpClient } from "../network/HttpClient";
+import { HttpClient } from "../network/HttpClient.js";
 import http from "http";
 import https from "https";
 

--- a/lib/msal-node/src/crypto/CryptoProvider.ts
+++ b/lib/msal-node/src/crypto/CryptoProvider.ts
@@ -4,10 +4,10 @@
  */
 
 import { ICrypto, PkceCodes } from "@azure/msal-common";
-import { GuidGenerator } from "./GuidGenerator";
-import { EncodingUtils } from "../utils/EncodingUtils";
-import { PkceGenerator } from "./PkceGenerator";
-import { HashUtils } from "./HashUtils";
+import { GuidGenerator } from "./GuidGenerator.js";
+import { EncodingUtils } from "../utils/EncodingUtils.js";
+import { PkceGenerator } from "./PkceGenerator.js";
+import { HashUtils } from "./HashUtils.js";
 
 /**
  * This class implements MSAL node's crypto interface, which allows it to perform base64 encoding and decoding, generating cryptographically random GUIDs and

--- a/lib/msal-node/src/crypto/HashUtils.ts
+++ b/lib/msal-node/src/crypto/HashUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Hash } from "../utils/Constants";
+import { Hash } from "../utils/Constants.js";
 import crypto from "crypto";
 
 export class HashUtils {

--- a/lib/msal-node/src/crypto/PkceGenerator.ts
+++ b/lib/msal-node/src/crypto/PkceGenerator.ts
@@ -4,9 +4,9 @@
  */
 
 import { Constants, PkceCodes } from "@azure/msal-common";
-import { CharSet, RANDOM_OCTET_SIZE } from "../utils/Constants";
-import { EncodingUtils } from "../utils/EncodingUtils";
-import { HashUtils } from "./HashUtils";
+import { CharSet, RANDOM_OCTET_SIZE } from "../utils/Constants.js";
+import { EncodingUtils } from "../utils/EncodingUtils.js";
+import { HashUtils } from "./HashUtils.js";
 import crypto from "crypto";
 
 /**

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -13,25 +13,25 @@
  * Breaking changes to these APIs will be shipped under a minor version, instead of a major version.
  */
 
-import * as internals from "./internals";
+import * as internals from "./internals.js";
 export { internals };
 
 // Interfaces
-export { IPublicClientApplication } from "./client/IPublicClientApplication";
-export { IConfidentialClientApplication } from "./client/IConfidentialClientApplication";
-export { ITokenCache } from "./cache/ITokenCache";
-export { ICacheClient } from "./cache/distributed/ICacheClient";
-export { IPartitionManager } from "./cache/distributed/IPartitionManager";
-export { ILoopbackClient } from "./network/ILoopbackClient";
+export { IPublicClientApplication } from "./client/IPublicClientApplication.js";
+export { IConfidentialClientApplication } from "./client/IConfidentialClientApplication.js";
+export { ITokenCache } from "./cache/ITokenCache.js";
+export { ICacheClient } from "./cache/distributed/ICacheClient.js";
+export { IPartitionManager } from "./cache/distributed/IPartitionManager.js";
+export { ILoopbackClient } from "./network/ILoopbackClient.js";
 
 // Clients and Configuration
-export { PublicClientApplication } from "./client/PublicClientApplication";
-export { ConfidentialClientApplication } from "./client/ConfidentialClientApplication";
-export { ClientApplication } from "./client/ClientApplication";
-export { ClientCredentialClient } from "./client/ClientCredentialClient";
-export { DeviceCodeClient } from "./client/DeviceCodeClient";
-export { OnBehalfOfClient } from "./client/OnBehalfOfClient";
-export { UsernamePasswordClient } from "./client/UsernamePasswordClient";
+export { PublicClientApplication } from "./client/PublicClientApplication.js";
+export { ConfidentialClientApplication } from "./client/ConfidentialClientApplication.js";
+export { ClientApplication } from "./client/ClientApplication.js";
+export { ClientCredentialClient } from "./client/ClientCredentialClient.js";
+export { DeviceCodeClient } from "./client/DeviceCodeClient.js";
+export { OnBehalfOfClient } from "./client/OnBehalfOfClient.js";
+export { UsernamePasswordClient } from "./client/UsernamePasswordClient.js";
 
 export {
     Configuration,
@@ -41,12 +41,12 @@ export {
     BrokerOptions,
     NodeTelemetryOptions,
     CacheOptions,
-} from "./config/Configuration";
-export { ClientAssertion } from "./client/ClientAssertion";
+} from "./config/Configuration.js";
+export { ClientAssertion } from "./client/ClientAssertion.js";
 
 // Cache and Storage
-export { TokenCache } from "./cache/TokenCache";
-export { NodeStorage } from "./cache/NodeStorage";
+export { TokenCache } from "./cache/TokenCache.js";
+export { NodeStorage } from "./cache/NodeStorage.js";
 export {
     CacheKVStore,
     JsonCache,
@@ -56,23 +56,23 @@ export {
     SerializedAccessTokenEntity,
     SerializedAppMetadataEntity,
     SerializedRefreshTokenEntity,
-} from "./cache/serializer/SerializerTypes";
-export { DistributedCachePlugin } from "./cache/distributed/DistributedCachePlugin";
+} from "./cache/serializer/SerializerTypes.js";
+export { DistributedCachePlugin } from "./cache/distributed/DistributedCachePlugin.js";
 
 // Crypto
-export { CryptoProvider } from "./crypto/CryptoProvider";
+export { CryptoProvider } from "./crypto/CryptoProvider.js";
 
 // Request objects
-export type { AuthorizationCodeRequest } from "./request/AuthorizationCodeRequest";
-export type { AuthorizationUrlRequest } from "./request/AuthorizationUrlRequest";
-export type { ClientCredentialRequest } from "./request/ClientCredentialRequest";
-export type { DeviceCodeRequest } from "./request/DeviceCodeRequest";
-export type { OnBehalfOfRequest } from "./request/OnBehalfOfRequest";
-export type { UsernamePasswordRequest } from "./request/UsernamePasswordRequest";
-export type { RefreshTokenRequest } from "./request/RefreshTokenRequest";
-export type { SilentFlowRequest } from "./request/SilentFlowRequest";
-export type { InteractiveRequest } from "./request/InteractiveRequest";
-export type { SignOutRequest } from "./request/SignOutRequest";
+export type { AuthorizationCodeRequest } from "./request/AuthorizationCodeRequest.js";
+export type { AuthorizationUrlRequest } from "./request/AuthorizationUrlRequest.js";
+export type { ClientCredentialRequest } from "./request/ClientCredentialRequest.js";
+export type { DeviceCodeRequest } from "./request/DeviceCodeRequest.js";
+export type { OnBehalfOfRequest } from "./request/OnBehalfOfRequest.js";
+export type { UsernamePasswordRequest } from "./request/UsernamePasswordRequest.js";
+export type { RefreshTokenRequest } from "./request/RefreshTokenRequest.js";
+export type { SilentFlowRequest } from "./request/SilentFlowRequest.js";
+export type { InteractiveRequest } from "./request/InteractiveRequest.js";
+export type { SignOutRequest } from "./request/SignOutRequest.js";
 
 // Common Object Formats
 export {
@@ -118,4 +118,4 @@ export {
     AppTokenProviderResult,
 } from "@azure/msal-common";
 
-export { version } from "./packageMetadata";
+export { version } from "./packageMetadata.js";

--- a/lib/msal-node/src/internals.ts
+++ b/lib/msal-node/src/internals.ts
@@ -8,5 +8,5 @@
  * Breaking changes to these APIs will be shipped under a minor version, instead of a major version.
  */
 
-export { Serializer } from "./cache/serializer/Serializer";
-export { Deserializer } from "./cache/serializer/Deserializer";
+export { Serializer } from "./cache/serializer/Serializer.js";
+export { Deserializer } from "./cache/serializer/Deserializer.js";

--- a/lib/msal-node/src/network/HttpClient.ts
+++ b/lib/msal-node/src/network/HttpClient.ts
@@ -9,8 +9,8 @@ import {
     NetworkResponse,
     HttpStatus,
 } from "@azure/msal-common";
-import { HttpMethod, Constants, ProxyStatus } from "../utils/Constants";
-import { NetworkUtils } from "../utils/NetworkUtils";
+import { HttpMethod, Constants, ProxyStatus } from "../utils/Constants.js";
+import { NetworkUtils } from "../utils/NetworkUtils.js";
 import http from "http";
 import https from "https";
 

--- a/lib/msal-node/src/network/LoopbackClient.ts
+++ b/lib/msal-node/src/network/LoopbackClient.ts
@@ -10,9 +10,9 @@ import {
     HttpStatus,
 } from "@azure/msal-common";
 import http from "http";
-import { NodeAuthError } from "../error/NodeAuthError";
-import { Constants, LOOPBACK_SERVER_CONSTANTS } from "../utils/Constants";
-import { ILoopbackClient } from "./ILoopbackClient";
+import { NodeAuthError } from "../error/NodeAuthError.js";
+import { Constants, LOOPBACK_SERVER_CONSTANTS } from "../utils/Constants.js";
+import { ILoopbackClient } from "./ILoopbackClient.js";
 
 export class LoopbackClient implements ILoopbackClient {
     private server: http.Server;

--- a/lib/msal-node/src/request/InteractiveRequest.ts
+++ b/lib/msal-node/src/request/InteractiveRequest.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ILoopbackClient } from "../network/ILoopbackClient";
-import { AuthorizationUrlRequest } from "./AuthorizationUrlRequest";
+import { ILoopbackClient } from "../network/ILoopbackClient.js";
+import { AuthorizationUrlRequest } from "./AuthorizationUrlRequest.js";
 
 /**
  * Request object passed by user to configure acquireTokenInteractive API

--- a/lib/msal-node/tsconfig.json
+++ b/lib/msal-node/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "include": [
     "src",
     "test"


### PR DESCRIPTION
- chore(msal-node): add $schema props for schema validation
- test(msal-node): add support for .js extension import
- build(msal-node): remove redundant pass
- feat(msal-node): change all relative imports to .js

I've made meaningful commits, so I recommend you review them instead of all the files at once.

The other solutions are:
1. to manually transform d.ts files after the build, which is a great way to introduce both complexity and brittleness to the project
2. use self-imports, allowing many entry-points `import { Configuration } from "@azure/msal-node/config/Configuration"` letting typescript and node to each resolve it in the way they understand. But this is a massive design-shift
3. using package.json `"imports"` entry. Just changing one problem for another, not a real solution and doesn't scale
4. emitting 2 `d.ts` versions, `d.mts` and `d.cts`. Thats possible but just.. redundant?

There are a few oddities, like the meme extensions importing only within their meme domain, but `d.ts` referencing non-existent `.js` files. Which is fine because it will just direct _Typescript_ to the correct `d.ts` and there isn't an interface difference between cjs and esm. Also `jest` had to be adjusted since it never got the memo that 3 LTS versions ago nodejs started supporting and advocating for `.js` extensions. If we ditch one of the meme extensions then this would be visually less scary, though it should be just as safe as it is now.

closes #6377

personal note:
Please don't bike-shed this pr for months, yes it would probably break node versions before 12 but come on. [even 16 is literally days away from deprecation](https://github.com/nodejs/release#release-schedule), it would be absolutely unreasonable.. This is over all a small change with a visually large foot print