### PR TITLE
Catch Dpapi Require error

### DIFF
--- a/change/@azure-msal-node-extensions-ad5fa611-2a29-46aa-b273-c3a6ff98add1.json
+++ b/change/@azure-msal-node-extensions-ad5fa611-2a29-46aa-b273-c3a6ff98add1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow requiring msal-node-extensions without Dpapi dependency",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "tyleonha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/test/dpapi-addon/Dpapi.spec.ts
+++ b/extensions/msal-node-extensions/test/dpapi-addon/Dpapi.spec.ts
@@ -8,8 +8,8 @@ import { DataProtectionScope } from "../../src/persistence/DataProtectionScope";
 import { platform } from "process";
 
 // DPAPI is only available on windows
-if (platform === "win32") {
-    describe("Test DPAPI addon", () => {
+describe("Test DPAPI addon", () => {
+    if (platform === "win32") {
         test("Protect and Unprotect data", () => {
             const data = Buffer.from("DPAPITestString");
 
@@ -58,8 +58,10 @@ if (platform === "win32") {
             );
             expect(decryptedData).toEqual(data);
         });
-    });
-} else {
-    // Jest require that a .spec.ts file contain at least one test.
-    test("Empty test", () => {});
-}
+    } else {
+        test("Should throw on non-Windows", () => {
+            const data = Buffer.from("DPAPITestString");
+            expect(() => Dpapi.protectData(data, null, DataProtectionScope.LocalMachine)).toThrow();
+        });
+    }
+});


### PR DESCRIPTION
For usages of msal-node-extensions that don't need persistance - like if you just want to use the Broker.

We are hitting this in VS Code because we are trying to bundle our code with Webpack... but since the require of DPAPI happens regardless of what features you use, we get an error from locating this `.node` file, which I have not included in our bundle.