### PR TITLE
Support state parameter on silent requests

### DIFF
--- a/change/@azure-msal-browser-7d3bb7a6-75d1-4ccb-9260-f874940e1847.json
+++ b/change/@azure-msal-browser-7d3bb7a6-75d1-4ccb-9260-f874940e1847.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support state on acquireTokenSilent",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1950,7 +1950,10 @@ export class StandardController implements IController {
                     throw error;
                 });
             this.activeSilentTokenRequests.set(silentRequestKey, response);
-            return response;
+            return {
+                ...(await response),
+                state: request.state,
+            };
         } else {
             this.logger.verbose(
                 "acquireTokenSilent has been called previously, returning the result from the first call",
@@ -1958,7 +1961,10 @@ export class StandardController implements IController {
             );
             // Discard measurements for memoized calls, as they are usually only a couple of ms and will artificially deflate metrics
             atsMeasurement.discard();
-            return cachedResponse;
+            return {
+                ...(await cachedResponse),
+                state: request.state,
+            };
         }
     }
 

--- a/lib/msal-browser/src/request/SilentRequest.ts
+++ b/lib/msal-browser/src/request/SilentRequest.ts
@@ -45,5 +45,6 @@ export type SilentRequest = Omit<
     forceRefresh?: boolean;
     cacheLookupPolicy?: CacheLookupPolicy;
     prompt?: string;
+    state?: string;
     tokenBodyParameters?: StringDict;
 };

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -3308,7 +3308,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 account: testAccount,
             });
 
-            expect(response).toBe(testTokenResponse);
+            expect(response).toEqual(testTokenResponse);
             expect(nativeAcquireTokenSpy.calledOnce).toBeTruthy();
             expect(silentSpy.calledOnce).toBeTruthy();
         });
@@ -3395,6 +3395,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expiresOn: new Date(Date.now() + 3600000),
                 account: testAccount,
                 tokenType: AuthenticationScheme.BEARER,
+                state: "test-state",
             };
             const silentCacheSpy = sinon
                 .stub(SilentCacheClient.prototype, "acquireToken")
@@ -3411,6 +3412,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const response = await pca.acquireTokenSilent({
                 scopes: ["openid"],
                 account: testAccount,
+                state: "test-state",
             });
             expect(response?.idToken).not.toBeNull();
             expect(response).toEqual(testTokenResponse);
@@ -3440,6 +3442,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expiresOn: new Date(Date.now() + 3600000),
                 account: testAccount,
                 tokenType: AuthenticationScheme.BEARER,
+                state: "test-state",
             };
             const silentCacheSpy = sinon
                 .stub(SilentCacheClient.prototype, "acquireToken")
@@ -3455,6 +3458,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const response = await pca.acquireTokenSilent({
                 scopes: ["openid"],
                 account: testAccount,
+                state: "test-state",
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy.calledOnce).toBe(true);
@@ -3483,6 +3487,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expiresOn: new Date(Date.now() + 3600000),
                 account: testAccount,
                 tokenType: AuthenticationScheme.BEARER,
+                state: "test-state",
             };
             const silentCacheSpy = sinon
                 .stub(SilentCacheClient.prototype, "acquireToken")
@@ -3502,6 +3507,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const response = await pca.acquireTokenSilent({
                 scopes: ["openid"],
                 account: testAccount,
+                state: "test-state",
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy.calledOnce).toBe(true);
@@ -3530,6 +3536,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expiresOn: new Date(Date.now() + 3600000),
                 account: testAccount,
                 tokenType: AuthenticationScheme.BEARER,
+                state: "test-state",
             };
             const silentCacheSpy = sinon
                 .stub(SilentCacheClient.prototype, "acquireToken")
@@ -3548,6 +3555,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const response = await pca.acquireTokenSilent({
                 scopes: ["openid"],
                 account: testAccount,
+                state: "test-state",
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy.calledOnce).toBe(true);


### PR DESCRIPTION
Adds support for `state` parameter on silent requests