### PR TITLE
[msal-node-extensions] Introducing KeyRingPersistence which uses @napi-rs/keyring and provides cross platform secure store operations

### DIFF
--- a/extensions/docs/msal-node-extensions.md
+++ b/extensions/docs/msal-node-extensions.md
@@ -73,14 +73,14 @@ const pca = new PublicClientApplication({
 
 The FilePersistenceWithDataProtection uses the Win32 CryptProtectData and CryptUnprotectData APIs. For more information on dataProtectionScope, or optionalEntropy, reference the documentation for those APIs.
 
-#### Mac:
+#### Linux / Mac:
 ```js
-const { KeychainPersistence } = require("@azure/msal-node-extensions");
+const { KeyRingPersistence } = require("@azure/msal-node-extensions");
 
 const cachePath = "path/to/cache/file.json";
 const serviceName = "test-msal-electron-service";
 const accountName = "test-msal-electron-account";
-const macPersistence = await KeychainPersistence.create(cachePath, serviceName, accountName);
+const macPersistence = await KeyRingPersistence.create(cachePath, serviceName, accountName);
 // Use the persistence object to initialize an MSAL PublicClientApplication with cachePlugin
 const pca = new PublicClientApplication({
                 auth: {
@@ -93,33 +93,9 @@ const pca = new PublicClientApplication({
 
 ```
 
-- cachePath is **not** where the cache will be stored. Instead, the extensions update this file with dummy data to update the file's update time, to check if the contents on the keychain should be loaded or not. It is also used as the location for the lock file.
+- cachePath is **not** where the cache will be stored. Instead, the extensions update this file with dummy data to update the file's update time, to check if the contents on the secret store should be loaded or not. It is also used as the location for the lock file.
 - service name under which the cache is stored the keychain.
 - account name under which the cache is stored in the keychain.
-
-#### Linux:
-```js
-const { LibSecretPersistence } = require("@azure/msal-node-extensions");
-
-const cachePath = "path/to/cache/file.json";
-const serviceName = "test-msal-electron-service";
-const accountName = "test-msal-electron-account";
-const linuxPersistence = await LibSecretPersistence.create(cachePath, serviceName, accountName);
-// Use the persistence object to initialize an MSAL PublicClientApplication with cachePlugin
-const pca = new PublicClientApplication({
-                auth: {
-                        clientId: "CLIENT_ID_HERE",
-                    },
-                cache: {
-                        cachePlugin: new PersistenceCachePlugin(linuxPersistence);
-                    },
-                });
-
-```
-
-- cachePath is **not** where the cache will be stored. Instead, the extensions update this file with dummy data to update the file's update time, to check if the contents on the secret service (Gnome Keyring for example) should be loaded or not. It is also used as the location for the lock file.
-- service name under which the cache is stored the secret service.
-- account name under which the cache is stored in the secret service.
 
 #### All platforms
 An unencrypted file persistence, which works across all platforms, is provided for convenience, although not recommended.

--- a/extensions/msal-node-extensions/package.json
+++ b/extensions/msal-node-extensions/package.json
@@ -60,9 +60,10 @@
   "dependencies": {
     "@azure/msal-common": "14.9.0",
     "@azure/msal-node-runtime": "^0.13.6-alpha.0",
-    "keytar": "^7.8.0"
+    "@napi-rs/keyring": "^1.1.6"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-typescript": "^11.1.0",
     "@types/jest": "^29.5.1",

--- a/extensions/msal-node-extensions/rollup.config.js
+++ b/extensions/msal-node-extensions/rollup.config.js
@@ -5,11 +5,28 @@
 
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
+import commonjs from '@rollup/plugin-commonjs';
 import pkg from "./package.json";
 
 const libraryHeader = `/*! ${pkg.name} v${pkg.version} ${new Date().toISOString().split("T")[0]} */`;
 const useStrictHeader = "'use strict';";
 const fileHeader = `${libraryHeader}\n${useStrictHeader}`;
+
+// Native dependencies (transitive) that need to be excluded from the bundle
+const nativeDependencies = [
+    "@napi-rs/keyring-darwin-arm64",
+    "@napi-rs/keyring-linux-arm64-gnu",
+    "@napi-rs/keyring-linux-arm64-musl",
+    "@napi-rs/keyring-win32-arm64-msvc",
+    "@napi-rs/keyring-darwin-x64",
+    "@napi-rs/keyring-win32-x64-msvc",
+    "@napi-rs/keyring-linux-x64-gnu",
+    "@napi-rs/keyring-linux-x64-musl",
+    "@napi-rs/keyring-freebsd-x64",
+    "@napi-rs/keyring-win32-ia32-msvc",
+    "@napi-rs/keyring-linux-arm-gnueabihf",
+    "@napi-rs/keyring-linux-riscv64-gnu"
+]
 
 export default [
     {
@@ -30,8 +47,8 @@ export default [
         },
         external: [
             ...Object.keys(pkg.dependencies || {}),
-            ...Object.keys(pkg.peerDependencies || {})
-
+            ...Object.keys(pkg.peerDependencies || {}),
+            ...nativeDependencies
         ],
         plugins: [
             typescript({
@@ -40,7 +57,8 @@ export default [
             }),
             nodeResolve({
                 preferBuiltins: true
-            })
+            }),
+            commonjs()
         ]
     },
     {
@@ -61,7 +79,8 @@ export default [
         },
         external: [
             ...Object.keys(pkg.dependencies || {}),
-            ...Object.keys(pkg.peerDependencies || {})
+            ...Object.keys(pkg.peerDependencies || {}),
+            ...nativeDependencies
         ],
         plugins: [
             typescript({
@@ -70,7 +89,8 @@ export default [
             }),
             nodeResolve({
                 preferBuiltins: true
-            })
+            }),
+            commonjs()
         ]
     }
 ];

--- a/extensions/msal-node-extensions/src/error/PersistenceError.ts
+++ b/extensions/msal-node-extensions/src/error/PersistenceError.ts
@@ -43,6 +43,15 @@ export class PersistenceError extends Error {
     }
 
     /**
+     * Error thrown when trying to write, load, or delete data from KeyRingPersistence.
+     */
+    static createKeyRingPersistenceError(
+        errorMessage: string
+    ): PersistenceError {
+        return new PersistenceError("KeyRingError", errorMessage);
+    }
+
+    /**
      * Error thrown when trying to write, load, or delete data from keychain on macOs.
      */
     static createKeychainPersistenceError(

--- a/extensions/msal-node-extensions/src/index.ts
+++ b/extensions/msal-node-extensions/src/index.ts
@@ -9,6 +9,7 @@ export { FilePersistenceWithDataProtection } from "./persistence/FilePersistence
 export { DataProtectionScope } from "./persistence/DataProtectionScope";
 export { KeychainPersistence } from "./persistence/KeychainPersistence";
 export { LibSecretPersistence } from "./persistence/LibSecretPersistence";
+export { KeyRingPersistence } from "./persistence/KeyRingPersistence";
 export { IPersistence } from "./persistence/IPersistence";
 export { CrossPlatformLockOptions } from "./lock/CrossPlatformLockOptions";
 export { PersistenceCreator } from "./persistence/PersistenceCreator";

--- a/extensions/msal-node-extensions/src/persistence/KeyRingPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/KeyRingPersistence.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @napi-rs/keyring is a native Node.js module that provides a simple API for reading and writing passwords to the operating system's secure store.
+ *  - Linux: The DBus-based Secret Service, the kernel keyutils, and a combo of the two.
+ *  - FreeBSD, OpenBSD: The DBus-based Secret Service.
+ *  - macOS, iOS: The local keychain.
+ *  - Windows: The Windows Credential Manager.
+ * More info: https://github.com/hwchen/keyring-rs?tab=readme-ov-file#platforms
+ */
+import { Entry } from "@napi-rs/keyring";
+import type { Logger, LoggerOptions } from "@azure/msal-common";
+import { dirname } from "path";
+import { isNodeError } from "../utils/TypeGuards.js";
+import { PersistenceError } from "../error/PersistenceError.js";
+import { BasePersistence } from "./BasePersistence.js";
+import type { IPersistence } from "./IPersistence.js";
+import { FilePersistence } from "./FilePersistence.js";
+
+/**
+ * Uses reads and writes passwords to operating systems secure store
+ *
+ * serviceName: Identifier used as key for whatever value is stored
+ * accountName: Account under which password should be stored
+ *
+ */
+export class KeyRingPersistence
+    extends BasePersistence
+    implements IPersistence
+{
+    private readonly entry: Entry;
+    private readonly filePersistence: FilePersistence;
+
+    private constructor(
+        filePersistence: FilePersistence,
+        readonly service: string,
+        readonly account: string
+    ) {
+        super();
+        this.entry = new Entry(service, account);
+        this.filePersistence = filePersistence;
+    }
+
+    public static async create(
+        fileLocation: string,
+        serviceName: string,
+        accountName: string,
+        loggerOptions?: LoggerOptions
+    ): Promise<KeyRingPersistence> {
+        const filePersistence = await FilePersistence.create(
+            fileLocation,
+            loggerOptions
+        );
+
+        return new KeyRingPersistence(
+            filePersistence,
+            serviceName,
+            accountName
+        );
+    }
+
+    public async save(contents: string): Promise<void> {
+        try {
+            this.entry.setPassword(contents);
+        } catch (e) {
+            if (isNodeError(e)) {
+                throw PersistenceError.createKeyRingPersistenceError(e.message);
+            }
+            throw e;
+        }
+
+        // Write dummy data to update file mtime
+        await this.filePersistence.save("{}");
+    }
+
+    public load(): Promise<string | null> {
+        try {
+            return Promise.resolve(this.entry.getPassword());
+        } catch (e) {
+            if (isNodeError(e)) {
+                throw PersistenceError.createKeyRingPersistenceError(e.message);
+            }
+            throw e;
+        }
+    }
+
+    public async delete(): Promise<boolean> {
+        try {
+            await this.filePersistence.delete();
+
+            return this.entry.deletePassword();
+        } catch (e) {
+            if (isNodeError(e)) {
+                throw PersistenceError.createKeyRingPersistenceError(e.message);
+            }
+            throw e;
+        }
+    }
+
+    reloadNecessary(lastSync: number): Promise<boolean> {
+        return this.filePersistence.reloadNecessary(lastSync);
+    }
+
+    getFilePath(): string {
+        return this.filePersistence.getFilePath();
+    }
+    getLogger(): Logger {
+        return this.filePersistence.getLogger();
+    }
+
+    createForPersistenceValidation(): Promise<IPersistence> {
+        const testCacheFileLocation = `${dirname(
+            this.filePersistence.getFilePath()
+        )}/test.cache`;
+        return KeyRingPersistence.create(
+            testCacheFileLocation,
+            "persistenceValidationServiceName",
+            "persistencValidationAccountName"
+        );
+    }
+}

--- a/extensions/msal-node-extensions/src/persistence/KeychainPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/KeychainPersistence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import keytar from "keytar";
+import keytar from "@napi-rs/keyring/keytar";
 import { FilePersistence } from "./FilePersistence";
 import { IPersistence } from "./IPersistence";
 import { PersistenceError } from "../error/PersistenceError";
@@ -13,6 +13,8 @@ import { BasePersistence } from "./BasePersistence";
 import { isNodeError } from "../utils/TypeGuards";
 
 /**
+ * @deprecated This class is deprecated in favor of the KeyRingPersistence class.
+ *
  * Uses reads and writes passwords to macOS keychain
  *
  * serviceName: Identifier used as key for whatever value is stored

--- a/extensions/msal-node-extensions/src/persistence/LibSecretPersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/LibSecretPersistence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import keytar from "keytar";
+import keytar from "@napi-rs/keyring/keytar";
 import { FilePersistence } from "./FilePersistence";
 import { IPersistence } from "./IPersistence";
 import { PersistenceError } from "../error/PersistenceError";
@@ -13,6 +13,8 @@ import { BasePersistence } from "./BasePersistence";
 import { isNodeError } from "../utils/TypeGuards";
 
 /**
+ * @deprecated This class is deprecated in favor of the KeyRingPersistence class.
+ *
  * Uses reads and writes passwords to Secret Service API/libsecret. Requires libsecret
  * to be installed.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,10 @@
             "dependencies": {
                 "@azure/msal-common": "14.9.0",
                 "@azure/msal-node-runtime": "^0.13.6-alpha.0",
-                "keytar": "^7.8.0"
+                "@napi-rs/keyring": "^1.1.6"
             },
             "devDependencies": {
+                "@rollup/plugin-commonjs": "^28.0.2",
                 "@rollup/plugin-node-resolve": "^15.0.2",
                 "@rollup/plugin-typescript": "^11.1.0",
                 "@types/jest": "^29.5.1",
@@ -10002,9 +10003,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
@@ -11767,6 +11768,208 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@napi-rs/keyring": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.1.6.tgz",
+            "integrity": "sha512-e6xoYELSMyaxcXv4MmEHhf0oOGsMnfWMmeu84CD91ICMgMH1I1vrLSMFpiPEQz03xD+pNQgAkQ7DwwBDozCuvw==",
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@napi-rs/keyring-darwin-arm64": "1.1.6",
+                "@napi-rs/keyring-darwin-x64": "1.1.6",
+                "@napi-rs/keyring-freebsd-x64": "1.1.6",
+                "@napi-rs/keyring-linux-arm-gnueabihf": "1.1.6",
+                "@napi-rs/keyring-linux-arm64-gnu": "1.1.6",
+                "@napi-rs/keyring-linux-arm64-musl": "1.1.6",
+                "@napi-rs/keyring-linux-riscv64-gnu": "1.1.6",
+                "@napi-rs/keyring-linux-x64-gnu": "1.1.6",
+                "@napi-rs/keyring-linux-x64-musl": "1.1.6",
+                "@napi-rs/keyring-win32-arm64-msvc": "1.1.6",
+                "@napi-rs/keyring-win32-ia32-msvc": "1.1.6",
+                "@napi-rs/keyring-win32-x64-msvc": "1.1.6"
+            }
+        },
+        "node_modules/@napi-rs/keyring-darwin-arm64": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.1.6.tgz",
+            "integrity": "sha512-8N+qvM+O6OSU59BTgDP/PvqYhoqfOcD2HGy1NgRFo1B0DRmkTp4U/DGZrV4Pk/nOP6Uf0PLqznfx3a/M8O5sjQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-darwin-x64": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.1.6.tgz",
+            "integrity": "sha512-r3Jgc5/ubfaao6Lmk/USA13IwU/GEVLP8NDfg5gYXjPVllU6bWnAaEDHVg7q4vl51kViwj9ELo6XTmOeJFut6A==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-freebsd-x64": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.1.6.tgz",
+            "integrity": "sha512-ayG396jZAt7j820gsEyW/LJKn+rf9KtgSPq1NKpvu84Y5GXopoFLyjMIP7wYZ1RLBL6SGKy27/f8S4f6YZ4DuA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.1.6.tgz",
+            "integrity": "sha512-8nXavgxcaUTUxyFHR+PEQF7eC8rITlYZNUmlf5amTb36y5bkNKrc3QLvCxjtbFSR/+KYzMi3vydoqNmFpF616w==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.1.6.tgz",
+            "integrity": "sha512-qsI2NTAxGD3mBhZvdyYGL+N0n1D/NAjV0zCpTsFKKSzdpIrQJ0nM5Y0HxlLi6TsHm61dMyXHkdHb0ut8AzTcGA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.1.6.tgz",
+            "integrity": "sha512-SB/2A4LtL+SrS2aZXl3rWBtyCVB2aG2zAU56kOGFDGwRZM2tqaITuQoM1QLOAMwu0eksN/Xedy95Yn2rkRH0nQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.1.6.tgz",
+            "integrity": "sha512-BcjXf33T2CoVgS87SvZ62Y6xxkbenNIeldy0r8O5nz6zFgN+wYB0scz5ulvowEYBQnhi4fmbxfneeqM/0HUOeA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.1.6.tgz",
+            "integrity": "sha512-eK0OxCBI6Wl8rFHYynrtEID6pxOwhPfnpIIpul7UPeqCCMJSyZpFN4lFP3oZ4vqX/6FnWjwMrR7IGbPgivdMjA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-linux-x64-musl": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.1.6.tgz",
+            "integrity": "sha512-Qb3NP98KFq4jXmk9PUQlcYrHjbzsBTtG+OOxX4YxUNKTGuUaIOGP79lB0w7jhns2oHdq8DwkW2ugzlmGSUaRSw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.1.6.tgz",
+            "integrity": "sha512-e794gO2CLD0P7JN2DVPT5CC60k3WmNWTWU5BVoQM8Hj0NYebx7j6LyxMIpdb2cztOHHiv7iltEHekgutf0TMlA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.1.6.tgz",
+            "integrity": "sha512-SUPafl6vKRMQBKZoSwIeBFZ+c7AGEKUy6mpAD9fVHDKHOBWP3VpHKda4YIlgGtQd3SxH0bjfqJ078Z5SYsDYZQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.1.6.tgz",
+            "integrity": "sha512-FkNhM1x5ijFzGSrRcshRxUxQSrrjxl4wCmvRcXnimWreOHyzNotT+/1EZtSfM/k8yhdK0HEkkVIMQl0UqfioRw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/@next/env": {
@@ -13955,6 +14158,67 @@
             "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
             "peerDependencies": {
                 "react": ">=16.14.0"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs": {
+            "version": "28.0.2",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.2.tgz",
+            "integrity": "sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "fdir": "^6.2.0",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=16.0.0 || 14 >= 14.17"
+            },
+            "peerDependencies": {
+                "rollup": "^2.68.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+            "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+            "dev": true,
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rollup/plugin-json": {
@@ -31353,6 +31617,15 @@
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
         },
+        "node_modules/is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*"
+            }
+        },
         "node_modules/is-regex": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -33960,7 +34233,10 @@
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
             "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+            "dev": true,
             "hasInstallScript": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "node-addon-api": "^4.3.0",
                 "prebuild-install": "^7.0.1"


### PR DESCRIPTION
This pull request introduces several changes to the `msal-node-extensions` package, focusing on updating dependencies, improving platform support, and deprecating old persistence classes in favor of a new implementation. The most important changes include the introduction of `KeyRingPersistence`, updates to the `rollup.config.js` file, and modifications to the documentation to reflect these changes.

### New Persistence Implementation:
* Added `KeyRingPersistence` class to handle secure storage across multiple platforms using the `@napi-rs/keyring` library. This class replaces the need for platform-specific persistence classes.

### Dependency Updates:
* Updated `package.json` to replace the `keytar` dependency with `@napi-rs/keyring` and added `@rollup/plugin-commonjs`.

### Build Configuration:
* Updated `rollup.config.js` to include `@rollup/plugin-commonjs` and exclude native dependencies from the bundle. [[1]](diffhunk://#diff-a171aacd7773f413d5bb55e37560035aec7a4ab19b5db28de4b01accba953c98R8-R30) [[2]](diffhunk://#diff-a171aacd7773f413d5bb55e37560035aec7a4ab19b5db28de4b01accba953c98L33-R51) [[3]](diffhunk://#diff-a171aacd7773f413d5bb55e37560035aec7a4ab19b5db28de4b01accba953c98L43-R61) [[4]](diffhunk://#diff-a171aacd7773f413d5bb55e37560035aec7a4ab19b5db28de4b01accba953c98L64-R83) [[5]](diffhunk://#diff-a171aacd7773f413d5bb55e37560035aec7a4ab19b5db28de4b01accba953c98L73-R93)

### Deprecation of Old Classes:
* Deprecated `KeychainPersistence` and `LibSecretPersistence` classes in favor of the new `KeyRingPersistence` class. [[1]](diffhunk://#diff-06e029ddeb62ef3b0c08ac12c9cd5a28d91bef8dcc84779904839e60f8e7f79bR16-R17) [[2]](diffhunk://#diff-e9342098d74c62d925e5ff4e11f9281b3ddbf67ba66e8a540063d0275683d187R16-R17)

### Documentation Updates:
* Updated `msal-node-extensions.md` to reflect the new `KeyRingPersistence` class and removed the old platform-specific persistence examples. [[1]](diffhunk://#diff-76d8f195bb732b5434f3e45207c691eaa2395b912ac70f6511746f3bad54c51dL76-R83) [[2]](diffhunk://#diff-76d8f195bb732b5434f3e45207c691eaa2395b912ac70f6511746f3bad54c51dL96-L123)