### PR TITLE
Minor perf optimization when creating hidden iframe

### DIFF
--- a/change/@azure-msal-browser-8cb5d434-71db-4a02-b2cc-dd7713e96e3d.json
+++ b/change/@azure-msal-browser-8cb5d434-71db-4a02-b2cc-dd7713e96e3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Performance optimization when creating hidden iframe",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_handler/SilentHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/SilentHandler.ts
@@ -203,7 +203,7 @@ function createHiddenIframe(): HTMLIFrameElement {
         "sandbox",
         "allow-scripts allow-same-origin allow-forms"
     );
-    document.getElementsByTagName("body")[0].appendChild(authFrame);
+    document.body.appendChild(authFrame);
 
     return authFrame;
 }


### PR DESCRIPTION
Using `document.body` directly is more performant than searching the document for body tags. 

Current P95 for hidden iframe creation is ~70ms which represents a significant portion of the time spent on client-side operations in ssoSilent/ATS