### PR TITLE
Better types for EventMessage

### DIFF
--- a/change/@azure-msal-browser-5f9144eb-3655-4e09-ba69-05e6263c1a18.json
+++ b/change/@azure-msal-browser-5f9144eb-3655-4e09-ba69-05e6263c1a18.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Better types for EventMessage ",
+  "packageName": "@azure/msal-browser",
+  "email": "slava@knyazev.io",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -33,7 +33,8 @@ export type EventMessage =
 | EventMessageWrapper<EventType.LOGOUT_END, InteractionType.Redirect | InteractionType.Popup, null, null>
 | EventMessageWrapper<EventType.LOGOUT_SUCCESS, InteractionType.Redirect | InteractionType.Popup, EndSessionRequest, null>
 | EventMessageWrapper<EventType.LOGIN_FAILURE, InteractionType.Redirect | InteractionType.Popup, null, AuthError | Error>
-| EventMessageWrapper<EventType.POPUP_OPENED, InteractionType.Popup, PopupEvent, null>;
+| EventMessageWrapper<EventType.ACCOUNT_ADDED, null, AccountInfo, null>
+| EventMessageWrapper<EventType.ACCOUNT_REMOVED, null, AccountInfo, null>;
 
 export type PopupEvent = {
     popupWindow: Window;

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -8,13 +8,32 @@ import { EventType } from "./EventType";
 import { InteractionStatus, InteractionType } from "../utils/BrowserConstants";
 import { PopupRequest, RedirectRequest, SilentRequest, SsoSilentRequest, EndSessionRequest } from "..";
 
-export type EventMessage = {
-    eventType: EventType;
-    interactionType: InteractionType | null;
-    payload: EventPayload;
-    error: EventError;
+type EventMessageWrapper<TEvent extends EventType, TInteraction extends InteractionType | null, TPayload extends EventPayload, TError extends EventError> = {
+    eventType: TEvent;
+    interactionType: TInteraction;
+    payload: TPayload;
+    error: TError;
     timestamp: number;
 };
+
+export type EventMessage =
+| EventMessageWrapper<EventType.LOGIN_START, InteractionType.Popup | InteractionType.Redirect, PopupRequest | RedirectRequest, null>
+| EventMessageWrapper<EventType.LOGIN_SUCCESS,InteractionType.Popup | InteractionType.Redirect, AuthenticationResult, null>
+| EventMessageWrapper<EventType.LOGIN_FAILURE, InteractionType.Popup | InteractionType.Redirect, null, AuthError | Error>
+| EventMessageWrapper<EventType.ACQUIRE_TOKEN_START, InteractionType.Popup | InteractionType.Redirect | InteractionType.Silent, PopupRequest | RedirectRequest | SilentRequest, null>
+| EventMessageWrapper<EventType.ACQUIRE_TOKEN_SUCCESS, InteractionType.Popup | InteractionType.Redirect | InteractionType.Silent, AuthenticationResult, null>
+| EventMessageWrapper<EventType.ACQUIRE_TOKEN_FAILURE, InteractionType.Popup | InteractionType.Redirect | InteractionType.Silent, null, AuthError | Error>
+| EventMessageWrapper<EventType.ACQUIRE_TOKEN_NETWORK_START, InteractionType.Silent, null, null>
+| EventMessageWrapper<EventType.SSO_SILENT_START, InteractionType.Silent, SsoSilentRequest, null>
+| EventMessageWrapper<EventType.SSO_SILENT_SUCCESS, InteractionType.Silent, AuthenticationResult, null>
+| EventMessageWrapper<EventType.SSO_SILENT_FAILURE, InteractionType.Silent, null, AuthError | Error>
+| EventMessageWrapper<EventType.HANDLE_REDIRECT_START, InteractionType.Redirect, null, null>
+| EventMessageWrapper<EventType.HANDLE_REDIRECT_END, InteractionType.Redirect, null, null>
+| EventMessageWrapper<EventType.LOGOUT_START, InteractionType.Redirect | InteractionType.Popup, EndSessionRequest, null>
+| EventMessageWrapper<EventType.LOGOUT_END, InteractionType.Redirect | InteractionType.Popup, null, null>
+| EventMessageWrapper<EventType.LOGOUT_SUCCESS, InteractionType.Redirect | InteractionType.Popup, EndSessionRequest, null>
+| EventMessageWrapper<EventType.LOGIN_FAILURE, InteractionType.Redirect | InteractionType.Popup, null, AuthError | Error>
+| EventMessageWrapper<EventType.POPUP_OPENED, InteractionType.Popup, PopupEvent, null>;
 
 export type PopupEvent = {
     popupWindow: Window;

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -17,6 +17,8 @@ type EventMessageWrapper<TEvent extends EventType, TInteraction extends Interact
 };
 
 export type EventMessage =
+| EventMessageWrapper<EventType.ACCOUNT_ADDED, null, AccountInfo, null>
+| EventMessageWrapper<EventType.ACCOUNT_REMOVED, null, AccountInfo, null>
 | EventMessageWrapper<EventType.LOGIN_START, InteractionType.Popup | InteractionType.Redirect, PopupRequest | RedirectRequest, null>
 | EventMessageWrapper<EventType.LOGIN_SUCCESS,InteractionType.Popup | InteractionType.Redirect, AuthenticationResult, null>
 | EventMessageWrapper<EventType.LOGIN_FAILURE, InteractionType.Popup | InteractionType.Redirect, null, AuthError | Error>
@@ -29,12 +31,11 @@ export type EventMessage =
 | EventMessageWrapper<EventType.SSO_SILENT_FAILURE, InteractionType.Silent, null, AuthError | Error>
 | EventMessageWrapper<EventType.HANDLE_REDIRECT_START, InteractionType.Redirect, null, null>
 | EventMessageWrapper<EventType.HANDLE_REDIRECT_END, InteractionType.Redirect, null, null>
+| EventMessageWrapper<EventType.POPUP_OPENED, InteractionType.Popup, PopupEvent, null>
 | EventMessageWrapper<EventType.LOGOUT_START, InteractionType.Redirect | InteractionType.Popup, EndSessionRequest, null>
-| EventMessageWrapper<EventType.LOGOUT_END, InteractionType.Redirect | InteractionType.Popup, null, null>
 | EventMessageWrapper<EventType.LOGOUT_SUCCESS, InteractionType.Redirect | InteractionType.Popup, EndSessionRequest, null>
 | EventMessageWrapper<EventType.LOGIN_FAILURE, InteractionType.Redirect | InteractionType.Popup, null, AuthError | Error>
-| EventMessageWrapper<EventType.ACCOUNT_ADDED, null, AccountInfo, null>
-| EventMessageWrapper<EventType.ACCOUNT_REMOVED, null, AccountInfo, null>;
+| EventMessageWrapper<EventType.LOGOUT_END, InteractionType.Redirect | InteractionType.Popup, null, null>;
 
 export type PopupEvent = {
     popupWindow: Window;


### PR DESCRIPTION
Improving typings via union types that correlate between events and payloads.

Based on https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/events.md

That doc seems somewhat outdated

- Missing `POPUP_OPENED` payload type. Im guessing its `PopupEvent`?
- Remove `ACTIVE_ACCOUNT_CHANGED`, `INITIALIZE_START`, `INITIALIZE_END`

This allows for TypeScript to refine types based on the `eventType` property, and match the correct payload type automatically.

Please review to make sure I got it right.