### PR TITLE
Add pipeline to run 1p PWB e2e tests

### DIFF
--- a/.pipelines/1p-e2e-pwb-wam-sample.yml
+++ b/.pipelines/1p-e2e-pwb-wam-sample.yml
@@ -1,0 +1,63 @@
+trigger: none # Disable push triggers
+
+pr:
+- dev
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+- task: NodeTool@0
+  displayName: 'Install Node.js'
+  inputs:
+      versionSpec: '18.x'
+
+- checkout: git://IDDP/msal-javascript-1p
+- script: |
+      npm run submodule:init
+  displayName: Initialize submodule
+
+- script: |
+      cd ./microsoft-authentication-library-for-js
+      git checkout $(System.PullRequest.SourceBranch)
+      git pull
+  displayName: 'Pull latest changes from 3P feature branch'
+
+- task: npmAuthenticate@0
+  displayName: 'Authenticate to npm package registry'
+  inputs:
+      workingFile: ./.npmrc
+
+- task: npmAuthenticate@0
+  displayName: 'Authenticate to npm package registry'
+  inputs:
+      workingFile: ./1ds.npmrc
+
+- script: |
+    npm ci --workspace=samples/Broker_WAMTestApp
+  displayName: 'Install dependencies'
+
+- task: Npm@1
+  inputs:
+    workingDir: 'samples/Broker_WAMTestApp'
+    command: 'custom'
+    customCommand: 'run build:package'
+  displayName: 'Build sample'
+
+- task: Npm@1
+  inputs:
+      workingDir: 'samples/Broker_WAMTestApp'
+      command: 'custom'
+      customCommand: 'run generate:certs'
+  displayName: 'Generate certificates'
+
+- task: Npm@1
+  inputs:
+    workingDir: 'samples/Broker_WAMTestApp'
+    command: 'custom'
+    customCommand: 'run test'
+  env:
+    AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+    AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+    AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+  displayName: 'Run e2e tests'


### PR DESCRIPTION
- Add pipeline to run 1p PWB e2e tests.
- PR needs to be merged first for the pipeline to run successfully.