### PR TITLE
Rollup bug for un-minified UMD output with regard to constants

### DIFF
--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -217,20 +217,14 @@ export class NestedAppAuthAdapter {
         if (isBridgeError(error)) {
             switch (error.status) {
                 case BridgeStatusCode.USER_CANCEL:
-                    return new ClientAuthError(
-                        ClientAuthErrorCodes.userCanceled
-                    );
+                    return new ClientAuthError("user_cancelled");
                 case BridgeStatusCode.NO_NETWORK:
-                    return new ClientAuthError(
-                        ClientAuthErrorCodes.noNetworkConnectivity
-                    );
+                    return new ClientAuthError("no_network_connectivity");
                 case BridgeStatusCode.ACCOUNT_UNAVAILABLE:
-                    return new ClientAuthError(
-                        ClientAuthErrorCodes.noAccountFound
-                    );
+                    return new ClientAuthError("no_account_found");
                 case BridgeStatusCode.DISABLED:
                     return new ClientAuthError(
-                        ClientAuthErrorCodes.nestedAppAuthBridgeDisabled
+                        "nested_app_auth_bridge_disabled"
                     );
                 case BridgeStatusCode.NESTED_APP_AUTH_UNAVAILABLE:
                     return new ClientAuthError(error.code, error.description);

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -20,7 +20,6 @@ import {
     Logger,
     AuthToken,
     TokenClaims,
-    ClientAuthErrorCodes,
 } from "@azure/msal-common";
 import { isBridgeError } from "../BridgeError";
 import { BridgeStatusCode } from "../BridgeStatusCode";


### PR DESCRIPTION
* Minified works likely because of Terser doing a better job of understanding what's going on
* For reasons only known to Rollup.... it seems to get confused when it starts resolve module dependencies.... when the same constant is referenced from 2 distinct entry points.

instead of normal output:

const noAccountFound = "no_account_found";

You see:

const index.noAccountFound = "no_account_found" 

This PR is a temporary fix?? Until we have time to understand rollup better and propose a PR to them.  OR until it gets fixed in a future release of rollup.

