### PR TITLE
Improve robustness of LoopbackClient

### DIFF
--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -17,7 +17,6 @@ import {
     NativeSignOutRequest,
     AccountInfo,
     INativeBrokerPlugin,
-    ServerAuthorizationCodeResponse,
 } from "@azure/msal-common";
 import { Configuration } from "../config/Configuration.js";
 import { ClientApplication } from "./ClientApplication.js";

--- a/lib/msal-node/src/network/ILoopbackClient.ts
+++ b/lib/msal-node/src/network/ILoopbackClient.ts
@@ -10,10 +10,11 @@ import { ServerAuthorizationCodeResponse } from "@azure/msal-common";
  * @public
  */
 export interface ILoopbackClient {
-    listenForAuthCode(
-        successTemplate?: string,
-        errorTemplate?: string
-    ): Promise<ServerAuthorizationCodeResponse>;
+    startServer(options: {
+        successTemplate?: string;
+        errorTemplate?: string;
+    }): Promise<void>;
+    waitForAuthCode(): Promise<ServerAuthorizationCodeResponse>;
     getRedirectUri(): string;
     closeServer(): void;
 }


### PR DESCRIPTION
This change addresses a few rough edges caused by Node's `http.server` APIs and how they behave in unexpected ways as well as some cleanup of the `ILoopbackClient` contract:

1. `server.close()` only prevents new connections from being accepted but does not clean up any open ones.
2. A race condition where we call `server.address()` potentially before the service has begun listening.
3. General cleanup like listening for the `listening` and `error` events on `server` instead of polling in a setInterval and avoiding mixing `async/await` with Promise constructors and chaining.
5. A small enhancement where we now clean up the server as soon as we have the final auth response or have failed in case the caller forgets to call `closeServer`

Unfortunately, I wasn't able to make this change without introducing some small breaks to the `ILoopbackClient`. This is because I needed to split apart waiting for the server to start listening and waiting for the auth code to come back, otherwise starting the redirect dance in the middle could run afoul of race conditions.

Any feedback, stylistic or otherwise would be greatly appreciated!