### PR TITLE
Add main field to package.json

### DIFF
--- a/change/@azure-msal-browser-ac2a4716-ca48-4957-a2d1-0da9ffeb09fa.json
+++ b/change/@azure-msal-browser-ac2a4716-ca48-4957-a2d1-0da9ffeb09fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add main field to package.json",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-5fd2c5c6-d21f-41ac-971f-d352c8213ea3.json
+++ b/change/@azure-msal-common-5fd2c5c6-d21f-41ac-971f-d352c8213ea3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add main field to package.json",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-3b0e11fc-905e-4270-aef2-63a28ddcf362.json
+++ b/change/@azure-msal-node-3b0e11fc-905e-4270-aef2-63a28ddcf362.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add main field to package.json",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -23,7 +23,7 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./lib/msal-browser.js",
+  "main": "./lib/msal-browser.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -23,6 +23,7 @@
   ],
   "type": "module",
   "sideEffects": false,
+  "main": "./lib/msal-browser.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/lib/msal-common/package.json
+++ b/lib/msal-common/package.json
@@ -22,6 +22,7 @@
     "oauth"
   ],
   "sideEffects": false,
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -22,6 +22,7 @@
     "oauth"
   ],
   "type": "module",
+  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Adds main field to package.json to unblock usage with consumers that don't understand the "exports" field & don't support ESM