### PR TITLE
Add multi-tenant support [LTS]

### DIFF
--- a/change/@azure-msal-browser-5ccdb56d-acb7-4277-bb93-3d847632b65f.json
+++ b/change/@azure-msal-browser-5ccdb56d-acb7-4277-bb93-3d847632b65f.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Add multi-tenant support [LTS] #6396",
   "packageName": "@azure/msal-browser",
-  "email": "hectormg@hey.com",
+  "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@azure-msal-browser-5ccdb56d-acb7-4277-bb93-3d847632b65f.json
+++ b/change/@azure-msal-browser-5ccdb56d-acb7-4277-bb93-3d847632b65f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add multi-tenant support [LTS] #6396",
+  "packageName": "@azure/msal-browser",
+  "email": "hectormg@hey.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-64829f7e-0b68-4227-b348-ba607182da56.json
+++ b/change/@azure-msal-common-64829f7e-0b68-4227-b348-ba607182da56.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add multi-tenant support [LTS] #6396",
+  "packageName": "@azure/msal-common",
+  "email": "hectormg@hey.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-64829f7e-0b68-4227-b348-ba607182da56.json
+++ b/change/@azure-msal-common-64829f7e-0b68-4227-b348-ba607182da56.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Add multi-tenant support [LTS] #6396",
   "packageName": "@azure/msal-common",
-  "email": "hectormg@hey.com",
+  "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/lib/msal-browser/docs/accounts.md
+++ b/lib/msal-browser/docs/accounts.md
@@ -6,10 +6,33 @@
 
 The `@azure/msal-browser` library provides the following APIs to access cached accounts:
 
-* `getAllAccounts()`: returns all the accounts currently in the cache. An application must choose an account to acquire tokens silently.
+* `getAllAccounts()`: returns all the accounts currently in the cache. A filter can be passed in to narrow down the returned accounts. An application must choose an account to acquire tokens silently.
+* `getAccountByFilter()`:  returns the first cached account that matches the filter passed in. The order in which accounts are read from the cache is arbitrary and there is no guarantee that the first account in the filtered list will be the same for any two calls of `getAccountByFilter`.
+
+#### Account Filter Object
+
+The following type represents the format to follow for the accountFilter object that can be passed into the APIs listed above. 
+
+>Note: A single account filter attribute is usually not guaranteed to uniquely identify a cached account object. Adding a combination of attributes that don't repeat together, such as `homeAccountId` + `localAccountId`, can help refine the search.
+
+``` typescript
+export type AccountFilter = {
+    homeAccountId?: string;
+    localAccountId?: string;
+    username?: string;
+    environment?: string;
+    realm?: string;
+    nativeAccountId?: string;
+    tenantProfile?: TenantProfile;
+    isHomeTenant?: boolean;
+};
+```
+
+The following `getAccount` APIs are marked for deprecation and will be removed in a future version of MSAL Browser. Please use `getAccountFilteredBy()` instead. 
 * `getAccountByHomeId()`: receives a `homeAccountId` string and returns the matching account from the cache.
 * `getAccountByLocalId()`: receives a `localAccountId` string and returns the matching account from the cache.
 * `getAccountByUsername()`: receives a `username` string and returns the matching account from the cache.
+
 
 The following is a usage examples that covers these APIs:
 
@@ -40,7 +63,7 @@ Now the `homeAccountId`, `localAccountId`, or `username` can be used to look up 
 ```javascript
 // This method attempts silent token acquisition and falls back on acquireTokenPopup
 async function getTokenPopup(request, account) {
-    request.account = myMSALObj.getAccountByHomeId(homeAccountId); // alternatively: myMSALObj.getAccountByLocalId(localAccountId) or myMSALObj.getAccountByUsername(username) 
+    request.account = myMSALObj.getAccountByFilter({ homeAccountId: homeAccountId }); // alternatively: { localAccountId: localAccountId } or { username: username }
     return await myMSALObj.acquireTokenSilent(request).catch(async (error) => {
        // Handle error
         return await myMSALObj.acquireTokenPopup(request);
@@ -83,3 +106,4 @@ Note: As of version 2.16.0 the active account is stored in the cache location co
 * Two apps hosted on different domains do not share account state due to browser storage being segemented by domain.
 * `getAllAccounts()` is not ordered and is not guaranteed to be in the same order across multiple calls
 * Each successful call to an acquireToken or login API will return exactly one account
+* As of 2.39.0, MSAL Browser supports [Multi-tenant Accounts](./multi-tenant-accounts.md).

--- a/lib/msal-browser/docs/multi-tenant-accounts.md
+++ b/lib/msal-browser/docs/multi-tenant-accounts.md
@@ -1,0 +1,120 @@
+# Multi-tenant Support in MSAL Browser
+
+> This is an advanced document regarding the acquisition of tokensacross tenants in `msal-browser`. For basic account information, please review the [Accounts](./accounts.md) document.
+
+## Multi-tenant Accounts
+
+As of v2.39.0, MSAL Browser supports the acquisition of access tokens for accounts across multiple tenants. In order to achieve this, MSAL caches the account information and auth artifacts for a user for each tenant it has authenticated with. 
+
+This means that with the exception of refresh tokens, which are shared across tenants, the MSAL cache may store multiple accounts, access tokens, and ID tokens for a single user. Each of these account records, in a multi-tenant context, will be referred to as a **"tenant profile"** of the main account.
+
+### Tenant Profiles
+
+A tenant profile is the record of a particular account in a particular tenant. When multi-tenant support is enabled, a distinct `AccountInfo` object will be cached containing the entire tenant profile for every tenant that the user authenticates with.
+
+All tenant profiles of an account include a reference to the original or "home" account. In MSAL, this identifier is the `homeAccountId` in the `AccountInfo` object.
+
+Although full tenant profiles are actually stored as `AccountInfo` objects, MSAL exports a type called `TenantProfile` which encapsulates the information required to retrieve a particular `AccountInfo` object representing a specific tenant profile. This type is shown and explained below:
+
+```javascript
+export type TenantProfile = {
+    objectId: string;
+    tenantId: string;
+    isHomeTenant: boolean;
+};
+```
+
+| Property | Definition |
+| -------- | ---------- |
+| `objectId`| Sourced from the `oid` claim in an ID token, the `objectId` is the value that uniquely identifies a user object within a specific tenant, also referred to as `localAccountId`.|
+| `tenantId` | Source from the `tid` claim in an ID token, the `tenantId` is the value that uniquely identifies a tenant. The combination of `objectId` and `tenantId` will fully and uniquely identify a user account's specfic tenant profile.|
+| `isHomeTenant` | A flag that specifies whether the tenant profile is the home tenant profile, determined by comparing the string `"[objectId].[tenantId]"` to the account record's `homeAccountId`.|
+
+## Usage
+
+### Configuration
+
+To make use of this advanced feature, you must enable multi-tenant accounts through the `Configuration` object.
+
+```javascript
+const msalConfig = {
+	auth: {
+		clientId: "your_client_id",
+		multiTenantAccountsEnabled: true
+	}
+}
+
+const myMSALObj = new PubliClientApplication(msalConfig);
+```
+
+### Authenticating with Multiple Tenants
+
+In order to authenticate with multiple tenants, you can use either `login` or `acquireToken` APIs normally, only setting the authority to the particular tenant you are requesting tokens for.
+
+```javascript
+const msalConfig = {
+    auth: {
+        clientId: "ENTER_CLIENT_ID",
+        authority: "https://login.microsoftonline.com/HOME_TENANT", // This is the authority that MSAL will default to for requests that don't specify their own authority.
+        multiTenantAccountsEnabled: true
+    }
+}
+
+const myMSALObj = new PublicClientApplication(msalConfig);
+
+// handleRedirectPromise has to be called to resume redirect requests
+myMSALObj.handleRedirectPromise().then(handleResponse).catch(err => {
+    console.error(err);
+});
+
+// Authority isn't specified because it is already the default set in the MSAL Config object
+const homeTenantRequest = {
+    scopes: ["HOME_TENANT_SCOPE"]
+};
+
+// Guest tenant authority overrides the MSAL config authority, meaning the user can authenticate with the tenant they are a guest in and acquire tokens for it
+const guestTenantRequest = {
+    scopes: ["GUEST_TENANT_SCOPE"],
+    authority: "https://login.microsoftonline.com/GUEST_TENANT"
+};
+
+const homeTenatAuthResponse = await myMSALObj.loginPopup(homeTenantRequest);
+const guestTenantAuthResponse = await myMSALObj.loginPopup(homeTenantRequest);
+```
+
+Once both login requests are successfully completed and the user has authenticated with each tenant, there will be one `AccountInfo` object, one ID token and one access token for each tenant. There will also be a single refresh token that will be used for both in the cache.
+
+
+### Acquiring Tokens Silently for Multiple Tenants
+
+In order to acquire cached tokens for a particular tenant, the `AccountInfo` object for that particular tenant must be passed into `acquireTokenSilent`. In order to facilitate this, when multi-tenant support is enabled, all returned account objects will include a `Map<String, TenantProfile>` object containing references to all the alternate tenant profiles in the cache. Also, a `getAccountByFilter()` API has been added that allows applications to pass in a `TenantProfile` object that will be used to find the `AccountInfo` object for that specific tenant profile.
+
+The sample code below shows how one can:
+
+- Filter the result of `getAllAccounts()` using the new optional `accountFilter` parameter to "flatten" the cached accounts into home accounts with a map of their tenant profiles (otherwise getAllAccounts will return the `AccountInfo` object for each tenant profile)
+- Extract the desired `TenantProfile` object from the home `AccountInfo` object
+- Use the `TenantProfile` object to get the `AccountInfo` object for that tenant profile
+- Use the guest tenant account object to acquire cached tokens that belong to it
+
+```javascript
+// When a filter is passed into getAllAccounts, it returns all cached accounts that match the filter. Use the special isHomeTenant filter to get the home accounts only.
+const homeAccount = myMSALObj.getAllAccounts({ isHomeTenant: true })[0]; // Assuming all cached accounts belong to the same user, there should only be one home account in the cache
+const tenantId = "GUEST_TENANT_ID"; // This will be the tenant you want to retrieve a cached token for
+const guestTenantProfile = homeAccount.tenantProfiles.get(tenantId);
+const guestTenantAccount = myMSALObj.getAccountByFilter({ tenantProfile: tenantProfile});
+
+
+const guestTenantAuthResponse = await myMSALObj.acquireTokenSilent({ ...guestTenantRequest, account: guestTenantAccount }).catch(async (error) => {
+        if (error instanceof msal.InteractionRequiredAuthError) {
+            // fallback to interaction when silent call fails
+            myMSALObj.acquireTokenRedirect(request);
+        } else {
+            console.error(error);
+        }
+});
+```
+
+
+## Multi-tenant Logout
+
+Calling the `logout` API with an account object passed in will result in all tenant profiles corresponding to that account being logged out and all of their account information and auth artifacts being removed from the cache.

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -4,7 +4,7 @@
  */
 
 import { CryptoOps } from "../crypto/CryptoOps";
-import { InteractionRequiredAuthError, AccountInfo, Constants, INetworkModule, AuthenticationResult, Logger, CommonSilentFlowRequest, ICrypto, DEFAULT_CRYPTO_IMPLEMENTATION, AuthError, PerformanceEvents, PerformanceCallbackFunction, StubPerformanceClient, IPerformanceClient, BaseAuthRequest, PromptValue, ClientAuthError, InProgressPerformanceEvent } from "@azure/msal-common";
+import { InteractionRequiredAuthError, AccountInfo, Constants, INetworkModule, AuthenticationResult, Logger, CommonSilentFlowRequest, ICrypto, DEFAULT_CRYPTO_IMPLEMENTATION, AuthError, PerformanceEvents, PerformanceCallbackFunction, StubPerformanceClient, IPerformanceClient, BaseAuthRequest, PromptValue, ClientAuthError, InProgressPerformanceEvent , TenantProfile } from "@azure/msal-common";
 import { BrowserCacheManager, DEFAULT_BROWSER_CACHE_MANAGER } from "../cache/BrowserCacheManager";
 import { BrowserConfiguration, buildConfiguration, CacheOptions, Configuration } from "../config/Configuration";
 import { InteractionType, ApiId, BrowserCacheLocation, WrapperSKU, TemporaryCacheKeys, CacheLookupPolicy } from "../utils/BrowserConstants";
@@ -36,7 +36,6 @@ import { BrowserAuthError } from "../error/BrowserAuthError";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest";
 import { NativeTokenRequest } from "../broker/nativeBroker/NativeRequest";
 import { BrowserPerformanceClient } from "../telemetry/BrowserPerformanceClient";
-import { TenantProfile } from "@azure/msal-common/dist/account/TenantProfile";
 
 export abstract class ClientApplication {
 

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -788,6 +788,7 @@ export abstract class ClientApplication {
      * This API is provided for convenience but getAccountById should be used for best reliability
      * @param username
      * @returns The account object stored in MSAL
+     * @deprecated - Use getAccountByFilter instead
      */
     getAccountByUsername(username: string): AccountInfo | null {
         this.logger.trace("getAccountByUsername called");
@@ -814,6 +815,7 @@ export abstract class ClientApplication {
      * or null when no matching account is found
      * @param homeAccountId
      * @returns The account object stored in MSAL
+     * @deprecated - Use getAccountByFilter instead
      */
     getAccountByHomeId(homeAccountId: string): AccountInfo | null {
         this.logger.trace("getAccountByHomeId called");
@@ -840,6 +842,7 @@ export abstract class ClientApplication {
      * or null when no matching account is found
      * @param localAccountId
      * @returns The account object stored in MSAL
+     * @deprecated - Use getAccountByFilter instead
      */
     getAccountByLocalId(localAccountId: string): AccountInfo | null {
         this.logger.trace("getAccountByLocalId called");

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -759,26 +759,17 @@ export abstract class ClientApplication {
     // #region Account APIs
 
     /**
-     * Returns all accounts that MSAL currently has cached data for
+     * Returns all accounts matching the filter that MSAL currently has cached data for
      * (the account object is created at the time of successful login)
      * or empty array when no accounts are found. If multi-tenant accounts are enabled, each account object
-     * will also contain references to it's matching alterante tenant profiles. The account list may contain multiple accounts
+     * will also contain references to it's matching alternate tenant profiles. The account list may contain multiple accounts
      * for the same user if they have signed into multiple tenants.
+     * @param accountFilter - used to filter accounts
      * @returns Array of account objects in cache
      */
-    getAllAccounts(): AccountInfo[] {
+    getAllAccounts(accountFilter?: AccountFilter): AccountInfo[] {
         this.logger.verbose("getAllAccounts called");
-        return this.isBrowserEnvironment ? this.browserStorage.getAllAccounts(this.config.auth.multiTenantAccountsEnabled) : [];
-    }
-
-    /**
-     * Returns all cached accounts that match the filter passed in.
-     * @param accountFilter 
-     * @returns All cached accounts that match the filter.
-     */
-    getAccountsByFilter(accountFilter: AccountFilter): AccountInfo[] {
-        this.logger.verbose("getAccountsByFilter called");
-        return this.isBrowserEnvironment ? this.browserStorage.getAllAccountsFilteredBy(accountFilter, this.config.auth.multiTenantAccountsEnabled) : [];
+        return this.isBrowserEnvironment ? this.browserStorage.getAllAccounts(accountFilter, this.config.auth.multiTenantAccountsEnabled) : [];
     }
 
     /**

--- a/lib/msal-browser/src/app/ClientApplication.ts
+++ b/lib/msal-browser/src/app/ClientApplication.ts
@@ -772,17 +772,13 @@ export abstract class ClientApplication {
     }
 
     /**
-     * Returns all AccountInfo objects that represent the user's home accounts with references to their corresponding
-     * guest accounts in the cache.
-     * @returns Array of home account objects in the cache with their respective tenant profile maps
+     * Returns all cached accounts that match the filter passed in.
+     * @param accountFilter 
+     * @returns All cached accounts that match the filter.
      */
-    getAllMultiTenantHomeAccounts(): AccountInfo[] {
-        this.logger.verbose("getAllMultiTenantHomeAccounts called");
-        if(this.config.auth.multiTenantAccountsEnabled) {
-            return this.isBrowserEnvironment ? this.browserStorage.getAllMultiTenantHomeAccounts() : [];
-        } else {
-            throw BrowserAuthError.createMultiTenantAccountsDisabledError();
-        }
+    getAccountsByFilter(accountFilter: AccountFilter): AccountInfo[] {
+        this.logger.verbose("getAccountsByFilter called");
+        return this.isBrowserEnvironment ? this.browserStorage.getAllAccountsFilteredBy(accountFilter, this.config.auth.multiTenantAccountsEnabled) : [];
     }
 
     /**

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -740,6 +740,15 @@ export class BrowserCacheManager extends CacheManager {
     }
 
     /**
+     * Returns active account with tenant profiles if found 
+     * @returns 
+     */
+    getActiveAccountMultiTenant(): AccountInfo | null {
+        const activeAccount = this.getActiveAccount();
+        return activeAccount ? this.buildMultiTenantAccount(activeAccount) : null;
+    }
+
+    /**
      * Sets the active account's localAccountId in cache
      * @param account
      */

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -344,6 +344,32 @@ export class BrowserCacheManager extends CacheManager {
     }
 
     /**
+     * Extends inherited removeAccount function to include removal of cross-tenant account keys from the map
+     * @param account 
+     */
+    async removeAccountMultiTenant(key: string): Promise<void> {
+        const account: AccountEntity | null = this.getAccount(key);
+        
+        if (!account) {
+            this.logger.trace("BrowserCacheManager.removeAccountMultiTenant: called but no matching account was found in the cache.");
+            return;
+        }
+
+        const accountCacheKey = account.generateAccountKey();
+        super.removeAccount(accountCacheKey, true);
+
+        // Remove cross-tenant account keys from the map
+        const accountId = account.generateAccountId();
+        const accountKeys = this.getAccountKeys();
+        accountKeys.forEach((key) => {
+            if (key.indexOf(accountId) === 0) {
+                this.removeAccountKeyFromMap(key);
+            }
+        });
+        
+    }
+
+    /**
      * Removes given idToken from the cache and from the key map
      * @param key 
      */

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -338,35 +338,30 @@ export class BrowserCacheManager extends CacheManager {
      * Extends inherited removeAccount function to include removal of the account key from the map
      * @param key 
      */
-    async removeAccount(key: string): Promise<void> {
-        super.removeAccount(key);
-        this.removeAccountKeyFromMap(key);
-    }
-
-    /**
-     * Extends inherited removeAccount function to include removal of cross-tenant account keys from the map
-     * @param account 
-     */
-    async removeAccountMultiTenant(key: string): Promise<void> {
-        const account: AccountEntity | null = this.getAccount(key);
+    async removeAccount(key: string, multiTenantAccountsEnabled?: boolean): Promise<void> {
+        if(multiTenantAccountsEnabled) {
+            const account: AccountEntity | null = this.getAccount(key);
         
-        if (!account) {
-            this.logger.trace("BrowserCacheManager.removeAccountMultiTenant: called but no matching account was found in the cache.");
-            return;
-        }
-
-        const accountCacheKey = account.generateAccountKey();
-        super.removeAccount(accountCacheKey, true);
-
-        // Remove cross-tenant account keys from the map
-        const accountId = account.generateAccountId();
-        const accountKeys = this.getAccountKeys();
-        accountKeys.forEach((key) => {
-            if (key.indexOf(accountId) === 0) {
-                this.removeAccountKeyFromMap(key);
+            if (!account) {
+                this.logger.trace("BrowserCacheManager.removeAccountMultiTenant: called but no matching account was found in the cache.");
+                return;
             }
-        });
-        
+    
+            const accountCacheKey = account.generateAccountKey();
+            super.removeAccount(accountCacheKey, true);
+    
+            // Remove cross-tenant account keys from the map
+            const accountId = account.generateAccountId();
+            const accountKeys = this.getAccountKeys();
+            accountKeys.forEach((key) => {
+                if (key.indexOf(accountId) === 0) {
+                    this.removeAccountKeyFromMap(key);
+                }
+            });
+        } else {
+            super.removeAccount(key);
+            this.removeAccountKeyFromMap(key);
+        }
     }
 
     /**

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -246,7 +246,7 @@ export function buildConfiguration({ auth: userInputAuth, cache: userInputCache,
             tenant: Constants.EMPTY_STRING
         },
         skipAuthorityMetadataCache: false,
-        multiTenatnAccountsEnabled: false  
+        multiTenantAccountsEnabled: false  
     };
 
     // Default cache options for browser

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -67,6 +67,10 @@ export type BrowserAuthOptions = {
      * Flag of whether to use the local metadata cache
      */
     skipAuthorityMetadataCache?: boolean;
+    /**
+     * Flag that enables multi-tenant account support.
+     */
+    enableMultiTenantAccounts: boolean;
 };
 
 /**
@@ -241,7 +245,8 @@ export function buildConfiguration({ auth: userInputAuth, cache: userInputCache,
             azureCloudInstance: AzureCloudInstance.None,
             tenant: Constants.EMPTY_STRING
         },
-        skipAuthorityMetadataCache: false,  
+        skipAuthorityMetadataCache: false,
+        enableMultiTenantAccounts: false  
     };
 
     // Default cache options for browser

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -70,7 +70,7 @@ export type BrowserAuthOptions = {
     /**
      * Flag that enables multi-tenant account support.
      */
-    enableMultiTenantAccounts: boolean;
+    multiTenantAccountsEnabled: boolean;
 };
 
 /**
@@ -246,7 +246,7 @@ export function buildConfiguration({ auth: userInputAuth, cache: userInputCache,
             tenant: Constants.EMPTY_STRING
         },
         skipAuthorityMetadataCache: false,
-        enableMultiTenantAccounts: false  
+        multiTenatnAccountsEnabled: false  
     };
 
     // Default cache options for browser

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -70,7 +70,7 @@ export type BrowserAuthOptions = {
     /**
      * Flag that enables multi-tenant account support.
      */
-    multiTenantAccountsEnabled: boolean;
+    multiTenantAccountsEnabled?: boolean;
 };
 
 /**

--- a/lib/msal-browser/src/error/BrowserAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserAuthError.ts
@@ -188,6 +188,10 @@ export const BrowserAuthErrorMessage = {
     nativePromptNotSupported: {
         code: "native_prompt_not_supported",
         desc: "The provided prompt is not supported by the native platform. This request should be routed to the web based flow."
+    },
+    multiTenantAccountsDisabled: {
+        code: "multi_tenant_accounts_disabled",
+        desc: "Multi-tenant accounts have not been enabled. Add multiTenantAccountsEnabled: true to the auth configuration object to use multi-tenant accounts."
     }
 };
 
@@ -541,5 +545,12 @@ export class BrowserAuthError extends AuthError {
      */
     static createNativePromptParameterNotSupportedError(): BrowserAuthError {
         return new BrowserAuthError(BrowserAuthErrorMessage.nativePromptNotSupported.code, BrowserAuthErrorMessage.nativePromptNotSupported.desc);
+    }
+
+    /**
+     * Create an error thrown when using an API that is only supported when multi-tenant accounts are enabled by use of the Configuration.auth.multiTenantAccountsEnabled setting.
+     */
+    static createMultiTenantAccountsDisabledError(): BrowserAuthError {
+        return new BrowserAuthError(BrowserAuthErrorMessage.multiTenantAccountsDisabled.code, BrowserAuthErrorMessage.multiTenantAccountsDisabled.desc);
     }
 }

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -55,7 +55,12 @@ export abstract class BaseInteractionClient {
             }
             // Clear given account.
             try {
-                await this.browserStorage.removeAccount(AccountEntity.generateAccountCacheKey(account));
+                const accountKey = AccountEntity.generateAccountCacheKey(account);
+                if (this.config.auth.multiTenantAccountsEnabled) {
+                    await this.browserStorage.removeAccountMultiTenant(accountKey);
+                } else {
+                    await this.browserStorage.removeAccount(accountKey);
+                }
                 this.logger.verbose("Cleared cache items belonging to the account provided in the logout request.");
             } catch (error) {
                 this.logger.error("Account provided in logout request was not found. Local cache unchanged.");

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -56,11 +56,7 @@ export abstract class BaseInteractionClient {
             // Clear given account.
             try {
                 const accountKey = AccountEntity.generateAccountCacheKey(account);
-                if (this.config.auth.multiTenantAccountsEnabled) {
-                    await this.browserStorage.removeAccountMultiTenant(accountKey);
-                } else {
-                    await this.browserStorage.removeAccount(accountKey);
-                }
+                await this.browserStorage.removeAccount(accountKey, this.config.auth.multiTenantAccountsEnabled);
                 this.logger.verbose("Cleared cache items belonging to the account provided in the logout request.");
             } catch (error) {
                 this.logger.error("Account provided in logout request was not found. Local cache unchanged.");

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -151,7 +151,8 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
             authOptions: {
                 clientId: this.config.auth.clientId,
                 authority: discoveredAuthority,
-                clientCapabilities: this.config.auth.clientCapabilities
+                clientCapabilities: this.config.auth.clientCapabilities,
+                multiTenantAccountsEnabled: this.config.auth.multiTenantAccountsEnabled
             },
             systemOptions: {
                 tokenRenewalOffsetSeconds: this.config.system.tokenRenewalOffsetSeconds,

--- a/lib/msal-common/src/account/AccountInfo.ts
+++ b/lib/msal-common/src/account/AccountInfo.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { TenantProfile } from "./TenantProfile";
 import { TokenClaims } from "./TokenClaims";
 /**
  * Account object with the following signature:
@@ -16,6 +17,7 @@ import { TokenClaims } from "./TokenClaims";
  * - idTokenClaims          - Object contains claims from ID token
  * - localAccountId         - The user's account ID
  * - nativeAccountId        - The user's native account ID
+ * - tenantProfiles         - The tenant profiles available for the account in a multi-tenant context
  */
 export type AccountInfo = {
     homeAccountId: string;
@@ -27,6 +29,7 @@ export type AccountInfo = {
     idToken?: string;
     idTokenClaims?: TokenClaims & { [key: string]: string | number | string[] | object | undefined | unknown };
     nativeAccountId?: string;
+    tenantProfiles?: Map<String, TenantProfile>;
 };
 
 export type ActiveAccountFilters = {

--- a/lib/msal-common/src/account/TenantProfile.ts
+++ b/lib/msal-common/src/account/TenantProfile.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Tenant profile for a given account.
+ * objectId     - 
+ * tenantId     - 
+ * isHomeTenant - 
+ */
+export type TenantProfile = {
+    objectId: string;
+    tenantId: string;
+    isHomeTenant: boolean;
+};

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -856,4 +856,13 @@ export class Authority {
 
         return ciamAuthority;
     }
+
+    /**
+     * Extract tenantId from authority
+     */
+    static getTenantFromAuthorityString(authority: string): string | undefined {
+        const authorityUrl = new UrlString(authority);
+        const authorityUrlComponents = authorityUrl.getUrlComponents();
+        return authorityUrlComponents.PathSegments[0];
+    }
 }

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -863,6 +863,13 @@ export class Authority {
     static getTenantFromAuthorityString(authority: string): string | undefined {
         const authorityUrl = new UrlString(authority);
         const authorityUrlComponents = authorityUrl.getUrlComponents();
-        return authorityUrlComponents.PathSegments[0];
+        /**
+         * Tenant ID is the path after the domain:
+         *  AAD Authority - domain/tenantId
+         *  B2C Authority - domain/tenantId?/tfp?/policy
+         */
+        return authorityUrlComponents.PathSegments.join(
+            Constants.FORWARD_SLASH
+        );
     }
 }

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -185,11 +185,21 @@ export abstract class CacheManager implements ICacheManager {
     abstract updateCredentialCacheKey(currentCacheKey: string, credential: ValidCredentialType): string;
 
     /**
-     * Returns all accounts in cache. If multi-tenant accounts are enabled, the account objects will also include
-     * their respective tenant profiles.
+     * Returns all accounts in the cache that match the filter. If in multi-tenant mode, the accounts will be returned
+     * with their respective tenant profiles. If no filter is passed in, all accounts will be returned.
+     * @param accountFilter 
+     * @param multiTenantAccountsEnabled 
+     * @returns all accounts in the cache that match the filter
      */
-    getAllAccounts(multiTenantAccountsEnabled?: boolean): AccountInfo[] {
-        return (multiTenantAccountsEnabled) ? this.getAllAccountsMultiTenant() : this.getAllCachedAccounts();
+    getAllAccounts(accountFilter?: AccountFilter, multiTenantAccountsEnabled?: boolean): AccountInfo[] {
+        if (accountFilter) {
+            return this.getAccountsFilteredBy(accountFilter).map((accountEntity) => { 
+                const accountInfo = accountEntity.getAccountInfo();
+                return (multiTenantAccountsEnabled) ? this.buildMultiTenantAccount(accountInfo) : accountInfo;
+            });
+        } else {
+            return (multiTenantAccountsEnabled) ? this.getAllAccountsMultiTenant() : this.getAllCachedAccounts();
+        }
     }
 
     /**
@@ -285,21 +295,6 @@ export abstract class CacheManager implements ICacheManager {
         });
         
         return { ...baseAccount, tenantProfiles };
-    }
-
-    /**
-     * Returns all accounts in the cache that match the filter. If in multi-tenant mode, the accounts will be returned
-     * with their respective tenant profiles.
-     * @param accountFilter 
-     * @param multiTenantAccountsEnabled 
-     * @returns all accounts in the cache that match the filter
-     */
-    getAllAccountsFilteredBy(accountFilter: AccountFilter, multiTenantAccountsEnabled?: boolean): AccountInfo[] {
-        const fitleredAccounts: AccountInfo[] = this.getAccountsFilteredBy(accountFilter).map((accountEntity) => { return accountEntity.getAccountInfo(); });
-        if (multiTenantAccountsEnabled) {
-            return fitleredAccounts.map((accountInfo) => { return this.buildMultiTenantAccount(accountInfo); });
-        } 
-        return fitleredAccounts;
     }
 
     /** 

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -226,7 +226,7 @@ export abstract class CacheManager implements ICacheManager {
      */
     private getAllAccountsMultiTenant(): AccountInfo[] {
         const allAccountKeys = this.getAccountKeys();
-        const allAccounts: AccountInfo[] = this.getAllAccounts();
+        const allAccounts: AccountInfo[] = this.getAllCachedAccounts();
         return allAccounts.map((baseAccount: AccountInfo) => {
             // Filter accounts down to those that share homeAccountId with baseAccount
             const filteredTenantProfileKeys = allAccountKeys.filter((key: string) => {

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -759,7 +759,7 @@ export abstract class CacheManager implements ICacheManager {
                 idTokens.push(idToken);
             }
         });
-        debugger;
+
         return idTokens;
     }
 

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -185,9 +185,17 @@ export abstract class CacheManager implements ICacheManager {
     abstract updateCredentialCacheKey(currentCacheKey: string, credential: ValidCredentialType): string;
 
     /**
+     * Returns all accounts in cache. If multi-tenant accounts are enabled, the account objects will also include
+     * their respective tenant profiles.
+     */
+    getAllAccounts(multiTenantAccountsEnabled?: boolean): AccountInfo[] {
+        return (multiTenantAccountsEnabled) ? this.getAllAccountsMultiTenant() : this.getAllCachedAccounts();
+    }
+
+    /**
      * Returns all accounts in cache
      */
-    getAllAccounts(): AccountInfo[] {
+    private getAllCachedAccounts(): AccountInfo[] {
         const allAccountKeys = this.getAccountKeys();
         if (allAccountKeys.length < 1) {
             return [];
@@ -216,9 +224,9 @@ export abstract class CacheManager implements ICacheManager {
     /**
      * Returns all home accounts with their respective guest tenant profiles in the cache
      */
-    getAllAccountsMultiTenant(): AccountInfo[] {
+    private getAllMultiTenantHomeAccounts(): AccountInfo[] {
         // Get all cached accounts
-        const cachedAccounts = this.getAllAccounts();
+        const cachedAccounts = this.getAllCachedAccounts();
 
         // Filter out cross-tenant/guest accounts
         const homeAccounts: AccountInfo[] = cachedAccounts.filter((account: AccountInfo) => { 

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -286,11 +286,13 @@ export abstract class CacheManager implements ICacheManager {
 
         // Map tenant profile accounts to their tenantProfiles for baseAccount
         tenantProfileAccounts.forEach((tenantProfileAccount: AccountInfo) => {
+            const localTenantId = tenantProfileAccount.tenantId.trim();
+            const homeTenanttId = tenantProfileAccount.homeAccountId.split(".")[1].trim();
             tenantProfiles.set(
                 tenantProfileAccount.tenantId, { 
                     objectId: tenantProfileAccount.localAccountId,
                     tenantId: tenantProfileAccount.tenantId,
-                    isHomeTenant: tenantProfileAccount.tenantId === tenantProfileAccount.homeAccountId.split(".")[1]
+                    isHomeTenant: localTenantId === homeTenanttId
                 });
         });
         

--- a/lib/msal-common/src/cache/utils/CacheTypes.ts
+++ b/lib/msal-common/src/cache/utils/CacheTypes.ts
@@ -42,6 +42,7 @@ export type AccountFilter = {
     realm?: string;
     nativeAccountId?: string;
     tenantProfile?: TenantProfile;
+    isHomeTenant?: boolean;
 };
 
 /**

--- a/lib/msal-common/src/cache/utils/CacheTypes.ts
+++ b/lib/msal-common/src/cache/utils/CacheTypes.ts
@@ -13,6 +13,7 @@ import { ThrottlingEntity } from "../entities/ThrottlingEntity";
 import { AuthorityMetadataEntity } from "../entities/AuthorityMetadataEntity";
 import { AuthenticationScheme } from "../../utils/Constants";
 import { ScopeSet } from "../../request/ScopeSet";
+import { TenantProfile } from "../../account/TenantProfile";
 
 export type AccountCache = Record<string, AccountEntity>;
 export type IdTokenCache = Record<string, IdTokenEntity>;
@@ -40,6 +41,7 @@ export type AccountFilter = {
     environment?: string;
     realm?: string;
     nativeAccountId?: string;
+    tenantProfile?: TenantProfile;
 };
 
 /**

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -97,7 +97,8 @@ export class AuthorizationCodeClient extends BaseClient {
             this.logger,
             this.config.serializableCache,
             this.config.persistencePlugin,
-            this.performanceClient
+            this.performanceClient,
+            this.config.authOptions.multiTenantAccountsEnabled
         );
 
         // Validate response. This function throws a server error if an error is returned by the server.
@@ -138,7 +139,15 @@ export class AuthorizationCodeClient extends BaseClient {
      */
     handleFragmentResponse(hashFragment: string, cachedState: string): AuthorizationCodePayload {
         // Handle responses.
-        const responseHandler = new ResponseHandler(this.config.authOptions.clientId, this.cacheManager, this.cryptoUtils, this.logger, null, null);
+        const responseHandler = new ResponseHandler(
+            this.config.authOptions.clientId,
+            this.cacheManager, this.cryptoUtils,
+            this.logger,
+            null,
+            null,
+            this.performanceClient,
+            this.config.authOptions.multiTenantAccountsEnabled
+        );
 
         // Deserialize hash fragment response parameters.
         const hashUrlString = new UrlString(hashFragment);

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -62,7 +62,9 @@ export class RefreshTokenClient extends BaseClient {
             this.cryptoUtils,
             this.logger,
             this.config.serializableCache,
-            this.config.persistencePlugin
+            this.config.persistencePlugin,
+            this.performanceClient,
+            this.config.authOptions.multiTenantAccountsEnabled
         );
         responseHandler.validateTokenResponse(response.body);
 

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -76,7 +76,8 @@ export type CommonClientConfiguration = {
  * - cloudDiscoveryMetadata      - A string containing the cloud discovery response. Used in AAD scenarios.
  * - clientCapabilities          - Array of capabilities which will be added to the claims.access_token.xms_cc request property on every network request.
  * - protocolMode                - Enum that represents the protocol that msal follows. Used for configuring proper endpoints.
- * - skipAuthorityMetadataCache      - A flag to choose whether to use or not use the local metadata cache during authority initialization. Defaults to false.
+ * - skipAuthorityMetadataCache  - A flag to choose whether to use or not use the local metadata cache during authority initialization. Defaults to false.
+ * - multiTenantAccountsEnabled  - A flag to enable multi tenant account support. Defaults to false.
  */
 export type AuthOptions = {
     clientId: string;
@@ -84,6 +85,7 @@ export type AuthOptions = {
     clientCapabilities?: Array<string>;
     azureCloudOptions?: AzureCloudOptions;
     skipAuthorityMetadataCache?: boolean;
+    multiTenantAccountsEnabled?: boolean;
 };
 
 /**
@@ -260,6 +262,7 @@ function buildAuthOptions(authOptions: AuthOptions): Required<AuthOptions> {
         clientCapabilities: [],
         azureCloudOptions: DEFAULT_AZURE_CLOUD_OPTIONS,
         skipAuthorityMetadataCache: false,
+        multiTenantAccountsEnabled: false,
         ...authOptions
     };
 }

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -37,7 +37,7 @@ export { ProtocolMode } from "./authority/ProtocolMode";
 export { INativeBrokerPlugin } from "./broker/nativeBroker/INativeBrokerPlugin";
 // Cache
 export { CacheManager, DefaultStorageClass } from "./cache/CacheManager";
-export { AccountCache, AccessTokenCache, IdTokenCache, RefreshTokenCache, AppMetadataCache, ValidCacheType, ValidCredentialType, TokenKeys } from "./cache/utils/CacheTypes";
+export { AccountCache, AccountFilter, AccessTokenCache, IdTokenCache, RefreshTokenCache, AppMetadataCache, ValidCacheType, ValidCredentialType, TokenKeys } from "./cache/utils/CacheTypes";
 export { CacheRecord } from "./cache/entities/CacheRecord";
 export { CredentialEntity } from "./cache/entities/CredentialEntity";
 export { AppMetadataEntity } from "./cache/entities/AppMetadataEntity";

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -26,6 +26,7 @@ export { TokenClaims } from "./account/TokenClaims";
 export { TokenClaims as IdTokenClaims } from "./account/TokenClaims";
 export { CcsCredential, CcsCredentialType } from "./account/CcsCredential";
 export { ClientInfo, buildClientInfo, buildClientInfoFromHomeAccountId } from "./account/ClientInfo";
+export { TenantProfile } from "./account/TenantProfile";
 // Authority
 export { Authority } from "./authority/Authority";
 export { AuthorityOptions, AzureCloudInstance } from "./authority/AuthorityOptions";

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,353 @@
         "rimraf": "^3.0.0",
         "semver": "^7.3.4",
         "ts-node": "^8.10.2",
-        "tslint": "^6.1.3",
-        "typedoc": "^0.20.32",
-        "typescript": "^3.9.7"
+        "typedoc": "^0.23.28",
+        "typescript": "^4.9.5"
+      }
+    },
+    "extensions/msal-node-extensions": {
+      "name": "@azure/msal-node-extensions",
+      "version": "1.0.0-beta.1",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.0.0-beta.1",
+        "@azure/msal-node-runtime": "^0.13.6-alpha.0",
+        "keytar": "^7.8.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^15.0.2",
+        "@rollup/plugin-typescript": "^11.1.0",
+        "@types/jest": "^29.5.1",
+        "@types/node": "^20.3.1",
+        "jest": "^29.5.0",
+        "node-addon-api": "^6.1.0",
+        "rollup": "^3.20.2",
+        "shx": "^0.3.4",
+        "ts-jest": "^29.1.0",
+        "tslib": "^2.0.0",
+        "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": "18 || 20"
+      }
+    },
+    "extensions/msal-node-extensions/node_modules/@types/node": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
+    },
+    "lib/msal-angular": {
+      "name": "@azure/msal-angular",
+      "version": "3.0.0-beta.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@angular-devkit/build-angular": "^15.1.5",
+        "@angular/animations": "^15.1.4",
+        "@angular/cli": "^15.1.5",
+        "@angular/common": "^15.1.4",
+        "@angular/compiler": "^15.1.4",
+        "@angular/compiler-cli": "^15.1.4",
+        "@angular/core": "^15.1.4",
+        "@angular/forms": "^15.1.4",
+        "@angular/platform-browser": "^15.1.4",
+        "@angular/platform-browser-dynamic": "^15.1.4",
+        "@angular/router": "^15.1.4",
+        "@azure/msal-browser": "^3.0.0-beta.1",
+        "@types/jasmine": "~3.6.0",
+        "@types/jasminewd2": "~2.0.3",
+        "@types/node": "^12.11.1",
+        "jasmine-core": "~4.0.0",
+        "jasmine-spec-reporter": "~5.0.0",
+        "karma": "~6.3.2",
+        "karma-chrome-launcher": "~3.1.0",
+        "karma-coverage-istanbul-reporter": "~3.0.2",
+        "karma-jasmine": "~5.0.0",
+        "karma-jasmine-html-reporter": "^2.0.0",
+        "ng-packagr": "^15.1.2",
+        "prettier": "2.8.7",
+        "rxjs": "^7.8.1",
+        "ts-node": "~8.3.0",
+        "tslib": "^2.0.0",
+        "typescript": "~4.8.4",
+        "zone.js": "~0.11.8"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^3.0.0-beta.1",
+        "rxjs": "^7.0.0"
+      }
+    },
+    "lib/msal-angular/node_modules/ts-node": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
+      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.0"
+      }
+    },
+    "lib/msal-angular/node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "lib/msal-browser": {
+      "name": "@azure/msal-browser",
+      "version": "3.0.0-beta.1",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.0.0-beta.1"
+      },
+      "devDependencies": {
+        "@azure/storage-blob": "^12.2.1",
+        "@babel/core": "^7.7.2",
+        "@babel/plugin-proposal-class-properties": "^7.7.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+        "@babel/preset-env": "^7.7.1",
+        "@babel/preset-typescript": "^7.7.2",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-terser": "^0.4.0",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "@types/jest": "^29.5.0",
+        "@types/node": "^20.3.1",
+        "@types/sinon": "^7.5.0",
+        "dotenv": "^8.2.0",
+        "fake-indexeddb": "^3.1.3",
+        "jest": "^29.5.0",
+        "jest-environment-jsdom": "^29.5.0",
+        "prettier": "2.8.7",
+        "rimraf": "^3.0.0",
+        "rollup": "^3.14.0",
+        "shx": "^0.3.2",
+        "sinon": "^7.5.0",
+        "ssri": "^8.0.1",
+        "ts-jest": "^29.1.0",
+        "tslib": "^1.10.0",
+        "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "lib/msal-browser/node_modules/@types/node": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
+    },
+    "lib/msal-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "lib/msal-common": {
+      "name": "@azure/msal-common",
+      "version": "14.0.0-beta.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.7.2",
+        "@babel/plugin-proposal-class-properties": "^7.7.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+        "@babel/preset-env": "^7.7.1",
+        "@babel/preset-typescript": "^7.7.2",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "@types/debug": "^4.1.5",
+        "@types/jest": "^29.5.0",
+        "@types/lodash": "^4.14.182",
+        "@types/node": "^20.3.1",
+        "@types/sinon": "^7.5.0",
+        "jest": "^29.5.0",
+        "lodash": "^4.17.21",
+        "prettier": "2.8.7",
+        "rimraf": "^3.0.2",
+        "rollup": "^3.14.0",
+        "shx": "^0.3.2",
+        "sinon": "^7.5.0",
+        "ts-jest": "^29.1.0",
+        "ts-node": "^10.9.1",
+        "tslib": "^1.10.0",
+        "typescript": "^4.9.5",
+        "yargs": "^17.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "lib/msal-common/node_modules/@types/node": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
+    },
+    "lib/msal-common/node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "lib/msal-common/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "lib/msal-node": {
+      "name": "@azure/msal-node",
+      "version": "2.0.0-beta.1",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.0.0-beta.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "devDependencies": {
+        "@microsoft/api-extractor": "^7.19.4",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "@types/jest": "^29.5.0",
+        "@types/jsonwebtoken": "^8.5.5",
+        "@types/node": "^20.3.1",
+        "@types/sinon": "^7.5.0",
+        "@types/uuid": "^7.0.0",
+        "jest": "^29.5.0",
+        "prettier": "2.8.7",
+        "rollup": "^3.20.1",
+        "sinon": "^7.5.0",
+        "ts-jest": "^29.1.0",
+        "tslib": "^1.10.0",
+        "typescript": "^4.9.5",
+        "yargs": "^17.3.1"
+      },
+      "engines": {
+        "node": "18 || 20"
+      }
+    },
+    "lib/msal-node/node_modules/@types/node": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
+    },
+    "lib/msal-node/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "lib/msal-react": {
+      "name": "@azure/msal-react",
+      "version": "2.0.0-beta.1",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-typescript": "^11.1.0",
+        "rollup": "^3.20.2"
+      },
+      "devDependencies": {
+        "@azure/msal-browser": "^3.0.0-beta.1",
+        "@testing-library/jest-dom": "^5.11.5",
+        "@testing-library/react": "^13.4.0",
+        "@types/jest": "^29.5.0",
+        "@types/react": "^18.2.13",
+        "@types/react-dom": "^18.2.6",
+        "jest": "^29.5.0",
+        "jest-environment-jsdom": "^29.5.0",
+        "prettier": "2.8.7",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "ts-jest": "^29.1.0",
+        "tslib": "^2.0.0",
+        "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^3.0.0-beta.1",
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
+      "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
+      "dev": true
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,13 +34,15 @@
         "rimraf": "^3.0.0",
         "semver": "^7.3.4",
         "ts-node": "^8.10.2",
-        "typedoc": "^0.23.28",
-        "typescript": "^4.9.5"
+        "tslint": "^6.1.3",
+        "typedoc": "^0.20.32",
+        "typescript": "^3.9.7"
       }
     },
     "extensions/msal-node-extensions": {
       "name": "@azure/msal-node-extensions",
       "version": "1.0.0-beta.1",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "14.0.0-beta.1",
@@ -64,15 +66,10 @@
         "node": "18 || 20"
       }
     },
-    "extensions/msal-node-extensions/node_modules/@types/node": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
-      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
-      "dev": true
-    },
     "lib/msal-angular": {
       "name": "@azure/msal-angular",
       "version": "3.0.0-beta.1",
+      "extraneous": true,
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^15.1.5",
@@ -110,44 +107,10 @@
         "rxjs": "^7.0.0"
       }
     },
-    "lib/msal-angular/node_modules/ts-node": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
-      "dev": true,
-      "dependencies": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.0"
-      }
-    },
-    "lib/msal-angular/node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "lib/msal-browser": {
       "name": "@azure/msal-browser",
       "version": "3.0.0-beta.1",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "14.0.0-beta.1"
@@ -183,21 +146,10 @@
         "node": ">=0.8.0"
       }
     },
-    "lib/msal-browser/node_modules/@types/node": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
-      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
-      "dev": true
-    },
-    "lib/msal-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
     "lib/msal-common": {
       "name": "@azure/msal-common",
       "version": "14.0.0-beta.1",
+      "extraneous": true,
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.7.2",
@@ -228,64 +180,10 @@
         "node": ">=0.8.0"
       }
     },
-    "lib/msal-common/node_modules/@types/node": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
-      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
-      "dev": true
-    },
-    "lib/msal-common/node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "lib/msal-common/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
     "lib/msal-node": {
       "name": "@azure/msal-node",
       "version": "2.0.0-beta.1",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "14.0.0-beta.1",
@@ -314,21 +212,10 @@
         "node": "18 || 20"
       }
     },
-    "lib/msal-node/node_modules/@types/node": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
-      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
-      "dev": true
-    },
-    "lib/msal-node/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
     "lib/msal-react": {
       "name": "@azure/msal-react",
       "version": "2.0.0-beta.1",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-typescript": "^11.1.0",
@@ -356,31 +243,6 @@
       "peerDependencies": {
         "@azure/msal-browser": "^3.0.0-beta.1",
         "react": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
-      "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
-      "dev": true
-    },
-    "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
@@ -1,0 +1,95 @@
+// Browser check variables
+// If you support IE, our recommendation is that you sign-in using Redirect APIs
+// If you as a developer are testing using Edge InPrivate mode, please add "isEdge" to the if check
+const ua = window.navigator.userAgent;
+const msie = ua.indexOf("MSIE ");
+const msie11 = ua.indexOf("Trident/");
+const msedge = ua.indexOf("Edge/");
+const isIE = msie > 0 || msie11 > 0;
+const isEdge = msedge > 0;
+
+let signInType;
+let accountId = "";
+
+// Create the main myMSALObj instance
+// configuration parameters are located at authConfig.js
+const myMSALObj = new msal.PublicClientApplication(msalConfig);
+
+// Redirect: once login is successful and redirects with tokens, call Graph API
+myMSALObj.handleRedirectPromise().then(handleResponse).catch(err => {
+    console.error(err);
+});
+
+function handleResponse(resp) {
+    if (resp !== null) {
+        accountId = resp.account.homeAccountId;
+        myMSALObj.setActiveAccount(resp.account);
+        showWelcomeMessage(resp.account);
+    } else {
+        // need to call getAccount here?
+        const currentAccounts = myMSALObj.getAllAccounts();
+        if (!currentAccounts || currentAccounts.length < 1) {
+            return;
+        } else if (currentAccounts.length > 1) {
+            // Add choose account code here
+        } else if (currentAccounts.length === 1) {
+            const activeAccount = currentAccounts[0];
+            myMSALObj.setActiveAccount(activeAccount);
+            accountId = activeAccount.homeAccountId;
+            showWelcomeMessage(activeAccount);
+        }
+    }
+}
+
+async function signIn(method) {
+    signInType = isIE ? "redirect" : method;
+    if (signInType === "popup") {
+        return myMSALObj.loginPopup(loginRequest).then(handleResponse).catch(function (error) {
+            console.log(error);
+        });
+    } else if (signInType === "redirect") {
+        return myMSALObj.loginRedirect(loginRequest)
+    }
+}
+
+function signOut(interactionType) {
+    const logoutRequest = {
+        account: myMSALObj.getAccountByHomeId(accountId)
+    };
+
+    if (interactionType === "popup") {
+        myMSALObj.logoutPopup(logoutRequest).then(() => {
+            window.location.reload();
+        });
+    } else {
+        myMSALObj.logoutRedirect(logoutRequest);
+    }
+}
+
+async function getTokenPopup(request, account) {
+    return await myMSALObj.acquireTokenSilent(request).catch(async (error) => {
+        console.log("silent token acquisition fails.");
+        if (error instanceof msal.InteractionRequiredAuthError) {
+            console.log("acquiring token using popup");
+            return myMSALObj.acquireTokenPopup(request).catch(error => {
+                console.error(error);
+            });
+        } else {
+            console.error(error);
+        }
+    });
+}
+
+// This function can be removed if you do not need to support IE
+async function getTokenRedirect(request, account) {
+    return await myMSALObj.acquireTokenSilent(request).catch(async (error) => {
+        console.log("silent token acquisition fails.");
+        if (error instanceof msal.InteractionRequiredAuthError) {
+            // fallback to interaction when silent call fails
+            console.log("acquiring token using redirect");
+            myMSALObj.acquireTokenRedirect(request);
+        } else {
+            console.error(error);
+        }
+    });
+}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
@@ -1,13 +1,3 @@
-// Browser check variables
-// If you support IE, our recommendation is that you sign-in using Redirect APIs
-// If you as a developer are testing using Edge InPrivate mode, please add "isEdge" to the if check
-const ua = window.navigator.userAgent;
-const msie = ua.indexOf("MSIE ");
-const msie11 = ua.indexOf("Trident/");
-const msedge = ua.indexOf("Edge/");
-const isIE = msie > 0 || msie11 > 0;
-const isEdge = msedge > 0;
-
 let signInType;
 let accountId = "";
 

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
@@ -11,8 +11,8 @@ myMSALObj.handleRedirectPromise().then(handleResponse).catch(err => {
 });
 
 function handleResponse() {
-    // getAccountsByFilter returns all cached accounts that match the filter. Use isHomeTenant filter to get the home accounts.
-    const homeAccounts = myMSALObj.getAccountsByFilter({ isHomeTenant: true });
+    // when a filter is passed into getAllAccounts, it returns all cached accounts that match the filter. Use isHomeTenant filter to get the home accounts.
+    const homeAccounts = myMSALObj.getAllAccounts({ isHomeTenant: true });
     if (!homeAccounts || homeAccounts.length < 1) {
         return;
     } else if (homeAccounts.length === 1) {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
@@ -11,8 +11,8 @@ myMSALObj.handleRedirectPromise().then(handleResponse).catch(err => {
 });
 
 function handleResponse() {
-    // getAllMultiTenantHomeAccounts returns all cached home and guest accounts
-    const homeAccounts = myMSALObj.getAllMultiTenantHomeAccounts();
+    // getAccountsByFilter returns all cached accounts that match the filter. Use isHomeTenant filter to get the home accounts.
+    const homeAccounts = myMSALObj.getAccountsByFilter({ isHomeTenant: true });
     if (!homeAccounts || homeAccounts.length < 1) {
         return;
     } else if (homeAccounts.length === 1) {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/auth.js
@@ -21,13 +21,17 @@ myMSALObj.handleRedirectPromise().then(handleResponse).catch(err => {
 });
 
 function handleResponse() {
-    const allAccounts = myMSALObj.getAllAccounts();
+    // getAllAccounts returns all cached home and guest accounts
+    const allAccounts = myMSALObj.getAllAccounts().filter((account) => {
+        // Keep only home accounts since their tenant profiles are populated and guest accounts can be obatinined by getAccountByTenantProfile
+        return account.homeAccountId.split(".")[0] === account.localAccountId;;
+    });
     if (!allAccounts || allAccounts.length < 1) {
         return;
     } else if (allAccounts.length === 1) {
         // Get all accounts returns the homeAccount with tenantProfiles when multiTenantAccountsEnabled is set to true
         pickActiveAccountAndTenantProfile(allAccounts[0]);
-    } else if (currentAccounts.length > 1) {
+    } else if (allAccounts.length > 1) {
             // Select account logic
     }
 }

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/authConfig.js
@@ -1,0 +1,66 @@
+const homeTenant = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+const guestTenant = "5d97b14d-c396-4aee-b524-c86d33e9b660"
+
+// Config object to be passed to Msal on creation
+const msalConfig = {
+    auth: {
+        clientId: "bc77b0a7-16aa-4af4-884b-41b968c9c71a",
+        authority: `https://login.microsoftonline.com/${guestTenant}`
+    },
+    cache: {
+        cacheLocation: "sessionStorage", // This configures where your cache will be stored
+        storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        loggerOptions: {
+            logLevel: msal.LogLevel.Trace,
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {
+                    return;
+                }
+                switch (level) {
+                    case msal.LogLevel.Error:
+                        console.error(message);
+                        return;
+                    case msal.LogLevel.Info:
+                        console.info(message);
+                        return;
+                    case msal.LogLevel.Verbose:
+                        console.debug(message);
+                        return;
+                    case msal.LogLevel.Warning:
+                        console.warn(message);
+                        return;
+                    default:
+                        console.log(message);
+                        return;
+                }
+            }
+        }
+    },
+    telemetry: {
+        application: {
+            appName: "MSAL Browser V2 Multi-tenant Sample",
+            appVersion: "1.0.0"
+        }
+    }
+};
+
+// Add here scopes for id token to be used at MS Identity Platform endpoints.
+const loginRequest = {
+    scopes: ["User.Read"]
+};
+
+// Add here the endpoints for MS Graph API services you would like to use.
+const graphConfig = {
+    graphMeEndpoint: "https://graph.microsoft.com/v1.0/me",
+};
+
+const silentRequest = {
+    scopes: ["openid", "profile", "User.Read"]
+};
+
+const guestTenantRequest = {
+    ...loginRequest,
+    authority: `https://login.microsoftonline.com/${homeTenant}`
+}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/authConfig.js
@@ -1,11 +1,13 @@
-const homeTenant = "72f988bf-86f1-41af-91ab-2d7cd011db47";
-const guestTenant = "5d97b14d-c396-4aee-b524-c86d33e9b660"
+const homeTenant = "ENTER_HOME_TENANT";
+const guestTenant = "ENTER_GUEST_TENANT"
+const baseAuthority = "https://login.microsoftonline.com"
 
 // Config object to be passed to Msal on creation
 const msalConfig = {
     auth: {
-        clientId: "bc77b0a7-16aa-4af4-884b-41b968c9c71a",
-        authority: `https://login.microsoftonline.com/${homeTenant}`
+        clientId: "ENTER_CLIENT_ID",
+        authority: `${baseAuthority}/${homeTenant}`,
+        multiTenantAccountsEnabled: true
     },
     cache: {
         cacheLocation: "sessionStorage", // This configures where your cache will be stored
@@ -62,5 +64,5 @@ const silentRequest = {
 
 const guestTenantRequest = {
     ...loginRequest,
-    authority: `https://login.microsoftonline.com/${guestTenant}`
+    authority: `${baseAuthority}/${guestTenant}`
 }

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/authConfig.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/authConfig.js
@@ -5,7 +5,7 @@ const guestTenant = "5d97b14d-c396-4aee-b524-c86d33e9b660"
 const msalConfig = {
     auth: {
         clientId: "bc77b0a7-16aa-4af4-884b-41b968c9c71a",
-        authority: `https://login.microsoftonline.com/${guestTenant}`
+        authority: `https://login.microsoftonline.com/${homeTenant}`
     },
     cache: {
         cacheLocation: "sessionStorage", // This configures where your cache will be stored
@@ -62,5 +62,5 @@ const silentRequest = {
 
 const guestTenantRequest = {
     ...loginRequest,
-    authority: `https://login.microsoftonline.com/${homeTenant}`
+    authority: `https://login.microsoftonline.com/${guestTenant}`
 }

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/graph.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/graph.js
@@ -1,0 +1,53 @@
+// Helper function to call MS Graph API endpoint 
+// using authorization bearer token scheme
+function callMSGraph(endpoint, accessToken, callback) {
+    const headers = new Headers();
+    const bearer = `Bearer ${accessToken}`;
+
+    headers.append("Authorization", bearer);
+
+    const options = {
+        method: "GET",
+        headers: headers
+    };
+
+    console.log('request made to Graph API at: ' + new Date().toString());
+
+    fetch(endpoint, options)
+        .then(response => response.json())
+        .then(response => callback(response, endpoint))
+        .catch(error => console.log(error));
+}
+
+async function seeProfileHome() {
+    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
+    if (currentAcc) {
+        const response = await getTokenPopup(loginRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+        profileButton.style.display = 'none';
+    }
+}
+
+async function seeProfileGuest() {
+    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
+    if (currentAcc) {
+        const response = await getTokenPopup(guestTenantRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+        guestProfileButton.style.display = 'none';
+    }
+}
+
+async function seeProfileRedirect() {
+    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
+    if (currentAcc) {
+        const response = await getTokenRedirect(loginRequest, currentAcc).catch(error => {
+            console.log(error);
+        });
+        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
+        profileButton.style.display = 'none';
+    }
+}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/graph.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/graph.js
@@ -19,35 +19,13 @@ function callMSGraph(endpoint, accessToken, callback) {
         .catch(error => console.log(error));
 }
 
-async function seeProfileHome() {
-    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
+async function seeProfile() {
+    const currentAcc = myMSALObj.getActiveAccount();
     if (currentAcc) {
-        const response = await getTokenPopup(loginRequest, currentAcc).catch(error => {
+        const request = {...loginRequest, authority: `${baseAuthority}/${currentAcc.tenantId}`};
+        const response = await getTokenRedirect(request, currentAcc).catch(error => {
             console.log(error);
         });
         callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
-        profileButton.style.display = 'none';
-    }
-}
-
-async function seeProfileGuest() {
-    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
-    if (currentAcc) {
-        const response = await getTokenPopup(guestTenantRequest, currentAcc).catch(error => {
-            console.log(error);
-        });
-        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
-        guestProfileButton.style.display = 'none';
-    }
-}
-
-async function seeProfileRedirect() {
-    const currentAcc = myMSALObj.getAccountByHomeId(accountId);
-    if (currentAcc) {
-        const response = await getTokenRedirect(loginRequest, currentAcc).catch(error => {
-            console.log(error);
-        });
-        callMSGraph(graphConfig.graphMeEndpoint, response.accessToken, updateUI);
-        profileButton.style.display = 'none';
     }
 }

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/index.html
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/index.html
@@ -15,35 +15,41 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
       <a class="navbar-brand" href="/">MS Identity Platform</a>
       <div class="btn-group ml-auto dropleft">
-          <button type="button" id="SignIn" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Sign In
-          </button>
-          <div class="dropdown-menu">
-            <button class="dropdown-item" id="popup" onclick="signIn(this.id)">Sign in using Popup</button>
-            <button class="dropdown-item" id="redirect" onclick="signIn(this.id)">Sign in using Redirect</button>
-          </div>
-      </div>
+        <button type="button" id="SignIn" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Sign In
+        </button>
+        <div class="dropdown-menu">
+          <button class="dropdown-item" id="popup" onclick="signIn(this.id)">Sign in using Popup</button>
+          <button class="dropdown-item" id="redirect" onclick="signIn(this.id)">Sign in using Redirect</button>
+        </div>
     </nav>
     <br>
     <h5 class="card-header text-center">Vanilla JavaScript SPA calling MS Graph API with MSAL.JS (w/ Multiple Tenants)</h5>
     <br>
     <div class="row" style="margin:auto" >
-    <div id="card-div" class="col-md-3" style="display:none">
+    <div id="card-div-profiles" class="col-md-3" style="display:none">
     <div class="card text-center">
       <div class="card-body">
-        <h5 class="card-title" id="WelcomeMessage">Please sign-in to see your profile and read your mails</h5>
-        <div id="profile-div"></div>
-        <br>
-        <br>
-        <button class="btn btn-primary" id="seeProfile" onclick="seeProfileHome()">See Profile</button>
-        <br>
-        <br>
-        <button class="btn btn-primary" id="seeProfileGuest" onclick="seeProfileGuest()">See Guest Tenant Profile</button>
+        <h5 class="card-title" id="PickProfileMessage">Please pick a tenant to acquire tokens for</h5>
+        <div id="tenant-profile-div">
+        </div>
       </div>
     </div>
     </div>
     <br>
     <br>
+    <div id="card-div-graph" class="col-md-3" style="display:none">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title" id="WelcomeMessage"></h5>
+          <div id="graph-profile-div">
+          </div>
+          <br>
+          <br>
+            <button class="btn btn-primary" id="seeProfileGuest" onclick="seeProfile()">See Graph Profile</button>
+        </div>
+      </div>
+      </div>
       <div class="col-md-4">
         <div class="list-group" id="list-tab" role="tablist">
         </div>

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/index.html
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/index.html
@@ -35,7 +35,7 @@
         <div id="profile-div"></div>
         <br>
         <br>
-        <button class="btn btn-primary" id="seeProfile" onclick="seeProfile()">See Profile</button>
+        <button class="btn btn-primary" id="seeProfile" onclick="seeProfileHome()">See Profile</button>
         <br>
         <br>
         <button class="btn btn-primary" id="seeProfileGuest" onclick="seeProfileGuest()">See Guest Tenant Profile</button>

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/index.html
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+    <title>Quickstart | MSAL.JS Vanilla JavaScript SPA</title>
+    
+    <script src="../../lib/msal-browser.js"></script>
+    
+    <!-- adding Bootstrap 4 for UI components  -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link rel="SHORTCUT ICON" href="https://c.s-microsoft.com/favicon.ico?v2" type="image/x-icon">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <a class="navbar-brand" href="/">MS Identity Platform</a>
+      <div class="btn-group ml-auto dropleft">
+          <button type="button" id="SignIn" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Sign In
+          </button>
+          <div class="dropdown-menu">
+            <button class="dropdown-item" id="popup" onclick="signIn(this.id)">Sign in using Popup</button>
+            <button class="dropdown-item" id="redirect" onclick="signIn(this.id)">Sign in using Redirect</button>
+          </div>
+      </div>
+    </nav>
+    <br>
+    <h5 class="card-header text-center">Vanilla JavaScript SPA calling MS Graph API with MSAL.JS (w/ Multiple Tenants)</h5>
+    <br>
+    <div class="row" style="margin:auto" >
+    <div id="card-div" class="col-md-3" style="display:none">
+    <div class="card text-center">
+      <div class="card-body">
+        <h5 class="card-title" id="WelcomeMessage">Please sign-in to see your profile and read your mails</h5>
+        <div id="profile-div"></div>
+        <br>
+        <br>
+        <button class="btn btn-primary" id="seeProfile" onclick="seeProfile()">See Profile</button>
+        <br>
+        <br>
+        <button class="btn btn-primary" id="seeProfileGuest" onclick="seeProfileGuest()">See Guest Tenant Profile</button>
+      </div>
+    </div>
+    </div>
+    <br>
+    <br>
+      <div class="col-md-4">
+        <div class="list-group" id="list-tab" role="tablist">
+        </div>
+      </div>
+      <div class="col-md-5">
+        <div class="tab-content" id="nav-tabContent">
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+
+    <!-- importing bootstrap.js and supporting js libraries -->
+    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>  
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    
+    <!-- importing app scripts | load order is important -->
+    <script type="text/javascript" src="./authConfig.js"></script>
+    <script type="text/javascript" src="./ui.js"></script>  
+    <script type="text/javascript" src="./auth.js"></script>
+    <script type="text/javascript" src="./graph.js"></script>
+  </body>
+</html>

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/ui.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/ui.js
@@ -15,10 +15,10 @@ const guestProfileButton = document.getElementById("seeProfileGuest");
 const tenantProfileDiv = document.getElementById("tenant-profile-div");
 const graphProfileDiv = document.getElementById("graph-profile-div");
 
-function showWelcomeMessage(homeAccount) {
+function showWelcomeMessage(activeAccount) {
     // Reconfiguring DOM elements
     cardDivGraphProfiles.style.display = 'initial';
-    welcomeDiv.innerHTML = `Welcome ${homeAccount.username}`;
+    welcomeDiv.innerHTML = `Welcome ${activeAccount.name}`;
     signInButton.setAttribute('class', "btn btn-success dropdown-toggle");
     signInButton.innerHTML = "Sign Out";
     popupButton.setAttribute('onClick', "signOut(this.id)");

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/ui.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/ui.js
@@ -1,0 +1,41 @@
+// Select DOM elements to work with
+const welcomeDiv = document.getElementById("WelcomeMessage");
+const signInButton = document.getElementById("SignIn");
+const popupButton = document.getElementById("popup");
+const redirectButton = document.getElementById("redirect");
+const cardDiv = document.getElementById("card-div");
+const mailButton = document.getElementById("readMail");
+const profileButton = document.getElementById("seeProfile");
+const guestProfileButton = document.getElementById("seeProfileGuest");
+const profileDiv = document.getElementById("profile-div");
+
+function showWelcomeMessage(account) {
+    // Reconfiguring DOM elements
+    cardDiv.style.display = 'initial';
+    welcomeDiv.innerHTML = `Welcome ${account.username}`;
+    signInButton.setAttribute('class', "btn btn-success dropdown-toggle");
+    signInButton.innerHTML = "Sign Out";
+    popupButton.setAttribute('onClick', "signOut(this.id)");
+    popupButton.innerHTML = "Sign Out with Popup";
+    redirectButton.setAttribute('onClick', "signOut(this.id)");
+    redirectButton.innerHTML = "Sign Out with Redirect";
+}
+
+function updateUI(data, endpoint) {
+    console.log('Graph API responded at: ' + new Date().toString());
+
+    if (endpoint === graphConfig.graphMeEndpoint) {
+        const title = document.createElement('p');
+        title.innerHTML = "<strong>Title: </strong>" + data.jobTitle;
+        const email = document.createElement('p');
+        email.innerHTML = "<strong>Mail: </strong>" + data.mail;
+        const phone = document.createElement('p');
+        phone.innerHTML = "<strong>Phone: </strong>" + data.businessPhones[0];
+        const address = document.createElement('p');
+        address.innerHTML = "<strong>Location: </strong>" + data.officeLocation;
+        profileDiv.appendChild(title);
+        profileDiv.appendChild(email);
+        profileDiv.appendChild(phone);
+        profileDiv.appendChild(address);
+    }
+}

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/ui.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multi-tenant/ui.js
@@ -1,18 +1,24 @@
 // Select DOM elements to work with
 const welcomeDiv = document.getElementById("WelcomeMessage");
+const pickProfileMessage = document.getElementById("PickProfileMessage");
+const signInDiv = document.getElementById("sign-in-div");
+const signOutDiv = document.getElementById("sign-out-div");
 const signInButton = document.getElementById("SignIn");
+const signOutButton = document.getElementById("SignOut");
 const popupButton = document.getElementById("popup");
 const redirectButton = document.getElementById("redirect");
-const cardDiv = document.getElementById("card-div");
+const cardDivTenantProfiles = document.getElementById("card-div-profiles");
+const cardDivGraphProfiles = document.getElementById("card-div-graph");
 const mailButton = document.getElementById("readMail");
 const profileButton = document.getElementById("seeProfile");
 const guestProfileButton = document.getElementById("seeProfileGuest");
-const profileDiv = document.getElementById("profile-div");
+const tenantProfileDiv = document.getElementById("tenant-profile-div");
+const graphProfileDiv = document.getElementById("graph-profile-div");
 
-function showWelcomeMessage(account) {
+function showWelcomeMessage(homeAccount) {
     // Reconfiguring DOM elements
-    cardDiv.style.display = 'initial';
-    welcomeDiv.innerHTML = `Welcome ${account.username}`;
+    cardDivGraphProfiles.style.display = 'initial';
+    welcomeDiv.innerHTML = `Welcome ${homeAccount.username}`;
     signInButton.setAttribute('class', "btn btn-success dropdown-toggle");
     signInButton.innerHTML = "Sign Out";
     popupButton.setAttribute('onClick', "signOut(this.id)");
@@ -21,9 +27,38 @@ function showWelcomeMessage(account) {
     redirectButton.innerHTML = "Sign Out with Redirect";
 }
 
+function createTenantProfileButton(tenantProfile, activeTenantId) {
+    const tenantIdButton = document.createElement('button');
+    const styleClass = (tenantProfile.tenantId === activeTenantId) ? "btn btn-success" : "btn btn-primary";
+    tenantIdButton.setAttribute('class', styleClass);
+    tenantIdButton.setAttribute('id', tenantProfile.tenantId);
+    tenantIdButton.setAttribute('onClick', "setActiveAccount(this.id)");
+    const label = `${tenantProfile.tenantId}${ tenantProfile.isHomeTenant ? " (Home Tenant)" : "" }`;
+    tenantIdButton.innerHTML = label;
+    return tenantIdButton;
+}
+
+function showTenantProfilePicker(tenantProfiles, activeAccount) {
+    // Reconfiguring DOM elements
+    cardDivTenantProfiles.style.display = 'initial';
+    pickProfileMessage.innerHTML = "Select a tenant profile to set as the active account";
+    tenantProfileDiv.innerHTML = "";
+    const sortedTenantProfiles = tenantProfiles.sort((profile) => { return profile.isHomeTenant ? -1 : 1;})
+    sortedTenantProfiles.forEach(function (profile) {
+        tenantProfileDiv.appendChild(createTenantProfileButton(profile, activeAccount.tenantId));
+        tenantProfileDiv.appendChild(document.createElement('br'));
+        tenantProfileDiv.appendChild(document.createElement('br'));
+    });
+    const newTenantProfileButton = document.createElement('button');
+    newTenantProfileButton.setAttribute('class', "btn btn-primary");
+    newTenantProfileButton.setAttribute('id', "new-tenant-button");
+    newTenantProfileButton.setAttribute('onClick', "requestGuestToken()");
+    newTenantProfileButton.innerHTML = "Add New Tenant Profile";
+    tenantProfileDiv.appendChild(newTenantProfileButton);
+}
+
 function updateUI(data, endpoint) {
     console.log('Graph API responded at: ' + new Date().toString());
-
     if (endpoint === graphConfig.graphMeEndpoint) {
         const title = document.createElement('p');
         title.innerHTML = "<strong>Title: </strong>" + data.jobTitle;
@@ -33,9 +68,10 @@ function updateUI(data, endpoint) {
         phone.innerHTML = "<strong>Phone: </strong>" + data.businessPhones[0];
         const address = document.createElement('p');
         address.innerHTML = "<strong>Location: </strong>" + data.officeLocation;
-        profileDiv.appendChild(title);
-        profileDiv.appendChild(email);
-        profileDiv.appendChild(phone);
-        profileDiv.appendChild(address);
+        graphProfileDiv.innerHTML = "";
+        graphProfileDiv.appendChild(title);
+        graphProfileDiv.appendChild(email);
+        graphProfileDiv.appendChild(phone);
+        graphProfileDiv.appendChild(address);
     }
 }


### PR DESCRIPTION
This PR:
- Adds `multiTenantAccountsEnabled` flag to auth config
- Adds `TenantProfile` type and `tenantProfiles: Map<String, TenantProfile>` optional attribute to `AccountInfo`
- Enables cross-tenant cache storage and retrieval when `multiTenantAccountsEnabled` is `true`
- Adds `getAllAccountsMultiTenant` API to allow applications to get an AccountInfo object of each home account in the cache with a map of tenant profiles for the matching cross-tenant accounts (alternate branch `multi-tenant-support-all-accounts` returns all accounts, home or guest, with their cross-tenant profiles)
- Add a multi-tenant sample demonstrating how to get accounts by tenant profile and how to get tokens for cross-tenant accounts
- Adds logic to logout to clear ALL tenant profile accounts from the cache matching the account passed in when `multiTenantAccountsEnabled` is `true`
- PENDING TESTS/DOCS