### PR TITLE
Managed Identity: ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse's "expires_in" value

### DIFF
--- a/change/@azure-msal-browser-5b9b3c14-8c3d-4be0-8605-ad47cb6b2563.json
+++ b/change/@azure-msal-browser-5b9b3c14-8c3d-4be0-8605-ad47cb6b2563.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "\"Managed Identity: ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse expires_in value #7529\"",
+  "packageName": "@azure/msal-browser",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-5b9b3c14-8c3d-4be0-8605-ad47cb6b2563.json
+++ b/change/@azure-msal-browser-5b9b3c14-8c3d-4be0-8605-ad47cb6b2563.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "\"Managed Identity: ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse expires_in value #7529\"",
+  "comment": "Managed Identity: ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse expires_in value #7529",
   "packageName": "@azure/msal-browser",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-9b5ebad2-65f6-4fb9-a86a-ddfb57bcff58.json
+++ b/change/@azure-msal-common-9b5ebad2-65f6-4fb9-a86a-ddfb57bcff58.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse's \"expires_in\" value",
+  "comment": "ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse's expires_in value",
   "packageName": "@azure/msal-common",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-9b5ebad2-65f6-4fb9-a86a-ddfb57bcff58.json
+++ b/change/@azure-msal-common-9b5ebad2-65f6-4fb9-a86a-ddfb57bcff58.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse's expires_in value",
+  "comment": "Managed Identity: ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse expires_in value #7529",
   "packageName": "@azure/msal-common",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-9b5ebad2-65f6-4fb9-a86a-ddfb57bcff58.json
+++ b/change/@azure-msal-common-9b5ebad2-65f6-4fb9-a86a-ddfb57bcff58.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ResponseHandler can now accept an ISO 8601 date in the ServerAuthorizationTokenResponse's \"expires_in\" value",
+  "packageName": "@azure/msal-common",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -300,11 +300,11 @@ export class TokenCache implements ITokenCache {
             : new ScopeSet(request.scopes);
         const expiresOn =
             options.expiresOn ||
-            response.expires_in + new Date().getTime() / 1000;
+            (response.expires_in as number) + new Date().getTime() / 1000;
 
         const extendedExpiresOn =
             options.extendedExpiresOn ||
-            (response.ext_expires_in || response.expires_in) +
+            (response.ext_expires_in || (response.expires_in as number)) +
                 new Date().getTime() / 1000;
 
         const accessTokenEntity = CacheHelpers.createAccessTokenEntity(

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -1141,7 +1141,9 @@ describe("RedirectClient", () => {
                 fromCache: false,
                 correlationId: RANDOM_TEST_GUID,
                 expiresOn: new Date(
-                    Date.now() + testServerTokenResponse.body.expires_in! * 1000
+                    Date.now() +
+                        (testServerTokenResponse.body.expires_in as number)! *
+                            1000
                 ),
                 account: testAccount,
                 tokenType: AuthenticationScheme.BEARER,

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2446,6 +2446,9 @@ export interface ISerializableTokenCache {
 // @public
 function isIdTokenEntity(entity: object): boolean;
 
+// @internal
+function isIso8601(dateString: string): boolean;
+
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "isRefreshTokenEntity" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3607,9 +3610,9 @@ export type ServerAuthorizationTokenResponse = {
     status?: number;
     token_type?: AuthenticationScheme;
     scope?: string;
-    expires_in?: number;
-    refresh_in?: number;
+    expires_in?: number | string;
     ext_expires_in?: number;
+    refresh_in?: number;
     access_token?: string;
     refresh_token?: string;
     refresh_token_expires_in?: number;
@@ -3956,7 +3959,8 @@ declare namespace TimeUtils {
         nowSeconds,
         isTokenExpired,
         wasClockTurnedBack,
-        delay
+        delay,
+        isIso8601
     }
 }
 export { TimeUtils }
@@ -4288,9 +4292,9 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/request/AuthenticationHeaderParser.ts:74:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:430:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:431:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:432:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:455:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:456:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:457:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceClient.ts:916:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceClient.ts:916:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
 // src/telemetry/performance/PerformanceClient.ts:928:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -52,6 +52,7 @@ import {
     updateAccountTenantProfileData,
 } from "../account/AccountInfo.js";
 import * as CacheHelpers from "../cache/utils/CacheHelpers.js";
+import { isIso8601 } from "../utils/TimeUtils.js";
 
 function parseServerErrorNo(
     serverResponse: ServerAuthorizationCodeResponse
@@ -426,6 +427,30 @@ export class ResponseHandler {
     }
 
     /**
+     * Calculates the number of seconds until the token expires.
+     *
+     * @param reqTimestamp - The timestamp when the request was made, in seconds.
+     * @param tokenExpirationTimestamp - The expiration timestamp of the token, which can be a number (or a number as a string), a string in ISO 8601 format, or undefined.
+     * @param returnValueIfUndefined - The value to return if the tokenExpirationTimestamp is undefined.
+     * @returns The number of seconds until the token expires, or the returnValueIfUndefined if the tokenExpirationTimestamp is undefined.
+     */
+    private getSecondsUntilTokenExpires(
+        reqTimestamp: number,
+        tokenExpirationTimestamp: number | string | undefined,
+        returnValueIfUndefined: number | undefined
+    ): number | undefined {
+        if (typeof tokenExpirationTimestamp === "string") {
+            return isIso8601(tokenExpirationTimestamp)
+                ? Math.floor(
+                      new Date(tokenExpirationTimestamp).getTime() / 1000
+                  ) - reqTimestamp
+                : parseInt(tokenExpirationTimestamp, 10);
+        } else {
+            return tokenExpirationTimestamp || returnValueIfUndefined;
+        }
+    }
+
+    /**
      * Generates CacheRecord
      * @param serverTokenResponse
      * @param idTokenObj
@@ -486,23 +511,26 @@ export class ResponseHandler {
 
             /*
              * Use timestamp calculated before request
-             * Server may return timestamps as strings, parse to numbers if so.
+             * Server may return timestamps as an ISO 8601 date string or a numeric string, parse to numbers if so.
              */
-            const expiresIn: number =
-                (typeof serverTokenResponse.expires_in === "string"
-                    ? parseInt(serverTokenResponse.expires_in, 10)
-                    : serverTokenResponse.expires_in) || 0;
+            const expiresIn: number = this.getSecondsUntilTokenExpires(
+                reqTimestamp,
+                serverTokenResponse.expires_in,
+                0
+            ) as number;
+            const tokenExpirationSeconds = reqTimestamp + expiresIn;
+
             const extExpiresIn: number =
                 (typeof serverTokenResponse.ext_expires_in === "string"
                     ? parseInt(serverTokenResponse.ext_expires_in, 10)
                     : serverTokenResponse.ext_expires_in) || 0;
+            const extendedTokenExpirationSeconds =
+                tokenExpirationSeconds + extExpiresIn;
+
             const refreshIn: number | undefined =
                 (typeof serverTokenResponse.refresh_in === "string"
                     ? parseInt(serverTokenResponse.refresh_in, 10)
                     : serverTokenResponse.refresh_in) || undefined;
-            const tokenExpirationSeconds = reqTimestamp + expiresIn;
-            const extendedTokenExpirationSeconds =
-                tokenExpirationSeconds + extExpiresIn;
             const refreshOnSeconds =
                 refreshIn && refreshIn > 0
                     ? reqTimestamp + refreshIn

--- a/lib/msal-common/src/response/ServerAuthorizationTokenResponse.ts
+++ b/lib/msal-common/src/response/ServerAuthorizationTokenResponse.ts
@@ -31,7 +31,7 @@ export type ServerAuthorizationTokenResponse = {
     // Success
     token_type?: AuthenticationScheme;
     scope?: string;
-    expires_in?: number | string; // Managed Identity can send an ISO 8601 string instead of a number (or a number as a string)
+    expires_in?: number | string; // Managed Identity can send an ISO 8601 string instead of a number
     ext_expires_in?: number;
     refresh_in?: number;
     access_token?: string;

--- a/lib/msal-common/src/response/ServerAuthorizationTokenResponse.ts
+++ b/lib/msal-common/src/response/ServerAuthorizationTokenResponse.ts
@@ -9,9 +9,9 @@ import { AuthenticationScheme } from "../utils/Constants.js";
  * Deserialized response object from server authorization code request.
  * - token_type: Indicates the token type value. Can be either Bearer or pop.
  * - scope: The scopes that the access_token is valid for.
- * - expires_in: How long the access token is valid (in seconds).
- * - refresh_in: Duration afer which a token should be renewed, regardless of expiration.
+ * - expires_in: How long the access token is valid (in seconds, or an ISO 8601 string).
  * - ext_expires_in: How long the access token is valid (in seconds) if the server isn't responding.
+ * - refresh_in: Duration afer which a token should be renewed, regardless of expiration.
  * - access_token: The requested access token. The app can use this token to authenticate to the secured resource, such as a web API.
  * - refresh_token: An OAuth 2.0 refresh token. The app can use this token acquire additional access tokens after the current access token expires.
  * - id_token: A JSON Web Token (JWT). The app can decode the segments of this token to request information about the user who signed in.
@@ -31,9 +31,9 @@ export type ServerAuthorizationTokenResponse = {
     // Success
     token_type?: AuthenticationScheme;
     scope?: string;
-    expires_in?: number;
-    refresh_in?: number;
+    expires_in?: number | string; // Managed Identity can send an ISO 8601 string instead of a number (or a number as a string)
     ext_expires_in?: number;
+    refresh_in?: number;
     access_token?: string;
     refresh_token?: string;
     refresh_token_expires_in?: number;

--- a/lib/msal-common/src/utils/TimeUtils.ts
+++ b/lib/msal-common/src/utils/TimeUtils.ts
@@ -48,3 +48,15 @@ export function wasClockTurnedBack(cachedAt: string): boolean {
 export function delay<T>(t: number, value?: T): Promise<T | void> {
     return new Promise((resolve) => setTimeout(() => resolve(value), t));
 }
+
+/**
+ * @internal
+ * Checks if a given date string is in ISO 8601 format.
+ *
+ * @param dateString - The date string to be checked.
+ * @returns boolean - Returns true if the date string is in ISO 8601 format, otherwise false.
+ */
+export function isIso8601(dateString: string): boolean {
+    const date = new Date(dateString);
+    return !isNaN(date.getTime()) && date.toISOString() === dateString;
+}

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -454,6 +454,55 @@ describe("ResponseHandler.ts", () => {
             );
         });
 
+        it("Ensure handleServerTokenResponse is able to parse token expiry information that is provided as ISO 8601 string", async () => {
+            const testRequest: BaseAuthRequest = {
+                authority: testAuthority.canonicalAuthority,
+                correlationId: "CORRELATION_ID",
+                scopes: ["openid", "profile", "User.Read", "email"],
+            };
+
+            const testResponse: ServerAuthorizationTokenResponse = {
+                ...AUTHENTICATION_RESULT.body,
+            };
+
+            const responseHandler = new ResponseHandler(
+                "this-is-a-client-id",
+                testCacheManager,
+                cryptoInterface,
+                logger,
+                null,
+                null
+            );
+
+            const timestamp = TimeUtils.nowSeconds();
+
+            // convert the test response's expires_in to an ISO string
+            const newExpiresIn = new Date(timestamp * 1000);
+            newExpiresIn.setSeconds(
+                newExpiresIn.getSeconds() + (testResponse.expires_in as number)
+            );
+            const newExpiresInIsoDate = newExpiresIn.toISOString();
+            testResponse.expires_in = newExpiresInIsoDate;
+
+            const response = await responseHandler.handleServerTokenResponse(
+                testResponse,
+                testAuthority,
+                timestamp,
+                testRequest
+            );
+
+            expect(
+                response.expiresOn && response.expiresOn.toISOString()
+            ).toEqual(newExpiresInIsoDate);
+            expect(
+                ((response.expiresOn as Date) &&
+                    Math.round((response.expiresOn as Date).getTime() / 1000)) -
+                    timestamp
+            ).toEqual(AUTHENTICATION_RESULT.body.expires_in);
+
+            jest.restoreAllMocks();
+        });
+
         it("includes spa_code in response as code", async () => {
             const testSpaCode = "sample-spa-code";
 

--- a/lib/msal-common/test/test_kit/StringConstants.ts
+++ b/lib/msal-common/test/test_kit/StringConstants.ts
@@ -508,8 +508,8 @@ export const AUTHENTICATION_RESULT = {
     body: {
         token_type: AuthenticationScheme.BEARER,
         scope: "openid profile User.Read email",
-        expires_in: 3599,
-        ext_expires_in: 3599,
+        expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+        ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
         access_token: "thisIs.an.accessT0ken",
         refresh_token: "thisIsARefreshT0ken",
         id_token: TEST_TOKENS.IDTOKEN_V2,
@@ -522,8 +522,8 @@ export const AUTHENTICATION_RESULT_NO_REFRESH_TOKEN = {
     body: {
         token_type: AuthenticationScheme.BEARER,
         scope: "openid profile User.Read email",
-        expires_in: 3599,
-        ext_expires_in: 3599,
+        expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+        ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
         access_token: "thisIs.an.accessT0ken",
         refresh_token: "",
         id_token:
@@ -537,8 +537,8 @@ export const POP_AUTHENTICATION_RESULT = {
     body: {
         token_type: AuthenticationScheme.POP,
         scope: "openid profile User.Read email",
-        expires_in: 3599,
-        ext_expires_in: 3599,
+        expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+        ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
         access_token: `${TEST_POP_VALUES.SAMPLE_POP_AT}`,
         refresh_token: "thisIsARefreshT0ken",
         id_token:
@@ -552,8 +552,8 @@ export const SSH_AUTHENTICATION_RESULT = {
     body: {
         token_type: AuthenticationScheme.SSH,
         scope: "https://pas.windows.net/CheckMyAccess/Linux/user_impersonation https://pas.windows.net/CheckMyAccess/Linux/.default",
-        "expires}_in": 3599,
-        ext_expires_in: 3599,
+        "expires}_in": TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+        ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
         access_token:
             "AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgrk+wGrNoM6ZcU8/aVc+O9nMQArnTpgQcN2nDOojq3LwAAAADAQABAAABAQCiPcGP8PriIUKC1EAiepduIitPFswHDoPpAUJqbzgKNLdTdy86OoGFpY9yKo9kVgCTdPj/v8cO76/+I1vlHk1p7Q9DeFe333LefRnBUT8tDiFC4wtYJDxhpCcuOsEIlHVhYPp33ZQZePomb9rzTCatzFnrP9b62FRpx0Y3pjk/lstOr50Bh/3ZlDFPH36chXwEDSOcW3QX+0y4FT6x5zxna9KrwpCOWVaBdqsHpoqruDhGwkCAaoL6RXCyQTZatcqJNWCcD6a8GFHAkTZMxh2LR0xPZ4JkIDofKbauP/s9FPlAJN+VhY+HthrduVzgRP3ELxqSCE8xmNV8R/AVv1OxAAAAAAAAAAAAAAABAAAASTE4ZmRhY2MyLThkMWEtNDMzOC04NWM4LTAwMjY1ZmI2NWVmNkA3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcAAAAZAAAAFWhlbW9yYWxAbWljcm9zb2Z0LmNvbQAAAABhcFyFAAAAAGFwa8EAAAAAAAABTAAAACBkaXNwbGF5bmFtZUBzc2hzZXJ2aWNlLmF6dXJlLm5ldAAAABIAAAAOSGVjdG9yIE1vcmFsZXMAAAAYb2lkQHNzaHNlcnZpY2UuYXp1cmUubmV0AAAAKAAAACQxOGZkYWNjMi04ZDFhLTQzMzgtODVjOC0wMDI2NWZiNjVlZjYAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAGHRpZEBzc2hzZXJ2aWNlLmF6dXJlLm5ldAAAACgAAAAkNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3AAAAAAAAARcAAAAHc3NoLXJzYQAAAAMBAAEAAAEBALH7FzF1rjvnZ4i2iBC2tz8qs/WP61n3/wFawgJxUnTx2vP/z5pG7f8qvumd7taOII0aSlp648SIfMw59WdUUtup5CnDYOcX1sUdivAj20m2PIDK6f+KWZ+7YKxJqCzJMH4GGlQvuDIhRKNT9oHfZgnYCCAmjXmJBtWyD052qqrkzOSn0/e9TKbjlTnTNcrIno3XDQ7xG+79vOD2GZMNopsKogWNxUdLFRu44ClKLRb4Xe00eVrANtBkv+mSJFFJS1Gxv611hpdGI2S0v1H+KvB26O7vuzGhZ/AevRemGhXQ5V5vwNEqXnVRVkBRszLKeN/+rxM436xQyVQGJMG+sVEAAAEUAAAADHJzYS1zaGEyLTI1NgAAAQBlbiFgkvtKprsj96PD2uIJ7ZypzE/t/iba7/eDvXXc3ixI8fBns2bSuNx7LF3i2vlAUgz6UHe4xW0voc+jmZKEI8jXj91C84npo7J4kCxAkfO4GmdwGhQMjNRoN+pZliPNtj5jQLsuVxgXoJARAEP8nSp372i2bn7iFzolXWPiWkF1MVFV9BLwL3uPDeqTZqurYcpXJnSX30owMyC9qf913MGvWujN2AKNyoX1OIm19EKUSVLMM7S65A5nuuOMrkaajumdEgCgiVQSgHjqD5gDix+EZy7w6L6b8nKqT2mu481dM2yMqejAWxgife4oPI07sGXf1kIOn8kTuZAHkiSH",
         refresh_token:
@@ -571,8 +571,8 @@ export const AUTHENTICATION_RESULT_WITH_FOCI = {
     body: {
         token_type: AuthenticationScheme.BEARER,
         scope: "openid profile User.Read email",
-        expires_in: 3599,
-        ext_expires_in: 3599,
+        expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+        ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
         access_token: "thisIs.an.accessT0ken",
         refresh_token: "thisIsARefreshT0ken",
         id_token: TEST_TOKENS.IDTOKEN_V2,
@@ -586,8 +586,8 @@ export const AUTHENTICATION_RESULT_DEFAULT_SCOPES = {
     body: {
         token_type: AuthenticationScheme.BEARER,
         scope: "openid profile offline_access User.Read",
-        expires_in: 3599,
-        ext_expires_in: 3599,
+        expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+        ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
         access_token: "thisIs.an.accessT0ken",
         refresh_token: "thisIsARefreshT0ken",
         id_token:
@@ -610,8 +610,8 @@ export const AUTHENTICATION_RESULT_WITH_HEADERS = {
     body: {
         token_type: AuthenticationScheme.BEARER,
         scope: "openid profile offline_access User.Read",
-        expires_in: 3599,
-        ext_expires_in: 3599,
+        expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+        ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
         access_token: "thisIs.an.accessT0ken",
         refresh_token: "thisIsARefreshT0ken",
         id_token:
@@ -624,8 +624,8 @@ export const CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT = {
     status: 200,
     body: {
         token_type: AuthenticationScheme.BEARER,
-        expires_in: 3599,
-        ext_expires_in: 3599,
+        expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+        ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
         access_token: "thisIs.an.accessT0ken",
     },
 };


### PR DESCRIPTION
Fixes #7393