### PR TITLE
Rethrow MSAL AuthErrors in NAA flow

### DIFF
--- a/change/@azure-msal-browser-778148ae-3ca5-4743-9e15-088de442467a.json
+++ b/change/@azure-msal-browser-778148ae-3ca5-4743-9e15-088de442467a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Rethrow MSAL AuthErrors in NAA flow",
+  "packageName": "@azure/msal-browser",
+  "email": "chris@paslawski.me",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -19,6 +19,7 @@ import {
     OIDC_DEFAULT_SCOPES,
     BaseAuthRequest,
     AccountFilter,
+    AuthError,
 } from "@azure/msal-common/browser";
 import { ITokenCache } from "../cache/ITokenCache.js";
 import { BrowserConfiguration } from "../config/Configuration.js";
@@ -250,7 +251,9 @@ export class NestedAppAuthController implements IController {
 
             return result;
         } catch (e) {
-            const error = this.nestedAppAuthAdapter.fromBridgeError(e);
+            const error = e instanceof AuthError
+                ? e
+                : this.nestedAppAuthAdapter.fromBridgeError(e);
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_FAILURE,
                 InteractionType.Popup,
@@ -347,7 +350,9 @@ export class NestedAppAuthController implements IController {
             });
             return result;
         } catch (e) {
-            const error = this.nestedAppAuthAdapter.fromBridgeError(e);
+            const error = e instanceof AuthError
+                ? e
+                : this.nestedAppAuthAdapter.fromBridgeError(e);
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_FAILURE,
                 InteractionType.Silent,

--- a/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
+++ b/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
@@ -12,11 +12,14 @@ import {
     ICrypto,
     LogLevel,
     Logger,
+    createClientAuthError,
 } from "@azure/msal-common";
 import {
     AuthenticationScheme,
+    AuthError,
     BrowserCacheLocation,
     CacheLookupPolicy,
+    ClientAuthErrorCodes,
     Configuration,
     IPublicClientApplication,
     SilentRequest,
@@ -31,6 +34,7 @@ import {
 import { IBridgeProxy } from "../../src/naa/IBridgeProxy.js";
 import MockBridge from "../naa/MockBridge.js";
 import {
+    BRIDGE_ERROR_PERSISTENT_ERROR_CLIENT,
     INIT_CONTEXT_RESPONSE,
     NAA_APP_CONSTANTS,
     NAA_AUTHORITY,
@@ -312,6 +316,64 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
             );
             const response = await pca.acquireTokenSilent(testRequest);
             expect(response.accessToken).toEqual(testResponse.accessToken);
+        });
+
+        it("acquireTokenSilent handles NAA BridgeError and throws MSAL error", async () => {
+            mockBridge.addErrorResponse("GetToken", BRIDGE_ERROR_PERSISTENT_ERROR_CLIENT);
+
+            const testRequest = {
+                scopes: [NAA_SCOPE],
+                account: testAccount,
+                correlationId: NAA_CORRELATION_ID,
+            };
+
+            await expect(
+                () => pca.acquireTokenSilent(testRequest)
+            ).rejects.toBeInstanceOf(AuthError);
+        });
+
+        it("acquireTokenSilent rethrows MSAL errors", async () => {
+            mockBridge.addAuthResultResponse("GetToken", SILENT_TOKEN_RESPONSE);
+            jest.spyOn(
+                NestedAppAuthAdapter.prototype as any,
+                "fromNaaTokenResponse"
+            ).mockImplementation(() => {
+                throw createClientAuthError(ClientAuthErrorCodes.nullOrEmptyToken);
+            });
+
+            const testRequest = {
+                scopes: [NAA_SCOPE],
+                account: testAccount,
+                correlationId: NAA_CORRELATION_ID,
+            };
+
+            await expect(
+                () => pca.acquireTokenSilent(testRequest)
+            ).rejects.toMatchObject(
+                createClientAuthError(ClientAuthErrorCodes.nullOrEmptyToken)
+            );
+        });
+
+        it("acquireTokenSilent throws ClientAuthError if access token is empty", async () => {
+            mockBridge.addAuthResultResponse("GetToken", {
+                ...SILENT_TOKEN_RESPONSE,
+                token: {
+                    ...SILENT_TOKEN_RESPONSE.token,
+                    access_token: "",
+                }
+            });
+
+            const testRequest = {
+                scopes: [NAA_SCOPE],
+                account: testAccount,
+                correlationId: NAA_CORRELATION_ID,
+            };
+
+            await expect(
+                () => pca.acquireTokenSilent(testRequest)
+            ).rejects.toMatchObject(
+                createClientAuthError(ClientAuthErrorCodes.nullOrEmptyToken)
+            );
         });
 
         afterEach(() => {


### PR DESCRIPTION
NAA flow catches errors and runs them through `fromBridgeError`, but not all errors in the `try` come from the bridge. Notably, `fromNaaTokenResponse` can throw a `ClientAuthError` if a token is empty, and cache codepaths can throw some `CacheError`s.

This PR ensures that if an error is already an MSAL `AuthError`, it does not get passed through `fromBridgeError` again and converted into an `unknown_error`.