### PR TITLE
Adding logging to make regional scenarios more clear

### DIFF
--- a/change/@azure-msal-node-92a2e589-8556-4d4c-8d36-f7375d161618.json
+++ b/change/@azure-msal-node-92a2e589-8556-4d4c-8d36-f7375d161618.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding logging to make regional scenarios more clear",
+  "packageName": "@azure/msal-node",
+  "email": "trwalke@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -237,19 +237,6 @@ export class Authority {
         }
     }
 
-    /**
-     * OAuth /token endpoint host for requests
-     */
-        public get tokenEndpointHost(): string {
-            if (this.discoveryComplete()) {
-                return new UrlString(this.metadata.token_endpoint).getUrlComponents().HostNameAndPort;
-            } else {
-                throw createClientAuthError(
-                    ClientAuthErrorCodes.endpointResolutionError
-                );
-            }
-        }
-
     public get deviceCodeEndpoint(): string {
         if (this.discoveryComplete()) {
             return this.replacePath(

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -237,6 +237,19 @@ export class Authority {
         }
     }
 
+    /**
+     * OAuth /token endpoint host for requests
+     */
+        public get tokenEndpointHost(): string {
+            if (this.discoveryComplete()) {
+                return new UrlString(this.metadata.token_endpoint).getUrlComponents().HostNameAndPort;
+            } else {
+                throw createClientAuthError(
+                    ClientAuthErrorCodes.endpointResolutionError
+                );
+            }
+        }
+
     public get deviceCodeEndpoint(): string {
         if (this.discoveryComplete()) {
             return this.replacePath(

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -412,7 +412,7 @@ export abstract class ClientApplication {
             : this.config.auth.azureCloudOptions;
 
         // using null assertion operator as we ensure that all config values have default values in buildConfiguration()
-        const discoveredAuthority: Authority = await this.createAuthority(
+        const discoveredAuthority = await this.createAuthority(
             authority,
             azureRegionConfiguration,
             requestCorrelationId,

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -412,10 +412,23 @@ export abstract class ClientApplication {
             : this.config.auth.azureCloudOptions;
 
         // using null assertion operator as we ensure that all config values have default values in buildConfiguration()
-        this.logger.verbose(
-            `building oauth client configuration with the authority: ${authority}`,
-            requestCorrelationId
-        );
+        this.logger.verbose("here-----------------------------------------------------------------------------------------------------------------");
+
+        if(azureRegionConfiguration?.azureRegion)
+        {
+            this.logger.verbose(
+                `Building oauth client configuration with the user provided authority: ${authority}, using provided region: ${azureRegionConfiguration?.azureRegion}.`,
+                requestCorrelationId
+            );
+        } 
+        else
+        {
+            this.logger.verbose(
+                `Building oauth client configuration with the user provided authority: ${authority}.`,
+                requestCorrelationId
+            );
+        }
+        
         const discoveredAuthority = await this.createAuthority(
             authority,
             azureRegionConfiguration,

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -412,28 +412,16 @@ export abstract class ClientApplication {
             : this.config.auth.azureCloudOptions;
 
         // using null assertion operator as we ensure that all config values have default values in buildConfiguration()
-        this.logger.verbose("here-----------------------------------------------------------------------------------------------------------------");
-
-        if(azureRegionConfiguration?.azureRegion)
-        {
-            this.logger.verbose(
-                `Building oauth client configuration with the user provided authority: ${authority}, using provided region: ${azureRegionConfiguration?.azureRegion}.`,
-                requestCorrelationId
-            );
-        } 
-        else
-        {
-            this.logger.verbose(
-                `Building oauth client configuration with the user provided authority: ${authority}.`,
-                requestCorrelationId
-            );
-        }
-        
-        const discoveredAuthority = await this.createAuthority(
+        const discoveredAuthority: Authority = await this.createAuthority(
             authority,
             azureRegionConfiguration,
             requestCorrelationId,
             userAzureCloudOptions
+        );
+
+        this.logger.info(
+            `Building oauth client configuration with the following authority: ${discoveredAuthority.tokenEndpoint}.`,
+            requestCorrelationId
         );
 
         serverTelemetryManager?.updateRegionDiscoveryMetadata(

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -229,6 +229,9 @@ export class ClientCredentialClient extends BaseClient {
                 authority.tokenEndpoint,
                 queryParametersString
             );
+
+            this.logger.info("Sending token request to host: " + authority.tokenEndpointHost);
+
             const requestBody = this.createTokenRequestBody(request);
             const headers: Record<string, string> =
                 this.createTokenRequestHeaders();

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -230,8 +230,6 @@ export class ClientCredentialClient extends BaseClient {
                 queryParametersString
             );
 
-            this.logger.info("Sending token request to host: " + authority.tokenEndpointHost);
-
             const requestBody = this.createTokenRequestBody(request);
             const headers: Record<string, string> =
                 this.createTokenRequestHeaders();
@@ -246,6 +244,10 @@ export class ClientCredentialClient extends BaseClient {
                 shrClaims: request.shrClaims,
                 sshKid: request.sshKid,
             };
+
+            this.logger.info(
+                "Sending token request to endpoint: " + authority.tokenEndpoint
+            );
 
             reqTimestamp = TimeUtils.nowSeconds();
             const response = await this.executePostToTokenEndpoint(


### PR DESCRIPTION
Was able to confirm the regional configuration api works. Logs make the used endpoint misleading. 
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/6510