### PR TITLE
localStorage encryption cookie set SameSite=None

### DIFF
--- a/change/@azure-msal-browser-1dde9e39-4138-48c1-b13d-55e395dd1c11.json
+++ b/change/@azure-msal-browser-1dde9e39-4138-48c1-b13d-55e395dd1c11.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Set SameSite=None on localStorage encryption cookie",
+  "comment": "Set SameSite=None on localStorage encryption cookie #7549",
   "packageName": "@azure/msal-browser",
   "email": "thomas.norling@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-1dde9e39-4138-48c1-b13d-55e395dd1c11.json
+++ b/change/@azure-msal-browser-1dde9e39-4138-48c1-b13d-55e395dd1c11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set SameSite=None on localStorage encryption cookie",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1782,7 +1782,7 @@ export type WrapperSKU = (typeof WrapperSKU)[keyof typeof WrapperSKU];
 // src/app/PublicClientNext.ts:89:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/LocalStorage.ts:269:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/LocalStorage.ts:327:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/LocalStorage.ts:358:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/LocalStorage.ts:356:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/Configuration.ts:246:5 - (ae-forgotten-export) The symbol "InternalAuthOptions" needs to be exported by the entry point index.d.ts
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1753,7 +1753,7 @@ const userCancelled = "user_cancelled";
 // Warning: (ae-missing-release-tag) "version" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const version = "4.0.2";
+export const version = "4.1.0";
 
 // Warning: (ae-missing-release-tag) "WrapperSKU" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "WrapperSKU" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1780,10 +1780,10 @@ export type WrapperSKU = (typeof WrapperSKU)[keyof typeof WrapperSKU];
 // src/app/PublicClientNext.ts:85:79 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/app/PublicClientNext.ts:88:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/app/PublicClientNext.ts:89:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/LocalStorage.ts:269:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/LocalStorage.ts:327:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/LocalStorage.ts:356:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/config/Configuration.ts:246:5 - (ae-forgotten-export) The symbol "InternalAuthOptions" needs to be exported by the entry point index.d.ts
+// src/cache/LocalStorage.ts:276:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/LocalStorage.ts:334:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/LocalStorage.ts:365:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/config/Configuration.ts:247:5 - (ae-forgotten-export) The symbol "InternalAuthOptions" needs to be exported by the entry point index.d.ts
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/navigation/NavigationClient.ts:36:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1753,7 +1753,7 @@ const userCancelled = "user_cancelled";
 // Warning: (ae-missing-release-tag) "version" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const version = "4.1.0";
+export const version = "4.0.2";
 
 // Warning: (ae-missing-release-tag) "WrapperSKU" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "WrapperSKU" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/lib/msal-browser/src/cache/CookieStorage.ts
+++ b/lib/msal-browser/src/cache/CookieStorage.ts
@@ -12,6 +12,13 @@ import { IWindowStorage } from "./IWindowStorage.js";
 // Cookie life calculation (hours * minutes * seconds * ms)
 const COOKIE_LIFE_MULTIPLIER = 24 * 60 * 60 * 1000;
 
+export const SameSiteOptions = {
+    Lax: "Lax",
+    None: "None",
+} as const;
+export type SameSiteOptions =
+    (typeof SameSiteOptions)[keyof typeof SameSiteOptions];
+
 export class CookieStorage implements IWindowStorage<string> {
     initialize(): Promise<void> {
         return Promise.resolve();
@@ -40,11 +47,12 @@ export class CookieStorage implements IWindowStorage<string> {
         key: string,
         value: string,
         cookieLifeDays?: number,
-        secure: boolean = true
+        secure: boolean = true,
+        sameSite: SameSiteOptions = SameSiteOptions.Lax
     ): void {
         let cookieStr = `${encodeURIComponent(key)}=${encodeURIComponent(
             value
-        )};path=/;SameSite=Lax;`;
+        )};path=/;SameSite=${sameSite};`;
 
         if (cookieLifeDays) {
             const expireTime = getCookieExpirationTime(cookieLifeDays);
@@ -52,6 +60,7 @@ export class CookieStorage implements IWindowStorage<string> {
         }
 
         if (secure) {
+            // SameSite None requires Secure flag
             cookieStr += "Secure;";
         }
 

--- a/lib/msal-browser/src/cache/CookieStorage.ts
+++ b/lib/msal-browser/src/cache/CookieStorage.ts
@@ -59,7 +59,7 @@ export class CookieStorage implements IWindowStorage<string> {
             cookieStr += `expires=${expireTime};`;
         }
 
-        if (secure) {
+        if (secure || sameSite === SameSiteOptions.None) {
             // SameSite None requires Secure flag
             cookieStr += "Secure;";
         }

--- a/lib/msal-browser/src/cache/LocalStorage.ts
+++ b/lib/msal-browser/src/cache/LocalStorage.ts
@@ -29,7 +29,7 @@ import {
     BrowserConfigurationAuthErrorCodes,
     createBrowserConfigurationAuthError,
 } from "../error/BrowserConfigurationAuthError.js";
-import { CookieStorage } from "./CookieStorage.js";
+import { CookieStorage, SameSiteOptions } from "./CookieStorage.js";
 import { IWindowStorage } from "./IWindowStorage.js";
 import { MemoryStorage } from "./MemoryStorage.js";
 import { getAccountKeys, getTokenKeys } from "./CacheHelpers.js";
@@ -143,7 +143,14 @@ export class LocalStorage implements IWindowStorage<string> {
                 id: id,
                 key: keyStr,
             };
-            cookies.setItem(ENCRYPTION_KEY, JSON.stringify(cookieData));
+
+            cookies.setItem(
+                ENCRYPTION_KEY,
+                JSON.stringify(cookieData),
+                0, // Expiration - 0 means cookie will be cleared at the end of the browser session
+                true, // Secure flag
+                SameSiteOptions.None // SameSite must be None to support iframed apps
+            );
         }
     }
 

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -136,7 +136,8 @@ export type CacheOptions = {
      */
     storeAuthStateInCookie?: boolean;
     /**
-     * If set, MSAL sets the "Secure" flag on cookies so they can only be sent over HTTPS. By default this flag is set to false.
+     * If set, MSAL sets the "Secure" flag on cookies so they can only be sent over HTTPS. By default this flag is set to true.
+     * @deprecated This option will be removed in a future major version and all cookies set will include the Secure attribute.
      */
     secureCookies?: boolean;
     /**

--- a/lib/msal-browser/test/cache/CookieStorage.spec.ts
+++ b/lib/msal-browser/test/cache/CookieStorage.spec.ts
@@ -6,6 +6,7 @@
 import {
     CookieStorage,
     getCookieExpirationTime,
+    SameSiteOptions,
 } from "../../src/cache/CookieStorage.js";
 
 const msalCacheKey = "msal.cookie.key";
@@ -35,6 +36,19 @@ describe("CookieStorage tests", () => {
         cookieStorage.setItem(msalCacheKey, cacheVal, 0, true);
         expect(document.cookie).toBe(`${msalCacheKey}=${cacheVal}`);
         expect(cookieSpy.mock.calls[0][0]).toContain("Secure");
+    });
+
+    it("sets SameSite=None", () => {
+        const cookieSpy = jest.spyOn(document, "cookie", "set");
+        cookieStorage.setItem(
+            msalCacheKey,
+            cacheVal,
+            0,
+            true,
+            SameSiteOptions.None
+        );
+        expect(document.cookie).toBe(`${msalCacheKey}=${cacheVal}`);
+        expect(cookieSpy.mock.calls[0][0]).toContain("SameSite=None");
     });
 
     it("sets expiration", () => {

--- a/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
+++ b/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
@@ -189,11 +189,15 @@ export class BrowserCacheUtils {
         numberOfTenants?: number;
     }): Promise<void> {
         if (this.storageType === "localStorage") {
-            let cookies;
-            await this.page.evaluate(() => {
-                cookies = document.cookie;
+            const cookies = await this.page.browserContext().cookies();
+            const matchingCookies = cookies.filter((cookie) => {
+                return cookie.name === "msal.cache.encryption" && 
+                cookie.domain === "localhost" &&
+                cookie.sameSite === "None" && 
+                cookie.secure === true && 
+                cookie.session === true
             });
-            expect(cookies).toContain("msal.cache.encryption");
+            expect(matchingCookies).toHaveLength(1);
         }
         
         const tokenStore = await this.getTokens();

--- a/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
+++ b/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
@@ -190,7 +190,7 @@ export class BrowserCacheUtils {
     }): Promise<void> {
         if (this.storageType === "localStorage") {
             let cookies;
-            this.page.evaluate(() => {
+            await this.page.evaluate(() => {
                 cookies = document.cookie;
             });
             expect(cookies).toContain("msal.cache.encryption");

--- a/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
+++ b/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
@@ -188,6 +188,14 @@ export class BrowserCacheUtils {
         refreshTokens?: number;
         numberOfTenants?: number;
     }): Promise<void> {
+        if (this.storageType === "localStorage") {
+            let cookies;
+            this.page.evaluate(() => {
+                cookies = document.cookie;
+            });
+            expect(cookies).toContain("msal.cache.encryption");
+        }
+        
         const tokenStore = await this.getTokens();
         const { scopes, idTokens, accessTokens, refreshTokens } = options;
         const numberOfTenants = options.numberOfTenants || 1;


### PR DESCRIPTION
Cookies aren't being set/can't be accessed in iframed apps without SameSite=None, breaking localStorage usage. This PR sets the needed attributes to support embedding