### PR TITLE
Capitalize first letter in log message

### DIFF
--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -1541,7 +1541,7 @@ export abstract class CacheManager implements ICacheManager {
         }
 
         this.commonLogger.info(
-            "CacheManager:getRefreshToken - returning refresh token"
+            "CacheManager:getRefreshToken - Returning refresh token"
         );
         return refreshTokens[0] as RefreshTokenEntity;
     }


### PR DESCRIPTION
I've made a small adjustment to maintain consistency in log messages. This change capitalizes the first letter in the log message that matches other log patterns.