### PR TITLE
Fix node-extensions tests

### DIFF
--- a/change/@azure-msal-node-extensions-bde7771e-4368-41e9-88a0-365a9979896b.json
+++ b/change/@azure-msal-node-extensions-bde7771e-4368-41e9-88a0-365a9979896b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix tests #6849",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/extensions/msal-node-extensions/jest.config.cjs
+++ b/extensions/msal-node-extensions/jest.config.cjs
@@ -7,5 +7,28 @@ const jestConfig = require("../../shared-configs/jest-config/jest.config.cjs");
 
 module.exports = {
     ...jestConfig,
+    transform: {
+        "^.+\\.tsx?$": [
+            "ts-jest",
+            {
+                // The configuration below is for mocking import.meta.url in DPAPI as jest only has experimental support for ESM
+                diagnostics: {
+                    ignoreCodes: [1343],
+                },
+                astTransformers: {
+                    before: [
+                        {
+                            path: "ts-jest-mock-import-meta",
+                            options: {
+                                metaObjectReplacement: {
+                                    url: "http://localhost:3000",
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+    },
     testEnvironment: "node",
 };

--- a/extensions/msal-node-extensions/package.json
+++ b/extensions/msal-node-extensions/package.json
@@ -72,6 +72,7 @@
     "rollup": "^3.20.2",
     "shx": "^0.3.4",
     "ts-jest": "^29.1.0",
+    "ts-jest-mock-import-meta": "^1.1.0",
     "tslib": "^2.0.0",
     "typescript": "^4.9.5"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
     "extensions/msal-node-extensions": {
       "name": "@azure/msal-node-extensions",
       "version": "1.0.10",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "14.6.1",
@@ -80,6 +81,7 @@
         "rollup": "^3.20.2",
         "shx": "^0.3.4",
         "ts-jest": "^29.1.0",
+        "ts-jest-mock-import-meta": "^1.1.0",
         "tslib": "^2.0.0",
         "typescript": "^4.9.5"
       },
@@ -52307,6 +52309,15 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest-mock-import-meta": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest-mock-import-meta/-/ts-jest-mock-import-meta-1.1.0.tgz",
+      "integrity": "sha512-PTmdWGbDZOPh8vyZUmCTK5PjeD2X3YO25MQPTbm0lMlNFigUDwz3opwXOlsrgD0i5u/MpDX0gdZKoVONxVjVEw==",
+      "dev": true,
+      "peerDependencies": {
+        "ts-jest": ">=20.0.0"
       }
     },
     "node_modules/ts-loader": {


### PR DESCRIPTION
Jest only has experimental support for ESM and is failing when parsing `import.meta` (ESM only) as it's assuming CJS. This PR mocks `import.meta` as suggested [here](https://github.com/kulshekhar/ts-jest/issues/3888#issuecomment-1722524078) to address for the time being. If/when jest/ts-jest address this on their end we can remove this. 