### PR TITLE
Enable New Client Credential Certificate E2E Tests on Pipeline

### DIFF
--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -89,6 +89,7 @@ extends:
                             - "auth-code"
                             - "auth-code-cli-app"
                             - "client-credentials"
+                            - "client-credentials-with-cert-from-key-vault"
                             - "device-code"
                             - "silent-flow"
                             - "b2c-user-flows"


### PR DESCRIPTION
This was meant to be included in #7367.

[Corresponding 1P PR](https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_git/msal-javascript-1p/pullrequest/15266)

You can click into the tests below and see that the new e2e tests completed successfully.