### PR TITLE
Angular 18 support doc updates

### DIFF
--- a/lib/msal-angular/FAQ.md
+++ b/lib/msal-angular/FAQ.md
@@ -44,7 +44,7 @@ Please see [here](https://github.com/AzureAD/microsoft-authentication-library-fo
 
 ### What versions of Angular are supported?
 
-MSAL Angular v3 currently supports Angular 15, 16, and 17.
+MSAL Angular v3 currently supports Angular 15, 16, 17 and 18.
 
 MSAL Angular v2 supports Angular 9, 10, 11, 12, 13 and 14.
 
@@ -52,7 +52,7 @@ MSAL Angular v2 supports Angular 9, 10, 11, 12, 13 and 14.
 
 Yes, server side rendering is supported through Angular universal. See our doc [here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/angular-universal.md) for more information.
 
-**Note:** MSAL Angular currently does not officially support Angular 17's server-side and prerendering capabilities. Using SSR with MSAL Angular may break your app.
+**Note:** MSAL Angular currently does not officially support Angular 17 and 18's server-side and prerendering capabilities. Using SSR with MSAL Angular may break your app.
 
 ### Does `@azure/msal-angular` support standalone components?
 

--- a/lib/msal-angular/README.md
+++ b/lib/msal-angular/README.md
@@ -45,7 +45,7 @@ At a minimum, `@azure/msal-angular` will follow the [support schedule of the mai
 
 | MSAL Angular version | MSAL support status | Supported Angular versions |
 | -------------------- | ------------------- | -------------------------- |
-| MSAL Angular v3      | Active development  | 15, 16, 17                 |
+| MSAL Angular v3      | Active development  | 15, 16, 17, 18             |
 | MSAL Angular v2      | In maintenance      | 9, 10, 11, 12, 13, 14      |
 | MSAL Angular v1      | In maintenance      | 6, 7, 8, 9                 |
 | MSAL Angular v0      | Out of support      | 4, 5                       |
@@ -94,6 +94,7 @@ Documentation specifically for MSAL Angular v1 can be found [here](https://githu
 - [Angular v16 B2C Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular-b2c-sample-app)
 - [Angular Standalone Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular-standalone-sample)
 - [Angular v17 Standalone Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular17-standalone-sample)
+- [Angular v18 Standalone Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular18-standalone-sample)
 
 ### MSAL Angular v2 Samples
 

--- a/lib/msal-angular/docs/angular-universal.md
+++ b/lib/msal-angular/docs/angular-universal.md
@@ -4,7 +4,7 @@ Angular Universal is minimally supported in `@azure/msal-angular`. As `@azure/ms
 
 Please see instructions from the [Angular docs](https://angular.io/guide/universal) on how to install Angular Universal with an existing application, and for more information on [browser-only global objects](https://angular.io/guide/universal#working-around-the-browser-apis).
 
-**Note:** MSAL Angular currently does not officially support Angular 17's server-side and prerendering capabilities. Using SSR with MSAL Angular may break your app.
+**Note:** MSAL Angular does not officially support Angular 17 and 18's server-side and prerendering capabilities. Using SSR with MSAL Angular may break your app.
 
 ## Using MSAL Angular with Angular Universal
 

--- a/lib/msal-angular/docs/configuration.md
+++ b/lib/msal-angular/docs/configuration.md
@@ -524,7 +524,7 @@ export function MSALGuardConfigFactory(): MsalGuardConfiguration {
 
 ## Configurations for Angular 17 apps with standalone components
 
-Angular 17 applications using standalone components can be used with [factory providers](#factory-providers) as above in the `app.config.ts` file, which is then imported into `main.ts` for bootstrapping.
+Angular 17 and 18 applications using standalone components can be used with [factory providers](#factory-providers) as above in the `app.config.ts` file, which is then imported into `main.ts` for bootstrapping.
 
 Please see our [Angular 17 Standalone Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular17-standalone-sample) for usage.
 

--- a/lib/msal-angular/docs/v2-v3-upgrade-guide.md
+++ b/lib/msal-angular/docs/v2-v3-upgrade-guide.md
@@ -1,6 +1,6 @@
 # Upgrading from MSAL Angular v2 to v3
 
-MSAL Angular v3 brings our Angular wrapper up-to-date with the latest version of MSAL common, and with out-of-the-box support for Angular 15, 16, 17, and rxjs 7.
+MSAL Angular v3 brings our Angular wrapper up-to-date with the latest version of MSAL common, and with out-of-the-box support for Angular 15, 16, 17, 18 and rxjs 7.
 
 This guide will demonstrate changes needed to migrate an existing application from `@azure/msal-angular` v2 to v3.
 
@@ -24,15 +24,15 @@ Due to initialization being built into `MsalRedirectComponent` and `handleRedire
 
 See the [guide to redirects](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-angular/docs/redirects.md) for set up details.
 
-## Angular 15, 16, 17, and rxjs@7
+## Angular 15, 16, 17, 18 and rxjs@7
 
 MSAL Angular now expects that your application is built with: 
 
-- `@angular/core@15` or `@angular/core@16` or `@angular/core@17`
-- `@angular/common@15` or `@angular/common@16` or `@angular/common@17`
+- `@angular/core@15` or `@angular/core@16` or `@angular/core@17` or `@angular/core@18`
+- `@angular/common@15` or `@angular/common@16` or `@angular/common@17` or `@angular/common@18`
 - `rxjs@7`
 
-Due to this change, MSAL Angular v3 is not backwards compatible with earlier versions of Angular and RxJS and you may need to update your application. Please follow the [Angular Update Guide](https://update.angular.io/) to update your application to Angular 15, 16, or 17.
+Due to this change, MSAL Angular v3 is not backwards compatible with earlier versions of Angular and RxJS and you may need to update your application. Please follow the [Angular Update Guide](https://update.angular.io/) to update your application to Angular 15, 16, 17 or 18.
 
 As with MSAL Angular v2, `rxjs-compat` is not required.
 
@@ -45,6 +45,7 @@ The following developer samples are now available:
 - [Angular 16 sample using B2C](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular-b2c-sample-app)
 - [Angular 16 sample using Angular standalone components](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular-standalone-sample)
 - [Angular 17 Standalone Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular17-standalone-sample)
+- [Angular 18 Standalone Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples/angular18-standalone-sample)
 
 The samples demonstrates basic configuration and usage, and may be improved and added to incrementally.
 


### PR DESCRIPTION
MSAL Angular documentation update for Angular 18 support.

This PR follows #7063, and will be merged once Angular 18 is released and tested.