### PR TITLE
Add correlation id param to initialize and clearTokensAndKeysWithClaims APIs to streamline telemetry data analysis

### DIFF
--- a/change/@azure-msal-browser-eecce831-c1f6-4fe0-a200-8e7708614e02.json
+++ b/change/@azure-msal-browser-eecce831-c1f6-4fe0-a200-8e7708614e02.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add correlation id param to initialize and clearTokensAndKeysWithClaims APIs to streamline telemetry data analysis #7190",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1362,9 +1362,7 @@ export class PublicClientApplication implements IPublicClientApplication {
     protected controller: IController;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    static createPublicClientApplication(configuration: Configuration, request?: InitializeApplicationRequest): Promise<IPublicClientApplication>;
+    static createPublicClientApplication(configuration: Configuration): Promise<IPublicClientApplication>;
     disableAccountStorageEvents(): void;
     enableAccountStorageEvents(): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -916,7 +916,7 @@ export interface IController {
     // (undocumented)
     hydrateCache(result: AuthenticationResult, request: SilentRequest | SsoSilentRequest | RedirectRequest | PopupRequest): Promise<void>;
     // (undocumented)
-    initialize(): Promise<void>;
+    initialize(correlationId?: string): Promise<void>;
     // (undocumented)
     initializeWrapperLibrary(sku: WrapperSKU, version: string): void;
     // @internal (undocumented)
@@ -1343,8 +1343,8 @@ export class PublicClientApplication implements IPublicClientApplication {
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     acquireTokenRedirect(request: RedirectRequest): Promise<void>;
-    // Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a parameter name
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a parameter name
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1386,7 +1386,7 @@ export class PublicClientApplication implements IPublicClientApplication {
     handleRedirectPromise(hash?: string | undefined): Promise<AuthenticationResult | null>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     hydrateCache(result: AuthenticationResult, request: SilentRequest | SsoSilentRequest | RedirectRequest | PopupRequest): Promise<void>;
-    initialize(): Promise<void>;
+    initialize(correlationId?: string): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     initializeWrapperLibrary(sku: WrapperSKU, version: string): void;

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -915,8 +915,10 @@ export interface IController {
     handleRedirectPromise(hash?: string): Promise<AuthenticationResult | null>;
     // (undocumented)
     hydrateCache(result: AuthenticationResult, request: SilentRequest | SsoSilentRequest | RedirectRequest | PopupRequest): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "InitializeApplicationRequest" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    initialize(correlationId?: string): Promise<void>;
+    initialize(request?: InitializeApplicationRequest): Promise<void>;
     // (undocumented)
     initializeWrapperLibrary(sku: WrapperSKU, version: string): void;
     // @internal (undocumented)
@@ -1325,14 +1327,14 @@ export { ProtocolMode }
 //
 // @public
 export class PublicClientApplication implements IPublicClientApplication {
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     // Warning: (tsdoc-undefined-tag) The TSDoc tag "@constructor" is not defined in this configuration
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1349,8 +1351,8 @@ export class PublicClientApplication implements IPublicClientApplication {
     acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     addEventCallback(callback: EventCallbackFunction): string | null;
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
@@ -1358,8 +1360,11 @@ export class PublicClientApplication implements IPublicClientApplication {
     clearCache(logoutRequest?: ClearCacheRequest): Promise<void>;
     // (undocumented)
     protected controller: IController;
-    // (undocumented)
-    static createPublicClientApplication(configuration: Configuration): Promise<IPublicClientApplication>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    static createPublicClientApplication(configuration: Configuration, request?: InitializeApplicationRequest): Promise<IPublicClientApplication>;
     disableAccountStorageEvents(): void;
     enableAccountStorageEvents(): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1388,7 +1393,7 @@ export class PublicClientApplication implements IPublicClientApplication {
     hydrateCache(result: AuthenticationResult, request: SilentRequest | SsoSilentRequest | RedirectRequest | PopupRequest): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    initialize(correlationId?: string): Promise<void>;
+    initialize(request?: InitializeApplicationRequest): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     initializeWrapperLibrary(sku: WrapperSKU, version: string): void;
@@ -1407,8 +1412,8 @@ export class PublicClientApplication implements IPublicClientApplication {
     logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     removeEventCallback(callbackId: string): void;
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     removePerformanceCallback(callbackId: string): boolean;

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1325,14 +1325,14 @@ export { ProtocolMode }
 //
 // @public
 export class PublicClientApplication implements IPublicClientApplication {
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     // Warning: (tsdoc-undefined-tag) The TSDoc tag "@constructor" is not defined in this configuration
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1349,8 +1349,8 @@ export class PublicClientApplication implements IPublicClientApplication {
     acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     addEventCallback(callback: EventCallbackFunction): string | null;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
@@ -1407,8 +1407,8 @@ export class PublicClientApplication implements IPublicClientApplication {
     logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     removeEventCallback(callbackId: string): void;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     removePerformanceCallback(callbackId: string): boolean;

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -915,8 +915,6 @@ export interface IController {
     handleRedirectPromise(hash?: string): Promise<AuthenticationResult | null>;
     // (undocumented)
     hydrateCache(result: AuthenticationResult, request: SilentRequest | SsoSilentRequest | RedirectRequest | PopupRequest): Promise<void>;
-    // Warning: (ae-forgotten-export) The symbol "InitializeApplicationRequest" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     initialize(request?: InitializeApplicationRequest): Promise<void>;
     // (undocumented)
@@ -969,6 +967,13 @@ export interface INavigationClient {
 }
 
 export { INetworkModule }
+
+// Warning: (ae-missing-release-tag) "InitializeApplicationRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type InitializeApplicationRequest = {
+    correlationId?: string;
+};
 
 // Warning: (ae-missing-release-tag) "inMemRedirectUnavailable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1343,8 +1343,8 @@ export class PublicClientApplication implements IPublicClientApplication {
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     acquireTokenRedirect(request: RedirectRequest): Promise<void>;
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a parameter name
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     acquireTokenSilent(silentRequest: SilentRequest): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1386,6 +1386,8 @@ export class PublicClientApplication implements IPublicClientApplication {
     handleRedirectPromise(hash?: string | undefined): Promise<AuthenticationResult | null>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     hydrateCache(result: AuthenticationResult, request: SilentRequest | SsoSilentRequest | RedirectRequest | PopupRequest): Promise<void>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     initialize(correlationId?: string): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -43,15 +43,12 @@ export class PublicClientApplication implements IPublicClientApplication {
      * Creates StandardController and passes it to the PublicClientApplication
      *
      * @param configuration {Configuration}
-     * @param request {?InitializeApplicationRequest}
      */
     public static async createPublicClientApplication(
-        configuration: Configuration,
-        request?: InitializeApplicationRequest
+        configuration: Configuration
     ): Promise<IPublicClientApplication> {
         const controller = await ControllerFactory.createV3Controller(
-            configuration,
-            request
+            configuration
         );
         const pca = new PublicClientApplication(configuration, controller);
 

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -30,6 +30,7 @@ import { ClearCacheRequest } from "../request/ClearCacheRequest";
 import { EndSessionPopupRequest } from "../request/EndSessionPopupRequest";
 import { NestedAppAuthController } from "../controllers/NestedAppAuthController";
 import { NestedAppOperatingContext } from "../operatingcontext/NestedAppOperatingContext";
+import { InitializeApplicationRequest } from "../request/InitializeApplicationRequest";
 
 /**
  * The PublicClientApplication class is the object exposed by the library to perform authentication and authorization functions in Single Page Applications
@@ -38,12 +39,19 @@ import { NestedAppOperatingContext } from "../operatingcontext/NestedAppOperatin
 export class PublicClientApplication implements IPublicClientApplication {
     protected controller: IController;
 
-    // creates StandardController and passes it to the PublicClientApplication
+    /**
+     * Creates StandardController and passes it to the PublicClientApplication
+     *
+     * @param configuration {Configuration}
+     * @param request {?InitializeApplicationRequest} correlation id
+     */
     public static async createPublicClientApplication(
-        configuration: Configuration
+        configuration: Configuration,
+        request?: InitializeApplicationRequest
     ): Promise<IPublicClientApplication> {
         const controller = await ControllerFactory.createV3Controller(
-            configuration
+            configuration,
+            request
         );
         const pca = new PublicClientApplication(configuration, controller);
 
@@ -80,10 +88,10 @@ export class PublicClientApplication implements IPublicClientApplication {
 
     /**
      * Initializer function to perform async startup tasks such as connecting to WAM extension
-     * @param correlationId {?string} correlation id
+     * @param request {?InitializeApplicationRequest}
      */
-    async initialize(correlationId?: string): Promise<void> {
-        return this.controller.initialize(correlationId);
+    async initialize(request?: InitializeApplicationRequest): Promise<void> {
+        return this.controller.initialize(request);
     }
 
     /**

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -43,7 +43,7 @@ export class PublicClientApplication implements IPublicClientApplication {
      * Creates StandardController and passes it to the PublicClientApplication
      *
      * @param configuration {Configuration}
-     * @param request {?InitializeApplicationRequest} correlation id
+     * @param request {?InitializeApplicationRequest}
      */
     public static async createPublicClientApplication(
         configuration: Configuration,

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -80,9 +80,10 @@ export class PublicClientApplication implements IPublicClientApplication {
 
     /**
      * Initializer function to perform async startup tasks such as connecting to WAM extension
+     * @param correlationId {?string} correlation id
      */
-    async initialize(): Promise<void> {
-        return this.controller.initialize();
+    async initialize(correlationId?: string): Promise<void> {
+        return this.controller.initialize(correlationId);
     }
 
     /**

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1266,13 +1266,16 @@ export class BrowserCacheManager extends CacheManager {
     /**
      * Clears all access tokes that have claims prior to saving the current one
      * @param performanceClient {IPerformanceClient}
+     * @param correlationId {string} correlation id
      * @returns
      */
     async clearTokensAndKeysWithClaims(
-        performanceClient: IPerformanceClient
+        performanceClient: IPerformanceClient,
+        correlationId: string
     ): Promise<void> {
         performanceClient.addQueueMeasurement(
-            PerformanceEvents.ClearTokensAndKeysWithClaims
+            PerformanceEvents.ClearTokensAndKeysWithClaims,
+            correlationId
         );
 
         const tokenKeys = this.getTokenKeys();

--- a/lib/msal-browser/src/controllers/ControllerFactory.ts
+++ b/lib/msal-browser/src/controllers/ControllerFactory.ts
@@ -9,14 +9,16 @@ import { IController } from "./IController";
 import { Configuration } from "../config/Configuration";
 import { StandardController } from "./StandardController";
 import { NestedAppAuthController } from "./NestedAppAuthController";
+import { InitializeApplicationRequest } from "../request/InitializeApplicationRequest";
 
 export async function createV3Controller(
-    config: Configuration
+    config: Configuration,
+    request?: InitializeApplicationRequest
 ): Promise<IController> {
     const standard = new StandardOperatingContext(config);
 
     await standard.initialize();
-    return StandardController.createController(standard);
+    return StandardController.createController(standard, request);
 }
 
 export async function createController(

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -27,7 +27,7 @@ import { EventCallbackFunction } from "../event/EventMessage";
 import { ClearCacheRequest } from "../request/ClearCacheRequest";
 
 export interface IController {
-    initialize(): Promise<void>;
+    initialize(correlationId?: string): Promise<void>;
 
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
 

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -28,6 +28,7 @@ import { ClearCacheRequest } from "../request/ClearCacheRequest";
 import { InitializeApplicationRequest } from "../request/InitializeApplicationRequest";
 
 export interface IController {
+    // TODO: Make request mandatory in the next major version?
     initialize(request?: InitializeApplicationRequest): Promise<void>;
 
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;

--- a/lib/msal-browser/src/controllers/IController.ts
+++ b/lib/msal-browser/src/controllers/IController.ts
@@ -25,9 +25,10 @@ import { EventHandler } from "../event/EventHandler";
 import { AuthenticationResult } from "../response/AuthenticationResult";
 import { EventCallbackFunction } from "../event/EventMessage";
 import { ClearCacheRequest } from "../request/ClearCacheRequest";
+import { InitializeApplicationRequest } from "../request/InitializeApplicationRequest";
 
 export interface IController {
-    initialize(correlationId?: string): Promise<void>;
+    initialize(request?: InitializeApplicationRequest): Promise<void>;
 
     acquireTokenPopup(request: PopupRequest): Promise<AuthenticationResult>;
 

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -301,8 +301,9 @@ export class StandardController implements IController {
 
     /**
      * Initializer function to perform async startup tasks such as connecting to WAM extension
+     * @param correlationId {?string} correlation id
      */
-    async initialize(): Promise<void> {
+    async initialize(correlationId?: string): Promise<void> {
         this.logger.trace("initialize called");
         if (this.initialized) {
             this.logger.info(
@@ -311,9 +312,12 @@ export class StandardController implements IController {
             return;
         }
 
+        const initCorrelationId =
+            correlationId || this.getRequestCorrelationId();
         const allowNativeBroker = this.config.system.allowNativeBroker;
         const initMeasurement = this.performanceClient.startMeasurement(
-            PerformanceEvents.InitializeClientApplication
+            PerformanceEvents.InitializeClientApplication,
+            initCorrelationId
         );
         this.eventHandler.emitEvent(EventType.INITIALIZE_START);
 
@@ -341,8 +345,9 @@ export class StandardController implements IController {
                 ),
                 PerformanceEvents.ClearTokensAndKeysWithClaims,
                 this.logger,
-                this.performanceClient
-            )(this.performanceClient);
+                this.performanceClient,
+                initCorrelationId
+            )(this.performanceClient, initCorrelationId);
         }
 
         this.initialized = true;

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -84,6 +84,7 @@ import { AuthenticationResult } from "../response/AuthenticationResult";
 import { ClearCacheRequest } from "../request/ClearCacheRequest";
 import { createNewGuid } from "../crypto/BrowserCrypto";
 import { initializeSilentRequest } from "../request/RequestHelpers";
+import { InitializeApplicationRequest } from "../request/InitializeApplicationRequest";
 
 function getAccountType(
     account?: AccountInfo
@@ -281,10 +282,11 @@ export class StandardController implements IController {
     }
 
     static async createController(
-        operatingContext: BaseOperatingContext
+        operatingContext: BaseOperatingContext,
+        request?: InitializeApplicationRequest
     ): Promise<IController> {
         const controller = new StandardController(operatingContext);
-        await controller.initialize();
+        await controller.initialize(request);
         return controller;
     }
 
@@ -301,9 +303,9 @@ export class StandardController implements IController {
 
     /**
      * Initializer function to perform async startup tasks such as connecting to WAM extension
-     * @param correlationId {?string} correlation id
+     * @param request {?InitializeApplicationRequest} correlation id
      */
-    async initialize(correlationId?: string): Promise<void> {
+    async initialize(request?: InitializeApplicationRequest): Promise<void> {
         this.logger.trace("initialize called");
         if (this.initialized) {
             this.logger.info(
@@ -313,7 +315,7 @@ export class StandardController implements IController {
         }
 
         const initCorrelationId =
-            correlationId || this.getRequestCorrelationId();
+            request?.correlationId || this.getRequestCorrelationId();
         const allowNativeBroker = this.config.system.allowNativeBroker;
         const initMeasurement = this.performanceClient.startMeasurement(
             PerformanceEvents.InitializeClientApplication,

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -66,6 +66,7 @@ export { AuthorizationUrlRequest } from "./request/AuthorizationUrlRequest";
 export { AuthorizationCodeRequest } from "./request/AuthorizationCodeRequest";
 export { AuthenticationResult } from "./response/AuthenticationResult";
 export { ClearCacheRequest } from "./request/ClearCacheRequest";
+export { InitializeApplicationRequest } from "./request/InitializeApplicationRequest";
 
 // Cache
 export { LoadTokenOptions } from "./cache/TokenCache";

--- a/lib/msal-browser/src/request/InitializeApplicationRequest.ts
+++ b/lib/msal-browser/src/request/InitializeApplicationRequest.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * InitializeApplicationRequest: Request object passed by user to initialize application
+ *
+ * - correlationId              - Unique GUID set per request to trace a request end-to-end for telemetry purposes.
+ */
+export type InitializeApplicationRequest = {
+    correlationId?: string;
+};

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -498,6 +498,35 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             // @ts-ignore
             expect(pca.nativeExtensionProvider).toBeUndefined();
         });
+
+        it("reports telemetry event using provided correlation id", (done) => {
+            pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient(testAppConfig),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
+                },
+            });
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].name).toEqual(
+                    PerformanceEvents.InitializeClientApplication
+                );
+                expect(events[0].correlationId).toEqual("test-correlation-id");
+                expect(
+                    events[0]["clearTokensAndKeysWithClaimsDurationMs"]
+                ).toBeGreaterThanOrEqual(0);
+                pca.removePerformanceCallback(callbackId);
+                done();
+            });
+
+            pca.initialize("test-correlation-id");
+        });
     });
 
     describe("handleRedirectPromise", () => {

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -525,7 +525,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 done();
             });
 
-            pca.initialize("test-correlation-id");
+            pca.initialize({ correlationId: "test-correlation-id" });
         });
     });
 

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -1105,10 +1105,12 @@ describe("BrowserCacheManager tests", () => {
                     ).toEqual(testAT4);
 
                     browserSessionStorage.clearTokensAndKeysWithClaims(
-                        getDefaultPerformanceClient()
+                        getDefaultPerformanceClient(),
+                        "test-correlation-id"
                     );
                     browserLocalStorage.clearTokensAndKeysWithClaims(
-                        getDefaultPerformanceClient()
+                        getDefaultPerformanceClient(),
+                        "test-correlation-id"
                     );
 
                     expect(


### PR DESCRIPTION
- Add correlation id param to initialize and clearTokensAndKeysWithClaims APIs to streamline telemetry data analysis