### PR TITLE
Adding aud / clientId to account cache key

### DIFF
--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -123,6 +123,7 @@ export class AccountEntity {
             accountInterface.homeAccountId,
             accountInterface.environment || "",
             homeTenantId || accountInterface.tenantId || "",
+            accountInterface.idTokenClaims?.aud || "",
         ];
 
         return accountKey.join(Separators.CACHE_KEY_SEPARATOR).toLowerCase();


### PR DESCRIPTION
We are currently encountering an issue when having multi app on the same domain

For example : 
- https://mydomain.com/app1 
- https://mydomain.com/app2

With the current implementation the cache key will collide making it impossible to use both app at the same time.

I suppose this is not the usual use case, would this type of change be ok for you ?