### PR TITLE
Add additional logging for NAA initialization

### DIFF
--- a/change/@azure-msal-browser-ab395da1-96b3-4e3e-aba4-97816697bd09.json
+++ b/change/@azure-msal-browser-ab395da1-96b3-4e3e-aba4-97816697bd09.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add additional logging for Nested App Auth initialization errors (#7064)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/ControllerFactory.ts
+++ b/lib/msal-browser/src/controllers/ControllerFactory.ts
@@ -29,10 +29,7 @@ export async function createController(
 
     await Promise.all(operatingContexts);
 
-    if (
-        teamsApp.isAvailable() &&
-        teamsApp.getConfig().auth.supportsNestedAppAuth
-    ) {
+    if (teamsApp.isAvailable()) {
         const controller = await import("./NestedAppAuthController");
         return controller.NestedAppAuthController.createController(teamsApp);
     } else if (standard.isAvailable()) {

--- a/lib/msal-browser/src/operatingcontext/TeamsAppOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/TeamsAppOperatingContext.ts
@@ -61,6 +61,11 @@ export class TeamsAppOperatingContext extends BaseOperatingContext {
          * TODO: Add implementation to check for presence of inject Nested App Auth Bridge JavaScript interface
          *
          */
+
+        if (!this.getConfig().auth.supportsNestedAppAuth) {
+            return false;
+        }
+
         try {
             if (typeof window !== "undefined") {
                 const bridgeProxy: IBridgeProxy = await BridgeProxy.create();
@@ -74,18 +79,19 @@ export class TeamsAppOperatingContext extends BaseOperatingContext {
                         this.activeAccount =
                             await bridgeProxy.getActiveAccount();
                     }
-                } catch (e) {
-                    this.activeAccount = undefined;
+                } catch {
+                    // Ignore errors
                 }
                 this.bridgeProxy = bridgeProxy;
                 this.available = bridgeProxy !== undefined;
-            } else {
-                this.available = false;
             }
-        } catch (e) {
-            this.available = false;
-        } finally {
-            return this.available;
+        } catch (ex) {
+            this.logger.infoPii(
+                `Could not initialize Nested App Auth bridge (${ex})`
+            );
         }
+
+        this.logger.info(`Nested App Auth Bridge available: ${this.available}`);
+        return this.available;
     }
 }


### PR DESCRIPTION
Add additional logging for NAA initialization to help diagnose if NestAppAuthController is being used for the session, or if it is falling back to StandardController. Also log exception that occurred in trying to use Nested App Auth bridge to get further details on failure cases. The change also avoids the time spent trying to initialize the bridge if caller does not opt-in to supportsNestedAppAuth.