### PR TITLE
fix: added missing isInteractionRequiredError to export

### DIFF
--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -147,6 +147,7 @@ export {
     InteractionRequiredAuthErrorCodes,
     InteractionRequiredAuthErrorMessage,
     createInteractionRequiredAuthError,
+    isInteractionRequiredError,
 } from "./error/InteractionRequiredAuthError";
 export {
     AuthError,


### PR DESCRIPTION
isInteractionRequiredError function was missing from the exported functions list and hence cannot be used by apps already relying on this. Added it back to the export list for msal-common module.