### PR TITLE
Nested App Auth fixes

### DIFF
--- a/change/@azure-msal-browser-2c8dca0f-fa93-46bc-a10d-44949d92f839.json
+++ b/change/@azure-msal-browser-2c8dca0f-fa93-46bc-a10d-44949d92f839.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Nested App Auth minor fixes (#6672)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -14,6 +14,7 @@ import {
     DEFAULT_CRYPTO_IMPLEMENTATION,
     PerformanceEvents,
     AccountFilter,
+    TimeUtils,
 } from "@azure/msal-common";
 import { ITokenCache } from "../cache/ITokenCache";
 import { BrowserConfiguration } from "../config/Configuration";
@@ -134,13 +135,15 @@ export class NestedAppAuthController implements IController {
         try {
             const naaRequest =
                 this.nestedAppAuthAdapter.toNaaTokenRequest(request);
+            const reqTimestamp = TimeUtils.nowSeconds();
             const response = await this.bridgeProxy.getTokenInteractive(
                 naaRequest
             );
             const result: AuthenticationResult =
                 this.nestedAppAuthAdapter.fromNaaTokenResponse(
                     naaRequest,
-                    response
+                    response,
+                    reqTimestamp
                 );
 
             this.operatingContext.setActiveAccount(result.account);
@@ -204,13 +207,15 @@ export class NestedAppAuthController implements IController {
 
         try {
             const naaRequest =
-                this.nestedAppAuthAdapter.toNaaSilentTokenRequest(request);
+                this.nestedAppAuthAdapter.toNaaTokenRequest(request);
+            const reqTimestamp = TimeUtils.nowSeconds();
             const response = await this.bridgeProxy.getTokenSilent(naaRequest);
 
             const result: AuthenticationResult =
                 this.nestedAppAuthAdapter.fromNaaTokenResponse(
                     naaRequest,
-                    response
+                    response,
+                    reqTimestamp
                 );
 
             this.operatingContext.setActiveAccount(result.account);

--- a/lib/msal-browser/src/naa/AccountInfo.ts
+++ b/lib/msal-browser/src/naa/AccountInfo.ts
@@ -12,4 +12,5 @@ export type AccountInfo = {
     name?: string;
     idToken?: string; // idTokenClaims can be parsed from idToken in MSAL.js
     platformBrokerId?: string; // Used by WAM previous called nativeAccountId
+    idTokenClaims?: object;
 };

--- a/lib/msal-browser/src/naa/AccountInfo.ts
+++ b/lib/msal-browser/src/naa/AccountInfo.ts
@@ -6,11 +6,10 @@
 export type AccountInfo = {
     homeAccountId?: string;
     environment: string;
-    tenantId: string;
+    tenantId?: string;
     username: string;
-    localAccountId: string;
+    localAccountId?: string;
     name?: string;
     idToken?: string; // idTokenClaims can be parsed from idToken in MSAL.js
     platformBrokerId?: string; // Used by WAM previous called nativeAccountId
-    idTokenClaims?: object;
 };

--- a/lib/msal-browser/src/naa/AccountInfo.ts
+++ b/lib/msal-browser/src/naa/AccountInfo.ts
@@ -4,7 +4,7 @@
  */
 
 export type AccountInfo = {
-    homeAccountId: string;
+    homeAccountId?: string;
     environment: string;
     tenantId: string;
     username: string;
@@ -13,5 +13,4 @@ export type AccountInfo = {
     idToken?: string; // idTokenClaims can be parsed from idToken in MSAL.js
     platformBrokerId?: string; // Used by WAM previous called nativeAccountId
     idTokenClaims?: object;
-    client_info?: string;
 };

--- a/lib/msal-browser/src/naa/BridgeError.ts
+++ b/lib/msal-browser/src/naa/BridgeError.ts
@@ -7,10 +7,10 @@ import { BridgeStatusCode } from "./BridgeStatusCode";
 
 export type BridgeError = {
     status: BridgeStatusCode;
-    code: string; // auth_flow_last_error such as invalid_grant
-    subError: string; // server_suberror_code such as consent_required
-    description: string;
-    properties: object; // additional telemetry info
+    code?: string; // auth_flow_last_error such as invalid_grant
+    subError?: string; // server_suberror_code such as consent_required
+    description?: string;
+    properties?: object; // additional telemetry info
 };
 
 export function isBridgeError(error: unknown): error is BridgeError {

--- a/lib/msal-browser/src/naa/BridgeProxy.ts
+++ b/lib/msal-browser/src/naa/BridgeProxy.ts
@@ -36,7 +36,7 @@ export class BridgeProxy implements IBridgeProxy {
     static crypto: Crypto;
     sdkName: string;
     sdkVersion: string;
-    capabilities: BridgeCapabilities;
+    capabilities?: BridgeCapabilities;
 
     /**
      * initializeNestedAppAuthBridge - Initializes the bridge to the host app
@@ -162,6 +162,10 @@ export class BridgeProxy implements IBridgeProxy {
         return this.sendRequest<AccountInfo>("GetActiveAccount", undefined);
     }
 
+    public getHostCapabilities(): BridgeCapabilities | null {
+        return this.capabilities ?? null;
+    }
+
     /**
      * A method used to send a request to the bridge
      * @param request A token request
@@ -206,7 +210,7 @@ export class BridgeProxy implements IBridgeProxy {
     private constructor(
         sdkName: string,
         sdkVersion: string,
-        capabilities: BridgeCapabilities
+        capabilities?: BridgeCapabilities
     ) {
         this.sdkName = sdkName;
         this.sdkVersion = sdkVersion;

--- a/lib/msal-browser/src/naa/IBridgeProxy.ts
+++ b/lib/msal-browser/src/naa/IBridgeProxy.ts
@@ -9,6 +9,7 @@ import {
     AccountByLocalIdRequest,
     AccountByUsernameRequest,
 } from "./AccountRequests";
+import { BridgeCapabilities } from "./BridgeCapabilities";
 import { TokenRequest } from "./TokenRequest";
 import { TokenResponse } from "./TokenResponse";
 
@@ -22,4 +23,5 @@ export interface IBridgeProxy {
             | AccountByUsernameRequest
     ): Promise<AccountInfo>;
     getActiveAccount(): Promise<AccountInfo>;
+    getHostCapabilities(): BridgeCapabilities | null;
 }

--- a/lib/msal-browser/src/naa/InitializeBridgeResponse.ts
+++ b/lib/msal-browser/src/naa/InitializeBridgeResponse.ts
@@ -6,7 +6,7 @@
 import { BridgeCapabilities } from "./BridgeCapabilities";
 
 export interface InitializeBridgeResponse {
-    capabilities: BridgeCapabilities;
+    capabilities?: BridgeCapabilities;
     sdkName: string;
     sdkVersion: string;
 }

--- a/lib/msal-browser/src/naa/TokenRequest.ts
+++ b/lib/msal-browser/src/naa/TokenRequest.ts
@@ -9,7 +9,6 @@ export type TokenRequest = {
     authority?: string;
     scope: string;
     correlationId: string;
-    prompt?: string; // Prompt used to identify interactive request
     nonce?: string;
     claims?: string;
     state?: string;
@@ -18,7 +17,6 @@ export type TokenRequest = {
     authenticationScheme?: string;
     shrClaims?: string;
     shrNonce?: string;
-    clientCapabilities?: string[]; // CP1 for CAE support
     resourceRequestMethod?: string;
     resourceRequestUri?: string;
     extendedExpiryToken?: boolean;

--- a/lib/msal-browser/src/naa/TokenResponse.ts
+++ b/lib/msal-browser/src/naa/TokenResponse.ts
@@ -16,6 +16,7 @@ export type TokenResponse = {
     state: string;
     shr?: string; // token binding enabled at native layer it is the access token, not the signing keys
     extendedLifetimeToken?: boolean;
+    authority?: string;
 };
 
 export type TokenResponseProperties = {

--- a/lib/msal-browser/src/naa/TokenResponse.ts
+++ b/lib/msal-browser/src/naa/TokenResponse.ts
@@ -8,12 +8,10 @@ import { AccountInfo } from "./AccountInfo";
 export type TokenResponse = {
     access_token: string;
     account: AccountInfo;
-    client_info: string;
     expires_in: number;
     id_token: string;
     properties: TokenResponseProperties | null;
     scope: string;
-    state: string;
     shr?: string; // token binding enabled at native layer it is the access token, not the signing keys
     extendedLifetimeToken?: boolean;
     authority?: string;

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -152,26 +152,31 @@ export class NestedAppAuthAdapter {
      */
     public fromNaaAccountInfo(
         fromAccount: NaaAccountInfo,
-        tokenClaims?: TokenClaims
+        idTokenClaims?: TokenClaims
     ): MsalAccountInfo {
+        const effectiveIdTokenClaims =
+            idTokenClaims || (fromAccount.idTokenClaims as TokenClaims);
+
         const localAccountId =
             fromAccount.localAccountId ||
-            tokenClaims?.oid ||
-            tokenClaims?.sub ||
+            effectiveIdTokenClaims?.oid ||
+            effectiveIdTokenClaims?.sub ||
             Constants.EMPTY_STRING;
 
         const tenantId =
-            fromAccount.tenantId || tokenClaims?.tid || Constants.EMPTY_STRING;
+            fromAccount.tenantId ||
+            effectiveIdTokenClaims?.tid ||
+            Constants.EMPTY_STRING;
 
         const homeAccountId =
             fromAccount.homeAccountId || `${localAccountId}.${tenantId}`;
 
         const username =
             fromAccount.username ||
-            tokenClaims?.preferred_username ||
+            effectiveIdTokenClaims?.preferred_username ||
             Constants.EMPTY_STRING;
 
-        const name = fromAccount.name || tokenClaims?.name;
+        const name = fromAccount.name || effectiveIdTokenClaims?.name;
 
         const account: MsalAccountInfo = {
             homeAccountId,
@@ -181,7 +186,7 @@ export class NestedAppAuthAdapter {
             localAccountId,
             name,
             idToken: fromAccount.idToken,
-            idTokenClaims: tokenClaims,
+            idTokenClaims: effectiveIdTokenClaims,
         };
 
         return account;

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -15,16 +15,18 @@ import {
     ClientConfigurationError,
     InteractionRequiredAuthError,
     ServerError,
-    TimeUtils,
     ICrypto,
     Logger,
     AuthToken,
     TokenClaims,
     ClientAuthErrorCodes,
+    AuthenticationScheme,
+    RequestParameterBuilder,
+    StringUtils,
+    Constants,
 } from "@azure/msal-common";
 import { isBridgeError } from "../BridgeError";
 import { BridgeStatusCode } from "../BridgeStatusCode";
-import { SilentRequest } from "../../request/SilentRequest";
 import { AuthenticationResult } from "../../response/AuthenticationResult";
 import {} from "../../error/BrowserAuthErrorCodes";
 
@@ -46,41 +48,6 @@ export class NestedAppAuthAdapter {
         this.logger = logger;
     }
 
-    public toNaaSilentTokenRequest(request: SilentRequest): TokenRequest {
-        let extraParams: Map<string, string>;
-        if (request.extraQueryParameters === undefined) {
-            extraParams = new Map<string, string>();
-        } else {
-            extraParams = new Map<string, string>(
-                Object.entries(request.extraQueryParameters)
-            );
-        }
-        /**
-         * Need to get information about the client to populate request correctly
-         * For example: client id, client capabilities
-         */
-        const tokenRequest: TokenRequest = {
-            userObjectId: request.account?.homeAccountId,
-            clientId: this.clientId,
-            authority: request.authority,
-            scope: request.scopes.join(" "),
-            correlationId:
-                request.correlationId !== undefined
-                    ? request.correlationId
-                    : this.crypto.createNewGuid(),
-            prompt: request.prompt !== undefined ? request.prompt : "",
-            claims: request.claims !== undefined ? request.claims : "",
-            authenticationScheme:
-                request.authenticationScheme !== undefined
-                    ? request.authenticationScheme
-                    : "",
-            clientCapabilities: this.clientCapabilities,
-            extraParameters: extraParams,
-        };
-
-        return tokenRequest;
-    }
-
     public toNaaTokenRequest(
         request: PopupRequest | RedirectRequest
     ): TokenRequest {
@@ -93,6 +60,11 @@ export class NestedAppAuthAdapter {
             );
         }
 
+        const requestBuilder = new RequestParameterBuilder();
+        const claims = requestBuilder.addClientCapabilitiesToClaims(
+            request.claims,
+            this.clientCapabilities
+        );
         const tokenRequest: TokenRequest = {
             userObjectId: request.account?.homeAccountId,
             clientId: this.clientId,
@@ -101,16 +73,12 @@ export class NestedAppAuthAdapter {
             correlationId:
                 request.correlationId !== undefined
                     ? request.correlationId
-                    : "",
-            prompt: request.prompt !== undefined ? request.prompt : "",
-            nonce: request.nonce !== undefined ? request.nonce : "",
-            claims: request.claims !== undefined ? request.claims : "",
-            state: request.state !== undefined ? request.state : "",
+                    : this.crypto.createNewGuid(),
+            nonce: request.nonce,
+            claims: !StringUtils.isEmptyObj(claims) ? claims : undefined,
+            state: request.state,
             authenticationScheme:
-                request.authenticationScheme !== undefined
-                    ? request.authenticationScheme
-                    : "",
-            clientCapabilities: undefined,
+                request.authenticationScheme || AuthenticationScheme.BEARER,
             extraParameters: extraParams,
         };
 
@@ -119,34 +87,31 @@ export class NestedAppAuthAdapter {
 
     public fromNaaTokenResponse(
         request: TokenRequest,
-        response: TokenResponse
+        response: TokenResponse,
+        reqTimestamp: number
     ): AuthenticationResult {
         const expiresOn = new Date(
-            TimeUtils.nowSeconds() + (response.expires_in || 0) * 1000
+            (reqTimestamp + (response.expires_in || 0)) * 1000
+        );
+        const idTokenClaims = AuthToken.extractTokenClaims(
+            response.id_token,
+            this.crypto.base64Decode
         );
 
-        const account = this.fromNaaAccountInfo(response.account);
-
         const authenticationResult: AuthenticationResult = {
-            authority: response.account.environment,
-            uniqueId: response.account.homeAccountId,
+            authority: response.authority || response.account.environment,
+            uniqueId: response.account.localAccountId,
             tenantId: response.account.tenantId,
             scopes: response.scope.split(" "),
-            account: this.fromNaaAccountInfo(response.account),
+            account: this.fromNaaAccountInfo(response.account, idTokenClaims),
             idToken: response.id_token !== undefined ? response.id_token : "",
-            idTokenClaims:
-                account.idTokenClaims !== undefined
-                    ? account.idTokenClaims
-                    : {},
+            idTokenClaims,
             accessToken: response.access_token,
             fromCache: true,
             expiresOn: expiresOn,
             tokenType:
-                request.authenticationScheme !== undefined
-                    ? request.authenticationScheme
-                    : "Bearer",
+                request.authenticationScheme || AuthenticationScheme.BEARER,
             correlationId: request.correlationId,
-            requestId: "",
             extExpiresOn: expiresOn,
             state: response.state,
         };
@@ -176,24 +141,36 @@ export class NestedAppAuthAdapter {
      *     authorityType?: string;
      * };
      */
-    public fromNaaAccountInfo(fromAccount: NaaAccountInfo): MsalAccountInfo {
-        let tokenClaims: TokenClaims | undefined;
-        if (fromAccount.idToken !== undefined) {
-            tokenClaims = AuthToken.extractTokenClaims(
-                fromAccount.idToken,
-                this.crypto.base64Decode
-            );
-        } else {
-            tokenClaims = undefined;
-        }
+    public fromNaaAccountInfo(
+        fromAccount: NaaAccountInfo,
+        tokenClaims?: TokenClaims
+    ): MsalAccountInfo {
+        const localAccountId =
+            fromAccount.localAccountId ||
+            tokenClaims?.oid ||
+            tokenClaims?.sub ||
+            Constants.EMPTY_STRING;
+
+        const tenantId =
+            fromAccount.tenantId || tokenClaims?.tid || Constants.EMPTY_STRING;
+
+        const homeAccountId =
+            fromAccount.homeAccountId || `${localAccountId}.${tenantId}`;
+
+        const username =
+            fromAccount.username ||
+            tokenClaims?.preferred_username ||
+            Constants.EMPTY_STRING;
+
+        const name = fromAccount.name || tokenClaims?.name;
 
         const account: MsalAccountInfo = {
-            homeAccountId: fromAccount.homeAccountId,
+            homeAccountId,
             environment: fromAccount.environment,
-            tenantId: fromAccount.tenantId,
-            username: fromAccount.username,
-            localAccountId: fromAccount.localAccountId,
-            name: fromAccount.name,
+            tenantId,
+            username,
+            localAccountId,
+            name,
             idToken: fromAccount.idToken,
             idTokenClaims: tokenClaims,
         };
@@ -233,7 +210,11 @@ export class NestedAppAuthAdapter {
                         ClientAuthErrorCodes.nestedAppAuthBridgeDisabled
                     );
                 case BridgeStatusCode.NESTED_APP_AUTH_UNAVAILABLE:
-                    return new ClientAuthError(error.code, error.description);
+                    return new ClientAuthError(
+                        error.code ||
+                            ClientAuthErrorCodes.nestedAppAuthBridgeDisabled,
+                        error.description
+                    );
                 case BridgeStatusCode.TRANSIENT_ERROR:
                 case BridgeStatusCode.PERSISTENT_ERROR:
                     return new ServerError(error.code, error.description);

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -23,7 +23,6 @@ import {
     AuthenticationScheme,
     RequestParameterBuilder,
     StringUtils,
-    Constants,
     createClientAuthError,
 } from "@azure/msal-common";
 import { isBridgeError } from "../BridgeError";
@@ -161,12 +160,10 @@ export class NestedAppAuthAdapter {
             fromAccount.localAccountId ||
             effectiveIdTokenClaims?.oid ||
             effectiveIdTokenClaims?.sub ||
-            Constants.EMPTY_STRING;
+            "";
 
         const tenantId =
-            fromAccount.tenantId ||
-            effectiveIdTokenClaims?.tid ||
-            Constants.EMPTY_STRING;
+            fromAccount.tenantId || effectiveIdTokenClaims?.tid || "";
 
         const homeAccountId =
             fromAccount.homeAccountId || `${localAccountId}.${tenantId}`;
@@ -174,7 +171,7 @@ export class NestedAppAuthAdapter {
         const username =
             fromAccount.username ||
             effectiveIdTokenClaims?.preferred_username ||
-            Constants.EMPTY_STRING;
+            "";
 
         const name = fromAccount.name || effectiveIdTokenClaims?.name;
 

--- a/lib/msal-browser/src/operatingcontext/TeamsAppOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/TeamsAppOperatingContext.ts
@@ -70,7 +70,10 @@ export class TeamsAppOperatingContext extends BaseOperatingContext {
                  * this.activeAccount = await bridgeProxy.getActiveAccount();
                  */
                 try {
-                    this.activeAccount = await bridgeProxy.getActiveAccount();
+                    if (bridgeProxy.getHostCapabilities()?.queryAccount) {
+                        this.activeAccount =
+                            await bridgeProxy.getActiveAccount();
+                    }
                 } catch (e) {
                     this.activeAccount = undefined;
                 }

--- a/lib/msal-browser/test/naa/BridgeProxyConstants.ts
+++ b/lib/msal-browser/test/naa/BridgeProxyConstants.ts
@@ -40,7 +40,7 @@ export const REDIRECT_REQUEST: RedirectRequest = {
 };
 
 export const SILENT_TOKEN_RESPONSE: TokenResponse = {
-    access_token: "",
+    access_token: TEST_TOKENS.ACCESS_TOKEN,
     account: {
         environment: "login.microsoftonline.com",
         homeAccountId:
@@ -67,12 +67,10 @@ export const SILENT_TOKEN_RESPONSE: TokenResponse = {
         tenantId: "51178b70-16cc-41b5-bef1-ae1808139065",
         username: "AdeleV@vc6w6.onmicrosoft.com",
     },
-    client_info: "",
     expires_in: 4290,
     id_token: TEST_TOKENS.IDTOKEN_V2,
     properties: null,
     scope: "User.Read",
-    state: "",
 };
 
 export const SILENT_TOKEN_REQUEST: TokenRequest = {

--- a/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
+++ b/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
@@ -75,13 +75,14 @@ describe("NestedAppAuthAdapter tests", () => {
             const result: AuthenticationResult =
                 nestedAppAuthAdapter.fromNaaTokenResponse(
                     SILENT_TOKEN_REQUEST,
-                    SILENT_TOKEN_RESPONSE
+                    SILENT_TOKEN_RESPONSE,
+                    0
                 );
             expect(result.authority).toBe(
                 SILENT_TOKEN_RESPONSE.account.environment
             );
             expect(result.uniqueId).toBe(
-                SILENT_TOKEN_RESPONSE.account.homeAccountId
+                SILENT_TOKEN_RESPONSE.account.localAccountId
             );
             expect(result.tenantId).toBe(
                 SILENT_TOKEN_RESPONSE.account.tenantId


### PR DESCRIPTION
Some minor fixes from initial NAA fix including:

- expiresOn AuthenticationResult contained the wrong value.
- expires_in should be used with timestamp before request was made to server, to account for time deltas between servers.
- authenticationScheme was returning empty
- AccountInfo was not returning idTokenClaims, and should use id token for properties as a fallback.
- Added authority parameter for server to host to return authority used in the request.
- Avoid making call to getActiveAccount if host does not support it.
- Merge client capabilities and claims before sending request to host.
- uniqueId should be localAccountId to match implementation of existing msal-browser.
- Removes toNaaSilentTokenRequest which had the same behavior as existing toNaaTokenRequest.
- Handle state parameter locally in MSAL.js