### PR TITLE
Append default scopes for the cache lookup

### DIFF
--- a/change/@azure-msal-common-8f860c9f-2980-4d15-b9d8-a8d815cf775a.json
+++ b/change/@azure-msal-common-8f860c9f-2980-4d15-b9d8-a8d815cf775a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Append default scopes for the cache lookup #6909",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -45,10 +45,9 @@ export class SilentFlowClient extends BaseClient {
         try {
             const [authResponse, cacheOutcome] = await this.acquireCachedToken({
                 ...request,
-                scopes:
-                    request.scopes?.length === 0
-                        ? [...OIDC_DEFAULT_SCOPES]
-                        : request.scopes,
+                scopes: request.scopes?.length
+                    ? request.scopes
+                    : [...OIDC_DEFAULT_SCOPES],
             });
 
             // if the token is not expired but must be refreshed; get a new one in the background

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -16,7 +16,7 @@ import {
 } from "../error/ClientAuthError";
 import { ResponseHandler } from "../response/ResponseHandler";
 import { CacheRecord } from "../cache/entities/CacheRecord";
-import { CacheOutcome } from "../utils/Constants";
+import { CacheOutcome, OIDC_DEFAULT_SCOPES } from "../utils/Constants";
 import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient";
 import { StringUtils } from "../utils/StringUtils";
 import { checkMaxAge, extractTokenClaims } from "../account/AuthToken";
@@ -43,9 +43,13 @@ export class SilentFlowClient extends BaseClient {
         request: CommonSilentFlowRequest
     ): Promise<AuthenticationResult> {
         try {
-            const [authResponse, cacheOutcome] = await this.acquireCachedToken(
-                request
-            );
+            const [authResponse, cacheOutcome] = await this.acquireCachedToken({
+                ...request,
+                scopes:
+                    request.scopes?.length === 0
+                        ? [...OIDC_DEFAULT_SCOPES]
+                        : request.scopes,
+            });
 
             // if the token is not expired but must be refreshed; get a new one in the background
             if (cacheOutcome === CacheOutcome.PROACTIVELY_REFRESHED) {


### PR DESCRIPTION
Changes:
- Append default scopes for the cache lookup.

Context:
ATS flow bypasses the cache and acquires a token from network if scopes are set to undefined or empty array due to the [scope validation logic](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/ae92c9a9fefcdc98b3bff206d66c9bc4db1db76c/lib/msal-common/src/request/ScopeSet.ts#L79). We need to append default scopes for cache lookup to make ATS cache and network flows consistent and improve perf for clients who are not providing scopes.
