### PR TITLE
Added initialize() to isAuthenticated() function to correctly handle redirects correctly

### DIFF
--- a/samples/msal-browser-samples/vue3-sample-app/src/router/Guard.ts
+++ b/samples/msal-browser-samples/vue3-sample-app/src/router/Guard.ts
@@ -17,7 +17,10 @@ export function registerGuard(router: Router) {
     });
 }
 
-export async function isAuthenticated(instance: PublicClientApplication, interactionType: InteractionType, loginRequest: PopupRequest|RedirectRequest): Promise<boolean> {    
+export async function isAuthenticated(instance: PublicClientApplication, interactionType: InteractionType, loginRequest: PopupRequest|RedirectRequest): Promise<boolean> {
+	// Must call and await the initialize
+    await instance.initialize();    
+    
     // If your application uses redirects for interaction, handleRedirectPromise must be called and awaited on each page load before determining if a user is signed in or not  
     return instance.handleRedirectPromise().then(() => {
         const accounts = instance.getAllAccounts();


### PR DESCRIPTION
After logging in, if we input into the address bar `http://localhost:3000/profile` this would fail authentication and redirect to `/failed`. The reason is because `isAuthenticated()` does not have `.initialize()` and throws an error

> {
>     "errorCode": "uninitialized_public_client_application",
>     "errorMessage": "You must call and await the initialize function before attempting to call any other MSAL API.  For more visit: aka.ms/msaljs/browser-errors",
>     "subError": "",
>     "name": "BrowserAuthError"
> }