### PR TITLE
Nested App Auth is not working with Android response

### DIFF
--- a/change/@azure-msal-browser-aaaeed43-6bc8-4ae5-a6f9-f491edebd304.json
+++ b/change/@azure-msal-browser-aaaeed43-6bc8-4ae5-a6f9-f491edebd304.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Nested App Auth fix for Android response (#6707)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/naa/AuthBridge.ts
+++ b/lib/msal-browser/src/naa/AuthBridge.ts
@@ -3,14 +3,15 @@
  * Licensed under the MIT License.
  */
 
+export type AuthBridgeResponse = string | { data: string };
 export interface AuthBridge {
     addEventListener: (
         eventName: string,
-        callback: (response: string) => void
+        callback: (response: AuthBridgeResponse) => void
     ) => void;
     postMessage: (message: string) => void;
     removeEventListener: (
         eventName: string,
-        callback: (response: string) => void
+        callback: (response: AuthBridgeResponse) => void
     ) => void;
 }

--- a/lib/msal-browser/src/naa/BridgeProxy.ts
+++ b/lib/msal-browser/src/naa/BridgeProxy.ts
@@ -9,7 +9,7 @@ import {
     AccountByLocalIdRequest,
     AccountByUsernameRequest,
 } from "./AccountRequests";
-import { AuthBridge } from "./AuthBridge";
+import { AuthBridge, AuthBridgeResponse } from "./AuthBridge";
 import { BridgeCapabilities } from "./BridgeCapabilities";
 import { BridgeRequest } from "./BridgeRequest";
 import { BridgeRequestEnvelope, BridgeMethods } from "./BridgeRequestEnvelope";
@@ -60,9 +60,11 @@ export class BridgeProxy implements IBridgeProxy {
 
             window.nestedAppAuthBridge.addEventListener(
                 "message",
-                (response: string) => {
+                (response: AuthBridgeResponse) => {
+                    const responsePayload =
+                        typeof response === "string" ? response : response.data;
                     const responseEnvelope: BridgeResponseEnvelope =
-                        JSON.parse(response);
+                        JSON.parse(responsePayload);
                     const request = BridgeProxy.bridgeRequests.find(
                         (element) =>
                             element.requestId === responseEnvelope.requestId


### PR DESCRIPTION
Android API to return a response through Nested App Auth bridge is in a slightly different format than the other platforms. The payload looks like { data: string } instead of string. The other implementations are all using a consistent format, and there is only one location in code that we depend on bridge response format. Fix is to allow both response formats.