### PR TITLE
Fix: Authority string tenant parsing throws error in certain OIDC scenario

### DIFF
--- a/change/@azure-msal-common-b4e1c008-e55c-45dd-8e77-8d3eab080be4.json
+++ b/change/@azure-msal-common-b4e1c008-e55c-45dd-8e77-8d3eab080be4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Prevents error thrown when Authority URL contains no path segments.",
+  "packageName": "@azure/msal-common",
+  "email": "bushb@umich.edu",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -1312,9 +1312,11 @@ export function getTenantFromAuthorityString(
      *  AAD Authority - domain/tenantId -> Credentials are cached with realm = tenantId
      *  B2C Authority - domain/{tenantId}?/.../policy -> Credentials are cached with realm = policy
      *  tenantId is downcased because B2C policies can have mixed case but tfp claim is downcased
+     *
+     * Note that we may not have any path segments in certain OIDC scenarios.
      */
     const tenantId =
-        authorityUrlComponents.PathSegments.slice(-1)[0].toLowerCase();
+        authorityUrlComponents.PathSegments.slice(-1)[0]?.toLowerCase();
 
     switch (tenantId) {
         case AADAuthorityConstants.COMMON:

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -2809,6 +2809,13 @@ describe("Authority.ts Class Unit Tests", () => {
                 getTenantFromAuthorityString(TEST_CONFIG.consumersAuthority)
             ).toBeUndefined();
         });
+
+        it("should not throw if authority has no path segments (certain OIDC scenarios)", () => {
+            const authorityUrl = "https://login.live.com";
+            expect(() =>
+                getTenantFromAuthorityString(authorityUrl)
+            ).not.toThrow();
+        });
     });
 
     describe("formatAuthorityUri", () => {


### PR DESCRIPTION
The authority string tenant parsing assumes that the authority URL will always have at least one PathSegment. This is not true in the case an application is using a separate OIDC-compliant authority. This handles this case gracefully, ultimately allowing the cached token to be reused.