### PR TITLE
Remove `files` from `package.json` that breaks packaging/deploying

### DIFF
--- a/change/@azure-msal-angular-d4b3f72c-ad95-4ea2-8a4b-647d15e122c2.json
+++ b/change/@azure-msal-angular-d4b3f72c-ad95-4ea2-8a4b-647d15e122c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove `files` from `package.json` that breaks packaging/deploying #6442",
+  "packageName": "@azure/msal-angular",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -12,9 +12,6 @@
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
   "description": "Microsoft Authentication Library for Angular",
-  "files": [
-    "src"
-  ],
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
- Remove `files` from `package.json` that breaks packaging/deploying: `npm run deploy` publishes an empty package.