### PR TITLE
Bump browser

### DIFF
--- a/change/@azure-msal-browser-d7f5c16a-135a-4f0a-b09b-ece89250679a.json
+++ b/change/@azure-msal-browser-d7f5c16a-135a-4f0a-b09b-ece89250679a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump browser #6882",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "3.7.1",
+  "version": "3.8.0",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",

--- a/lib/msal-browser/src/packageMetadata.ts
+++ b/lib/msal-browser/src/packageMetadata.ts
@@ -1,3 +1,3 @@
 /* eslint-disable header/header */
 export const name = "@azure/msal-browser";
-export const version = "3.7.1";
+export const version = "3.8.0";


### PR DESCRIPTION
Bumping msal-browser manually so release pipeline bumps it to 3.9.0 and it skips 3.8.0 which was unpublished in msal-browser-1p