### PR TITLE
Fix empty telemetry error code for the redirect flow when server response is empty

### DIFF
--- a/change/@azure-msal-browser-41250903-bf9b-44df-a518-d7bcf47cbe16.json
+++ b/change/@azure-msal-browser-41250903-bf9b-44df-a518-d7bcf47cbe16.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix empty telemetry error code for the redirect flow when server response is empty #7056",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -455,11 +455,7 @@ export class StandardController implements IController {
                 this.logger,
                 this.performanceClient,
                 rootMeasurement.event.correlationId
-            )(
-                hash,
-                this.performanceClient,
-                rootMeasurement.event.correlationId
-            );
+            )(hash);
         }
 
         return redirectResponse
@@ -497,7 +493,13 @@ export class StandardController implements IController {
                     EventType.HANDLE_REDIRECT_END,
                     InteractionType.Redirect
                 );
-                rootMeasurement.end({ success: false });
+
+                rootMeasurement.end(
+                    {
+                        success: false,
+                    },
+                    new AuthError("no_server_response")
+                );
 
                 return result;
             })

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -191,13 +191,9 @@ export class RedirectClient extends StandardInteractionClient {
      * - if true, performs logic to cache and navigate
      * - if false, handles hash string and parses response
      * @param hash {string?} url hash
-     * @param performanceClient {IPerformanceClient?}
-     * @param correlationId {string?} correlation identifier
      */
     async handleRedirectPromise(
-        hash?: string,
-        performanceClient?: IPerformanceClient,
-        correlationId?: string
+        hash?: string
     ): Promise<AuthenticationResult | null> {
         const serverTelemetryManager = this.initializeServerTelemetryManager(
             ApiId.handleRedirectPromise
@@ -220,12 +216,6 @@ export class RedirectClient extends StandardInteractionClient {
                 this.browserStorage.cleanRequestByInteractionType(
                     InteractionType.Redirect
                 );
-                if (performanceClient && correlationId) {
-                    performanceClient?.addFields(
-                        { errorCode: "no_server_response" },
-                        correlationId
-                    );
-                }
                 return null;
             }
 

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -865,6 +865,32 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             });
         });
 
+        it("Emits performance event with error code if no response is provided", (done) => {
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com",
+            };
+            sinon
+                .stub(StandardController.prototype, "getAllAccounts")
+                .returns([testAccount]);
+            sinon
+                .stub(RedirectClient.prototype, "handleRedirectPromise")
+                .resolves(null);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events.length).toEqual(1);
+                expect(events[0].success).toBe(false);
+                expect(events[0].errorCode).toBe("no_server_response");
+                pca.removePerformanceCallback(callbackId);
+                done();
+            });
+
+            pca.handleRedirectPromise();
+        });
+
         it("Multiple concurrent calls to handleRedirectPromise return the same promise", async () => {
             const stateString = TEST_STATE_VALUES.TEST_STATE_REDIRECT;
             const browserCrypto = new CryptoOps(new Logger({}));


### PR DESCRIPTION
- Fix empty telemetry error code for the redirect flow when server response is empty.

**NOTE** Empty error code is caused by parent measurement empty error code overriding child one.