### PR TITLE
Add __initializeNestedAppAuth function for Nested App Auth

### DIFF
--- a/change/@azure-msal-browser-63f3d1ba-774e-4690-8f70-22dd5663ae78.json
+++ b/change/@azure-msal-browser-63f3d1ba-774e-4690-8f70-22dd5663ae78.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add __initializeNestedAppAuth function for Nested App Auth (#7289)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/operatingcontext/NestedAppOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/NestedAppOperatingContext.ts
@@ -8,6 +8,12 @@ import { IBridgeProxy } from "../naa/IBridgeProxy";
 import { BridgeProxy } from "../naa/BridgeProxy";
 import { AccountContext } from "../naa/BridgeAccountContext";
 
+declare global {
+    interface Window {
+        __initializeNestedAppAuth?(): Promise<void>;
+    }
+}
+
 export class NestedAppOperatingContext extends BaseOperatingContext {
     protected bridgeProxy: IBridgeProxy | undefined = undefined;
     protected accountContext: AccountContext | null = null;
@@ -54,13 +60,12 @@ export class NestedAppOperatingContext extends BaseOperatingContext {
      * @returns Promise<boolean> indicating whether this operating context is currently available.
      */
     async initialize(): Promise<boolean> {
-        /*
-         * TODO: Add implementation to check for presence of inject Nested App Auth Bridge JavaScript interface
-         *
-         */
-
         try {
             if (typeof window !== "undefined") {
+                if (typeof self.__initializeNestedAppAuth === "function") {
+                    await self.__initializeNestedAppAuth();
+                }
+
                 const bridgeProxy: IBridgeProxy = await BridgeProxy.create();
                 /*
                  * Because we want single sign on we expect the host app to provide the account context

--- a/lib/msal-browser/src/operatingcontext/NestedAppOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/NestedAppOperatingContext.ts
@@ -62,8 +62,8 @@ export class NestedAppOperatingContext extends BaseOperatingContext {
     async initialize(): Promise<boolean> {
         try {
             if (typeof window !== "undefined") {
-                if (typeof self.__initializeNestedAppAuth === "function") {
-                    await self.__initializeNestedAppAuth();
+                if (typeof window.__initializeNestedAppAuth === "function") {
+                    await window.__initializeNestedAppAuth();
                 }
 
                 const bridgeProxy: IBridgeProxy = await BridgeProxy.create();


### PR DESCRIPTION
Add a function call to `__initializeNestedAppAuth` that can be used to setup Nested App Auth dependencies such as the bridge. It is an optional function, and may only be needed in some implementations.