### PR TITLE
Make SHR header configurable

### DIFF
--- a/change/@azure-msal-browser-e672d970-f88c-4dfa-b355-16836b75598b.json
+++ b/change/@azure-msal-browser-e672d970-f88c-4dfa-b355-16836b75598b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make SHR header configurable #6654",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-ae2c1758-b86f-47eb-acfc-a5f85946997f.json
+++ b/change/@azure-msal-common-ae2c1758-b86f-47eb-acfc-a5f85946997f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make SHR header configurable #6654",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1911,6 +1911,7 @@ export class StandardController implements IController {
             resourceRequestUri: request.resourceRequestUri,
             shrClaims: request.shrClaims,
             sshKid: request.sshKid,
+            shrOptions: request.shrOptions,
         };
         const silentRequestKey = JSON.stringify(thumbprint);
 

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -9,6 +9,7 @@ import {
     JoseHeader,
     Logger,
     PerformanceEvents,
+    ShrOptions,
     SignedHttpRequest,
     SignedHttpRequestParameters,
 } from "@azure/msal-common";
@@ -161,6 +162,7 @@ export class CryptoOps implements ICrypto {
     async signJwt(
         payload: SignedHttpRequest,
         kid: string,
+        shrOptions?: ShrOptions,
         correlationId?: string
     ): Promise<string> {
         const signJwtMeasurement = this.performanceClient?.startMeasurement(
@@ -180,15 +182,15 @@ export class CryptoOps implements ICrypto {
             cachedKeyPair.publicKey
         );
         const publicKeyJwkString = getSortedObjectString(publicKeyJwk);
-
         // Base64URL encode public key thumbprint with keyId only: BASE64URL({ kid: "FULL_PUBLIC_KEY_HASH" })
         const encodedKeyIdThumbprint = urlEncode(JSON.stringify({ kid: kid }));
-
         // Generate header
         const shrHeader = JoseHeader.getShrHeaderString({
-            kid: encodedKeyIdThumbprint,
+            ...shrOptions?.header,
             alg: publicKeyJwk.alg,
+            kid: encodedKeyIdThumbprint,
         });
+
         const encodedShrHeader = urlEncode(shrHeader);
 
         // Generate payload

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -135,6 +135,7 @@ export {
     // Utils
     StringUtils,
     UrlString,
+    JsonWebTokenTypes,
     // AzureCloudInstance enum
     AzureCloudInstance,
     AzureCloudOptions,

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -8,7 +8,7 @@ import {
     createClientAuthError,
 } from "../error/ClientAuthError";
 import { BaseAuthRequest } from "../request/BaseAuthRequest";
-import { SignedHttpRequest } from "./SignedHttpRequest";
+import { ShrOptions, SignedHttpRequest } from "./SignedHttpRequest";
 
 /**
  * The PkceCodes type describes the structure
@@ -22,7 +22,11 @@ export type PkceCodes = {
 
 export type SignedHttpRequestParameters = Pick<
     BaseAuthRequest,
-    "resourceRequestMethod" | "resourceRequestUri" | "shrClaims" | "shrNonce"
+    | "resourceRequestMethod"
+    | "resourceRequestUri"
+    | "shrClaims"
+    | "shrNonce"
+    | "shrOptions"
 > & {
     correlationId?: string;
 };
@@ -68,6 +72,7 @@ export interface ICrypto {
     signJwt(
         payload: SignedHttpRequest,
         kid: string,
+        shrOptions?: ShrOptions,
         correlationId?: string
     ): Promise<string>;
     /**

--- a/lib/msal-common/src/crypto/JoseHeader.ts
+++ b/lib/msal-common/src/crypto/JoseHeader.ts
@@ -7,17 +7,17 @@ import {
     JoseHeaderErrorCodes,
     createJoseHeaderError,
 } from "../error/JoseHeaderError";
-import { JsonTypes } from "../utils/Constants";
+import { JsonWebTokenTypes } from "../utils/Constants";
 
 export type JoseHeaderOptions = {
-    typ?: JsonTypes;
+    typ?: JsonWebTokenTypes;
     alg?: string;
     kid?: string;
 };
 
 /** @internal */
 export class JoseHeader {
-    public typ?: JsonTypes;
+    public typ?: JsonWebTokenTypes;
     public alg?: string;
     public kid?: string;
 
@@ -48,7 +48,7 @@ export class JoseHeader {
 
         const shrHeader = new JoseHeader({
             // Access Token PoP headers must have type pop, but the type header can be overriden for special cases
-            typ: shrHeaderOptions.typ || JsonTypes.Pop,
+            typ: shrHeaderOptions.typ || JsonWebTokenTypes.Pop,
             kid: shrHeaderOptions.kid,
             alg: shrHeaderOptions.alg,
         });

--- a/lib/msal-common/src/crypto/PopTokenGenerator.ts
+++ b/lib/msal-common/src/crypto/PopTokenGenerator.ts
@@ -133,6 +133,7 @@ export class PopTokenGenerator {
             resourceRequestUri,
             shrClaims,
             shrNonce,
+            shrOptions,
         } = request;
 
         const resourceUrlString = resourceRequestUri
@@ -154,6 +155,7 @@ export class PopTokenGenerator {
                 ...claims,
             },
             keyId,
+            shrOptions,
             request.correlationId
         );
     }

--- a/lib/msal-common/src/crypto/SignedHttpRequest.ts
+++ b/lib/msal-common/src/crypto/SignedHttpRequest.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { JoseHeaderOptions } from "./JoseHeader";
+
 export type SignedHttpRequest = {
     at?: string;
     cnf?: object;
@@ -13,4 +15,8 @@ export type SignedHttpRequest = {
     ts?: number;
     nonce?: string;
     client_claims?: string;
+};
+
+export type ShrOptions = {
+    header: JoseHeaderOptions;
 };

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -105,7 +105,7 @@ export {
     DEFAULT_CRYPTO_IMPLEMENTATION,
     SignedHttpRequestParameters,
 } from "./crypto/ICrypto";
-export { SignedHttpRequest } from "./crypto/SignedHttpRequest";
+export { SignedHttpRequest, ShrOptions } from "./crypto/SignedHttpRequest";
 export { IGuidGenerator } from "./crypto/IGuidGenerator";
 export { JoseHeader } from "./crypto/JoseHeader";
 // Request
@@ -193,6 +193,7 @@ export {
     GrantType,
     AADAuthorityConstants,
     HttpStatus,
+    JsonWebTokenTypes,
 } from "./utils/Constants";
 export { StringUtils } from "./utils/StringUtils";
 export { StringDict } from "./utils/MsalTypes";

--- a/lib/msal-common/src/network/RequestThumbprint.ts
+++ b/lib/msal-common/src/network/RequestThumbprint.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { ShrOptions } from "../crypto/SignedHttpRequest";
 import { AuthenticationScheme } from "../utils/Constants";
 
 /**
@@ -19,4 +20,5 @@ export type RequestThumbprint = {
     resourceRequestUri?: string;
     shrClaims?: string;
     sshKid?: string;
+    shrOptions?: ShrOptions;
 };

--- a/lib/msal-common/src/request/BaseAuthRequest.ts
+++ b/lib/msal-common/src/request/BaseAuthRequest.ts
@@ -7,6 +7,7 @@ import { AuthenticationScheme } from "../utils/Constants";
 import { AzureCloudOptions } from "../config/ClientConfiguration";
 import { StringDict } from "../utils/MsalTypes";
 import { StoreInCache } from "./StoreInCache";
+import { ShrOptions } from "../crypto/SignedHttpRequest";
 
 /**
  * BaseAuthRequest
@@ -17,6 +18,7 @@ import { StoreInCache } from "./StoreInCache";
  * - claims                  - A stringified claims request which will be added to all /authorize and /token calls
  * - shrClaims               - A stringified claims object which will be added to a Signed HTTP Request
  * - shrNonce                - A server-generated timestamp that has been encrypted and base64URL encoded, which will be added to a Signed HTTP Request.
+ * - shrOptions              - An object containing options for the Signed HTTP Request
  * - resourceRequestMethod   - HTTP Request type used to request data from the resource (i.e. "GET", "POST", etc.).  Used for proof-of-possession flows.
  * - resourceRequestUri      - URI that token will be used for. Used for proof-of-possession flows.
  * - sshJwk                  - A stringified JSON Web Key representing a public key that can be signed by an SSH certificate.
@@ -34,6 +36,7 @@ export type BaseAuthRequest = {
     claims?: string;
     shrClaims?: string;
     shrNonce?: string;
+    shrOptions?: ShrOptions;
     resourceRequestMethod?: string;
     resourceRequestUri?: string;
     sshJwk?: string;

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -433,11 +433,12 @@ export const CacheOutcome = {
 } as const;
 export type CacheOutcome = (typeof CacheOutcome)[keyof typeof CacheOutcome];
 
-export const JsonTypes = {
+export const JsonWebTokenTypes = {
     Jwt: "JWT",
     Jwk: "JWK",
     Pop: "pop",
 } as const;
-export type JsonTypes = (typeof JsonTypes)[keyof typeof JsonTypes];
+export type JsonWebTokenTypes =
+    (typeof JsonWebTokenTypes)[keyof typeof JsonWebTokenTypes];
 
 export const ONE_DAY_IN_MS = 86400000;

--- a/lib/msal-common/test/crypto/JoseHeader.spec.ts
+++ b/lib/msal-common/test/crypto/JoseHeader.spec.ts
@@ -3,7 +3,7 @@ import {
     JoseHeaderErrorCodes,
     JoseHeaderErrorMessages,
 } from "../../src/error/JoseHeaderError";
-import { JsonTypes } from "../../src/utils/Constants";
+import { JsonWebTokenTypes } from "../../src/utils/Constants";
 import {
     TEST_CRYPTO_ALGORITHMS,
     TEST_POP_VALUES,
@@ -15,10 +15,23 @@ describe("JoseHeader.ts Unit Tests", () => {
             const shrHeaderString = JoseHeader.getShrHeaderString({
                 alg: TEST_CRYPTO_ALGORITHMS.rsa,
                 kid: TEST_POP_VALUES.KID,
+                typ: JsonWebTokenTypes.Pop,
             });
 
             expect(shrHeaderString).toBe(
-                `{"typ":"${JsonTypes.Pop}","alg":"${TEST_CRYPTO_ALGORITHMS.rsa}","kid":"${TEST_POP_VALUES.KID}"}`
+                `{"typ":"${JsonWebTokenTypes.Pop}","alg":"${TEST_CRYPTO_ALGORITHMS.rsa}","kid":"${TEST_POP_VALUES.KID}"}`
+            );
+        });
+
+        it("should override the typ header if provided", () => {
+            const shrHeaderString = JoseHeader.getShrHeaderString({
+                alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                kid: TEST_POP_VALUES.KID,
+                typ: JsonWebTokenTypes.Jwt,
+            });
+
+            expect(shrHeaderString).toBe(
+                `{"typ":"${JsonWebTokenTypes.Jwt}","alg":"${TEST_CRYPTO_ALGORITHMS.rsa}","kid":"${TEST_POP_VALUES.KID}"}`
             );
         });
 
@@ -26,17 +39,32 @@ describe("JoseHeader.ts Unit Tests", () => {
             expect(() =>
                 JoseHeader.getShrHeaderString({
                     alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                    typ: JsonWebTokenTypes.Pop,
                 })
             ).toThrowError(
                 JoseHeaderErrorMessages[JoseHeaderErrorCodes.missingKidError]
             );
         });
 
-        it("should throw if kid header is missing", () => {
+        it("should throw if alg header is missing", () => {
             expect(() =>
-                JoseHeader.getShrHeaderString({ kid: TEST_POP_VALUES.KID })
+                JoseHeader.getShrHeaderString({
+                    kid: TEST_POP_VALUES.KID,
+                    typ: JsonWebTokenTypes.Pop,
+                })
             ).toThrowError(
                 JoseHeaderErrorMessages[JoseHeaderErrorCodes.missingAlgError]
+            );
+        });
+
+        it("should throw if typ header is missing", () => {
+            expect(() =>
+                JoseHeader.getShrHeaderString({
+                    kid: TEST_POP_VALUES.KID,
+                    alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                })
+            ).toThrowError(
+                JoseHeaderErrorMessages[JoseHeaderErrorCodes.missingTypError]
             );
         });
     });

--- a/lib/msal-common/test/crypto/JoseHeader.spec.ts
+++ b/lib/msal-common/test/crypto/JoseHeader.spec.ts
@@ -56,16 +56,5 @@ describe("JoseHeader.ts Unit Tests", () => {
                 JoseHeaderErrorMessages[JoseHeaderErrorCodes.missingAlgError]
             );
         });
-
-        it("should throw if typ header is missing", () => {
-            expect(() =>
-                JoseHeader.getShrHeaderString({
-                    kid: TEST_POP_VALUES.KID,
-                    alg: TEST_CRYPTO_ALGORITHMS.rsa,
-                })
-            ).toThrowError(
-                JoseHeaderErrorMessages[JoseHeaderErrorCodes.missingTypError]
-            );
-        });
     });
 });


### PR DESCRIPTION
This PR:
- Adds an `shrOptions` attribute to `BaseAuthRequest` to allow applications to override header claims such as `typ` in the SHR returned
- Renames and exposes `JsonWebTokenTypes` for convenience