### PR TITLE
Make `eventName` of type string for `BrowserPerformanceClient` and `PerformanceClient`

### DIFF
--- a/change/@azure-msal-browser-f70b2a1b-4926-45f0-a049-ba56721ed32d.json
+++ b/change/@azure-msal-browser-f70b2a1b-4926-45f0-a049-ba56721ed32d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make `eventName` of type string for `BrowserPerformanceClient` and `PerformanceClient` #6386",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-29f2c77c-1976-48ce-ae52-707516c30302.json
+++ b/change/@azure-msal-common-29f2c77c-1976-48ce-ae52-707516c30302.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make `eventName` of type string for `BrowserPerformanceClient` and `PerformanceClient` #6386",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -143,6 +143,8 @@ export {
     PerformanceCallbackFunction,
     PerformanceEvent,
     PerformanceEvents,
+    // Telemetry
+    InProgressPerformanceEvent,
 } from "@azure/msal-common";
 
 export { version } from "./packageMetadata";

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
@@ -104,7 +104,7 @@ export class BrowserPerformanceClient
      * @returns {((event?: Partial<PerformanceEvent>) => PerformanceEvent| null)}
      */
     startMeasurement(
-        measureName: PerformanceEvents,
+        measureName: string,
         correlationId?: string
     ): InProgressPerformanceEvent {
         // Capture page visibilityState and then invoke start/end measurement
@@ -195,7 +195,7 @@ export class BrowserPerformanceClient
      * @returns
      */
     addQueueMeasurement(
-        eventName: PerformanceEvents,
+        eventName: string,
         correlationId?: string,
         queueTime?: number,
         manuallyCompleted?: boolean

--- a/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/IPerformanceClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { PerformanceEvent, PerformanceEvents } from "./PerformanceEvent";
+import { PerformanceEvent } from "./PerformanceEvent";
 import { IPerformanceMeasurement } from "./IPerformanceMeasurement";
 
 export type PerformanceCallbackFunction = (events: PerformanceEvent[]) => void;
@@ -42,12 +42,12 @@ export interface IPerformanceClient {
     generateId(): string;
     calculateQueuedTime(preQueueTime: number, currentTime: number): number;
     addQueueMeasurement(
-        eventName: PerformanceEvents,
+        eventName: string,
         correlationId?: string,
         queueTime?: number,
         manuallyCompleted?: boolean
     ): void;
-    setPreQueueTime(eventName: PerformanceEvents, correlationId?: string): void;
+    setPreQueueTime(eventName: string, correlationId?: string): void;
 }
 
 /**
@@ -57,7 +57,7 @@ export type QueueMeasurement = {
     /**
      * Name of performance event
      */
-    eventName: PerformanceEvents;
+    eventName: string;
 
     /**
      * Time spent in JS queue

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -139,10 +139,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @param {string} correlationId
      * @returns {number}
      */
-    getPreQueueTime(
-        eventName: PerformanceEvents,
-        correlationId: string
-    ): number | void {
+    getPreQueueTime(eventName: string, correlationId: string): number | void {
         const preQueueEvent: PreQueueEvent | undefined =
             this.preQueueTimeByCorrelationId.get(correlationId);
 
@@ -204,7 +201,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
      * @returns
      */
     addQueueMeasurement(
-        eventName: PerformanceEvents,
+        eventName: string,
         correlationId?: string,
         queueTime?: number,
         manuallyCompleted?: boolean


### PR DESCRIPTION
- Make `eventName` of type string for `BrowserPerformanceClient` and `PerformanceClient`. 
- Expose `InProgressPerformanceEvent` to get rid of `msal-common` dep in 1p.