### PR TITLE
Fix downstream ESM imports, fixes #6573

### DIFF
--- a/change/@azure-msal-node-extensions-25a8325b-07d2-4bf8-91b6-ed1140578fdf.json
+++ b/change/@azure-msal-node-extensions-25a8325b-07d2-4bf8-91b6-ed1140578fdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix downstream ESM imports, fixes #6573",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "janusz@corechain.tech",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/src/persistence/KeychainPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/KeychainPersistence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { setPassword, getPassword, deletePassword } from "keytar";
+import keytar from "keytar";
 import { FilePersistence } from "./FilePersistence";
 import { IPersistence } from "./IPersistence";
 import { PersistenceError } from "../error/PersistenceError";
@@ -57,7 +57,11 @@ export class KeychainPersistence
 
     public async save(contents: string): Promise<void> {
         try {
-            await setPassword(this.serviceName, this.accountName, contents);
+            await keytar.setPassword(
+                this.serviceName,
+                this.accountName,
+                contents
+            );
         } catch (err) {
             if (isNodeError(err)) {
                 throw PersistenceError.createKeychainPersistenceError(
@@ -73,7 +77,7 @@ export class KeychainPersistence
 
     public async load(): Promise<string | null> {
         try {
-            return await getPassword(this.serviceName, this.accountName);
+            return await keytar.getPassword(this.serviceName, this.accountName);
         } catch (err) {
             if (isNodeError(err)) {
                 throw PersistenceError.createKeychainPersistenceError(
@@ -88,7 +92,10 @@ export class KeychainPersistence
     public async delete(): Promise<boolean> {
         try {
             await this.filePersistence.delete();
-            return await deletePassword(this.serviceName, this.accountName);
+            return await keytar.deletePassword(
+                this.serviceName,
+                this.accountName
+            );
         } catch (err) {
             if (isNodeError(err)) {
                 throw PersistenceError.createKeychainPersistenceError(

--- a/extensions/msal-node-extensions/src/persistence/LibSecretPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/LibSecretPersistence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { setPassword, getPassword, deletePassword } from "keytar";
+import keytar from "keytar";
 import { FilePersistence } from "./FilePersistence";
 import { IPersistence } from "./IPersistence";
 import { PersistenceError } from "../error/PersistenceError";
@@ -58,7 +58,11 @@ export class LibSecretPersistence
 
     public async save(contents: string): Promise<void> {
         try {
-            await setPassword(this.serviceName, this.accountName, contents);
+            await keytar.setPassword(
+                this.serviceName,
+                this.accountName,
+                contents
+            );
         } catch (err) {
             if (isNodeError(err)) {
                 throw PersistenceError.createLibSecretError(err.message);
@@ -72,7 +76,7 @@ export class LibSecretPersistence
 
     public async load(): Promise<string | null> {
         try {
-            return await getPassword(this.serviceName, this.accountName);
+            return await keytar.getPassword(this.serviceName, this.accountName);
         } catch (err) {
             if (isNodeError(err)) {
                 throw PersistenceError.createLibSecretError(err.message);
@@ -85,7 +89,10 @@ export class LibSecretPersistence
     public async delete(): Promise<boolean> {
         try {
             await this.filePersistence.delete();
-            return await deletePassword(this.serviceName, this.accountName);
+            return await keytar.deletePassword(
+                this.serviceName,
+                this.accountName
+            );
         } catch (err) {
             if (isNodeError(err)) {
                 throw PersistenceError.createLibSecretError(err.message);


### PR DESCRIPTION
Uses default import for importing keytar (a CJS module), which is really the only foolproof way of importing CJS from an ESM context.

I confirmed by creating a simple package:
```json5
// msal-node-extensions/foo/package.json
{ "type": "module" }
```

```js
// msal-node-extensions/foo/index.js
import * as msal from "../dist/index.mjs";
msal;
```


Running `node foo/index.mjs` on `dev` gives the following error:

```
file:///.../microsoft-authentication-library-for-js/extensions/msal-node-extensions/dist/persistence/KeychainPersistence.mjs:3
import { setPassword, getPassword, deletePassword } from 'keytar';
                                   ^^^^^^^^^^^^^^
SyntaxError: Named export 'deletePassword' not found. The requested module 'keytar' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'keytar';
const { setPassword, getPassword, deletePassword } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)

Node.js v18.17.1
```

Running the same command on this branch succeeds (no output, exit code 0).

Not sure of a good/reliable way to encode that in an automated test, but I'd be happy to add one if anyone has any suggestions