### PR TITLE
Mute no_server_response error when back navigation is detected

### DIFF
--- a/change/@azure-msal-browser-f27b9a8d-ad98-44f7-8af5-f0ece472b848.json
+++ b/change/@azure-msal-browser-f27b9a8d-ad98-44f7-8af5-f0ece472b848.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Mute no_server_response error when back navigation is detected #7342",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -1827,6 +1827,50 @@ describe("RedirectClient", () => {
             });
             redirectClient.handleRedirectPromise("", rootMeasurement);
         });
+
+        it("mutes no_server_response error when back navigation is detected", async () => {
+            // @ts-ignore
+            window.performance.getEntriesByType = () => {
+                return [{ type: "back_forward" }];
+            };
+
+            browserStorage.setInteractionInProgress(true);
+            const loginRequestUrl = window.location.href;
+            window.location.hash = "";
+            window.sessionStorage.setItem(
+                `${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`,
+                loginRequestUrl
+            );
+            const res = await redirectClient.handleRedirectPromise(
+                "",
+                rootMeasurement
+            );
+            expect(res).toBeNull();
+            expect(rootMeasurement.event.errorCode).toBeUndefined();
+        });
+
+        it("does not mute no_server_response error when back navigation is not detected", async () => {
+            // @ts-ignore
+            window.performance.getEntriesByType = () => {
+                return [];
+            };
+
+            browserStorage.setInteractionInProgress(true);
+            const loginRequestUrl = window.location.href;
+            window.location.hash = "";
+            window.sessionStorage.setItem(
+                `${Constants.CACHE_PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.ORIGIN_URI}`,
+                loginRequestUrl
+            );
+            const res = await redirectClient.handleRedirectPromise(
+                "",
+                rootMeasurement
+            );
+            expect(res).toBeNull();
+            expect(rootMeasurement.event.errorCode).toEqual(
+                "no_server_response"
+            );
+        });
     });
 
     describe("acquireToken", () => {


### PR DESCRIPTION
- Mute no_server_response error when back navigation is detected. This change addresses an issue with `handleRedirectPromise` that instruments "no_server_response" error code when user navigates back to the app page from account picker UX.