### PR TITLE
SHA-256 thumbprints now use PSS padding

### DIFF
--- a/change/@azure-msal-node-b4962068-75d2-482f-8866-07bdd0556859.json
+++ b/change/@azure-msal-node-b4962068-75d2-482f-8866-07bdd0556859.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "SHA-256 thumbprints now use PSS padding",
+  "packageName": "@azure/msal-node",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-b4962068-75d2-482f-8866-07bdd0556859.json
+++ b/change/@azure-msal-node-b4962068-75d2-482f-8866-07bdd0556859.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "SHA-256 thumbprints now use PSS padding",
+  "comment": "SHA-256 thumbprints now use PSS padding #7200",
   "packageName": "@azure/msal-node",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-node/src/client/ClientAssertion.ts
+++ b/lib/msal-node/src/client/ClientAssertion.ts
@@ -132,8 +132,11 @@ export class ClientAssertion {
         const issuedAt = TimeUtils.nowSeconds();
         this.expirationTime = issuedAt + 600;
 
+        const algorithm = this.useSha256
+            ? JwtConstants.PSS_256
+            : JwtConstants.RSA_256;
         const header: jwt.JwtHeader = {
-            alg: JwtConstants.RSA_256,
+            alg: algorithm,
         };
 
         const thumbprintHeader = this.useSha256

--- a/lib/msal-node/src/utils/Constants.ts
+++ b/lib/msal-node/src/utils/Constants.ts
@@ -146,6 +146,7 @@ export type ApiId = (typeof ApiId)[keyof typeof ApiId];
 export const JwtConstants = {
     ALGORITHM: "alg",
     RSA_256: "RS256",
+    PSS_256: "PS256",
     X5T_256: "x5t#S256",
     X5T: "x5t",
     X5C: "x5c",

--- a/lib/msal-node/test/client/ClientAssertion.spec.ts
+++ b/lib/msal-node/test/client/ClientAssertion.spec.ts
@@ -87,7 +87,7 @@ describe("Client assertion test", () => {
 
         const expectedOptions = {
             header: {
-                [JwtConstants.ALGORITHM]: JwtConstants.RSA_256,
+                [JwtConstants.ALGORITHM]: JwtConstants.PSS_256,
                 [JwtConstants.X5T_256]: EncodingUtils.base64EncodeUrl(
                     TEST_CONSTANTS.THUMBPRINT256,
                     "hex"
@@ -149,7 +149,7 @@ describe("Client assertion test", () => {
 
         const expectedOptions = {
             header: {
-                [JwtConstants.ALGORITHM]: JwtConstants.RSA_256,
+                [JwtConstants.ALGORITHM]: JwtConstants.PSS_256,
                 [JwtConstants.X5T_256]: EncodingUtils.base64EncodeUrl(
                     TEST_CONSTANTS.THUMBPRINT256,
                     "hex"


### PR DESCRIPTION
SHA-256 thumbprints now use PSS padding.
SHA-1 thumbprints still use RSA padding.

Manually tested with `thumbprint` and `thumbprintSha256` passed into `clientCertificate`.