### PR TITLE
Create one correlationId across a flow

### DIFF
--- a/change/@azure-msal-browser-91b9f9a9-61f8-4966-b520-8556ffe9a5e0.json
+++ b/change/@azure-msal-browser-91b9f9a9-61f8-4966-b520-8556ffe9a5e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Generate one correlation id across a flow #6650",
+  "packageName": "@azure/msal-browser",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -141,7 +141,7 @@ export abstract class BaseInteractionClient {
     ): Promise<BaseAuthRequest> {
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.InitializeBaseRequest,
-            request.correlationId
+            this.correlationId
         );
         const authority = request.authority || this.config.auth.authority;
 
@@ -266,7 +266,6 @@ export abstract class BaseInteractionClient {
     /**
      * Used to get a discovered version of the default authority.
      * @param requestAuthority
-     * @param requestCorrelationId
      */
     protected async getDiscoveredAuthority(
         requestAuthority?: string

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -57,7 +57,7 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
     ): Promise<CommonAuthorizationCodeRequest> {
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.StandardInteractionClientInitializeAuthorizationCodeRequest,
-            request.correlationId
+            this.correlationId
         );
         const generatedPkceParams = await invokeAsync(
             generatePkceCodes,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1704,9 +1704,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 tokenType: AuthenticationScheme.BEARER,
             };
 
+            jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                RANDOM_TEST_GUID
+            );
+
             const nativeAcquireTokenSpy = sinon
                 .stub(NativeInteractionClient.prototype, "acquireToken")
-                .callsFake(async () => {
+                .callsFake(async (request) => {
+                    expect(request.correlationId).toBe(RANDOM_TEST_GUID);
                     return testTokenResponse;
                 });
             const popupSpy = sinon

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -971,6 +971,17 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     return;
                 });
 
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].correlationId).toBe(RANDOM_TEST_GUID);
+                expect(events[0].success).toBe(true);
+                expect(events[0].accessTokenSize).toBe(16);
+                expect(events[0].idTokenSize).toBe(12);
+                expect(events[0].requestId).toBe(undefined);
+                expect(events[0].visibilityChangeCount).toBe(0);
+                pca.removePerformanceCallback(callbackId);
+                done();
+            });
+
             pca.loginRedirect();
         });
 
@@ -1638,6 +1649,16 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
                     return testTokenResponse;
                 });
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].correlationId).toBe(RANDOM_TEST_GUID);
+                expect(events[0].success).toBe(true);
+                expect(events[0].accessTokenSize).toBe(16);
+                expect(events[0].idTokenSize).toBe(12);
+                expect(events[0].requestId).toBe(undefined);
+                expect(events[0].visibilityChangeCount).toBe(0);
+                pca.removePerformanceCallback(callbackId);
+                done();
+            });
 
             pca.loginPopup();
         });

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -958,11 +958,15 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         });
 
         it("Uses default request if no request provided", (done) => {
+            jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                RANDOM_TEST_GUID
+            );
             sinon
                 .stub(StandardController.prototype, "acquireTokenRedirect")
                 .callsFake(async (request): Promise<void> => {
                     expect(request.scopes).toContain("openid");
                     expect(request.scopes).toContain("profile");
+                    expect(request.correlationId).toEqual(RANDOM_TEST_GUID);
                     done();
                     return;
                 });
@@ -1042,6 +1046,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 username: "AbeLi@microsoft.com",
                 nativeAccountId: "test-nativeAccountId",
             };
+
+            jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                RANDOM_TEST_GUID
+            );
 
             const nativeAcquireTokenSpy = sinon
                 .stub(NativeInteractionClient.prototype, "acquireTokenRedirect")
@@ -1617,11 +1625,15 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 account: testAccount,
                 tokenType: AuthenticationScheme.BEARER,
             };
+            jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                RANDOM_TEST_GUID
+            );
             sinon
                 .stub(StandardController.prototype, "acquireTokenPopup")
                 .callsFake(async (request) => {
                     expect(request.scopes).toContain("openid");
                     expect(request.scopes).toContain("profile");
+                    expect(request.correlationId).toEqual(RANDOM_TEST_GUID);
                     done();
 
                     return testTokenResponse;


### PR DESCRIPTION
When the request is not initialized with a correlationId, this PR ensures that the msal js generates only one correlationId across the flow and the perf events around the flow. 