### PR TITLE
Fix uncaught exceptions in acquireTokenSilent

### DIFF
--- a/change/@azure-msal-browser-94058809-8f02-4078-bdc6-02ff59c54ae3.json
+++ b/change/@azure-msal-browser-94058809-8f02-4078-bdc6-02ff59c54ae3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix uncaught exceptions in acquireTokenSilent",
+  "comment": "Fix uncaught exceptions in acquireTokenSilent #7073",
   "packageName": "@azure/msal-browser",
   "email": "thomas.norling@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-94058809-8f02-4078-bdc6-02ff59c54ae3.json
+++ b/change/@azure-msal-browser-94058809-8f02-4078-bdc6-02ff59c54ae3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix uncaught exceptions in acquireTokenSilent",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -158,7 +158,7 @@ export class StandardController implements IController {
     >;
 
     // Active Iframe request
-    private activeIframeRequest: [Promise<void>, string] | undefined;
+    private activeIframeRequest: [Promise<boolean>, string] | undefined;
 
     private ssoSilentMeasurement?: InProgressPerformanceEvent;
     private acquireTokenByCodeAsyncMeasurement?: InProgressPerformanceEvent;
@@ -2039,13 +2039,11 @@ export class StandardController implements IController {
 
             if (shouldTryToResolveSilently) {
                 if (!this.activeIframeRequest) {
-                    let _resolve: () => void,
-                        _reject: (reason?: AuthError | Error) => void;
+                    let _resolve: (result: boolean) => void;
                     // Always set the active request tracker immediately after checking it to prevent races
                     this.activeIframeRequest = [
-                        new Promise((resolve, reject) => {
+                        new Promise((resolve) => {
                             _resolve = resolve;
-                            _reject = reject;
                         }),
                         silentRequest.correlationId,
                     ];
@@ -2061,11 +2059,11 @@ export class StandardController implements IController {
                         silentRequest.correlationId
                     )(silentRequest)
                         .then((iframeResult) => {
-                            _resolve();
+                            _resolve(true);
                             return iframeResult;
                         })
                         .catch((e) => {
-                            _reject(e);
+                            _resolve(false);
                             throw e;
                         })
                         .finally(() => {
@@ -2087,20 +2085,11 @@ export class StandardController implements IController {
                         awaitIframeCorrelationId: activeCorrelationId,
                     });
 
-                    // Await for errors first so we can distinguish errors thrown by activePromise versus errors thrown by .then below
-                    await activePromise.catch(() => {
-                        awaitConcurrentIframeMeasure.end({
-                            success: false,
-                        });
-                        this.logger.info(
-                            `Iframe request with correlationId: ${activeCorrelationId} failed. Interaction is required.`
-                        );
-                        // If previous iframe request failed, it's unlikely to succeed this time. Throw original error.
-                        throw refreshTokenError;
+                    const activePromiseResult = await activePromise;
+                    awaitConcurrentIframeMeasure.end({
+                        success: activePromiseResult,
                     });
-
-                    return activePromise.then(() => {
-                        awaitConcurrentIframeMeasure.end({ success: true });
+                    if (activePromiseResult) {
                         this.logger.verbose(
                             `Parallel iframe request with correlationId: ${activeCorrelationId} succeeded. Retrying cache and/or RT redemption`,
                             silentRequest.correlationId
@@ -2110,7 +2099,13 @@ export class StandardController implements IController {
                             silentRequest,
                             cacheLookupPolicy
                         );
-                    });
+                    } else {
+                        this.logger.info(
+                            `Iframe request with correlationId: ${activeCorrelationId} failed. Interaction is required.`
+                        );
+                        // If previous iframe request failed, it's unlikely to succeed this time. Throw original error.
+                        throw refreshTokenError;
+                    }
                 } else {
                     // Cache policy set to skip and another iframe request is already in progress
                     this.logger.warning(


### PR DESCRIPTION
A recent change to optimize parallel iframed calls resulted in a regression that logged an uncaught exception to the console in the event that a single iframed call was made and failed. This happened because the stored promise rejected and didn't have a catch handler registered because there is not a parallel call dependent on this promise.

This PR resolves this issue by ensuring that the stored promise never rejects but rather resolves with a true/false indicating whether the call succeeded or failed.

Fixes #7052