### PR TITLE
Relax loadExternalTokens requirements to allow loading without id_token

### DIFF
--- a/change/@azure-msal-browser-0474c317-1328-4830-96f7-71655d4ba381.json
+++ b/change/@azure-msal-browser-0474c317-1328-4830-96f7-71655d4ba381.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Relax loadExternalTokens requirements to allow loading access or refresh tokens without id_token",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-92206105-8112-4c8a-a5e5-b17c66272340.json
+++ b/change/@azure-msal-common-92206105-8112-4c8a-a5e5-b17c66272340.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make idTokenClaims optional when creating AccountEntity",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/docs/testing.md
+++ b/lib/msal-browser/docs/testing.md
@@ -29,7 +29,7 @@ See the type definitions for each, which can be imported from `@azure/msal-brows
 
 You can provide any combination of id, access and refresh tokens for caching but at a minimum the `loadExternalTokens` API requires one of the following sets of input parameters to identify who the tokens belong to and be capable of storing them in the cache:
 
--   A `SilentRequest` object with account information, OR
+-   A `SilentRequest` object with [account information](https://azuread.github.io/microsoft-authentication-library-for-js/ref/types/_azure_msal_browser.AccountInfo.html), OR
 -   A `SilentRequest` object with the authority AND a `LoadTokenOptions` object with `clientInfo`, OR
 -   A `SilentRequest` object with the authority AND a server response object with `client_info`
 -   A `SilentRequest` object with the authority AND a server response object with `id_token`

--- a/lib/msal-browser/docs/testing.md
+++ b/lib/msal-browser/docs/testing.md
@@ -27,7 +27,7 @@ See the type definitions for each, which can be imported from `@azure/msal-brows
 
 ## Loading tokens
 
-You can provide any combination of id, access and refresh tokens for caching but at a minimum the `loadExternalTokens` API requires one of the following sets of input parameters to identify who the tokens belong to and be capable of storing them in the cache:
+You can provide any combination of id, access and refresh tokens for caching but at a minimum the `loadExternalTokens` API requires one of the following sets of input parameters to identify token associations and cache appropriately:
 
 -   A `SilentRequest` object with [account information](https://azuread.github.io/microsoft-authentication-library-for-js/ref/types/_azure_msal_browser.AccountInfo.html), OR
 -   A `SilentRequest` object with the authority AND a `LoadTokenOptions` object with `clientInfo`, OR

--- a/lib/msal-browser/docs/testing.md
+++ b/lib/msal-browser/docs/testing.md
@@ -2,41 +2,45 @@
 
 ## The loadExternalTokens() API
 
-MSAL Browser starting version 2.17.0 has added the `loadExternalTokens()` API, which allows the loading of id tokens and access tokens to the MSAL cache, which can then be fetched using `acquireTokenSilent()`. 
+The `loadExternalTokens()` API allows the loading of id, access and refresh tokens to the MSAL cache, which can then be fetched using `acquireTokenSilent()`.
 
-**Note: This is an advanced feature that is intended for testing purposes in the browser environment only. Loading tokens to your application's cache may cause your app to break. Additionally, we recommend `loadExternalTokens()` API to be used with unit and integration tests. For E2E testing, please refer to our [TestingSample](../../../samples/msal-browser-samples/TestingSample) instead.**
+**Note: This is an advanced feature that is intended for testing purposes in the browser environment only. We do not recommend using this in a production app. For E2E testing recommendations, please refer to our [TestingSample](../../../samples/msal-browser-samples/TestingSample) instead.**
 
-The `loadExternalTokens()` API can be accessed by calling `getTokenCache()` on MSAL Browser's `PublicClientApplication` instance. 
+The `loadExternalTokens()` API can be accessed by calling `getTokenCache()` on MSAL Browser's `PublicClientApplication` instance.
 
 ```js
 const msalTokenCache = myMSALObj.getTokenCache();
-msalTokenCache.loadExternalTokens(silentRequest, serverResponse, loadTokenOptions);
+msalTokenCache.loadExternalTokens(
+    silentRequest,
+    serverResponse,
+    loadTokenOptions
+);
 ```
 
 `loadExternalTokens()` takes in a request of type `SilentRequest`, a response of type `ExternalTokenResponse`, and options of type `LoadTokenOptions`.
 
 See the type definitions for each, which can be imported from `@azure/msal-browser`:
 
-- [`SilentRequest`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#silentrequest)
-- [`ExternalTokenResponse`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_common.html#externaltokenresponse)
-    - Note that the server response you receive will also have a refresh token attached. Currently, `loadExternalTokens()` does not load refresh tokens.
+-   [`SilentRequest`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/types/_azure_msal_browser.SilentRequest.html)
+-   [`ExternalTokenResponse`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/types/_azure_msal_browser.ExternalTokenResponse.html)
+-   [`LoadTokenOptions`](https://azuread.github.io/microsoft-authentication-library-for-js/ref/types/_azure_msal_browser.LoadTokenOptions.html)
 
-```ts
-export type LoadTokenOptions = {
-    clientInfo?: string,
-    extendedExpiresOn?: number
-};
-```
+## Loading tokens
+
+You can provide any combination of id, access and refresh tokens for caching but at a minimum the `loadExternalTokens` API requires one of the following sets of input parameters to identify who the tokens belong to and be capable of storing them in the cache:
+
+-   A `SilentRequest` object with account information, OR
+-   A `SilentRequest` object with the authority AND a `LoadTokenOptions` object with `clientInfo`, OR
+-   A `SilentRequest` object with the authority AND a server response object with `client_info`
+-   A `SilentRequest` object with the authority AND a server response object with `id_token`
+
+The examples below show loading tokens individually, however, you may provide any 1, 2 or all 3 in a single request.
 
 ### Loading id tokens
 
-Provide the following to load an id token:
+In addition to the parameters listed [above](#loading-tokens) provide the following to load an id token:
 
-1. A server response with the id token, scopes, token_type, and expires_in value, and
-1. Either:
-    - A `SilentRequest` object with account information, OR
-    - A `SilentRequest` object with the authority AND a `LoadTokenOptions` object with `clientInfo`, OR
-    - A `SilentRequest` object with the authority AND a server response object with `client_info`
+1. A server response with the id_token field
 
 An account will also be set in the cache based on the information provided above.
 
@@ -44,72 +48,83 @@ See the code examples below:
 
 ```ts
 const silentRequest: SilentRequest = {
-    scopes: ["User.Read", "email"],
     account: {
         homeAccountId: "your-home-account-id",
         environment: "login.microsoftonline.com",
         tenantId: "your-tenant-id",
         username: "test@contoso.com",
-        localAccountId: "your-local-account-id"
-    }
+        localAccountId: "your-local-account-id",
+    },
 };
 
 const serverResponse: ExternalTokenResponse = {
-    token_type: AuthenticationScheme.BEARER, // "Bearer"
-    scope: "User.Read email",
-    expires_in: 3599,
-    id_token: "id-token-here"
-}
+    id_token: "id-token-here",
+};
 
 const loadTokenOptions: LoadTokenOptions = {};
+
+const pca = new PublicClientApplication({
+    auth: { clientId: "your-client-id" },
+});
+pca.getTokenCache().loadExternalTokens(
+    silentRequest,
+    serverResponse,
+    loadTokenOptions
+);
 
 // OR
 
 const silentRequest: SilentRequest = {
-    scopes: ["User.Read", "email"],
-    authority: "https://login.microsoftonline.com/your-tenant-id"
+    scopes: [],
+    authority: "https://login.microsoftonline.com/your-tenant-id",
 };
 
 const serverResponse: ExternalTokenResponse = {
-    token_type: AuthenticationScheme.BEARER, // "Bearer"
-    scope: "User.Read email",
-    expires_in: 3599,
     id_token: "id-token-here",
-}
+};
 
 const loadTokenOptions: LoadTokenOptions = {
-    clientInfo: "client-info-here"
+    clientInfo: "client-info-here",
 };
+
+const pca = new PublicClientApplication({
+    auth: { clientId: "your-client-id" },
+});
+pca.getTokenCache().loadExternalTokens(
+    silentRequest,
+    serverResponse,
+    loadTokenOptions
+);
 
 // OR
 
 const silentRequest: SilentRequest = {
-    scopes: ["User.Read", "email"],
-    authority: "https://login.microsoftonline.com/your-tenant-id"
+    scopes: [],
+    authority: "https://login.microsoftonline.com/your-tenant-id",
 };
 
 const serverResponse: ExternalTokenResponse = {
-    token_type: AuthenticationScheme.BEARER, // "Bearer"
-    scope: "User.Read email",
-    expires_in: 3599,
     id_token: "id-token-here",
-    client_info: "client-info-here"
-}
+    client_info: "client-info-here",
+};
 
 const loadTokenOptions: LoadTokenOptions = {};
+
+const pca = new PublicClientApplication({
+    auth: { clientId: "your-client-id" },
+});
+pca.getTokenCache().loadExternalTokens(
+    silentRequest,
+    serverResponse,
+    loadTokenOptions
+);
 ```
 
 ### Loading access tokens
 
-Access tokens can optionally be loaded using `loadExternalTokens()`. Provide the following to load an access token (note that an id token is mandatory and will be loaded when loading access tokens):
+In addition to the parameters listed [above](#loading-tokens) provide the following to load an access token:
 
-1. A server response with and id token, an access token, `expires_in` value, token_type, and scopes, and
-1. Either:
-    - A `SilentRequest` object with account information, OR
-    - A `SilentRequest` object with the authority AND a `LoadTokenOptions` object with `clientInfo`, 
-    - A `SilentRequest` object with the authority AND a server response object with `client_info`
-    and
-1. The `LoadTokenOptions` object must also have an `extendedExpiresOn` value.
+1. A server response with an `access_token`, `expires_in`, `token_type`, and `scope`
 
 See the code examples below:
 
@@ -121,19 +136,64 @@ const silentRequest: SilentRequest = {
         environment: "login.microsoftonline.com",
         tenantId: "your-tenant-id",
         username: "test@contoso.com",
-        localAccountId: "your-local-account-id"
-    }
+        localAccountId: "your-local-account-id",
+    },
 };
 
 const serverResponse: ExternalTokenResponse = {
     token_type: AuthenticationScheme.BEARER, // "Bearer"
     scope: "User.Read email",
     expires_in: 3599,
-    id_token: "id-token-here",
-    access_token: "access-token-here"
-}
+    access_token: "access-token-here",
+};
 
 const loadTokenOptions: LoadTokenOptions = {
-    extendedExpiresOn: 6599
+    extendedExpiresOn: 6599,
 };
+
+const pca = new PublicClientApplication({
+    auth: { clientId: "your-client-id" },
+});
+pca.getTokenCache().loadExternalTokens(
+    silentRequest,
+    serverResponse,
+    loadTokenOptions
+);
+```
+
+### Loading refresh tokens
+
+In addition to the parameters listed [above](#loading-tokens) provide the following to load a refresh token:
+
+1. A server response with a `refresh_token` and optionally `refresh_token_expires_in`
+
+See the code examples below:
+
+```ts
+const silentRequest: SilentRequest = {
+    scopes: [],
+    account: {
+        homeAccountId: "your-home-account-id",
+        environment: "login.microsoftonline.com",
+        tenantId: "your-tenant-id",
+        username: "test@contoso.com",
+        localAccountId: "your-local-account-id",
+    },
+};
+
+const serverResponse: ExternalTokenResponse = {
+    refresh_token: "refresh-token-here",
+    refresh_token_expires_in: "86399",
+};
+
+const loadTokenOptions: LoadTokenOptions = {};
+
+const pca = new PublicClientApplication({
+    auth: { clientId: "your-client-id" },
+});
+pca.getTokenCache().loadExternalTokens(
+    silentRequest,
+    serverResponse,
+    loadTokenOptions
+);
 ```

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1864,11 +1864,10 @@ export class BrowserCacheManager extends CacheManager {
             claimsHash
         );
 
-        const cacheRecord = new CacheRecord(
-            undefined,
-            idTokenEntity,
-            accessTokenEntity
-        );
+        const cacheRecord = {
+            idToken: idTokenEntity,
+            accessToken: accessTokenEntity,
+        };
         return this.saveCacheRecord(cacheRecord);
     }
 

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -178,6 +178,9 @@ export class TokenCache implements ITokenCache {
             this.storage.setAccount(accountEntity);
             return accountEntity;
         } else if (!authority || (!clientInfo && !idTokenClaims)) {
+            this.logger.error(
+                "TokenCache - if an account is not provided on the request, authority and either clientInfo or idToken must be provided instead."
+            );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.unableToLoadToken
             );
@@ -260,9 +263,14 @@ export class TokenCache implements ITokenCache {
         tenantId: string,
         options: LoadTokenOptions
     ): AccessTokenEntity | null {
-        if (!response.access_token || !response.expires_in) {
+        if (!response.access_token) {
             this.logger.verbose(
                 "TokenCache - no access token found in response"
+            );
+            return null;
+        } else if (!response.expires_in) {
+            this.logger.warning(
+                "TokenCache - no expiration set on the access token. Cannot add it to the cache."
             );
             return null;
         }

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -114,9 +114,9 @@ export class TokenCache implements ITokenCache {
 
         const cacheRecordAccount: AccountEntity = this.loadAccount(
             request,
+            options.clientInfo || response.client_info || "",
             idTokenClaims,
-            authority,
-            options.clientInfo || response.client_info
+            authority
         );
 
         const idToken = this.loadIdToken(
@@ -165,9 +165,9 @@ export class TokenCache implements ITokenCache {
      */
     private loadAccount(
         request: SilentRequest,
+        clientInfo: string,
         idTokenClaims?: TokenClaims,
-        authority?: Authority,
-        clientInfo?: string
+        authority?: Authority
     ): AccountEntity {
         this.logger.verbose("TokenCache - loading account");
 
@@ -177,7 +177,7 @@ export class TokenCache implements ITokenCache {
             );
             this.storage.setAccount(accountEntity);
             return accountEntity;
-        } else if (!idTokenClaims || !authority || !clientInfo) {
+        } else if (!authority || (!clientInfo && !idTokenClaims)) {
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.unableToLoadToken
             );
@@ -191,14 +191,14 @@ export class TokenCache implements ITokenCache {
             idTokenClaims
         );
 
-        const claimsTenantId = idTokenClaims.tid;
+        const claimsTenantId = idTokenClaims?.tid;
 
         const cachedAccount = buildAccountToCache(
             this.storage,
             authority,
             homeAccountId,
-            idTokenClaims,
             base64Decode,
+            idTokenClaims,
             clientInfo,
             authority.hostnameAndPort,
             claimsTenantId,
@@ -322,7 +322,7 @@ export class TokenCache implements ITokenCache {
             response.refresh_token,
             this.config.auth.clientId,
             response.foci,
-            undefined,
+            undefined, // userAssertionHash
             response.refresh_token_expires_in
         );
 

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1963,7 +1963,8 @@ export class StandardController implements IController {
         request: SilentRequest & { correlationId: string },
         account: AccountInfo
     ): Promise<AuthenticationResult> {
-        const trackPageVisibility = () => this.trackPageVisibility(request.correlationId);
+        const trackPageVisibility = () =>
+            this.trackPageVisibility(request.correlationId);
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.AcquireTokenSilentAsync,
             request.correlationId
@@ -2123,7 +2124,10 @@ export class StandardController implements IController {
                 throw tokenRenewalError;
             })
             .finally(() => {
-                document.removeEventListener("visibilitychange", trackPageVisibility);
+                document.removeEventListener(
+                    "visibilitychange",
+                    trackPageVisibility
+                );
             });
     }
 

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -454,8 +454,8 @@ export class NativeInteractionClient extends BaseInteractionClient {
             this.browserStorage,
             authority,
             homeAccountIdentifier,
-            idTokenClaims,
             base64Decode,
+            idTokenClaims,
             response.client_info,
             undefined, // environment
             idTokenClaims.tid,

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -728,11 +728,10 @@ export class NativeInteractionClient extends BaseInteractionClient {
                 base64Decode
             );
 
-        const nativeCacheRecord = new CacheRecord(
-            undefined,
-            cachedIdToken,
-            cachedAccessToken
-        );
+        const nativeCacheRecord = {
+            idToken: cachedIdToken,
+            accessToken: cachedAccessToken,
+        };
 
         void this.nativeStorageManager.saveCacheRecord(
             nativeCacheRecord,

--- a/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/NativeInteractionClient.ts
@@ -25,7 +25,6 @@ import {
     AuthError,
     CommonSilentFlowRequest,
     AccountInfo,
-    CacheRecord,
     AADServerParamKeys,
     TokenClaims,
     createClientAuthError,

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -1643,11 +1643,7 @@ describe("BrowserCacheManager tests", () => {
                     );
 
                     cacheManager
-                        .saveCacheRecord(
-                            new CacheRecord(),
-                            undefined,
-                            "test-correlation-id"
-                        )
+                        .saveCacheRecord({}, undefined, "test-correlation-id")
                         .then(() => {
                             throw new Error(
                                 "saveCacheRecord should have thrown"

--- a/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/NativeInteractionClient.spec.ts
@@ -90,14 +90,6 @@ const testAccessTokenEntity: AccessTokenEntity = {
     cachedAt: `${TimeUtils.nowSeconds()}`,
 };
 
-const testCacheRecord: CacheRecord = {
-    account: testAccountEntity,
-    idToken: TEST_ID_TOKEN,
-    accessToken: testAccessTokenEntity,
-    refreshToken: null,
-    appMetadata: null,
-};
-
 describe("NativeInteractionClient Tests", () => {
     globalThis.MessageChannel = require("worker_threads").MessageChannel; // jsdom does not include an implementation for MessageChannel
 
@@ -196,18 +188,18 @@ describe("NativeInteractionClient Tests", () => {
             jest.spyOn(
                 CacheManager.prototype,
                 "getAccessToken"
-            ).mockReturnValue(testCacheRecord.accessToken);
+            ).mockReturnValue(testAccessTokenEntity);
             jest.spyOn(CacheManager.prototype, "getIdToken").mockReturnValue(
-                testCacheRecord.idToken
+                TEST_ID_TOKEN
             );
             jest.spyOn(
                 CacheManager.prototype,
                 "readAppMetadataFromCache"
-            ).mockReturnValue(testCacheRecord.appMetadata);
+            ).mockReturnValue(null);
             jest.spyOn(
                 CacheManager.prototype,
                 "readAccountFromCache"
-            ).mockReturnValue(testCacheRecord.account);
+            ).mockReturnValue(testAccountEntity);
         });
 
         it("Tokens found in cache", async () => {

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -129,7 +129,7 @@ export class AccountEntity {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static createAccount(accountDetails: {
         homeAccountId: string;
-        idTokenClaims: TokenClaims;
+        idTokenClaims?: TokenClaims;
         clientInfo?: string;
         cloudGraphHostName?: string;
         msGraphHost?: string;
@@ -651,7 +651,7 @@ const bindingKeyNotRemoved = "binding_key_not_removed";
 // Warning: (ae-missing-release-tag) "buildAccountToCache" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function buildAccountToCache(cacheStorage: CacheManager, authority: Authority, homeAccountId: string, idTokenClaims: TokenClaims, base64Decode: (input: string) => string, clientInfo?: string, environment?: string, claimsTenantId?: string | null, authCodePayload?: AuthorizationCodePayload, nativeAccountId?: string, logger?: Logger): AccountEntity;
+export function buildAccountToCache(cacheStorage: CacheManager, authority: Authority, homeAccountId: string, base64Decode: (input: string) => string, idTokenClaims?: TokenClaims, clientInfo?: string, environment?: string, claimsTenantId?: string | null, authCodePayload?: AuthorizationCodePayload, nativeAccountId?: string, logger?: Logger): AccountEntity;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -918,19 +918,13 @@ const cacheQuotaExceededErrorCode = "cache_quota_exceeded";
 // Warning: (ae-internal-missing-underscore) The name "CacheRecord" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export class CacheRecord {
-    constructor(accountEntity?: AccountEntity | null, idTokenEntity?: IdTokenEntity | null, accessTokenEntity?: AccessTokenEntity | null, refreshTokenEntity?: RefreshTokenEntity | null, appMetadataEntity?: AppMetadataEntity | null);
-    // (undocumented)
-    accessToken: AccessTokenEntity | null;
-    // (undocumented)
-    account: AccountEntity | null;
-    // (undocumented)
-    appMetadata: AppMetadataEntity | null;
-    // (undocumented)
-    idToken: IdTokenEntity | null;
-    // (undocumented)
-    refreshToken: RefreshTokenEntity | null;
-}
+export type CacheRecord = {
+    account?: AccountEntity | null;
+    idToken?: IdTokenEntity | null;
+    accessToken?: AccessTokenEntity | null;
+    refreshToken?: RefreshTokenEntity | null;
+    appMetadata?: AppMetadataEntity | null;
+};
 
 // Warning: (ae-missing-release-tag) "CacheType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "CacheType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1949,7 +1943,7 @@ const EXPIRES_IN = "expires_in";
 // Warning: (ae-missing-release-tag) "ExternalTokenResponse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export type ExternalTokenResponse = Pick<ServerAuthorizationTokenResponse, "token_type" | "scope" | "expires_in" | "id_token" | "refresh_token"> & {
+export type ExternalTokenResponse = Pick<ServerAuthorizationTokenResponse, "token_type" | "scope" | "expires_in" | "ext_expires_in" | "id_token" | "refresh_token" | "refresh_token_expires_in" | "foci"> & {
     access_token?: string;
     client_info?: string;
 };

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -135,7 +135,7 @@ export class AccountEntity {
     static createAccount(
         accountDetails: {
             homeAccountId: string;
-            idTokenClaims: TokenClaims;
+            idTokenClaims?: TokenClaims;
             clientInfo?: string;
             cloudGraphHostName?: string;
             msGraphHost?: string;
@@ -189,8 +189,8 @@ export class AccountEntity {
         // How do you account for MSA CID here?
         account.localAccountId =
             clientInfo?.uid ||
-            accountDetails.idTokenClaims.oid ||
-            accountDetails.idTokenClaims.sub ||
+            accountDetails.idTokenClaims?.oid ||
+            accountDetails.idTokenClaims?.sub ||
             "";
 
         /*
@@ -199,14 +199,14 @@ export class AccountEntity {
          * policy is configured to return more than 1 email.
          */
         const preferredUsername =
-            accountDetails.idTokenClaims.preferred_username ||
-            accountDetails.idTokenClaims.upn;
-        const email = accountDetails.idTokenClaims.emails
+            accountDetails.idTokenClaims?.preferred_username ||
+            accountDetails.idTokenClaims?.upn;
+        const email = accountDetails.idTokenClaims?.emails
             ? accountDetails.idTokenClaims.emails[0]
             : null;
 
         account.username = preferredUsername || email || "";
-        account.name = accountDetails.idTokenClaims.name;
+        account.name = accountDetails.idTokenClaims?.name || "";
 
         account.cloudGraphHostName = accountDetails.cloudGraphHostName;
         account.msGraphHost = accountDetails.msGraphHost;

--- a/lib/msal-common/src/cache/entities/CacheRecord.ts
+++ b/lib/msal-common/src/cache/entities/CacheRecord.ts
@@ -10,24 +10,10 @@ import { AccountEntity } from "./AccountEntity";
 import { AppMetadataEntity } from "./AppMetadataEntity";
 
 /** @internal */
-export class CacheRecord {
-    account: AccountEntity | null;
-    idToken: IdTokenEntity | null;
-    accessToken: AccessTokenEntity | null;
-    refreshToken: RefreshTokenEntity | null;
-    appMetadata: AppMetadataEntity | null;
-
-    constructor(
-        accountEntity?: AccountEntity | null,
-        idTokenEntity?: IdTokenEntity | null,
-        accessTokenEntity?: AccessTokenEntity | null,
-        refreshTokenEntity?: RefreshTokenEntity | null,
-        appMetadataEntity?: AppMetadataEntity | null
-    ) {
-        this.account = accountEntity || null;
-        this.idToken = idTokenEntity || null;
-        this.accessToken = accessTokenEntity || null;
-        this.refreshToken = refreshTokenEntity || null;
-        this.appMetadata = appMetadataEntity || null;
-    }
-}
+export type CacheRecord = {
+    account?: AccountEntity | null;
+    idToken?: IdTokenEntity | null;
+    accessToken?: AccessTokenEntity | null;
+    refreshToken?: RefreshTokenEntity | null;
+    appMetadata?: AppMetadataEntity | null;
+};

--- a/lib/msal-common/src/response/ExternalTokenResponse.ts
+++ b/lib/msal-common/src/response/ExternalTokenResponse.ts
@@ -17,7 +17,14 @@ import { ServerAuthorizationTokenResponse } from "./ServerAuthorizationTokenResp
  */
 export type ExternalTokenResponse = Pick<
     ServerAuthorizationTokenResponse,
-    "token_type" | "scope" | "expires_in" | "id_token" | "refresh_token"
+    | "token_type"
+    | "scope"
+    | "expires_in"
+    | "ext_expires_in"
+    | "id_token"
+    | "refresh_token"
+    | "refresh_token_expires_in"
+    | "foci"
 > & {
     access_token?: string;
     client_info?: string;

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -553,13 +553,13 @@ export class ResponseHandler {
             };
         }
 
-        return new CacheRecord(
-            cachedAccount,
-            cachedIdToken,
-            cachedAccessToken,
-            cachedRefreshToken,
-            cachedAppMetadata
-        );
+        return {
+            account: cachedAccount,
+            idToken: cachedIdToken,
+            accessToken: cachedAccessToken,
+            refreshToken: cachedRefreshToken,
+            appMetadata: cachedAppMetadata,
+        };
     }
 
     /**

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -454,8 +454,8 @@ export class ResponseHandler {
                 this.cacheStorage,
                 authority,
                 this.homeAccountIdentifier,
-                idTokenClaims,
                 this.cryptoObj.base64Decode,
+                idTokenClaims,
                 serverTokenResponse.client_info,
                 env,
                 claimsTenantId,
@@ -688,8 +688,8 @@ export function buildAccountToCache(
     cacheStorage: CacheManager,
     authority: Authority,
     homeAccountId: string,
-    idTokenClaims: TokenClaims,
     base64Decode: (input: string) => string,
+    idTokenClaims?: TokenClaims,
     clientInfo?: string,
     environment?: string,
     claimsTenantId?: string | null,
@@ -730,6 +730,7 @@ export function buildAccountToCache(
 
     if (
         claimsTenantId &&
+        idTokenClaims &&
         !tenantProfiles.find((tenantProfile) => {
             return tenantProfile.tenantId === claimsTenantId;
         })

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -96,7 +96,7 @@ describe("CacheManager.ts test cases", () => {
             ac.authorityType = "MSSTS";
 
             const accountKey = ac.generateAccountKey();
-            const cacheRecord = new CacheRecord();
+            const cacheRecord: CacheRecord = {};
             cacheRecord.account = ac;
             await mockCache.cacheManager.saveCacheRecord(cacheRecord);
             const mockCacheAccount = mockCache.cacheManager.getAccount(
@@ -126,7 +126,7 @@ describe("CacheManager.ts test cases", () => {
             };
 
             const atKey = CacheHelpers.generateCredentialKey(at);
-            const cacheRecord = new CacheRecord();
+            const cacheRecord: CacheRecord = {};
             cacheRecord.accessToken = at;
             await mockCache.cacheManager.saveCacheRecord(cacheRecord);
             const mockCacheAT = mockCache.cacheManager.getAccessTokenCredential(
@@ -158,7 +158,7 @@ describe("CacheManager.ts test cases", () => {
             );
 
             const atKey = CacheHelpers.generateCredentialKey(at);
-            const cacheRecord = new CacheRecord();
+            const cacheRecord: CacheRecord = {};
             cacheRecord.accessToken = at;
             await mockCache.cacheManager.saveCacheRecord(cacheRecord, {
                 accessToken: false,
@@ -185,7 +185,7 @@ describe("CacheManager.ts test cases", () => {
             };
 
             const atKey = CacheHelpers.generateCredentialKey(at);
-            const cacheRecord = new CacheRecord();
+            const cacheRecord: CacheRecord = {};
             cacheRecord.accessToken = at;
             await mockCache.cacheManager.saveCacheRecord(cacheRecord);
             const mockCacheAT = mockCache.cacheManager.getAccessTokenCredential(
@@ -214,7 +214,7 @@ describe("CacheManager.ts test cases", () => {
             );
 
             const idTokenKey = CacheHelpers.generateCredentialKey(idToken);
-            const cacheRecord = new CacheRecord();
+            const cacheRecord: CacheRecord = {};
             cacheRecord.idToken = idToken;
             await mockCache.cacheManager.saveCacheRecord(cacheRecord, {
                 idToken: false,
@@ -290,7 +290,7 @@ describe("CacheManager.ts test cases", () => {
 
             const refreshTokenKey =
                 CacheHelpers.generateCredentialKey(refreshToken);
-            const cacheRecord = new CacheRecord();
+            const cacheRecord: CacheRecord = {};
             cacheRecord.refreshToken = refreshToken;
             await mockCache.cacheManager.saveCacheRecord(cacheRecord, {
                 refreshToken: false,
@@ -672,7 +672,7 @@ describe("CacheManager.ts test cases", () => {
         ac.authorityType = "MSSTS";
 
         const accountKey = ac.generateAccountKey();
-        const cacheRecord = new CacheRecord();
+        const cacheRecord: CacheRecord = {};
         cacheRecord.account = ac;
         await mockCache.cacheManager.saveCacheRecord(cacheRecord);
 
@@ -697,7 +697,7 @@ describe("CacheManager.ts test cases", () => {
         };
 
         const credKey = CacheHelpers.generateCredentialKey(accessTokenEntity);
-        const cacheRecord = new CacheRecord();
+        const cacheRecord: CacheRecord = {};
         cacheRecord.accessToken = accessTokenEntity;
         await mockCache.cacheManager.saveCacheRecord(cacheRecord);
 
@@ -725,7 +725,7 @@ describe("CacheManager.ts test cases", () => {
         };
 
         const credKey = CacheHelpers.generateCredentialKey(accessTokenEntity);
-        const cacheRecord = new CacheRecord();
+        const cacheRecord: CacheRecord = {};
         cacheRecord.accessToken = accessTokenEntity;
         await mockCache.cacheManager.saveCacheRecord(cacheRecord);
 


### PR DESCRIPTION
Refactors `loadExternalTokens` to allow loading of any combination of tokens. Previously id_token was required in order to load access and/or refresh tokens, now client_info or an AccountInfo object can be used instead.