### PR TITLE
Make AADServerParamKeys individual exports

### DIFF
--- a/change/@azure-msal-common-56aaaf1b-8d93-4703-9d51-cab03b646fdf.json
+++ b/change/@azure-msal-common-56aaaf1b-8d93-4703-9d51-cab03b646fdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move AADServerParamKeys to individual exports #6701",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -13,9 +13,9 @@ import {
     AuthenticationScheme,
     PromptValue,
     Separators,
-    AADServerParamKeys,
     HeaderNames,
 } from "../utils/Constants";
+import * as AADServerParamKeys from "../constants/AADServerParamKeys";
 import {
     ClientConfiguration,
     isOidcProtocolMode,

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -17,8 +17,8 @@ import {
     AuthenticationScheme,
     Errors,
     HeaderNames,
-    AADServerParamKeys,
 } from "../utils/Constants";
+import * as AADServerParamKeys from "../constants/AADServerParamKeys";
 import { ResponseHandler } from "../response/ResponseHandler";
 import { AuthenticationResult } from "../response/AuthenticationResult";
 import { PopTokenGenerator } from "../crypto/PopTokenGenerator";

--- a/lib/msal-common/src/constants/AADServerParamKeys.ts
+++ b/lib/msal-common/src/constants/AADServerParamKeys.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
 export const CLIENT_ID = "client_id";
 export const REDIRECT_URI = "redirect_uri";
 export const RESPONSE_TYPE = "response_type";

--- a/lib/msal-common/src/constants/AADServerParamKeys.ts
+++ b/lib/msal-common/src/constants/AADServerParamKeys.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+export const CLIENT_ID = "client_id";
+export const REDIRECT_URI = "redirect_uri";
+export const RESPONSE_TYPE = "response_type";
+export const RESPONSE_MODE = "response_mode";
+export const GRANT_TYPE = "grant_type";
+export const CLAIMS = "claims";
+export const SCOPE = "scope";
+export const ERROR = "error";
+export const ERROR_DESCRIPTION = "error_description";
+export const ACCESS_TOKEN = "access_token";
+export const ID_TOKEN = "id_token";
+export const REFRESH_TOKEN = "refresh_token";
+export const EXPIRES_IN = "expires_in";
+export const STATE = "state";
+export const NONCE = "nonce";
+export const PROMPT = "prompt";
+export const SESSION_STATE = "session_state";
+export const CLIENT_INFO = "client_info";
+export const CODE = "code";
+export const CODE_CHALLENGE = "code_challenge";
+export const CODE_CHALLENGE_METHOD = "code_challenge_method";
+export const CODE_VERIFIER = "code_verifier";
+export const CLIENT_REQUEST_ID = "client-request-id";
+export const X_CLIENT_SKU = "x-client-SKU";
+export const X_CLIENT_VER = "x-client-VER";
+export const X_CLIENT_OS = "x-client-OS";
+export const X_CLIENT_CPU = "x-client-CPU";
+export const X_CLIENT_CURR_TELEM = "x-client-current-telemetry";
+export const X_CLIENT_LAST_TELEM = "x-client-last-telemetry";
+export const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
+export const X_APP_NAME = "x-app-name";
+export const X_APP_VER = "x-app-ver";
+export const POST_LOGOUT_URI = "post_logout_redirect_uri";
+export const ID_TOKEN_HINT = "id_token_hint";
+export const DEVICE_CODE = "device_code";
+export const CLIENT_SECRET = "client_secret";
+export const CLIENT_ASSERTION = "client_assertion";
+export const CLIENT_ASSERTION_TYPE = "client_assertion_type";
+export const TOKEN_TYPE = "token_type";
+export const REQ_CNF = "req_cnf";
+export const OBO_ASSERTION = "assertion";
+export const REQUESTED_TOKEN_USE = "requested_token_use";
+export const ON_BEHALF_OF = "on_behalf_of";
+export const FOCI = "foci";
+export const CCS_HEADER = "X-AnchorMailbox";
+export const RETURN_SPA_CODE = "return_spa_code";
+export const NATIVE_BROKER = "nativebroker";
+export const LOGOUT_HINT = "logout_hint";
+export const SID = "sid";
+export const LOGIN_HINT = "login_hint";
+export const DOMAIN_HINT = "domain_hint";

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -181,12 +181,10 @@ export {
     CacheAccountType,
     AuthenticationScheme,
     CodeChallengeMethodValues,
-    SSOTypes,
     PasswordGrantConstants,
     ThrottlingConstants,
     ClaimsRequestKeys,
     HeaderNames,
-    AADServerParamKeys,
     Errors,
     THE_FAMILY_ID,
     ONE_DAY_IN_MS,
@@ -195,6 +193,7 @@ export {
     HttpStatus,
     JsonWebTokenTypes,
 } from "./utils/Constants";
+export * as AADServerParamKeys from "./constants/AADServerParamKeys";
 export { StringUtils } from "./utils/StringUtils";
 export { StringDict } from "./utils/MsalTypes";
 export {

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -4,10 +4,8 @@
  */
 
 import {
-    AADServerParamKeys,
     Constants,
     ResponseMode,
-    SSOTypes,
     CLIENT_INFO,
     AuthenticationScheme,
     ClaimsRequestKeys,
@@ -16,6 +14,7 @@ import {
     ThrottlingConstants,
     HeaderNames,
 } from "../utils/Constants";
+import * as AADServerParamKeys from "../constants/AADServerParamKeys";
 import { ScopeSet } from "./ScopeSet";
 import {
     createClientConfigurationError,
@@ -161,7 +160,7 @@ export class RequestParameterBuilder {
      */
     addDomainHint(domainHint: string): void {
         this.parameters.set(
-            SSOTypes.DOMAIN_HINT,
+            AADServerParamKeys.DOMAIN_HINT,
             encodeURIComponent(domainHint)
         );
     }
@@ -171,7 +170,10 @@ export class RequestParameterBuilder {
      * @param loginHint
      */
     addLoginHint(loginHint: string): void {
-        this.parameters.set(SSOTypes.LOGIN_HINT, encodeURIComponent(loginHint));
+        this.parameters.set(
+            AADServerParamKeys.LOGIN_HINT,
+            encodeURIComponent(loginHint)
+        );
     }
 
     /**
@@ -201,7 +203,7 @@ export class RequestParameterBuilder {
      * @param sid
      */
     addSid(sid: string): void {
-        this.parameters.set(SSOTypes.SID, encodeURIComponent(sid));
+        this.parameters.set(AADServerParamKeys.SID, encodeURIComponent(sid));
     }
 
     /**

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -123,62 +123,6 @@ export type AADAuthorityConstants =
     (typeof AADAuthorityConstants)[keyof typeof AADAuthorityConstants];
 
 /**
- * Keys in the hashParams sent by AAD Server
- */
-export const AADServerParamKeys = {
-    CLIENT_ID: "client_id",
-    REDIRECT_URI: "redirect_uri",
-    RESPONSE_TYPE: "response_type",
-    RESPONSE_MODE: "response_mode",
-    GRANT_TYPE: "grant_type",
-    CLAIMS: "claims",
-    SCOPE: "scope",
-    ERROR: "error",
-    ERROR_DESCRIPTION: "error_description",
-    ACCESS_TOKEN: "access_token",
-    ID_TOKEN: "id_token",
-    REFRESH_TOKEN: "refresh_token",
-    EXPIRES_IN: "expires_in",
-    STATE: "state",
-    NONCE: "nonce",
-    PROMPT: "prompt",
-    SESSION_STATE: "session_state",
-    CLIENT_INFO: "client_info",
-    CODE: "code",
-    CODE_CHALLENGE: "code_challenge",
-    CODE_CHALLENGE_METHOD: "code_challenge_method",
-    CODE_VERIFIER: "code_verifier",
-    CLIENT_REQUEST_ID: "client-request-id",
-    X_CLIENT_SKU: "x-client-SKU",
-    X_CLIENT_VER: "x-client-VER",
-    X_CLIENT_OS: "x-client-OS",
-    X_CLIENT_CPU: "x-client-CPU",
-    X_CLIENT_CURR_TELEM: "x-client-current-telemetry",
-    X_CLIENT_LAST_TELEM: "x-client-last-telemetry",
-    X_MS_LIB_CAPABILITY: "x-ms-lib-capability",
-    X_APP_NAME: "x-app-name",
-    X_APP_VER: "x-app-ver",
-    POST_LOGOUT_URI: "post_logout_redirect_uri",
-    ID_TOKEN_HINT: "id_token_hint",
-    DEVICE_CODE: "device_code",
-    CLIENT_SECRET: "client_secret",
-    CLIENT_ASSERTION: "client_assertion",
-    CLIENT_ASSERTION_TYPE: "client_assertion_type",
-    TOKEN_TYPE: "token_type",
-    REQ_CNF: "req_cnf",
-    OBO_ASSERTION: "assertion",
-    REQUESTED_TOKEN_USE: "requested_token_use",
-    ON_BEHALF_OF: "on_behalf_of",
-    FOCI: "foci",
-    CCS_HEADER: "X-AnchorMailbox",
-    RETURN_SPA_CODE: "return_spa_code",
-    NATIVE_BROKER: "nativebroker",
-    LOGOUT_HINT: "logout_hint",
-} as const;
-export type AADServerParamKeys =
-    (typeof AADServerParamKeys)[keyof typeof AADServerParamKeys];
-
-/**
  * Claims request keys
  */
 export const ClaimsRequestKeys = {
@@ -201,22 +145,6 @@ export const PromptValue = {
     CREATE: "create",
     NO_SESSION: "no_session",
 };
-
-/**
- * SSO Types - generated to populate hints
- */
-export const SSOTypes = {
-    ACCOUNT: "account",
-    SID: "sid",
-    LOGIN_HINT: "login_hint",
-    ID_TOKEN: "id_token",
-    DOMAIN_HINT: "domain_hint",
-    ORGANIZATIONS: "organizations",
-    CONSUMERS: "consumers",
-    ACCOUNT_ID: "accountIdentifier",
-    HOMEACCOUNT_ID: "homeAccountIdentifier",
-} as const;
-export type SSOTypes = (typeof SSOTypes)[keyof typeof SSOTypes];
 
 /**
  * allowed values for codeVerifier

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -20,16 +20,15 @@ import {
 import { ClientConfiguration } from "../../src/config/ClientConfiguration";
 import { BaseClient } from "../../src/client/BaseClient";
 import {
-    AADServerParamKeys,
     PromptValue,
     ResponseMode,
-    SSOTypes,
     AuthenticationScheme,
     ThrottlingConstants,
     Constants,
     HeaderNames,
     ONE_DAY_IN_MS,
 } from "../../src/utils/Constants";
+import * as AADServerParamKeys from "../../src/constants/AADServerParamKeys";
 import { ClientTestUtils, MockStorageClass } from "./ClientTestUtils";
 import { TestError } from "../test_kit/TestErrors";
 import { Authority } from "../../src/authority/Authority";
@@ -268,14 +267,14 @@ describe("AuthorizationCodeClient unit tests", () => {
             ).toBe(true);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         TEST_CONFIG.LOGIN_HINT
                     )}`
                 )
             ).toBe(true);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.DOMAIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.DOMAIN_HINT}=${encodeURIComponent(
                         TEST_CONFIG.DOMAIN_HINT
                     )}`
                 )
@@ -328,7 +327,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         TEST_CONFIG.LOGIN_HINT
                     )}`
                 )
@@ -398,7 +397,9 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.SID}=${encodeURIComponent(testTokenClaims.sid)}`
+                    `${AADServerParamKeys.SID}=${encodeURIComponent(
+                        testTokenClaims.sid
+                    )}`
                 )
             ).toBe(true);
             expect(
@@ -465,12 +466,14 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.SID}=${encodeURIComponent(testTokenClaims.sid)}`
+                    `${AADServerParamKeys.SID}=${encodeURIComponent(
+                        testTokenClaims.sid
+                    )}`
                 )
             ).toBe(false);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         testTokenClaims.login_hint
                     )}`
                 )
@@ -513,11 +516,15 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(loginUrl).toEqual(
-                expect.not.arrayContaining([`${SSOTypes.LOGIN_HINT}=`])
+                expect.not.arrayContaining([
+                    `${AADServerParamKeys.LOGIN_HINT}=`,
+                ])
             );
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.SID}=${encodeURIComponent(TEST_CONFIG.SID)}`
+                    `${AADServerParamKeys.SID}=${encodeURIComponent(
+                        TEST_CONFIG.SID
+                    )}`
                 )
             ).toBe(true);
         });
@@ -552,12 +559,12 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         TEST_CONFIG.LOGIN_HINT
                     )}`
                 )
             ).toBe(true);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
         });
 
         it("Ignores sid if prompt!=None", async () => {
@@ -587,8 +594,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 responseMode: ResponseMode.FRAGMENT,
             };
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
-            expect(loginUrl.includes(`${SSOTypes.LOGIN_HINT}=`)).toBe(false);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.LOGIN_HINT}=`)).toBe(
+                false
+            );
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
         });
 
         it("Prefers loginHint over Account if both provided and account does not have token claims", async () => {
@@ -620,19 +629,19 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         TEST_CONFIG.LOGIN_HINT
                     )}`
                 )
             ).toBe(true);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         TEST_ACCOUNT_INFO.username
                     )}`
                 )
             ).toBe(false);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
         });
 
         it("Uses sid from account if not provided in request and prompt=None, overrides login_hint", async () => {
@@ -691,10 +700,14 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.SID}=${encodeURIComponent(testTokenClaims.sid)}`
+                    `${AADServerParamKeys.SID}=${encodeURIComponent(
+                        testTokenClaims.sid
+                    )}`
                 )
             ).toBe(true);
-            expect(loginUrl.includes(`${SSOTypes.LOGIN_HINT}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.LOGIN_HINT}=`)).toBe(
+                false
+            );
         });
 
         it("Uses loginHint instead of sid from account prompt!=None", async () => {
@@ -766,10 +779,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 responseMode: ResponseMode.FRAGMENT,
             };
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         TEST_CONFIG.LOGIN_HINT
                     )}`
                 )
@@ -846,12 +859,12 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         TEST_CONFIG.LOGIN_HINT
                     )}`
                 )
             ).toBe(true);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
         });
 
         it("Sets login_hint to Account.username if login_hint and sid are not provided", async () => {
@@ -882,12 +895,12 @@ describe("AuthorizationCodeClient unit tests", () => {
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
             expect(
                 loginUrl.includes(
-                    `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                    `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                         TEST_ACCOUNT_INFO.username
                     )}`
                 )
             ).toBe(true);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
         });
 
         it("Ignores Account if prompt is select_account", async () => {
@@ -917,8 +930,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 responseMode: ResponseMode.FRAGMENT,
             };
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
-            expect(loginUrl.includes(`${SSOTypes.LOGIN_HINT}=`)).toBe(false);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.LOGIN_HINT}=`)).toBe(
+                false
+            );
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
         });
 
         it("Ignores loginHint if prompt is select_account", async () => {
@@ -948,8 +963,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 responseMode: ResponseMode.FRAGMENT,
             };
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
-            expect(loginUrl.includes(`${SSOTypes.LOGIN_HINT}=`)).toBe(false);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.LOGIN_HINT}=`)).toBe(
+                false
+            );
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
         });
 
         it("Ignores sid if prompt is select_account", async () => {
@@ -979,8 +996,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 responseMode: ResponseMode.FRAGMENT,
             };
             const loginUrl = await client.getAuthCodeUrl(authCodeUrlRequest);
-            expect(loginUrl.includes(`${SSOTypes.LOGIN_HINT}=`)).toBe(false);
-            expect(loginUrl.includes(`${SSOTypes.SID}=`)).toBe(false);
+            expect(loginUrl.includes(`${AADServerParamKeys.LOGIN_HINT}=`)).toBe(
+                false
+            );
+            expect(loginUrl.includes(`${AADServerParamKeys.SID}=`)).toBe(false);
         });
 
         it("Creates a login URL with scopes from given token request", async () => {

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -22,13 +22,13 @@ import {
 } from "../test_kit/StringConstants";
 import { BaseClient } from "../../src/client/BaseClient";
 import {
-    AADServerParamKeys,
     GrantType,
     Constants,
     CredentialType,
     AuthenticationScheme,
     ThrottlingConstants,
 } from "../../src/utils/Constants";
+import * as AADServerParamKeys from "../../src/constants/AADServerParamKeys";
 import { ClientTestUtils, MockStorageClass } from "./ClientTestUtils";
 import { Authority } from "../../src/authority/Authority";
 import { RefreshTokenClient } from "../../src/client/RefreshTokenClient";

--- a/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
+++ b/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
@@ -1,13 +1,12 @@
 import {
     Constants,
-    SSOTypes,
     PromptValue,
-    AADServerParamKeys,
     ResponseMode,
     GrantType,
     AuthenticationScheme,
     HeaderNames,
 } from "../../src/utils/Constants";
+import * as AADServerParamKeys from "../../src/constants/AADServerParamKeys";
 import {
     TEST_CONFIG,
     TEST_URIS,
@@ -92,14 +91,14 @@ describe("RequestParameterBuilder unit tests", () => {
         ).toBe(true);
         expect(
             requestQueryString.includes(
-                `${SSOTypes.DOMAIN_HINT}=${encodeURIComponent(
+                `${AADServerParamKeys.DOMAIN_HINT}=${encodeURIComponent(
                     TEST_CONFIG.DOMAIN_HINT
                 )}`
             )
         ).toBe(true);
         expect(
             requestQueryString.includes(
-                `${SSOTypes.LOGIN_HINT}=${encodeURIComponent(
+                `${AADServerParamKeys.LOGIN_HINT}=${encodeURIComponent(
                     TEST_CONFIG.LOGIN_HINT
                 )}`
             )
@@ -174,7 +173,9 @@ describe("RequestParameterBuilder unit tests", () => {
         ).toBe(true);
         expect(
             requestQueryString.includes(
-                `${SSOTypes.SID}=${encodeURIComponent(TEST_CONFIG.SID)}`
+                `${AADServerParamKeys.SID}=${encodeURIComponent(
+                    TEST_CONFIG.SID
+                )}`
             )
         ).toBe(true);
         expect(


### PR DESCRIPTION
Moves AADServerParamKeys to separate exports under a new "Constants" folder. Removes SSOTypes which was redundant.