### PR TITLE
Set TypeScript composite: false

### DIFF
--- a/change/@azure-msal-browser-651ea081-203f-4c34-9d93-450d948d45df.json
+++ b/change/@azure-msal-browser-651ea081-203f-4c34-9d93-450d948d45df.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Turn off composite/project references",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-common-af89001e-29b7-4895-ba07-a2d2e38be634.json
+++ b/change/@azure-msal-common-af89001e-29b7-4895-ba07-a2d2e38be634.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Turn off composite/project references",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-node-9a4635e1-8f4e-49a4-ad0c-790a30783084.json
+++ b/change/@azure-msal-node-9a4635e1-8f4e-49a4-ad0c-790a30783084.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Turn off composite/project references",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-node-extensions-bf0066b9-b6ab-4d4e-8554-fb4bd95ebc37.json
+++ b/change/@azure-msal-node-extensions-bf0066b9-b6ab-4d4e-8554-fb4bd95ebc37.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Turn off composite/project references",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-react-1fde2465-8fb0-4475-ace3-9ca1f57f7b6f.json
+++ b/change/@azure-msal-react-1fde2465-8fb0-4475-ace3-9ca1f57f7b6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Turn off composite/project references",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/extensions/msal-node-extensions/tsconfig.json
+++ b/extensions/msal-node-extensions/tsconfig.json
@@ -15,6 +15,7 @@
       "esnext"
     ],
     "importHelpers": true,
+    "composite": false,
     "declaration": true,
     "sourceMap": true,
     "rootDir": "./",
@@ -28,10 +29,5 @@
       "node",
       "jest"
     ]
-  },
-  "references": [
-    {
-      "path": "../../lib/msal-common"
-    }
-  ]
+  }
 }

--- a/lib/msal-browser/tsconfig.json
+++ b/lib/msal-browser/tsconfig.json
@@ -11,6 +11,7 @@
         ],
         "outDir": "./dist",
         "allowUnusedLabels": false,
+        "composite": false,
         "noImplicitReturns": true,
         "esModuleInterop": true,
         "resolveJsonModule": true,
@@ -19,11 +20,6 @@
             "jest"
         ]
     },
-    "references": [
-        {
-            "path": "../msal-common"
-        }
-    ],
     "include": [
         "src",
         "test"

--- a/lib/msal-common/tsconfig.json
+++ b/lib/msal-common/tsconfig.json
@@ -37,6 +37,7 @@
         ],
         "outDir": "./dist",
         "allowUnusedLabels": false,
+        "composite": false,
         "noImplicitReturns": true,
         "esModuleInterop": true,
         "resolveJsonModule": true,

--- a/lib/msal-node/tsconfig.json
+++ b/lib/msal-node/tsconfig.json
@@ -22,6 +22,7 @@
     "outDir": "./dist",
     "strict": true,
     "noImplicitAny": true,
+    "composite": false,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "strictPropertyInitialization": false,
@@ -43,10 +44,5 @@
     ]
   },
   "compileOnSave": false,
-  "buildOnSave": false,
-  "references": [
-    {
-      "path": "../msal-common"
-    }
-  ]
+  "buildOnSave": false
 }

--- a/lib/msal-react/tsconfig.json
+++ b/lib/msal-react/tsconfig.json
@@ -17,6 +17,7 @@
     "rootDir": "./",
     "outDir": "./dist",
     "strict": true,
+    "composite": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
@@ -31,10 +32,5 @@
       "jest",
       "react"
     ]
-  },
-  "references": [
-    {
-      "path": "../msal-browser"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
The composite and project references settings in TypeScript are used, among other things, to speed up build times when the project has already been built previously. Unfortunately, the generated tsbuildinfo file is either incorrect or outdated and causing subsequent builds to fail. The only way to get ourselves out of this state is to delete the tsbuildinfo file, which defeats the purpose of the composite/project references settings. 

This PR turns off composite and project references to address the local build issues.