### PR TITLE
Move build request functions

### DIFF
--- a/change/@azure-msal-browser-53df8bcf-ecc8-4643-b8e8-d7c08e37f667.json
+++ b/change/@azure-msal-browser-53df8bcf-ecc8-4643-b8e8-d7c08e37f667.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "move build request functions",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -82,6 +82,7 @@ import { IController } from "./IController";
 import { AuthenticationResult } from "../response/AuthenticationResult";
 import { ClearCacheRequest } from "../request/ClearCacheRequest";
 import { createNewGuid } from "../crypto/BrowserCrypto";
+import { initializeSilentRequest } from "../request/RequestHelpers";
 
 export class StandardController implements IController {
     // OperatingContext
@@ -1072,7 +1073,6 @@ export class StandardController implements IController {
      * @returns A promise that, when resolved, returns the access token
      */
     protected async acquireTokenFromCache(
-        silentCacheClient: SilentCacheClient,
         commonRequest: CommonSilentFlowRequest,
         cacheLookupPolicy: CacheLookupPolicy
     ): Promise<AuthenticationResult> {
@@ -1084,6 +1084,9 @@ export class StandardController implements IController {
             case CacheLookupPolicy.Default:
             case CacheLookupPolicy.AccessToken:
             case CacheLookupPolicy.AccessTokenAndRefreshToken:
+                const silentCacheClient = this.createSilentCacheClient(
+                    commonRequest.correlationId
+                );
                 return invokeAsync(
                     silentCacheClient.acquireToken.bind(silentCacheClient),
                     PerformanceEvents.SilentCacheClientAcquireToken,
@@ -1939,7 +1942,7 @@ export class StandardController implements IController {
      * @returns {Promise.<AuthenticationResult>} - a promise that is fulfilled when this function has completed, or rejected if an error was raised. Returns the {@link AuthResponse}
      */
     protected async acquireTokenSilentAsync(
-        request: SilentRequest,
+        request: SilentRequest & { correlationId: string },
         account: AccountInfo
     ): Promise<AuthenticationResult> {
         this.performanceClient.addQueueMeasurement(
@@ -2004,19 +2007,19 @@ export class StandardController implements IController {
                 "acquireTokenSilent - attempting to acquire token from web flow"
             );
 
-            const silentCacheClient = this.createSilentCacheClient(
-                request.correlationId
-            );
-
             const silentRequest = await invokeAsync(
-                silentCacheClient.initializeSilentRequest.bind(
-                    silentCacheClient
-                ),
+                initializeSilentRequest,
                 PerformanceEvents.InitializeSilentRequest,
                 this.logger,
                 this.performanceClient,
                 request.correlationId
-            )(request, account);
+            )(
+                request,
+                account,
+                this.config,
+                this.performanceClient,
+                this.logger
+            );
 
             const cacheLookupPolicy =
                 request.cacheLookupPolicy || CacheLookupPolicy.Default;
@@ -2027,7 +2030,7 @@ export class StandardController implements IController {
                 this.logger,
                 this.performanceClient,
                 silentRequest.correlationId
-            )(silentCacheClient, silentRequest, cacheLookupPolicy).catch(
+            )(silentRequest, cacheLookupPolicy).catch(
                 (cacheError: AuthError) => {
                     if (
                         request.cacheLookupPolicy ===
@@ -2036,8 +2039,6 @@ export class StandardController implements IController {
                         throw cacheError;
                     }
 
-                    // block the reload if it occurred inside a hidden iframe
-                    BrowserUtils.blockReloadInHiddenIframes();
                     this.eventHandler.emitEvent(
                         EventType.ACQUIRE_TOKEN_NETWORK_START,
                         InteractionType.Silent,

--- a/lib/msal-browser/src/crypto/BrowserCrypto.ts
+++ b/lib/msal-browser/src/crypto/BrowserCrypto.ts
@@ -13,6 +13,7 @@ import {
     PerformanceEvents,
 } from "@azure/msal-common";
 import { KEY_FORMAT_JWK } from "../utils/BrowserConstants";
+import { urlEncodeArr } from "../encode/Base64Encode";
 
 /**
  * This file defines functions used by the browser library to perform cryptography operations such as
@@ -201,4 +202,14 @@ export async function sign(
         key,
         data
     ) as Promise<ArrayBuffer>;
+}
+
+/**
+ * Returns the SHA-256 hash of an input string
+ * @param plainText
+ */
+export async function hashString(plainText: string): Promise<string> {
+    const hashBuffer: ArrayBuffer = await sha256Digest(plainText);
+    const hashBytes = new Uint8Array(hashBuffer);
+    return urlEncodeArr(hashBytes);
 }

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -249,11 +249,7 @@ export class CryptoOps implements ICrypto {
      * @param plainText
      */
     async hashString(plainText: string): Promise<string> {
-        const hashBuffer: ArrayBuffer = await BrowserCrypto.sha256Digest(
-            plainText
-        );
-        const hashBytes = new Uint8Array(hashBuffer);
-        return urlEncodeArr(hashBytes);
+        return BrowserCrypto.hashString(plainText);
     }
 }
 

--- a/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
@@ -13,7 +13,6 @@ import {
     PerformanceEvents,
     invokeAsync,
 } from "@azure/msal-common";
-import { SilentRequest } from "../request/SilentRequest";
 import { ApiId } from "../utils/BrowserConstants";
 import {
     BrowserAuthError,
@@ -39,11 +38,21 @@ export class SilentCacheClient extends StandardInteractionClient {
             ApiId.acquireTokenSilent_silentFlow
         );
 
-        const silentAuthClient = await this.createSilentFlowClient(
+        const clientConfig = await invokeAsync(
+            this.getClientConfiguration.bind(this),
+            PerformanceEvents.StandardInteractionClientGetClientConfiguration,
+            this.logger,
+            this.performanceClient,
+            this.correlationId
+        )(
             serverTelemetryManager,
             silentRequest.authority,
             silentRequest.azureCloudOptions,
             silentRequest.account
+        );
+        const silentAuthClient = new SilentFlowClient(
+            clientConfig,
+            this.performanceClient
         );
         this.logger.verbose("Silent auth client created");
 
@@ -85,51 +94,5 @@ export class SilentCacheClient extends StandardInteractionClient {
         this.logger.verbose("logoutRedirect called");
         const validLogoutRequest = this.initializeLogoutRequest(logoutRequest);
         return this.clearCacheOnLogout(validLogoutRequest?.account);
-    }
-
-    /**
-     * Creates an Silent Flow Client with the given authority, or the default authority.
-     * @param serverTelemetryManager
-     * @param authorityUrl
-     */
-    protected async createSilentFlowClient(
-        serverTelemetryManager: ServerTelemetryManager,
-        authorityUrl?: string,
-        azureCloudOptions?: AzureCloudOptions,
-        account?: AccountInfo
-    ): Promise<SilentFlowClient> {
-        // Create auth module.
-        const clientConfig = await invokeAsync(
-            this.getClientConfiguration.bind(this),
-            PerformanceEvents.StandardInteractionClientGetClientConfiguration,
-            this.logger,
-            this.performanceClient,
-            this.correlationId
-        )(serverTelemetryManager, authorityUrl, azureCloudOptions, account);
-        return new SilentFlowClient(clientConfig, this.performanceClient);
-    }
-
-    async initializeSilentRequest(
-        request: SilentRequest,
-        account: AccountInfo
-    ): Promise<CommonSilentFlowRequest> {
-        this.performanceClient.addQueueMeasurement(
-            PerformanceEvents.InitializeSilentRequest,
-            this.correlationId
-        );
-
-        const baseRequest = await invokeAsync(
-            this.initializeBaseRequest.bind(this),
-            PerformanceEvents.InitializeBaseRequest,
-            this.logger,
-            this.performanceClient,
-            this.correlationId
-        )(request);
-        return {
-            ...request,
-            ...baseRequest,
-            account: account,
-            forceRefresh: request.forceRefresh || false,
-        };
     }
 }

--- a/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
@@ -7,9 +7,6 @@ import { StandardInteractionClient } from "./StandardInteractionClient";
 import {
     CommonSilentFlowRequest,
     SilentFlowClient,
-    ServerTelemetryManager,
-    AccountInfo,
-    AzureCloudOptions,
     PerformanceEvents,
     invokeAsync,
 } from "@azure/msal-common";

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -20,6 +20,7 @@ import {
     BrowserAuthErrorCodes,
 } from "../error/BrowserAuthError";
 import { AuthenticationResult } from "../response/AuthenticationResult";
+import { initializeBaseRequest } from "../request/RequestHelpers";
 
 export class SilentRefreshClient extends StandardInteractionClient {
     /**
@@ -35,12 +36,12 @@ export class SilentRefreshClient extends StandardInteractionClient {
         );
 
         const baseRequest = await invokeAsync(
-            this.initializeBaseRequest.bind(this),
+            initializeBaseRequest,
             PerformanceEvents.InitializeBaseRequest,
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(request);
+        )(request, this.config, this.performanceClient, this.logger);
         const silentRequest: CommonSilentFlowRequest = {
             ...request,
             ...baseRequest,

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -32,6 +32,7 @@ import { PopupRequest } from "../request/PopupRequest";
 import { SsoSilentRequest } from "../request/SsoSilentRequest";
 import { generatePkceCodes } from "../crypto/PkceGenerator";
 import { createNewGuid } from "../crypto/BrowserCrypto";
+import { initializeBaseRequest } from "../request/RequestHelpers";
 
 /**
  * Defines the class structure and helper functions used by the "standard", non-brokered auth flows (popup, redirect, silent (RT), silent (iframe))
@@ -315,12 +316,17 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
         );
 
         const baseRequest: BaseAuthRequest = await invokeAsync(
-            this.initializeBaseRequest.bind(this),
+            initializeBaseRequest,
             PerformanceEvents.InitializeBaseRequest,
             this.logger,
             this.performanceClient,
             this.correlationId
-        )(request);
+        )(
+            { ...request, correlationId: this.correlationId },
+            this.config,
+            this.performanceClient,
+            this.logger
+        );
 
         const validatedRequest: AuthorizationUrlRequest = {
             ...baseRequest,

--- a/lib/msal-browser/src/request/RequestHelpers.ts
+++ b/lib/msal-browser/src/request/RequestHelpers.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {
     AccountInfo,
     AuthenticationScheme,

--- a/lib/msal-browser/src/request/RequestHelpers.ts
+++ b/lib/msal-browser/src/request/RequestHelpers.ts
@@ -1,0 +1,107 @@
+import {
+    AccountInfo,
+    AuthenticationScheme,
+    BaseAuthRequest,
+    ClientConfigurationErrorCodes,
+    CommonSilentFlowRequest,
+    IPerformanceClient,
+    Logger,
+    PerformanceEvents,
+    StringUtils,
+    createClientConfigurationError,
+    invokeAsync,
+} from "@azure/msal-common";
+import { BrowserConfiguration } from "../config/Configuration";
+import { SilentRequest } from "./SilentRequest";
+import { hashString } from "../crypto/BrowserCrypto";
+
+/**
+ * Initializer function for all request APIs
+ * @param request
+ */
+export async function initializeBaseRequest(
+    request: Partial<BaseAuthRequest> & { correlationId: string },
+    config: BrowserConfiguration,
+    performanceClient: IPerformanceClient,
+    logger: Logger
+): Promise<BaseAuthRequest> {
+    performanceClient.addQueueMeasurement(
+        PerformanceEvents.InitializeBaseRequest,
+        request.correlationId
+    );
+    const authority = request.authority || config.auth.authority;
+
+    const scopes = [...((request && request.scopes) || [])];
+
+    const validatedRequest: BaseAuthRequest = {
+        ...request,
+        correlationId: request.correlationId,
+        authority,
+        scopes,
+    };
+
+    // Set authenticationScheme to BEARER if not explicitly set in the request
+    if (!validatedRequest.authenticationScheme) {
+        validatedRequest.authenticationScheme = AuthenticationScheme.BEARER;
+        logger.verbose(
+            'Authentication Scheme wasn\'t explicitly set in request, defaulting to "Bearer" request'
+        );
+    } else {
+        if (
+            validatedRequest.authenticationScheme === AuthenticationScheme.SSH
+        ) {
+            if (!request.sshJwk) {
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshJwk
+                );
+            }
+            if (!request.sshKid) {
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshKid
+                );
+            }
+        }
+        logger.verbose(
+            `Authentication Scheme set to "${validatedRequest.authenticationScheme}" as configured in Auth request`
+        );
+    }
+
+    // Set requested claims hash if claims-based caching is enabled and claims were requested
+    if (
+        config.cache.claimsBasedCachingEnabled &&
+        request.claims &&
+        // Checks for empty stringified object "{}" which doesn't qualify as requested claims
+        !StringUtils.isEmptyObj(request.claims)
+    ) {
+        validatedRequest.requestedClaimsHash = await hashString(request.claims);
+    }
+
+    return validatedRequest;
+}
+
+export async function initializeSilentRequest(
+    request: SilentRequest & { correlationId: string },
+    account: AccountInfo,
+    config: BrowserConfiguration,
+    performanceClient: IPerformanceClient,
+    logger: Logger
+): Promise<CommonSilentFlowRequest> {
+    performanceClient.addQueueMeasurement(
+        PerformanceEvents.InitializeSilentRequest,
+        request.correlationId
+    );
+
+    const baseRequest = await invokeAsync(
+        initializeBaseRequest,
+        PerformanceEvents.InitializeBaseRequest,
+        logger,
+        performanceClient,
+        request.correlationId
+    )(request, config, performanceClient, logger);
+    return {
+        ...request,
+        ...baseRequest,
+        account: account,
+        forceRefresh: request.forceRefresh || false,
+    };
+}

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -3559,27 +3559,29 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 username: "AbeLi@microsoft.com",
             };
 
-            sinon
-                // @ts-ignore
-                .stub(BaseInteractionClient.prototype, "initializeBaseRequest")
-                .callsFake(async () => {
-                    throw new Error("Test error message");
-                });
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockRejectedValue(new Error("Test error message"));
 
             const callbackId = pca.addPerformanceCallback(
                 (events: PerformanceEvent[]) => {
-                    expect(events.length).toEqual(1);
-                    const event = events[0];
-                    expect(event.name).toBe(
-                        PerformanceEvents.AcquireTokenSilent
-                    );
-                    expect(event.correlationId).toBeDefined();
-                    expect(event.success).toBeFalsy();
-                    expect(event.errorName).toEqual("Error");
-                    expect(event.errorStack?.length).toEqual(5);
-                    expect(event.incompleteSubsCount).toEqual(0);
-                    pca.removePerformanceCallback(callbackId);
-                    done();
+                    try {
+                        expect(events.length).toEqual(1);
+                        const event = events[0];
+                        expect(event.name).toBe(
+                            PerformanceEvents.AcquireTokenSilent
+                        );
+                        expect(event.correlationId).toBeDefined();
+                        expect(event.success).toBeFalsy();
+                        expect(event.errorName).toEqual("Error");
+                        expect(event.errorStack?.length).toBeGreaterThan(1);
+                        expect(event.incompleteSubsCount).toEqual(0);
+                        pca.removePerformanceCallback(callbackId);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
                 }
             );
 
@@ -3587,6 +3589,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
+                cacheLookupPolicy: CacheLookupPolicy.AccessToken,
             }).catch(() => {});
         });
 
@@ -4199,7 +4202,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 RANDOM_TEST_GUID
             );
             sinon
-                .stub(CryptoOps.prototype, "hashString")
+                .stub(BrowserCrypto, "hashString")
                 .resolves(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
             const silentATStub = sinon
                 .stub(

--- a/lib/msal-browser/test/crypto/SignedHttpRequest.spec.ts
+++ b/lib/msal-browser/test/crypto/SignedHttpRequest.spec.ts
@@ -1,7 +1,6 @@
 import { SignedHttpRequest } from "../../src/crypto/SignedHttpRequest";
-import * as BrowserCrypto from "../../src/crypto/BrowserCrypto";
 import { createHash } from "crypto";
-import { AuthToken, Logger } from "@azure/msal-common";
+import { AuthToken } from "@azure/msal-common";
 import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 import { base64Decode } from "../../src/encode/Base64Decode";
 
@@ -13,7 +12,7 @@ describe("SignedHttpRequest.ts Unit Tests", () => {
     jest.setTimeout(30000);
 
     beforeEach(() => {
-        jest.spyOn(BrowserCrypto, "sha256Digest").mockImplementation(
+        jest.spyOn(window.crypto.subtle, "digest").mockImplementation(
             (): Promise<ArrayBuffer> => {
                 return Promise.resolve(
                     createHash("SHA256")


### PR DESCRIPTION
- Move initializeBaseRequest and initializeSilentRequest out of the InteractionClient classes
- Move implementation for hashString from CryptoOps to BrowserCrypto

These changes pave the way for better handling of concurrent iframe requests