### PR TITLE
`msal-angular@3.0.4` patch release

### DIFF
--- a/change/@azure-msal-angular-d4b3f72c-ad95-4ea2-8a4b-647d15e122c2.json
+++ b/change/@azure-msal-angular-d4b3f72c-ad95-4ea2-8a4b-647d15e122c2.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Remove `files` from `package.json` that breaks packaging/deploying #6442",
-  "packageName": "@azure/msal-angular",
-  "email": "kshabelko@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/lib/msal-angular/CHANGELOG.json
+++ b/lib/msal-angular/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@azure/msal-angular",
   "entries": [
     {
+      "date": "Wed, 06 Sep 2023 17:19:21 GMT",
+      "version": "3.0.4",
+      "tag": "@azure/msal-angular_v3.0.4",
+      "comments": {
+        "patch": [
+          {
+            "author": "kshabelko@microsoft.com",
+            "package": "@azure/msal-angular",
+            "commit": "a88c48e20021dd4f5aa8535fba21f71a16455ff4",
+            "comment": "Remove `files` from `package.json` that breaks packaging/deploying #6442"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 05 Sep 2023 22:13:47 GMT",
       "version": "3.0.3",
       "tag": "@azure/msal-angular_v3.0.3",

--- a/lib/msal-angular/CHANGELOG.md
+++ b/lib/msal-angular/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @azure/msal-angular
 
-This log was last generated on Tue, 05 Sep 2023 22:13:47 GMT and should not be manually modified.
+This log was last generated on Wed, 06 Sep 2023 17:19:21 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 3.0.4
+
+Wed, 06 Sep 2023 17:19:21 GMT
+
+### Patches
+
+- Remove `files` from `package.json` that breaks packaging/deploying #6442 (kshabelko@microsoft.com)
 
 ## 3.0.3
 

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/msal-angular",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "author": {
     "name": "Microsoft",
     "email": "nugetaad@microsoft.com",

--- a/lib/msal-angular/src/packageMetadata.ts
+++ b/lib/msal-angular/src/packageMetadata.ts
@@ -1,3 +1,3 @@
 /* eslint-disable header/header */
 export const name = '@azure/msal-angular';
-export const version = '3.0.3';
+export const version = '3.0.4';

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
     },
     "lib/msal-angular": {
       "name": "@azure/msal-angular",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^15.1.5",


### PR DESCRIPTION
- `msal-angular@3.0.4` patch release to address an issue with missing dist folders in `msal-angular@3.0.4`