### PR TITLE
Managed Identity Documentation Updates

### DIFF
--- a/lib/msal-node/docs/managed-identity.md
+++ b/lib/msal-node/docs/managed-identity.md
@@ -2,7 +2,7 @@
 
 ### Note
 
-> This feature is in preview and feedback is welcome. See the [preview package](https://www.npmjs.com/package/@azure/msal-node/v/2.6.5-alpha.0) that has been upload to npm.
+> This feature is available in msal-node 2.7.0.
 
 A common challenge for developers is the management of secrets, credentials, certificates, and keys used to secure communication between services. [Managed identities](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) in Azure eliminate the need for developers to handle these credentials manually. MSALJS's msal-node library supports acquiring tokens through the managed identity service when used with applications running inside Azure infrastructure, such as:
 

--- a/samples/msal-node-samples/Managed-Identity/Imds/README.md
+++ b/samples/msal-node-samples/Managed-Identity/Imds/README.md
@@ -4,7 +4,6 @@ This sample demonstrates how to use [managed identity via the msal-node library]
 
 ## Note
 
--   The functionality for this sample is in preview (alpha)
 -   This sample is written in TypeScript and was developed with Node version 18.17.0.
 
 ## Virtual Machine Setup

--- a/samples/msal-node-samples/Managed-Identity/Imds/README.md
+++ b/samples/msal-node-samples/Managed-Identity/Imds/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to use [managed identity via the msal-node library]
 
 ## Note
 
--   This sample is written in TypeScript and was developed with Node version 18.17.0.
+-   This sample is written in TypeScript and was developed with Node version 18.17.0. Managed Identity is available in msal-node 2.7.0.
 
 ## Virtual Machine Setup
 

--- a/samples/msal-node-samples/Managed-Identity/Imds/README.md
+++ b/samples/msal-node-samples/Managed-Identity/Imds/README.md
@@ -4,7 +4,8 @@ This sample demonstrates how to use [managed identity via the msal-node library]
 
 ## Note
 
--   This sample is written in TypeScript and was developed with Node version 18.17.0. Managed Identity is available in msal-node 2.7.0.
+-   This sample is written in TypeScript and was developed with Node version 18.17.0.
+-   Managed Identity is available in msal-node 2.7.0.
 
 ## Virtual Machine Setup
 

--- a/samples/msal-node-samples/Managed-Identity/Imds/package.json
+++ b/samples/msal-node-samples/Managed-Identity/Imds/package.json
@@ -7,7 +7,7 @@
     "start:app": "npm run build && node build/index.js"
   },
   "dependencies": {
-    "@azure/msal-node": "^2.6.5-alpha.0",
+    "@azure/msal-node": "^2.7.0",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {

--- a/samples/msal-node-samples/Managed-Identity/ServiceFabric/README.md
+++ b/samples/msal-node-samples/Managed-Identity/ServiceFabric/README.md
@@ -4,7 +4,8 @@ This sample demonstrates how to use [managed identity via the msal-node library]
 
 ## Note
 
--   This sample is written in TypeScript and was developed with Node version 18.17.0. Managed Identity is available in msal-node 2.7.0.
+-   This sample is written in TypeScript and was developed with Node version 18.17.0.
+-   Managed Identity is available in msal-node 2.7.0.
 
 ## Service Fabric Cluster Setup
 

--- a/samples/msal-node-samples/Managed-Identity/ServiceFabric/README.md
+++ b/samples/msal-node-samples/Managed-Identity/ServiceFabric/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to use [managed identity via the msal-node library]
 
 ## Note
 
--   This sample is written in TypeScript and was developed with Node version 18.17.0.
+-   This sample is written in TypeScript and was developed with Node version 18.17.0. Managed Identity is available in msal-node 2.7.0.
 
 ## Service Fabric Cluster Setup
 

--- a/samples/msal-node-samples/Managed-Identity/ServiceFabric/README.md
+++ b/samples/msal-node-samples/Managed-Identity/ServiceFabric/README.md
@@ -4,7 +4,6 @@ This sample demonstrates how to use [managed identity via the msal-node library]
 
 ## Note
 
--   The functionality for this sample is in preview (alpha)
 -   This sample is written in TypeScript and was developed with Node version 18.17.0.
 
 ## Service Fabric Cluster Setup

--- a/samples/msal-node-samples/Managed-Identity/ServiceFabric/package.json
+++ b/samples/msal-node-samples/Managed-Identity/ServiceFabric/package.json
@@ -7,7 +7,7 @@
     "start:app": "npm run build && node build/index.js"
   },
   "dependencies": {
-    "@azure/msal-node": "^2.6.5-alpha.0",
+    "@azure/msal-node": "^2.7.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2"
   },


### PR DESCRIPTION
Updated managed identity docs now that the feature is out of alpha and is available in msal-node v 2.7.0.