### PR TITLE
addressing rollup issue based when using 2 outputs for one input

### DIFF
--- a/change/@azure-msal-browser-26cf862f-e7fd-48e4-ba9d-80cda5042501.json
+++ b/change/@azure-msal-browser-26cf862f-e7fd-48e4-ba9d-80cda5042501.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "addressing rollup issue based on combined configuration",
+  "packageName": "@azure/msal-browser",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/rollup.config.js
+++ b/lib/msal-browser/rollup.config.js
@@ -51,6 +51,24 @@ export default [
                 sourcemap: true,
                 entryFileNames: "msal-browser.cjs"
             },
+        ],
+        plugins: [
+            nodeResolve({
+                browser: true,
+                resolveOnly: ["@azure/msal-common", "tslib"]
+            }),
+            typescript({
+                typescript: require("typescript"),
+                tsconfig: "tsconfig.build.json",
+                sourceMap: true,
+                compilerOptions: { outDir: "./lib" }
+            })
+        ]
+    },
+    {
+        input: "src/index.ts",
+        preserveModules: false,
+        output: [
             {
                 dir: "lib",
                 format: "umd",


### PR DESCRIPTION
I saw random discussion about a problem with trying to output both cjs and umd at the same time.  I split and the issues with the UMD output went away.  (no longer prefixing inlined dyanamic imports with "index."

I confirmed the UMD output no longer is prefixed.... let's see how the various builds do now.