### PR TITLE
Skip hanging tests

### DIFF
--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -317,7 +317,8 @@ describe("PublicClientApplication", () => {
     });
 
     describe("acquireTokenInteractive tests", () => {
-        test("acquireTokenInteractive succeeds", async () => {
+        // Causing pipeline to hang, needs to be fixed
+        test.skip("acquireTokenInteractive succeeds", async () => {
             const authApp = new PublicClientApplication(appConfig);
 
             let redirectUri: string;
@@ -372,7 +373,8 @@ describe("PublicClientApplication", () => {
             expect(response.account).toEqual(mockAuthenticationResult.account);
         });
 
-        test("acquireTokenInteractive - getting redirectUri waits for server to start", async () => {
+        // Causing pipeline to hang, needs to be fixed
+        test.skip("acquireTokenInteractive - getting redirectUri waits for server to start", async () => {
             const authApp = new PublicClientApplication(appConfig);
 
             let redirectUri: string;


### PR DESCRIPTION
2 tests appear to be causing the CI pipeline to hang indefinitely. Skipping until we can determine what's happening and how to re-enable them.