### PR TITLE
Fix bug causing temporary cache not to be cleared & turn on return-await lint rule

### DIFF
--- a/change/@azure-msal-browser-fc538376-3a85-4f38-97a3-62beb4f8b12e.json
+++ b/change/@azure-msal-browser-fc538376-3a85-4f38-97a3-62beb4f8b12e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix bug causing temporary cache not to be cleared",
+  "comment": "Fix bug causing temporary cache not to be cleared #6676",
   "packageName": "@azure/msal-browser",
   "email": "thomas.norling@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-fc538376-3a85-4f38-97a3-62beb4f8b12e.json
+++ b/change/@azure-msal-browser-fc538376-3a85-4f38-97a3-62beb4f8b12e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug causing temporary cache not to be cleared",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-1115da03-5165-4bc2-aad2-aef6dea82100.json
+++ b/change/@azure-msal-common-1115da03-5165-4bc2-aad2-aef6dea82100.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Turn on return-await lint rule #6678",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-7d7ba6ef-1ff9-4d1d-9b53-945fafd5eadd.json
+++ b/change/@azure-msal-node-7d7ba6ef-1ff9-4d1d-9b53-945fafd5eadd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Turn on return-await lint rule #6678",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/DatabaseStorage.ts
+++ b/lib/msal-browser/src/cache/DatabaseStorage.ts
@@ -85,7 +85,7 @@ export class DatabaseStorage<T> implements IAsyncStorage<T> {
      */
     private async validateDbIsOpen(): Promise<void> {
         if (!this.dbOpen) {
-            return await this.open();
+            return this.open();
         }
     }
 

--- a/lib/msal-browser/src/controllers/ControllerFactory.ts
+++ b/lib/msal-browser/src/controllers/ControllerFactory.ts
@@ -16,7 +16,7 @@ export async function createV3Controller(
     await standard.initialize();
 
     const controller = await import("./StandardController");
-    return await controller.StandardController.createController(standard);
+    return controller.StandardController.createController(standard);
 }
 
 export async function createController(
@@ -34,12 +34,12 @@ export async function createController(
         teamsApp.getConfig().auth.supportsNestedAppAuth
     ) {
         const controller = await import("./NestedAppAuthController");
-        return await controller.NestedAppAuthController.createController(
+        return controller.NestedAppAuthController.createController(
             teamsApp
         );
     } else if (standard.isAvailable()) {
         const controller = await import("./StandardController");
-        return await controller.StandardController.createController(standard);
+        return controller.StandardController.createController(standard);
     } else {
         // Since neither of the actual operating contexts are available keep the UnknownOperatingContextController
         return null;

--- a/lib/msal-browser/src/controllers/ControllerFactory.ts
+++ b/lib/msal-browser/src/controllers/ControllerFactory.ts
@@ -34,9 +34,7 @@ export async function createController(
         teamsApp.getConfig().auth.supportsNestedAppAuth
     ) {
         const controller = await import("./NestedAppAuthController");
-        return controller.NestedAppAuthController.createController(
-            teamsApp
-        );
+        return controller.NestedAppAuthController.createController(teamsApp);
     } else if (standard.isAvailable()) {
         const controller = await import("./StandardController");
         return controller.StandardController.createController(standard);

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -923,10 +923,10 @@ export class StandardController implements IController {
                     );
                     atbcMeasurement.discard();
                 }
-                return response;
+                return await response;
             } else if (request.nativeAccountId) {
                 if (this.canUseNative(request, request.nativeAccountId)) {
-                    return this.acquireTokenNative(
+                    return await this.acquireTokenNative(
                         {
                             ...request,
                             correlationId,

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -151,7 +151,7 @@ export class CryptoOps implements ICrypto {
      * Removes all cryptographic keys from IndexedDB storage
      */
     async clearKeystore(): Promise<boolean> {
-        return await this.cache.clear();
+        return this.cache.clear();
     }
 
     /**

--- a/lib/msal-browser/src/crypto/SignedHttpRequest.ts
+++ b/lib/msal-browser/src/crypto/SignedHttpRequest.ts
@@ -71,6 +71,6 @@ export class SignedHttpRequest {
      * @returns If keys are properly deleted
      */
     async removeKeys(publicKeyThumbprint: string): Promise<boolean> {
-        return await this.cryptoOps.removeTokenBindingKey(publicKeyThumbprint);
+        return this.cryptoOps.removeTokenBindingKey(publicKeyThumbprint);
     }
 }

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -283,7 +283,7 @@ export abstract class BaseInteractionClient {
             this.logger.verbose(
                 "Creating discovered authority with request authority"
             );
-            return await AuthorityFactory.createDiscoveredInstance(
+            return AuthorityFactory.createDiscoveredInstance(
                 requestAuthority,
                 this.config.system.networkClient,
                 this.browserStorage,
@@ -295,7 +295,7 @@ export abstract class BaseInteractionClient {
         this.logger.verbose(
             "Creating discovered authority with configured authority"
         );
-        return await AuthorityFactory.createDiscoveredInstance(
+        return AuthorityFactory.createDiscoveredInstance(
             this.config.auth.authority,
             this.config.system.networkClient,
             this.browserStorage,

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -372,7 +372,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
                 reqTimestamp
             );
             this.browserStorage.setInteractionInProgress(false);
-            return result;
+            return await result;
         } catch (e) {
             this.browserStorage.setInteractionInProgress(false);
             throw e;
@@ -533,7 +533,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             if (!request.keyId) {
                 throw createClientAuthError(ClientAuthErrorCodes.keyIdMissing);
             }
-            return await popTokenGenerator.signPopToken(
+            return popTokenGenerator.signPopToken(
                 response.access_token,
                 request.keyId,
                 shrParameters

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -339,7 +339,7 @@ export class PopupClient extends StandardInteractionClient {
                     this.browserCrypto,
                     validRequest.state
                 );
-                return nativeInteractionClient.acquireToken({
+                return await nativeInteractionClient.acquireToken({
                     ...validRequest,
                     state: userRequestState,
                     prompt: undefined, // Server should handle the prompt, ideally native broker can do this part silently

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -254,7 +254,7 @@ export class RedirectClient extends StandardInteractionClient {
                 this.logger.verbose(
                     "NavigateToLoginRequestUrl set to false, handling response"
                 );
-                return this.handleResponse(
+                return await this.handleResponse(
                     serverParams,
                     serverTelemetryManager
                 );
@@ -313,7 +313,7 @@ export class RedirectClient extends StandardInteractionClient {
 
                 // If navigateInternal implementation returns false, handle the hash now
                 if (!processHashOnRedirect) {
-                    return this.handleResponse(
+                    return await this.handleResponse(
                         serverParams,
                         serverTelemetryManager
                     );

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -483,7 +483,7 @@ export class RedirectClient extends StandardInteractionClient {
             this.logger,
             this.performanceClient
         );
-        return await interactionHandler.handleCodeResponse(serverParams, state);
+        return interactionHandler.handleCodeResponse(serverParams, state);
     }
 
     /**

--- a/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
@@ -114,7 +114,7 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
             );
 
             // Handle auth code parameters from request
-            return invokeAsync(
+            return await invokeAsync(
                 interactionHandler.handleCodeResponseFromServer.bind(
                     interactionHandler
                 ),

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -319,7 +319,7 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
             userAuthority,
             requestAzureCloudOptions || this.config.auth.azureCloudOptions
         );
-        return await invokeAsync(
+        return invokeAsync(
             AuthorityFactory.createDiscoveredInstance.bind(AuthorityFactory),
             PerformanceEvents.AuthorityFactoryCreateDiscoveredInstance,
             this.logger,

--- a/lib/msal-browser/src/interaction_handler/SilentHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/SilentHandler.ts
@@ -40,7 +40,7 @@ export async function initiateAuthRequest(
         throw createBrowserAuthError(BrowserAuthErrorCodes.emptyNavigateUri);
     }
     if (navigateFrameWait) {
-        return await invokeAsync(
+        return invokeAsync(
             loadFrame,
             PerformanceEvents.SilentHandlerLoadFrame,
             logger,

--- a/lib/msal-browser/src/naa/BridgeProxy.ts
+++ b/lib/msal-browser/src/naa/BridgeProxy.ts
@@ -101,7 +101,7 @@ export class BridgeProxy implements IBridgeProxy {
                 }
             );
 
-            return promise;
+            return await promise;
         } catch (error) {
             window.console.log(error);
             throw error;

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -140,7 +140,7 @@ export class RefreshTokenClient extends BaseClient {
         // if the app is part of the family, retrive a Family refresh token if present and make a refreshTokenRequest
         if (isFOCI) {
             try {
-                return invokeAsync(
+                return await invokeAsync(
                     this.acquireTokenWithCachedRefreshToken.bind(this),
                     PerformanceEvents.RefreshTokenClientAcquireTokenWithCachedRefreshToken,
                     this.logger,

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -231,7 +231,7 @@ export class SilentFlowClient extends BaseClient {
             checkMaxAge(authTime, request.maxAge);
         }
 
-        return await ResponseHandler.generateAuthenticationResult(
+        return ResponseHandler.generateAuthenticationResult(
             this.cryptoUtils,
             this.authority,
             cacheRecord,

--- a/lib/msal-common/src/crypto/PopTokenGenerator.ts
+++ b/lib/msal-common/src/crypto/PopTokenGenerator.ts
@@ -140,7 +140,7 @@ export class PopTokenGenerator {
             ? new UrlString(resourceRequestUri)
             : undefined;
         const resourceUrlComponents = resourceUrlString?.getUrlComponents();
-        return await this.cryptoUtils.signJwt(
+        return this.cryptoUtils.signJwt(
             {
                 at: payload,
                 ts: TimeUtils.nowSeconds(),

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -342,7 +342,7 @@ export class ResponseHandler {
                     this.logger.warning(
                         "Account used to refresh tokens not in persistence, refreshed tokens will not be stored in the cache"
                     );
-                    return ResponseHandler.generateAuthenticationResult(
+                    return await ResponseHandler.generateAuthenticationResult(
                         this.cryptoObj,
                         authority,
                         cacheRecord,

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -185,7 +185,7 @@ export abstract class ClientApplication {
                 "Auth code client created",
                 validRequest.correlationId
             );
-            return authorizationCodeClient.acquireToken(
+            return await authorizationCodeClient.acquireToken(
                 validRequest,
                 authCodePayLoad
             );
@@ -238,7 +238,7 @@ export abstract class ClientApplication {
                 "Refresh token client created",
                 validRequest.correlationId
             );
-            return refreshTokenClient.acquireToken(validRequest);
+            return await refreshTokenClient.acquireToken(validRequest);
         } catch (e) {
             if (e instanceof AuthError) {
                 e.setCorrelationId(validRequest.correlationId);
@@ -286,7 +286,7 @@ export abstract class ClientApplication {
                 "Silent flow client created",
                 validRequest.correlationId
             );
-            return silentFlowClient.acquireToken(validRequest);
+            return await silentFlowClient.acquireToken(validRequest);
         } catch (e) {
             if (e instanceof AuthError) {
                 e.setCorrelationId(validRequest.correlationId);
@@ -337,7 +337,7 @@ export abstract class ClientApplication {
                 "Username password client created",
                 validRequest.correlationId
             );
-            return usernamePasswordClient.acquireToken(validRequest);
+            return await usernamePasswordClient.acquireToken(validRequest);
         } catch (e) {
             if (e instanceof AuthError) {
                 e.setCorrelationId(validRequest.correlationId);
@@ -581,7 +581,7 @@ export abstract class ClientApplication {
                 this.config.auth.skipAuthorityMetadataCache,
         };
 
-        return await AuthorityFactory.createDiscoveredInstance(
+        return AuthorityFactory.createDiscoveredInstance(
             authorityUrl,
             this.config.system.networkClient,
             this.storage,

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -55,7 +55,7 @@ export class ClientCredentialClient extends BaseClient {
         this.scopeSet = new ScopeSet(request.scopes || []);
 
         if (request.skipCache) {
-            return await this.executeTokenRequest(request, this.authority);
+            return this.executeTokenRequest(request, this.authority);
         }
 
         const [cachedAuthenticationResult, lastCacheOutcome] =
@@ -80,7 +80,7 @@ export class ClientCredentialClient extends BaseClient {
             // return the cached token
             return cachedAuthenticationResult;
         } else {
-            return await this.executeTokenRequest(request, this.authority);
+            return this.executeTokenRequest(request, this.authority);
         }
     }
 

--- a/lib/msal-node/src/client/ConfidentialClientApplication.ts
+++ b/lib/msal-node/src/client/ConfidentialClientApplication.ts
@@ -158,7 +158,7 @@ export class ConfidentialClientApplication
                 "Client credential client created",
                 validRequest.correlationId
             );
-            return clientCredentialClient.acquireToken(validRequest);
+            return await clientCredentialClient.acquireToken(validRequest);
         } catch (e) {
             if (e instanceof AuthError) {
                 e.setCorrelationId(validRequest.correlationId);
@@ -203,7 +203,7 @@ export class ConfidentialClientApplication
                 "On behalf of client created",
                 validRequest.correlationId
             );
-            return oboClient.acquireToken(validRequest);
+            return await oboClient.acquireToken(validRequest);
         } catch (e) {
             if (e instanceof AuthError) {
                 e.setCorrelationId(validRequest.correlationId);

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -60,7 +60,7 @@ export class DeviceCodeClient extends BaseClient {
 
         // Validate response. This function throws a server error if an error is returned by the server.
         responseHandler.validateTokenResponse(response);
-        return await responseHandler.handleServerTokenResponse(
+        return responseHandler.handleServerTokenResponse(
             response,
             this.authority,
             reqTimestamp,

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -59,7 +59,7 @@ export class OnBehalfOfClient extends BaseClient {
         );
 
         if (request.skipCache) {
-            return await this.executeTokenRequest(
+            return this.executeTokenRequest(
                 request,
                 this.authority,
                 this.userAssertionHash
@@ -151,7 +151,7 @@ export class OnBehalfOfClient extends BaseClient {
             this.config.serverTelemetryManager.incrementCacheHits();
         }
 
-        return await ResponseHandler.generateAuthenticationResult(
+        return ResponseHandler.generateAuthenticationResult(
             this.cryptoUtils,
             this.authority,
             {

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -117,7 +117,7 @@ export class PublicClientApplication
                 "Device code client created",
                 validRequest.correlationId
             );
-            return deviceCodeClient.acquireToken(validRequest);
+            return await deviceCodeClient.acquireToken(validRequest);
         } catch (e) {
             if (e instanceof AuthError) {
                 e.setCorrelationId(validRequest.correlationId);

--- a/shared-configs/eslint-config-msal/index.js
+++ b/shared-configs/eslint-config-msal/index.js
@@ -63,6 +63,7 @@ module.exports = {
         "@typescript-eslint/no-unused-vars": 2,
         "@typescript-eslint/prefer-interface": 0,
         "@typescript-eslint/no-floating-promises": 2,
+        "@typescript-eslint/return-await": 2,
         "eol-last": 2,
         "eqeqeq": 2,
         "header/header": [


### PR DESCRIPTION
In some edge cases if an error is thrown during redirect response handling temporary cache may not be cleared resulting in interaction_in_progress errors when attempting to recover with a new redirect request. This was caused by an unawaited asynchronous call inside a synchronous try/catch which includes the cleanup logic.

Also turns on the return-await lint rule which requires any returned promises inside try/catch/finally to be awaited and disallows promises returned outside try/catch/finally from being awaited

Fixes #6676