### PR TITLE
Fix Node PCA tests

### DIFF
--- a/change/@azure-msal-node-599c3080-3d1d-4823-b22d-0957fc717e33.json
+++ b/change/@azure-msal-node-599c3080-3d1d-4823-b22d-0957fc717e33.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix PCA test mocks",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -6,6 +6,7 @@ import {
     TEST_CONSTANTS,
     TEST_DATA_CLIENT_INFO,
     mockAccountInfo,
+    DEFAULT_OPENID_CONFIG_RESPONSE,
 } from "../utils/TestConstants";
 import {
     ClientConfiguration,
@@ -94,10 +95,12 @@ describe("PublicClientApplication", () => {
     };
 
     beforeEach(() => {
-        jest.clearAllMocks();
-
         mockTelemetryManager;
         setupAuthorityFactory_createDiscoveredInstance_mock();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     test("exports a class", () => {
@@ -809,11 +812,15 @@ describe("PublicClientApplication", () => {
         };
 
         const authApp = new PublicClientApplication(appConfig);
-        await authApp.getAuthCodeUrl(request);
-        expect(AuthorizationCodeClient).toHaveBeenCalledTimes(1);
-        expect(AuthorizationCodeClient).toHaveBeenCalledWith(
-            expect.objectContaining(expectedConfig)
-        );
+        const url = await authApp.getAuthCodeUrl(request);
+        expect(
+            url.startsWith(
+                DEFAULT_OPENID_CONFIG_RESPONSE.body.authorization_endpoint
+            )
+        ).toBe(true);
+        expect(url).toContain(appConfig.auth.clientId);
+        expect(url).toContain(encodeURIComponent(request.redirectUri));
+        expect(url).toContain(encodeURIComponent(request.scopes.join(" ")));
     });
 
     test("acquireTokenByUsernamePassword", async () => {
@@ -849,6 +856,12 @@ describe("PublicClientApplication", () => {
             refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
         };
 
+        const mockRefreshTokenClient =
+            getMsalCommonAutoMock().RefreshTokenClient;
+        jest.spyOn(msalCommon, "RefreshTokenClient").mockImplementation(
+            (config) => new mockRefreshTokenClient(config)
+        );
+
         const authorityMock =
             setupAuthorityFactory_createDiscoveredInstance_mock(fakeAuthority);
 
@@ -881,6 +894,12 @@ describe("PublicClientApplication", () => {
             refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
             authority: TEST_CONSTANTS.ALTERNATE_AUTHORITY,
         };
+
+        const mockRefreshTokenClient =
+            getMsalCommonAutoMock().RefreshTokenClient;
+        jest.spyOn(msalCommon, "RefreshTokenClient").mockImplementation(
+            (config) => new mockRefreshTokenClient(config)
+        );
 
         const authorityMock =
             setupAuthorityFactory_createDiscoveredInstance_mock();
@@ -925,6 +944,12 @@ describe("PublicClientApplication", () => {
             refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
         };
 
+        const mockRefreshTokenClient =
+            getMsalCommonAutoMock().RefreshTokenClient;
+        jest.spyOn(msalCommon, "RefreshTokenClient").mockImplementation(
+            (config) => new mockRefreshTokenClient(config)
+        );
+
         const authorityMock =
             setupAuthorityFactory_createDiscoveredInstance_mock(fakeAuthority);
 
@@ -968,6 +993,12 @@ describe("PublicClientApplication", () => {
             scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
             refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
         };
+
+        const mockRefreshTokenClient =
+            getMsalCommonAutoMock().RefreshTokenClient;
+        jest.spyOn(msalCommon, "RefreshTokenClient").mockImplementation(
+            (config) => new mockRefreshTokenClient(config)
+        );
 
         const authorityMock =
             setupAuthorityFactory_createDiscoveredInstance_mock(fakeAuthority);

--- a/lib/msal-node/test/client/test-fixtures.ts
+++ b/lib/msal-node/test/client/test-fixtures.ts
@@ -11,7 +11,10 @@ import {
 } from "@azure/msal-common";
 
 import * as msalCommon from "@azure/msal-common";
-import { TEST_CONSTANTS } from "../utils/TestConstants";
+import {
+    DEFAULT_OPENID_CONFIG_RESPONSE,
+    TEST_CONSTANTS,
+} from "../utils/TestConstants";
 
 // @ts-ignore
 const mockServerTelemetryManager: ServerTelemetryManager = {
@@ -53,6 +56,14 @@ export const fakeAuthority: Authority = {
         region_source: undefined,
         region_outcome: undefined,
     },
+    options: {
+        protocolMode: ProtocolMode.AAD,
+        knownAuthorities: [],
+        cloudDiscoveryMetadata: "",
+        authorityMetadata: "",
+    },
+    authorizationEndpoint:
+        DEFAULT_OPENID_CONFIG_RESPONSE.body.authorization_endpoint,
     resolveEndpointsAsync: () => {
         return new Promise<void>((resolve) => {
             resolve();


### PR DESCRIPTION
Node PCA tests aren't restoring mocks after each test leading to inconsistent behavior when some tests are run before others. This PR ensures mocks are cleared after each test and fixes the tests affected.