### PR TITLE
Add NotAuthenticatedComponent to MsalAuthenticationTemplate.tsx

### DIFF
--- a/lib/msal-react/src/components/MsalAuthenticationTemplate.tsx
+++ b/lib/msal-react/src/components/MsalAuthenticationTemplate.tsx
@@ -45,6 +45,7 @@ export function MsalAuthenticationTemplate({
     authenticationRequest,
     loadingComponent: LoadingComponent,
     errorComponent: ErrorComponent,
+    notAuthenticatedComponent: NotAuthenticatedComponent,
     children,
 }: MsalAuthenticationProps): React.ReactElement | null {
     const accountIdentifier: AccountIdentifiers = useMemo(() => {
@@ -80,6 +81,10 @@ export function MsalAuthenticationTemplate({
 
     if (!!LoadingComponent && context.inProgress !== InteractionStatus.None) {
         return <LoadingComponent {...context} />;
+    }
+
+    if (!!NotAuthenticatedComponent) {
+        return <NotAuthenticatedComponent {...context} />;
     }
 
     return null;


### PR DESCRIPTION
### Background:

I wanted to use `MsalAuthenticationTemplate` for react on a website, where I have a logout option.

### Use case:
When all content is wrapped in this component, and a user uses the logout option (having set `msal.logout({ onRedirectNavigate: () => false })`), no content is visible.

This change will add a property which is visible when there's no error, `isAuthenticated` is `falsy`, and `context.inProgress` is `InteractionStatus.None`.

The reason why this needs to be done at this place is that it's not possible to know whether an error occurred outside this component - all other props can be checked also outside this component.