### PR TITLE
Remove msal-angular2 references

### DIFF
--- a/lib/msal-angular/docs/configuration.md
+++ b/lib/msal-angular/docs/configuration.md
@@ -107,7 +107,7 @@ import { IPublicClientApplication, PublicClientApplication, InteractionType, Bro
 export function MSALInstanceFactory(): IPublicClientApplication {
   return new PublicClientApplication({
     auth: {
-      clientId: "6226576d-37e9-49eb-b201-ec1eeb0029b6",
+      clientId: "b5c2e510-4a17-4feb-b219-e55aa5b74144",
       redirectUri: "http://localhost:4200",
       postLogoutRedirectUri: "http://localhost:4200"
     },

--- a/lib/msal-angular/docs/redirects.md
+++ b/lib/msal-angular/docs/redirects.md
@@ -76,7 +76,7 @@ export function loggerCallback(logLevel: LogLevel, message: string) {
 export function MSALInstanceFactory(): IPublicClientApplication {
   return new PublicClientApplication({
     auth: {
-      clientId: '6226576d-37e9-49eb-b201-ec1eeb0029b6',
+      clientId: 'b5c2e510-4a17-4feb-b219-e55aa5b74144',
       redirectUri: 'http://localhost:4200',
       postLogoutRedirectUri: 'http://localhost:4200'
     },

--- a/lib/msal-angular/src/msal.broadcast.service.spec.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.spec.ts
@@ -14,7 +14,7 @@ let subscription: Subscription;
 
 const msalInstance = new PublicClientApplication({
   auth: {
-    clientId: "6226576d-37e9-49eb-b201-ec1eeb0029b6",
+    clientId: "b5c2e510-4a17-4feb-b219-e55aa5b74144",
     redirectUri: "http://localhost:4200",
   },
 });

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -32,7 +32,7 @@ let browserSystemOptions: BrowserSystemOptions;
 function MSALInstanceFactory(): IPublicClientApplication {
   return new PublicClientApplication({
     auth: {
-      clientId: "6226576d-37e9-49eb-b201-ec1eeb0029b6",
+      clientId: "b5c2e510-4a17-4feb-b219-e55aa5b74144",
       redirectUri: "http://localhost:4200",
     },
     system: {

--- a/lib/msal-angular/src/msal.interceptor.spec.ts
+++ b/lib/msal-angular/src/msal.interceptor.spec.ts
@@ -43,7 +43,7 @@ const sampleAccountInfo: AccountInfo = {
 function MSALInstanceFactory(): IPublicClientApplication {
   return new PublicClientApplication({
     auth: {
-      clientId: "6226576d-37e9-49eb-b201-ec1eeb0029b6",
+      clientId: "b5c2e510-4a17-4feb-b219-e55aa5b74144",
       redirectUri: "http://localhost:4200",
     },
   });

--- a/lib/msal-angular/src/msal.navigation.client.spec.ts
+++ b/lib/msal-angular/src/msal.navigation.client.spec.ts
@@ -20,7 +20,7 @@ let routerMock = {
 
 const msalInstance = new PublicClientApplication({
   auth: {
-    clientId: "6226576d-37e9-49eb-b201-ec1eeb0029b6",
+    clientId: "b5c2e510-4a17-4feb-b219-e55aa5b74144",
     redirectUri: "http://localhost:4200",
   },
 });

--- a/lib/msal-angular/src/msal.redirect.component.spec.ts
+++ b/lib/msal-angular/src/msal.redirect.component.spec.ts
@@ -14,7 +14,7 @@ let broadcastService: MsalBroadcastService;
 function MSALInstanceFactory(): IPublicClientApplication {
   return new PublicClientApplication({
     auth: {
-      clientId: "6226576d-37e9-49eb-b201-ec1eeb0029b6",
+      clientId: "b5c2e510-4a17-4feb-b219-e55aa5b74144",
       redirectUri: "http://localhost:4200",
     },
   });

--- a/lib/msal-angular/src/msal.service.spec.ts
+++ b/lib/msal-angular/src/msal.service.spec.ts
@@ -14,7 +14,7 @@ let broadcastService: MsalBroadcastService;
 
 const msalInstance = new PublicClientApplication({
   auth: {
-    clientId: "6226576d-37e9-49eb-b201-ec1eeb0029b6",
+    clientId: "b5c2e510-4a17-4feb-b219-e55aa5b74144",
     redirectUri: "http://localhost:4200",
   },
 });


### PR DESCRIPTION
This PR removes references to `msal-angular2` app client ID in docs and unit tests, replaces with client Id currently used in samples.