### PR TITLE
Create default tenant profile without idToken

### DIFF
--- a/change/@azure-msal-browser-e9608897-9661-4710-a6de-258b1797f95c.json
+++ b/change/@azure-msal-browser-e9608897-9661-4710-a6de-258b1797f95c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Generate tenantProfile even without idTokenClaims",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-b6c12ea5-317c-4f0a-ab8e-ed6d3b659935.json
+++ b/change/@azure-msal-common-b6c12ea5-317c-4f0a-ab8e-ed6d3b659935.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Generate tenantProfile even without idTokenClaims",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -28,7 +28,7 @@ import {
     IdTokenEntity,
     AccessTokenEntity,
     TenantProfile,
-    buildTenantProfileFromIdTokenClaims,
+    buildTenantProfile,
 } from "@azure/msal-common";
 import { isBridgeError } from "../BridgeError";
 import { BridgeStatusCode } from "../BridgeStatusCode";
@@ -192,8 +192,10 @@ export class NestedAppAuthAdapter {
 
         const tenantProfiles = new Map<string, TenantProfile>();
 
-        const tenantProfile = buildTenantProfileFromIdTokenClaims(
+        const tenantProfile = buildTenantProfile(
             homeAccountId,
+            localAccountId,
+            tenantId,
             effectiveIdTokenClaims
         );
         tenantProfiles.set(tenantId, tenantProfile);

--- a/lib/msal-browser/test/cache/TestStorageManager.ts
+++ b/lib/msal-browser/test/cache/TestStorageManager.ts
@@ -16,11 +16,6 @@ import {
     ValidCredentialType,
     TokenKeys,
     CacheHelpers,
-    TokenClaims,
-    CredentialType,
-    buildTenantProfileFromIdTokenClaims,
-    TenantProfile,
-    AccountInfo,
 } from "@azure/msal-common";
 
 const ACCOUNT_KEYS = "ACCOUNT_KEYS";

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -40,6 +40,7 @@ import {
     BrowserAuthError,
     BrowserAuthErrorCodes,
     BrowserAuthErrorMessage,
+    PublicClientApplication,
     SilentRequest,
 } from "../../src";
 import { base64Decode } from "../../src/encode/Base64Decode";
@@ -465,6 +466,19 @@ describe("TokenCache tests", () => {
                 options
             );
 
+            // Validate account can be retrieved
+            const pca = new PublicClientApplication(configuration);
+            expect(pca.getAllAccounts()).toHaveLength(1);
+            expect(
+                pca.getAccount({
+                    localAccountId: result.account.localAccountId,
+                    homeAccountId: result.account.homeAccountId,
+                    realm: result.account.tenantId,
+                    environment: result.account.environment,
+                })
+            ).toEqual(result.account);
+
+            // Validate tokens can be retrieved
             expect(
                 browserStorage.getRefreshTokenCredential(refreshTokenKey)
             ).toEqual(refreshTokenEntity);

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -671,10 +671,10 @@ export function buildClientInfoFromHomeAccountId(homeAccountId: string): ClientI
 // @public (undocumented)
 export function buildStaticAuthorityOptions(authOptions: Partial<AuthorityOptions>): StaticAuthorityOptions;
 
-// Warning: (ae-missing-release-tag) "buildTenantProfileFromIdTokenClaims" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "buildTenantProfile" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
-export function buildTenantProfileFromIdTokenClaims(homeAccountId: string, idTokenClaims: TokenClaims): TenantProfile;
+// @public
+export function buildTenantProfile(homeAccountId: string, localAccountId: string, tenantId: string, idTokenClaims?: TokenClaims): TenantProfile;
 
 // Warning: (ae-missing-release-tag) "CacheAccountType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "CacheAccountType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4208,40 +4208,40 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/authority/AuthorityOptions.ts:26:5 - (ae-forgotten-export) The symbol "CloudInstanceDiscoveryResponse" needs to be exported by the entry point index.d.ts
 // src/cache/CacheManager.ts:297:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:298:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:581:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1649:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1650:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1664:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1665:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:571:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1639:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1640:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1654:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1655:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1675:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1676:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1685:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1686:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1695:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1696:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1712:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1713:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1727:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1728:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1761:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1762:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1776:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1777:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1788:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1789:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1800:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1801:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1812:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1813:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1830:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1831:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1855:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1856:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1875:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1876:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1895:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1896:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1907:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1908:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1916:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1702:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1703:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1717:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1718:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1751:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1752:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1766:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1767:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1778:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1779:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1790:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1791:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1802:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1803:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1820:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1821:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1845:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1846:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1865:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1866:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1885:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1886:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1897:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1898:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1906:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/utils/CacheTypes.ts:94:53 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
 // src/cache/utils/CacheTypes.ts:94:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
 // src/client/AuthorizationCodeClient.ts:228:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/account/AccountInfo.ts
+++ b/lib/msal-common/src/account/AccountInfo.ts
@@ -77,10 +77,10 @@ export function tenantIdMatchesHomeTenant(
 
 /**
  * Build tenant profile
- * @param homeAccountId
- * @param localAccountId
- * @param tenantId
- * @param idTokenClaims
+ * @param homeAccountId - Home account identifier for this account object
+ * @param localAccountId - Local account identifer for this account object
+ * @param tenantId - Full tenant or organizational id that this account belongs to
+ * @param idTokenClaims - Claims from the ID token
  * @returns
  */
 export function buildTenantProfile(

--- a/lib/msal-common/src/account/AccountInfo.ts
+++ b/lib/msal-common/src/account/AccountInfo.ts
@@ -75,26 +75,44 @@ export function tenantIdMatchesHomeTenant(
     );
 }
 
-export function buildTenantProfileFromIdTokenClaims(
+/**
+ * Build tenant profile
+ * @param homeAccountId
+ * @param localAccountId
+ * @param tenantId
+ * @param idTokenClaims
+ * @returns
+ */
+export function buildTenantProfile(
     homeAccountId: string,
-    idTokenClaims: TokenClaims
+    localAccountId: string,
+    tenantId: string,
+    idTokenClaims?: TokenClaims
 ): TenantProfile {
-    const { oid, sub, tid, name, tfp, acr } = idTokenClaims;
+    if (idTokenClaims) {
+        const { oid, sub, tid, name, tfp, acr } = idTokenClaims;
 
-    /**
-     * Since there is no way to determine if the authority is AAD or B2C, we exhaust all the possible claims that can serve as tenant ID with the following precedence:
-     * tid - TenantID claim that identifies the tenant that issued the token in AAD. Expected in all AAD ID tokens, not present in B2C ID Tokens.
-     * tfp - Trust Framework Policy claim that identifies the policy that was used to authenticate the user. Functions as tenant for B2C scenarios.
-     * acr - Authentication Context Class Reference claim used only with older B2C policies. Fallback in case tfp is not present, but likely won't be present anyway.
-     */
-    const tenantId = tid || tfp || acr || "";
+        /**
+         * Since there is no way to determine if the authority is AAD or B2C, we exhaust all the possible claims that can serve as tenant ID with the following precedence:
+         * tid - TenantID claim that identifies the tenant that issued the token in AAD. Expected in all AAD ID tokens, not present in B2C ID Tokens.
+         * tfp - Trust Framework Policy claim that identifies the policy that was used to authenticate the user. Functions as tenant for B2C scenarios.
+         * acr - Authentication Context Class Reference claim used only with older B2C policies. Fallback in case tfp is not present, but likely won't be present anyway.
+         */
+        const tenantId = tid || tfp || acr || "";
 
-    return {
-        tenantId: tenantId,
-        localAccountId: oid || sub || "",
-        name: name,
-        isHomeTenant: tenantIdMatchesHomeTenant(tenantId, homeAccountId),
-    };
+        return {
+            tenantId: tenantId,
+            localAccountId: oid || sub || "",
+            name: name,
+            isHomeTenant: tenantIdMatchesHomeTenant(tenantId, homeAccountId),
+        };
+    } else {
+        return {
+            tenantId,
+            localAccountId,
+            isHomeTenant: tenantIdMatchesHomeTenant(tenantId, homeAccountId),
+        };
+    }
 }
 
 /**
@@ -122,8 +140,10 @@ export function updateAccountTenantProfileData(
         // Ignore isHomeTenant, loginHint, and sid which are part of tenant profile but not base account info
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { isHomeTenant, ...claimsSourcedTenantProfile } =
-            buildTenantProfileFromIdTokenClaims(
+            buildTenantProfile(
                 baseAccountInfo.homeAccountId,
+                baseAccountInfo.localAccountId,
+                baseAccountInfo.tenantId,
                 idTokenClaims
             );
 

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -303,22 +303,12 @@ export abstract class CacheManager implements ICacheManager {
         accountFilter?: AccountFilter
     ): AccountInfo[] {
         return cachedAccounts.flatMap((accountEntity) => {
-            return this.getAccountInfoForTenantProfiles(
+            return this.getTenantProfilesFromAccountEntity(
                 accountEntity,
+                accountFilter?.tenantId,
                 accountFilter
             );
         });
-    }
-
-    private getAccountInfoForTenantProfiles(
-        accountEntity: AccountEntity,
-        accountFilter?: AccountFilter
-    ): AccountInfo[] {
-        return this.getTenantProfilesFromAccountEntity(
-            accountEntity,
-            accountFilter?.tenantId,
-            accountFilter
-        );
     }
 
     private getTenantedAccountInfoByFilter(

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -10,7 +10,7 @@ import { ClientInfo, buildClientInfo } from "../../account/ClientInfo";
 import {
     AccountInfo,
     TenantProfile,
-    buildTenantProfileFromIdTokenClaims,
+    buildTenantProfile,
 } from "../../account/AccountInfo";
 import {
     createClientAuthError,
@@ -214,15 +214,13 @@ export class AccountEntity {
         if (accountDetails.tenantProfiles) {
             account.tenantProfiles = accountDetails.tenantProfiles;
         } else {
-            const tenantProfiles = [];
-            if (accountDetails.idTokenClaims) {
-                const tenantProfile = buildTenantProfileFromIdTokenClaims(
-                    accountDetails.homeAccountId,
-                    accountDetails.idTokenClaims
-                );
-                tenantProfiles.push(tenantProfile);
-            }
-            account.tenantProfiles = tenantProfiles;
+            const tenantProfile = buildTenantProfile(
+                accountDetails.homeAccountId,
+                account.localAccountId,
+                account.realm,
+                accountDetails.idTokenClaims
+            );
+            account.tenantProfiles = [tenantProfile];
         }
 
         return account;

--- a/lib/msal-common/src/index.ts
+++ b/lib/msal-common/src/index.ts
@@ -41,7 +41,7 @@ export {
     TenantProfile,
     updateAccountTenantProfileData,
     tenantIdMatchesHomeTenant,
-    buildTenantProfileFromIdTokenClaims,
+    buildTenantProfile,
 } from "./account/AccountInfo";
 export { AuthToken };
 export {

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -48,7 +48,7 @@ import {
 } from "../account/TokenClaims";
 import {
     AccountInfo,
-    buildTenantProfileFromIdTokenClaims,
+    buildTenantProfile,
     updateAccountTenantProfileData,
 } from "../account/AccountInfo";
 import * as CacheHelpers from "../cache/utils/CacheHelpers";
@@ -744,16 +744,17 @@ export function buildAccountToCache(
         );
 
     const tenantProfiles = baseAccount.tenantProfiles || [];
-
+    const tenantId = claimsTenantId || baseAccount.realm;
     if (
-        claimsTenantId &&
-        idTokenClaims &&
+        tenantId &&
         !tenantProfiles.find((tenantProfile) => {
-            return tenantProfile.tenantId === claimsTenantId;
+            return tenantProfile.tenantId === tenantId;
         })
     ) {
-        const newTenantProfile = buildTenantProfileFromIdTokenClaims(
+        const newTenantProfile = buildTenantProfile(
             homeAccountId,
+            baseAccount.localAccountId,
+            tenantId,
             idTokenClaims
         );
         tenantProfiles.push(newTenantProfile);

--- a/lib/msal-common/test/account/AccountInfo.spec.ts
+++ b/lib/msal-common/test/account/AccountInfo.spec.ts
@@ -45,7 +45,7 @@ describe("AccountInfo Unit Tests", () => {
         });
     });
 
-    describe("buildTenantProfileFromIdTokenClaims()", () => {
+    describe("buildTenantProfile()", () => {
         describe("correctly sets tenantId", () => {
             it("from the tid claim when present", () => {
                 const idTokenClaims = {
@@ -53,11 +53,12 @@ describe("AccountInfo Unit Tests", () => {
                     tfp: ID_TOKEN_EXTRA_CLAIMS.tfp,
                     acr: ID_TOKEN_EXTRA_CLAIMS.acr,
                 };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.tenantId).toEqual(idTokenClaims.tid);
                 expect(tenantProfile.tenantId).not.toEqual(idTokenClaims.tfp);
                 expect(tenantProfile.tenantId).not.toEqual(idTokenClaims.acr);
@@ -68,11 +69,12 @@ describe("AccountInfo Unit Tests", () => {
                     tfp: ID_TOKEN_EXTRA_CLAIMS.tfp,
                     acr: ID_TOKEN_EXTRA_CLAIMS.acr,
                 };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.tenantId).toEqual(idTokenClaims.tfp);
                 expect(tenantProfile.tenantId).not.toEqual(idTokenClaims.acr);
                 expect(tenantProfile.tenantId).not.toEqual("");
@@ -82,23 +84,36 @@ describe("AccountInfo Unit Tests", () => {
                 const idTokenClaims = {
                     acr: ID_TOKEN_EXTRA_CLAIMS.acr,
                 };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.tenantId).toEqual(idTokenClaims.acr);
                 expect(tenantProfile.tenantId).not.toEqual("");
             });
 
             it("falls back to empty string when tid, tfp and acr claims not present", () => {
                 const idTokenClaims = { iss: ID_TOKEN_CLAIMS.iss };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.tenantId).toEqual("");
+            });
+
+            it("falls back to provided values when idTokenClaims are not present", () => {
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId
+                );
+                expect(tenantProfile.tenantId).toEqual(
+                    TEST_ACCOUNT_INFO.tenantId
+                );
             });
         });
 
@@ -108,11 +123,12 @@ describe("AccountInfo Unit Tests", () => {
                     oid: ID_TOKEN_CLAIMS.oid,
                     sub: ID_TOKEN_CLAIMS.sub,
                 };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.localAccountId).toEqual(idTokenClaims.oid);
                 expect(tenantProfile.localAccountId).not.toEqual(
                     idTokenClaims.sub
@@ -124,11 +140,12 @@ describe("AccountInfo Unit Tests", () => {
                 const idTokenClaims = {
                     sub: ID_TOKEN_CLAIMS.sub,
                 };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.localAccountId).toEqual(idTokenClaims.sub);
                 expect(tenantProfile.localAccountId).not.toEqual("");
             });
@@ -137,12 +154,24 @@ describe("AccountInfo Unit Tests", () => {
                 const idTokenClaims = {
                     iss: ID_TOKEN_CLAIMS.iss,
                 };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.localAccountId).toEqual("");
+            });
+
+            it("falls back to provided values when idTokenClaims not provided", () => {
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId
+                );
+                expect(tenantProfile.localAccountId).toEqual(
+                    TEST_ACCOUNT_INFO.localAccountId
+                );
             });
         });
 
@@ -151,11 +180,12 @@ describe("AccountInfo Unit Tests", () => {
                 const idTokenClaims = {
                     name: ID_TOKEN_CLAIMS.name,
                 };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.name).toEqual(idTokenClaims.name);
                 expect(tenantProfile.name).not.toEqual("");
             });
@@ -164,11 +194,12 @@ describe("AccountInfo Unit Tests", () => {
                 const idTokenClaims = {
                     iss: ID_TOKEN_CLAIMS.iss,
                 };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        TEST_ACCOUNT_INFO.homeAccountId,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    TEST_ACCOUNT_INFO.homeAccountId,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.name).toBeUndefined();
             });
         });
@@ -179,31 +210,34 @@ describe("AccountInfo Unit Tests", () => {
 
             it("to true when tenantId matches utid portion of homeAccountId", () => {
                 const idTokenClaims = { tid: TEST_UTID };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        HOME_ACCOUNT_ID,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    HOME_ACCOUNT_ID,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.isHomeTenant).toBe(true);
             });
 
             it("to false when tenantId does not match utid portion of homeAccountId", () => {
                 const idTokenClaims = { tid: "different-tenant-id" };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        HOME_ACCOUNT_ID,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    HOME_ACCOUNT_ID,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.isHomeTenant).toBe(false);
             });
 
             it("to false when tenantId is undefined utid portion of homeAccountId", () => {
                 const idTokenClaims = { iss: ID_TOKEN_CLAIMS.iss };
-                const tenantProfile =
-                    AccountInfo.buildTenantProfileFromIdTokenClaims(
-                        HOME_ACCOUNT_ID,
-                        idTokenClaims
-                    );
+                const tenantProfile = AccountInfo.buildTenantProfile(
+                    HOME_ACCOUNT_ID,
+                    TEST_ACCOUNT_INFO.localAccountId,
+                    TEST_ACCOUNT_INFO.tenantId,
+                    idTokenClaims
+                );
                 expect(tenantProfile.isHomeTenant).toBe(false);
             });
         });

--- a/shared-test-utils/src/CredentialGenerators.ts
+++ b/shared-test-utils/src/CredentialGenerators.ts
@@ -5,7 +5,7 @@ import {
     IdTokenEntity,
     TenantProfile,
     TokenClaims,
-    buildTenantProfileFromIdTokenClaims,
+    buildTenantProfile,
 } from "@azure/msal-common";
 
 export function buildAccountFromIdTokenClaims(
@@ -30,8 +30,10 @@ export function buildAccountFromIdTokenClaims(
         tenantProfiles: new Map<string, TenantProfile>([
             [
                 tenantId,
-                buildTenantProfileFromIdTokenClaims(
+                buildTenantProfile(
                     homeAccountId,
+                    oid || "",
+                    tenantId,
                     idTokenClaims
                 ),
             ],
@@ -41,8 +43,10 @@ export function buildAccountFromIdTokenClaims(
         const guestTenantId = guestIdTokenClaims.tid || "";
         accountInfo.tenantProfiles?.set(
             guestTenantId,
-            buildTenantProfileFromIdTokenClaims(
+            buildTenantProfile(
                 accountInfo.homeAccountId,
+                accountInfo.localAccountId,
+                guestTenantId,
                 guestIdTokenClaims
             )
         );


### PR DESCRIPTION
Account lookup doesn't work at all if the cached accounts don't have a tenant profile, which can happen if there is no id token yet. This PR updates account generation to build a default tenant profile when an idToken is not present