### PR TITLE
Fixes for esm imports

### DIFF
--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -38,7 +38,7 @@ import {
 import {
     ManagedIdentityConfiguration,
     ManagedIdentityNodeConfiguration,
-} from "../config/Configuration";
+} from "../config/Configuration.js";
 
 /**
  * OAuth2.0 client credential grant

--- a/lib/msal-node/src/client/ManagedIdentityApplication.ts
+++ b/lib/msal-node/src/client/ManagedIdentityApplication.ts
@@ -23,18 +23,18 @@ import {
     ManagedIdentityConfiguration,
     ManagedIdentityNodeConfiguration,
     buildManagedIdentityConfiguration,
-} from "../config/Configuration";
+} from "../config/Configuration.js";
 import { version, name } from "../packageMetadata.js";
-import { ManagedIdentityRequest } from "../request/ManagedIdentityRequest";
-import { CryptoProvider } from "../crypto/CryptoProvider";
-import { ClientCredentialClient } from "./ClientCredentialClient";
-import { ManagedIdentityClient } from "./ManagedIdentityClient";
-import { ManagedIdentityRequestParams } from "../request/ManagedIdentityRequestParams";
-import { NodeStorage } from "../cache/NodeStorage";
+import { ManagedIdentityRequest } from "../request/ManagedIdentityRequest.js";
+import { CryptoProvider } from "../crypto/CryptoProvider.js";
+import { ClientCredentialClient } from "./ClientCredentialClient.js";
+import { ManagedIdentityClient } from "./ManagedIdentityClient.js";
+import { ManagedIdentityRequestParams } from "../request/ManagedIdentityRequestParams.js";
+import { NodeStorage } from "../cache/NodeStorage.js";
 import {
     DEFAULT_AUTHORITY_FOR_MANAGED_IDENTITY,
     ManagedIdentitySourceNames,
-} from "../utils/Constants";
+} from "../utils/Constants.js";
 
 /**
  * Class to initialize a managed identity and identify the service

--- a/lib/msal-node/src/config/ManagedIdentityId.ts
+++ b/lib/msal-node/src/config/ManagedIdentityId.ts
@@ -6,12 +6,12 @@
 import {
     ManagedIdentityErrorCodes,
     createManagedIdentityError,
-} from "../error/ManagedIdentityError";
+} from "../error/ManagedIdentityError.js";
 import {
     DEFAULT_MANAGED_IDENTITY_ID,
     ManagedIdentityIdType,
-} from "../utils/Constants";
-import { ManagedIdentityIdParams } from "./Configuration";
+} from "../utils/Constants.js";
+import { ManagedIdentityIdParams } from "./Configuration.js";
 
 export class ManagedIdentityId {
     private _id: string;


### PR DESCRIPTION
This PR fixes some import issues in the builded .d.ts files because we were getting the following error on a couple of files.
```
 error TS2835: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you 
mean '../config/Configuration.mjs'?

2 import { ManagedIdentityConfiguration } from "../config/Configuration";
```

The lack of the for esm required suffixes made it impossible to compile, if you look at some other files like `PublicClientApplication` those already contains the correct suffixes so this PR just fixes some of the imports that were missing this and should not break any backwards compatibility.