### PR TITLE
Update @azure/msal-react compatible versions to include Node v20

### DIFF
--- a/lib/msal-react/package.json
+++ b/lib/msal-react/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@azure/msal-browser": "^3.2.0",
-    "react": "^16.8.0 || ^17 || ^18"
+    "react": "^16.8.0 || ^17 || ^18 || ^20"
   },
   "devDependencies": {
     "@azure/msal-browser": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,7 +383,7 @@
       },
       "peerDependencies": {
         "@azure/msal-browser": "^3.2.0",
-        "react": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17 || ^18 || ^20"
       }
     },
     "lib/msal-react/node_modules/@types/node": {


### PR DESCRIPTION
This pull request addresses an issue related to the compatibility of the @azure/msal-react package with Node.js versions. Currently, the package specifies a compatibility range that does not include Node.js version 20. This compatibility issue results in a warning message when installing the package, as follows:


```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@azure/msal-node@1.16.0',
npm WARN EBADENGINE   required: { node: '10 || 12 || 14 || 16 || 18' },
npm WARN EBADENGINE   current: { node: 'v20.8.1', npm: '10.1.0' }
npm WARN EBADENGINE }
```