### PR TITLE
Convert ThrottlingEntity into a type

### DIFF
--- a/change/@azure-msal-browser-db45337f-959c-40db-b8a7-6e906fdc913b.json
+++ b/change/@azure-msal-browser-db45337f-959c-40db-b8a7-6e906fdc913b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Convert ThrottlingEntity into a Type",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-8a857037-5571-48eb-9211-8efca31765b2.json
+++ b/change/@azure-msal-common-8a857037-5571-48eb-9211-8efca31765b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Convert ThrottlingEntity into a Type",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-5000935d-29a7-4c4c-a80c-602d7f5f9b05.json
+++ b/change/@azure-msal-node-5000935d-29a7-4c4c-a80c-602d7f5f9b05.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Convert ThrottlingEntity into a Type",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1119,7 +1119,7 @@ export class BrowserCacheManager extends CacheManager {
         const parsedThrottlingCache = this.validateAndParseJson(value);
         if (
             !parsedThrottlingCache ||
-            !ThrottlingEntity.isThrottlingEntity(
+            !CacheHelpers.isThrottlingEntity(
                 throttlingCacheKey,
                 parsedThrottlingCache
             )
@@ -1131,10 +1131,7 @@ export class BrowserCacheManager extends CacheManager {
         }
 
         this.logger.trace("BrowserCacheManager.getThrottlingCache: cache hit");
-        return CacheManager.toObject(
-            new ThrottlingEntity(),
-            parsedThrottlingCache
-        );
+        return parsedThrottlingCache as ThrottlingEntity;
     }
 
     /**

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -1561,8 +1561,9 @@ describe("BrowserCacheManager tests", () => {
 
                 it("getThrottlingCache returns ThrottlingEntity", () => {
                     const testKey = "throttling";
-                    const testVal = new ThrottlingEntity();
-                    testVal.throttleTime = 60;
+                    const testVal = {
+                        throttleTime: 60,
+                    };
 
                     browserLocalStorage.setThrottlingCache(testKey, testVal);
                     browserSessionStorage.setThrottlingCache(testKey, testVal);
@@ -1570,15 +1571,10 @@ describe("BrowserCacheManager tests", () => {
                     expect(
                         browserSessionStorage.getThrottlingCache(testKey)
                     ).toEqual(testVal);
-                    expect(
-                        browserSessionStorage.getThrottlingCache(testKey)
-                    ).toBeInstanceOf(ThrottlingEntity);
+
                     expect(
                         browserLocalStorage.getThrottlingCache(testKey)
                     ).toEqual(testVal);
-                    expect(
-                        browserLocalStorage.getThrottlingCache(testKey)
-                    ).toBeInstanceOf(ThrottlingEntity);
                 });
             });
 
@@ -2470,8 +2466,7 @@ describe("BrowserCacheManager tests", () => {
 
                 it("getThrottlingCache returns ThrottlingEntity", () => {
                     const testKey = "throttling";
-                    const testVal = new ThrottlingEntity();
-                    testVal.throttleTime = 60;
+                    const testVal = { throttleTime: 60 };
 
                     browserLocalStorage.setThrottlingCache(testKey, testVal);
                     browserSessionStorage.setThrottlingCache(testKey, testVal);
@@ -2480,14 +2475,8 @@ describe("BrowserCacheManager tests", () => {
                         browserSessionStorage.getThrottlingCache(testKey)
                     ).toEqual(testVal);
                     expect(
-                        browserSessionStorage.getThrottlingCache(testKey)
-                    ).toBeInstanceOf(ThrottlingEntity);
-                    expect(
                         browserLocalStorage.getThrottlingCache(testKey)
                     ).toEqual(testVal);
-                    expect(
-                        browserLocalStorage.getThrottlingCache(testKey)
-                    ).toBeInstanceOf(ThrottlingEntity);
                 });
             });
 

--- a/lib/msal-common/src/cache/entities/ThrottlingEntity.ts
+++ b/lib/msal-common/src/cache/entities/ThrottlingEntity.ts
@@ -3,9 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ThrottlingConstants } from "../../utils/Constants";
-
-export class ThrottlingEntity {
+export type ThrottlingEntity = {
     // Unix-time value representing the expiration of the throttle
     throttleTime: number;
     // Information provided by the server
@@ -13,24 +11,4 @@ export class ThrottlingEntity {
     errorCodes?: Array<string>;
     errorMessage?: string;
     subError?: string;
-
-    /**
-     * validates if a given cache entry is "Throttling", parses <key,value>
-     * @param key
-     * @param entity
-     */
-    static isThrottlingEntity(key: string, entity?: object): boolean {
-        let validateKey: boolean = false;
-        if (key) {
-            validateKey =
-                key.indexOf(ThrottlingConstants.THROTTLING_PREFIX) === 0;
-        }
-
-        let validateEntity: boolean = true;
-        if (entity) {
-            validateEntity = entity.hasOwnProperty("throttleTime");
-        }
-
-        return validateKey && validateEntity;
-    }
-}
+};

--- a/lib/msal-common/src/cache/utils/CacheHelpers.ts
+++ b/lib/msal-common/src/cache/utils/CacheHelpers.ts
@@ -14,6 +14,7 @@ import {
     CredentialType,
     SERVER_TELEM_CONSTANTS,
     Separators,
+    ThrottlingConstants,
 } from "../../utils/Constants";
 import { TimeUtils } from "../../utils/TimeUtils";
 import { AccessTokenEntity } from "../entities/AccessTokenEntity";
@@ -326,6 +327,25 @@ export function isServerTelemetryEntity(key: string, entity?: object): boolean {
             entity.hasOwnProperty("failedRequests") &&
             entity.hasOwnProperty("errors") &&
             entity.hasOwnProperty("cacheHits");
+    }
+
+    return validateKey && validateEntity;
+}
+
+/**
+ * validates if a given cache entry is "Throttling", parses <key,value>
+ * @param key
+ * @param entity
+ */
+export function isThrottlingEntity(key: string, entity?: object): boolean {
+    let validateKey: boolean = false;
+    if (key) {
+        validateKey = key.indexOf(ThrottlingConstants.THROTTLING_PREFIX) === 0;
+    }
+
+    let validateEntity: boolean = true;
+    if (entity) {
+        validateEntity = entity.hasOwnProperty("throttleTime");
     }
 
     return validateKey && validateEntity;

--- a/lib/msal-common/test/cache/entities/ThrottlingEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/ThrottlingEntity.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ThrottlingEntity } from "../../../src/cache/entities/ThrottlingEntity";
+import { CacheHelpers } from "../../../src";
 import { ThrottlingConstants, Separators } from "../../../src/utils/Constants";
 import { TEST_CONFIG } from "../../test_kit/StringConstants";
 
@@ -17,24 +17,24 @@ describe("ThrottlingEntity", () => {
             const throttlingObject = {
                 throttleTime: 0,
             };
-            expect(
-                ThrottlingEntity.isThrottlingEntity(key, throttlingObject)
-            ).toBe(true);
+            expect(CacheHelpers.isThrottlingEntity(key, throttlingObject)).toBe(
+                true
+            );
         });
 
         it("Verifies if an object is a ThrottlingEntity when no object is given", () => {
-            expect(ThrottlingEntity.isThrottlingEntity(key)).toBe(true);
+            expect(CacheHelpers.isThrottlingEntity(key)).toBe(true);
             // @ts-ignore
-            expect(ThrottlingEntity.isThrottlingEntity(key, null)).toBe(true);
+            expect(CacheHelpers.isThrottlingEntity(key, null)).toBe(true);
         });
 
         it("Verifies if an object is not a ThrottlingEntity based on field", () => {
             const throttlingObject = {
                 test: 0,
             };
-            expect(
-                ThrottlingEntity.isThrottlingEntity(key, throttlingObject)
-            ).toBe(false);
+            expect(CacheHelpers.isThrottlingEntity(key, throttlingObject)).toBe(
+                false
+            );
         });
 
         it("Verifies if an object is not a ThrottlingEntity based on key", () => {
@@ -42,14 +42,14 @@ describe("ThrottlingEntity", () => {
                 throttleTime: 0,
             };
             expect(
-                ThrottlingEntity.isThrottlingEntity("asd", throttlingObject)
+                CacheHelpers.isThrottlingEntity("asd", throttlingObject)
             ).toBe(false);
-            expect(
-                ThrottlingEntity.isThrottlingEntity("", throttlingObject)
-            ).toBe(false);
+            expect(CacheHelpers.isThrottlingEntity("", throttlingObject)).toBe(
+                false
+            );
             expect(
                 // @ts-ignore
-                ThrottlingEntity.isThrottlingEntity(null, throttlingObject)
+                CacheHelpers.isThrottlingEntity(null, throttlingObject)
             ).toBe(false);
         });
     });

--- a/lib/msal-node/src/cache/NodeStorage.ts
+++ b/lib/msal-node/src/cache/NodeStorage.ts
@@ -421,10 +421,7 @@ export class NodeStorage extends CacheManager {
         ) as ThrottlingEntity;
         if (
             throttlingCache &&
-            ThrottlingEntity.isThrottlingEntity(
-                throttlingCacheKey,
-                throttlingCache
-            )
+            CacheHelpers.isThrottlingEntity(throttlingCacheKey, throttlingCache)
         ) {
             return throttlingCache;
         }


### PR DESCRIPTION
Continues the work to convert all our cache entities from static classes into Types & functions for perf and size