### PR TITLE
[Msal node] expose the type through msal-node imported from common

### DIFF
--- a/change/@azure-msal-node-2dc90eeb-427f-4832-8b7b-fbd13d7ade87.json
+++ b/change/@azure-msal-node-2dc90eeb-427f-4832-8b7b-fbd13d7ade87.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "expose the api from msal-node imported from common",
+  "packageName": "@azure/msal-node",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -120,7 +120,7 @@ export {
     IAppTokenProvider,
     AppTokenProviderParameters,
     AppTokenProviderResult,
-    INativeBrokerPlugin
+    INativeBrokerPlugin,
 } from "@azure/msal-common";
 
 export { version } from "./packageMetadata.js";

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -120,6 +120,7 @@ export {
     IAppTokenProvider,
     AppTokenProviderParameters,
     AppTokenProviderResult,
+    INativeBrokerPlugin
 } from "@azure/msal-common";
 
 export { version } from "./packageMetadata.js";


### PR DESCRIPTION
- Exposing the type needed from @azure/msal-common through @azure/msal-node (`INativeBrokerPlugin`)