### PR TITLE
Fix external account loading

### DIFF
--- a/change/@azure-msal-browser-523e4a81-0be7-4b81-853b-ef53334e8748.json
+++ b/change/@azure-msal-browser-523e4a81-0be7-4b81-853b-ef53334e8748.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix external account loading #6744",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-bdd493ce-0c46-4ec5-b2db-9eba6d5b8030.json
+++ b/change/@azure-msal-common-bdd493ce-0c46-4ec5-b2db-9eba6d5b8030.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix external account loading #6744",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -270,9 +270,10 @@ export class TokenCache implements ITokenCache {
                 idTokenClaims,
                 base64Decode,
                 clientInfo,
+                authority.hostnameAndPort,
                 claimsTenantId,
-                undefined,
-                undefined,
+                undefined, // authCodePayload
+                undefined, // nativeAccountId
                 this.logger
             );
 

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -430,6 +430,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             idTokenClaims,
             base64Decode,
             response.client_info,
+            undefined, // environment
             idTokenClaims.tid,
             undefined,
             response.account.id,

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -432,7 +432,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             response.client_info,
             undefined, // environment
             idTokenClaims.tid,
-            undefined,
+            undefined, // auth code payload
             response.account.id,
             this.logger
         );

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -164,11 +164,6 @@ describe("TokenCache tests", () => {
             );
             refreshTokenKey =
                 CacheHelpers.generateCredentialKey(refreshTokenEntity);
-
-            jest.spyOn(
-                Authority.prototype,
-                "getPreferredCache"
-            ).mockReturnValue(testEnvironment);
         });
 
         afterEach(() => {

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -438,7 +438,7 @@ export class ResponseHandler {
                 env,
                 claimsTenantId,
                 authCodePayload,
-                undefined,
+                undefined, // nativeAccountId
                 this.logger
             );
         }

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -435,6 +435,7 @@ export class ResponseHandler {
                 idTokenClaims,
                 this.cryptoObj.base64Decode,
                 serverTokenResponse.client_info,
+                env,
                 claimsTenantId,
                 authCodePayload,
                 undefined,
@@ -654,6 +655,7 @@ export function buildAccountToCache(
     idTokenClaims: TokenClaims,
     base64Decode: (input: string) => string,
     clientInfo?: string,
+    environment?: string,
     claimsTenantId?: string | null,
     authCodePayload?: AuthorizationCodePayload,
     nativeAccountId?: string,
@@ -676,9 +678,10 @@ export function buildAccountToCache(
         cachedAccount ||
         AccountEntity.createAccount(
             {
-                homeAccountId: homeAccountId,
-                idTokenClaims: idTokenClaims,
-                clientInfo: clientInfo,
+                homeAccountId,
+                idTokenClaims,
+                clientInfo,
+                environment,
                 cloudGraphHostName: authCodePayload?.cloud_graph_host_name,
                 msGraphHost: authCodePayload?.msgraph_host,
                 nativeAccountId: nativeAccountId,


### PR DESCRIPTION
This PR:
- Adds environment as an optional parameter to `buildAccountToCache` utility function and passes in `authority.hostNameAndPort` as environment when `loadAccount` in `TokenCache` calls it.