### PR TITLE
Fix Client Credential Regression Test

### DIFF
--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -26,6 +26,12 @@ jobs:
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
 
+            - name: Create output file if it doesn't exist
+              run: |
+                  if [ ! -f regression-tests/msal-node/client-credential/output.txt ]; then
+                    touch regression-tests/msal-node/client-credential/output.txt
+                  fi
+
             - name: Run benchmark
               run: npm run start
               working-directory: regression-tests/msal-node/client-credential

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -26,12 +26,6 @@ jobs:
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
 
-            - name: Create output file if it doesn't exist
-              run: |
-                  if [ ! -f regression-tests/msal-node/client-credential/output.txt ]; then
-                    touch regression-tests/msal-node/client-credential/output.txt
-                  fi
-
             - name: Run benchmark
               run: npm run start
               working-directory: regression-tests/msal-node/client-credential

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -11,36 +11,36 @@ on:
             - "lib/msal-common/**/*"
             - "!**.md"
             - ".github/workflows/client-credential.yml"
-            
+
     merge_group:
         types: [checks_requested]
 
 jobs:
-  benchmark:
-    name: Run msal-node client-credential Regression Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - name: Run benchmark
-        run: cd regression-tests/msal-node/client-credential && npm install && node index.js | tee output.txt
+    benchmark:
+        name: Run msal-node client-credential Regression Test
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+            - name: Run benchmark
+              run: cd regression-tests/msal-node/client-credential && npm run start:build
 
-      - name: Download previous benchmark data
-        uses: actions/cache@v4
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
+            - name: Download previous benchmark data
+              uses: actions/cache@v4
+              with:
+                  path: ./cache
+                  key: ${{ runner.os }}-benchmark
 
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: msal-node client-credential Regression Test
-          tool: 'benchmarkjs'
-          output-file-path: regression-tests/msal-node/client-credential/output.txt
-          external-data-json-path: ./cache/client-credential-benchmark-data.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '110%'
-          comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: '@bgavrilMS @robbie-microsoft'
+            - name: Store benchmark result
+              uses: benchmark-action/github-action-benchmark@v1
+              with:
+                  name: msal-node client-credential Regression Test
+                  tool: "benchmarkjs"
+                  output-file-path: regression-tests/msal-node/client-credential/output.txt
+                  external-data-json-path: ./cache/client-credential-benchmark-data.json
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  # Show alert with commit comment on detecting possible performance regression
+                  alert-threshold: "110%"
+                  comment-on-alert: true
+                  fail-on-alert: false
+                  alert-comment-cc-users: "@bgavrilMS @robbie-microsoft"

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -23,7 +23,8 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
             - name: Run benchmark
-              run: cd regression-tests/msal-node/client-credential && npm run start:build
+              run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential && npm run start:build
+              working-directory: regression-tests/msal-node/client-credential
 
             - name: Download previous benchmark data
               uses: actions/cache@v4

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -30,7 +30,7 @@ jobs:
               run: npm run build --workspace=lib/msal-common --workspace=lib/msal-node
 
             - name: Run benchmark
-              run: node index.js | tee output.txt
+              run: npm install && node index.js | tee output.txt
               working-directory: regression-tests/msal-node/client-credential
 
             - name: Download previous benchmark data

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -22,8 +22,13 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
+
+            - name: Install dependencies
+              run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
+              working-directory: regression-tests/msal-node/client-credential
+
             - name: Run benchmark
-              run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential && npm run start:build
+              run: npm run start
               working-directory: regression-tests/msal-node/client-credential
 
             - name: Download previous benchmark data

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -24,7 +24,7 @@ jobs:
             - uses: actions/setup-node@v4
 
             - name: Install dependencies
-              run: npm install
+              run: npm install --workspace=lib/msal-common --workspace=lib/msal-node
 
             - name: Build Packages
               run: npm run build --workspace=lib/msal-common --workspace=lib/msal-node

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node
 
-            - name: Build Packages
+            - name: Build dependencies
               run: npm run build --workspace=lib/msal-common --workspace=lib/msal-node
 
             - name: Run benchmark

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -27,7 +27,7 @@ jobs:
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
 
             - name: Run benchmark
-              run: npm run start
+              run: node index.js | tee output.txt
               working-directory: regression-tests/msal-node/client-credential
 
             - name: Download previous benchmark data

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -25,7 +25,6 @@ jobs:
 
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
-              working-directory: regression-tests/msal-node/client-credential
 
             - name: Run benchmark
               run: npm run start

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -24,7 +24,10 @@ jobs:
             - uses: actions/setup-node@v4
 
             - name: Install dependencies
-              run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
+              run: npm install
+
+            - name: Build Packages
+              run: npm run build --workspace=lib/msal-common --workspace=lib/msal-node
 
             - name: Run benchmark
               run: node index.js | tee output.txt

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -19,7 +19,10 @@ jobs:
             - uses: actions/setup-node@v4
 
             - name: Install dependencies
-              run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
+              run: npm install
+
+            - name: Build Packages
+              run: npm run build --workspace=lib/msal-common --workspace=lib/msal-node
 
             - name: Run benchmark
               run: node index.js | tee output.txt

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -1,35 +1,35 @@
 # Do not run this workflow on pull request since this workflow has permission to modify contents.
 on:
-  push:
-    branches:
-      - dev
+    push:
+        branches:
+            - dev
 
 permissions:
-  # deployments permission to deploy GitHub pages website
-  deployments: write
-  # contents permission to update benchmark contents in gh-pages branch
-  contents: write
+    # deployments permission to deploy GitHub pages website
+    deployments: write
+    # contents permission to update benchmark contents in gh-pages branch
+    contents: write
 
 jobs:
-  benchmark:
-    name: Performance regression check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - name: Run benchmark
-        run: cd regression-tests/msal-node/client-credential && npm install && node index.js | tee output.txt
+    benchmark:
+        name: Performance regression check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+            - name: Run benchmark
+              run: cd regression-tests/msal-node/client-credential && npm run start:build
 
-      # gh-pages branch is updated and pushed automatically with extracted benchmark data
-      # By default, this action assumes that gh-pages is the GitHub Pages branch and that
-      # /dev/bench is a path to put the benchmark dashboard page. They can be tweaked by
-      # the gh-pages-branch, gh-repository and benchmark-data-dir-path inputs.
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: msal-node client-credential Regression Test
-          tool: 'benchmarkjs'
-          output-file-path: regression-tests/msal-node/client-credential/output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Push and deploy GitHub pages branch automatically
-          auto-push: true
+            # gh-pages branch is updated and pushed automatically with extracted benchmark data
+            # By default, this action assumes that gh-pages is the GitHub Pages branch and that
+            # /dev/bench is a path to put the benchmark dashboard page. They can be tweaked by
+            # the gh-pages-branch, gh-repository and benchmark-data-dir-path inputs.
+            - name: Store benchmark result
+              uses: benchmark-action/github-action-benchmark@v1
+              with:
+                  name: msal-node client-credential Regression Test
+                  tool: "benchmarkjs"
+                  output-file-path: regression-tests/msal-node/client-credential/output.txt
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  # Push and deploy GitHub pages branch automatically
+                  auto-push: true

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -21,12 +21,6 @@ jobs:
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
 
-            - name: Create output file if it doesn't exist
-              run: |
-                  if [ ! -f regression-tests/msal-node/client-credential/output.txt ]; then
-                    touch regression-tests/msal-node/client-credential/output.txt
-                  fi
-
             - name: Run benchmark
               run: npm run start
               working-directory: regression-tests/msal-node/client-credential

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
               run: npm run build --workspace=lib/msal-common --workspace=lib/msal-node
 
             - name: Run benchmark
-              run: node index.js | tee output.txt
+              run: npm install && node index.js | tee output.txt
               working-directory: regression-tests/msal-node/client-credential
 
             # gh-pages branch is updated and pushed automatically with extracted benchmark data

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
 
             - name: Run benchmark
-              run: npm run start
+              run: node index.js | tee output.txt
               working-directory: regression-tests/msal-node/client-credential
 
             # gh-pages branch is updated and pushed automatically with extracted benchmark data

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -21,6 +21,12 @@ jobs:
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
 
+            - name: Create output file if it doesn't exist
+              run: |
+                  if [ ! -f regression-tests/msal-node/client-credential/output.txt ]; then
+                    touch regression-tests/msal-node/client-credential/output.txt
+                  fi
+
             - name: Run benchmark
               run: npm run start
               working-directory: regression-tests/msal-node/client-credential

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
             - uses: actions/setup-node@v4
 
             - name: Install dependencies
-              run: npm install
+              run: npm install --workspace=lib/msal-common --workspace=lib/msal-node
 
             - name: Build Packages
               run: npm run build --workspace=lib/msal-common --workspace=lib/msal-node

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -17,10 +17,12 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
+            - name: Install dependencies
+              run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
+              working-directory: regression-tests/msal-node/client-credential
             - name: Run benchmark
-              - run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential && npm run start:build
-                working-directory: regression-tests/msal-node/client-credential
-
+              run: npm run start
+              working-directory: regression-tests/msal-node/client-credential
             # gh-pages branch is updated and pushed automatically with extracted benchmark data
             # By default, this action assumes that gh-pages is the GitHub Pages branch and that
             # /dev/bench is a path to put the benchmark dashboard page. They can be tweaked by

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -18,7 +18,8 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
             - name: Run benchmark
-              run: cd regression-tests/msal-node/client-credential && npm run start:build
+              - run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential && npm run start:build
+                working-directory: regression-tests/msal-node/client-credential
 
             # gh-pages branch is updated and pushed automatically with extracted benchmark data
             # By default, this action assumes that gh-pages is the GitHub Pages branch and that

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node
 
-            - name: Build Packages
+            - name: Build dependencies
               run: npm run build --workspace=lib/msal-common --workspace=lib/msal-node
 
             - name: Run benchmark

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -17,12 +17,14 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
+
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential
-              working-directory: regression-tests/msal-node/client-credential
+
             - name: Run benchmark
               run: npm run start
               working-directory: regression-tests/msal-node/client-credential
+
             # gh-pages branch is updated and pushed automatically with extracted benchmark data
             # By default, this action assumes that gh-pages is the GitHub Pages branch and that
             # /dev/bench is a path to put the benchmark dashboard page. They can be tweaked by

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node index.js | tee output.txt",
-    "build:all": "npm install --workspace=@azure/msal-common --workspace=@azure/msal-node --workspace=regression-tests/msal-node/client-credential",
+    "build:all": "cd ../../../ && npm install --workspace=@azure/msal-common --workspace=@azure/msal-node --workspace=regression-tests/msal-node/client-credential",
     "start:build": "npm run build:all && npm start"
   },
   "author": "",

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node index.js | tee output.txt",
-    "build:package": "cd ../../.. && npm run build:all --workspace=lib/msal-node",
+    "build:package": "cd ../../.. && npm run build:all --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential",
     "start:build": "npm run build:package && npm start"
   },
   "author": "",

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node index.js | tee output.txt",
-    "build:all": "cd ../../../ && npm install --workspace=@azure/msal-common --workspace=@azure/msal-node --workspace=regression-tests/msal-node/client-credential",
+    "build:all": "cd ../../../ && npm install && npm run build --workspace=@azure/msal-common --workspace=@azure/msal-node",
     "start:build": "npm run build:all && npm start"
   },
   "author": "",

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -8,7 +8,7 @@
     "start": "node index.js | tee output.txt",
     "build:install": "cd ../../../ && npm install --workspace=@azure/msal-common --workspace=@azure/msal-node --workspace=regression-tests/msal-node/client-credential",
     "build:all": "cd ../../../ && npm run build --workspace=@azure/msal-common --workspace=@azure/msal-node",
-    "start:build": "npm run build:install && npm run build:all && npm start"
+    "start:build": "npm run build:install && npm run build:all && npm install && npm start"
   },
   "author": "",
   "license": "MIT",

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -6,8 +6,9 @@
   "type": "module",
   "scripts": {
     "start": "node index.js | tee output.txt",
-    "build:all": "cd ../../../ && npm install && npm run build --workspace=@azure/msal-common --workspace=@azure/msal-node",
-    "start:build": "npm run build:all && npm start"
+    "build:install": "cd ../../../ && npm install --workspace=@azure/msal-common --workspace=@azure/msal-node --workspace=regression-tests/msal-node/client-credential",
+    "build:all": "cd ../../../ && npm run build --workspace=@azure/msal-common --workspace=@azure/msal-node",
+    "start:build": "npm run build:install && npm run build:all && npm install && npm start"
   },
   "author": "",
   "license": "MIT",

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -8,7 +8,7 @@
     "start": "node index.js | tee output.txt",
     "build:install": "cd ../../../ && npm install --workspace=@azure/msal-common --workspace=@azure/msal-node --workspace=regression-tests/msal-node/client-credential",
     "build:all": "cd ../../../ && npm run build --workspace=@azure/msal-common --workspace=@azure/msal-node",
-    "start:build": "npm run build:install && npm run build:all && npm install && npm start"
+    "start:build": "npm run build:install && npm run build:all && npm start"
   },
   "author": "",
   "license": "MIT",

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -5,12 +5,14 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node index.js | tee output.txt",
+    "build:package": "cd ../../.. && npm run build:all --workspace=lib/msal-node",
+    "start:build": "npm run build:package && npm start"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@azure/msal-node": "^2.0.0",
+    "@azure/msal-node": "^3.0.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@azure/msal-node": "^3.0.0",
+    "@azure/msal-node": "^2.0.0",
     "benchmark": "^2.1.4"
   }
 }

--- a/regression-tests/msal-node/client-credential/package.json
+++ b/regression-tests/msal-node/client-credential/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node index.js | tee output.txt",
-    "build:package": "cd ../../.. && npm run build:all --workspace=lib/msal-common --workspace=lib/msal-node --workspace=regression-tests/msal-node/client-credential",
-    "start:build": "npm run build:package && npm start"
+    "build:all": "npm install --workspace=@azure/msal-common --workspace=@azure/msal-node --workspace=regression-tests/msal-node/client-credential",
+    "start:build": "npm run build:all && npm start"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
The regression test wasn't part of workspaces; It was never pointing to the local msal-node version and instead was pulling msal-node from npm.