### PR TITLE
Allow passing popup parent for multi-window flows

### DIFF
--- a/change/@azure-msal-browser-53b636b7-4f91-42f7-bd68-0f574a15d20f.json
+++ b/change/@azure-msal-browser-53b636b7-4f91-42f7-bd68-0f574a15d20f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow passing popup parent for multi-window flows",
+  "packageName": "@azure/msal-browser",
+  "email": "chrp@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -52,6 +52,7 @@ export type PopupParams = {
     popup?: Window | null;
     popupName: string;
     popupWindowAttributes: PopupWindowAttributes;
+    popupWindowParent: Window;
 };
 
 export class PopupClient extends StandardInteractionClient {
@@ -96,7 +97,11 @@ export class PopupClient extends StandardInteractionClient {
                 request.scopes || OIDC_DEFAULT_SCOPES,
                 request.authority || this.config.auth.authority
             );
-            const popupWindowAttributes = request.popupWindowAttributes || {};
+            const popupParams: PopupParams = {
+                popupName,
+                popupWindowAttributes: request.popupWindowAttributes || {},
+                popupWindowParent: request.popupWindowParent ?? window,
+            };
 
             // asyncPopups flag is true. Acquires token without first opening popup. Popup will be opened later asynchronously.
             if (this.config.system.asyncPopups) {
@@ -104,24 +109,20 @@ export class PopupClient extends StandardInteractionClient {
                 // Passes on popup position and dimensions if in request
                 return this.acquireTokenPopupAsync(
                     request,
-                    popupName,
-                    popupWindowAttributes
+                    popupParams
                 );
             } else {
                 // asyncPopups flag is set to false. Opens popup before acquiring token.
                 this.logger.verbose(
                     "asyncPopup set to false, opening popup before acquiring token"
                 );
-                const popup = this.openSizedPopup(
+                popupParams.popup = this.openSizedPopup(
                     "about:blank",
-                    popupName,
-                    popupWindowAttributes
+                    popupParams
                 );
                 return this.acquireTokenPopupAsync(
                     request,
-                    popupName,
-                    popupWindowAttributes,
-                    popup
+                    popupParams
                 );
             }
         } catch (e) {
@@ -138,13 +139,14 @@ export class PopupClient extends StandardInteractionClient {
             this.logger.verbose("logoutPopup called");
             const validLogoutRequest =
                 this.initializeLogoutRequest(logoutRequest);
-
-            const popupName = this.generateLogoutPopupName(validLogoutRequest);
+            const popupParams: PopupParams = {
+                popupName: this.generateLogoutPopupName(validLogoutRequest),
+                popupWindowAttributes: logoutRequest?.popupWindowAttributes || {},
+                popupWindowParent: logoutRequest?.popupWindowParent ?? window,
+            };
             const authority = logoutRequest && logoutRequest.authority;
             const mainWindowRedirectUri =
                 logoutRequest && logoutRequest.mainWindowRedirectUri;
-            const popupWindowAttributes =
-                logoutRequest?.popupWindowAttributes || {};
 
             // asyncPopups flag is true. Acquires token without first opening popup. Popup will be opened later asynchronously.
             if (this.config.system.asyncPopups) {
@@ -152,26 +154,21 @@ export class PopupClient extends StandardInteractionClient {
                 // Passes on popup position and dimensions if in request
                 return this.logoutPopupAsync(
                     validLogoutRequest,
-                    popupName,
-                    popupWindowAttributes,
+                    popupParams,
                     authority,
-                    undefined,
                     mainWindowRedirectUri
                 );
             } else {
                 // asyncPopups flag is set to false. Opens popup before logging out.
                 this.logger.verbose("asyncPopup set to false, opening popup");
-                const popup = this.openSizedPopup(
+                popupParams.popup = this.openSizedPopup(
                     "about:blank",
-                    popupName,
-                    popupWindowAttributes
+                    popupParams
                 );
                 return this.logoutPopupAsync(
                     validLogoutRequest,
-                    popupName,
-                    popupWindowAttributes,
+                    popupParams,
                     authority,
-                    popup,
                     mainWindowRedirectUri
                 );
             }
@@ -192,9 +189,7 @@ export class PopupClient extends StandardInteractionClient {
      */
     protected async acquireTokenPopupAsync(
         request: PopupRequest,
-        popupName: string,
-        popupWindowAttributes: PopupWindowAttributes,
-        popup?: Window | null
+        popupParams: PopupParams,
     ): Promise<AuthenticationResult> {
         this.logger.verbose("acquireTokenPopupAsync called");
         const serverTelemetryManager = this.initializeServerTelemetryManager(
@@ -269,14 +264,9 @@ export class PopupClient extends StandardInteractionClient {
             );
 
             // Show the UI once the url has been created. Get the window handle for the popup.
-            const popupParameters: PopupParams = {
-                popup,
-                popupName,
-                popupWindowAttributes,
-            };
             const popupWindow: Window = this.initiateAuthRequest(
                 navigateUrl,
-                popupParameters
+                popupParams
             );
             this.eventHandler.emitEvent(
                 EventType.POPUP_OPENED,
@@ -286,7 +276,7 @@ export class PopupClient extends StandardInteractionClient {
             );
 
             // Monitor the window for the hash. Return the string value and close the popup when the hash is received. Default timeout is 60 seconds.
-            const responseString = await this.monitorPopupForHash(popupWindow);
+            const responseString = await this.monitorPopupForHash(popupWindow, popupParams.popupWindowParent);
 
             const serverParams = invoke(
                 ResponseHandler.deserializeResponse,
@@ -356,10 +346,8 @@ export class PopupClient extends StandardInteractionClient {
 
             return result;
         } catch (e) {
-            if (popup) {
-                // Close the synchronous popup if an error is thrown before the window unload event is registered
-                popup.close();
-            }
+            // Close the synchronous popup if an error is thrown before the window unload event is registered
+            popupParams.popup?.close();
 
             if (e instanceof AuthError) {
                 (e as AuthError).setCorrelationId(this.correlationId);
@@ -381,10 +369,8 @@ export class PopupClient extends StandardInteractionClient {
      */
     protected async logoutPopupAsync(
         validRequest: CommonEndSessionRequest,
-        popupName: string,
-        popupWindowAttributes: PopupWindowAttributes,
+        popupParams: PopupParams,
         requestAuthority?: string,
-        popup?: Window | null,
         mainWindowRedirectUri?: string
     ): Promise<void> {
         this.logger.verbose("logoutPopupAsync called");
@@ -450,9 +436,7 @@ export class PopupClient extends StandardInteractionClient {
                         );
                     }
 
-                    if (popup) {
-                        popup.close();
-                    }
+                    popupParams.popup?.close();
 
                     return;
                 }
@@ -468,11 +452,7 @@ export class PopupClient extends StandardInteractionClient {
             );
 
             // Open the popup window to requestUrl.
-            const popupWindow = this.openPopup(logoutUri, {
-                popupName,
-                popupWindowAttributes,
-                popup,
-            });
+            const popupWindow = this.openPopup(logoutUri, popupParams);
             this.eventHandler.emitEvent(
                 EventType.POPUP_OPENED,
                 InteractionType.Popup,
@@ -480,7 +460,7 @@ export class PopupClient extends StandardInteractionClient {
                 null
             );
 
-            await this.monitorPopupForHash(popupWindow).catch(() => {
+            await this.monitorPopupForHash(popupWindow, popupParams.popupWindowParent).catch(() => {
                 // Swallow any errors related to monitoring the window. Server logout is best effort
             });
 
@@ -509,10 +489,8 @@ export class PopupClient extends StandardInteractionClient {
                 this.logger.verbose("No main window navigation requested");
             }
         } catch (e) {
-            if (popup) {
-                // Close the synchronous popup if an error is thrown before the window unload event is registered
-                popup.close();
-            }
+            // Close the synchronous popup if an error is thrown before the window unload event is registered
+            popupParams.popup?.close();
 
             if (e instanceof AuthError) {
                 (e as AuthError).setCorrelationId(this.correlationId);
@@ -562,7 +540,7 @@ export class PopupClient extends StandardInteractionClient {
      * @param popupWindow - window that is being monitored
      * @param timeout - timeout for processing hash once popup is redirected back to application
      */
-    monitorPopupForHash(popupWindow: Window): Promise<string> {
+    monitorPopupForHash(popupWindow: Window, popupWindowParent: Window): Promise<string> {
         return new Promise<string>((resolve, reject) => {
             this.logger.verbose(
                 "PopupHandler.monitorPopupForHash - polling started"
@@ -617,7 +595,7 @@ export class PopupClient extends StandardInteractionClient {
                 resolve(responseString);
             }, this.config.system.pollIntervalMilliseconds);
         }).finally(() => {
-            this.cleanPopup(popupWindow);
+            this.cleanPopup(popupWindow, popupWindowParent);
         });
     }
 
@@ -651,8 +629,7 @@ export class PopupClient extends StandardInteractionClient {
                 );
                 popupWindow = this.openSizedPopup(
                     urlNavigate,
-                    popupParams.popupName,
-                    popupParams.popupWindowAttributes
+                    popupParams,
                 );
             }
 
@@ -666,7 +643,7 @@ export class PopupClient extends StandardInteractionClient {
                 popupWindow.focus();
             }
             this.currentWindow = popupWindow;
-            window.addEventListener("beforeunload", this.unloadWindow);
+            popupParams.popupWindowParent.addEventListener("beforeunload", this.unloadWindow);
 
             return popupWindow;
         } catch (e) {
@@ -689,25 +666,24 @@ export class PopupClient extends StandardInteractionClient {
      */
     openSizedPopup(
         urlNavigate: string,
-        popupName: string,
-        popupWindowAttributes: PopupWindowAttributes
+        { popupName, popupWindowAttributes, popupWindowParent }: PopupParams
     ): Window | null {
         /**
          * adding winLeft and winTop to account for dual monitor
          * using screenLeft and screenTop for IE8 and earlier
          */
-        const winLeft = window.screenLeft ? window.screenLeft : window.screenX;
-        const winTop = window.screenTop ? window.screenTop : window.screenY;
+        const winLeft = popupWindowParent.screenLeft ? popupWindowParent.screenLeft : popupWindowParent.screenX;
+        const winTop = popupWindowParent.screenTop ? popupWindowParent.screenTop : popupWindowParent.screenY;
         /**
          * window.innerWidth displays browser window"s height and width excluding toolbars
          * using document.documentElement.clientWidth for IE8 and earlier
          */
         const winWidth =
-            window.innerWidth ||
+            popupWindowParent.innerWidth ||
             document.documentElement.clientWidth ||
             document.body.clientWidth;
         const winHeight =
-            window.innerHeight ||
+            popupWindowParent.innerHeight ||
             document.documentElement.clientHeight ||
             document.body.clientHeight;
 
@@ -750,7 +726,7 @@ export class PopupClient extends StandardInteractionClient {
             );
         }
 
-        return window.open(
+        return popupWindowParent.open(
             urlNavigate,
             popupName,
             `width=${width}, height=${height}, top=${top}, left=${left}, scrollbars=yes`
@@ -775,13 +751,12 @@ export class PopupClient extends StandardInteractionClient {
      * Closes popup, removes any state vars created during popup calls.
      * @param popupWindow
      */
-    cleanPopup(popupWindow?: Window): void {
-        if (popupWindow) {
-            // Close window.
-            popupWindow.close();
-        }
+    cleanPopup(popupWindow: Window, popupWindowParent: Window): void {
+        // Close window.
+        popupWindow.close();
+
         // Remove window unload function
-        window.removeEventListener("beforeunload", this.unloadWindow);
+        popupWindowParent.removeEventListener("beforeunload", this.unloadWindow);
 
         // Interaction is completed - remove interaction status.
         this.browserStorage.setInteractionInProgress(false);

--- a/lib/msal-browser/src/request/EndSessionPopupRequest.ts
+++ b/lib/msal-browser/src/request/EndSessionPopupRequest.ts
@@ -16,6 +16,7 @@ import { PopupWindowAttributes } from "./PopupWindowAttributes";
  * - mainWindowRedirectUri  - URI to navigate the main window to after logout is complete
  * - popupWindowAttributes  - Optional popup window attributes. popupSize with height and width, and popupPosition with top and left can be set.
  * - logoutHint             - A string that specifies the account that is being logged out in order to skip the server account picker on logout
+ * - popupWindowParent      - Optional window object to use as the parent when opening popup windows. Uses global `window` if not given.
  */
 export type EndSessionPopupRequest = Partial<
     Omit<CommonEndSessionRequest, "tokenQueryParameters">

--- a/lib/msal-browser/src/request/EndSessionPopupRequest.ts
+++ b/lib/msal-browser/src/request/EndSessionPopupRequest.ts
@@ -23,4 +23,5 @@ export type EndSessionPopupRequest = Partial<
     authority?: string;
     mainWindowRedirectUri?: string;
     popupWindowAttributes?: PopupWindowAttributes;
+    popupWindowParent?: Window;
 };

--- a/lib/msal-browser/src/request/PopupRequest.ts
+++ b/lib/msal-browser/src/request/PopupRequest.ts
@@ -48,4 +48,5 @@ export type PopupRequest = Partial<
     scopes: Array<string>;
     popupWindowAttributes?: PopupWindowAttributes;
     tokenBodyParameters?: StringDict;
+    popupWindowParent?: Window;
 };

--- a/lib/msal-browser/src/request/PopupRequest.ts
+++ b/lib/msal-browser/src/request/PopupRequest.ts
@@ -32,6 +32,7 @@ import { PopupWindowAttributes } from "./PopupWindowAttributes";
  * - claims                     - In cases where Azure AD tenant admin has enabled conditional access policies, and the policy has not been met, exceptions will contain claims that need to be consented to.
  * - nonce                      - A value included in the request that is returned in the id token. A randomly generated unique value is typically used to mitigate replay attacks.
  * - popupWindowAttributes      - Optional popup window attributes. popupSize with height and width, and popupPosition with top and left can be set.
+ * - popupWindowParent          - Optional window object to use as the parent when opening popup windows. Uses global `window` if not given.
  */
 
 export type PopupRequest = Partial<

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -206,7 +206,7 @@ describe("PopupClient", () => {
             try {
                 await popupClient.acquireToken(request);
             } catch (e) {}
-            expect(popupSpy.getCall(0).args).toHaveLength(3);
+            expect(popupSpy.getCall(0).args).toHaveLength(2);
         });
 
         it("opens popups asynchronously if configured", async () => {
@@ -271,7 +271,7 @@ describe("PopupClient", () => {
                 await popupClient.acquireToken(request);
             } catch (e) {}
             expect(popupSpy.calledOnce).toBeTruthy();
-            expect(popupSpy.getCall(0).args).toHaveLength(3);
+            expect(popupSpy.getCall(0).args).toHaveLength(2);
             expect(
                 popupSpy
                     .getCall(0)
@@ -800,7 +800,7 @@ describe("PopupClient", () => {
             try {
                 await popupClient.logout();
             } catch (e) {}
-            expect(popupSpy.getCall(0).args).toHaveLength(3);
+            expect(popupSpy.getCall(0).args).toHaveLength(2);
         });
 
         it("opens popups asynchronously if configured", async () => {
@@ -840,14 +840,14 @@ describe("PopupClient", () => {
 
             sinon
                 .stub(PopupClient.prototype, "openSizedPopup")
-                .callsFake((urlNavigate, popupName) => {
+                .callsFake((urlNavigate, popupParams) => {
                     expect(
                         urlNavigate.startsWith(
                             TEST_URIS.TEST_END_SESSION_ENDPOINT
                         )
                     ).toBeTruthy();
                     expect(
-                        popupName.startsWith(
+                        popupParams.popupName.startsWith(
                             `msal.${TEST_CONFIG.MSAL_CLIENT_ID}`
                         )
                     ).toBeTruthy();
@@ -1385,8 +1385,13 @@ describe("PopupClient", () => {
 
     describe("openSizedPopup", () => {
         it("opens a popup with urlNavigate", () => {
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: {},
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
-            popupClient.openSizedPopup("http://localhost/", "popup", {});
+            popupClient.openSizedPopup("http://localhost/", popupParams);
 
             expect(windowOpenSpy.calledWith("http://localhost/", "popup")).toBe(
                 true
@@ -1394,8 +1399,28 @@ describe("PopupClient", () => {
         });
 
         it("opens a popup with about:blank", () => {
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: {},
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
-            popupClient.openSizedPopup("about:blank", "popup", {});
+            popupClient.openSizedPopup("about:blank", popupParams);
+
+            expect(windowOpenSpy.calledWith("about:blank", "popup")).toBe(true);
+        });
+
+        it("opens a popup using passed window parent", () => {
+            const windowOpenSpy = sinon.stub(window, "open");
+            const windowParent = {
+                open: windowOpenSpy,
+            };
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: {},
+                popupWindowParent: windowParent as unknown as Window,
+            };
+            popupClient.openSizedPopup("about:blank", popupParams);
 
             expect(windowOpenSpy.calledWith("about:blank", "popup")).toBe(true);
         });
@@ -1411,11 +1436,15 @@ describe("PopupClient", () => {
                     left: 100,
                 },
             };
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: testPopupWindowAttributes,
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
             popupClient.openSizedPopup(
                 "about:blank",
-                "popup",
-                testPopupWindowAttributes
+                popupParams
             );
 
             expect(
@@ -1428,8 +1457,13 @@ describe("PopupClient", () => {
         });
 
         it("opens a popup with default size and position if empty object passed in for popupWindowAttributes", () => {
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: {},
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
-            popupClient.openSizedPopup("about:blank", "popup", {});
+            popupClient.openSizedPopup("about:blank", popupParams);
 
             expect(
                 windowOpenSpy.calledWith(
@@ -1451,11 +1485,15 @@ describe("PopupClient", () => {
                     left: 0,
                 },
             };
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: testPopupWindowAttributes,
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
             popupClient.openSizedPopup(
                 "about:blank",
-                "popup",
-                testPopupWindowAttributes
+                popupParams
             );
 
             expect(
@@ -1474,11 +1512,15 @@ describe("PopupClient", () => {
                     width: 100,
                 },
             };
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: testPopupWindowAttributes,
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
             popupClient.openSizedPopup(
                 "about:blank",
-                "popup",
-                testPopupWindowAttributes
+                popupParams
             );
 
             expect(
@@ -1497,11 +1539,15 @@ describe("PopupClient", () => {
                     left: 100,
                 },
             };
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: testPopupWindowAttributes,
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
             popupClient.openSizedPopup(
                 "about:blank",
-                "popup",
-                testPopupWindowAttributes
+                popupParams
             );
 
             expect(
@@ -1520,11 +1566,15 @@ describe("PopupClient", () => {
                     width: 99999,
                 },
             };
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: testPopupWindowAttributes,
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
             popupClient.openSizedPopup(
                 "about:blank",
-                "popup",
-                testPopupWindowAttributes
+                popupParams
             );
 
             expect(
@@ -1543,11 +1593,15 @@ describe("PopupClient", () => {
                     left: 99999,
                 },
             };
+            const popupParams = {
+                popupName: "popup",
+                popupWindowAttributes: testPopupWindowAttributes,
+                popupWindowParent: window,
+            };
             const windowOpenSpy = sinon.stub(window, "open");
             popupClient.openSizedPopup(
                 "about:blank",
-                "popup",
-                testPopupWindowAttributes
+                popupParams
             );
 
             expect(
@@ -1590,6 +1644,7 @@ describe("PopupClient", () => {
                 popupName: "name",
                 popupWindowAttributes: {},
                 popup: popupWindow,
+                popupWindowParent: window,
             };
             popupClient.openPopup("http://localhost", popupParams);
             popupClient.unloadWindow(new Event("test"));
@@ -1607,7 +1662,7 @@ describe("PopupClient", () => {
                 close: () => {},
                 closed: false,
             };
-            popupClient.monitorPopupForHash(popup).catch((error) => {
+            popupClient.monitorPopupForHash(popup, window).catch((error) => {
                 expect(error.errorCode).toEqual("user_cancelled");
                 done();
             });
@@ -1628,7 +1683,7 @@ describe("PopupClient", () => {
                 close: () => {},
                 closed: false,
             };
-            popupClient.monitorPopupForHash(popup).then((hash) => {
+            popupClient.monitorPopupForHash(popup, window).then((hash) => {
                 expect(hash).toEqual("code=testCode");
                 done();
             });
@@ -1685,8 +1740,7 @@ describe("PopupClient", () => {
             );
 
             const result = await popupClient
-                //@ts-ignore
-                .monitorPopupForHash(popup)
+                .monitorPopupForHash(popup as Window, window)
                 .catch((e) => {
                     expect(e.errorCode).toEqual(
                         BrowserAuthErrorMessage.monitorPopupTimeoutError.code
@@ -1708,8 +1762,7 @@ describe("PopupClient", () => {
                 close: () => {},
             };
 
-            // @ts-ignore
-            popupClient.monitorPopupForHash(popup).then((hash: string) => {
+            popupClient.monitorPopupForHash(popup as unknown as Window, window).then((hash: string) => {
                 expect(hash).toEqual("#code=hello");
                 done();
             });
@@ -1763,8 +1816,7 @@ describe("PopupClient", () => {
                 close: () => {},
             };
 
-            // @ts-ignore
-            const result = await popupClient.monitorPopupForHash(popup);
+            const result = await popupClient.monitorPopupForHash(popup as unknown as Window, window);
             expect(result).toEqual("?code=authCode");
         });
 
@@ -1778,8 +1830,7 @@ describe("PopupClient", () => {
                 closed: true,
             };
 
-            // @ts-ignore
-            popupClient.monitorPopupForHash(popup).catch((error: AuthError) => {
+            popupClient.monitorPopupForHash(popup as unknown as Window, window).catch((error: AuthError) => {
                 expect(error.errorCode).toEqual("user_cancelled");
                 done();
             });
@@ -1842,12 +1893,14 @@ describe("PopupClient", () => {
                 popupClient.initiateAuthRequest("", {
                     popupName: "name",
                     popupWindowAttributes: {},
+                    popupWindowParent: window,
                 })
             ).toThrow(BrowserAuthErrorMessage.emptyNavigateUriError.desc);
             expect(() =>
                 popupClient.initiateAuthRequest("", {
                     popupName: "name",
                     popupWindowAttributes: {},
+                    popupWindowParent: window,
                 })
             ).toThrow(BrowserAuthError);
 
@@ -1892,11 +1945,12 @@ describe("PopupClient", () => {
             popupClient.initiateAuthRequest(TEST_URIS.ALTERNATE_INSTANCE, {
                 popupName: "name",
                 popupWindowAttributes: {},
+                popupWindowParent: window,
             });
         });
     });
 
-    describe("openPopup", () => {
+    describe("initiateAuthRequest", () => {
         afterEach(() => {
             sinon.restore();
         });
@@ -1925,8 +1979,10 @@ describe("PopupClient", () => {
             const popupWindow = popupClient.initiateAuthRequest(
                 "http://localhost/#/code=hello",
                 {
-                    // @ts-ignore
-                    popup: windowObject,
+                    popup: windowObject as unknown as Window,
+                    popupName: "name",
+                    popupWindowAttributes: {},
+                    popupWindowParent: window,
                 }
             );
 
@@ -1955,10 +2011,34 @@ describe("PopupClient", () => {
                 {
                     popupName: "name",
                     popupWindowAttributes: {},
+                    popupWindowParent: window,
                 }
             );
 
             expect(popupWindow).toEqual(window);
+        });
+
+        it("opens popup using passed window parent", () => {
+            const popupWindowParent = {
+                open: sinon.spy((url, target) => window),
+                addEventListener: sinon.spy(),
+            };
+            const windowOpenSpy = sinon.stub(window, "open");
+            sinon.stub(window, "focus");
+
+            const popupWindow = popupClient.initiateAuthRequest(
+                "http://localhost/#/code=hello",
+                {
+                    popupName: "name",
+                    popupWindowAttributes: {},
+                    popupWindowParent: popupWindowParent as unknown as Window,
+                }
+            );
+
+            expect(popupWindow).toEqual(window);
+            expect(windowOpenSpy.called).toBe(false);
+            expect(popupWindowParent.open.calledWith("http://localhost/#/code=hello", "name")).toBe(true);
+            expect(popupWindowParent.addEventListener.calledWith("beforeunload")).toBe(true);
         });
 
         it("throws error if no popup passed in but window.open returns null", () => {
@@ -1977,7 +2057,7 @@ describe("PopupClient", () => {
             expect(() =>
                 popupClient.initiateAuthRequest(
                     "http://localhost/#/code=hello",
-                    { popupName: "name", popupWindowAttributes: {} }
+                    { popupName: "name", popupWindowAttributes: {}, popupWindowParent: window }
                 )
             ).toThrow(
                 createBrowserAuthError(BrowserAuthErrorCodes.popupWindowError)
@@ -2001,6 +2081,7 @@ describe("PopupClient", () => {
                         popup: null,
                         popupName: "name",
                         popupWindowAttributes: {},
+                        popupWindowParent: window,
                     }
                 )
             ).toThrow(


### PR DESCRIPTION
Outlook has multi-window scenarios where MSAL code is running in the main window, but being rendered into a popup window. This is interfering with MSAL popup token flows, because the click/user interaction is being done in the popup window, but the call to MSAL acquireTokenPopup is being done in the separate main window, and so when MSAL goes to call `window.open`, the browser is blocking the popup as the interaction did not occur in the same window and `popup_window_error` is returned.

The proposed fix is to add a `popupWindowParent` parameter to the `PopupRequest` interface, which MSAL will use instead of `window` when invoking `window.open`. This makes the browser happy that the popup is being opened and parented to the same window where the interaction occurred. It also fixes UI parenting/z-index issues with the MSAL popup.

If a `popupWindowParent` is not specified, then today's behaviour is preserved, and `window` is used.