### PR TITLE
Making appid part of the id

### DIFF
--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -74,6 +74,7 @@ export class AccountEntity {
             tenantId: this.realm,
             username: this.username,
             localAccountId: this.localAccountId,
+            idTokenClaims: this.idTokenClaims,
         });
     }
 
@@ -103,6 +104,8 @@ export class AccountEntity {
             accountInterface.homeAccountId,
             accountInterface.environment || Constants.EMPTY_STRING,
             accountInterface.tenantId || Constants.EMPTY_STRING,
+            accountInterface.idTokenClaims?.appid || Constants.EMPTY_STRING,
+
         ];
 
         return accountKey.join(Separators.CACHE_KEY_SEPARATOR).toLowerCase();

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
     "extensions/msal-node-extensions": {
       "name": "@azure/msal-node-extensions",
       "version": "1.0.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "14.0.3",
@@ -66902,7 +66903,7 @@
       "name": "msal-vue-sample",
       "version": "0.0.0",
       "dependencies": {
-        "@azure/msal-browser": "^3.0.0-beta.0",
+        "@azure/msal-browser": "^3.1.0",
         "element-plus": "^2.2.19",
         "vue": "^3.2.41",
         "vue-router": "^4.1.5"


### PR DESCRIPTION
I wanted to use 2 (or more) PublicClientApplication in my app. It's not working correctly because both account will share the same `AccountCacheKey` so I wanted to try this. 

```ts

const foo = new PublicClientApplication({
  auth: {
    clientId: "client-id-foo",
    authority:
      "https://login.microsoftonline.com/my-aad-tenant",  
  }
});

const bar = new PublicClientApplication({
  auth: {
    clientId: "client-id-bar",
    authority:
      "https://login.microsoftonline.com/my-aad-tenant",
  }
});

await foo.initialize();
await bar.initialize();

```
But I can't build the repo locally, the `npm run build:all` command works the first time, then it will no work anymore

```
> @azure/msal-browser@3.1.0 build
> npm run clean && npm run build:modules


> @azure/msal-browser@3.1.0 clean
> shx rm -rf dist lib


> @azure/msal-browser@3.1.0 build:modules
> rollup -c --strictDeprecations --bundleConfigAsCjs


src/index.ts → dist...
(!) Plugin typescript: @rollup/plugin-typescript TS2307: Cannot find module '@azure/msal-common' or its corresponding type declarations.
src/app/IPublicClientApplication.ts: (10:8)

10 } from "@azure/msal-common";
          ~~~~~~~~~~~~~~~~~~~~

src/app/PublicClientApplication.ts: (19:8)

19 } from "@azure/msal-common";

...

src/telemetry/BrowserPerformanceClient.ts: (175:14)

175         this.preQueueTimeByCorrelationId.set(correlationId, {
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

[!] RollupError: "AccountInfo" is not exported by "../msal-common/dist/index.mjs", imported by "src/index.ts".
https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module
src/index.ts (40:0)
38: export { AuthenticationScheme,
39: // Account
40: AccountInfo, AccountEntity, IdTokenClaims,
    ^
41: // Error
42: AuthError, AuthErrorMessage, ClientAuthError, ClientAuthErrorCodes, ClientAuthErrorMessage, ClientConfigurationError,...
    at error (/Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:353:30)
    at Module.error (/Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:15206:16)
    at Module.getVariableForExportName (/Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:15370:29)
    at Module.includeAllExports (/Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:15443:37)
    at Graph.includeStatements (/Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:26231:36)
    at Graph.build (/Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:26147:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at /Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:27061:13
    at catchUnfinishedHookActions (/Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:26317:16)
    at rollupInternal (/Users/baptiste/www/msaljs/node_modules/rollup/dist/shared/rollup.js:27056:5)


npm ERR! Lifecycle script `build:modules` failed with error:
npm ERR! Error: command failed
npm ERR!   in workspace: @azure/msal-browser@3.1.0
npm ERR!   at location: /Users/baptiste/www/msaljs/lib/msal-browser
npm ERR! Lifecycle script `build` failed with error:
npm ERR! Error: command failed
npm ERR!   in workspace: @azure/msal-browser@3.1.0
npm ERR!   at location: /Users/baptiste/www/msaljs/lib/msal-browser
npm ERR! Lifecycle script `build:all` failed with error:
npm ERR! Error: command failed
npm ERR!   in workspace: @azure/msal-browser@3.1.0
npm ERR!   at location: /Users/baptiste/www/msaljs/lib/msal-browser
```


Did I miss some configuration to do in order to test this localy ?