### PR TITLE
Fix: Require is not defined in MJS

### DIFF
--- a/change/@azure-msal-node-extensions-0c4a6dbe-42ab-4fa0-a73b-b35ba5b0c611.json
+++ b/change/@azure-msal-node-extensions-0c4a6dbe-42ab-4fa0-a73b-b35ba5b0c611.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Create require when it is not defined in MJS",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "altinokd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/src/Dpapi.ts
+++ b/extensions/msal-node-extensions/src/Dpapi.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { createRequire } from "module";
+
 export interface DpapiBindings {
     protectData(
         dataToEncrypt: Uint8Array,
@@ -29,7 +31,13 @@ let Dpapi: DpapiBindings;
 if (process.platform !== "win32") {
     Dpapi = new defaultDpapi();
 } else {
-    Dpapi = require(`../bin/${process.arch}/dpapi`);
+    // In .mjs files, require is not defined. We need to use createRequire to get a require function
+    const safeRequire =
+        typeof require !== "undefined"
+            ? require
+            : createRequire(import.meta.url);
+
+    Dpapi = safeRequire(`../bin/${process.arch}/dpapi`);
 }
 
 export { Dpapi };

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
     "extensions/msal-node-extensions": {
       "name": "@azure/msal-node-extensions",
       "version": "1.0.9",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "14.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
     "extensions/msal-node-extensions": {
       "name": "@azure/msal-node-extensions",
       "version": "1.0.9",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "14.6.0",


### PR DESCRIPTION
Currently, I'm getting the below error when I use msal-node-extension package in an ES module.

```
ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and 'D:\git\my-repo\node_modules\my-package\package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///D:/git/my-repo/node_modules/@azure/msal-node-extensions/dist/Dpapi.mjs:20:5
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
 ```

To fix this issue, I'm creating the `require` when it's not defined. So that this code is safe to run in both msj and cjs