### PR TITLE
Fix AcquireTokenSilentAsync sub-measurement instrumentation

### DIFF
--- a/change/@azure-msal-browser-1ee87769-69c6-42ea-bc8a-70f7f43a86dd.json
+++ b/change/@azure-msal-browser-1ee87769-69c6-42ea-bc8a-70f7f43a86dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix AcquireTokenSilentAsync sub-measurement instrumentation #6947",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -3577,6 +3577,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(event.success).toBeFalsy();
                     expect(event.errorName).toEqual("Error");
                     expect(event.errorStack?.length).toEqual(5);
+                    expect(event.incompleteSubsCount).toEqual(0);
                     pca.removePerformanceCallback(callbackId);
                     done();
                 }


### PR DESCRIPTION
- Fix AcquireTokenSilentAsync sub-measurement instrumentation.

**Note**: AcquireTokenSilentAsync is already instrumented [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/d8cd9acf63b39a426455c0b2f64f0c43a21abf44/lib/msal-browser/src/controllers/StandardController.ts#L1879).