### PR TITLE
Remove preflightBrowserEnvironmentCheck from Controller

### DIFF
--- a/change/@azure-msal-browser-e1f0a45c-bbe4-44c5-9f03-edfe1fde1c78.json
+++ b/change/@azure-msal-browser-e1f0a45c-bbe4-44c5-9f03-edfe1fde1c78.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Move preflightBrowserEnvironmentCheck to BrowserUtils",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -15,7 +15,7 @@ import { PopupRequest } from "../request/PopupRequest";
 import { SilentRequest } from "../request/SilentRequest";
 import { SsoSilentRequest } from "../request/SsoSilentRequest";
 import { EndSessionRequest } from "../request/EndSessionRequest";
-import { ApiId, InteractionType, WrapperSKU } from "../utils/BrowserConstants";
+import { ApiId, WrapperSKU } from "../utils/BrowserConstants";
 import { INavigationClient } from "../navigation/INavigationClient";
 import { EndSessionPopupRequest } from "../request/EndSessionPopupRequest";
 import { ITokenCache } from "../cache/ITokenCache";

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -119,10 +119,4 @@ export interface IController {
 
     /** @internal */
     getEventHandler(): EventHandler;
-
-    /** @internal */
-    preflightBrowserEnvironmentCheck(
-        interactionType: InteractionType,
-        isAppEmbedded?: boolean
-    ): void;
 }

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -502,12 +502,6 @@ export class NestedAppAuthController implements IController {
     getRedirectResponse(): Map<string, Promise<AuthenticationResult | null>> {
         throw NestedAppAuthError.createUnsupportedError();
     }
-    preflightBrowserEnvironmentCheck(
-        interactionType: InteractionType, // eslint-disable-line @typescript-eslint/no-unused-vars
-        setInteractionInProgress?: boolean | undefined // eslint-disable-line @typescript-eslint/no-unused-vars
-    ): void {
-        throw NestedAppAuthError.createUnsupportedError();
-    }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async clearCache(logoutRequest?: ClearCacheRequest): Promise<void> {

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -525,7 +525,8 @@ export class StandardController implements IController {
         // Preflight request
         const correlationId = this.getRequestCorrelationId(request);
         this.logger.verbose("acquireTokenRedirect called", correlationId);
-        this.preflightBrowserEnvironmentCheck(InteractionType.Redirect);
+        BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
+        this.browserStorage.setInteractionInProgress(true);
 
         // If logged in, emit acquire token events
         const isLoggedIn = this.getAllAccounts().length > 0;
@@ -579,7 +580,7 @@ export class StandardController implements IController {
                             this.createRedirectClient(correlationId);
                         return redirectClient.acquireToken(request);
                     }
-                    this.getBrowserStorage().setInteractionInProgress(false);
+                    this.browserStorage.setInteractionInProgress(false);
                     throw e;
                 });
         } else {
@@ -628,7 +629,8 @@ export class StandardController implements IController {
 
         try {
             this.logger.verbose("acquireTokenPopup called", correlationId);
-            this.preflightBrowserEnvironmentCheck(InteractionType.Popup);
+            BrowserUtils.preflightCheck(this.initialized);
+            this.browserStorage.setInteractionInProgress(true);
         } catch (e) {
             // Since this function is syncronous we need to reject
             return Promise.reject(e);
@@ -661,7 +663,7 @@ export class StandardController implements IController {
                 ApiId.acquireTokenPopup
             )
                 .then((response) => {
-                    this.getBrowserStorage().setInteractionInProgress(false);
+                    this.browserStorage.setInteractionInProgress(false);
                     atPopupMeasurement.end({
                         success: true,
                         isNativeBroker: true,
@@ -686,7 +688,7 @@ export class StandardController implements IController {
                             this.createPopupClient(correlationId);
                         return popupClient.acquireToken(request);
                     }
-                    this.getBrowserStorage().setInteractionInProgress(false);
+                    this.browserStorage.setInteractionInProgress(false);
                     throw e;
                 });
         } else {
@@ -795,7 +797,7 @@ export class StandardController implements IController {
             prompt: request.prompt,
             correlationId: correlationId,
         };
-        this.preflightBrowserEnvironmentCheck(InteractionType.Silent);
+        BrowserUtils.preflightCheck(this.initialized);
         this.ssoSilentMeasurement = this.performanceClient.startMeasurement(
             PerformanceEvents.SsoSilent,
             correlationId
@@ -892,8 +894,8 @@ export class StandardController implements IController {
         request: AuthorizationCodeRequest
     ): Promise<AuthenticationResult> {
         const correlationId = this.getRequestCorrelationId(request);
-        this.preflightBrowserEnvironmentCheck(InteractionType.Silent);
         this.logger.trace("acquireTokenByCode called", correlationId);
+        BrowserUtils.preflightCheck(this.initialized);
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_BY_CODE_START,
             InteractionType.Silent,
@@ -1190,7 +1192,8 @@ export class StandardController implements IController {
      */
     async logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void> {
         const correlationId = this.getRequestCorrelationId(logoutRequest);
-        this.preflightBrowserEnvironmentCheck(InteractionType.Redirect);
+        BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
+        this.browserStorage.setInteractionInProgress(true);
 
         const redirectClient = this.createRedirectClient(correlationId);
         return redirectClient.logout(logoutRequest);
@@ -1203,7 +1206,9 @@ export class StandardController implements IController {
     logoutPopup(logoutRequest?: EndSessionPopupRequest): Promise<void> {
         try {
             const correlationId = this.getRequestCorrelationId(logoutRequest);
-            this.preflightBrowserEnvironmentCheck(InteractionType.Popup);
+            BrowserUtils.preflightCheck(this.initialized);
+            this.browserStorage.setInteractionInProgress(true);
+
             const popupClient = this.createPopupClient(correlationId);
             return popupClient.logout(logoutRequest);
         } catch (e) {
@@ -1423,77 +1428,6 @@ export class StandardController implements IController {
     }
 
     // #region Helpers
-
-    /**
-     * Helper to validate app environment before making an auth request
-     *
-     * @protected
-     * @param {InteractionType} interactionType What kind of interaction is being used
-     * @param {boolean} [isAppEmbedded=false] Whether to set interaction in progress temp cache flag
-     */
-    public preflightBrowserEnvironmentCheck(
-        interactionType: InteractionType,
-        isAppEmbedded: boolean = false
-    ): void {
-        this.logger.verbose("preflightBrowserEnvironmentCheck started");
-        // Block request if not in browser environment
-        BrowserUtils.blockNonBrowserEnvironment(this.isBrowserEnvironment);
-
-        // Block redirects if in an iframe
-        BrowserUtils.blockRedirectInIframe(
-            interactionType,
-            this.config.system.allowRedirectInIframe
-        );
-
-        // Block auth requests inside a hidden iframe
-        BrowserUtils.blockReloadInHiddenIframes();
-
-        // Block redirectUri opened in a popup from calling MSAL APIs
-        BrowserUtils.blockAcquireTokenInPopups();
-
-        // Block token acquisition before initialize has been called
-        BrowserUtils.blockAPICallsBeforeInitialize(this.initialized);
-
-        // Block redirects if memory storage is enabled but storeAuthStateInCookie is not
-        if (
-            interactionType === InteractionType.Redirect &&
-            this.config.cache.cacheLocation ===
-                BrowserCacheLocation.MemoryStorage &&
-            !this.config.cache.storeAuthStateInCookie
-        ) {
-            throw createBrowserConfigurationAuthError(
-                BrowserConfigurationAuthErrorCodes.inMemRedirectUnavailable
-            );
-        }
-
-        if (
-            interactionType === InteractionType.Redirect ||
-            interactionType === InteractionType.Popup
-        ) {
-            this.preflightInteractiveRequest(!isAppEmbedded);
-        }
-    }
-
-    /**
-     * Preflight check for interactive requests
-     *
-     * @protected
-     * @param {boolean} setInteractionInProgress Whether to set interaction in progress temp cache flag
-     */
-    protected preflightInteractiveRequest(
-        setInteractionInProgress: boolean
-    ): void {
-        this.logger.verbose(
-            "preflightInteractiveRequest called, validating app environment"
-        );
-        // block the reload if it occurred inside a hidden iframe
-        BrowserUtils.blockReloadInHiddenIframes();
-
-        // Set interaction in progress temporary cache or throw if alread set.
-        if (setInteractionInProgress) {
-            this.getBrowserStorage().setInteractionInProgress(true);
-        }
-    }
 
     /**
      * Acquire a token from native device (e.g. WAM)
@@ -1821,13 +1755,6 @@ export class StandardController implements IController {
     }
 
     /**
-     * Returns the browser storage
-     */
-    public getBrowserStorage(): BrowserCacheManager {
-        return this.browserStorage;
-    }
-
-    /**
      * Returns the browser env indicator
      */
     public isBrowserEnv(): boolean {
@@ -1920,7 +1847,7 @@ export class StandardController implements IController {
             cacheLookupPolicy: request.cacheLookupPolicy,
         });
 
-        this.preflightBrowserEnvironmentCheck(InteractionType.Silent);
+        BrowserUtils.preflightCheck(this.initialized);
         this.logger.verbose("acquireTokenSilent called", correlationId);
 
         const account = request.account || this.getActiveAccount();

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -52,10 +52,6 @@ import { SsoSilentRequest } from "../request/SsoSilentRequest";
 import { EventCallbackFunction, EventError } from "../event/EventMessage";
 import { EventType } from "../event/EventType";
 import { EndSessionRequest } from "../request/EndSessionRequest";
-import {
-    BrowserConfigurationAuthErrorCodes,
-    createBrowserConfigurationAuthError,
-} from "../error/BrowserConfigurationAuthError";
 import { EndSessionPopupRequest } from "../request/EndSessionPopupRequest";
 import { INavigationClient } from "../navigation/INavigationClient";
 import { EventHandler } from "../event/EventHandler";

--- a/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
+++ b/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
@@ -149,13 +149,13 @@ export class UnknownOperatingContextController implements IController {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<AuthenticationResult>;
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     acquireTokenRedirect(request: RedirectRequest): Promise<void> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return Promise.resolve();
     }
     acquireTokenSilent(
@@ -163,7 +163,7 @@ export class UnknownOperatingContextController implements IController {
         silentRequest: SilentRequest
     ): Promise<AuthenticationResult> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<AuthenticationResult>;
     }
     acquireTokenByCode(
@@ -171,7 +171,7 @@ export class UnknownOperatingContextController implements IController {
         request: AuthorizationCodeRequest
     ): Promise<AuthenticationResult> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<AuthenticationResult>;
     }
     acquireTokenNative(
@@ -195,7 +195,7 @@ export class UnknownOperatingContextController implements IController {
         accountId?: string | undefined
     ): Promise<AuthenticationResult> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<AuthenticationResult>;
     }
     acquireTokenByRefreshToken(
@@ -205,7 +205,7 @@ export class UnknownOperatingContextController implements IController {
         silentRequest: SilentRequest
     ): Promise<AuthenticationResult> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<AuthenticationResult>;
     }
     addEventCallback(callback: EventCallbackFunction): string | null {
@@ -217,22 +217,22 @@ export class UnknownOperatingContextController implements IController {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     addPerformanceCallback(callback: PerformanceCallbackFunction): string {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return "";
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     removePerformanceCallback(callbackId: string): boolean {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return true;
     }
     enableAccountStorageEvents(): void {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
     }
     disableAccountStorageEvents(): void {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
     }
 
     handleRedirectPromise(
@@ -247,19 +247,19 @@ export class UnknownOperatingContextController implements IController {
         request?: PopupRequest | undefined
     ): Promise<AuthenticationResult> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<AuthenticationResult>;
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     loginRedirect(request?: RedirectRequest | undefined): Promise<void> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<void>;
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     logout(logoutRequest?: EndSessionRequest | undefined): Promise<void> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<void>;
     }
     logoutRedirect(
@@ -267,7 +267,7 @@ export class UnknownOperatingContextController implements IController {
         logoutRequest?: EndSessionRequest | undefined
     ): Promise<void> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<void>;
     }
     logoutPopup(
@@ -275,7 +275,7 @@ export class UnknownOperatingContextController implements IController {
         logoutRequest?: EndSessionPopupRequest | undefined
     ): Promise<void> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<void>;
     }
     ssoSilent(
@@ -292,12 +292,12 @@ export class UnknownOperatingContextController implements IController {
         >
     ): Promise<AuthenticationResult> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Promise<AuthenticationResult>;
     }
     getTokenCache(): ITokenCache {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as ITokenCache;
     }
     getLogger(): Logger {
@@ -306,16 +306,16 @@ export class UnknownOperatingContextController implements IController {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setLogger(logger: Logger): void {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setActiveAccount(account: AccountInfo | null): void {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
     }
     getActiveAccount(): AccountInfo | null {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return null;
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -325,45 +325,36 @@ export class UnknownOperatingContextController implements IController {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setNavigationClient(navigationClient: INavigationClient): void {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
     }
     getConfiguration(): BrowserConfiguration {
         return this.config;
     }
     isBrowserEnv(): boolean {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return true;
     }
     getBrowserCrypto(): ICrypto {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as ICrypto;
     }
     getPerformanceClient(): IPerformanceClient {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as IPerformanceClient;
     }
     getRedirectResponse(): Map<string, Promise<AuthenticationResult | null>> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
         return {} as Map<string, Promise<AuthenticationResult | null>>;
-    }
-    preflightBrowserEnvironmentCheck(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        interactionType: InteractionType,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        isAppEmbedded?: boolean | undefined
-    ): void {
-        blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async clearCache(logoutRequest?: ClearCacheRequest): Promise<void> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -378,6 +369,6 @@ export class UnknownOperatingContextController implements IController {
             | PopupRequest
     ): Promise<void> {
         blockAPICallsBeforeInitialize(this.initialized);
-        blockNonBrowserEnvironment(this.isBrowserEnvironment);
+        blockNonBrowserEnvironment();
     }
 }

--- a/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
+++ b/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
@@ -29,7 +29,7 @@ import { RedirectRequest } from "../request/RedirectRequest";
 import { SilentRequest } from "../request/SilentRequest";
 import { SsoSilentRequest } from "../request/SsoSilentRequest";
 import { AuthenticationResult } from "../response/AuthenticationResult";
-import { ApiId, WrapperSKU, InteractionType } from "../utils/BrowserConstants";
+import { ApiId, WrapperSKU } from "../utils/BrowserConstants";
 import { IController } from "./IController";
 import { UnknownOperatingContext } from "../operatingcontext/UnknownOperatingContext";
 import { CryptoOps } from "../crypto/CryptoOps";

--- a/lib/msal-browser/src/utils/BrowserUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserUtils.ts
@@ -8,8 +8,13 @@ import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
 } from "../error/BrowserAuthError";
-import { InteractionType, BrowserConstants } from "./BrowserConstants";
+import { BrowserConstants, BrowserCacheLocation } from "./BrowserConstants";
 import * as BrowserCrypto from "../crypto/BrowserCrypto";
+import {
+    BrowserConfigurationAuthErrorCodes,
+    createBrowserConfigurationAuthError,
+} from "../error/BrowserConfigurationAuthError";
+import { BrowserConfiguration } from "../config/Configuration";
 
 /**
  * Clears hash from window url.
@@ -93,16 +98,8 @@ export function blockReloadInHiddenIframes(): void {
  * @param interactionType Interaction type for the request
  * @param allowRedirectInIframe Config value to allow redirects when app is inside an iframe
  */
-export function blockRedirectInIframe(
-    interactionType: InteractionType,
-    allowRedirectInIframe: boolean
-): void {
-    const isIframedApp = isInIframe();
-    if (
-        interactionType === InteractionType.Redirect &&
-        isIframedApp &&
-        !allowRedirectInIframe
-    ) {
+export function blockRedirectInIframe(allowRedirectInIframe: boolean): void {
+    if (isInIframe() && !allowRedirectInIframe) {
         // If we are not in top frame, we shouldn't redirect. This is also handled by the service.
         throw createBrowserAuthError(BrowserAuthErrorCodes.redirectInIframe);
     }
@@ -122,10 +119,8 @@ export function blockAcquireTokenInPopups(): void {
  * Throws error if token requests are made in non-browser environment
  * @param isBrowserEnvironment Flag indicating if environment is a browser.
  */
-export function blockNonBrowserEnvironment(
-    isBrowserEnvironment: boolean
-): void {
-    if (!isBrowserEnvironment) {
+export function blockNonBrowserEnvironment(): void {
+    if (typeof window === "undefined") {
         throw createBrowserAuthError(
             BrowserAuthErrorCodes.nonBrowserEnvironment
         );
@@ -140,6 +135,46 @@ export function blockAPICallsBeforeInitialize(initialized: boolean): void {
     if (!initialized) {
         throw createBrowserAuthError(
             BrowserAuthErrorCodes.uninitializedPublicClientApplication
+        );
+    }
+}
+
+/**
+ * Helper to validate app environment before making an auth request
+ * @param initialized
+ */
+export function preflightCheck(initialized: boolean): void {
+    // Block request if not in browser environment
+    blockNonBrowserEnvironment();
+
+    // Block auth requests inside a hidden iframe
+    blockReloadInHiddenIframes();
+
+    // Block redirectUri opened in a popup from calling MSAL APIs
+    blockAcquireTokenInPopups();
+
+    // Block token acquisition before initialize has been called
+    blockAPICallsBeforeInitialize(initialized);
+}
+
+/**
+ * Helper to validate app enviornment before making redirect request
+ * @param initialized
+ * @param config
+ */
+export function redirectPreflightCheck(
+    initialized: boolean,
+    config: BrowserConfiguration
+): void {
+    preflightCheck(initialized);
+    blockRedirectInIframe(config.system.allowRedirectInIframe);
+    // Block redirects if memory storage is enabled but storeAuthStateInCookie is not
+    if (
+        config.cache.cacheLocation === BrowserCacheLocation.MemoryStorage &&
+        !config.cache.storeAuthStateInCookie
+    ) {
+        throw createBrowserConfigurationAuthError(
+            BrowserConfigurationAuthErrorCodes.inMemRedirectUnavailable
         );
     }
 }

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -5244,9 +5244,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             await pca.initialize();
 
             // @ts-ignore
-            pca.getBrowserStorage().setAccount(testAccount);
+            pca.browserStorage.setAccount(testAccount);
             // @ts-ignore
-            pca.getBrowserStorage().setIdTokenCredential(testIdToken);
+            pca.browserStorage.setIdTokenCredential(testIdToken);
         });
 
         afterEach(() => {
@@ -5316,15 +5316,15 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             await pca.initialize();
 
             // @ts-ignore
-            pca.getBrowserStorage().setAccount(testAccount1);
+            pca.browserStorage.setAccount(testAccount1);
             // @ts-ignore
-            pca.getBrowserStorage().setAccount(testAccount2);
+            pca.browserStorage.setAccount(testAccount2);
 
             // @ts-ignore
-            pca.getBrowserStorage().setIdTokenCredential(idToken1);
+            pca.browserStorage.setIdTokenCredential(idToken1);
 
             // @ts-ignore
-            pca.getBrowserStorage().setIdTokenCredential(idToken2);
+            pca.browserStorage.setIdTokenCredential(idToken2);
         });
 
         afterEach(() => {
@@ -5540,14 +5540,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca = (pca as any).controller;
             await pca.initialize();
             // @ts-ignore
-            pca.getBrowserStorage().setAccount(testAccount1);
+            pca.browserStorage.setAccount(testAccount1);
             // @ts-ignore
-            pca.getBrowserStorage().setAccount(testAccount2);
+            pca.browserStorage.setAccount(testAccount2);
 
             // @ts-ignore
-            pca.getBrowserStorage().setIdTokenCredential(idToken1);
+            pca.browserStorage.setIdTokenCredential(idToken1);
             // @ts-ignore
-            pca.getBrowserStorage().setIdTokenCredential(idToken2);
+            pca.browserStorage.setIdTokenCredential(idToken2);
         });
 
         afterEach(() => {
@@ -5806,48 +5806,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 WrapperSKU.React,
                 "1.0.0",
             ]);
-        });
-    });
-
-    describe("preflightBrowserEnvironmentCheck", () => {
-        beforeEach(async () => {
-            pca = (pca as any).controller;
-            await pca.initialize();
-        });
-
-        it("throws an error if initialize was not called prior", async () => {
-            pca = new PublicClientApplication({
-                auth: {
-                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
-                },
-            });
-
-            pca = (pca as any).controller;
-
-            expect(() =>
-                // @ts-ignore
-                pca.preflightBrowserEnvironmentCheck(InteractionType.Popup)
-            ).toThrow(
-                createBrowserAuthError(
-                    BrowserAuthErrorCodes.uninitializedPublicClientApplication
-                )
-            );
-        });
-
-        it("calls setInteractionInProgress", () => {
-            // @ts-ignore
-            pca.preflightBrowserEnvironmentCheck(InteractionType.Popup);
-
-            // @ts-ignore
-            expect(pca.browserStorage.getInteractionInProgress()).toBeTruthy;
-        });
-
-        it("doesnt call setInteractionInProgress", () => {
-            // @ts-ignore
-            pca.preflightBrowserEnvironmentCheck(InteractionType.Popup, false);
-
-            // @ts-ignore
-            expect(pca.browserStorage.getInteractionInProgress()).toBeFalsy;
         });
     });
 

--- a/lib/msal-browser/test/utils/BrowserUtils.spec.ts
+++ b/lib/msal-browser/test/utils/BrowserUtils.spec.ts
@@ -97,10 +97,7 @@ describe("BrowserUtils.ts Function Unit Tests", () => {
         it("throws when inside an iframe", (done) => {
             jest.spyOn(window, "parent", "get").mockReturnValue({ ...window });
             try {
-                BrowserUtils.blockRedirectInIframe(
-                    InteractionType.Redirect,
-                    false
-                );
+                BrowserUtils.blockRedirectInIframe(false);
             } catch (e) {
                 const browserAuthError = e as BrowserAuthError;
                 expect(browserAuthError.errorCode).toBe(
@@ -112,11 +109,11 @@ describe("BrowserUtils.ts Function Unit Tests", () => {
 
         it("doesnt throw when inside an iframe and redirects are allowed", () => {
             jest.spyOn(window, "parent", "get").mockReturnValue({ ...window });
-            BrowserUtils.blockRedirectInIframe(InteractionType.Redirect, true);
+            BrowserUtils.blockRedirectInIframe(true);
         });
 
         it("doesnt throw when not inside an iframe", () => {
-            BrowserUtils.blockRedirectInIframe(InteractionType.Redirect, false);
+            BrowserUtils.blockRedirectInIframe(false);
         });
     });
 


### PR DESCRIPTION
Removes `preflightBrowserEnvironmentCheck` from IController interface and moves the implementation to BrowserUtils