### PR TITLE
Fix Environment.getUserRootDirectory() on Non-Windows Platforms

### DIFF
--- a/change/@azure-msal-node-extensions-be2bc48f-eda0-4092-8349-ef6f659fcf8d.json
+++ b/change/@azure-msal-node-extensions-be2bc48f-eda0-4092-8349-ef6f659fcf8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Environment.getUserRootDirectory() only ever executes Windows code path",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "janusz@corechain.tech",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/src/utils/Environment.ts
+++ b/extensions/msal-node-extensions/src/utils/Environment.ts
@@ -57,7 +57,7 @@ export class Environment {
     }
 
     static getUserRootDirectory(): string | null {
-        return !this.isWindowsPlatform
+        return !this.isWindowsPlatform()
             ? this.getUserHomeDirOnUnix()
             : this.getUserHomeDirOnWindows();
     }

--- a/extensions/msal-node-extensions/test/utils/Environment.spec.ts
+++ b/extensions/msal-node-extensions/test/utils/Environment.spec.ts
@@ -1,0 +1,9 @@
+import { Environment } from "../../src/utils/Environment";
+
+describe("Environment", () => {
+    test("Environment.isWindowsPlatform() should be called by Environment.getUserRootDirectory()", () => {
+        const spy = jest.spyOn(Environment, "isWindowsPlatform");
+        Environment.getUserRootDirectory();
+        expect(spy).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
fix: `Environment.getUserRootDirectory()` only ever executes Windows code path

From the Azure msal-node [docs](https://github.com/MicrosoftDocs/azure-docs/blob/e622cd3bded2530b8db7843cd9539fd16f0cd67c/articles/active-directory/develop/msal-node-extensions.md?plain=1#L50-L52):
```typescript
// You can use the helper functions provided through the Environment class to construct your cache path
// The helper functions provide consistent implementations across Windows, Mac and Linux.
const cachePath = path.join(Environment.getUserRootDirectory(), "./cache.json");
```
The existing (broken) code:

https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/9934e3b07118403898e65091035d26295e55f128/extensions/msal-node-extensions/src/utils/Environment.ts#L59-L63

msal-node-extensions: `Environment.getUserHomeDirOnUnix()` was never called, because `!this.isWindowsPlatform` would always be false, since `isWindowsPlatform()` is a static method and not a property getter (or property)