### PR TITLE
Update retry for invalid_grant errors

### DIFF
--- a/change/@azure-msal-browser-3a4cabb3-b4c2-46c4-a275-e6c3352004fd.json
+++ b/change/@azure-msal-browser-3a4cabb3-b4c2-46c4-a275-e6c3352004fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update request retry for invalid_grant #7249",
+  "packageName": "@azure/msal-browser",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1615,18 +1615,16 @@ export class BrowserCacheManager extends CacheManager {
 
     /**
      * Create request retry key to cache retry status
-     * @param correlationId
      */
-    generateRequestRetriedKey(correlationId: string): string {
-        return `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${correlationId}`;
+    generateRequestRetriedKey(): string {
+        return `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${this.clientId}`;
     }
 
     /**
      * Gets the request retry value from the cache
-     * @param correlationId
      */
-    getRequestRetried(correlationId: string): number | null {
-        const requestRetriedKey = this.generateRequestRetriedKey(correlationId);
+    getRequestRetried(): number | null {
+        const requestRetriedKey = this.generateRequestRetriedKey();
         const cachedRetryNumber = this.getTemporaryCache(requestRetriedKey);
         if (!cachedRetryNumber) {
             return null;
@@ -1636,11 +1634,10 @@ export class BrowserCacheManager extends CacheManager {
 
     /**
      * Sets the request retry value to "retried" in the cache
-     * @param correlationId
      */
-    setRequestRetried(correlationId: string): void {
+    setRequestRetried(): void {
         this.logger.trace("BrowserCacheManager.setRequestRetried called");
-        const requestRetriedKey = this.generateRequestRetriedKey(correlationId);
+        const requestRetriedKey = this.generateRequestRetriedKey();
         this.setTemporaryCache(requestRetriedKey, "1", false);
     }
 
@@ -1648,11 +1645,8 @@ export class BrowserCacheManager extends CacheManager {
      * Removes all request retry values in the cache
      */
     removeRequestRetried(): void {
-        this.temporaryCacheStorage.getKeys().forEach((key) => {
-            if (key.indexOf(TemporaryCacheKeys.REQUEST_RETRY) !== -1) {
-                this.removeTemporaryItem(key);
-            }
-        });
+        const requestRetriedKey = this.generateRequestRetriedKey();
+        this.removeTemporaryItem(requestRetriedKey);
     }
 
     /**

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -266,46 +266,43 @@ export class PopupClient extends StandardInteractionClient {
             }
 
             if (
-                e instanceof ServerError &&
-                e.errorCode === BrowserConstants.INVALID_GRANT_ERROR
+                !authClient ||
+                !(e instanceof ServerError) ||
+                e.errorCode !== BrowserConstants.INVALID_GRANT_ERROR
             ) {
-                if (!authClient) {
-                    throw e;
-                } else {
-                    this.performanceClient.addFields(
-                        {
-                            retryError: e.errorCode,
-                        },
-                        this.correlationId
-                    );
-
-                    const retryAuthCodeRequest = await invokeAsync(
-                        this.initializeAuthorizationCodeRequest.bind(this),
-                        PerformanceEvents.StandardInteractionClientInitializeAuthorizationCodeRequest,
-                        this.logger,
-                        this.performanceClient,
-                        this.correlationId
-                    )(validRequest);
-
-                    return await invokeAsync(
-                        this.acquireTokenPopupAsyncHelper.bind(this),
-                        PerformanceEvents.PopupClientTokenHelper,
-                        this.logger,
-                        this.performanceClient,
-                        this.correlationId
-                    )(
-                        authClient,
-                        retryAuthCodeRequest,
-                        validRequest,
-                        request,
-                        popupName,
-                        popupWindowAttributes,
-                        popup
-                    );
-                }
+                throw e;
             }
 
-            throw e;
+            this.performanceClient.addFields(
+                {
+                    retryError: e.errorCode,
+                },
+                this.correlationId
+            );
+
+            const retryAuthCodeRequest = await invokeAsync(
+                this.initializeAuthorizationCodeRequest.bind(this),
+                PerformanceEvents.StandardInteractionClientInitializeAuthorizationCodeRequest,
+                this.logger,
+                this.performanceClient,
+                this.correlationId
+            )(validRequest);
+
+            return await invokeAsync(
+                this.acquireTokenPopupAsyncHelper.bind(this),
+                PerformanceEvents.PopupClientTokenHelper,
+                this.logger,
+                this.performanceClient,
+                this.correlationId
+            )(
+                authClient,
+                retryAuthCodeRequest,
+                validRequest,
+                request,
+                popupName,
+                popupWindowAttributes,
+                popup
+            );
         }
     }
 

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -356,9 +356,7 @@ export class RedirectClient extends StandardInteractionClient {
                     this.correlationId
                 );
 
-                const requestRetried = this.browserStorage.getRequestRetried(
-                    this.correlationId
-                );
+                const requestRetried = this.browserStorage.getRequestRetried();
 
                 if (requestRetried) {
                     this.logger.error(
@@ -372,15 +370,15 @@ export class RedirectClient extends StandardInteractionClient {
                     this.browserStorage.getCachedRedirectRequest();
                 if (!redirectRequest) {
                     this.logger.error(
-                        `Unable to retry. Please retry with redirect request and correlationId: ${this.correlationId}`
+                        "Unable to retry. Please retry with redirect request"
                     );
-                    this.browserStorage.setRequestRetried(this.correlationId);
+                    this.browserStorage.setRequestRetried();
                     throw createBrowserAuthError(
                         BrowserAuthErrorCodes.failedToRetry
                     );
                 }
 
-                this.browserStorage.setRequestRetried(this.correlationId);
+                this.browserStorage.setRequestRetried();
 
                 await this.acquireToken(redirectRequest);
                 return null;

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -159,39 +159,36 @@ export class SilentIframeClient extends StandardInteractionClient {
             }
 
             if (
-                e instanceof ServerError &&
-                e.errorCode === BrowserConstants.INVALID_GRANT_ERROR
+                !authClient ||
+                !(e instanceof ServerError) ||
+                e.errorCode !== BrowserConstants.INVALID_GRANT_ERROR
             ) {
-                if (!authClient) {
-                    throw e;
-                } else {
-                    this.performanceClient.addFields(
-                        {
-                            retryError: e.errorCode,
-                        },
-                        this.correlationId
-                    );
-
-                    const retrySilentRequest: AuthorizationUrlRequest =
-                        await invokeAsync(
-                            this.initializeAuthorizationRequest.bind(this),
-                            PerformanceEvents.StandardInteractionClientInitializeAuthorizationRequest,
-                            this.logger,
-                            this.performanceClient,
-                            request.correlationId
-                        )(inputRequest, InteractionType.Silent);
-
-                    return await invokeAsync(
-                        this.silentTokenHelper.bind(this),
-                        PerformanceEvents.SilentIframeClientTokenHelper,
-                        this.logger,
-                        this.performanceClient,
-                        this.correlationId
-                    )(authClient, retrySilentRequest);
-                }
+                throw e;
             }
 
-            throw e;
+            this.performanceClient.addFields(
+                {
+                    retryError: e.errorCode,
+                },
+                this.correlationId
+            );
+
+            const retrySilentRequest: AuthorizationUrlRequest =
+                await invokeAsync(
+                    this.initializeAuthorizationRequest.bind(this),
+                    PerformanceEvents.StandardInteractionClientInitializeAuthorizationRequest,
+                    this.logger,
+                    this.performanceClient,
+                    request.correlationId
+                )(inputRequest, InteractionType.Silent);
+
+            return await invokeAsync(
+                this.silentTokenHelper.bind(this),
+                PerformanceEvents.SilentIframeClientTokenHelper,
+                this.logger,
+                this.performanceClient,
+                this.correlationId
+            )(authClient, retrySilentRequest);
         }
     }
 

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -2980,7 +2980,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger
             );
-            const requestRetriedKey = browserStorage.generateRequestRetriedKey();
+            const requestRetriedKey =
+                browserStorage.generateRequestRetriedKey();
             expect(requestRetriedKey).toBe(
                 `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.MSAL_CLIENT_ID}`
             );
@@ -3000,9 +3001,7 @@ describe("BrowserCacheManager tests", () => {
 
             browserStorage.getRequestRetried();
 
-            expect(
-                browserStorage.getRequestRetried()
-            ).toEqual(1);
+            expect(browserStorage.getRequestRetried()).toEqual(1);
         });
 
         it("setRequestRetried() sets a request retry value for client Id", () => {

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -2980,11 +2980,9 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger
             );
-            const requestRetriedKey = browserStorage.generateRequestRetriedKey(
-                TEST_CONFIG.CORRELATION_ID
-            );
+            const requestRetriedKey = browserStorage.generateRequestRetriedKey();
             expect(requestRetriedKey).toBe(
-                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.CORRELATION_ID}`
+                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.MSAL_CLIENT_ID}`
             );
         });
 
@@ -2996,18 +2994,18 @@ describe("BrowserCacheManager tests", () => {
                 logger
             );
             browserStorage.setTemporaryCache(
-                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.CORRELATION_ID}`,
+                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.MSAL_CLIENT_ID}`,
                 "1"
             );
 
-            browserStorage.getRequestRetried(TEST_CONFIG.CORRELATION_ID);
+            browserStorage.getRequestRetried();
 
             expect(
-                browserStorage.getRequestRetried(TEST_CONFIG.CORRELATION_ID)
+                browserStorage.getRequestRetried()
             ).toEqual(1);
         });
 
-        it("setRequestRetried() sets a request retry value for correlationId", () => {
+        it("setRequestRetried() sets a request retry value for client Id", () => {
             const browserStorage = new BrowserCacheManager(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 cacheConfig,
@@ -3015,16 +3013,16 @@ describe("BrowserCacheManager tests", () => {
                 logger
             );
 
-            browserStorage.setRequestRetried(TEST_CONFIG.CORRELATION_ID);
+            browserStorage.setRequestRetried();
 
             expect(
                 window.sessionStorage[
-                    `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.CORRELATION_ID}`
+                    `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.MSAL_CLIENT_ID}`
                 ]
             ).toBeTruthy();
         });
 
-        it("removeRequestRetried() removes all temporary cache items with request retried value", () => {
+        it("removeRequestRetried() removes request retried value for clientId", () => {
             const browserStorage = new BrowserCacheManager(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 cacheConfig,
@@ -3032,18 +3030,13 @@ describe("BrowserCacheManager tests", () => {
                 logger
             );
             browserStorage.setTemporaryCache(
-                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.111`,
-                "1"
-            );
-            browserStorage.setTemporaryCache(
-                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.222`,
+                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.MSAL_CLIENT_ID}`,
                 "1"
             );
 
             browserStorage.removeRequestRetried();
 
-            expect(browserStorage.getRequestRetried("111")).toEqual(null);
-            expect(browserStorage.getRequestRetried("222")).toEqual(null);
+            expect(browserStorage.getRequestRetried()).toEqual(null);
         });
 
         it("Successfully retrieves redirect request from cache", async () => {

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -578,7 +578,7 @@ describe("RedirectClient", () => {
                 )
             ).toEqual(null);
             expect(
-                browserStorage.getRequestRetried(TEST_CONFIG.CORRELATION_ID)
+                browserStorage.getRequestRetried()
             ).toEqual(null);
         });
 
@@ -1986,7 +1986,7 @@ describe("RedirectClient", () => {
                 )
             ).toEqual(null);
             expect(
-                browserStorage.getRequestRetried(TEST_CONFIG.CORRELATION_ID)
+                browserStorage.getRequestRetried()
             ).toEqual(1);
         });
 
@@ -2023,7 +2023,7 @@ describe("RedirectClient", () => {
                 "123523"
             );
             window.sessionStorage.setItem(
-                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.CORRELATION_ID}`,
+                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.REQUEST_RETRY}.${TEST_CONFIG.MSAL_CLIENT_ID}`,
                 JSON.stringify(1)
             );
             const testRedirectRequest: RedirectRequest = {
@@ -2095,9 +2095,7 @@ describe("RedirectClient", () => {
                         )
                     ).toEqual(null);
                     expect(
-                        browserStorage.getRequestRetried(
-                            TEST_CONFIG.CORRELATION_ID
-                        )
+                        browserStorage.getRequestRetried()
                     ).toEqual(null);
 
                     done();
@@ -2191,9 +2189,7 @@ describe("RedirectClient", () => {
                         )
                     ).toEqual(null);
                     expect(
-                        browserStorage.getRequestRetried(
-                            TEST_CONFIG.CORRELATION_ID
-                        )
+                        browserStorage.getRequestRetried()
                     ).toEqual(1);
                     done();
                 });

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -577,9 +577,7 @@ describe("RedirectClient", () => {
                     TemporaryCacheKeys.REDIRECT_REQUEST
                 )
             ).toEqual(null);
-            expect(
-                browserStorage.getRequestRetried()
-            ).toEqual(null);
+            expect(browserStorage.getRequestRetried()).toEqual(null);
         });
 
         it("gets hash from cache and calls native broker if hash contains accountId", async () => {
@@ -1985,9 +1983,7 @@ describe("RedirectClient", () => {
                     TemporaryCacheKeys.REDIRECT_REQUEST
                 )
             ).toEqual(null);
-            expect(
-                browserStorage.getRequestRetried()
-            ).toEqual(1);
+            expect(browserStorage.getRequestRetried()).toEqual(1);
         });
 
         it("throws invalid_grant error if already retried", (done) => {
@@ -2094,9 +2090,7 @@ describe("RedirectClient", () => {
                             TemporaryCacheKeys.REDIRECT_REQUEST
                         )
                     ).toEqual(null);
-                    expect(
-                        browserStorage.getRequestRetried()
-                    ).toEqual(null);
+                    expect(browserStorage.getRequestRetried()).toEqual(null);
 
                     done();
                 });
@@ -2188,9 +2182,7 @@ describe("RedirectClient", () => {
                             TemporaryCacheKeys.REDIRECT_REQUEST
                         )
                     ).toEqual(null);
-                    expect(
-                        browserStorage.getRequestRetried()
-                    ).toEqual(1);
+                    expect(browserStorage.getRequestRetried()).toEqual(1);
                     done();
                 });
         });


### PR DESCRIPTION
This PR:
- Updates `RedirectClient` and `BrowserCacheManager` and tests to use the client ID instead of the correlation ID when caching retry value.
- Cleans up error logic in `SilentIframeClient` and `PopupClient`.