### PR TITLE
Fix failing response handler test because of missing correlation ID

### DIFF
--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -492,7 +492,8 @@ describe("ResponseHandler.ts", () => {
                     cloudDiscoveryMetadata: "",
                     authorityMetadata: "",
                 },
-                logger
+                logger,
+                TEST_CONFIG.CORRELATION_ID
             );
 
             const timestamp = TimeUtils.nowSeconds();


### PR DESCRIPTION
Adds missing correlation ID to authority initializer in ResponseHandler spec