### PR TITLE
Add missing sendTime prop to NAA request

### DIFF
--- a/lib/msal-browser/src/naa/BridgeProxy.ts
+++ b/lib/msal-browser/src/naa/BridgeProxy.ts
@@ -80,6 +80,7 @@ export class BridgeProxy implements IBridgeProxy {
                         messageType: "NestedAppAuthRequest",
                         method: "GetInitContext",
                         requestId: BrowserCrypto.createNewGuid(),
+                        sendTime: Date.now(),
                     };
                     const request: BridgeRequest = {
                         requestId: message.requestId,
@@ -156,6 +157,7 @@ export class BridgeProxy implements IBridgeProxy {
             messageType: "NestedAppAuthRequest",
             method: method,
             requestId: BrowserCrypto.createNewGuid(),
+            sendTime: Date.now(),
             ...requestParams,
         };
 


### PR DESCRIPTION
`sendTime` prop is present on `BridgeResponseEnvelope` but not used for nested app auth requests. Adds value here which is useful to have on host side.