### PR TITLE
Upload screenshots on E2E test failure

### DIFF
--- a/.pipelines/1p-e2e.yml
+++ b/.pipelines/1p-e2e.yml
@@ -42,7 +42,7 @@ extends:
             policheck:
                 break: true
         stages:
-            - stage: e2e_tests
+            - stage: e2e_test
               displayName: "E2E Tests"
               variables:
                   Codeql.Enabled: true

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -50,7 +50,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: master
+          ref: upload-screenshots
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
     parameters:

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -50,7 +50,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: upload-screenshots
+          ref: master
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
     parameters:

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/client-capabilities/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/client-capabilities/test/browser.spec.ts
@@ -16,8 +16,9 @@ import {
     LabClient,
 } from "e2e-test-utils";
 import { JWT } from "jose";
+import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/client-capabilities");
 let sampleHomeUrl = "";
 let username = "";
 let accountPwd = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/client-capabilities/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/client-capabilities/test/browser.spec.ts
@@ -18,7 +18,7 @@ import {
 import { JWT } from "jose";
 import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/client-capabilities");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/client-capabilities");
 let sampleHomeUrl = "";
 let username = "";
 let accountPwd = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
@@ -27,7 +27,7 @@ import fs from "fs";
 import path from "path";
 import { RedirectRequest } from "../../../../../../lib/msal-browser/src";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserAAD");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/customizable-e2e-test/browserAAD");
 let sampleHomeUrl = "";
 
 describe("AAD-Prod Tests", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
@@ -24,9 +24,10 @@ import {
     request as aadTokenRequest,
 } from "../authConfigs/aadAuthConfig.json";
 import fs from "fs";
+import path from "path";
 import { RedirectRequest } from "../../../../../../lib/msal-browser/src";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/default tests`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserAAD");
 let sampleHomeUrl = "";
 
 describe("AAD-Prod Tests", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADMultiTenant.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADMultiTenant.spec.ts
@@ -28,7 +28,7 @@ import fs from "fs";
 import path from "path";
 import { GuestHomedIn } from "e2e-test-utils/src/Constants";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserAADMultiTenant");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/customizable-e2e-test/browserAADMultiTenant");
 let sampleHomeUrl = "";
 
 describe("AAD-Prod Tests", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADMultiTenant.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADMultiTenant.spec.ts
@@ -25,9 +25,10 @@ import {
     tenants as aadTenants,
 } from "../authConfigs/aadMultiTenantAuthConfig.json";
 import fs from "fs";
+import path from "path";
 import { GuestHomedIn } from "e2e-test-utils/src/Constants";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/multiTenantTests`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserAADMultiTenant");
 let sampleHomeUrl = "";
 
 describe("AAD-Prod Tests", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
@@ -27,7 +27,7 @@ import fs from "fs";
 import path from "path";
 import { RedirectRequest } from "../../../../../../lib/msal-browser/src";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserAADTenanted");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/customizable-e2e-test/browserAADTenanted");
 let sampleHomeUrl = "";
 
 describe("AAD-Prod Tests", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
@@ -24,9 +24,10 @@ import {
     request as aadTokenRequest,
 } from "../authConfigs/aadTenantedAuthConfig.json";
 import fs from "fs";
+import path from "path";
 import { RedirectRequest } from "../../../../../../lib/msal-browser/src";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/default tests`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserAADTenanted");
 let sampleHomeUrl = "";
 
 describe("AAD-Prod Tests", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserB2C.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserB2C.spec.ts
@@ -27,7 +27,7 @@ import {
 import fs from "fs";
 import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserB2C");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/customizable-e2e-test/browserB2C");
 let sampleHomeUrl = "";
 
 describe("B2C Tests", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserB2C.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserB2C.spec.ts
@@ -25,8 +25,9 @@ import {
     request as b2cTokenRequest,
 } from "../authConfigs/b2cAuthConfig.json";
 import fs from "fs";
+import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/default tests`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserB2C");
 let sampleHomeUrl = "";
 
 describe("B2C Tests", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserMemStorage.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserMemStorage.spec.ts
@@ -24,7 +24,7 @@ import {
 import fs from "fs";
 import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserMemStorage");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/customizable-e2e-test/browserMemStorage");
 
 async function verifyTokenStore(
     BrowserCache: BrowserCacheUtils,

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserMemStorage.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserMemStorage.spec.ts
@@ -22,8 +22,9 @@ import {
     request as memStorageTokenRequest,
 } from "../authConfigs/memStorageAuthConfig.json";
 import fs from "fs";
+import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/memStorage`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/browserMemStorage");
 
 async function verifyTokenStore(
     BrowserCache: BrowserCacheUtils,

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
@@ -25,7 +25,7 @@ import {
 import fs from "fs";
 import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/localStorage");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/customizable-e2e-test/localStorage");
 
 describe("LocalStorage Tests", function () {
     let username = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
@@ -23,8 +23,9 @@ import {
     request as aadTokenRequest,
 } from "../authConfigs/localStorageAuthConfig.json";
 import fs from "fs";
+import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/localStorageTests`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/customizable-e2e-test/localStorage");
 
 describe("LocalStorage Tests", function () {
     let username = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multipleResources/test/multiple_resources.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multipleResources/test/multiple_resources.spec.ts
@@ -16,7 +16,7 @@ import {
 } from "e2e-test-utils";
 import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/multiple_resources");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/multiple_resources");
 let username = "";
 let accountPwd = "";
 let sampleHomeUrl = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multipleResources/test/multiple_resources.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/multipleResources/test/multiple_resources.spec.ts
@@ -14,7 +14,9 @@ import {
     AppTypes,
     LabClient,
 } from "e2e-test-utils";
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
+import path from "path";
+
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/multiple_resources");
 let username = "";
 let accountPwd = "";
 let sampleHomeUrl = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/onPageLoad/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/onPageLoad/test/browser.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "e2e-test-utils";
 import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/onPageLoad");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/onPageLoad");
 let sampleHomeUrl = "";
 let username = "";
 let accountPwd = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/onPageLoad/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/onPageLoad/test/browser.spec.ts
@@ -13,8 +13,9 @@ import {
     AppTypes,
     LabClient,
 } from "e2e-test-utils";
+import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/onPageLoad");
 let sampleHomeUrl = "";
 let username = "";
 let accountPwd = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/test/browser.spec.ts
@@ -14,8 +14,9 @@ import {
     LabClient,
 } from "e2e-test-utils";
 import { JWK, JWT } from "jose";
+import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots`;
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/pop");
 let sampleHomeUrl = "";
 let username = "";
 let accountPwd = "";

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/test/browser.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/pop/test/browser.spec.ts
@@ -16,7 +16,7 @@ import {
 import { JWK, JWT } from "jose";
 import path from "path";
 
-const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../test/screenshots/pop");
+const SCREENSHOT_BASE_FOLDER_NAME = path.join(__dirname, "../../../test/screenshots/pop");
 let sampleHomeUrl = "";
 let username = "";
 let accountPwd = "";

--- a/samples/msal-node-samples/ElectronSystemBrowserTestApp/tests/electron-code-aad.spec.ts
+++ b/samples/msal-node-samples/ElectronSystemBrowserTestApp/tests/electron-code-aad.spec.ts
@@ -30,7 +30,7 @@ let browserPage: Page;
 let username: string;
 let accountPwd: string;
 
-const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/ElectronSystemBrowserTestApp/AAD`;
+const screenshotFolder = path.join(__dirname, "screenshots/ElectronSystemBrowserTestApp");
 
 const TEST_CACHE_LOCATION = `${__dirname}/../data/aad.cache.json`;
 

--- a/samples/msal-node-samples/auth-code-cli-app/test/auth-code-cli.spec.ts
+++ b/samples/msal-node-samples/auth-code-cli-app/test/auth-code-cli.spec.ts
@@ -10,7 +10,6 @@ import {
     setupCredentials,
     RETRY_TIMES,
     enterCredentials,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     NodeCacheTestUtils,
     LabClient,
@@ -18,6 +17,7 @@ import {
     AppTypes,
     AzureEnvironments,
 } from "e2e-test-utils";
+import path from "path";
 
 import { PublicClientApplication } from "@azure/msal-node";
 
@@ -40,7 +40,7 @@ describe("Auth Code CLI AAD Prod Tests", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/auth-code-cli/aad`;
+    const screenshotFolder = path.join(__dirname, "screenshots/auth-code-cli-app");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);

--- a/samples/msal-node-samples/auth-code/test/auth-code-aad-agc-confidential.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-aad-agc-confidential.spec.ts
@@ -9,7 +9,6 @@ import {
     createFolder,
     RETRY_TIMES,
     enterCredentials,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -17,6 +16,7 @@ import {
     getCredentials,
 } from "e2e-test-utils";
 import { ConfidentialClientApplication } from "@azure/msal-node";
+import path from "path";
 
 // Set test cache name/location
 const TEST_CACHE_LOCATION = `${__dirname}/data/aad-agc-confidential.cache.json`;
@@ -53,7 +53,7 @@ describe("Auth Code AAD AGC Confidential Tests", () => {
     let username: string;
     let password: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/auth-code/aad-agc-confidential`;
+    const screenshotFolder = path.join(__dirname, "screenshots/auth-code/aad-agc-confidential");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);

--- a/samples/msal-node-samples/auth-code/test/auth-code-aad-agc-public.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-aad-agc-public.spec.ts
@@ -9,7 +9,6 @@ import {
     createFolder,
     RETRY_TIMES,
     enterCredentials,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -17,6 +16,7 @@ import {
     getCredentials,
 } from "e2e-test-utils";
 import { PublicClientApplication } from "@azure/msal-node";
+import path from "path";
 
 // Set test cache name/location
 const TEST_CACHE_LOCATION = `${__dirname}/data/aad-agc-public.cache.json`;
@@ -52,7 +52,7 @@ describe("Auth Code AAD AGC Public Tests", () => {
     let username: string;
     let password: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/auth-code/aad-agc-public`;
+    const screenshotFolder = path.join(__dirname, "screenshots/auth-code/aad-agc-public");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);

--- a/samples/msal-node-samples/auth-code/test/auth-code-aad.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-aad.spec.ts
@@ -10,7 +10,6 @@ import {
     setupCredentials,
     RETRY_TIMES,
     enterCredentials,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -19,6 +18,7 @@ import {
     AppTypes,
     AzureEnvironments,
 } from "e2e-test-utils";
+import path from "path";
 
 import { PublicClientApplication } from "@azure/msal-node";
 
@@ -46,7 +46,7 @@ describe("Auth Code AAD Prod Tests", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/auth-code/aad`;
+    const screenshotFolder = path.join(__dirname, "screenshots/auth-code/aad");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);

--- a/samples/msal-node-samples/auth-code/test/auth-code-adfs.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-adfs.spec.ts
@@ -6,7 +6,6 @@ import {
     RETRY_TIMES,
     enterCredentialsADFS,
     enterCredentialsADFSWithConsent,
-    SCREENSHOT_BASE_FOLDER_NAME,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
     LabClient,
@@ -17,6 +16,7 @@ import {
     UserTypes,
 } from "e2e-test-utils";
 import { PublicClientApplication } from "@azure/msal-node";
+import path from "path";
 
 const TEST_CACHE_LOCATION = `${__dirname}/data/adfs.cache.json`;
 
@@ -37,7 +37,7 @@ describe("Auth Code ADFS 2019 Tests", () => {
     let page: puppeteer.Page;
     let port: string;
     let homeRoute: string;
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/auth-code/adfs`;
+    const screenshotFolder = path.join(__dirname, "screenshots/auth-code/adfs");
 
     beforeAll(async () => {
         // @ts-ignore

--- a/samples/msal-node-samples/auth-code/test/auth-code-b2c-aad.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-b2c-aad.spec.ts
@@ -10,7 +10,6 @@ import {
     setupCredentials,
     b2cAadPpeAccountEnterCredentials,
     RETRY_TIMES,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -19,6 +18,7 @@ import {
     AppTypes,
     AzureEnvironments,
 } from "e2e-test-utils";
+import path from "path";
 
 import { PublicClientApplication } from "@azure/msal-node";
 
@@ -46,7 +46,7 @@ describe.skip("Auth Code B2C Tests (aad account)", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/auth-code/b2c/aad-account`;
+    const screenshotFolder = path.join(__dirname, "screenshots/auth-code/b2c-aad");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);

--- a/samples/msal-node-samples/auth-code/test/auth-code-b2c-local.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-b2c-local.spec.ts
@@ -10,7 +10,6 @@ import {
     setupCredentials,
     b2cLocalAccountEnterCredentials,
     RETRY_TIMES,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -19,6 +18,7 @@ import {
     B2cProviders,
     UserTypes,
 } from "e2e-test-utils";
+import path from "path";
 
 import { PublicClientApplication } from "@azure/msal-node";
 
@@ -46,7 +46,7 @@ describe("Auth Code B2C Tests (local account)", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/auth-code/b2c/local-account`;
+    const screenshotFolder = path.join(__dirname, "screenshots/auth-code/b2c-local");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);

--- a/samples/msal-node-samples/auth-code/test/auth-code-b2c-msa.spec.ts
+++ b/samples/msal-node-samples/auth-code/test/auth-code-b2c-msa.spec.ts
@@ -10,7 +10,6 @@ import {
     setupCredentials,
     b2cMsaAccountEnterCredentials,
     RETRY_TIMES,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -19,6 +18,7 @@ import {
     B2cProviders,
     UserTypes,
 } from "e2e-test-utils";
+import path from "path";
 
 import { PublicClientApplication } from "@azure/msal-node";
 
@@ -46,7 +46,7 @@ describe("Auth Code B2C Tests (msa account)", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/auth-code/b2c/msa-account`;
+    const screenshotFolder = path.join(__dirname, "screenshots/auth-code/b2c-msa");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);

--- a/samples/msal-node-samples/b2c-user-flows/test/user-flows-local.spec.ts
+++ b/samples/msal-node-samples/b2c-user-flows/test/user-flows-local.spec.ts
@@ -10,7 +10,6 @@ import {
     setupCredentials,
     b2cLocalAccountEnterCredentials,
     RETRY_TIMES,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -19,6 +18,7 @@ import {
     B2cProviders,
     UserTypes,
 } from "e2e-test-utils";
+import path from "path";
 
 import { ConfidentialClientApplication } from "@azure/msal-node";
 
@@ -48,7 +48,7 @@ describe("B2C User Flow Tests", () => {
 
     let clientSecret: { secret: string; value: string };
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/user-flows/local-account`;
+    const screenshotFolder = path.join(__dirname, "screenshots/b2c-user-flows/local");
 
     beforeAll(async () => {
         createFolder(screenshotFolder);

--- a/samples/msal-node-samples/b2c-user-flows/test/user-flows-msa.spec.ts
+++ b/samples/msal-node-samples/b2c-user-flows/test/user-flows-msa.spec.ts
@@ -10,7 +10,6 @@ import {
     setupCredentials,
     b2cMsaAccountEnterCredentials,
     RETRY_TIMES,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -19,6 +18,7 @@ import {
     B2cProviders,
     UserTypes,
 } from "e2e-test-utils";
+import path from "path";
 
 import { ConfidentialClientApplication } from "@azure/msal-node";
 
@@ -48,7 +48,7 @@ describe("B2C User Flow Tests", () => {
 
     let clientSecret: { secret: string; value: string };
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/user-flows/msa-account`;
+    const screenshotFolder = path.join(__dirname, "screenshots/b2c-user-flows/msa");
 
     beforeAll(async () => {
         createFolder(screenshotFolder);

--- a/samples/msal-node-samples/device-code/test/device-code-aad-agc.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-aad-agc.spec.ts
@@ -11,13 +11,13 @@ import {
     approveRemoteConnect,
     enterCredentials,
     enterDeviceCode,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     NodeCacheTestUtils,
     getKeyVaultSecretClient,
     getCredentials,
 } from "e2e-test-utils";
 import { Configuration, PublicClientApplication } from "@azure/msal-node";
+import path from "path";
 
 // Set test cache name/location
 const TEST_CACHE_LOCATION = `${__dirname}/data/aad-agc.cache.json`;
@@ -53,13 +53,13 @@ describe("Device Code AAD AGC Tests", () => {
     let username: string;
     let password: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/device-code/aad-agc`;
+    const screenshotFolder = path.join(__dirname, "screenshots/device-code/aad-agc");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
         // @ts-ignore
         browser = await global.__BROWSER__;
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         const keyVaultSecretClient = await getKeyVaultSecretClient();
         [username, password] = await getCredentials(keyVaultSecretClient);

--- a/samples/msal-node-samples/device-code/test/device-code-aad.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-aad.spec.ts
@@ -12,7 +12,6 @@ import {
     approveRemoteConnect,
     enterCredentials,
     enterDeviceCode,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     NodeCacheTestUtils,
     LabClient,
@@ -21,6 +20,7 @@ import {
     AzureEnvironments,
 } from "e2e-test-utils";
 import { Configuration, PublicClientApplication } from "@azure/msal-node";
+import path from "path";
 
 // Set test cache name/location
 const TEST_CACHE_LOCATION = `${__dirname}/data/aad.cache.json`;
@@ -46,13 +46,13 @@ describe("Device Code AAD Prod Tests", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/device-code/aad`;
+    const screenshotFolder = path.join(__dirname, "screenshots/device-code/aad");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
         // @ts-ignore
         browser = await global.__BROWSER__;
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         // Configure Lab API Query Parameters
         const labApiParms: LabApiQueryParams = {

--- a/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
@@ -11,7 +11,6 @@ import {
     RETRY_TIMES,
     enterCredentialsADFSWithConsent,
     enterDeviceCode,
-    SCREENSHOT_BASE_FOLDER_NAME,
     validateCacheLocation,
     NodeCacheTestUtils,
     LabClient,
@@ -21,7 +20,7 @@ import {
     FederationProviders,
     UserTypes,
 } from "e2e-test-utils";
-
+import path from "path";
 import { Configuration, PublicClientApplication } from "@azure/msal-node";
 
 // Set test cache name/location
@@ -48,13 +47,13 @@ describe("Device Code ADFS 2019 Tests", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/device-code/adfs`;
+    const screenshotFolder = path.join(__dirname, "screenshots/device-code/adfs");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
         // @ts-ignore
         browser = await global.__BROWSER__;
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         // Configure Lab API Query Parameters
         const labApiParms: LabApiQueryParams = {

--- a/samples/msal-node-samples/on-behalf-of/test/obo-aad.spec.ts
+++ b/samples/msal-node-samples/on-behalf-of/test/obo-aad.spec.ts
@@ -8,8 +8,7 @@ import {
     Screenshot,
     createFolder,
     setupCredentials,
-    enterCredentials,
-    SCREENSHOT_BASE_FOLDER_NAME,
+    enterCredentials
     validateCacheLocation,
     SAMPLE_HOME_URL,
     NodeCacheTestUtils,
@@ -60,7 +59,7 @@ describe("OBO AAD Tests", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/obo/aad`;
+    const screenshotFolder = path.join(__dirname, "screenshots/on-behalf-of")
 
     beforeAll(async () => {
         await validateCacheLocation(WEB_APP_TEST_CACHE_LOCATION);

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-aad-agc-confidential.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-aad-agc-confidential.spec.ts
@@ -11,7 +11,6 @@ import {
     RETRY_TIMES,
     clickSignIn,
     enterCredentials,
-    SCREENSHOT_BASE_FOLDER_NAME,
     SAMPLE_HOME_URL,
     SUCCESSFUL_GRAPH_CALL_ID,
     SUCCESSFUL_GET_ALL_ACCOUNTS_ID,
@@ -22,6 +21,7 @@ import {
     getCredentials,
 } from "e2e-test-utils";
 import { ConfidentialClientApplication, TokenCache } from "@azure/msal-node";
+import path from "path";
 
 // Set test cache name/location
 const TEST_CACHE_LOCATION = `${__dirname}/data/aad-agc-confidential.cache.json`;
@@ -63,7 +63,7 @@ describe("Silent Flow AAD AGC Confidential Tests", () => {
     let username: string;
     let password: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/silent-flow/aad-agc-confidential`;
+    const screenshotFolder = path.join(__dirname, "screenshots/silent-flow/aad-agc-confidential");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
@@ -72,7 +72,7 @@ describe("Silent Flow AAD AGC Confidential Tests", () => {
         port = 3005;
         homeRoute = `${SAMPLE_HOME_URL}:${port}`;
 
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         const keyVaultSecretClient = await getKeyVaultSecretClient();
         [username, password] = await getCredentials(keyVaultSecretClient);

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-aad-agc-public.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-aad-agc-public.spec.ts
@@ -11,7 +11,6 @@ import {
     RETRY_TIMES,
     clickSignIn,
     enterCredentials,
-    SCREENSHOT_BASE_FOLDER_NAME,
     SAMPLE_HOME_URL,
     SUCCESSFUL_GRAPH_CALL_ID,
     SUCCESSFUL_GET_ALL_ACCOUNTS_ID,
@@ -22,6 +21,7 @@ import {
     getCredentials,
 } from "e2e-test-utils";
 import { PublicClientApplication, TokenCache } from "@azure/msal-node";
+import path from "path";
 
 // Set test cache name/location
 const TEST_CACHE_LOCATION = `${__dirname}/data/aad-agc-public.cache.json`;
@@ -62,7 +62,7 @@ describe("Silent Flow AAD AGC Public Tests", () => {
     let username: string;
     let password: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/silent-flow/aad-agc-public`;
+    const screenshotFolder = path.join(__dirname, "screenshots/silent-flow/aad-agc-public");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
@@ -71,7 +71,7 @@ describe("Silent Flow AAD AGC Public Tests", () => {
         port = 3004;
         homeRoute = `${SAMPLE_HOME_URL}:${port}`;
 
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         const keyVaultSecretClient = await getKeyVaultSecretClient();
         [username, password] = await getCredentials(keyVaultSecretClient);

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-aad.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-aad.spec.ts
@@ -12,7 +12,6 @@ import {
     RETRY_TIMES,
     clickSignIn,
     enterCredentials,
-    SCREENSHOT_BASE_FOLDER_NAME,
     SAMPLE_HOME_URL,
     SUCCESSFUL_GRAPH_CALL_ID,
     SUCCESSFUL_GET_ALL_ACCOUNTS_ID,
@@ -24,7 +23,7 @@ import {
     AppTypes,
     AzureEnvironments,
 } from "e2e-test-utils";
-
+import path from "path";
 import { PublicClientApplication, TokenCache } from "@azure/msal-node";
 
 // Set test cache name/location
@@ -55,7 +54,7 @@ describe("Silent Flow AAD Prod Tests", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/silent-flow/aad`;
+    const screenshotFolder = path.join(__dirname, "screenshots/silent-flow/aad");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
@@ -64,7 +63,7 @@ describe("Silent Flow AAD Prod Tests", () => {
         port = 3002;
         homeRoute = `${SAMPLE_HOME_URL}:${port}`;
 
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         const labApiParms: LabApiQueryParams = {
             azureEnvironment: AzureEnvironments.CLOUD,

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-adfs.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-adfs.spec.ts
@@ -12,7 +12,6 @@ import {
     RETRY_TIMES,
     clickSignIn,
     enterCredentialsADFS,
-    SCREENSHOT_BASE_FOLDER_NAME,
     SAMPLE_HOME_URL,
     SUCCESSFUL_GRAPH_CALL_ID,
     SUCCESSFUL_GET_ALL_ACCOUNTS_ID,
@@ -26,7 +25,7 @@ import {
     FederationProviders,
     UserTypes,
 } from "e2e-test-utils";
-
+import path from "path";
 import { PublicClientApplication, TokenCache } from "@azure/msal-node";
 
 // Set test cache name/location
@@ -57,7 +56,7 @@ describe("Silent Flow ADFS 2019 Tests", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/silent-flow/adfs`;
+    const screenshotFolder = path.join(__dirname, "screenshots/silent-flow/adfs");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
@@ -66,7 +65,7 @@ describe("Silent Flow ADFS 2019 Tests", () => {
         port = 3003;
         homeRoute = `${SAMPLE_HOME_URL}:${port}`;
 
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
         const labApiParms: LabApiQueryParams = {
             azureEnvironment: AzureEnvironments.CLOUD,
             appType: AppTypes.CLOUD,

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-b2c-aad.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-b2c-aad.spec.ts
@@ -12,7 +12,6 @@ import {
     ONE_SECOND_IN_MS,
     RETRY_TIMES,
     clickSignIn,
-    SCREENSHOT_BASE_FOLDER_NAME,
     SAMPLE_HOME_URL,
     SUCCESSFUL_GET_ALL_ACCOUNTS_ID,
     validateCacheLocation,
@@ -22,7 +21,7 @@ import {
     AppTypes,
     AzureEnvironments,
 } from "e2e-test-utils";
-
+import path from "path";
 import { PublicClientApplication, TokenCache } from "@azure/msal-node";
 
 // Set test cache name/location
@@ -53,7 +52,7 @@ describe.skip("Silent Flow B2C Tests (aad account)", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/silent-flow/b2c/aad-account`;
+    const screenshotFolder = path.join(__dirname, "screenshots/silent-flow/b2c-aad");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
@@ -64,7 +63,7 @@ describe.skip("Silent Flow B2C Tests (aad account)", () => {
         port = 3006;
         homeRoute = `${SAMPLE_HOME_URL}:${port}`;
 
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         const labApiParms: LabApiQueryParams = {
             azureEnvironment: AzureEnvironments.CLOUD,

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-b2c-local.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-b2c-local.spec.ts
@@ -12,7 +12,6 @@ import {
     ONE_SECOND_IN_MS,
     RETRY_TIMES,
     clickSignIn,
-    SCREENSHOT_BASE_FOLDER_NAME,
     SAMPLE_HOME_URL,
     SUCCESSFUL_GET_ALL_ACCOUNTS_ID,
     validateCacheLocation,
@@ -23,6 +22,7 @@ import {
     UserTypes,
 } from "e2e-test-utils";
 import { PublicClientApplication, TokenCache } from "@azure/msal-node";
+import path from "path";
 
 // Set test cache name/location
 const TEST_CACHE_LOCATION = `${__dirname}/data/b2c-local.cache.json`;
@@ -52,7 +52,7 @@ describe("Silent Flow B2C Tests", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/silent-flow/b2c/local-account`;
+    const screenshotFolder = path.join(__dirname, "screenshots/silent-flow/b2c-local");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
@@ -63,7 +63,7 @@ describe("Silent Flow B2C Tests", () => {
         port = 3007;
         homeRoute = `${SAMPLE_HOME_URL}:${port}`;
 
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         const labApiParms: LabApiQueryParams = {
             userType: UserTypes.B2C,

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-b2c-msa.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-b2c-msa.spec.ts
@@ -12,7 +12,6 @@ import {
     ONE_SECOND_IN_MS,
     RETRY_TIMES,
     clickSignIn,
-    SCREENSHOT_BASE_FOLDER_NAME,
     SAMPLE_HOME_URL,
     SUCCESSFUL_GET_ALL_ACCOUNTS_ID,
     validateCacheLocation,
@@ -22,7 +21,7 @@ import {
     B2cProviders,
     UserTypes,
 } from "e2e-test-utils";
-
+import path from "path";
 import { PublicClientApplication, TokenCache } from "@azure/msal-node";
 
 // Set test cache name/location
@@ -53,7 +52,7 @@ describe("Silent Flow B2C Tests (msa account)", () => {
     let username: string;
     let accountPwd: string;
 
-    const screenshotFolder = `${SCREENSHOT_BASE_FOLDER_NAME}/silent-flow/b2c/msa-account`;
+    const screenshotFolder = path.join(__dirname, "screenshots/silent-flow/b2c-msa");
 
     beforeAll(async () => {
         await validateCacheLocation(TEST_CACHE_LOCATION);
@@ -64,7 +63,7 @@ describe("Silent Flow B2C Tests (msa account)", () => {
         port = 3008;
         homeRoute = `${SAMPLE_HOME_URL}:${port}`;
 
-        createFolder(SCREENSHOT_BASE_FOLDER_NAME);
+        createFolder(screenshotFolder);
 
         const labApiParms: LabApiQueryParams = {
             userType: UserTypes.B2C,


### PR DESCRIPTION
Update screenshot folder locations for E2E tests so they will be uploaded to pipeline artifacts on failure