### PR TITLE
Fix compatibility issues with Nested App Auth and msal-react

### DIFF
--- a/change/@azure-msal-browser-dd178f11-067c-4ea4-8f95-b933bca97ed0.json
+++ b/change/@azure-msal-browser-dd178f11-067c-4ea4-8f95-b933bca97ed0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix compatibility issue with Nested App Auth and msal-react (#6892)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -116,25 +116,43 @@ export class NestedAppAuthController implements IController {
         return Promise.resolve();
     }
 
+    private ensureValidRequest<
+        T extends
+            | SsoSilentRequest
+            | SilentRequest
+            | PopupRequest
+            | RedirectRequest
+    >(request: T) {
+        if (request?.correlationId) {
+            return request;
+        }
+        return {
+            ...request,
+            correlationId: this.browserCrypto.createNewGuid(),
+        };
+    }
+
     private async acquireTokenInteractive(
         request: PopupRequest | RedirectRequest
     ): Promise<AuthenticationResult> {
+        const validRequest = this.ensureValidRequest(request);
+
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
             InteractionType.Popup,
-            request
+            validRequest
         );
 
         const atPopupMeasurement = this.performanceClient.startMeasurement(
             PerformanceEvents.AcquireTokenPopup,
-            request.correlationId
+            validRequest.correlationId
         );
 
         atPopupMeasurement?.add({ nestedAppAuthRequest: true });
 
         try {
             const naaRequest =
-                this.nestedAppAuthAdapter.toNaaTokenRequest(request);
+                this.nestedAppAuthAdapter.toNaaTokenRequest(validRequest);
             const reqTimestamp = TimeUtils.nowSeconds();
             const response = await this.bridgeProxy.getTokenInteractive(
                 naaRequest
@@ -186,15 +204,16 @@ export class NestedAppAuthController implements IController {
     private async acquireTokenSilentInternal(
         request: SilentRequest
     ): Promise<AuthenticationResult> {
+        const validRequest = this.ensureValidRequest(request);
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
             InteractionType.Silent,
-            request
+            validRequest
         );
 
         const ssoSilentMeasurement = this.performanceClient.startMeasurement(
             PerformanceEvents.SsoSilent,
-            request.correlationId
+            validRequest.correlationId
         );
 
         ssoSilentMeasurement?.increment({
@@ -207,7 +226,7 @@ export class NestedAppAuthController implements IController {
 
         try {
             const naaRequest =
-                this.nestedAppAuthAdapter.toNaaTokenRequest(request);
+                this.nestedAppAuthAdapter.toNaaTokenRequest(validRequest);
             const reqTimestamp = TimeUtils.nowSeconds();
             const response = await this.bridgeProxy.getTokenSilent(naaRequest);
 
@@ -392,7 +411,7 @@ export class NestedAppAuthController implements IController {
     handleRedirectPromise(
         hash?: string | undefined // eslint-disable-line @typescript-eslint/no-unused-vars
     ): Promise<AuthenticationResult | null> {
-        throw NestedAppAuthError.createUnsupportedError();
+        return Promise.resolve(null);
     }
     loginPopup(
         request?: PopupRequest | undefined // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -122,7 +122,7 @@ export class NestedAppAuthController implements IController {
             | SilentRequest
             | PopupRequest
             | RedirectRequest
-    >(request: T) {
+    >(request: T): T {
         if (request?.correlationId) {
             return request;
         }

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -58,7 +58,6 @@ export class NestedAppAuthAdapter {
             | SilentRequest
             | SsoSilentRequest
     ): TokenRequest {
-        request.authority;
         let extraParams: Map<string, string>;
         if (request.extraQueryParameters === undefined) {
             extraParams = new Map<string, string>();

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -23,12 +23,15 @@ import {
     RequestParameterBuilder,
     StringUtils,
     createClientAuthError,
+    OIDC_DEFAULT_SCOPES,
 } from "@azure/msal-common";
 import { isBridgeError } from "../BridgeError";
 import { BridgeStatusCode } from "../BridgeStatusCode";
 import { AuthenticationResult } from "../../response/AuthenticationResult";
 import {} from "../../error/BrowserAuthErrorCodes";
 import { AuthResult } from "../AuthResult";
+import { SsoSilentRequest } from "../../request/SsoSilentRequest";
+import { SilentRequest } from "../../request/SilentRequest";
 
 export class NestedAppAuthAdapter {
     protected crypto: ICrypto;
@@ -49,8 +52,13 @@ export class NestedAppAuthAdapter {
     }
 
     public toNaaTokenRequest(
-        request: PopupRequest | RedirectRequest
+        request:
+            | PopupRequest
+            | RedirectRequest
+            | SilentRequest
+            | SsoSilentRequest
     ): TokenRequest {
+        request.authority;
         let extraParams: Map<string, string>;
         if (request.extraQueryParameters === undefined) {
             extraParams = new Map<string, string>();
@@ -65,11 +73,12 @@ export class NestedAppAuthAdapter {
             request.claims,
             this.clientCapabilities
         );
+        const scopes = request.scopes || OIDC_DEFAULT_SCOPES;
         const tokenRequest: TokenRequest = {
             platformBrokerId: request.account?.homeAccountId,
             clientId: this.clientId,
             authority: request.authority,
-            scope: request.scopes.join(" "),
+            scope: scopes.join(" "),
             correlationId:
                 request.correlationId !== undefined
                     ? request.correlationId


### PR DESCRIPTION
There were a few bugs that were blocking usage of msal-react in the Nested App Auth code path.

1. handleRedirectPromise was throwing an error, and msal-react depends on calling this before it sets user authenticated status.
2. The function useMsalAuthentication takes request as an optional parameter, although Nested App Auth code path was considering it a required parameter. It was throwing exceptions if request was undefined, and correlation id is not generated until after performance event starts for requests.