### PR TITLE
Remove bumpDeps false from beachball:bump:ci command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "beachball:bump": "beachball bump --branch origin/dev --bumpDeps false && node release-scripts/updateVersion.js",
         "beachball:bump:alpha": "beachball bump --branch origin/dev --bumpDeps false --prerelease-prefix alpha",
         "beachball:bump:beta": "beachball bump --branch origin/dev --bumpDeps false --prerelease-prefix beta",
-        "beachball:bump:official": "beachball bump --branch origin/dev --bumpDeps false",
+        "beachball:bump:official": "beachball bump --branch origin/dev",
         "beachball:release": "node ./.github/create-releases.js"
     },
     "workspaces": [


### PR DESCRIPTION
This PR:
- Removes bumpDeps false from package.json so dependent packages get bumped correctly