### PR TITLE
Update CODEOWNERS to account for MSAL-Node Confidential Client Regression Test (New) Workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,8 @@
 /extensions/msal-node-extensions/ @sameerag @tnorling @hectormmg @peterzenz
 
 # MSAL Node Confidential Client Regression Tests
+.github/workflows/client-credential-benchmark.yml @bgavrilMS @robbie-microsoft @trwalke @pmaytak @gladjohn @neha-bhargava @rayluo @Avery-Dunn
+.github/workflows/msal-node-confidential-client-benchmarks.yml @bgavrilMS @robbie-microsoft @trwalke @pmaytak @gladjohn @neha-bhargava @rayluo @Avery-Dunn
 /regression-tests/msal-node/ @bgavrilMS @robbie-microsoft @trwalke @pmaytak @gladjohn @neha-bhargava @rayluo @Avery-Dunn
 
 # MSAL React


### PR DESCRIPTION
I've added everyone on the MSAL Confidential Client team to the two new workflows in the Client Credentials regression tests.