### PR TITLE
Update README file to fix inconsistent variable naming

### DIFF
--- a/lib/msal-node/docs/initialize-confidential-client-application.md
+++ b/lib/msal-node/docs/initialize-confidential-client-application.md
@@ -58,7 +58,7 @@ const cca = new msal.ConfidentialClientApplication(clientConfig);
 
 [Configuration](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_node.html#configuration) options for node have `common` parameters and `specific` paremeters per authentication flow.
 
--   `clientId` is mandatory to initialize a public client application
+-   `clientId` is mandatory to initialize a confidential client application
 -   `authority` defaults to `https://login.microsoftonline.com/common/` if the user does not set it during configuration
 -   A Client credential is mandatory for confidential clients. Client credential can be a:
     -   `clientSecret` is secret string generated set on the app registration.

--- a/lib/msal-node/docs/initialize-confidential-client-application.md
+++ b/lib/msal-node/docs/initialize-confidential-client-application.md
@@ -51,7 +51,7 @@ const clientConfig = {
         clientAssertion: clientAssertionCallback, // or a predetermined clientAssertion string
     },
 };
-const pca = new msal.ConfidentialClientApplication(clientConfig);
+const cca = new msal.ConfidentialClientApplication(clientConfig);
 ```
 
 ## Configuration Basics


### PR DESCRIPTION
pca is used for PublicClientApplication, and cca (which the other doc) used for ConfidentialClientApplication.