### PR TITLE
Use 127.0.0.1 when spinning up local loopback server

### DIFF
--- a/change/@azure-msal-node-234bf880-8502-4a8e-8755-b58175525b0c.json
+++ b/change/@azure-msal-node-234bf880-8502-4a8e-8755-b58175525b0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use '127.0.0.1' for the host when spinning up local loopback server",
+  "packageName": "@azure/msal-node",
+  "email": "tyleonha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/network/LoopbackClient.ts
+++ b/lib/msal-node/src/network/LoopbackClient.ts
@@ -74,7 +74,7 @@ export class LoopbackClient implements ILoopbackClient {
                         resolve(authCodeResponse);
                     }
                 );
-                this.server.listen(0); // Listen on any available port
+                this.server.listen(0, '127.0.0.1'); // Listen on any available port
             }
         );
     }


### PR DESCRIPTION
1. Security: 127.0.0.1 binds the server to the local machine only, making it inaccessible from external networks. 0.0.0.0 binds the server to all available network interfaces, potentially exposing it to external access.
2. Performance: Binding to 127.0.0.1 can be more efficient as it restricts traffic to the local machine, avoiding unnecessary network overhead.
3. Simplicity: Using 127.0.0.1 ensures that only local applications can connect, simplifying debugging and reducing the risk of unintended access.