### PR TITLE
Add ID Token secret to AccountInfo in all reponses

### DIFF
--- a/change/@azure-msal-browser-af35c487-7a43-42cf-ac76-963628c56965.json
+++ b/change/@azure-msal-browser-af35c487-7a43-42cf-ac76-963628c56965.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add ID Token secret to AccountInfo in all reponses #6903",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-e0a01d96-1412-41e7-b8f8-7743a0cc3936.json
+++ b/change/@azure-msal-common-e0a01d96-1412-41e7-b8f8-7743a0cc3936.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add ID Token secret to AccountInfo in all reponses #6903",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-4ec87814-6ab3-433f-a0b5-ca19ce520c81.json
+++ b/change/@azure-msal-node-4ec87814-6ab3-433f-a0b5-ca19ce520c81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add ID Token secret to AccountInfo in all reponses #6903",
+  "packageName": "@azure/msal-node",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -262,6 +262,7 @@ export class NativeInteractionClient extends BaseInteractionClient {
             const fullAccount = {
                 ...account,
                 idTokenClaims: result?.idTokenClaims as TokenClaims,
+                idToken: result?.idToken,
             };
 
             return {

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -611,7 +611,8 @@ export class NativeInteractionClient extends BaseInteractionClient {
         const accountInfo: AccountInfo | null = updateAccountTenantProfileData(
             accountEntity.getAccountInfo(),
             undefined, // tenantProfile optional
-            idTokenClaims
+            idTokenClaims,
+            response.id_token
         );
 
         /**

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -5231,6 +5231,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         const matchAccount: AccountInfo = {
             ...testAccountInfo,
             idTokenClaims: ID_TOKEN_CLAIMS,
+            idToken: TEST_TOKENS.IDTOKEN_V2,
         };
 
         const testIdToken: IdTokenEntity = buildIdToken(
@@ -5282,6 +5283,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             buildAccountFromIdTokenClaims(ID_TOKEN_CLAIMS);
         const testAccountInfo1: AccountInfo = testAccount1.getAccountInfo();
         testAccountInfo1.idTokenClaims = ID_TOKEN_CLAIMS;
+        testAccountInfo1.idToken = TEST_TOKENS.IDTOKEN_V2;
 
         testAccount1.clientInfo =
             TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
@@ -5298,6 +5300,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             buildAccountFromIdTokenClaims(ID_TOKEN_ALT_CLAIMS);
         const testAccountInfo2: AccountInfo = testAccount2.getAccountInfo();
         testAccountInfo2.idTokenClaims = ID_TOKEN_ALT_CLAIMS;
+        testAccountInfo2.idToken = TEST_TOKENS.IDTOKEN_V2_ALT;
 
         testAccount2.clientInfo =
             TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED;
@@ -5508,6 +5511,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         const testAccountInfo1: AccountInfo = {
             ...testAccount1.getAccountInfo(),
             idTokenClaims: ID_TOKEN_CLAIMS,
+            idToken: TEST_TOKENS.IDTOKEN_V2,
         };
 
         const idToken1: IdTokenEntity = buildIdToken(
@@ -5523,6 +5527,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         const testAccountInfo2: AccountInfo = {
             ...testAccount2.getAccountInfo(),
             idTokenClaims: ID_TOKEN_ALT_CLAIMS,
+            idToken: TEST_TOKENS.IDTOKEN_V2_ALT,
         };
 
         const idToken2: IdTokenEntity = buildIdToken(
@@ -5850,6 +5855,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
         const testAccount: AccountInfo = {
             ...buildAccountFromIdTokenClaims(ID_TOKEN_CLAIMS).getAccountInfo(),
             idTokenClaims: ID_TOKEN_CLAIMS,
+            idToken: TEST_TOKENS.IDTOKEN_V2,
         };
 
         const testAuthenticationResult: AuthenticationResult = {

--- a/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
@@ -76,6 +76,7 @@ const testAccountEntity: AccountEntity = buildAccountFromIdTokenClaims(
 const TEST_ACCOUNT_INFO: AccountInfo = {
     ...testAccountEntity.getAccountInfo(),
     idTokenClaims: ID_TOKEN_CLAIMS,
+    idToken: TEST_TOKENS.IDTOKEN_V2,
 };
 
 const TEST_ID_TOKEN: IdTokenEntity = buildIdToken(

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -3711,6 +3711,7 @@ describe("RedirectClient", () => {
             const testAccountInfo: AccountInfo = {
                 ...testAccountEntity.getAccountInfo(),
                 idTokenClaims: ID_TOKEN_CLAIMS,
+                idToken: TEST_TOKENS.IDTOKEN_V2,
             };
 
             const testIdToken: IdTokenEntity = buildIdToken(

--- a/lib/msal-browser/test/interaction_client/SilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentCacheClient.spec.ts
@@ -34,6 +34,7 @@ const testAccountEntity: AccountEntity = buildAccountFromIdTokenClaims(
 const testAccount: AccountInfo = {
     ...testAccountEntity.getAccountInfo(),
     idTokenClaims: ID_TOKEN_CLAIMS,
+    idToken: TEST_TOKENS.IDTOKEN_V2,
 };
 
 const testIdToken: IdTokenEntity = buildIdToken(
@@ -135,7 +136,6 @@ describe("SilentCacheClient", () => {
             sinon
                 .stub(CacheManager.prototype, "getRefreshToken")
                 .returns(testRefreshTokenEntity);
-
             await expect(
                 silentCacheClient.acquireToken({
                     authority: TEST_CONFIG.validAuthority,

--- a/lib/msal-common/src/account/AccountInfo.ts
+++ b/lib/msal-common/src/account/AccountInfo.ts
@@ -106,7 +106,8 @@ export function buildTenantProfileFromIdTokenClaims(
 export function updateAccountTenantProfileData(
     baseAccountInfo: AccountInfo,
     tenantProfile?: TenantProfile,
-    idTokenClaims?: TokenClaims
+    idTokenClaims?: TokenClaims,
+    idTokenSecret?: string
 ): AccountInfo {
     let updatedAccountInfo = baseAccountInfo;
     // Tenant Profile overrides passed in account info
@@ -130,6 +131,7 @@ export function updateAccountTenantProfileData(
             ...updatedAccountInfo,
             ...claimsSourcedTenantProfile,
             idTokenClaims: idTokenClaims,
+            idToken: idTokenSecret,
         };
 
         return updatedAccountInfo;

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -373,7 +373,8 @@ export abstract class CacheManager implements ICacheManager {
         tenantedAccountInfo = updateAccountTenantProfileData(
             accountInfo,
             tenantProfile,
-            idTokenClaims
+            idTokenClaims,
+            idToken?.secret
         );
 
         return tenantedAccountInfo;

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -257,7 +257,8 @@ export class SilentFlowClient extends BaseClient {
             cacheRecord,
             true,
             request,
-            idTokenClaims
+            idTokenClaims,
+            cacheRecord.idToken?.secret
         );
     }
 }

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -257,8 +257,7 @@ export class SilentFlowClient extends BaseClient {
             cacheRecord,
             true,
             request,
-            idTokenClaims,
-            cacheRecord.idToken?.secret
+            idTokenClaims
         );
     }
 }

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -625,7 +625,8 @@ export class ResponseHandler {
             ? updateAccountTenantProfileData(
                   cacheRecord.account.getAccountInfo(),
                   undefined, // tenantProfile optional
-                  idTokenClaims
+                  idTokenClaims,
+                  cacheRecord.idToken?.secret
               )
             : null;
 

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -309,6 +309,7 @@ describe("RefreshTokenClient unit tests", () => {
         const testAccount: AccountInfo =
             buildAccountFromIdTokenClaims(ID_TOKEN_CLAIMS).getAccountInfo();
         testAccount.idTokenClaims = ID_TOKEN_CLAIMS;
+        testAccount.idToken = TEST_TOKENS.IDTOKEN_V2;
 
         beforeEach(async () => {
             sinon
@@ -1057,6 +1058,7 @@ describe("RefreshTokenClient unit tests", () => {
         const testAccount: AccountInfo =
             buildAccountFromIdTokenClaims(ID_TOKEN_CLAIMS).getAccountInfo();
         testAccount.idTokenClaims = ID_TOKEN_CLAIMS;
+        testAccount.idToken = TEST_TOKENS.IDTOKEN_V2;
 
         beforeEach(async () => {
             sinon

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -11,6 +11,7 @@ import {
     TEST_DATA_CLIENT_INFO,
     ID_TOKEN_CLAIMS,
     TEST_URIS,
+    TEST_TOKENS,
 } from "../test_kit/StringConstants";
 import { BaseClient } from "../../src/client/BaseClient";
 import {
@@ -63,6 +64,7 @@ const testAccountEntity: AccountEntity =
 const testAccount: AccountInfo = {
     ...testAccountEntity.getAccountInfo(),
     idTokenClaims: ID_TOKEN_CLAIMS,
+    idToken: TEST_TOKENS.IDTOKEN_V2,
 };
 
 const testIdToken: IdTokenEntity = {

--- a/lib/msal-node/test/utils/TestConstants.ts
+++ b/lib/msal-node/test/utils/TestConstants.ts
@@ -231,6 +231,7 @@ export const mockAccountInfo: AccountInfo = {
     tenantId: ID_TOKEN_CLAIMS.tid,
     username: ID_TOKEN_CLAIMS.preferred_username,
     idTokenClaims: ID_TOKEN_CLAIMS,
+    idToken: TEST_CONSTANTS.ID_TOKEN,
     name: ID_TOKEN_CLAIMS.name,
     nativeAccountId: undefined,
     tenantProfiles: new Map<string, TenantProfile>([


### PR DESCRIPTION
This PR:
- Adds the ID token to the account info object updated from tenant profiles
- Fixes #6900 