### PR TITLE
Backported fix for multiple matching tokens error

### DIFF
--- a/change/@azure-msal-common-a6532552-313d-484f-b0f9-4a399a3ffff0.json
+++ b/change/@azure-msal-common-a6532552-313d-484f-b0f9-4a399a3ffff0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Backported fix for multiple matching tokens error",
+  "packageName": "@azure/msal-common",
+  "email": "rgins16@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-a6532552-313d-484f-b0f9-4a399a3ffff0.json
+++ b/change/@azure-msal-common-a6532552-313d-484f-b0f9-4a399a3ffff0.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Backported fix for multiple matching tokens error",
   "packageName": "@azure/msal-common",
-  "email": "rgins16@gmail.com",
+  "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -964,7 +964,7 @@ export abstract class CacheManager implements ICacheManager {
             this.commonLogger.info("CacheManager:getRefreshToken - No refresh token found.");
             return null;
         }
-        // TODO: address the else case after remove functions address environment aliases
+        // address the else case after remove functions address environment aliases
 
         this.commonLogger.info("CacheManager:getRefreshToken - returning refresh token");
         return refreshTokens[0] as RefreshTokenEntity;

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -731,7 +731,13 @@ export abstract class CacheManager implements ICacheManager {
             this.commonLogger.info("CacheManager:getIdToken - No token found");
             return null;
         } else if (numIdTokens > 1) {
-            throw ClientAuthError.createMultipleMatchingTokensInCacheError();
+            this.commonLogger.info(
+                "CacheManager:getIdToken - Multiple id tokens found, clearing them"
+            );
+            idTokens.forEach((idToken) => {
+                this.removeIdToken(idToken.generateCredentialKey());
+            });
+            return null;
         }
 
         this.commonLogger.info("CacheManager:getIdToken - Returning id token");
@@ -845,7 +851,13 @@ export abstract class CacheManager implements ICacheManager {
             this.commonLogger.info("CacheManager:getAccessToken - No token found");
             return null;
         } else if (numAccessTokens > 1) {
-            throw ClientAuthError.createMultipleMatchingTokensInCacheError();
+            this.commonLogger.info(
+                "CacheManager:getAccessToken - Multiple access tokens found, clearing them"
+            );
+            accessTokens.forEach((accessToken) => {
+                this.removeAccessToken(accessToken.generateCredentialKey());
+            });
+            return null;
         }
 
         this.commonLogger.info("CacheManager:getAccessToken - Returning access token");
@@ -952,7 +964,7 @@ export abstract class CacheManager implements ICacheManager {
             this.commonLogger.info("CacheManager:getRefreshToken - No refresh token found.");
             return null;
         }
-        // address the else case after remove functions address environment aliases
+        // TODO: address the else case after remove functions address environment aliases
 
         this.commonLogger.info("CacheManager:getRefreshToken - returning refresh token");
         return refreshTokens[0] as RefreshTokenEntity;

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -138,6 +138,26 @@ export class MockStorageClass extends CacheManager {
     removeItem(key: string): void {
         if (!!this.store[key]) {
             delete this.store[key];
+
+            const tokenKeys = this.getTokenKeys();
+
+            const idTokenIndex = tokenKeys.idToken.indexOf(key);
+            if (idTokenIndex > -1) {
+                tokenKeys.idToken.splice(idTokenIndex, 1);
+                this.store[TOKEN_KEYS] = tokenKeys;
+            }
+
+            const accessTokenIndex = tokenKeys.accessToken.indexOf(key);
+            if (accessTokenIndex > -1) {
+                tokenKeys.accessToken.splice(accessTokenIndex, 1);
+                this.store[TOKEN_KEYS] = tokenKeys;
+            }
+
+            const refreshTokenIndex = tokenKeys.refreshToken.indexOf(key);
+            if (refreshTokenIndex > -1) {
+                tokenKeys.refreshToken.splice(refreshTokenIndex, 1);
+                this.store[TOKEN_KEYS] = tokenKeys;
+            }
         }
     }
     containsKey(key: string): boolean {


### PR DESCRIPTION
Backporting [this bugfix](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/6311) for "multiple matching tokens" error.

We have a customer who won't upgrade to MSALJS v2.x