### PR TITLE
Add 1p and 3p fallback logic to test utils environment variable setup

### DIFF
--- a/samples/e2eTestUtils/src/LabClient.ts
+++ b/samples/e2eTestUtils/src/LabClient.ts
@@ -9,7 +9,20 @@ import {
 import { LabApiQueryParams } from "./LabApiQueryParams";
 import * as dotenv from "dotenv";
 
-dotenv.config({ path: __dirname + `/../../../.env` });
+// Try 1p repo config first
+dotenv.config({ path: __dirname + `/../../../../.env` });
+// If CLIENT_ID is not set, try the 3p repo for test env config
+if (process.env[ENV_VARIABLES.CLIENT_ID]) {
+    console.log("Found test environment variables in 1p directory");
+} else {
+    console.log(
+        "Test environment variables in 1p directory not found, trying 3p directory"
+    );
+    dotenv.config({ path: __dirname + `/../../../.env` });
+    if (process.env[ENV_VARIABLES.CLIENT_ID]) {
+        console.log("Found test environment variables in 3p directory");
+    }
+}
 
 export class LabClient {
     private credentials: ClientSecretCredential;

--- a/samples/e2eTestUtils/src/LabClient.ts
+++ b/samples/e2eTestUtils/src/LabClient.ts
@@ -12,16 +12,8 @@ import * as dotenv from "dotenv";
 // Try 1p repo config first
 dotenv.config({ path: __dirname + `/../../../../.env` });
 // If CLIENT_ID is not set, try the 3p repo for test env config
-if (process.env[ENV_VARIABLES.CLIENT_ID]) {
-    console.log("Found test environment variables in 1p directory");
-} else {
-    console.log(
-        "Test environment variables in 1p directory not found, trying 3p directory"
-    );
+if (!process.env[ENV_VARIABLES.CLIENT_ID]) {
     dotenv.config({ path: __dirname + `/../../../.env` });
-    if (process.env[ENV_VARIABLES.CLIENT_ID]) {
-        console.log("Found test environment variables in 3p directory");
-    }
 }
 
 export class LabClient {


### PR DESCRIPTION
Currently LabClient test utils search for a .env file in the 3p repo only. If the .env file is placed in the msal-javascript-1p directory, it won't find them for local testing. This PR prioritizes the higher-level .env and falls back to the 3p .env file if the test env variables aren't found there.