### PR TITLE
Remove e2e-test-utils from the Angular 17 standalone sample

### DIFF
--- a/samples/msal-angular-v3-samples/angular17-standalone-sample/package.json
+++ b/samples/msal-angular-v3-samples/angular17-standalone-sample/package.json
@@ -34,7 +34,6 @@
     "@angular/compiler-cli": "^17.3.0",
     "@types/jasmine": "~5.1.0",
     "@types/jest": "^29.5.12",
-    "e2e-test-utils": "^0.0.1",
     "jasmine-core": "~5.1.0",
     "jest": "^29.7.0",
     "karma": "~6.4.0",


### PR DESCRIPTION
Without removing the reference to e2e-test-utils, it does not seem possible to build the standalone sample for Angular 17. This removes that reference.