### PR TITLE
Fix iframe fallback when RT is not found in cache

### DIFF
--- a/change/@azure-msal-browser-6d9ef336-f49e-47ba-9191-05676f55c887.json
+++ b/change/@azure-msal-browser-6d9ef336-f49e-47ba-9191-05676f55c887.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix iframe fallback when RT is not found in cache",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -48,11 +48,6 @@ export interface IController {
         accountId?: string
     ): Promise<AuthenticationResult>;
 
-    acquireTokenByRefreshToken(
-        commonRequest: CommonSilentFlowRequest,
-        silentRequest: SilentRequest
-    ): Promise<AuthenticationResult>;
-
     addEventCallback(callback: EventCallbackFunction): string | null;
 
     removeEventCallback(callbackId: string): void;

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -8,7 +8,6 @@ import {
     Logger,
     PerformanceCallbackFunction,
     IPerformanceClient,
-    CommonSilentFlowRequest,
     AccountFilter,
 } from "@azure/msal-common";
 import { RedirectRequest } from "../request/RedirectRequest";

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -53,7 +53,6 @@ export class SilentRefreshClient extends StandardInteractionClient {
             silentRequest.authority,
             silentRequest.azureCloudOptions
         );
-        this.logger.verbose("Refresh token client created");
         // Send request to renew token. Auth module will throw errors if token cannot be renewed.
         return invokeAsync(
             refreshTokenClient.acquireTokenByRefreshToken.bind(
@@ -63,24 +62,11 @@ export class SilentRefreshClient extends StandardInteractionClient {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(silentRequest)
-            .then((result) => result as AuthenticationResult)
-            .then((result: AuthenticationResult) => {
-                this.performanceClient.addFields(
-                    {
-                        fromCache: result.fromCache,
-                        requestId: result.requestId,
-                    },
-                    request.correlationId
-                );
-
-                return result;
-            })
-            .catch((e: AuthError) => {
-                (e as AuthError).setCorrelationId(this.correlationId);
-                serverTelemetryManager.cacheFailedRequest(e);
-                throw e;
-            });
+        )(silentRequest).catch((e: AuthError) => {
+            (e as AuthError).setCorrelationId(this.correlationId);
+            serverTelemetryManager.cacheFailedRequest(e);
+            throw e;
+        }) as Promise<AuthenticationResult>;
     }
 
     /**

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -3461,6 +3461,52 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentIframeSpy.calledOnce).toBe(true);
         });
 
+        it("Calls SilentIframeClient.acquireToken and returns its response if no RT is cached", async () => {
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com",
+            };
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: new Date(Date.now() + 3600000),
+                account: testAccount,
+                tokenType: AuthenticationScheme.BEARER,
+            };
+            const silentCacheSpy = sinon
+                .stub(SilentCacheClient.prototype, "acquireToken")
+                .rejects("Expired");
+            const silentRefreshSpy = sinon
+                .stub(SilentRefreshClient.prototype, "acquireToken")
+                .rejects(
+                    createInteractionRequiredAuthError(
+                        InteractionRequiredAuthErrorCodes.noTokensFound
+                    )
+                );
+            const silentIframeSpy = sinon
+                .stub(SilentIframeClient.prototype, "acquireToken")
+                .resolves(testTokenResponse);
+
+            const response = await pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+            });
+            expect(response).toEqual(testTokenResponse);
+            expect(silentCacheSpy.calledOnce).toBe(true);
+            expect(silentRefreshSpy.calledOnce).toBe(true);
+            expect(silentIframeSpy.calledOnce).toBe(true);
+        });
+
         it("makes one network request with multiple parallel silent requests with same request", async () => {
             const testServerTokenResponse = {
                 token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,


### PR DESCRIPTION
It seems this fallback behavior was missed in the transition from v2 to v3. When the RT cannot be found in the cache we should try to fallback to the iframe flow. Also includes minor refactor to make the code more readable and remove some unnecessary work.