### PR TITLE
Fix exception when BroadcastChannel is not available in JS Runtime

### DIFF
--- a/change/@azure-msal-browser-18368ebe-3a6e-4580-b297-f0b3708fb0de.json
+++ b/change/@azure-msal-browser-18368ebe-3a6e-4580-b297-f0b3708fb0de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix exception when BroadcastChannel is not available in JS Runtime (#7569)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1781,8 +1781,8 @@ export type WrapperSKU = (typeof WrapperSKU)[keyof typeof WrapperSKU];
 // src/cache/LocalStorage.ts:354:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/LocalStorage.ts:385:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/Configuration.ts:247:5 - (ae-forgotten-export) The symbol "InternalAuthOptions" needs to be exported by the entry point index.d.ts
-// src/event/EventHandler.ts:109:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/event/EventHandler.ts:135:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/event/EventHandler.ts:113:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/event/EventHandler.ts:139:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/navigation/NavigationClient.ts:36:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-browser/src/event/EventHandler.ts
+++ b/lib/msal-browser/src/event/EventHandler.ts
@@ -23,12 +23,16 @@ export class EventHandler {
         [EventCallbackFunction, Array<EventType>]
     >;
     private logger: Logger;
-    private broadcastChannel: BroadcastChannel;
+    private broadcastChannel?: BroadcastChannel;
 
     constructor(logger?: Logger) {
         this.eventCallbacks = new Map();
         this.logger = logger || new Logger({});
-        this.broadcastChannel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+        if (typeof BroadcastChannel !== "undefined") {
+            this.broadcastChannel = new BroadcastChannel(
+                BROADCAST_CHANNEL_NAME
+            );
+        }
         this.invokeCrossTabCallbacks = this.invokeCrossTabCallbacks.bind(this);
     }
 
@@ -95,7 +99,7 @@ export class EventHandler {
             case EventType.ACCOUNT_REMOVED:
             case EventType.ACTIVE_ACCOUNT_CHANGED:
                 // Send event to other open tabs / MSAL instances on same domain
-                this.broadcastChannel.postMessage(message);
+                this.broadcastChannel?.postMessage(message);
                 break;
             default:
                 // Emit event to callbacks registered in this instance
@@ -143,7 +147,7 @@ export class EventHandler {
      * Listen for events broadcasted from other tabs/instances
      */
     subscribeCrossTab(): void {
-        this.broadcastChannel.addEventListener(
+        this.broadcastChannel?.addEventListener(
             "message",
             this.invokeCrossTabCallbacks
         );
@@ -153,7 +157,7 @@ export class EventHandler {
      * Unsubscribe from broadcast events
      */
     unsubscribeCrossTab(): void {
-        this.broadcastChannel.removeEventListener(
+        this.broadcastChannel?.removeEventListener(
             "message",
             this.invokeCrossTabCallbacks
         );

--- a/lib/msal-browser/test/naa/JSRuntime.spec.ts
+++ b/lib/msal-browser/test/naa/JSRuntime.spec.ts
@@ -12,7 +12,10 @@ import { PublicClientNext } from "../../src/app/PublicClientNext.js";
 import { TEST_CONFIG, TEST_TOKENS } from "../utils/StringConstants.js";
 import { randomFillSync } from "crypto";
 import { TokenClaims } from "@azure/msal-common";
-import { CacheLookupPolicy } from "../../src/index.js";
+import {
+    CacheLookupPolicy,
+    createNestablePublicClientApplication,
+} from "../../src/index.js";
 import { InteractionRequiredAuthError } from "@azure/msal-common";
 
 /**
@@ -39,6 +42,7 @@ describe("JS Runtime Nested App Auth", () => {
         // Remove global properties that can be reset after test that don't have full implementations in JS Runtime
         deleteGlobalProperty("crypto");
         deleteGlobalProperty("TextEncoder");
+        deleteGlobalProperty("BroadcastChannel");
         deleteGlobalProperty("btoa");
 
         // Add platform API Nested App Auth depends on
@@ -61,10 +65,9 @@ describe("JS Runtime Nested App Auth", () => {
             INIT_CONTEXT_RESPONSE
         );
 
-        const pca = await PublicClientNext.createPublicClientApplication({
+        const pca = await createNestablePublicClientApplication({
             auth: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
-                supportsNestedAppAuth: true,
             },
         });
 


### PR DESCRIPTION
There is an exception when calling createNestablePublicClientApplication in JS Runtime due to BroadcastChannel not being available in that environment. Unfortunately, the JS Runtime test missed this because BroadcastChannel is now available in node by default.