### PR TITLE
Remove invalid prompt for silent request instead of throwing an error

### DIFF
--- a/change/@azure-msal-browser-92a9fdcc-89e6-4dbf-a598-c7ce652171cd.json
+++ b/change/@azure-msal-browser-92a9fdcc-89e6-4dbf-a598-c7ce652171cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove invalid prompt for silent request instead of throwing an error #6895",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -93,15 +93,16 @@ export class SilentIframeClient extends StandardInteractionClient {
             );
         }
 
-        // Check that prompt is set to none or no_session, throw error if it is set to anything else.
+        // Check the prompt value
         if (
             request.prompt &&
             request.prompt !== PromptValue.NONE &&
             request.prompt !== PromptValue.NO_SESSION
         ) {
-            throw createBrowserAuthError(
-                BrowserAuthErrorCodes.silentPromptValueError
+            this.logger.verbose(
+                `SilentIframeClient. Removing invalid prompt ${request.prompt}`
             );
+            delete request.prompt;
         }
 
         // Create silent request

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -94,15 +94,19 @@ export class SilentIframeClient extends StandardInteractionClient {
         }
 
         // Check the prompt value
-        if (
-            request.prompt &&
-            request.prompt !== PromptValue.NONE &&
-            request.prompt !== PromptValue.NO_SESSION
-        ) {
-            this.logger.verbose(
-                `SilentIframeClient. Removing invalid prompt ${request.prompt}`
-            );
-            delete request.prompt;
+        const inputRequest = { ...request };
+        if (inputRequest.prompt) {
+            if (
+                inputRequest.prompt !== PromptValue.NONE &&
+                inputRequest.prompt !== PromptValue.NO_SESSION
+            ) {
+                this.logger.warning(
+                    `SilentIframeClient. Replacing invalid prompt ${inputRequest.prompt} with ${PromptValue.NONE}`
+                );
+                inputRequest.prompt = PromptValue.NONE;
+            }
+        } else {
+            inputRequest.prompt = PromptValue.NONE;
         }
 
         // Create silent request
@@ -112,13 +116,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(
-            {
-                ...request,
-                prompt: request.prompt || PromptValue.NONE,
-            },
-            InteractionType.Silent
-        );
+        )(inputRequest, InteractionType.Silent);
         BrowserUtils.preconnect(silentRequest.authority);
 
         const serverTelemetryManager = this.initializeServerTelemetryManager(


### PR DESCRIPTION
- Remove invalid prompt for silent request instead of throwing an error.

Fixes an issue when request prompt bleeds from msal-react MsalAuthenticationTemplate into ATS silentIframeClient.