### PR TITLE
Send the error template back when there's an error response

### DIFF
--- a/change/@azure-msal-node-1bf044d7-51fc-4da3-81fa-d442c2f6c076.json
+++ b/change/@azure-msal-node-1bf044d7-51fc-4da3-81fa-d442c2f6c076.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Send the error template back when there's an error response",
+  "packageName": "@azure/msal-node",
+  "email": "tyleonha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/network/LoopbackClient.ts
+++ b/lib/msal-node/src/network/LoopbackClient.ts
@@ -65,6 +65,12 @@ export class LoopbackClient implements ILoopbackClient {
                             }); // Prevent auth code from being saved in the browser history
                             res.end();
                         }
+                        if (authCodeResponse.error) {
+                            res.end(
+                                errorTemplate ||
+                                    `Error occurred: ${authCodeResponse.error}`
+                            );
+                        }
                         resolve(authCodeResponse);
                     }
                 );


### PR DESCRIPTION
Without this, the redirect in the browser resolves when the server is closed which makes it unclear, in the browser, that there was an error. This renders the errorTemplate already passed in.