### PR TITLE
adding extra option to msal guard to be stricter, check if active user token is not expired

### DIFF
--- a/lib/msal-angular/docs/msal-guard.md
+++ b/lib/msal-angular/docs/msal-guard.md
@@ -8,13 +8,154 @@ You may also need a route guard that addresses specific needs. We encourage you 
 
 ## Configurations
 
-### Configuring the `MsalGuard` in the *app.module.ts* and *app-routing.module.ts*
+### Configuring the `MsalGuard` in the _app.module.ts_ and _app-routing.module.ts_
 
-The `MsalGuard` can be added to your application as a provider in the *app.module.ts*, with its configuration. The imports takes in an instance of MSAL, as well as two Angular-specific configuration objects. The second argument is a [`MsalGuardConfiguration`](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/src/msal.guard.config.ts) object, which contain the values for `interactionType`, an optional `authRequest`, and an optional `loginFailedRoute`.
+The `MsalGuard` can be added to your application as a provider in the _app.module.ts_, with its configuration. The imports takes in an instance of MSAL, as well as two Angular-specific configuration objects. The second argument is a [`MsalGuardConfiguration`](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/src/msal.guard.config.ts) object, which contain the values for `interactionType`, an optional `authRequest`, and an optional `loginFailedRoute`.
 
-The `MsalGuard` is then used to protect routes in the *app-routing.module.ts*. The code sample below demonstrates adding the `MsalGuard` to the `Profile` route. Protecting the `Profile` route means that even if a user does not sign in using the `Login` button, if they try to access the `Profile` route or click the `Profile` button, the `MsalGuard` will prompt the user to authenticate via popup or redirect before showing the `Profile` page.
+The `MsalGuard` is then used to protect routes in the _app-routing.module.ts_. The code sample below demonstrates adding the `MsalGuard` to the `Profile` route. Protecting the `Profile` route means that even if a user does not sign in using the `Login` button, if they try to access the `Profile` route or click the `Profile` button, the `MsalGuard` will prompt the user to authenticate via popup or redirect before showing the `Profile` page.
 
 Your configuration may look like the below. See our [configuration doc](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/configuration.md) on other ways to configure MSAL Angular for your app, and the sections below for more details on the `MsalConfiguration` object and interfaces for routing.
+
+```javascript
+// app.module.ts
+import { NgModule } from "@angular/core";
+import { HTTP_INTERCEPTORS, HttpClientModule } from "@angular/common/http";
+import { MsalModule, MsalRedirectComponent, MsalGuard } from "@azure/msal-angular"; // Import MsalInterceptor
+import { InteractionType, PublicClientApplication } from "@azure/msal-browser";
+import { AppComponent } from "./app.component";
+import { AppRoutingModule } from "./app-routing.module";
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [
+    MsalModule.forRoot(
+      new PublicClientApplication({
+        // MSAL Configuration
+      }),
+      {
+        // MSAL Guard Configuration
+        interactionType: InteractionType.Redirect,
+        authRequest: {
+          scopes: ["user.read"],
+        },
+        loginFailedRoute: "/login-failed",
+      },
+      {
+        // MSAL Interceptor Configurations
+      }
+    ),
+    AppRoutingModule,
+  ],
+  providers: [
+    // ...
+    MsalGuard,
+  ],
+  bootstrap: [AppComponent, MsalRedirectComponent],
+})
+export class AppModule {}
+```
+
+```javascript
+// app-routing.module.ts
+import { NgModule } from "@angular/core";
+import { Routes, RouterModule } from "@angular/router";
+import { HomeComponent } from "./home/home.component";
+import { ProfileComponent } from "./profile/profile.component";
+import { MsalGuard } from "@azure/msal-angular";
+
+const routes: Routes = [
+  {
+    path: "profile",
+    component: ProfileComponent,
+    canActivate: [MsalGuard],
+  },
+  {
+    path: "",
+    component: HomeComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule],
+})
+export class AppRoutingModule {}
+```
+
+### Interaction Type
+
+Setting the interaction type determines how the `MsalGuard` will interactively prompt for login. The `InteractionType` can be imported from `@azure/msal-browser` and set to `Popup` or `Redirect`.
+
+### Optional authRequest
+
+The optional `authRequest` is an advanced featured that is not required. However, we recommend setting `authRequest` on the `MsalGuardConfiguration` with `scopes` so that consent may be obtained for the scopes upfront. If consent for `scopes` are not consented to upfront, scopes can be obtained incrementally. This may result in a consent dialogue being presented to your app user multiple times.
+
+Consenting to scopes upfront is demonstrated in the code samples above, and in our [samples](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples).
+
+All possible parameters for the request object can be found here: [`PopupRequest`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/modules/_src_request_popuprequest_.html) and [`RedirectRequest`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/modules/_src_request_redirectrequest_.html).
+
+### Login Failed Route
+
+The `loginFailedRoute` string can be set on `MsalGuardConfiguration`. The `MsalGuard` will redirect to this route if login is required and fails.
+
+See the Angular sample for examples of implementing it in the [configuration](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v3-samples/angular15-sample-app/src/app/app.module.ts#L66) and [app routing module](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v3-samples/angular15-sample-app/src/app/app-routing.module.ts#L20).
+
+Note that redirecting on failure is not available for Angular 9 applications that use the `CanLoad` interface due to base type differences.
+
+### Interfaces
+
+In addition to `canActivate`, `MsalGuard` also implements `canActivateChild` and `canLoad`, and these can be added to your route definitions in _app-routing.module.ts_. You can see these used in our [older MSAL Angular v2 Angular 11 sample application](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/msal-lts/samples/msal-angular-v2-samples/angular11-sample-app/src/app/app-routing.module.ts), as well as below. For more information on interfaces, see the [Angular docs](https://angular.io/api/router).
+
+```js
+const routes: Routes = [
+  {
+    path: "profile",
+    canActivateChild: [MsalGuard],
+    children: [
+      {
+        path: "",
+        component: ProfileComponent,
+      },
+      {
+        path: "detail",
+        component: DetailComponent,
+      },
+    ],
+  },
+  {
+    path: "lazyLoad",
+    loadChildren: () => import("./lazy/lazy.module").then((m) => m.LazyModule),
+    canLoad: [MsalGuard],
+  },
+];
+```
+
+### Optional enableCheckForExpiredToken
+
+```javascript
+{
+  ...
+  enableCheckForExpiredToken?: boolean;
+  minimumSecondsBeforeTokenExpiration?: number;
+  silentAuthRequest?:
+    | SilentRequest
+    | ((authService: MsalService, state: RouterStateSnapshot) => SilentRequest);
+  ...
+}
+
+```
+
+The configuration property `enableCheckForExpiredToken` when set to `true` changes the behaviour of the msal guard in how to decide if an interactive login is required. When set to `true` the guard will only activate the route if we have a non expired token present. It can be configured that when token is expired, that a silent refresh is attempted to acquire a non expired token. If this succeeds the route is also activated.
+
+The default behaviour of the msal guard ( `enableCheckForExpiredToken` not set or set to `false`) is decided by the predicate `this.authService.instance.getAllAccounts().length`, when falsey an interactive login is done.
+The consequence is that an account can exist, but its token can be expired. In that case the MsalGuard will in the default behaviour allow the route to activate. This can still eventually result in an interactive login by the interceptor because the token could not be refreshed anymore (there is a time limit on refreshing tokens) If we want a stronger guarantee such as a non expired token is present then the property `enableCheckForExpiredToken` can be used.
+
+When configuration property `enableCheckForExpiredToken` is set to `true`, then `authService.instance.getActiveAccount()` will be called.
+If no active account then an interactive login will be called.
+When there is an interactive Account, it will be checked if the token is not expired. This is done by comparing `now() in seconds + minimumSecondsBeforeTokenExpiration < token_expiration_in_seconds`.
+So by setting the property `minimumSecondsBeforeTokenExpiration` you can ensure that token should be not expiring within `minimumSecondsBeforeTokenExpiration` seconds.
+When the token is expired and the propery `silentAuthRequest` is set, then an attempt will be done to silently refresh the token.
+If this succeeds no interactive login is required. If it fails an interactive login will be done
 
 ```javascript
 // app.module.ts
@@ -38,7 +179,12 @@ import { AppRoutingModule } from './app-routing.module';
             authRequest: {
                 scopes: ['user.read']
             },
-            loginFailedRoute: '/login-failed'
+            loginFailedRoute: '/login-failed',
+            enableCheckForExpiredToken: true,
+            minimumSecondsBeforeTokenExpiration: 60,
+            silentAuthRequest: (authService: MsalService, state: RouterStateSnapshot) =>{
+                return { account:authService.instance.getActiveAccount(), scopes: [...] } as SilentRequest
+            }
         }, {
             // MSAL Interceptor Configurations
         }),
@@ -53,81 +199,6 @@ import { AppRoutingModule } from './app-routing.module';
 export class AppModule { }
 ```
 
-```javascript
-// app-routing.module.ts
-import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
-import { HomeComponent } from './home/home.component';
-import { ProfileComponent } from './profile/profile.component';
-import { MsalGuard } from '@azure/msal-angular';
-
-const routes: Routes = [
-    {
-        path: 'profile',
-        component: ProfileComponent,
-        canActivate: [MsalGuard]
-    },
-    {
-        path: '',
-        component: HomeComponent
-    },
-];
-
-@NgModule({
-    imports: [RouterModule.forRoot(routes)],
-    exports: [RouterModule]
-})
-export class AppRoutingModule { }
-```
-
-### Interaction Type
-
-Setting the interaction type determines how the `MsalGuard` will interactively prompt for login. The `InteractionType` can be imported from `@azure/msal-browser` and set to `Popup` or `Redirect`.
-
-### Optional authRequest
-
-The optional `authRequest` is an advanced featured that is not required. However, we recommend setting `authRequest` on the `MsalGuardConfiguration` with `scopes` so that consent may be obtained for the scopes upfront. If consent for `scopes` are not consented to upfront, scopes can be obtained incrementally. This may result in a consent dialogue being presented to your app user multiple times.
-
-Consenting to scopes upfront is demonstrated in the code samples above, and in our [samples](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-angular-v3-samples).
-
-All possible parameters for the request object can be found here: [`PopupRequest`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/modules/_src_request_popuprequest_.html) and [`RedirectRequest`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/modules/_src_request_redirectrequest_.html).
-
-### Login Failed Route
-
-The `loginFailedRoute` string can be set on `MsalGuardConfiguration`. The `MsalGuard` will redirect to this route if login is required and fails.
-
-See the Angular sample for examples of implementing it in the [configuration](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v3-samples/angular15-sample-app/src/app/app.module.ts#L66) and [app routing module](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-v3-samples/angular15-sample-app/src/app/app-routing.module.ts#L20). 
-
-Note that redirecting on failure is not available for Angular 9 applications that use the `CanLoad` interface due to base type differences.
-
-### Interfaces
-
-In addition to `canActivate`, `MsalGuard` also implements `canActivateChild` and `canLoad`, and these can be added to your route definitions in *app-routing.module.ts*. You can see these used in our [older MSAL Angular v2 Angular 11 sample application](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/msal-lts/samples/msal-angular-v2-samples/angular11-sample-app/src/app/app-routing.module.ts), as well as below. For more information on interfaces, see the [Angular docs](https://angular.io/api/router).
-
-```js
-const routes: Routes = [
-    {
-        path: 'profile',
-        canActivateChild: [MsalGuard],
-        children: [
-        {
-            path: '',
-            component: ProfileComponent
-        },
-        {
-            path: 'detail',
-            component: DetailComponent
-        }
-        ]
-    },
-    { 
-        path: 'lazyLoad', 
-        loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule),
-        canLoad: [MsalGuard]
-    },
-];
-```
-
 ## Considerations when using the MSAL Guard
 
 ### Using the MSAL Guard on the home page
@@ -138,28 +209,29 @@ Our additional recommendations depend on your routing strategy, and can be found
 
 ### Using the MSAL Guard with path routing
 
-When using the `PathLocationStrategy` and redirects with your Angular app, we recommend using a dedicated route for redirects, which will help prevent looping. This route should also be your `redirectUri`, and should not be protected by the `MsalGuard`. 
+When using the `PathLocationStrategy` and redirects with your Angular app, we recommend using a dedicated route for redirects, which will help prevent looping. This route should also be your `redirectUri`, and should not be protected by the `MsalGuard`.
 
 ```javascript
 const routes: Routes = [
-    {
-        path: 'profile',
-        component: ProfileComponent,
-        canActivate: [MsalGuard]
-    },
-    {
-        // Dedicated route for redirects
-        path: 'auth', 
-        component: MsalRedirectComponent
-    },
-    {
-        path: '',
-        component: HomeComponent
-    }
+  {
+    path: "profile",
+    component: ProfileComponent,
+    canActivate: [MsalGuard],
+  },
+  {
+    // Dedicated route for redirects
+    path: "auth",
+    component: MsalRedirectComponent,
+  },
+  {
+    path: "",
+    component: HomeComponent,
+  },
 ];
 ```
 
 To log users in upon reaching your app, when using the `PathLocationStrategy`, we recommend:
+
 - Setting the `MsalGuard` on your initial page
 - Set your `redirectUri` to `'http://localhost:4200/auth'`
 - Adding an `'auth'` path to your routes, setting the `MsalRedirectComponent` as the component (this route should not be protected by the `MsalGuard`)
@@ -170,30 +242,31 @@ Our [Angular 15 sample](https://github.com/AzureAD/microsoft-authentication-libr
 
 ### Using the MSAL Guard with hash routing
 
-When using the `HashLocationStrategy` with your Angular app, we strongly recommend setting placeholder routes (such as `/code`) in your *app-routing.module.ts* to prevent triggering the Angular router when AAD returns the auth code response in the hash, as you may experience issues completing authentication without doing so. These placeholder routes should not be protected by the `MsalGuard`, and should not point to a component that triggers interaction or makes protected API calls on page load.
+When using the `HashLocationStrategy` with your Angular app, we strongly recommend setting placeholder routes (such as `/code`) in your _app-routing.module.ts_ to prevent triggering the Angular router when AAD returns the auth code response in the hash, as you may experience issues completing authentication without doing so. These placeholder routes should not be protected by the `MsalGuard`, and should not point to a component that triggers interaction or makes protected API calls on page load.
 
 ```javascript
 const routes: Routes = [
   {
-    path: 'profile',
+    path: "profile",
     component: ProfileComponent,
-    canActivate: [MsalGuard]
+    canActivate: [MsalGuard],
   },
   {
     // Needed for hash routing
-    path: 'code',
-    component: HomeComponent
+    path: "code",
+    component: HomeComponent,
   },
   {
-    path: '',
-    component: HomeComponent
-  }
+    path: "",
+    component: HomeComponent,
+  },
 ];
 ```
 
 The `redirectUri` in the MSAL Configuration should also be set to the home page.
 
 To log users in upon reaching your app, when using the `HashLocationStrategy`, we recommend:
+
 - Setting the `MsalGuard` on your initial page
 - Not setting the `MsalGuard` on placeholder routes (e.g. `/code`, `/error`)
 - Making sure the `MsalRedirectComponent` is bootstrapped
@@ -203,6 +276,6 @@ See our [older MSAL Angular v2 Angular 11 sample](https://github.com/AzureAD/mic
 
 ## Changes from msal-angular v1 to v2
 
-* **Configuration**: `MsalAngularConfiguration` has been deprecated and no longer works. Configuring the `MsalGuard` is now done through the `MsalGuardConfiguration`.
-* **Interfaces**: `MsalGuard` now implements `CanActivateChild` and `CanLoad` in addition to `CanActivate`. See the section above on `Interfaces` for more details.
-* **Redirect on failure**: `MsalGuard` configuration now has a `loginFailedRoute` that can be configured. See the section above on the `loginFailedRoute` for details.
+- **Configuration**: `MsalAngularConfiguration` has been deprecated and no longer works. Configuring the `MsalGuard` is now done through the `MsalGuardConfiguration`.
+- **Interfaces**: `MsalGuard` now implements `CanActivateChild` and `CanLoad` in addition to `CanActivate`. See the section above on `Interfaces` for more details.
+- **Redirect on failure**: `MsalGuard` configuration now has a `loginFailedRoute` that can be configured. See the section above on the `loginFailedRoute` for details.

--- a/lib/msal-angular/src/msal.guard.config.ts
+++ b/lib/msal-angular/src/msal.guard.config.ts
@@ -8,6 +8,7 @@ import {
   PopupRequest,
   RedirectRequest,
   InteractionType,
+  SilentRequest,
 } from "@azure/msal-browser";
 import { MsalService } from "./msal.service";
 
@@ -24,4 +25,9 @@ export type MsalGuardConfiguration = {
         state: RouterStateSnapshot
       ) => MsalGuardAuthRequest);
   loginFailedRoute?: string;
+  enableCheckForExpiredToken?: boolean;
+  minimumSecondsBeforeTokenExpiration?: number;
+  silentAuthRequest?:
+    | SilentRequest
+    | ((authService: MsalService, state: RouterStateSnapshot) => SilentRequest);
 };

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -7,13 +7,14 @@ import {
   AccountInfo,
   AuthenticationResult,
   BrowserSystemOptions,
+  InteractionStatus,
   InteractionType,
   IPublicClientApplication,
   LogLevel,
   PublicClientApplication,
   UrlString,
 } from "@azure/msal-browser";
-import { of } from "rxjs";
+import { BehaviorSubject, of } from "rxjs";
 import {
   MsalModule,
   MsalGuard,
@@ -21,6 +22,7 @@ import {
   MsalBroadcastService,
 } from "./public-api";
 import { MsalGuardConfiguration } from "./msal.guard.config";
+import { bootstrapApplication } from "@angular/platform-browser";
 
 let guard: MsalGuard;
 let authService: MsalService;
@@ -388,14 +390,12 @@ describe("MsalGuard", () => {
 
   it("returns false for option enableCheckForExpiredToken is true and token is expired and silentRefresh fails", (done) => {
     enableCheckForExpiredToken = true;
+    silentAuthRequest = {};
     initializeMsal();
 
-    authService.handleRedirectObservable().subscribe();
-
-    spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
-      //@ts-ignore
-      of("test")
-    );
+    authService.handleRedirectObservable().subscribe((result) => {
+      console.log("handleRedirectObservable result", result);
+    });
 
     spyOn(
       PublicClientApplication.prototype,
@@ -410,6 +410,8 @@ describe("MsalGuard", () => {
       of({ accessToken: undefined } as AuthenticationResult)
     );
 
+    spyOn(guard as any, "loginInteractively").and.returnValue(of(false));
+
     guard.canActivate(routeMock, routeStateMock).subscribe((result) => {
       expect(result).toBeFalse();
       done();
@@ -419,14 +421,12 @@ describe("MsalGuard", () => {
   it("returns false for option enableCheckForExpiredToken is true and token is not expired but not within minimumSecondsBeforeTokenExpiration and silentRefresh fails", (done) => {
     enableCheckForExpiredToken = true;
     minimumSecondsBeforeTokenExpiration = 60;
+    silentAuthRequest = {};
     initializeMsal();
 
-    authService.handleRedirectObservable().subscribe();
-
-    spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
-      //@ts-ignore
-      of("test")
-    );
+    authService.handleRedirectObservable().subscribe((result) => {
+      console.log("handleRedirectObservable result", result);
+    });
 
     spyOn(
       PublicClientApplication.prototype,
@@ -441,6 +441,8 @@ describe("MsalGuard", () => {
       of({ accessToken: undefined } as AuthenticationResult)
     );
 
+    spyOn(guard as any, "loginInteractively").and.returnValue(of(false));
+
     guard.canActivate(routeMock, routeStateMock).subscribe((result) => {
       expect(result).toBeFalse();
       done();
@@ -452,12 +454,9 @@ describe("MsalGuard", () => {
     silentAuthRequest = {}; // set silentauth request or it will not be tried
     initializeMsal();
 
-    authService.handleRedirectObservable().subscribe();
-
-    spyOn(MsalService.prototype, "handleRedirectObservable").and.returnValue(
-      //@ts-ignore
-      of("test")
-    );
+    authService.handleRedirectObservable().subscribe((result) => {
+      console.log("handleRedirectObservable result", result);
+    });
 
     spyOn(
       PublicClientApplication.prototype,

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -353,8 +353,17 @@ export class MsalGuard {
           return this.authService.acquireTokenSilent(silentRequest);
         }),
         map((authResult) => {
-          this.authService.getLogger().info("Guard - silent refresh succeeded");
-          return !!authResult.accessToken;
+          if (!!authResult.accessToken) {
+            this.authService
+              .getLogger()
+              .info("Guard - silent refresh succeeded");
+            return true;
+          } else {
+            this.authService
+              .getLogger()
+              .warning("Guard - silent refresh did not return a token");
+            return false;
+          }
         }),
         catchError((err) => {
           this.authService

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -19,9 +19,10 @@ import {
   PopupRequest,
   RedirectRequest,
   AuthenticationResult,
+  InteractionStatus,
 } from "@azure/msal-browser";
 import { Observable, of } from "rxjs";
-import { concatMap, catchError, map } from "rxjs/operators";
+import { concatMap, catchError, map, filter, take } from "rxjs/operators";
 import { MsalService } from "./msal.service";
 import { MsalGuardConfiguration } from "./msal.guard.config";
 import { MsalBroadcastService } from "./msal.broadcast.service";
@@ -177,7 +178,16 @@ export class MsalGuard {
         return this.authService.handleRedirectObservable();
       }),
       concatMap(() => {
-        if (!this.authService.instance.getAllAccounts().length) {
+        if (!this.msalGuardConfig.enableCheckForExpiredToken) {
+          return of(!this.authService.instance.getAllAccounts().length);
+        } else {
+          return this.isTokenStillValidForActiveAccountRefreshIfPossible(
+            state
+          ).pipe(map((validToken) => !validToken));
+        }
+      }),
+      concatMap((requireLogin) => {
+        if (requireLogin) {
           if (state) {
             this.authService
               .getLogger()
@@ -192,9 +202,19 @@ export class MsalGuard {
           return of(false);
         }
 
-        this.authService
-          .getLogger()
-          .verbose("Guard - at least 1 account exists, can activate or load");
+        if (!this.msalGuardConfig.enableCheckForExpiredToken) {
+          this.authService
+            .getLogger()
+            .verbose("Guard - at least 1 account exists, can activate or load");
+        }
+
+        if (!!this.msalGuardConfig.enableCheckForExpiredToken) {
+          this.authService
+            .getLogger()
+            .verbose(
+              "Guard - active account has a valid token, can activate or load"
+            );
+        }
 
         // Prevent navigating the app to /#code= or /code=
         if (state) {
@@ -286,5 +306,67 @@ export class MsalGuard {
   canMatch(): Observable<boolean | UrlTree> {
     this.authService.getLogger().verbose("Guard - canLoad");
     return this.activateHelper();
+  }
+
+  /*
+   * will return false if no active account or token expired and silent refresh failed
+   * will return true if we have a non expired token
+   */
+  isTokenStillValidForActiveAccountRefreshIfPossible(
+    state: RouterStateSnapshot
+  ): Observable<boolean> {
+    const activeAccount = this.authService.instance.getActiveAccount();
+
+    if (!activeAccount) {
+      return of(false);
+    }
+
+    const now = Math.round(Date.now() / 1000);
+    const expiration = <number>activeAccount.idTokenClaims?.["exp"];
+
+    const expired =
+      now + (this.msalGuardConfig.minimumSecondsBeforeTokenExpiration ?? 0) >
+      expiration;
+
+    if (!expired) {
+      return of(true);
+    } else {
+      if (!this.msalGuardConfig.silentAuthRequest) {
+        return of(false);
+      }
+      this.authService
+        .getLogger()
+        .info(
+          "Guard - token for active account is expired. Initiating silent refresh"
+        );
+      const silentRequest =
+        typeof this.msalGuardConfig.silentAuthRequest === "function"
+          ? this.msalGuardConfig.silentAuthRequest(this.authService, state)
+          : { ...this.msalGuardConfig.silentAuthRequest };
+
+      return this.msalBroadcastService.inProgress$.pipe(
+        filter(
+          (status: InteractionStatus) => status === InteractionStatus.None
+        ),
+        take(1),
+        concatMap(() => {
+          return this.authService.acquireTokenSilent(silentRequest);
+        }),
+        map((authResult) => {
+          this.authService.getLogger().info("Guard - silent refresh succeeded");
+          return !!authResult.accessToken;
+        }),
+        catchError((err) => {
+          this.authService
+            .getLogger()
+            .warning(
+              `Guard - silent refresh failed. Reporting no valid token. error: ${JSON.stringify(
+                err
+              )}`
+            );
+          return of(false);
+        })
+      );
+    }
   }
 }


### PR DESCRIPTION
Currently the MsalGuard will not redirect to login when there is an active user which has an expired token.
So if you use the guard to be sure that no login will be needed going further, then this current implementation of MsalGuard is not enough. 

The only check in the guard currently is:
!this.authService.instance.getAllAccounts().length

so only if getAllAccounts().length is falsey it will redirect to login.
But this allows for a account with an expired token.

An extra option is added to MsalGuardConfiguration:
enableCheckForExpiredToken?: boolean;

So if enableCheckForExpiredToken is false or does not exist then behavior is as before.
When enableCheckForExpiredToken true then we do a check if the token is not expired on the 
"this.authService.instance.getActiveAccount()". If expired or no active user a login will be done
Extra option is included so that when token is expired, a silentRefresh is attempted and if succesfull then route activation can continue





