### PR TITLE
Refactor bootstrap of angualr standalone sample

### DIFF
--- a/samples/msal-angular-v3-samples/angular-standalone-sample/src/app/app.component.ts
+++ b/samples/msal-angular-v3-samples/angular-standalone-sample/src/app/app.component.ts
@@ -31,8 +31,6 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.authService.handleRedirectObservable().subscribe();
-
     this.isIframe = window !== window.parent && !window.opener; // Remove this line to use Angular Universal
     this.setLoginDisplay();
 

--- a/samples/msal-angular-v3-samples/angular-standalone-sample/src/index.html
+++ b/samples/msal-angular-v3-samples/angular-standalone-sample/src/index.html
@@ -11,6 +11,7 @@
 
 <body class="mat-typography">
   <app-root></app-root>
+  <app-redirect></app-redirect>
 </body>
 
 </html>

--- a/samples/msal-angular-v3-samples/angular-standalone-sample/src/main.ts
+++ b/samples/msal-angular-v3-samples/angular-standalone-sample/src/main.ts
@@ -7,7 +7,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
 import { Route, provideRouter, withDisabledInitialNavigation, withEnabledBlockingInitialNavigation } from '@angular/router';
-import { MsalInterceptor, MSAL_INSTANCE, MsalInterceptorConfiguration, MsalGuardConfiguration, MSAL_GUARD_CONFIG, MSAL_INTERCEPTOR_CONFIG, MsalService, MsalGuard, MsalBroadcastService } from '@azure/msal-angular';
+import { MsalInterceptor, MSAL_INSTANCE, MsalInterceptorConfiguration, MsalGuardConfiguration, MSAL_GUARD_CONFIG, MSAL_INTERCEPTOR_CONFIG, MsalService, MsalGuard, MsalBroadcastService, MsalRedirectComponent } from '@azure/msal-angular';
 import { IPublicClientApplication, PublicClientApplication, InteractionType, BrowserCacheLocation, LogLevel, BrowserUtils } from '@azure/msal-browser';
 import { AppComponent } from './app/app.component';
 import { HomeComponent } from './app/home/home.component';
@@ -113,4 +113,5 @@ bootstrapApplication(AppComponent, {
         MsalBroadcastService
     ]
 })
+  .then(ref => ref.bootstrap(MsalRedirectComponent))
   .catch(err => console.error(err));


### PR DESCRIPTION
The documentation and example for bootstrapping redirects for Angular standalone application is not correct. It implies that there is no way in an Angular standalone application to bootstrap the `MsalRedirectComponent` as you can in an application with an `app.module.ts`. This is actually incorrect. The `MsalRedirectComponent` can be bootstrapped in the `main.ts` file by using the `Promise<ApplicationRef>` returned by the `bootstrapApplication` function.

The PR corrects that by refactoring the Angular standalone sample and updating the documentation.