### PR TITLE
Check HostNameAndPort is defined before calling endsWith

### DIFF
--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -1240,7 +1240,7 @@ export class Authority {
         // check if transformation is needed
         if (
             authorityUrlComponents.PathSegments.length === 0 &&
-            authorityUrlComponents.HostNameAndPort.endsWith(
+            authorityUrlComponents.HostNameAndPort?.endsWith(
                 Constants.CIAM_AUTH_URL
             )
         ) {


### PR DESCRIPTION
Occasionally the HostNameAndPort is undefined which causes the page to crash. This change checks it is defined before trying to call `endsWith`.

Using:
```
    "@azure/msal-browser": "^2.32.2",
    "@azure/msal-react": "^1.5.2",
```