### PR TITLE
fix : msal-browser acquireTokenSilentAsync memory leak

### DIFF
--- a/change/@azure-msal-browser-3f818d90-03e6-43c9-b57d-c03d404cc5a7.json
+++ b/change/@azure-msal-browser-3f818d90-03e6-43c9-b57d-c03d404cc5a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix : msal-browser acquireTokenSilentAsync memory leak",
+  "packageName": "@azure/msal-browser",
+  "email": "127046736+shaouari-Dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1963,6 +1963,7 @@ export class StandardController implements IController {
         request: SilentRequest & { correlationId: string },
         account: AccountInfo
     ): Promise<AuthenticationResult> {
+        const trackPageVisibility = () => this.trackPageVisibility(request.correlationId);
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.AcquireTokenSilentAsync,
             request.correlationId
@@ -1981,9 +1982,7 @@ export class StandardController implements IController {
             );
         }
 
-        document.addEventListener("visibilitychange", () =>
-            this.trackPageVisibility(request.correlationId)
-        );
+        document.addEventListener("visibilitychange", trackPageVisibility);
 
         const silentRequest = await invokeAsync(
             initializeSilentRequest,
@@ -2124,9 +2123,7 @@ export class StandardController implements IController {
                 throw tokenRenewalError;
             })
             .finally(() => {
-                document.removeEventListener("visibilitychange", () =>
-                    this.trackPageVisibility(request.correlationId)
-                );
+                document.removeEventListener("visibilitychange", trackPageVisibility);
             });
     }
 


### PR DESCRIPTION
This pull request addresses a memory leak issue in the MSAL-Browser library. 

The issue was originally identified in Zone.js for Angular 16, where the use of arrow functions in the visibilitychange event listeners caused problems. Specifically, Zone.js cannot compare the arrow functions when adding and removing the event listeners, which leads to the tasks not being properly removed and resulting in a more important memory leaks over time.