### PR TITLE
Discard empty redirect telemetry events with no error codes

### DIFF
--- a/change/@azure-msal-browser-2e85fe15-6556-4439-ae1e-6999a0c982a5.json
+++ b/change/@azure-msal-browser-2e85fe15-6556-4439-ae1e-6999a0c982a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Discard empty redirect telemetry events with no error codes #7058",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -494,9 +494,17 @@ export class StandardController implements IController {
                     InteractionType.Redirect
                 );
 
+                /*
+                 * Instrument an event only if an error code is set. Otherwise, discard it when the redirect response
+                 * is empty and the error code is missing.
+                 */
                 if (rootMeasurement.event.errorCode) {
                     rootMeasurement.end({ success: false });
                 } else {
+                    /*
+                     * Discard a measurement and all sub-measurements if error code is empty to make sure
+                     *
+                     */
                     rootMeasurement.discard();
                 }
 

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -488,21 +488,22 @@ export class StandardController implements IController {
                         success: true,
                         accountType: getAccountType(result.account),
                     });
+                } else {
+                    /*
+                     * Instrument an event only if an error code is set. Otherwise, discard it when the redirect response
+                     * is empty and the error code is missing.
+                     */
+                    if (rootMeasurement.event.errorCode) {
+                        rootMeasurement.end({ success: false });
+                    } else {
+                        rootMeasurement.discard();
+                    }
                 }
+
                 this.eventHandler.emitEvent(
                     EventType.HANDLE_REDIRECT_END,
                     InteractionType.Redirect
                 );
-
-                /*
-                 * Instrument an event only if an error code is set. Otherwise, discard it when the redirect response
-                 * is empty and the error code is missing.
-                 */
-                if (rootMeasurement.event.errorCode) {
-                    rootMeasurement.end({ success: false });
-                } else {
-                    rootMeasurement.discard();
-                }
 
                 return result;
             })

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -501,10 +501,6 @@ export class StandardController implements IController {
                 if (rootMeasurement.event.errorCode) {
                     rootMeasurement.end({ success: false });
                 } else {
-                    /*
-                     * Discard a measurement and all sub-measurements if error code is empty to make sure
-                     *
-                     */
                     rootMeasurement.discard();
                 }
 

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -455,11 +455,7 @@ export class StandardController implements IController {
                 this.logger,
                 this.performanceClient,
                 rootMeasurement.event.correlationId
-            )(
-                hash,
-                this.performanceClient,
-                rootMeasurement.event.correlationId
-            );
+            )(hash, rootMeasurement);
         }
 
         return redirectResponse
@@ -497,7 +493,12 @@ export class StandardController implements IController {
                     EventType.HANDLE_REDIRECT_END,
                     InteractionType.Redirect
                 );
-                rootMeasurement.end({ success: false });
+
+                if (rootMeasurement.event.errorCode) {
+                    rootMeasurement.end({ success: false });
+                } else {
+                    rootMeasurement.discard();
+                }
 
                 return result;
             })

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -21,6 +21,7 @@ import {
     invokeAsync,
     ServerResponseType,
     UrlUtils,
+    InProgressPerformanceEvent,
 } from "@azure/msal-common";
 import { StandardInteractionClient } from "./StandardInteractionClient";
 import {
@@ -190,14 +191,12 @@ export class RedirectClient extends StandardInteractionClient {
      * Checks if navigateToLoginRequestUrl is set, and:
      * - if true, performs logic to cache and navigate
      * - if false, handles hash string and parses response
-     * @param hash {string?} url hash
-     * @param performanceClient {IPerformanceClient?}
-     * @param correlationId {string?} correlation identifier
+     * @param hash {string} url hash
+     * @param parentMeasurement {InProgressPerformanceEvent} parent measurement
      */
     async handleRedirectPromise(
-        hash?: string,
-        performanceClient?: IPerformanceClient,
-        correlationId?: string
+        hash: string = "",
+        parentMeasurement: InProgressPerformanceEvent
     ): Promise<AuthenticationResult | null> {
         const serverTelemetryManager = this.initializeServerTelemetryManager(
             ApiId.handleRedirectPromise
@@ -220,12 +219,7 @@ export class RedirectClient extends StandardInteractionClient {
                 this.browserStorage.cleanRequestByInteractionType(
                     InteractionType.Redirect
                 );
-                if (performanceClient && correlationId) {
-                    performanceClient?.addFields(
-                        { errorCode: "no_server_response" },
-                        correlationId
-                    );
-                }
+                parentMeasurement.event.errorCode = "no_server_response";
                 return null;
             }
 


### PR DESCRIPTION
- Discard empty redirect telemetry events with no error codes. 
- Replace performanceClient with parentMeasurement param to track child errors without throwing.