### PR TITLE
Managed Identity: ManagedIdentityTokenResponse's expires_in is now calculated correctly

### DIFF
--- a/change/@azure-msal-node-49d49907-3102-4357-b19e-376b63d7fd97.json
+++ b/change/@azure-msal-node-49d49907-3102-4357-b19e-376b63d7fd97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Managed Identity: ManagedIdentityTokenResponse's expires_in is now calculated correctly",
+  "packageName": "@azure/msal-node",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -81,27 +81,38 @@ export abstract class BaseManagedIdentitySource {
     public getServerTokenResponse(
         response: NetworkResponse<ManagedIdentityTokenResponse>
     ): ServerAuthorizationTokenResponse {
+        let refreshIn, expiresIn: number | undefined;
+        if (response.body.expires_on) {
+            expiresIn = response.body.expires_on - TimeUtils.nowSeconds();
+
+            // compute refresh_in as 1/2 of expires_in, but only if expires_in > 2h
+            if (expiresIn > 2 * 3600) {
+                refreshIn = expiresIn / 2;
+            }
+        }
+
         const serverTokenResponse: ServerAuthorizationTokenResponse = {
             status: response.status,
 
             // success
             access_token: response.body.access_token,
-            expires_in: response.body.expires_on,
+            expires_in: expiresIn,
             scope: response.body.resource,
             token_type: response.body.token_type,
+            refresh_in: refreshIn,
 
             // error
             error: response.body.message,
             correlation_id: response.body.correlationId,
         };
 
-        // compute refresh_in as 1/2 of expires_in, but only if expires_in > 2h
-        if (
-            serverTokenResponse.expires_in &&
-            serverTokenResponse.expires_in > 2 * 3600
-        ) {
-            serverTokenResponse.refresh_in = serverTokenResponse.expires_in / 2;
-        }
+        // // compute refresh_in as 1/2 of expires_in, but only if expires_in > 2h
+        // if (
+        //     serverTokenResponse.expires_in &&
+        //     serverTokenResponse.expires_in > 2 * 3600
+        // ) {
+        //     serverTokenResponse.refresh_in = serverTokenResponse.expires_in / 2;
+        // }
 
         return serverTokenResponse;
     }

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -106,14 +106,6 @@ export abstract class BaseManagedIdentitySource {
             correlation_id: response.body.correlationId,
         };
 
-        // // compute refresh_in as 1/2 of expires_in, but only if expires_in > 2h
-        // if (
-        //     serverTokenResponse.expires_in &&
-        //     serverTokenResponse.expires_in > 2 * 3600
-        // ) {
-        //     serverTokenResponse.refresh_in = serverTokenResponse.expires_in / 2;
-        // }
-
         return serverTokenResponse;
     }
 

--- a/lib/msal-node/test/test_kit/ManagedIdentityTestUtils.ts
+++ b/lib/msal-node/test/test_kit/ManagedIdentityTestUtils.ts
@@ -9,6 +9,7 @@ import {
     INetworkModule,
     NetworkRequestOptions,
     NetworkResponse,
+    TimeUtils,
 } from "@azure/msal-common";
 import {
     MANAGED_IDENTITY_RESOURCE,
@@ -100,7 +101,9 @@ export class ManagedIdentityNetworkClient implements INetworkModule {
                 body: {
                     access_token: TEST_TOKENS.ACCESS_TOKEN,
                     client_id: this.clientId,
-                    expires_on: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN * 3, // 3 hours
+                    expires_on:
+                        TimeUtils.nowSeconds() +
+                        TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN * 3, // 3 hours in the future
                     resource: MANAGED_IDENTITY_RESOURCE.replace(
                         "/.default",
                         ""
@@ -122,7 +125,9 @@ export class ManagedIdentityNetworkClient implements INetworkModule {
                 body: {
                     access_token: TEST_TOKENS.ACCESS_TOKEN,
                     client_id: this.clientId,
-                    expires_on: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN * 3, // 3 hours
+                    expires_on:
+                        TimeUtils.nowSeconds() +
+                        TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN * 3, // 3 hours in the future
                     resource: (
                         this.resource || MANAGED_IDENTITY_RESOURCE
                     ).replace("/.default", ""),


### PR DESCRIPTION
ManagedIdentityTokenResponse's expires_in is now calculated correctly, and matches the .net implementation