### PR TITLE
Replace MSA lab account with hardcoded UPN

### DIFF
--- a/samples/e2eTestUtils/src/Constants.ts
+++ b/samples/e2eTestUtils/src/Constants.ts
@@ -7,6 +7,8 @@ export const ENV_VARIABLES = {
 export const LAB_API_ENDPOINT = "https://msidlab.com/api";
 export const LAB_SCOPE = "https://request.msidlab.com/.default";
 
+export const B2C_MSA_TEST_UPN = "b2cmsatest@outlook.com";
+
 export const ParamKeys = {
     AZURE_ENVIRONMENT: "azureenvironment",
     USER_TYPE: "usertype",

--- a/samples/e2eTestUtils/src/index.ts
+++ b/samples/e2eTestUtils/src/index.ts
@@ -42,6 +42,7 @@ export {
     FederationProviders,
     UserTypes,
     B2cProviders,
+    B2C_MSA_TEST_UPN,
 } from "./Constants";
 export { BrowserCacheUtils } from "./BrowserCacheTestUtils";
 export { Browser, Page, BrowserContext } from "puppeteer";

--- a/samples/msal-angular-v3-samples/angular-b2c-sample-app/test/msa-account.spec.ts
+++ b/samples/msal-angular-v3-samples/angular-b2c-sample-app/test/msa-account.spec.ts
@@ -9,6 +9,7 @@ import {
   UserTypes,
   B2cProviders,
   BrowserCacheUtils,
+  B2C_MSA_TEST_UPN,
 } from 'e2e-test-utils';
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/msa-account-tests`;
@@ -38,6 +39,9 @@ describe('B2C user-flow tests (msa account)', () => {
     const envResponse = await labClient.getVarsByCloudEnvironment(labApiParams);
 
     [username, accountPwd] = await setupCredentials(envResponse[0], labClient);
+
+    // TODO: Remove when B2C MSA account is available in the lab
+    username = B2C_MSA_TEST_UPN;
   });
 
   beforeEach(async () => {

--- a/samples/msal-node-samples/auth-code/test/auth-code-b2c-msa.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-b2c-msa.spec.ts
@@ -18,6 +18,7 @@ import {
     LabApiQueryParams,
     B2cProviders,
     UserTypes,
+    B2C_MSA_TEST_UPN,
 } from "e2e-test-utils";
 
 import { PublicClientApplication } from "@azure/msal-node";
@@ -73,6 +74,9 @@ describe("Auth Code B2C Tests (msa account)", () => {
             envResponse[0],
             labClient
         );
+
+        // TODO: Remove when B2C MSA account is available in the lab
+        username = B2C_MSA_TEST_UPN;
     });
 
     afterAll(async () => {

--- a/samples/msal-node-samples/b2c-user-flows/test/user-flows-msa.spec.ts
+++ b/samples/msal-node-samples/b2c-user-flows/test/user-flows-msa.spec.ts
@@ -18,6 +18,7 @@ import {
     LabApiQueryParams,
     B2cProviders,
     UserTypes,
+    B2C_MSA_TEST_UPN,
 } from "e2e-test-utils";
 
 import { ConfidentialClientApplication } from "@azure/msal-node";
@@ -73,6 +74,9 @@ describe("B2C User Flow Tests", () => {
             envResponse[0],
             labClient
         );
+        
+        // TODO: Remove when B2C MSA account is available in the lab
+        username = B2C_MSA_TEST_UPN;
     });
 
     afterAll(async () => {

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-b2c-msa.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-b2c-msa.spec.ts
@@ -21,6 +21,7 @@ import {
     LabApiQueryParams,
     B2cProviders,
     UserTypes,
+    B2C_MSA_TEST_UPN,
 } from "e2e-test-utils";
 
 import { PublicClientApplication, TokenCache } from "@azure/msal-node";
@@ -79,6 +80,9 @@ describe("Silent Flow B2C Tests (msa account)", () => {
             envResponse[0],
             labClient
         );
+
+        // TODO: Remove when B2C MSA account is available in the lab
+        username = B2C_MSA_TEST_UPN;
 
         publicClientApplication = new PublicClientApplication({
             auth: config.authOptions,

--- a/samples/msal-react-samples/b2c-sample/test/msa-account.spec.ts
+++ b/samples/msal-react-samples/b2c-sample/test/msa-account.spec.ts
@@ -9,6 +9,7 @@ import {
     UserTypes,
     B2cProviders,
     BrowserCacheUtils,
+    B2C_MSA_TEST_UPN,
 } from "e2e-test-utils";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/msa-account-tests`;
@@ -43,6 +44,9 @@ describe("B2C user-flow tests (msa account)", () => {
             envResponse[0],
             labClient
         );
+
+        // TODO: Remove when B2C MSA account is available in the lab
+        username = B2C_MSA_TEST_UPN;
     });
 
     beforeEach(async () => {


### PR DESCRIPTION
This PR replaces the lab-obtained UPN for the B2C MSA account with a hardcoded e-mail as a temporary measure until it can be added to the lab API