### PR TITLE
Nested App Auth: allow empty parameters for loginPopup

### DIFF
--- a/change/@azure-msal-browser-0e07359f-e5c7-42a4-a825-4a80c43b7d7d.json
+++ b/change/@azure-msal-browser-0e07359f-e5c7-42a4-a825-4a80c43b7d7d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Nested App Auth: allow empty parameters for loginPopup (#6941)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -26,7 +26,12 @@ import { PopupRequest } from "../request/PopupRequest";
 import { RedirectRequest } from "../request/RedirectRequest";
 import { SilentRequest } from "../request/SilentRequest";
 import { SsoSilentRequest } from "../request/SsoSilentRequest";
-import { ApiId, WrapperSKU, InteractionType, DEFAULT_REQUEST } from "../utils/BrowserConstants";
+import {
+    ApiId,
+    WrapperSKU,
+    InteractionType,
+    DEFAULT_REQUEST,
+} from "../utils/BrowserConstants";
 import { IController } from "./IController";
 import { TeamsAppOperatingContext } from "../operatingcontext/TeamsAppOperatingContext";
 import { IBridgeProxy } from "../naa/IBridgeProxy";
@@ -418,7 +423,6 @@ export class NestedAppAuthController implements IController {
     loginPopup(
         request?: PopupRequest | undefined // eslint-disable-line @typescript-eslint/no-unused-vars
     ): Promise<AuthenticationResult> {
-        
         return this.acquireTokenInteractive(request || DEFAULT_REQUEST);
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -26,7 +26,7 @@ import { PopupRequest } from "../request/PopupRequest";
 import { RedirectRequest } from "../request/RedirectRequest";
 import { SilentRequest } from "../request/SilentRequest";
 import { SsoSilentRequest } from "../request/SsoSilentRequest";
-import { ApiId, WrapperSKU, InteractionType } from "../utils/BrowserConstants";
+import { ApiId, WrapperSKU, InteractionType, DEFAULT_REQUEST } from "../utils/BrowserConstants";
 import { IController } from "./IController";
 import { TeamsAppOperatingContext } from "../operatingcontext/TeamsAppOperatingContext";
 import { IBridgeProxy } from "../naa/IBridgeProxy";
@@ -418,11 +418,8 @@ export class NestedAppAuthController implements IController {
     loginPopup(
         request?: PopupRequest | undefined // eslint-disable-line @typescript-eslint/no-unused-vars
     ): Promise<AuthenticationResult> {
-        if (request !== undefined) {
-            return this.acquireTokenInteractive(request);
-        } else {
-            throw NestedAppAuthError.createUnsupportedError();
-        }
+        
+        return this.acquireTokenInteractive(request || DEFAULT_REQUEST);
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     loginRedirect(request?: RedirectRequest | undefined): Promise<void> {

--- a/lib/msal-browser/src/naa/BridgeProxy.ts
+++ b/lib/msal-browser/src/naa/BridgeProxy.ts
@@ -15,6 +15,7 @@ import { BridgeStatusCode } from "./BridgeStatusCode";
 import { IBridgeProxy } from "./IBridgeProxy";
 import { InitContext } from "./InitContext";
 import { TokenRequest } from "./TokenRequest";
+import * as BrowserCrypto from "../crypto/BrowserCrypto";
 
 declare global {
     interface Window {
@@ -29,7 +30,6 @@ declare global {
  */
 export class BridgeProxy implements IBridgeProxy {
     static bridgeRequests: BridgeRequest[] = [];
-    static crypto: Crypto;
     sdkName: string;
     sdkVersion: string;
     capabilities?: BridgeCapabilities;
@@ -47,13 +47,8 @@ export class BridgeProxy implements IBridgeProxy {
         if (window.nestedAppAuthBridge === undefined) {
             throw new Error("window.nestedAppAuthBridge is undefined");
         }
-        if (window.crypto === undefined) {
-            throw new Error("window.crypto is undefined");
-        }
 
         try {
-            BridgeProxy.crypto = window.crypto;
-
             window.nestedAppAuthBridge.addEventListener(
                 "message",
                 (response: AuthBridgeResponse) => {
@@ -84,7 +79,7 @@ export class BridgeProxy implements IBridgeProxy {
                     const message: BridgeRequestEnvelope = {
                         messageType: "NestedAppAuthRequest",
                         method: "GetInitContext",
-                        requestId: BridgeProxy.getRandomId(),
+                        requestId: BrowserCrypto.createNewGuid(),
                     };
                     const request: BridgeRequest = {
                         requestId: message.requestId,
@@ -106,10 +101,6 @@ export class BridgeProxy implements IBridgeProxy {
             window.console.log(error);
             throw error;
         }
-    }
-
-    public static getRandomId(): string {
-        return BridgeProxy.crypto.randomUUID();
     }
 
     /**
@@ -164,7 +155,7 @@ export class BridgeProxy implements IBridgeProxy {
         const message: BridgeRequestEnvelope = {
             messageType: "NestedAppAuthRequest",
             method: method,
-            requestId: BridgeProxy.getRandomId(),
+            requestId: BrowserCrypto.createNewGuid(),
             ...requestParams,
         };
 

--- a/lib/msal-browser/test/naa/BridgeProxy.spec.ts
+++ b/lib/msal-browser/test/naa/BridgeProxy.spec.ts
@@ -46,13 +46,6 @@ describe("BridgeProxy tests", () => {
                 "window.nestedAppAuthBridge is undefined"
             );
         });
-
-        it("should throw an error if window.crypto is undefined", () => {
-            windowSpy.mockImplementation(() => ({ nestedAppAuthBridge: {} }));
-            expect(() => BridgeProxy.create()).rejects.toThrow(
-                "window.crypto is undefined"
-            );
-        });
     });
 
     describe("get token silent tests", () => {


### PR DESCRIPTION
This change allows empty parameters for loginPopup by using a default request to match the behavior of StandardController. It also removes the dependency on crypto.randomUUID() which is not used elsewhere in the MSAL code base. Use the shared implementation to generate UUID v7 instead.