### PR TITLE
Support COOP same-origin-allow-popups

### DIFF
--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -564,55 +564,6 @@ export class PopupClient extends StandardInteractionClient {
                     );
                 } 
             }, this.config.system.pollIntervalMilliseconds);
-
-            // const intervalId = setInterval(() => {
-            //     // Window is closed
-            //     if (popupWindow.closed) {
-            //         this.logger.error(
-            //             "PopupHandler.monitorPopupForHash - window closed"
-            //         );
-            //         clearInterval(intervalId);
-            //         reject(
-            //             createBrowserAuthError(
-            //                 BrowserAuthErrorCodes.userCancelled
-            //             )
-            //         );
-            //         return;
-            //     }
-
-            //     let href = "";
-            //     try {
-            //         /*
-            //          * Will throw if cross origin,
-            //          * which should be caught and ignored
-            //          * since we need the interval to keep running while on STS UI.
-            //          */
-            //         href = popupWindow.location.href;
-            //     } catch (e) {}
-
-            //     // Don't process blank pages or cross domain
-            //     if (!href || href === "about:blank") {
-            //         return;
-            //     }
-            //     clearInterval(intervalId);
-
-            //     let responseString = "";
-            //     const responseType =
-            //         this.config.auth.OIDCOptions.serverResponseType;
-            //     if (popupWindow) {
-            //         if (responseType === ServerResponseType.QUERY) {
-            //             responseString = popupWindow.location.search;
-            //         } else {
-            //             responseString = popupWindow.location.hash;
-            //         }
-            //     }
-
-            //     this.logger.verbose(
-            //         "PopupHandler.monitorPopupForHash - popup window is on same origin as caller"
-            //     );
-
-            //     resolve(responseString);
-            // }, this.config.system.pollIntervalMilliseconds);
         }).finally(() => {
             this.cleanPopup(popupWindow, popupWindowParent);
         });

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -548,22 +548,20 @@ export class PopupClient extends StandardInteractionClient {
         popupWindowParent: Window
     ): Promise<string> {
         return new Promise<string>((resolve, reject) => {
-            setTimeout(() => {
-                this.logger.verbose(
-                    "PopupHandler.monitorPopupForHash - polling started"
+            this.logger.verbose(
+                "PopupHandler.monitorPopupForHash"
+            );
+            this.authChannel.onmessage = function (event) {
+                resolve(event.data);
+            }     
+            this.authChannel.onmessageerror = function (event) {
+                console.log('BroadcastChannel error', event.data);
+                reject(
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.popupWindowError
+                    )
                 );
-                this.authChannel.onmessage = function (event) {
-                    resolve(event.data);
-                }     
-                this.authChannel.onmessageerror = function (event) {
-                    console.log('BroadcastChannel error', event.data);
-                    reject(
-                        createBrowserAuthError(
-                            BrowserAuthErrorCodes.popupWindowError
-                        )
-                    );
-                } 
-            }, this.config.system.pollIntervalMilliseconds);
+            }
         }).finally(() => {
             this.cleanPopup(popupWindow, popupWindowParent);
         });


### PR DESCRIPTION
Example of using [BroadcastChannel](https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts) to communicate between the same origin across browsing contexts, enabling popup auth flow when the app has a cross-origin opener policy of "same-origin-allow-popups"

*The final solution should ensure the correct InteractionType is used for redirects vs popups and should handle the case where popup window is closed by user