### PR TITLE
Fix token refresh with relative redirectUri

### DIFF
--- a/change/@azure-msal-browser-08c573f5-354f-4cc7-829c-aaab16e17860.json
+++ b/change/@azure-msal-browser-08c573f5-354f-4cc7-829c-aaab16e17860.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "Fix token refreshes with relative redirectUri",
-  "packageName": "@azure/msal-browser",
-  "email": "thomas.norling@microsoft.com",
-  "dependentChangeType": "patch"
+    "type": "patch",
+    "comment": "Fix token refreshes with relative redirectUri #6761",
+    "packageName": "@azure/msal-browser",
+    "email": "thomas.norling@microsoft.com",
+    "dependentChangeType": "patch"
 }

--- a/change/@azure-msal-browser-08c573f5-354f-4cc7-829c-aaab16e17860.json
+++ b/change/@azure-msal-browser-08c573f5-354f-4cc7-829c-aaab16e17860.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix token refreshes with relative redirectUri",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-bdfc362d-71b8-4f7a-81f9-e2bff4f9f887.json
+++ b/change/@azure-msal-common-bdfc362d-71b8-4f7a-81f9-e2bff4f9f887.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix token refreshes with relative redirectUri",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-bdfc362d-71b8-4f7a-81f9-e2bff4f9f887.json
+++ b/change/@azure-msal-common-bdfc362d-71b8-4f7a-81f9-e2bff4f9f887.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "Fix token refreshes with relative redirectUri",
-  "packageName": "@azure/msal-common",
-  "email": "thomas.norling@microsoft.com",
-  "dependentChangeType": "patch"
+    "type": "patch",
+    "comment": "Fix token refreshes with relative redirectUri #6761",
+    "packageName": "@azure/msal-common",
+    "email": "thomas.norling@microsoft.com",
+    "dependentChangeType": "patch"
 }

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -44,6 +44,14 @@ export class SilentRefreshClient extends StandardInteractionClient {
             ...request,
             ...baseRequest,
         };
+
+        if (request.redirectUri) {
+            // Make sure any passed redirectUri is converted to an absolute URL - redirectUri is not a required parameter for refresh token redemption so only include if explicitly provided
+            silentRequest.redirectUri = this.getRedirectUri(
+                request.redirectUri
+            );
+        }
+
         const serverTelemetryManager = this.initializeServerTelemetryManager(
             ApiId.acquireTokenSilent_silentFlow
         );

--- a/lib/msal-common/src/request/CommonSilentFlowRequest.ts
+++ b/lib/msal-common/src/request/CommonSilentFlowRequest.ts
@@ -24,6 +24,8 @@ export type CommonSilentFlowRequest = BaseAuthRequest & {
     account: AccountInfo;
     /** Skip cache lookup and forces network call(s) to get fresh tokens */
     forceRefresh: boolean;
+    /** RedirectUri registered on the app registration - only required in brokering scenarios */
+    redirectUri?: string;
     /** Key value pairs to include on the POST body to the /token endpoint */
     tokenBodyParameters?: StringDict;
     /** If refresh token will expire within the configured value, consider it already expired. Used to pre-emptively invoke interaction when cached refresh token is close to expiry. */


### PR DESCRIPTION
In 3.2.0 we added redirectUri to the /token request in order to support broker scenarios. This caused a regression when refreshing tokens with relative URLs. This PR addresses this issue.

Fixes #6733  