### PR TITLE
Revert 'Use high precision TS for NAA message time (#7243)'

### DIFF
--- a/change/@azure-msal-browser-25572a0b-84d6-4cf8-897b-cb033d46a99c.json
+++ b/change/@azure-msal-browser-25572a0b-84d6-4cf8-897b-cb033d46a99c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert 'Use high precision TS for NAA message time (#7243)'",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/naa/BridgeProxy.ts
+++ b/lib/msal-browser/src/naa/BridgeProxy.ts
@@ -16,7 +16,6 @@ import { IBridgeProxy } from "./IBridgeProxy";
 import { InitContext } from "./InitContext";
 import { TokenRequest } from "./TokenRequest";
 import * as BrowserCrypto from "../crypto/BrowserCrypto";
-import { supportsBrowserPerformanceNow } from "../telemetry/BrowserPerformanceClient";
 
 declare global {
     interface Window {
@@ -82,9 +81,7 @@ export class BridgeProxy implements IBridgeProxy {
                         messageType: "NestedAppAuthRequest",
                         method: "GetInitContext",
                         requestId: BrowserCrypto.createNewGuid(),
-                        sendTime: supportsBrowserPerformanceNow()
-                            ? window.performance.now()
-                            : Date.now(),
+                        sendTime: Date.now(),
                     };
                     const request: BridgeRequest = {
                         requestId: message.requestId,
@@ -160,9 +157,7 @@ export class BridgeProxy implements IBridgeProxy {
             messageType: "NestedAppAuthRequest",
             method: method,
             requestId: BrowserCrypto.createNewGuid(),
-            sendTime: supportsBrowserPerformanceNow()
-                ? window.performance.now()
-                : Date.now(),
+            sendTime: Date.now(),
             ...requestParams,
         };
 

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceClient.ts
@@ -42,7 +42,7 @@ function getPerfMeasurementModule() {
 /**
  * Returns boolean, indicating whether browser supports window.performance.now() function.
  */
-export function supportsBrowserPerformanceNow(): boolean {
+function supportsBrowserPerformanceNow(): boolean {
     return (
         typeof window !== "undefined" &&
         typeof window.performance !== "undefined" &&


### PR DESCRIPTION
Reverting because:
1. Office parser for `sendTime` is expecting a whole number = mills since epoch
2. `sendTime` should be system time, and is used by native to identify how long the request took from being initiated to being handled