### PR TITLE
Removed Managed Identity Resource URI Validation

### DIFF
--- a/change/@azure-msal-node-4db7cb53-4748-451c-8675-2bb9a4fe0bb1.json
+++ b/change/@azure-msal-node-4db7cb53-4748-451c-8675-2bb9a4fe0bb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed Managed Identity Resource URI Validation",
+  "packageName": "@azure/msal-node",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/client/ManagedIdentityApplication.ts
+++ b/lib/msal-node/src/client/ManagedIdentityApplication.ts
@@ -122,17 +122,6 @@ export class ManagedIdentityApplication {
     public async acquireToken(
         managedIdentityRequestParams: ManagedIdentityRequestParams
     ): Promise<AuthenticationResult> {
-        const resourceUrlString = new UrlString(
-            managedIdentityRequestParams.resource.replace("/.default", "")
-        );
-        try {
-            resourceUrlString.validateAsUri();
-        } catch (e) {
-            throw createManagedIdentityError(
-                ManagedIdentityErrorCodes.invalidResource
-            );
-        }
-
         const managedIdentityRequest: ManagedIdentityRequest = {
             forceRefresh: managedIdentityRequestParams.forceRefresh,
             resource: managedIdentityRequestParams.resource.replace(

--- a/lib/msal-node/src/client/ManagedIdentityApplication.ts
+++ b/lib/msal-node/src/client/ManagedIdentityApplication.ts
@@ -16,7 +16,8 @@ import {
     ProtocolMode,
     StaticAuthorityOptions,
     AuthenticationResult,
-    UrlString,
+    createClientConfigurationError,
+    ClientConfigurationErrorCodes,
 } from "@azure/msal-common";
 import {
     ManagedIdentityConfiguration,
@@ -31,10 +32,6 @@ import { ManagedIdentityClient } from "./ManagedIdentityClient";
 import { ManagedIdentityRequestParams } from "../request/ManagedIdentityRequestParams";
 import { NodeStorage } from "../cache/NodeStorage";
 import { DEFAULT_AUTHORITY_FOR_MANAGED_IDENTITY } from "../utils/Constants";
-import {
-    ManagedIdentityErrorCodes,
-    createManagedIdentityError,
-} from "../error/ManagedIdentityError";
 
 /**
  * Class to initialize a managed identity and identify the service
@@ -122,6 +119,12 @@ export class ManagedIdentityApplication {
     public async acquireToken(
         managedIdentityRequestParams: ManagedIdentityRequestParams
     ): Promise<AuthenticationResult> {
+        if (!managedIdentityRequestParams.resource) {
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlEmptyError
+            );
+        }
+
         const managedIdentityRequest: ManagedIdentityRequest = {
             forceRefresh: managedIdentityRequestParams.forceRefresh,
             resource: managedIdentityRequestParams.resource.replace(

--- a/lib/msal-node/src/error/ManagedIdentityError.ts
+++ b/lib/msal-node/src/error/ManagedIdentityError.ts
@@ -14,8 +14,6 @@ export { ManagedIdentityErrorCodes };
 export const ManagedIdentityErrorMessages = {
     [ManagedIdentityErrorCodes.invalidManagedIdentityIdType]:
         "More than one ManagedIdentityIdType was provided.",
-    [ManagedIdentityErrorCodes.invalidResource]:
-        "The supplied resource is an invalid URL.",
     [ManagedIdentityErrorCodes.missingId]:
         "A ManagedIdentityId id was not provided.",
     [ManagedIdentityErrorCodes.MsiEnvironmentVariableUrlMalformedErrorCodes

--- a/lib/msal-node/src/error/ManagedIdentityErrorCodes.ts
+++ b/lib/msal-node/src/error/ManagedIdentityErrorCodes.ts
@@ -6,7 +6,6 @@
 import { ManagedIdentityEnvironmentVariableNames } from "../utils/Constants";
 
 export const invalidManagedIdentityIdType = "invalid_managed_identity_id_type";
-export const invalidResource = "invalid_resource";
 export const missingId = "missing_client_id";
 export const networkUnavailable = "network_unavailable";
 export const unableToCreateAzureArc = "unable_to_create_azure_arc";

--- a/lib/msal-node/test/client/ManagedIdentitySources/Imds.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/Imds.spec.ts
@@ -779,33 +779,6 @@ describe("Acquires a token successfully via an IMDS Managed Identity", () => {
     });
 
     describe("Errors", () => {
-        test("throws an error when an invalid resource is provided", async () => {
-            expect(ManagedIdentityTestUtils.isIMDS()).toBe(true);
-
-            const systemAssignedManagedIdentityApplication: ManagedIdentityApplication =
-                new ManagedIdentityApplication(systemAssignedConfig);
-
-            await expect(
-                systemAssignedManagedIdentityApplication.acquireToken({
-                    resource: "invalid_resource",
-                })
-            ).rejects.toMatchObject(
-                createManagedIdentityError(
-                    ManagedIdentityErrorCodes.invalidResource
-                )
-            );
-
-            await expect(
-                systemAssignedManagedIdentityApplication.acquireToken({
-                    resource: "",
-                })
-            ).rejects.toMatchObject(
-                createClientConfigurationError(
-                    ClientConfigurationErrorCodes.urlEmptyError
-                )
-            );
-        });
-
         test("throws an error when more than one managed identity type is provided", () => {
             expect(ManagedIdentityTestUtils.isIMDS()).toBe(true);
 

--- a/lib/msal-node/test/client/ManagedIdentitySources/Imds.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/Imds.spec.ts
@@ -779,6 +779,23 @@ describe("Acquires a token successfully via an IMDS Managed Identity", () => {
     });
 
     describe("Errors", () => {
+        test("throws an error when an invalid resource is provided", async () => {
+            expect(ManagedIdentityTestUtils.isIMDS()).toBe(true);
+
+            const systemAssignedManagedIdentityApplication: ManagedIdentityApplication =
+                new ManagedIdentityApplication(systemAssignedConfig);
+
+            await expect(
+                systemAssignedManagedIdentityApplication.acquireToken({
+                    resource: "",
+                })
+            ).rejects.toMatchObject(
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.urlEmptyError
+                )
+            );
+        });
+
         test("throws an error when more than one managed identity type is provided", () => {
             expect(ManagedIdentityTestUtils.isIMDS()).toBe(true);
 
@@ -795,7 +812,7 @@ describe("Acquires a token successfully via an IMDS Managed Identity", () => {
 
             expect(() => {
                 new ManagedIdentityApplication(badUserAssignedClientIdConfig);
-            }).toThrowError(
+            }).toThrow(
                 createManagedIdentityError(
                     ManagedIdentityErrorCodes.invalidManagedIdentityIdType
                 )


### PR DESCRIPTION
Removed Managed Identity Resource URI Validation. URI's can start with strings other than "https". "api://", for example.

After a discussion with Bogdan, we decided it would be best to remove this validation entirely.