### PR TITLE
Don't use temporary cache for silent & popup flows

### DIFF
--- a/change/@azure-msal-browser-7c734503-8069-411f-8bfb-472e0dc65ba2.json
+++ b/change/@azure-msal-browser-7c734503-8069-411f-8bfb-472e0dc65ba2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Don't use temporary cache for silent & popup flows #6586",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-542684b7-2f3a-4793-87ef-e63aa1516284.json
+++ b/change/@azure-msal-common-542684b7-2f3a-4793-87ef-e63aa1516284.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't use temporary cache for silent & popup flows #6586",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -42,9 +42,7 @@ import { INavigationClient } from "../navigation/INavigationClient";
 import { EventHandler } from "../event/EventHandler";
 import { BrowserCacheManager } from "../cache/BrowserCacheManager";
 import { BrowserConfiguration } from "../config/Configuration";
-import {
-    InteractionHandler
-} from "../interaction_handler/InteractionHandler";
+import { InteractionHandler } from "../interaction_handler/InteractionHandler";
 import { PopupWindowAttributes } from "../request/PopupWindowAttributes";
 import { EventError } from "../event/EventMessage";
 import { AuthenticationResult } from "../response/AuthenticationResult";

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -139,7 +139,6 @@ export class RedirectClient extends StandardInteractionClient {
                 this.browserStorage,
                 authCodeRequest,
                 this.logger,
-                this.browserCrypto,
                 this.performanceClient
             );
 
@@ -463,15 +462,9 @@ export class RedirectClient extends StandardInteractionClient {
             this.browserStorage,
             cachedRequest,
             this.logger,
-            this.browserCrypto,
             this.performanceClient
         );
-        return await interactionHandler.handleCodeResponseFromHash(
-            hash,
-            state,
-            authClient.authority,
-            this.networkClient
-        );
+        return await interactionHandler.handleCodeResponseFromHash(hash, state);
     }
 
     /**

--- a/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
@@ -8,7 +8,6 @@ import {
     Logger,
     CommonAuthorizationCodeRequest,
     AuthError,
-    Constants,
     IPerformanceClient,
     PerformanceEvents,
     invokeAsync,
@@ -81,13 +80,6 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
             this.performanceClient,
             request.correlationId
         )(request, InteractionType.Silent);
-        this.browserStorage.updateCacheEntries(
-            silentRequest.state,
-            silentRequest.nonce,
-            silentRequest.authority,
-            silentRequest.loginHint || Constants.EMPTY_STRING,
-            silentRequest.account || null
-        );
 
         const serverTelemetryManager = this.initializeServerTelemetryManager(
             this.apiId
@@ -137,9 +129,7 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
                     cloud_graph_host_name: request.cloudGraphHostName,
                     cloud_instance_host_name: request.cloudInstanceHostName,
                 },
-                silentRequest.state,
-                authClient.authority,
-                this.networkClient,
+                silentRequest,
                 false
             );
         } catch (e) {
@@ -147,7 +137,6 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
                 (e as AuthError).setCorrelationId(this.correlationId);
                 serverTelemetryManager.cacheFailedRequest(e);
             }
-            this.browserStorage.cleanRequestByState(silentRequest.state);
             throw e;
         }
     }

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -10,7 +10,6 @@ import {
     CommonAuthorizationCodeRequest,
     AuthorizationCodeClient,
     AuthError,
-    Constants,
     UrlString,
     ServerAuthorizationCodeResponse,
     ProtocolUtils,

--- a/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
@@ -126,10 +126,7 @@ export class InteractionHandler {
                 this.logger,
                 this.performanceClient,
                 request.correlationId
-            )(
-                authCodeResponse.cloud_instance_host_name,
-                request.correlationId
-            );
+            )(authCodeResponse.cloud_instance_host_name, request.correlationId);
         }
 
         // Nonce validation not needed when redirect not involved (e.g. hybrid spa, renewing token via rt)

--- a/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
@@ -7,17 +7,13 @@ import {
     AuthorizationCodePayload,
     CommonAuthorizationCodeRequest,
     AuthorizationCodeClient,
-    AuthorityFactory,
-    Authority,
-    INetworkModule,
     CcsCredential,
     Logger,
     ServerError,
     IPerformanceClient,
     PerformanceEvents,
     invokeAsync,
-    createClientAuthError,
-    ClientAuthErrorCodes,
+    CcsCredentialType,
 } from "@azure/msal-common";
 
 import { BrowserCacheManager } from "../cache/BrowserCacheManager";
@@ -25,10 +21,8 @@ import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
 } from "../error/BrowserAuthError";
-import { TemporaryCacheKeys } from "../utils/BrowserConstants";
 import { AuthenticationResult } from "../response/AuthenticationResult";
-
-export type InteractionParams = {};
+import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest";
 
 /**
  * Abstract class which defines operations for a browser interaction handling class.
@@ -60,34 +54,22 @@ export class InteractionHandler {
      */
     async handleCodeResponseFromHash(
         locationHash: string,
-        state: string,
-        authority: Authority,
-        networkModule: INetworkModule
+        request: AuthorizationUrlRequest
     ): Promise<AuthenticationResult> {
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.HandleCodeResponseFromHash,
-            this.authCodeRequest.correlationId
+            request.correlationId
         );
         // Check that location hash isn't empty.
         if (!locationHash) {
             throw createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError);
         }
 
-        // Handle code response.
-        const stateKey = this.browserStorage.generateStateKey(state);
-        const requestState = this.browserStorage.getTemporaryCache(stateKey);
-        if (!requestState) {
-            throw createClientAuthError(
-                ClientAuthErrorCodes.stateNotFound,
-                "Cached State"
-            );
-        }
-
         let authCodeResponse;
         try {
             authCodeResponse = this.authModule.handleFragmentResponse(
                 locationHash,
-                requestState
+                request.state
             );
         } catch (e) {
             if (
@@ -108,8 +90,8 @@ export class InteractionHandler {
             PerformanceEvents.HandleCodeResponseFromServer,
             this.logger,
             this.performanceClient,
-            this.authCodeRequest.correlationId
-        )(authCodeResponse, state, authority, networkModule);
+            request.correlationId
+        )(authCodeResponse, request);
     }
 
     /**
@@ -122,32 +104,16 @@ export class InteractionHandler {
      */
     async handleCodeResponseFromServer(
         authCodeResponse: AuthorizationCodePayload,
-        state: string,
-        authority: Authority,
-        networkModule: INetworkModule,
+        request: AuthorizationUrlRequest,
         validateNonce: boolean = true
     ): Promise<AuthenticationResult> {
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.HandleCodeResponseFromServer,
-            this.authCodeRequest.correlationId
+            request.correlationId
         );
         this.logger.trace(
             "InteractionHandler.handleCodeResponseFromServer called"
         );
-
-        // Handle code response.
-        const stateKey = this.browserStorage.generateStateKey(state);
-        const requestState = this.browserStorage.getTemporaryCache(stateKey);
-        if (!requestState) {
-            throw createClientAuthError(
-                ClientAuthErrorCodes.stateNotFound,
-                "Cached State"
-            );
-        }
-
-        // Get cached items
-        const nonceKey = this.browserStorage.generateNonceKey(requestState);
-        const cachedNonce = this.browserStorage.getTemporaryCache(nonceKey);
 
         // Assign code to request
         this.authCodeRequest.code = authCodeResponse.code;
@@ -155,32 +121,32 @@ export class InteractionHandler {
         // Check for new cloud instance
         if (authCodeResponse.cloud_instance_host_name) {
             await invokeAsync(
-                this.updateTokenEndpointAuthority.bind(this),
+                this.authModule.updateAuthority.bind(this.authModule),
                 PerformanceEvents.UpdateTokenEndpointAuthority,
                 this.logger,
                 this.performanceClient,
-                this.authCodeRequest.correlationId
+                request.correlationId
             )(
                 authCodeResponse.cloud_instance_host_name,
-                authority,
-                networkModule
+                request.correlationId
             );
         }
 
         // Nonce validation not needed when redirect not involved (e.g. hybrid spa, renewing token via rt)
         if (validateNonce) {
-            authCodeResponse.nonce = cachedNonce || undefined;
+            // TODO: Assigning "response nonce" to "request nonce" is confusing. Refactor the function doing validation to accept request nonce directly
+            authCodeResponse.nonce = request.nonce || undefined;
         }
 
-        authCodeResponse.state = requestState;
+        authCodeResponse.state = request.state;
 
         // Add CCS parameters if available
         if (authCodeResponse.client_info) {
             this.authCodeRequest.clientInfo = authCodeResponse.client_info;
         } else {
-            const cachedCcsCred = this.checkCcsCredentials();
-            if (cachedCcsCred) {
-                this.authCodeRequest.ccsCredential = cachedCcsCred;
+            const ccsCred = this.createCcsCredentials(request);
+            if (ccsCred) {
+                this.authCodeRequest.ccsCredential = ccsCred;
             }
         }
 
@@ -190,62 +156,29 @@ export class InteractionHandler {
             PerformanceEvents.AuthClientAcquireToken,
             this.logger,
             this.performanceClient,
-            this.authCodeRequest.correlationId
+            request.correlationId
         )(this.authCodeRequest, authCodeResponse)) as AuthenticationResult;
-        this.browserStorage.cleanRequestByState(state);
         return tokenResponse;
     }
 
     /**
-     * Updates authority based on cloudInstanceHostname
-     * @param cloudInstanceHostname
-     * @param authority
-     * @param networkModule
+     * Build ccs creds if available
      */
-    protected async updateTokenEndpointAuthority(
-        cloudInstanceHostname: string,
-        authority: Authority,
-        networkModule: INetworkModule
-    ): Promise<void> {
-        this.performanceClient.addQueueMeasurement(
-            PerformanceEvents.UpdateTokenEndpointAuthority,
-            this.authCodeRequest.correlationId
-        );
-        const cloudInstanceAuthorityUri = `https://${cloudInstanceHostname}/${authority.tenant}/`;
-        const cloudInstanceAuthority =
-            await AuthorityFactory.createDiscoveredInstance(
-                cloudInstanceAuthorityUri,
-                networkModule,
-                this.browserStorage,
-                authority.options,
-                this.logger,
-                this.performanceClient,
-                this.authCodeRequest.correlationId
-            );
-        this.authModule.updateAuthority(cloudInstanceAuthority);
-    }
-
-    /**
-     * Looks up ccs creds in the cache
-     */
-    protected checkCcsCredentials(): CcsCredential | null {
-        // Look up ccs credential in temp cache
-        const cachedCcsCred = this.browserStorage.getTemporaryCache(
-            TemporaryCacheKeys.CCS_CREDENTIAL,
-            true
-        );
-        if (cachedCcsCred) {
-            try {
-                return JSON.parse(cachedCcsCred) as CcsCredential;
-            } catch (e) {
-                this.authModule.logger.error(
-                    "Cache credential could not be parsed"
-                );
-                this.authModule.logger.errorPii(
-                    `Cache credential could not be parsed: ${cachedCcsCred}`
-                );
-            }
+    protected createCcsCredentials(
+        request: AuthorizationUrlRequest
+    ): CcsCredential | null {
+        if (request.account) {
+            return {
+                credential: request.account.homeAccountId,
+                type: CcsCredentialType.HOME_ACCOUNT_ID,
+            };
+        } else if (request.loginHint) {
+            return {
+                credential: request.loginHint,
+                type: CcsCredentialType.UPN,
+            };
         }
+
         return null;
     }
 }

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -147,10 +147,6 @@ describe("SilentIframeClient", () => {
                         )
                     );
                 });
-            const browserStorageSpy = sinon.spy(
-                BrowserCacheManager.prototype,
-                "cleanRequestByState"
-            );
 
             silentIframeClient
                 .acquireToken({
@@ -159,7 +155,6 @@ describe("SilentIframeClient", () => {
                 })
                 .catch(() => {
                     expect(telemetryStub.calledOnce).toBe(true);
-                    expect(browserStorageSpy.calledOnce).toBe(true);
                     done();
                 });
         });

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -354,12 +354,23 @@ describe("InteractionHandler.ts Unit Tests", () => {
             const tokenResponse =
                 await interactionHandler.handleCodeResponseFromServer(
                     testCodeResponse,
-                    TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                    authorityInstance,
-                    authConfig.networkInterface!
+                    {
+                        authority: "https://www.contoso.com/common/",
+                        scopes: ["User.Read"],
+                        correlationId: TEST_CONFIG.CORRELATION_ID,
+                        redirectUri: "/",
+                        responseMode: "fragment",
+                        nonce: TEST_CONFIG.CORRELATION_ID,
+                        state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
+                    }
                 );
 
-            expect(updateAuthoritySpy.calledWith(authority)).toBe(true);
+            expect(
+                updateAuthoritySpy.calledWith(
+                    "contoso.com",
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).toBe(true);
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(
                 acquireTokenSpy.calledWith(
@@ -378,12 +389,15 @@ describe("InteractionHandler.ts Unit Tests", () => {
                 browserStorage
             );
             expect(
-                interactionHandler.handleCodeResponseFromHash(
-                    "",
-                    "",
-                    authorityInstance,
-                    authConfig.networkInterface!
-                )
+                interactionHandler.handleCodeResponseFromHash("", {
+                    authority: "https://www.contoso.com/common/",
+                    scopes: ["User.Read"],
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
+                    redirectUri: "/",
+                    responseMode: "fragment",
+                    nonce: TEST_CONFIG.CORRELATION_ID,
+                    state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
+                })
             ).rejects.toMatchObject(
                 createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError)
             );
@@ -392,9 +406,7 @@ describe("InteractionHandler.ts Unit Tests", () => {
                 interactionHandler.handleCodeResponseFromHash(
                     //@ts-ignore
                     null,
-                    "",
-                    authorityInstance,
-                    authConfig.networkInterface
+                    ""
                 )
             ).rejects.toMatchObject(
                 createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError)
@@ -495,11 +507,22 @@ describe("InteractionHandler.ts Unit Tests", () => {
             const tokenResponse =
                 await interactionHandler.handleCodeResponseFromHash(
                     TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT,
-                    TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                    authorityInstance,
-                    authConfig.networkInterface!
+                    {
+                        authority: "https://www.contoso.com/common/",
+                        scopes: ["User.Read"],
+                        correlationId: TEST_CONFIG.CORRELATION_ID,
+                        redirectUri: "/",
+                        responseMode: "fragment",
+                        nonce: TEST_CONFIG.CORRELATION_ID,
+                        state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
+                    }
                 );
-            expect(updateAuthoritySpy.calledWith(authority)).toBe(true);
+            expect(
+                updateAuthoritySpy.calledWith(
+                    "contoso.com",
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).toBe(true);
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(
                 acquireTokenSpy.calledWith(
@@ -612,11 +635,22 @@ describe("InteractionHandler.ts Unit Tests", () => {
             const tokenResponse =
                 await interactionHandler.handleCodeResponseFromHash(
                     TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT,
-                    TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                    authorityInstance,
-                    authConfig.networkInterface!
+                    {
+                        authority: "https://www.contoso.com/common/",
+                        scopes: ["User.Read"],
+                        correlationId: TEST_CONFIG.CORRELATION_ID,
+                        redirectUri: "/",
+                        responseMode: "fragment",
+                        nonce: TEST_CONFIG.CORRELATION_ID,
+                        state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
+                    }
                 );
-            expect(updateAuthoritySpy.calledWith(authority)).toBe(true);
+            expect(
+                updateAuthoritySpy.calledWith(
+                    "contoso.com",
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).toBe(true);
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(
                 acquireTokenSpy.calledWith(

--- a/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/RedirectHandler.spec.ts
@@ -208,7 +208,6 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 browserStorage,
                 defaultTokenRequest,
                 browserRequestLogger,
-                browserCrypto,
                 performanceClient
             );
             expect(redirectHandler).toBeInstanceOf(RedirectHandler);
@@ -223,7 +222,6 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 browserStorage,
                 defaultTokenRequest,
                 browserRequestLogger,
-                browserCrypto,
                 performanceClient
             );
 
@@ -267,7 +265,6 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 browserStorage,
                 defaultTokenRequest,
                 browserRequestLogger,
-                browserCrypto,
                 performanceClient
             );
             redirectHandler.initiateAuthRequest(
@@ -308,7 +305,6 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 browserStorage,
                 defaultTokenRequest,
                 browserRequestLogger,
-                browserCrypto,
                 performanceClient
             );
             redirectHandler.initiateAuthRequest(
@@ -348,7 +344,6 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 browserStorage,
                 defaultTokenRequest,
                 browserRequestLogger,
-                browserCrypto,
                 performanceClient
             );
             redirectHandler.initiateAuthRequest(
@@ -370,16 +365,10 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 browserStorage,
                 defaultTokenRequest,
                 browserRequestLogger,
-                browserCrypto,
                 performanceClient
             );
             expect(
-                redirectHandler.handleCodeResponseFromHash(
-                    "",
-                    "",
-                    authorityInstance,
-                    authConfig.networkInterface!
-                )
+                redirectHandler.handleCodeResponseFromHash("", "")
             ).rejects.toMatchObject(
                 createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError)
             );
@@ -388,9 +377,7 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 redirectHandler.handleCodeResponseFromHash(
                     //@ts-ignore
                     null,
-                    "",
-                    authorityInstance,
-                    authConfig.networkInterface!
+                    ""
                 )
             ).rejects.toMatchObject(
                 createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError)
@@ -487,15 +474,12 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 browserStorage,
                 testAuthCodeRequest,
                 browserRequestLogger,
-                browserCrypto,
                 performanceClient
             );
             const tokenResponse =
                 await redirectHandler.handleCodeResponseFromHash(
                     TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT,
-                    TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                    authorityInstance,
-                    authConfig.networkInterface!
+                    TEST_STATE_VALUES.TEST_STATE_REDIRECT
                 );
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(
@@ -611,15 +595,12 @@ describe("RedirectHandler.ts Unit Tests", () => {
                 browserStorage,
                 testAuthCodeRequest,
                 browserRequestLogger,
-                browserCrypto,
                 performanceClient
             );
             const tokenResponse =
                 await redirectHandler.handleCodeResponseFromHash(
                     TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT,
-                    TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                    authorityInstance,
-                    authConfig.networkInterface!
+                    TEST_STATE_VALUES.TEST_STATE_REDIRECT
                 );
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -194,8 +194,7 @@ export class AuthorizationCodeClient extends BaseClient {
         // Get code response
         responseHandler.validateServerAuthorizationCodeResponse(
             serverParams,
-            cachedState,
-            this.cryptoUtils
+            cachedState
         );
 
         // throw when there is no auth code in the response

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -4,7 +4,6 @@
  */
 
 import { ServerAuthorizationTokenResponse } from "./ServerAuthorizationTokenResponse";
-import { buildClientInfo } from "../account/ClientInfo";
 import { ICrypto } from "../crypto/ICrypto";
 import {
     ClientAuthErrorCodes,
@@ -81,16 +80,15 @@ export class ResponseHandler {
     /**
      * Function which validates server authorization code response.
      * @param serverResponseHash
-     * @param cachedState
+     * @param requestState
      * @param cryptoObj
      */
     validateServerAuthorizationCodeResponse(
-        serverResponseHash: ServerAuthorizationCodeResponse,
-        cachedState: string,
-        cryptoObj: ICrypto
+        serverResponse: ServerAuthorizationCodeResponse,
+        requestState: string
     ): void {
-        if (!serverResponseHash.state || !cachedState) {
-            throw serverResponseHash.state
+        if (!serverResponse.state || !requestState) {
+            throw serverResponse.state
                 ? createClientAuthError(
                       ClientAuthErrorCodes.stateNotFound,
                       "Cached State"
@@ -101,66 +99,62 @@ export class ResponseHandler {
                   );
         }
 
-        let decodedServerResponseHash: string;
-        let decodedCachedState: string;
+        let decodedServerResponseState: string;
+        let decodedRequestState: string;
 
         try {
-            decodedServerResponseHash = decodeURIComponent(
-                serverResponseHash.state
+            decodedServerResponseState = decodeURIComponent(
+                serverResponse.state
             );
         } catch (e) {
             throw createClientAuthError(
                 ClientAuthErrorCodes.invalidState,
-                serverResponseHash.state
+                serverResponse.state
             );
         }
 
         try {
-            decodedCachedState = decodeURIComponent(cachedState);
+            decodedRequestState = decodeURIComponent(requestState);
         } catch (e) {
             throw createClientAuthError(
                 ClientAuthErrorCodes.invalidState,
-                serverResponseHash.state
+                serverResponse.state
             );
         }
 
-        if (decodedServerResponseHash !== decodedCachedState) {
+        if (decodedServerResponseState !== decodedRequestState) {
             throw createClientAuthError(ClientAuthErrorCodes.stateMismatch);
         }
 
         // Check for error
         if (
-            serverResponseHash.error ||
-            serverResponseHash.error_description ||
-            serverResponseHash.suberror
+            serverResponse.error ||
+            serverResponse.error_description ||
+            serverResponse.suberror
         ) {
             if (
                 isInteractionRequiredError(
-                    serverResponseHash.error,
-                    serverResponseHash.error_description,
-                    serverResponseHash.suberror
+                    serverResponse.error,
+                    serverResponse.error_description,
+                    serverResponse.suberror
                 )
             ) {
                 throw new InteractionRequiredAuthError(
-                    serverResponseHash.error || Constants.EMPTY_STRING,
-                    serverResponseHash.error_description,
-                    serverResponseHash.suberror,
-                    serverResponseHash.timestamp || Constants.EMPTY_STRING,
-                    serverResponseHash.trace_id || Constants.EMPTY_STRING,
-                    serverResponseHash.correlation_id || Constants.EMPTY_STRING,
-                    serverResponseHash.claims || Constants.EMPTY_STRING
+                    serverResponse.error || "",
+                    serverResponse.error_description,
+                    serverResponse.suberror,
+                    serverResponse.timestamp || "",
+                    serverResponse.trace_id || "",
+                    serverResponse.correlation_id || "",
+                    serverResponse.claims || ""
                 );
             }
 
             throw new ServerError(
-                serverResponseHash.error || Constants.EMPTY_STRING,
-                serverResponseHash.error_description,
-                serverResponseHash.suberror
+                serverResponse.error || "",
+                serverResponse.error_description,
+                serverResponse.suberror
             );
-        }
-
-        if (serverResponseHash.client_info) {
-            buildClientInfo(serverResponseHash.client_info, cryptoObj);
         }
     }
 

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -594,8 +594,7 @@ describe("ResponseHandler.ts", () => {
             try {
                 responseHandler.validateServerAuthorizationCodeResponse(
                     testServerCodeResponse,
-                    "differentState",
-                    cryptoInterface
+                    "differentState"
                 );
             } catch (e) {
                 expect(e).toBeInstanceOf(ClientAuthError);
@@ -622,8 +621,7 @@ describe("ResponseHandler.ts", () => {
             );
             responseHandler.validateServerAuthorizationCodeResponse(
                 testServerCodeResponse,
-                TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
-                cryptoInterface
+                TEST_STATE_VALUES.URI_ENCODED_LIB_STATE
             );
         });
 
@@ -646,8 +644,7 @@ describe("ResponseHandler.ts", () => {
             );
             responseHandler.validateServerAuthorizationCodeResponse(
                 testServerCodeResponse,
-                testAltState,
-                cryptoInterface
+                testAltState
             );
         });
 
@@ -670,8 +667,7 @@ describe("ResponseHandler.ts", () => {
             try {
                 responseHandler.validateServerAuthorizationCodeResponse(
                     testServerCodeResponse,
-                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
-                    cryptoInterface
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE
                 );
             } catch (e) {
                 expect(e).toBeInstanceOf(InteractionRequiredAuthError);
@@ -698,8 +694,7 @@ describe("ResponseHandler.ts", () => {
             try {
                 responseHandler.validateServerAuthorizationCodeResponse(
                     testServerCodeResponse,
-                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
-                    cryptoInterface
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE
                 );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
@@ -726,8 +721,7 @@ describe("ResponseHandler.ts", () => {
             try {
                 responseHandler.validateServerAuthorizationCodeResponse(
                     testServerCodeResponse,
-                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
-                    cryptoInterface
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE
                 );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
@@ -754,46 +748,12 @@ describe("ResponseHandler.ts", () => {
             try {
                 responseHandler.validateServerAuthorizationCodeResponse(
                     testServerCodeResponse,
-                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
-                    cryptoInterface
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE
                 );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 done();
             }
-        });
-
-        it("calls buildClientInfo if clientInfo in response", () => {
-            const testServerCodeResponse: ServerAuthorizationCodeResponse = {
-                code: "testCode",
-                client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
-                state: TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
-            };
-            // Can't spy on buildClientInfo, spy on one of its function calls instead
-            const buildClientInfoSpy = sinon.spy(
-                cryptoInterface,
-                "base64Decode"
-            );
-
-            const responseHandler = new ResponseHandler(
-                "this-is-a-client-id",
-                testCacheManager,
-                cryptoInterface,
-                logger,
-                null,
-                null
-            );
-            responseHandler.validateServerAuthorizationCodeResponse(
-                testServerCodeResponse,
-                TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
-                cryptoInterface
-            );
-            expect(buildClientInfoSpy.calledOnce).toBe(true);
-            expect(
-                buildClientInfoSpy.calledWith(
-                    TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO
-                )
-            ).toBe(true);
         });
 
         it("does not call buildClientInfo if clientInfo not in response", () => {
@@ -817,8 +777,7 @@ describe("ResponseHandler.ts", () => {
             );
             responseHandler.validateServerAuthorizationCodeResponse(
                 testServerCodeResponse,
-                TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
-                cryptoInterface
+                TEST_STATE_VALUES.URI_ENCODED_LIB_STATE
             );
             expect(buildClientInfoSpy.notCalled).toBe(true);
         });
@@ -842,8 +801,7 @@ describe("ResponseHandler.ts", () => {
             try {
                 responseHandler.validateServerAuthorizationCodeResponse(
                     testServerCodeResponse,
-                    "dummy-state-%20%%%30%%%%%40",
-                    cryptoInterface
+                    "dummy-state-%20%%%30%%%%%40"
                 );
             } catch (e) {
                 expect(e).toBeInstanceOf(ClientAuthError);


### PR DESCRIPTION
Silent and Popup flows don't need to use temporary cache because they don't lose context the way the Redirect flow does. Applying this across the board causes unnecessary stringification, storage, lookup and parsing in those flows, especially since the code isn't shared across those flows anyway.

This PR refactors the popup and silent flows to pass the request object through the stack instead of storing and looking up in sessionStorage. The redirect flow will continue to utilize sessionStorage for temp cache.