### PR TITLE
Fix `useIsAuthenticated` hook briefly returning false even though the user is authenticated

### DIFF
--- a/change/@azure-msal-react-5355b5e3-0c1c-4e23-ae9d-a6d96ef4285d.json
+++ b/change/@azure-msal-react-5355b5e3-0c1c-4e23-ae9d-a6d96ef4285d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix useIsAuthenticated returning incorrect value during useEffect update",
+  "comment": "Fix useIsAuthenticated returning incorrect value during useEffect update #7057",
   "packageName": "@azure/msal-react",
   "email": "kade@hatchedlabs.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-react-5355b5e3-0c1c-4e23-ae9d-a6d96ef4285d.json
+++ b/change/@azure-msal-react-5355b5e3-0c1c-4e23-ae9d-a6d96ef4285d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix useIsAuthenticated returning incorrect value during useEffect update",
+  "packageName": "@azure/msal-react",
+  "email": "kade@hatchedlabs.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-react/src/hooks/useIsAuthenticated.ts
+++ b/lib/msal-react/src/hooks/useIsAuthenticated.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
 import { useMsal } from "./useMsal";
 import { AccountIdentifiers } from "../types/AccountIdentifiers";
 import { AccountInfo, InteractionStatus } from "@azure/msal-browser";
@@ -32,16 +32,12 @@ function isAuthenticated(
 export function useIsAuthenticated(matchAccount?: AccountIdentifiers): boolean {
     const { accounts: allAccounts, inProgress } = useMsal();
 
-    const [hasAuthenticated, setHasAuthenticated] = useState<boolean>(() => {
+    const isUserAuthenticated = useMemo(() => {
         if (inProgress === InteractionStatus.Startup) {
             return false;
         }
         return isAuthenticated(allAccounts, matchAccount);
-    });
+    }, [allAccounts, inProgress, matchAccount]);
 
-    useEffect(() => {
-        setHasAuthenticated(isAuthenticated(allAccounts, matchAccount));
-    }, [allAccounts, matchAccount]);
-
-    return hasAuthenticated;
+    return isUserAuthenticated;
 }

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -664,9 +664,7 @@ describe("MsalAuthenticationTemplate tests", () => {
             await waitFor(() =>
                 expect(acquireTokenPopupSpy).toHaveBeenCalledTimes(1)
             );
-            expect(
-                screen.queryByText("This text will always display.")
-            ).toBeInTheDocument();
+            await screen.findByText("This text will always display.");
             expect(
                 screen.queryByText("A user is authenticated!")
             ).toBeInTheDocument();
@@ -697,16 +695,18 @@ describe("MsalAuthenticationTemplate tests", () => {
                     return Promise.resolve();
                 });
 
-            render(
-                <MsalProvider instance={pca}>
-                    <p>This text will always display.</p>
-                    <MsalAuthenticationTemplate
-                        interactionType={InteractionType.Redirect}
-                    >
-                        <span> A user is authenticated!</span>
-                    </MsalAuthenticationTemplate>
-                </MsalProvider>
-            );
+            await act(async () => {
+                render(
+                    <MsalProvider instance={pca}>
+                        <p>This text will always display.</p>
+                        <MsalAuthenticationTemplate
+                            interactionType={InteractionType.Redirect}
+                        >
+                            <span> A user is authenticated!</span>
+                        </MsalAuthenticationTemplate>
+                    </MsalProvider>
+                );
+            });
 
             await waitFor(() =>
                 expect(handleRedirectSpy).toHaveBeenCalledTimes(1)
@@ -764,9 +764,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 expect(acquireTokenSilentSpy).toHaveBeenCalledTimes(1)
             );
             await waitFor(() => expect(ssoSilentSpy).toHaveBeenCalledTimes(1));
-            expect(
-                screen.queryByText("This text will always display.")
-            ).toBeInTheDocument();
+            await screen.findByText("This text will always display.");
             expect(
                 screen.queryByText("A user is authenticated!")
             ).toBeInTheDocument();
@@ -825,6 +823,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                             error: null,
                             timestamp: 10000,
                         };
+
                         eventCallbacks.forEach((callback) => {
                             callback(eventMessage);
                         });
@@ -863,7 +862,7 @@ describe("MsalAuthenticationTemplate tests", () => {
             await waitFor(() =>
                 expect(acquireTokenSilentSpy).toHaveBeenCalledTimes(1)
             );
-            act(() => {
+            await act(async () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Redirect,
@@ -871,6 +870,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                     error: null,
                     timestamp: 10000,
                 };
+
                 eventCallbacks.forEach((callback) => {
                     callback(eventMessage);
                 });
@@ -923,7 +923,7 @@ describe("MsalAuthenticationTemplate tests", () => {
             await waitFor(() =>
                 expect(acquireTokenSilentSpy).toHaveBeenCalledTimes(1)
             );
-            expect(screen.queryByText("Error Occurred")).toBeInTheDocument();
+            await screen.findByText("Error Occurred");
             expect(
                 screen.queryByText("This text will always display.")
             ).toBeInTheDocument();

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -827,7 +827,6 @@ describe("MsalAuthenticationTemplate tests", () => {
                             error: null,
                             timestamp: 10000,
                         };
-
                         eventCallbacks.forEach((callback) => {
                             callback(eventMessage);
                         });
@@ -874,7 +873,6 @@ describe("MsalAuthenticationTemplate tests", () => {
                     error: null,
                     timestamp: 10000,
                 };
-
                 eventCallbacks.forEach((callback) => {
                     callback(eventMessage);
                 });

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -664,7 +664,9 @@ describe("MsalAuthenticationTemplate tests", () => {
             await waitFor(() =>
                 expect(acquireTokenPopupSpy).toHaveBeenCalledTimes(1)
             );
-            await screen.findByText("This text will always display.");
+            expect(
+                await screen.findByText("This text will always display.")
+            ).toBeInTheDocument();
             expect(
                 screen.queryByText("A user is authenticated!")
             ).toBeInTheDocument();
@@ -766,7 +768,7 @@ describe("MsalAuthenticationTemplate tests", () => {
             await waitFor(() => expect(ssoSilentSpy).toHaveBeenCalledTimes(1));
             expect(
                 await screen.findByText("This text will always display.")
-            ).toBeVisible();
+            ).toBeInTheDocument();
             expect(
                 screen.queryByText("A user is authenticated!")
             ).toBeInTheDocument();

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -764,7 +764,9 @@ describe("MsalAuthenticationTemplate tests", () => {
                 expect(acquireTokenSilentSpy).toHaveBeenCalledTimes(1)
             );
             await waitFor(() => expect(ssoSilentSpy).toHaveBeenCalledTimes(1));
-            await screen.findByText("This text will always display.");
+            expect(
+                await screen.findByText("This text will always display.")
+            ).toBeVisible();
             expect(
                 screen.queryByText("A user is authenticated!")
             ).toBeInTheDocument();
@@ -923,7 +925,9 @@ describe("MsalAuthenticationTemplate tests", () => {
             await waitFor(() =>
                 expect(acquireTokenSilentSpy).toHaveBeenCalledTimes(1)
             );
-            await screen.findByText("Error Occurred");
+            expect(
+                await screen.findByText("Error Occurred")
+            ).toBeInTheDocument();
             expect(
                 screen.queryByText("This text will always display.")
             ).toBeInTheDocument();

--- a/lib/msal-react/test/hooks/useIsAuthenticated.spec.tsx
+++ b/lib/msal-react/test/hooks/useIsAuthenticated.spec.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Configuration, PublicClientApplication } from "@azure/msal-browser";
+import { TEST_CONFIG, testAccount } from "../TestConstants";
+import { MsalProvider, useIsAuthenticated, withMsal } from "../../src/index";
+
+describe("withMsal tests", () => {
+    let pca: PublicClientApplication;
+    const msalConfig: Configuration = {
+        auth: {
+            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+        },
+        system: {
+            allowNativeBroker: false,
+        },
+    };
+
+    let handleRedirectSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        pca = new PublicClientApplication(msalConfig);
+        handleRedirectSpy = jest.spyOn(pca, "handleRedirectPromise");
+        jest.spyOn(pca, "getAllAccounts").mockImplementation(() => []);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("useAuthenticated always returns true if user has an account", async () => {
+        const invalidAuthStateCallback = jest.fn();
+
+        const testComponent = ({ ...props }) => {
+            const isAuth = useIsAuthenticated();
+            const accounts = props.msalContext.accounts;
+
+            if (accounts.length > 0 && !isAuth) {
+                invalidAuthStateCallback();
+            }
+
+            return (
+                <>
+                    <p>This component has been wrapped by msal</p>
+                    {accounts.length === 0 && <p>No accounts</p>}
+                    {accounts.length > 0 && <p>Has accounts</p>}
+                    {isAuth && <p>Is authed</p>}
+                    {!isAuth && <p>Not authed</p>}
+                </>
+            );
+        };
+
+        const WrappedComponent = withMsal(testComponent);
+        const { rerender } = render(
+            <MsalProvider instance={pca}>
+                <WrappedComponent />
+            </MsalProvider>
+        );
+
+        await waitFor(() => expect(handleRedirectSpy).toHaveBeenCalledTimes(1));
+
+        expect(await screen.findByText("No accounts")).toBeInTheDocument();
+        expect(await screen.findByText("Not authed")).toBeInTheDocument();
+
+        const pcaWithAccounts = new PublicClientApplication(msalConfig);
+        jest.spyOn(pcaWithAccounts, "getAllAccounts").mockImplementation(() => [
+            testAccount,
+        ]);
+
+        await act(async () =>
+            rerender(
+                <MsalProvider instance={pcaWithAccounts}>
+                    <WrappedComponent />
+                </MsalProvider>
+            )
+        );
+
+        expect(await screen.findByText("Has accounts")).toBeInTheDocument();
+        expect(await screen.findByText("Is authed")).toBeInTheDocument();
+        expect(invalidAuthStateCallback).toHaveBeenCalledTimes(0);
+    });
+});

--- a/lib/msal-react/test/hooks/useIsAuthenticated.spec.tsx
+++ b/lib/msal-react/test/hooks/useIsAuthenticated.spec.tsx
@@ -5,7 +5,7 @@ import { Configuration, PublicClientApplication } from "@azure/msal-browser";
 import { TEST_CONFIG, testAccount } from "../TestConstants";
 import { MsalProvider, useIsAuthenticated, withMsal } from "../../src/index";
 
-describe("withMsal tests", () => {
+describe("useIsAuthenticated tests", () => {
     let pca: PublicClientApplication;
     const msalConfig: Configuration = {
         auth: {


### PR DESCRIPTION
Addresses https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/6918

The current `useIsAuthenticated` has an unnecessary `useEffect`, which causes it to briefly return `false` in some cases even when an account is present. See https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state and https://react.dev/learn/you-might-not-need-an-effect#caching-expensive-calculations 

This PR switches to use the `useMemo` recommendation

I added a unit test that passes now, but fails with the old implementation:
```
 FAIL  test/hooks/useIsAuthenticated.spec.tsx
  ● withMsal tests › useAuthenticated always returns true if user has an account

    expect(jest.fn()).toHaveBeenCalledTimes(expected)

    Expected number of calls: 0
    Received number of calls: 1

      78 |         expect(await screen.findByText("Has accounts")).toBeInTheDocument();
      79 |         expect(await screen.findByText("Is authed")).toBeInTheDocument();
    > 80 |         expect(invalidAuthStateCallback).toHaveBeenCalledTimes(0);
         |                                          ^
      81 |     });
      82 | });
      83 |

      at Object.<anonymous> (test/hooks/useIsAuthenticated.spec.tsx:80:42)
```

I also had to tweak some act / await / async code in other tests, presumably because now it takes fewer renders for the hook to start returning the correct value. Without the tweaks a couple tests were failing, and others printed warning about updating state outside of an `act(...)`. 