### PR TITLE
Add back rejectUnauthorized request option to support self-signed certificates

### DIFF
--- a/samples/e2eTestUtils/jest-puppeteer-utils/serverUtils.js
+++ b/samples/e2eTestUtils/jest-puppeteer-utils/serverUtils.js
@@ -45,6 +45,7 @@ async function isServerUp(port, timeout) {
                 host: "localhost",
                 port: port,
                 family: 4,
+                rejectUnauthorized: false,
             };
 
             https


### PR DESCRIPTION
- Add back "rejectUnauthorized" request option to support self-signed certificates
- Fixes regression in https samples introduced by changes in https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/7486