### PR TITLE
AuthorityMetadataEntity refactor into Type

### DIFF
--- a/change/@azure-msal-browser-ec422c16-887b-4752-8ba4-7d499a201fe1.json
+++ b/change/@azure-msal-browser-ec422c16-887b-4752-8ba4-7d499a201fe1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactor AuthorityMetadataEntity into type",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-9527971d-12e8-459d-95da-4a81ed67eeb9.json
+++ b/change/@azure-msal-common-9527971d-12e8-459d-95da-4a81ed67eeb9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactor AuthorityMetadataEntity into type",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-32e7a850-e8e6-46ca-bc70-b99eed7ef131.json
+++ b/change/@azure-msal-node-32e7a850-e8e6-46ca-bc70-b99eed7ef131.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactor AuthorityMetadataEntity into type",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -950,18 +950,12 @@ export class BrowserCacheManager extends CacheManager {
         const parsedMetadata = this.validateAndParseJson(value);
         if (
             parsedMetadata &&
-            AuthorityMetadataEntity.isAuthorityMetadataEntity(
-                key,
-                parsedMetadata
-            )
+            CacheHelpers.isAuthorityMetadataEntity(key, parsedMetadata)
         ) {
             this.logger.trace(
                 "BrowserCacheManager.getAuthorityMetadata: cache hit"
             );
-            return CacheManager.toObject(
-                new AuthorityMetadataEntity(),
-                parsedMetadata
-            );
+            return parsedMetadata as AuthorityMetadataEntity;
         }
         return null;
     }

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -184,6 +184,27 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             NavigationClient.prototype,
             "navigateInternal"
         ).mockImplementation();
+
+        jest.spyOn(
+            CacheManager.prototype,
+            "getAuthorityMetadataByAlias"
+        ).mockImplementation((host) => {
+            const authorityMetadata: AuthorityMetadataEntity = {
+                aliases: [host],
+                preferred_cache: host,
+                preferred_network: host,
+                aliasesFromNetwork: false,
+                canonical_authority: host,
+                authorization_endpoint: "",
+                token_endpoint: "",
+                end_session_endpoint: "",
+                issuer: "",
+                jwks_uri: "",
+                endpointsFromNetwork: false,
+                expiresAt: CacheHelpers.generateAuthorityMetadataExpiresAt(),
+            };
+            return authorityMetadata;
+        });
     });
 
     afterEach(() => {
@@ -5088,21 +5109,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca = (pca as any).controller;
             await pca.initialize();
 
-            sinon
-                .stub(CacheManager.prototype, "getAuthorityMetadataByAlias")
-                .callsFake((host) => {
-                    const authorityMetadata = new AuthorityMetadataEntity();
-                    authorityMetadata.updateCloudDiscoveryMetadata(
-                        {
-                            aliases: [host],
-                            preferred_cache: host,
-                            preferred_network: host,
-                        },
-                        false
-                    );
-                    return authorityMetadata;
-                });
-
             // @ts-ignore
             pca.getBrowserStorage().setAccount(testAccount);
             // @ts-ignore
@@ -5172,20 +5178,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         beforeEach(async () => {
             pca = (pca as any).controller;
             await pca.initialize();
-            sinon
-                .stub(CacheManager.prototype, "getAuthorityMetadataByAlias")
-                .callsFake((host) => {
-                    const authorityMetadata = new AuthorityMetadataEntity();
-                    authorityMetadata.updateCloudDiscoveryMetadata(
-                        {
-                            aliases: [host],
-                            preferred_cache: host,
-                            preferred_network: host,
-                        },
-                        false
-                    );
-                    return authorityMetadata;
-                });
 
             // @ts-ignore
             pca.getBrowserStorage().setAccount(testAccount1);
@@ -5418,21 +5410,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca.getBrowserStorage().setIdTokenCredential(idToken1);
             // @ts-ignore
             pca.getBrowserStorage().setIdTokenCredential(idToken2);
-
-            sinon
-                .stub(CacheManager.prototype, "getAuthorityMetadataByAlias")
-                .callsFake((host) => {
-                    const authorityMetadata = new AuthorityMetadataEntity();
-                    authorityMetadata.updateCloudDiscoveryMetadata(
-                        {
-                            aliases: [host],
-                            preferred_cache: host,
-                            preferred_network: host,
-                        },
-                        false
-                    );
-                    return authorityMetadata;
-                });
         });
 
         afterEach(() => {

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -1404,27 +1404,33 @@ describe("BrowserCacheManager tests", () => {
 
             describe("AuthorityMetadata", () => {
                 const key = `authority-metadata-${TEST_CONFIG.MSAL_CLIENT_ID}-${Constants.DEFAULT_AUTHORITY_HOST}`;
-                const testObj: AuthorityMetadataEntity =
-                    new AuthorityMetadataEntity();
-                testObj.aliases = [Constants.DEFAULT_AUTHORITY_HOST];
-                testObj.preferred_cache = Constants.DEFAULT_AUTHORITY_HOST;
-                testObj.preferred_network = Constants.DEFAULT_AUTHORITY_HOST;
-                testObj.canonical_authority = Constants.DEFAULT_AUTHORITY;
-                testObj.authorization_endpoint =
-                    //@ts-ignore
-                    DEFAULT_OPENID_CONFIG_RESPONSE.body.authorization_endpoint;
-                testObj.token_endpoint =
-                    //@ts-ignore
-                    DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint;
-                testObj.end_session_endpoint =
-                    //@ts-ignore
-                    DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint;
-                //@ts-ignore
-                testObj.issuer = DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer;
-                //@ts-ignore
-                testObj.jwks_uri = DEFAULT_OPENID_CONFIG_RESPONSE.body.jwks_uri;
-                testObj.aliasesFromNetwork = false;
-                testObj.endpointsFromNetwork = false;
+                const testObj: AuthorityMetadataEntity = {
+                    aliases: [Constants.DEFAULT_AUTHORITY_HOST],
+                    preferred_cache: Constants.DEFAULT_AUTHORITY_HOST,
+                    preferred_network: Constants.DEFAULT_AUTHORITY_HOST,
+                    canonical_authority: Constants.DEFAULT_AUTHORITY,
+                    authorization_endpoint:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body
+                            .authorization_endpoint,
+                    token_endpoint:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint,
+                    end_session_endpoint:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body
+                            .end_session_endpoint,
+                    issuer:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer,
+                    jwks_uri:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body.jwks_uri,
+                    aliasesFromNetwork: false,
+                    endpointsFromNetwork: false,
+                    expiresAt:
+                        CacheHelpers.generateAuthorityMetadataExpiresAt(),
+                };
 
                 it("getAuthorityMetadata() returns null if key is not in cache", () => {
                     expect(
@@ -1436,14 +1442,14 @@ describe("BrowserCacheManager tests", () => {
                 });
 
                 it("getAuthorityMetadata() returns null if isAuthorityMetadataEntity returns false", () => {
-                    sinon
-                        .stub(
-                            AuthorityMetadataEntity,
-                            "isAuthorityMetadataEntity"
-                        )
-                        .returns(false);
-                    browserSessionStorage.setAuthorityMetadata(key, testObj);
-                    browserLocalStorage.setAuthorityMetadata(key, testObj);
+                    browserSessionStorage.setAuthorityMetadata(key, {
+                        // @ts-ignore
+                        invalidKey: "invalidValue",
+                    });
+                    browserLocalStorage.setAuthorityMetadata(key, {
+                        // @ts-ignore
+                        invalidKey: "invalidValue",
+                    });
                     expect(
                         browserSessionStorage.getAuthorityMetadata(key)
                     ).toBeNull();
@@ -2308,27 +2314,33 @@ describe("BrowserCacheManager tests", () => {
 
             describe("AuthorityMetadata", () => {
                 const key = `authority-metadata-${TEST_CONFIG.MSAL_CLIENT_ID}-${Constants.DEFAULT_AUTHORITY_HOST}`;
-                const testObj: AuthorityMetadataEntity =
-                    new AuthorityMetadataEntity();
-                testObj.aliases = [Constants.DEFAULT_AUTHORITY_HOST];
-                testObj.preferred_cache = Constants.DEFAULT_AUTHORITY_HOST;
-                testObj.preferred_network = Constants.DEFAULT_AUTHORITY_HOST;
-                testObj.canonical_authority = Constants.DEFAULT_AUTHORITY;
-                testObj.authorization_endpoint =
-                    // @ts-ignore
-                    DEFAULT_OPENID_CONFIG_RESPONSE.body.authorization_endpoint;
-                testObj.token_endpoint =
-                    // @ts-ignore
-                    DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint;
-                testObj.end_session_endpoint =
-                    // @ts-ignore
-                    DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint;
-                // @ts-ignore
-                testObj.issuer = DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer;
-                // @ts-ignore
-                testObj.jwks_uri = DEFAULT_OPENID_CONFIG_RESPONSE.body.jwks_uri;
-                testObj.aliasesFromNetwork = false;
-                testObj.endpointsFromNetwork = false;
+                const testObj: AuthorityMetadataEntity = {
+                    aliases: [Constants.DEFAULT_AUTHORITY_HOST],
+                    preferred_cache: Constants.DEFAULT_AUTHORITY_HOST,
+                    preferred_network: Constants.DEFAULT_AUTHORITY_HOST,
+                    canonical_authority: Constants.DEFAULT_AUTHORITY,
+                    authorization_endpoint:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body
+                            .authorization_endpoint,
+                    token_endpoint:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint,
+                    end_session_endpoint:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body
+                            .end_session_endpoint,
+                    issuer:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer,
+                    jwks_uri:
+                        //@ts-ignore
+                        DEFAULT_OPENID_CONFIG_RESPONSE.body.jwks_uri,
+                    aliasesFromNetwork: false,
+                    endpointsFromNetwork: false,
+                    expiresAt:
+                        CacheHelpers.generateAuthorityMetadataExpiresAt(),
+                };
 
                 it("getAuthorityMetadata() returns null if key is not in cache", () => {
                     expect(
@@ -2340,14 +2352,14 @@ describe("BrowserCacheManager tests", () => {
                 });
 
                 it("getAuthorityMetadata() returns null if isAuthorityMetadataEntity returns false", () => {
-                    sinon
-                        .stub(
-                            AuthorityMetadataEntity,
-                            "isAuthorityMetadataEntity"
-                        )
-                        .returns(false);
-                    browserSessionStorage.setAuthorityMetadata(key, testObj);
-                    browserLocalStorage.setAuthorityMetadata(key, testObj);
+                    browserSessionStorage.setAuthorityMetadata(key, {
+                        // @ts-ignore
+                        invalidKey: "invalidValue",
+                    });
+                    browserLocalStorage.setAuthorityMetadata(key, {
+                        // @ts-ignore
+                        invalidKey: "invalidValue",
+                    });
 
                     expect(
                         browserSessionStorage.getAuthorityMetadata(key)

--- a/lib/msal-common/src/cache/entities/AuthorityMetadataEntity.ts
+++ b/lib/msal-common/src/cache/entities/AuthorityMetadataEntity.ts
@@ -3,13 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { CloudDiscoveryMetadata } from "../../authority/CloudDiscoveryMetadata";
-import { OpenIdConfigResponse } from "../../authority/OpenIdConfigResponse";
-import { AUTHORITY_METADATA_CONSTANTS } from "../../utils/Constants";
-import { TimeUtils } from "../../utils/TimeUtils";
-
 /** @internal */
-export class AuthorityMetadataEntity {
+export type AuthorityMetadataEntity = {
     aliases: Array<string>;
     preferred_cache: string;
     preferred_network: string;
@@ -22,91 +17,4 @@ export class AuthorityMetadataEntity {
     endpointsFromNetwork: boolean;
     expiresAt: number;
     jwks_uri: string;
-
-    constructor() {
-        this.expiresAt =
-            TimeUtils.nowSeconds() +
-            AUTHORITY_METADATA_CONSTANTS.REFRESH_TIME_SECONDS;
-    }
-
-    /**
-     * Update the entity with new aliases, preferred_cache and preferred_network values
-     * @param metadata
-     * @param fromNetwork
-     */
-    updateCloudDiscoveryMetadata(
-        metadata: CloudDiscoveryMetadata,
-        fromNetwork: boolean
-    ): void {
-        this.aliases = metadata.aliases;
-        this.preferred_cache = metadata.preferred_cache;
-        this.preferred_network = metadata.preferred_network;
-        this.aliasesFromNetwork = fromNetwork;
-    }
-
-    /**
-     * Update the entity with new endpoints
-     * @param metadata
-     * @param fromNetwork
-     */
-    updateEndpointMetadata(
-        metadata: OpenIdConfigResponse,
-        fromNetwork: boolean
-    ): void {
-        this.authorization_endpoint = metadata.authorization_endpoint;
-        this.token_endpoint = metadata.token_endpoint;
-        this.end_session_endpoint = metadata.end_session_endpoint;
-        this.issuer = metadata.issuer;
-        this.endpointsFromNetwork = fromNetwork;
-        this.jwks_uri = metadata.jwks_uri;
-    }
-
-    /**
-     * Save the authority that was used to create this cache entry
-     * @param authority
-     */
-    updateCanonicalAuthority(authority: string): void {
-        this.canonical_authority = authority;
-    }
-
-    /**
-     * Reset the exiresAt value
-     */
-    resetExpiresAt(): void {
-        this.expiresAt =
-            TimeUtils.nowSeconds() +
-            AUTHORITY_METADATA_CONSTANTS.REFRESH_TIME_SECONDS;
-    }
-
-    /**
-     * Returns whether or not the data needs to be refreshed
-     */
-    isExpired(): boolean {
-        return this.expiresAt <= TimeUtils.nowSeconds();
-    }
-
-    /**
-     * Validates an entity: checks for all expected params
-     * @param entity
-     */
-    static isAuthorityMetadataEntity(key: string, entity: object): boolean {
-        if (!entity) {
-            return false;
-        }
-
-        return (
-            key.indexOf(AUTHORITY_METADATA_CONSTANTS.CACHE_KEY) === 0 &&
-            entity.hasOwnProperty("aliases") &&
-            entity.hasOwnProperty("preferred_cache") &&
-            entity.hasOwnProperty("preferred_network") &&
-            entity.hasOwnProperty("canonical_authority") &&
-            entity.hasOwnProperty("authorization_endpoint") &&
-            entity.hasOwnProperty("token_endpoint") &&
-            entity.hasOwnProperty("issuer") &&
-            entity.hasOwnProperty("aliasesFromNetwork") &&
-            entity.hasOwnProperty("endpointsFromNetwork") &&
-            entity.hasOwnProperty("expiresAt") &&
-            entity.hasOwnProperty("jwks_uri")
-        );
-    }
-}
+};

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -61,15 +61,21 @@ describe("CacheManager.ts test cases", () => {
         authorityMetadataStub = sinon
             .stub(CacheManager.prototype, "getAuthorityMetadataByAlias")
             .callsFake((host) => {
-                const authorityMetadata = new AuthorityMetadataEntity();
-                authorityMetadata.updateCloudDiscoveryMetadata(
-                    {
-                        aliases: [host],
-                        preferred_cache: host,
-                        preferred_network: host,
-                    },
-                    false
-                );
+                const authorityMetadata: AuthorityMetadataEntity = {
+                    aliases: [host],
+                    preferred_cache: host,
+                    preferred_network: host,
+                    aliasesFromNetwork: false,
+                    canonical_authority: host,
+                    authorization_endpoint: "",
+                    token_endpoint: "",
+                    end_session_endpoint: "",
+                    issuer: "",
+                    jwks_uri: "",
+                    endpointsFromNetwork: false,
+                    expiresAt:
+                        CacheHelpers.generateAuthorityMetadataExpiresAt(),
+                };
                 return authorityMetadata;
             });
     });
@@ -2202,16 +2208,20 @@ describe("CacheManager.ts test cases", () => {
 
     it("getRefreshToken with environment aliases", () => {
         authorityMetadataStub.callsFake((host) => {
-            const authorityMetadata = new AuthorityMetadataEntity();
-            authorityMetadata.updateCloudDiscoveryMetadata(
-                {
-                    aliases: ["login.microsoftonline.com", "login.windows.net"],
-                    preferred_network: host,
-                    preferred_cache: host,
-                },
-                false
-            );
-
+            const authorityMetadata: AuthorityMetadataEntity = {
+                aliases: ["login.microsoftonline.com", "login.windows.net"],
+                preferred_cache: host,
+                preferred_network: host,
+                aliasesFromNetwork: false,
+                canonical_authority: host,
+                authorization_endpoint: "",
+                token_endpoint: "",
+                end_session_endpoint: "",
+                issuer: "",
+                jwks_uri: "",
+                endpointsFromNetwork: false,
+                expiresAt: CacheHelpers.generateAuthorityMetadataExpiresAt(),
+            };
             return authorityMetadata;
         });
         const mockedAccountInfo: AccountInfo = {

--- a/lib/msal-common/test/cache/MockCache.ts
+++ b/lib/msal-common/test/cache/MockCache.ts
@@ -5,7 +5,6 @@
 
 import {
     AppMetadataEntity,
-    AuthorityMetadataEntity,
     CacheManager,
     ICrypto,
     RefreshTokenEntity,
@@ -248,7 +247,7 @@ export class MockCache {
 
     // create authorityMetadata entries
     createAuthorityMetadataEntries(): void {
-        const authorityMetadata_data = {
+        const authorityMetadata = {
             aliases: [
                 "login.microsoftonline.com",
                 "login.windows.net",
@@ -258,7 +257,7 @@ export class MockCache {
             aliasesFromNetwork: false,
             authorization_endpoint:
                 "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-            canonicalAuthority: "https://login.microsoftonline.com/common",
+            canonical_authority: "https://login.microsoftonline.com/common",
             end_session_endpoint:
                 "https://login.microsoftonline.com/common/oauth2/v2.0/logout",
             endpointsFromNetwork: false,
@@ -267,14 +266,11 @@ export class MockCache {
             jwks_uri:
                 "https://login.microsoftonline.com/common/discovery/v2.0/keys",
             preferred_cache: "login.windows.net",
+            preferred_network: "login.microsoftonline.com",
             token_endpoint:
                 "https://login.microsoftonline.com/common/oauth2/v2.0/token",
         };
 
-        const authorityMetadata = CacheManager.toObject(
-            new AuthorityMetadataEntity(),
-            authorityMetadata_data
-        );
         const cacheKey = this.cacheManager.generateAuthorityMetadataCacheKey(
             authorityMetadata.preferred_cache
         );

--- a/lib/msal-common/test/cache/entities/AuthorityMetadataEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AuthorityMetadataEntity.spec.ts
@@ -1,10 +1,10 @@
-import { AuthorityMetadataEntity } from "../../../src/cache/entities/AuthorityMetadataEntity";
 import {
     DEFAULT_OPENID_CONFIG_RESPONSE,
     TEST_CONFIG,
 } from "../../test_kit/StringConstants";
 import { Constants } from "../../../src/utils/Constants";
 import { TimeUtils } from "../../../src/utils/TimeUtils";
+import { CacheHelpers } from "../../../src";
 
 describe("AuthorityMetadataEntity.ts Unit Tests", () => {
     const key = `authority-metadata-${TEST_CONFIG.MSAL_CLIENT_ID}-${Constants.DEFAULT_AUTHORITY_HOST}`;
@@ -26,9 +26,7 @@ describe("AuthorityMetadataEntity.ts Unit Tests", () => {
     };
 
     it("Verify if an object is a AuthorityMetadataEntity", () => {
-        expect(
-            AuthorityMetadataEntity.isAuthorityMetadataEntity(key, testObj)
-        ).toBe(true);
+        expect(CacheHelpers.isAuthorityMetadataEntity(key, testObj)).toBe(true);
     });
 
     it("Verify if an object is a AuthorityMetadataEntity (without end_session_endpoint)", () => {
@@ -36,24 +34,19 @@ describe("AuthorityMetadataEntity.ts Unit Tests", () => {
             ...testObj,
         };
         delete metadata["end_session_endpoint"];
-        expect(
-            AuthorityMetadataEntity.isAuthorityMetadataEntity(key, metadata)
-        ).toBe(true);
+        expect(CacheHelpers.isAuthorityMetadataEntity(key, metadata)).toBe(
+            true
+        );
     });
 
     it("Verify an object is not a AuthorityMetadataEntity", () => {
         expect(
             // @ts-ignore
-            AuthorityMetadataEntity.isAuthorityMetadataEntity(key, null)
+            CacheHelpers.isAuthorityMetadataEntity(key, null)
         ).toBe(false);
-        expect(AuthorityMetadataEntity.isAuthorityMetadataEntity(key, {})).toBe(
-            false
-        );
+        expect(CacheHelpers.isAuthorityMetadataEntity(key, {})).toBe(false);
         expect(
-            AuthorityMetadataEntity.isAuthorityMetadataEntity(
-                "not-a-real-key",
-                testObj
-            )
+            CacheHelpers.isAuthorityMetadataEntity("not-a-real-key", testObj)
         ).toBe(false);
 
         Object.keys(testObj).forEach((key) => {
@@ -61,7 +54,7 @@ describe("AuthorityMetadataEntity.ts Unit Tests", () => {
             delete incompleteTestObject[key];
 
             expect(
-                AuthorityMetadataEntity.isAuthorityMetadataEntity(
+                CacheHelpers.isAuthorityMetadataEntity(
                     key,
                     incompleteTestObject
                 )

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -159,7 +159,7 @@ export class MockStorageClass extends CacheManager {
         return this.store[key] as AuthorityMetadataEntity;
     }
     setAuthorityMetadata(key: string, value: AuthorityMetadataEntity): void {
-        this.store[key] = value;
+        this.store[key] = { ...value };
     }
 
     // Throttling cache

--- a/lib/msal-node/src/cache/NodeStorage.ts
+++ b/lib/msal-node/src/cache/NodeStorage.ts
@@ -383,10 +383,7 @@ export class NodeStorage extends CacheManager {
         ) as AuthorityMetadataEntity;
         if (
             authorityMetadataEntity &&
-            AuthorityMetadataEntity.isAuthorityMetadataEntity(
-                key,
-                authorityMetadataEntity
-            )
+            CacheHelpers.isAuthorityMetadataEntity(key, authorityMetadataEntity)
         ) {
             return authorityMetadataEntity;
         }

--- a/lib/msal-node/test/cache/Storage.spec.ts
+++ b/lib/msal-node/test/cache/Storage.spec.ts
@@ -7,6 +7,7 @@ import {
     AccessTokenEntity,
     IdTokenEntity,
     RefreshTokenEntity,
+    CacheHelpers,
 } from "@azure/msal-common";
 import {
     JsonCache,
@@ -421,22 +422,23 @@ describe("Storage tests for msal-node: ", () => {
         describe("AuthorityMetadata", () => {
             const host = "login.microsoftonline.com";
             const key = `authority-metadata-${clientId}-${host}`;
-            const testObj: AuthorityMetadataEntity =
-                new AuthorityMetadataEntity();
-            testObj.aliases = [host];
-            testObj.preferred_cache = host;
-            testObj.preferred_network = host;
-            testObj.canonical_authority = TEST_CONSTANTS.DEFAULT_AUTHORITY;
-            testObj.authorization_endpoint =
-                DEFAULT_OPENID_CONFIG_RESPONSE.body.authorization_endpoint;
-            testObj.token_endpoint =
-                DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint;
-            testObj.end_session_endpoint =
-                DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint;
-            testObj.issuer = DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer;
-            testObj.jwks_uri = DEFAULT_OPENID_CONFIG_RESPONSE.body.jwks_uri;
-            testObj.aliasesFromNetwork = false;
-            testObj.endpointsFromNetwork = false;
+            const testObj: AuthorityMetadataEntity = {
+                aliases: [host],
+                preferred_cache: host,
+                preferred_network: host,
+                canonical_authority: TEST_CONSTANTS.DEFAULT_AUTHORITY,
+                authorization_endpoint:
+                    DEFAULT_OPENID_CONFIG_RESPONSE.body.authorization_endpoint,
+                token_endpoint:
+                    DEFAULT_OPENID_CONFIG_RESPONSE.body.token_endpoint,
+                end_session_endpoint:
+                    DEFAULT_OPENID_CONFIG_RESPONSE.body.end_session_endpoint,
+                issuer: DEFAULT_OPENID_CONFIG_RESPONSE.body.issuer,
+                jwks_uri: DEFAULT_OPENID_CONFIG_RESPONSE.body.jwks_uri,
+                aliasesFromNetwork: false,
+                endpointsFromNetwork: false,
+                expiresAt: CacheHelpers.generateAuthorityMetadataExpiresAt(),
+            };
 
             it("getAuthorityMetadata() returns null if key is not in cache", () => {
                 const nodeStorage = new NodeStorage(


### PR DESCRIPTION
Continues the work to convert cache entities from Classes into Types for size/perf gains