### PR TITLE
Return requestId in OBO AuthenticationResult

### DIFF
--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -31,6 +31,7 @@ import {
     TokenClaims,
     UrlString,
 } from "@azure/msal-common";
+import { HeaderNames } from "../utils/Constants";
 import { EncodingUtils } from "../utils/EncodingUtils";
 
 /**
@@ -281,6 +282,9 @@ export class OnBehalfOfClient extends BaseClient {
             request.correlationId
         );
 
+        // Retrieve requestId from response headers
+        const requestId = response.headers?.[HeaderNames.X_MS_REQUEST_ID];
+
         const responseHandler = new ResponseHandler(
             this.config.authOptions.clientId,
             this.cacheManager,
@@ -297,7 +301,10 @@ export class OnBehalfOfClient extends BaseClient {
             reqTimestamp,
             request,
             undefined,
-            userAssertionHash
+            userAssertionHash,
+            undefined,
+            undefined,
+            requestId
         );
 
         return tokenResponse;

--- a/lib/msal-node/test/test_kit/StringConstants.ts
+++ b/lib/msal-node/test/test_kit/StringConstants.ts
@@ -348,6 +348,19 @@ export const AUTHENTICATION_RESULT_DEFAULT_SCOPES = {
     },
 };
 
+export const CORS_RESPONSE_HEADERS = {
+    xMsRequestId: "xMsRequestId",
+    xMsHttpVer: "xMsHttpVer",
+};
+
+export const AUTHENTICATION_RESULT_WITH_HEADERS = {
+    ...AUTHENTICATION_RESULT,
+    headers: {
+        "x-ms-request-id": CORS_RESPONSE_HEADERS.xMsRequestId,
+        "x-ms-httpver": CORS_RESPONSE_HEADERS.xMsHttpVer,
+    },
+};
+
 export const CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT = {
     status: 200,
     body: {


### PR DESCRIPTION
Return requestId in OBO AuthenticationResult so we can get the requestId for figuring out why some requests succeed and others don't.