### PR TITLE
Typo in JSDoc of deprecated BrowserAuthErrorMessage 

### DIFF
--- a/change/@azure-msal-browser-e4c3386d-0fd8-4875-bef9-4c16a6b530b1.json
+++ b/change/@azure-msal-browser-e4c3386d-0fd8-4875-bef9-4c16a6b530b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "doc: JSDoc for deprecated BrowserAuthErrorMessage",
+  "packageName": "@azure/msal-browser",
+  "email": "renaud.aste@ocea-sb.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-browser-e4c3386d-0fd8-4875-bef9-4c16a6b530b1.json
+++ b/change/@azure-msal-browser-e4c3386d-0fd8-4875-bef9-4c16a6b530b1.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "doc: JSDoc for deprecated BrowserAuthErrorMessage",
   "packageName": "@azure/msal-browser",
   "email": "renaud.aste@ocea-sb.com",

--- a/lib/msal-browser/src/error/BrowserAuthError.ts
+++ b/lib/msal-browser/src/error/BrowserAuthError.ts
@@ -92,7 +92,11 @@ export const BrowserAuthErrorMessages = {
 
 /**
  * BrowserAuthErrorMessage class containing string constants used by error codes and messages.
- * @deprecated Use BrowserAuthBrowserAuthErrorCodes instead
+ * @deprecated Use exported BrowserAuthErrorCodes instead.
+ * In your app you can do :
+ * ```
+ * import { BrowserAuthErrorCodes } from "@azure/msal-browser";
+ * ```
  */
 export const BrowserAuthErrorMessage = {
     pkceNotGenerated: {


### PR DESCRIPTION
1. There was a typo : `BrowserAuthBrowserAuthErrorCodes` VS `BrowserAuthErrorCodes`.
2. Also, the JSDoc wasn't clear to me as `BrowserAuthErrorCodes` is not a TS class but an export alias.