### PR TITLE
Add getAccount API to IPublicClientApplication

### DIFF
--- a/change/@azure-msal-browser-7b8679dc-1a5c-44b1-8f0a-bb52821145a9.json
+++ b/change/@azure-msal-browser-7b8679dc-1a5c-44b1-8f0a-bb52821145a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add getAccount API to IPublicClientApplication (#7019)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    AccountFilter,
     AccountInfo,
     Logger,
     PerformanceCallbackFunction,
@@ -43,6 +44,7 @@ export interface IPublicClientApplication {
     removePerformanceCallback(callbackId: string): boolean;
     enableAccountStorageEvents(): void;
     disableAccountStorageEvents(): void;
+    getAccount(accountFilter: AccountFilter): AccountInfo | null;
     getAccountByHomeId(homeAccountId: string): AccountInfo | null;
     getAccountByLocalId(localId: string): AccountInfo | null;
     getAccountByUsername(userName: string): AccountInfo | null;
@@ -112,6 +114,9 @@ export const stubbedPublicClientApplication: IPublicClientApplication = {
     },
     getAllAccounts: () => {
         return [];
+    },
+    getAccount: () => {
+        return null;
     },
     getAccountByHomeId: () => {
         return null;


### PR DESCRIPTION
Add  getAccount(accountFilter: AccountFilter) API to IPublicClientApplication so that it can be called by the PCA returned from PublicClientNext.createPublicClientApplication.