### PR TITLE
Fix MSA e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "extensions/msal-node-extensions": {
             "name": "@azure/msal-node-extensions",
             "version": "1.0.11",
+            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-common": "14.7.0",

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -307,22 +307,22 @@ export async function enterCredentials(
             throw e;
         });
     } catch (e) {
-        return;
-    }
-
-    // keep me signed in MSA
-    try {
-        await page.waitForSelector("#kmsiTitle", { timeout: 1000 });
-        await screenshot.takeScreenshot(page, "keepMeSignedInPage");
-        await Promise.all([
-            page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG),
-            page.click("#acceptButton"),
-        ]).catch(async (e) => {
-            await screenshot.takeScreenshot(page, "errorPage").catch(() => {});
-            throw e;
-        });
-    } catch (e) {
-        return;
+        // keep me signed in MSA
+        try {
+            await page.waitForSelector("#kmsiTitle", { timeout: 1000 });
+            await screenshot.takeScreenshot(page, "keepMeSignedInPage");
+            await Promise.all([
+                page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG),
+                page.click("#acceptButton"),
+            ]).catch(async (e) => {
+                await screenshot
+                    .takeScreenshot(page, "errorPage")
+                    .catch(() => {});
+                throw e;
+            });
+        } catch (e) {
+            return;
+        }
     }
 
     // agce: private tenant sign in page

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -297,18 +297,17 @@ export async function enterCredentials(
 
     // keep me signed in page
     try {
-        let buttonTag;
         const aadKmsi = page
             .waitForSelector("#idSIButton9", { timeout: 1000 })
             .then(() => {
-                buttonTag = "#idSIButton9";
+                return "#idSIButton9";
             });
         const msaKmsi = page
             .waitForSelector("#kmsiTitle", { timeout: 1000 })
             .then(() => {
-                buttonTag = "#acceptButton";
+                return "#acceptButton";
             });
-        await Promise.race([aadKmsi, msaKmsi]);
+        const buttonTag = await Promise.race([aadKmsi, msaKmsi]);
         await screenshot.takeScreenshot(page, "keepMeSignedInPage");
         await Promise.all([
             page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG),

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -297,32 +297,28 @@ export async function enterCredentials(
 
     // keep me signed in page
     try {
-        await page.waitForSelector("#idSIButton9", { timeout: 1000 });
+        let buttonTag;
+        const aadKmsi = page
+            .waitForSelector("#idSIButton9", { timeout: 1000 })
+            .then(() => {
+                buttonTag = "#idSIButton9";
+            });
+        const msaKmsi = page
+            .waitForSelector("#kmsiTitle", { timeout: 1000 })
+            .then(() => {
+                buttonTag = "#acceptButton";
+            });
+        await Promise.race([aadKmsi, msaKmsi]);
         await screenshot.takeScreenshot(page, "keepMeSignedInPage");
         await Promise.all([
             page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG),
-            page.click("#idSIButton9"),
+            page.click(buttonTag),
         ]).catch(async (e) => {
             await screenshot.takeScreenshot(page, "errorPage").catch(() => {});
             throw e;
         });
     } catch (e) {
-        // keep me signed in MSA
-        try {
-            await page.waitForSelector("#kmsiTitle", { timeout: 1000 });
-            await screenshot.takeScreenshot(page, "keepMeSignedInPage");
-            await Promise.all([
-                page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG),
-                page.click("#acceptButton"),
-            ]).catch(async (e) => {
-                await screenshot
-                    .takeScreenshot(page, "errorPage")
-                    .catch(() => {});
-                throw e;
-            });
-        } catch (e) {
-            return;
-        }
+        return;
     }
 
     // agce: private tenant sign in page

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -297,11 +297,11 @@ export async function enterCredentials(
 
     // keep me signed in page
     try {
-        await page.waitForSelector("#idSIButton9", { timeout: 1000 });
+        await page.waitForSelector("#kmsiTitle", { timeout: 1000 });
         await screenshot.takeScreenshot(page, "keepMeSignedInPage");
         await Promise.all([
             page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG),
-            page.click("#idSIButton9"),
+            page.click("#acceptButton"),
         ]).catch(async (e) => {
             await screenshot.takeScreenshot(page, "errorPage").catch(() => {});
             throw e;

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -297,6 +297,21 @@ export async function enterCredentials(
 
     // keep me signed in page
     try {
+        await page.waitForSelector("#idSIButton9", { timeout: 1000 });
+        await screenshot.takeScreenshot(page, "keepMeSignedInPage");
+        await Promise.all([
+            page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG),
+            page.click("#idSIButton9"),
+        ]).catch(async (e) => {
+            await screenshot.takeScreenshot(page, "errorPage").catch(() => {});
+            throw e;
+        });
+    } catch (e) {
+        return;
+    }
+
+    // keep me signed in MSA
+    try {
         await page.waitForSelector("#kmsiTitle", { timeout: 1000 });
         await screenshot.takeScreenshot(page, "keepMeSignedInPage");
         await Promise.all([

--- a/samples/msal-react-samples/b2c-sample/test/msa-account.spec.ts
+++ b/samples/msal-react-samples/b2c-sample/test/msa-account.spec.ts
@@ -113,6 +113,7 @@ describe("B2C user-flow tests (msa account)", () => {
             await editProfileButton.click();
         }
         let displayName = (Math.random() + 1).toString(36).substring(7); // generate a random string
+        await page.waitForNavigation();
         await page.waitForSelector("#attributeVerification", { visible: true });
         await page.$eval("#displayName", (el: any) => (el.value = "")), // clear the text field
             await page.type("#displayName", `${displayName}`),


### PR DESCRIPTION
This PR:
- Replaces sign-in button ID with #kmsiTitle ID for KMSI page in MSA flows