### PR TITLE
Do not add v2.0 to authority endpoint if already exists

### DIFF
--- a/change/@azure-msal-common-ddf6cb76-26e2-40de-b764-8b2c753ad77a.json
+++ b/change/@azure-msal-common-ddf6cb76-26e2-40de-b764-8b2c753ad77a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Do not add v2.0 to authority endpoint if already exists #6457",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -356,6 +356,7 @@ export class Authority {
     protected get defaultOpenIdConfigurationEndpoint(): string {
         const canonicalAuthorityHost = this.hostnameAndPort;
         if (
+            this.canonicalAuthority.endsWith("v2.0/") ||
             this.authorityType === AuthorityType.Adfs ||
             (this.protocolMode !== ProtocolMode.AAD &&
                 !this.isAliasOfKnownMicrosoftAuthority(canonicalAuthorityHost))

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -2543,6 +2543,32 @@ describe("Authority.ts Class Unit Tests", () => {
             );
         });
 
+        it("v2 is not added to authority if already provided", async () => {
+            const authorityUrl =
+                "https://login.microsoftonline.com/test-tenant-id/v2.0";
+            let endpoint = "";
+            authority = new Authority(
+                authorityUrl,
+                networkInterface,
+                mockStorage,
+                { ...authorityOptions, knownAuthorities: [authorityUrl] },
+                logger
+            );
+            jest.spyOn(
+                networkInterface,
+                <any>"sendGetRequestAsync"
+            ).mockImplementation((openIdConfigEndpoint) => {
+                // @ts-ignore
+                endpoint = openIdConfigEndpoint;
+                return DEFAULT_OPENID_CONFIG_RESPONSE;
+            });
+
+            await authority.resolveEndpointsAsync();
+            expect(endpoint).toBe(
+                `${authorityUrl}/.well-known/openid-configuration`
+            );
+        });
+
         it("DSTS authority uses v2 well-known endpoint with common authority", async () => {
             const authorityUrl =
                 "https://login.microsoftonline.com/dstsv2/common/";


### PR DESCRIPTION
- Do not add v2.0 to authority endpoint if already exists.