### PR TITLE
Capture and instrument cache errors

### DIFF
--- a/change/@azure-msal-browser-f1688cf2-852c-4b32-a5b1-8b3a4393ace9.json
+++ b/change/@azure-msal-browser-f1688cf2-852c-4b32-a5b1-8b3a4393ace9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Capture and instrument cache errors #7021",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-704006a4-ebc8-4197-85c9-261e01c15332.json
+++ b/change/@azure-msal-common-704006a4-ebc8-4197-85c9-261e01c15332.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Capture and instrument cache errors #7021",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1886,16 +1886,18 @@ export class BrowserCacheManager extends CacheManager {
                 this.performanceClient &&
                 correlationId
             ) {
-                const tokenKeys = this.getTokenKeys();
+                try {
+                    const tokenKeys = this.getTokenKeys();
 
-                this.performanceClient.addFields(
-                    {
-                        cacheRtCount: tokenKeys.refreshToken.length,
-                        cacheIdCount: tokenKeys.idToken.length,
-                        cacheAtCount: tokenKeys.accessToken.length,
-                    },
-                    correlationId
-                );
+                    this.performanceClient.addFields(
+                        {
+                            cacheRtCount: tokenKeys.refreshToken.length,
+                            cacheIdCount: tokenKeys.idToken.length,
+                            cacheAtCount: tokenKeys.accessToken.length,
+                        },
+                        correlationId
+                    );
+                } catch (e) {}
             }
 
             throw e;

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -37,6 +37,8 @@ import {
     IPerformanceClient,
     StaticAuthorityOptions,
     CacheHelpers,
+    StoreInCache,
+    CacheError,
 } from "@azure/msal-common";
 import { CacheOptions } from "../config/Configuration";
 import {
@@ -79,6 +81,8 @@ export class BrowserCacheManager extends CacheManager {
     protected temporaryCacheStorage: IWindowStorage<string>;
     // Logger instance
     protected logger: Logger;
+    // Telemetry perf client
+    protected performanceClient?: IPerformanceClient;
 
     // Cookie life calculation (hours * minutes * seconds * ms)
     protected readonly COOKIE_LIFE_MULTIPLIER = 24 * 60 * 60 * 1000;
@@ -88,7 +92,8 @@ export class BrowserCacheManager extends CacheManager {
         cacheConfig: Required<CacheOptions>,
         cryptoImpl: ICrypto,
         logger: Logger,
-        staticAuthorityOptions?: StaticAuthorityOptions
+        staticAuthorityOptions?: StaticAuthorityOptions,
+        performanceClient?: IPerformanceClient
     ) {
         super(clientId, cryptoImpl, logger, staticAuthorityOptions);
         this.cacheConfig = cacheConfig;
@@ -107,6 +112,8 @@ export class BrowserCacheManager extends CacheManager {
             this.migrateCacheEntries();
             this.createKeyMaps();
         }
+
+        this.performanceClient = performanceClient;
     }
 
     /**
@@ -1854,6 +1861,45 @@ export class BrowserCacheManager extends CacheManager {
             accessTokenEntity
         );
         return this.saveCacheRecord(cacheRecord);
+    }
+
+    /**
+     * saves a cache record
+     * @param cacheRecord {CacheRecord}
+     * @param storeInCache {?StoreInCache}
+     * @param correlationId {?string} correlation id
+     */
+    async saveCacheRecord(
+        cacheRecord: CacheRecord,
+        storeInCache?: StoreInCache,
+        correlationId?: string
+    ): Promise<void> {
+        try {
+            await super.saveCacheRecord(
+                cacheRecord,
+                storeInCache,
+                correlationId
+            );
+        } catch (e) {
+            if (
+                e instanceof CacheError &&
+                this.performanceClient &&
+                correlationId
+            ) {
+                const tokenKeys = this.getTokenKeys();
+
+                this.performanceClient.addFields(
+                    {
+                        cacheRtCount: tokenKeys.refreshToken.length,
+                        cacheIdCount: tokenKeys.idToken.length,
+                        cacheAtCount: tokenKeys.accessToken.length,
+                    },
+                    correlationId
+                );
+            }
+
+            throw e;
+        }
     }
 }
 

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -207,7 +207,8 @@ export class StandardController implements IController {
                   this.config.cache,
                   this.browserCrypto,
                   this.logger,
-                  buildStaticAuthorityOptions(this.config.auth)
+                  buildStaticAuthorityOptions(this.config.auth),
+                  this.performanceClient
               )
             : DEFAULT_BROWSER_CACHE_MANAGER(
                   this.config.auth.clientId,
@@ -227,7 +228,9 @@ export class StandardController implements IController {
             this.config.auth.clientId,
             nativeCacheOptions,
             this.browserCrypto,
-            this.logger
+            this.logger,
+            undefined,
+            this.performanceClient
         );
 
         // Initialize the token cache

--- a/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
+++ b/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
@@ -106,7 +106,9 @@ export class UnknownOperatingContextController implements IController {
                   this.config.auth.clientId,
                   this.config.cache,
                   this.browserCrypto,
-                  this.logger
+                  this.logger,
+                  undefined,
+                  this.performanceClient
               )
             : DEFAULT_BROWSER_CACHE_MANAGER(
                   this.config.auth.clientId,

--- a/lib/msal-common/src/error/CacheError.ts
+++ b/lib/msal-common/src/error/CacheError.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as CacheErrorCodes from "./CacheErrorCodes";
+export { CacheErrorCodes };
+
+export const CacheErrorMessages = {
+    [CacheErrorCodes.cacheQuotaExceededErrorCode]:
+        "Exceeded cache storage capacity.",
+    [CacheErrorCodes.cacheUnknownErrorCode]:
+        "Unexpected error occurred when using cache storage.",
+};
+
+/**
+ * Error thrown when there is an error with the cache
+ */
+export class CacheError extends Error {
+    /**
+     * Short string denoting error
+     */
+    errorCode: string;
+
+    /**
+     * Detailed description of error
+     */
+    errorMessage: string;
+
+    constructor(errorCode: string, errorMessage?: string) {
+        const message =
+            errorMessage ||
+            (CacheErrorMessages[errorCode]
+                ? CacheErrorMessages[errorCode]
+                : CacheErrorMessages[CacheErrorCodes.cacheUnknownErrorCode]);
+
+        super(`${errorCode}: ${message}`);
+        Object.setPrototypeOf(this, CacheError.prototype);
+
+        this.name = "CacheError";
+        this.errorCode = errorCode;
+        this.errorMessage = message;
+    }
+}

--- a/lib/msal-common/src/error/CacheErrorCodes.ts
+++ b/lib/msal-common/src/error/CacheErrorCodes.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const cacheQuotaExceededErrorCode = "cache_quota_exceeded";
+export const cacheUnknownErrorCode = "cache_error_unknown";

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -168,6 +168,7 @@ export {
     createAuthError,
 } from "./error/AuthError";
 export { ServerError } from "./error/ServerError";
+export { CacheError, CacheErrorCodes } from "./error/CacheError";
 export {
     ClientAuthError,
     ClientAuthErrorMessage,

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -364,7 +364,8 @@ export class ResponseHandler {
             }
             await this.cacheStorage.saveCacheRecord(
                 cacheRecord,
-                request.storeInCache
+                request.storeInCache,
+                request.correlationId
             );
         } finally {
             if (

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -23,6 +23,7 @@ import {
 import { IPerformanceMeasurement } from "./IPerformanceMeasurement";
 import { StubPerformanceMeasurement } from "./StubPerformanceClient";
 import { AuthError } from "../../error/AuthError";
+import { CacheError } from "../../error/CacheError";
 
 export interface PreQueueEvent {
     name: PerformanceEvents;
@@ -153,6 +154,9 @@ export function addError(
     } else if (error instanceof AuthError) {
         event.errorCode = error.errorCode;
         event.subErrorCode = error.subError;
+        return;
+    } else if (error instanceof CacheError) {
+        event.errorCode = error.errorCode;
         return;
     } else if (event.errorStack?.length) {
         logger.trace(

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -804,6 +804,11 @@ export type PerformanceEvent = {
 
     // Event context as JSON string
     context?: string;
+
+    // Number of tokens in the cache to be reported when cache quota is exceeded
+    cacheRtCount?: number;
+    cacheIdCount?: number;
+    cacheAtCount?: number;
 };
 
 export type PerformanceEventContext = {

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -3,17 +3,17 @@ import { ServerAuthorizationTokenResponse } from "../../src/response/ServerAutho
 import { ResponseHandler } from "../../src/response/ResponseHandler";
 import {
     AUTHENTICATION_RESULT,
+    ID_TOKEN_CLAIMS,
+    POP_AUTHENTICATION_RESULT,
     RANDOM_TEST_GUID,
     TEST_CONFIG,
-    ID_TOKEN_CLAIMS,
+    TEST_CRYPTO_VALUES,
     TEST_DATA_CLIENT_INFO,
-    TEST_STATE_VALUES,
     TEST_POP_VALUES,
-    POP_AUTHENTICATION_RESULT,
-    TEST_URIS,
+    TEST_STATE_VALUES,
     TEST_TOKEN_LIFETIMES,
     TEST_TOKENS,
-    TEST_CRYPTO_VALUES,
+    TEST_URIS,
 } from "../test_kit/StringConstants";
 import { Authority } from "../../src/authority/Authority";
 import {
@@ -29,7 +29,7 @@ import { AuthenticationResult } from "../../src/response/AuthenticationResult";
 import { AuthenticationScheme } from "../../src/utils/Constants";
 import { AuthorityOptions } from "../../src/authority/AuthorityOptions";
 import { ProtocolMode } from "../../src/authority/ProtocolMode";
-import { LogLevel, Logger } from "../../src/logger/Logger";
+import { Logger, LogLevel } from "../../src/logger/Logger";
 import * as AuthToken from "../../src/account/AuthToken";
 import { AccountEntity } from "../../src/cache/entities/AccountEntity";
 import { BaseAuthRequest } from "../../src/request/BaseAuthRequest";
@@ -41,6 +41,13 @@ import {
 } from "../../src/error/ClientAuthError";
 import { InteractionRequiredAuthError } from "../../src/error/InteractionRequiredAuthError";
 import { ServerError } from "../../src/error/ServerError";
+import {
+    CacheError,
+    CacheErrorCodes,
+    CacheErrorMessages,
+} from "../../src/error/CacheError";
+import { CacheManager } from "../../src/cache/CacheManager";
+import { cacheQuotaExceededErrorCode } from "../../src/error/CacheErrorCodes";
 
 const networkInterface: INetworkModule = {
     sendGetRequestAsync<T>(url: string, options?: NetworkRequestOptions): T {
@@ -892,6 +899,195 @@ describe("ResponseHandler.ts", () => {
                 const err = e as ClientAuthError;
                 expect(err.errorCode).toBe(ClientAuthErrorCodes.invalidState);
                 done();
+            }
+        });
+    });
+
+    describe("captures cache error", () => {
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it("captures cache quota error by checking error code", async () => {
+            const testRequest: BaseAuthRequest = {
+                authority: testAuthority.canonicalAuthority,
+                correlationId: "CORRELATION_ID",
+                scopes: ["openid", "profile", "User.Read", "email"],
+            };
+            const testResponse: ServerAuthorizationTokenResponse = {
+                ...AUTHENTICATION_RESULT.body,
+            };
+            const errorMessage = "storage error message";
+            const quotaExceededError = new Error(errorMessage);
+            quotaExceededError.name = "QuotaExceededError";
+
+            sinon
+                // @ts-ignore
+                .stub(CacheManager.prototype, "saveAccessToken")
+                .throws(quotaExceededError);
+
+            const responseHandler = new ResponseHandler(
+                "this-is-a-client-id",
+                testCacheManager,
+                cryptoInterface,
+                logger,
+                null,
+                null
+            );
+
+            try {
+                const timestamp = TimeUtils.nowSeconds();
+                await responseHandler.handleServerTokenResponse(
+                    testResponse,
+                    testAuthority,
+                    timestamp,
+                    testRequest
+                );
+                throw Error("should throw cache error");
+            } catch (e) {
+                expect(e).toBeInstanceOf(CacheError);
+                const cacheError: CacheError = e as CacheError;
+                expect(cacheError.errorCode).toEqual("cache_quota_exceeded");
+                expect(cacheError.errorMessage).toEqual(
+                    CacheErrorMessages[cacheQuotaExceededErrorCode]
+                );
+            }
+        });
+
+        it("captures cache quota error by checking error message", async () => {
+            const testRequest: BaseAuthRequest = {
+                authority: testAuthority.canonicalAuthority,
+                correlationId: "CORRELATION_ID",
+                scopes: ["openid", "profile", "User.Read", "email"],
+            };
+            const testResponse: ServerAuthorizationTokenResponse = {
+                ...AUTHENTICATION_RESULT.body,
+            };
+            const errorMessage =
+                "Failed to run localstorage.setItem(). Local storage exceeded the quota.";
+            const quotaExceededError = new Error(errorMessage);
+
+            sinon
+                // @ts-ignore
+                .stub(CacheManager.prototype, "saveAccessToken")
+                .throws(quotaExceededError);
+
+            const responseHandler = new ResponseHandler(
+                "this-is-a-client-id",
+                testCacheManager,
+                cryptoInterface,
+                logger,
+                null,
+                null
+            );
+
+            try {
+                const timestamp = TimeUtils.nowSeconds();
+                await responseHandler.handleServerTokenResponse(
+                    testResponse,
+                    testAuthority,
+                    timestamp,
+                    testRequest
+                );
+                throw Error("should throw cache error");
+            } catch (e) {
+                expect(e).toBeInstanceOf(CacheError);
+                const cacheError: CacheError = e as CacheError;
+                expect(cacheError.errorCode).toEqual("cache_quota_exceeded");
+                expect(cacheError.errorMessage).toEqual(
+                    CacheErrorMessages[cacheQuotaExceededErrorCode]
+                );
+            }
+        });
+
+        it("captures dummy cache error", async () => {
+            const testRequest: BaseAuthRequest = {
+                authority: testAuthority.canonicalAuthority,
+                correlationId: "CORRELATION_ID",
+                scopes: ["openid", "profile", "User.Read", "email"],
+            };
+            const testResponse: ServerAuthorizationTokenResponse = {
+                ...AUTHENTICATION_RESULT.body,
+            };
+            const errorMessage = "Dummy cache error";
+            const error = new Error(errorMessage);
+            error.name = "DummyError";
+
+            sinon
+                // @ts-ignore
+                .stub(CacheManager.prototype, "saveAccessToken")
+                .throws(error);
+
+            const responseHandler = new ResponseHandler(
+                "this-is-a-client-id",
+                testCacheManager,
+                cryptoInterface,
+                logger,
+                null,
+                null
+            );
+
+            try {
+                const timestamp = TimeUtils.nowSeconds();
+                await responseHandler.handleServerTokenResponse(
+                    testResponse,
+                    testAuthority,
+                    timestamp,
+                    testRequest
+                );
+                throw Error("should throw cache error");
+            } catch (e) {
+                expect(e).toBeInstanceOf(CacheError);
+                const cacheError: CacheError = e as CacheError;
+                expect(cacheError.errorCode).toEqual("DummyError");
+                expect(cacheError.errorMessage).toEqual(errorMessage);
+            }
+        });
+
+        it("captures unknown cache error", async () => {
+            const testRequest: BaseAuthRequest = {
+                authority: testAuthority.canonicalAuthority,
+                correlationId: "CORRELATION_ID",
+                scopes: ["openid", "profile", "User.Read", "email"],
+            };
+            const testResponse: ServerAuthorizationTokenResponse = {
+                ...AUTHENTICATION_RESULT.body,
+            };
+            const errorMessage = "Dummy cache error";
+            const error = new DOMException(errorMessage);
+
+            sinon
+                // @ts-ignore
+                .stub(CacheManager.prototype, "saveAccessToken")
+                .throws(error);
+
+            const responseHandler = new ResponseHandler(
+                "this-is-a-client-id",
+                testCacheManager,
+                cryptoInterface,
+                logger,
+                null,
+                null
+            );
+
+            try {
+                const timestamp = TimeUtils.nowSeconds();
+                await responseHandler.handleServerTokenResponse(
+                    testResponse,
+                    testAuthority,
+                    timestamp,
+                    testRequest
+                );
+                throw Error("should throw cache error");
+            } catch (e) {
+                expect(e).toBeInstanceOf(CacheError);
+                const cacheError: CacheError = e as CacheError;
+                expect(cacheError.errorCode).toEqual(
+                    CacheErrorCodes.cacheUnknownErrorCode
+                );
+                expect(cacheError.errorMessage).toEqual(
+                    CacheErrorMessages[CacheErrorCodes.cacheUnknownErrorCode]
+                );
             }
         });
     });


### PR DESCRIPTION
- Add CacheError.
- Capture and throw cache errors as CacheError.
- Instrument the number of tokens in the cache if CacheError occurs.

**Note**: Cache errors, like "cache quota exceeded", are not captured and reported as empty errors at the moment.