### PR TITLE
Reworked Managed Identity Retry Policy to be per-request

### DIFF
--- a/change/@azure-msal-node-4a430a9c-a11a-4acd-bb18-f8eaa2dcdba6.json
+++ b/change/@azure-msal-node-4a430a9c-a11a-4acd-bb18-f8eaa2dcdba6.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Reworked Managed Identity Retry Policy to be per-request, which is based on the Managed Identity source.",
+  "comment": "Reworked Managed Identity Retry Policy to be per-request, which is based on the Managed Identity source. #7603",
   "packageName": "@azure/msal-node",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-node-4a430a9c-a11a-4acd-bb18-f8eaa2dcdba6.json
+++ b/change/@azure-msal-node-4a430a9c-a11a-4acd-bb18-f8eaa2dcdba6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Reworked Managed Identity Retry Policy to be per-request, which is based on the Managed Identity source.",
+  "packageName": "@azure/msal-node",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/src/client/ManagedIdentityApplication.ts
+++ b/lib/msal-node/src/client/ManagedIdentityApplication.ts
@@ -111,7 +111,8 @@ export class ManagedIdentityApplication {
             this.logger,
             ManagedIdentityApplication.nodeStorage as NodeStorage,
             this.networkClient,
-            this.cryptoProvider
+            this.cryptoProvider,
+            this.config.disableInternalRetries
         );
     }
 

--- a/lib/msal-node/src/client/ManagedIdentityClient.ts
+++ b/lib/msal-node/src/client/ManagedIdentityClient.ts
@@ -35,6 +35,7 @@ export class ManagedIdentityClient {
     private nodeStorage: NodeStorage;
     private networkClient: INetworkModule;
     private cryptoProvider: CryptoProvider;
+    private disableInternalRetries: boolean;
 
     private static identitySource?: BaseManagedIdentitySource;
     public static sourceName?: ManagedIdentitySourceNames;
@@ -43,12 +44,14 @@ export class ManagedIdentityClient {
         logger: Logger,
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
-        cryptoProvider: CryptoProvider
+        cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean
     ) {
         this.logger = logger;
         this.nodeStorage = nodeStorage;
         this.networkClient = networkClient;
         this.cryptoProvider = cryptoProvider;
+        this.disableInternalRetries = disableInternalRetries;
     }
 
     public async sendManagedIdentityTokenRequest(
@@ -64,6 +67,7 @@ export class ManagedIdentityClient {
                     this.nodeStorage,
                     this.networkClient,
                     this.cryptoProvider,
+                    this.disableInternalRetries,
                     managedIdentityId
                 );
         }
@@ -126,6 +130,7 @@ export class ManagedIdentityClient {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         managedIdentityId: ManagedIdentityId
     ): BaseManagedIdentitySource {
         const source =
@@ -134,25 +139,29 @@ export class ManagedIdentityClient {
                 nodeStorage,
                 networkClient,
                 cryptoProvider,
+                disableInternalRetries,
                 managedIdentityId
             ) ||
             AppService.tryCreate(
                 logger,
                 nodeStorage,
                 networkClient,
-                cryptoProvider
+                cryptoProvider,
+                disableInternalRetries
             ) ||
             MachineLearning.tryCreate(
                 logger,
                 nodeStorage,
                 networkClient,
-                cryptoProvider
+                cryptoProvider,
+                disableInternalRetries
             ) ||
             CloudShell.tryCreate(
                 logger,
                 nodeStorage,
                 networkClient,
                 cryptoProvider,
+                disableInternalRetries,
                 managedIdentityId
             ) ||
             AzureArc.tryCreate(
@@ -160,9 +169,16 @@ export class ManagedIdentityClient {
                 nodeStorage,
                 networkClient,
                 cryptoProvider,
+                disableInternalRetries,
                 managedIdentityId
             ) ||
-            Imds.tryCreate(logger, nodeStorage, networkClient, cryptoProvider);
+            Imds.tryCreate(
+                logger,
+                nodeStorage,
+                networkClient,
+                cryptoProvider,
+                disableInternalRetries
+            );
         if (!source) {
             throw createManagedIdentityError(
                 ManagedIdentityErrorCodes.unableToCreateSource

--- a/lib/msal-node/src/client/ManagedIdentitySources/AppService.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/AppService.ts
@@ -13,11 +13,16 @@ import {
     ManagedIdentityEnvironmentVariableNames,
     ManagedIdentitySourceNames,
     ManagedIdentityIdType,
+    MANAGED_IDENTITY_MAX_RETRIES,
+    MANAGED_IDENTITY_RETRY_DELAY,
+    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
 } from "../../utils/Constants.js";
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import { ManagedIdentityRequestParameters } from "../../config/ManagedIdentityRequestParameters.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import { NodeStorage } from "../../cache/NodeStorage.js";
+import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
+import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 // MSI Constants. Docs for MSI are available here https://docs.microsoft.com/azure/app-service/overview-managed-identity
 const APP_SERVICE_MSI_API_VERSION: string = "2019-08-01";
@@ -34,10 +39,24 @@ export class AppService extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         identityEndpoint: string,
         identityHeader: string
     ) {
-        super(logger, nodeStorage, networkClient, cryptoProvider);
+        let networkClientHelper: INetworkModule = networkClient;
+        if (!disableInternalRetries) {
+            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
+                MANAGED_IDENTITY_MAX_RETRIES,
+                MANAGED_IDENTITY_RETRY_DELAY,
+                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
+            );
+            networkClientHelper = new HttpClientWithRetries(
+                networkClient,
+                linearRetryPolicy
+            );
+        }
+
+        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
 
         this.identityEndpoint = identityEndpoint;
         this.identityHeader = identityHeader;
@@ -60,7 +79,8 @@ export class AppService extends BaseManagedIdentitySource {
         logger: Logger,
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
-        cryptoProvider: CryptoProvider
+        cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean
     ): AppService | null {
         const [identityEndpoint, identityHeader] =
             AppService.getEnvironmentVariables();
@@ -90,6 +110,7 @@ export class AppService extends BaseManagedIdentitySource {
             nodeStorage,
             networkClient,
             cryptoProvider,
+            disableInternalRetries,
             identityEndpoint,
             identityHeader
         );

--- a/lib/msal-node/src/client/ManagedIdentitySources/AppService.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/AppService.ts
@@ -13,16 +13,11 @@ import {
     ManagedIdentityEnvironmentVariableNames,
     ManagedIdentitySourceNames,
     ManagedIdentityIdType,
-    MANAGED_IDENTITY_MAX_RETRIES,
-    MANAGED_IDENTITY_RETRY_DELAY,
-    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
 } from "../../utils/Constants.js";
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import { ManagedIdentityRequestParameters } from "../../config/ManagedIdentityRequestParameters.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import { NodeStorage } from "../../cache/NodeStorage.js";
-import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
-import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 // MSI Constants. Docs for MSI are available here https://docs.microsoft.com/azure/app-service/overview-managed-identity
 const APP_SERVICE_MSI_API_VERSION: string = "2019-08-01";
@@ -43,20 +38,13 @@ export class AppService extends BaseManagedIdentitySource {
         identityEndpoint: string,
         identityHeader: string
     ) {
-        let networkClientHelper: INetworkModule = networkClient;
-        if (!disableInternalRetries) {
-            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
-                MANAGED_IDENTITY_MAX_RETRIES,
-                MANAGED_IDENTITY_RETRY_DELAY,
-                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
-            );
-            networkClientHelper = new HttpClientWithRetries(
-                networkClient,
-                linearRetryPolicy
-            );
-        }
-
-        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
+        super(
+            logger,
+            nodeStorage,
+            networkClient,
+            cryptoProvider,
+            disableInternalRetries
+        );
 
         this.identityEndpoint = identityEndpoint;
         this.identityHeader = identityHeader;

--- a/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
@@ -26,6 +26,9 @@ import {
     AUTHORIZATION_HEADER_NAME,
     AZURE_ARC_SECRET_FILE_MAX_SIZE_BYTES,
     HttpMethod,
+    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
+    MANAGED_IDENTITY_MAX_RETRIES,
+    MANAGED_IDENTITY_RETRY_DELAY,
     METADATA_HEADER_NAME,
     ManagedIdentityEnvironmentVariableNames,
     ManagedIdentityIdType,
@@ -42,6 +45,8 @@ import {
 import { ManagedIdentityTokenResponse } from "../../response/ManagedIdentityTokenResponse.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import path from "path";
+import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
+import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 export const ARC_API_VERSION: string = "2019-11-01";
 export const DEFAULT_AZURE_ARC_IDENTITY_ENDPOINT: string =
@@ -74,9 +79,23 @@ export class AzureArc extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         identityEndpoint: string
     ) {
-        super(logger, nodeStorage, networkClient, cryptoProvider);
+        let networkClientHelper: INetworkModule = networkClient;
+        if (!disableInternalRetries) {
+            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
+                MANAGED_IDENTITY_MAX_RETRIES,
+                MANAGED_IDENTITY_RETRY_DELAY,
+                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
+            );
+            networkClientHelper = new HttpClientWithRetries(
+                networkClient,
+                linearRetryPolicy
+            );
+        }
+
+        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
 
         this.identityEndpoint = identityEndpoint;
     }
@@ -122,6 +141,7 @@ export class AzureArc extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         managedIdentityId: ManagedIdentityId
     ): AzureArc | null {
         const [identityEndpoint, imdsEndpoint] =
@@ -181,6 +201,7 @@ export class AzureArc extends BaseManagedIdentitySource {
             nodeStorage,
             networkClient,
             cryptoProvider,
+            disableInternalRetries,
             identityEndpoint
         );
     }

--- a/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
@@ -26,9 +26,6 @@ import {
     AUTHORIZATION_HEADER_NAME,
     AZURE_ARC_SECRET_FILE_MAX_SIZE_BYTES,
     HttpMethod,
-    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
-    MANAGED_IDENTITY_MAX_RETRIES,
-    MANAGED_IDENTITY_RETRY_DELAY,
     METADATA_HEADER_NAME,
     ManagedIdentityEnvironmentVariableNames,
     ManagedIdentityIdType,
@@ -45,8 +42,6 @@ import {
 import { ManagedIdentityTokenResponse } from "../../response/ManagedIdentityTokenResponse.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import path from "path";
-import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
-import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 export const ARC_API_VERSION: string = "2019-11-01";
 export const DEFAULT_AZURE_ARC_IDENTITY_ENDPOINT: string =
@@ -82,20 +77,13 @@ export class AzureArc extends BaseManagedIdentitySource {
         disableInternalRetries: boolean,
         identityEndpoint: string
     ) {
-        let networkClientHelper: INetworkModule = networkClient;
-        if (!disableInternalRetries) {
-            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
-                MANAGED_IDENTITY_MAX_RETRIES,
-                MANAGED_IDENTITY_RETRY_DELAY,
-                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
-            );
-            networkClientHelper = new HttpClientWithRetries(
-                networkClient,
-                linearRetryPolicy
-            );
-        }
-
-        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
+        super(
+            logger,
+            nodeStorage,
+            networkClient,
+            cryptoProvider,
+            disableInternalRetries
+        );
 
         this.identityEndpoint = identityEndpoint;
     }

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -32,6 +32,7 @@ import {
     createManagedIdentityError,
 } from "../../error/ManagedIdentityError.js";
 import { isIso8601 } from "../../utils/TimeUtils.js";
+import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 /**
  * Managed Identity User Assigned Id Query Parameter Names
@@ -50,17 +51,20 @@ export abstract class BaseManagedIdentitySource {
     private nodeStorage: NodeStorage;
     private networkClient: INetworkModule;
     private cryptoProvider: CryptoProvider;
+    private disableInternalRetries: boolean;
 
     constructor(
         logger: Logger,
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
-        cryptoProvider: CryptoProvider
+        cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean
     ) {
         this.logger = logger;
         this.nodeStorage = nodeStorage;
         this.networkClient = networkClient;
         this.cryptoProvider = cryptoProvider;
+        this.disableInternalRetries = disableInternalRetries;
     }
 
     abstract createRequest(
@@ -151,20 +155,32 @@ export abstract class BaseManagedIdentitySource {
                 networkRequest.computeParametersBodyString();
         }
 
+        /**
+         * Initializes the network client helper based on the retry policy configuration.
+         * If internal retries are disabled, it uses the provided network client directly.
+         * Otherwise, it wraps the network client with an HTTP client that supports retries.
+         */
+        const networkClientHelper: INetworkModule = this.disableInternalRetries
+            ? this.networkClient
+            : new HttpClientWithRetries(
+                  this.networkClient,
+                  networkRequest.retryPolicy
+              );
+
         const reqTimestamp = TimeUtils.nowSeconds();
         let response: NetworkResponse<ManagedIdentityTokenResponse>;
         try {
             // Sources that send POST requests: Cloud Shell
             if (networkRequest.httpMethod === HttpMethod.POST) {
                 response =
-                    await this.networkClient.sendPostRequestAsync<ManagedIdentityTokenResponse>(
+                    await networkClientHelper.sendPostRequestAsync<ManagedIdentityTokenResponse>(
                         networkRequest.computeUri(),
                         networkRequestOptions
                     );
                 // Sources that send GET requests: App Service, Azure Arc, IMDS, Service Fabric
             } else {
                 response =
-                    await this.networkClient.sendGetRequestAsync<ManagedIdentityTokenResponse>(
+                    await networkClientHelper.sendGetRequestAsync<ManagedIdentityTokenResponse>(
                         networkRequest.computeUri(),
                         networkRequestOptions
                     );
@@ -189,7 +205,7 @@ export abstract class BaseManagedIdentitySource {
         const serverTokenResponse: ServerAuthorizationTokenResponse =
             await this.getServerTokenResponseAsync(
                 response,
-                this.networkClient,
+                networkClientHelper,
                 networkRequest,
                 networkRequestOptions
             );

--- a/lib/msal-node/src/client/ManagedIdentitySources/CloudShell.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/CloudShell.ts
@@ -10,6 +10,9 @@ import { NodeStorage } from "../../cache/NodeStorage.js";
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import {
     HttpMethod,
+    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
+    MANAGED_IDENTITY_MAX_RETRIES,
+    MANAGED_IDENTITY_RETRY_DELAY,
     METADATA_HEADER_NAME,
     ManagedIdentityEnvironmentVariableNames,
     ManagedIdentityIdType,
@@ -21,6 +24,8 @@ import {
     createManagedIdentityError,
 } from "../../error/ManagedIdentityError.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
+import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
+import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 /**
  * Original source of code: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/src/CloudShellManagedIdentitySource.cs
@@ -33,9 +38,23 @@ export class CloudShell extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         msiEndpoint: string
     ) {
-        super(logger, nodeStorage, networkClient, cryptoProvider);
+        let networkClientHelper: INetworkModule = networkClient;
+        if (!disableInternalRetries) {
+            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
+                MANAGED_IDENTITY_MAX_RETRIES,
+                MANAGED_IDENTITY_RETRY_DELAY,
+                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
+            );
+            networkClientHelper = new HttpClientWithRetries(
+                networkClient,
+                linearRetryPolicy
+            );
+        }
+
+        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
 
         this.msiEndpoint = msiEndpoint;
     }
@@ -52,6 +71,7 @@ export class CloudShell extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         managedIdentityId: ManagedIdentityId
     ): CloudShell | null {
         const [msiEndpoint] = CloudShell.getEnvironmentVariables();
@@ -89,6 +109,7 @@ export class CloudShell extends BaseManagedIdentitySource {
             nodeStorage,
             networkClient,
             cryptoProvider,
+            disableInternalRetries,
             msiEndpoint
         );
     }

--- a/lib/msal-node/src/client/ManagedIdentitySources/CloudShell.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/CloudShell.ts
@@ -10,9 +10,6 @@ import { NodeStorage } from "../../cache/NodeStorage.js";
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import {
     HttpMethod,
-    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
-    MANAGED_IDENTITY_MAX_RETRIES,
-    MANAGED_IDENTITY_RETRY_DELAY,
     METADATA_HEADER_NAME,
     ManagedIdentityEnvironmentVariableNames,
     ManagedIdentityIdType,
@@ -24,8 +21,6 @@ import {
     createManagedIdentityError,
 } from "../../error/ManagedIdentityError.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
-import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
-import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 /**
  * Original source of code: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/src/CloudShellManagedIdentitySource.cs
@@ -41,20 +36,13 @@ export class CloudShell extends BaseManagedIdentitySource {
         disableInternalRetries: boolean,
         msiEndpoint: string
     ) {
-        let networkClientHelper: INetworkModule = networkClient;
-        if (!disableInternalRetries) {
-            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
-                MANAGED_IDENTITY_MAX_RETRIES,
-                MANAGED_IDENTITY_RETRY_DELAY,
-                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
-            );
-            networkClientHelper = new HttpClientWithRetries(
-                networkClient,
-                linearRetryPolicy
-            );
-        }
-
-        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
+        super(
+            logger,
+            nodeStorage,
+            networkClient,
+            cryptoProvider,
+            disableInternalRetries
+        );
 
         this.msiEndpoint = msiEndpoint;
     }

--- a/lib/msal-node/src/client/ManagedIdentitySources/Imds.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/Imds.ts
@@ -131,11 +131,6 @@ export class Imds extends BaseManagedIdentitySource {
 
         // bodyParameters calculated in BaseManagedIdentity.acquireTokenWithManagedIdentity
 
-        /*
-         * TODO: define IMDS.
-         * request.retryPolicy = ...
-         */
-
         return request;
     }
 }

--- a/lib/msal-node/src/client/ManagedIdentitySources/Imds.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/Imds.ts
@@ -11,9 +11,6 @@ import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import {
     API_VERSION_QUERY_PARAMETER_NAME,
     HttpMethod,
-    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
-    MANAGED_IDENTITY_MAX_RETRIES,
-    MANAGED_IDENTITY_RETRY_DELAY,
     METADATA_HEADER_NAME,
     ManagedIdentityEnvironmentVariableNames,
     ManagedIdentityIdType,
@@ -21,8 +18,6 @@ import {
     RESOURCE_BODY_OR_QUERY_PARAMETER_NAME,
 } from "../../utils/Constants.js";
 import { NodeStorage } from "../../cache/NodeStorage.js";
-import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
-import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
 
 // IMDS constants. Docs for IMDS are available here https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
 const IMDS_TOKEN_PATH: string = "/metadata/identity/oauth2/token";
@@ -42,20 +37,13 @@ export class Imds extends BaseManagedIdentitySource {
         disableInternalRetries: boolean,
         identityEndpoint: string
     ) {
-        let networkClientHelper: INetworkModule = networkClient;
-        if (!disableInternalRetries) {
-            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
-                MANAGED_IDENTITY_MAX_RETRIES,
-                MANAGED_IDENTITY_RETRY_DELAY,
-                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
-            );
-            networkClientHelper = new HttpClientWithRetries(
-                networkClient,
-                linearRetryPolicy
-            );
-        }
-
-        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
+        super(
+            logger,
+            nodeStorage,
+            networkClient,
+            cryptoProvider,
+            disableInternalRetries
+        );
 
         this.identityEndpoint = identityEndpoint;
     }
@@ -142,6 +130,11 @@ export class Imds extends BaseManagedIdentitySource {
         }
 
         // bodyParameters calculated in BaseManagedIdentity.acquireTokenWithManagedIdentity
+
+        /*
+         * TODO: define IMDS.
+         * request.retryPolicy = ...
+         */
 
         return request;
     }

--- a/lib/msal-node/src/client/ManagedIdentitySources/Imds.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/Imds.ts
@@ -11,6 +11,9 @@ import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import {
     API_VERSION_QUERY_PARAMETER_NAME,
     HttpMethod,
+    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
+    MANAGED_IDENTITY_MAX_RETRIES,
+    MANAGED_IDENTITY_RETRY_DELAY,
     METADATA_HEADER_NAME,
     ManagedIdentityEnvironmentVariableNames,
     ManagedIdentityIdType,
@@ -18,6 +21,8 @@ import {
     RESOURCE_BODY_OR_QUERY_PARAMETER_NAME,
 } from "../../utils/Constants.js";
 import { NodeStorage } from "../../cache/NodeStorage.js";
+import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
+import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
 
 // IMDS constants. Docs for IMDS are available here https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
 const IMDS_TOKEN_PATH: string = "/metadata/identity/oauth2/token";
@@ -34,9 +39,23 @@ export class Imds extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         identityEndpoint: string
     ) {
-        super(logger, nodeStorage, networkClient, cryptoProvider);
+        let networkClientHelper: INetworkModule = networkClient;
+        if (!disableInternalRetries) {
+            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
+                MANAGED_IDENTITY_MAX_RETRIES,
+                MANAGED_IDENTITY_RETRY_DELAY,
+                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
+            );
+            networkClientHelper = new HttpClientWithRetries(
+                networkClient,
+                linearRetryPolicy
+            );
+        }
+
+        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
 
         this.identityEndpoint = identityEndpoint;
     }
@@ -45,7 +64,8 @@ export class Imds extends BaseManagedIdentitySource {
         logger: Logger,
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
-        cryptoProvider: CryptoProvider
+        cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean
     ): Imds {
         let validatedIdentityEndpoint: string;
 
@@ -88,6 +108,7 @@ export class Imds extends BaseManagedIdentitySource {
             nodeStorage,
             networkClient,
             cryptoProvider,
+            disableInternalRetries,
             validatedIdentityEndpoint
         );
     }

--- a/lib/msal-node/src/client/ManagedIdentitySources/MachineLearning.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/MachineLearning.ts
@@ -14,11 +14,16 @@ import {
     ManagedIdentityIdType,
     METADATA_HEADER_NAME,
     ML_AND_SF_SECRET_HEADER_NAME,
+    MANAGED_IDENTITY_MAX_RETRIES,
+    MANAGED_IDENTITY_RETRY_DELAY,
+    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
 } from "../../utils/Constants.js";
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import { ManagedIdentityRequestParameters } from "../../config/ManagedIdentityRequestParameters.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import { NodeStorage } from "../../cache/NodeStorage.js";
+import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
+import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 const MACHINE_LEARNING_MSI_API_VERSION: string = "2017-09-01";
 
@@ -31,10 +36,24 @@ export class MachineLearning extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         msiEndpoint: string,
         secret: string
     ) {
-        super(logger, nodeStorage, networkClient, cryptoProvider);
+        let networkClientHelper: INetworkModule = networkClient;
+        if (!disableInternalRetries) {
+            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
+                MANAGED_IDENTITY_MAX_RETRIES,
+                MANAGED_IDENTITY_RETRY_DELAY,
+                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
+            );
+            networkClientHelper = new HttpClientWithRetries(
+                networkClient,
+                linearRetryPolicy
+            );
+        }
+
+        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
 
         this.msiEndpoint = msiEndpoint;
         this.secret = secret;
@@ -54,7 +73,8 @@ export class MachineLearning extends BaseManagedIdentitySource {
         logger: Logger,
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
-        cryptoProvider: CryptoProvider
+        cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean
     ): MachineLearning | null {
         const [msiEndpoint, secret] = MachineLearning.getEnvironmentVariables();
 
@@ -83,6 +103,7 @@ export class MachineLearning extends BaseManagedIdentitySource {
             nodeStorage,
             networkClient,
             cryptoProvider,
+            disableInternalRetries,
             msiEndpoint,
             secret
         );

--- a/lib/msal-node/src/client/ManagedIdentitySources/MachineLearning.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/MachineLearning.ts
@@ -14,16 +14,11 @@ import {
     ManagedIdentityIdType,
     METADATA_HEADER_NAME,
     ML_AND_SF_SECRET_HEADER_NAME,
-    MANAGED_IDENTITY_MAX_RETRIES,
-    MANAGED_IDENTITY_RETRY_DELAY,
-    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
 } from "../../utils/Constants.js";
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import { ManagedIdentityRequestParameters } from "../../config/ManagedIdentityRequestParameters.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import { NodeStorage } from "../../cache/NodeStorage.js";
-import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
-import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 const MACHINE_LEARNING_MSI_API_VERSION: string = "2017-09-01";
 
@@ -40,20 +35,13 @@ export class MachineLearning extends BaseManagedIdentitySource {
         msiEndpoint: string,
         secret: string
     ) {
-        let networkClientHelper: INetworkModule = networkClient;
-        if (!disableInternalRetries) {
-            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
-                MANAGED_IDENTITY_MAX_RETRIES,
-                MANAGED_IDENTITY_RETRY_DELAY,
-                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
-            );
-            networkClientHelper = new HttpClientWithRetries(
-                networkClient,
-                linearRetryPolicy
-            );
-        }
-
-        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
+        super(
+            logger,
+            nodeStorage,
+            networkClient,
+            cryptoProvider,
+            disableInternalRetries
+        );
 
         this.msiEndpoint = msiEndpoint;
         this.secret = secret;

--- a/lib/msal-node/src/client/ManagedIdentitySources/ServiceFabric.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/ServiceFabric.ts
@@ -17,12 +17,7 @@ import {
     ManagedIdentitySourceNames,
     RESOURCE_BODY_OR_QUERY_PARAMETER_NAME,
     ML_AND_SF_SECRET_HEADER_NAME,
-    MANAGED_IDENTITY_MAX_RETRIES,
-    MANAGED_IDENTITY_RETRY_DELAY,
-    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
 } from "../../utils/Constants.js";
-import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
-import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 // MSI Constants. Docs for MSI are available here https://docs.microsoft.com/azure/app-service/overview-managed-identity
 const SERVICE_FABRIC_MSI_API_VERSION: string = "2019-07-01-preview";
@@ -43,20 +38,13 @@ export class ServiceFabric extends BaseManagedIdentitySource {
         identityEndpoint: string,
         identityHeader: string
     ) {
-        let networkClientHelper: INetworkModule = networkClient;
-        if (!disableInternalRetries) {
-            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
-                MANAGED_IDENTITY_MAX_RETRIES,
-                MANAGED_IDENTITY_RETRY_DELAY,
-                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
-            );
-            networkClientHelper = new HttpClientWithRetries(
-                networkClient,
-                linearRetryPolicy
-            );
-        }
-
-        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
+        super(
+            logger,
+            nodeStorage,
+            networkClient,
+            cryptoProvider,
+            disableInternalRetries
+        );
 
         this.identityEndpoint = identityEndpoint;
         this.identityHeader = identityHeader;

--- a/lib/msal-node/src/client/ManagedIdentitySources/ServiceFabric.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/ServiceFabric.ts
@@ -17,7 +17,12 @@ import {
     ManagedIdentitySourceNames,
     RESOURCE_BODY_OR_QUERY_PARAMETER_NAME,
     ML_AND_SF_SECRET_HEADER_NAME,
+    MANAGED_IDENTITY_MAX_RETRIES,
+    MANAGED_IDENTITY_RETRY_DELAY,
+    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
 } from "../../utils/Constants.js";
+import { LinearRetryPolicy } from "../../retry/LinearRetryPolicy.js";
+import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
 
 // MSI Constants. Docs for MSI are available here https://docs.microsoft.com/azure/app-service/overview-managed-identity
 const SERVICE_FABRIC_MSI_API_VERSION: string = "2019-07-01-preview";
@@ -34,10 +39,24 @@ export class ServiceFabric extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         identityEndpoint: string,
         identityHeader: string
     ) {
-        super(logger, nodeStorage, networkClient, cryptoProvider);
+        let networkClientHelper: INetworkModule = networkClient;
+        if (!disableInternalRetries) {
+            const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
+                MANAGED_IDENTITY_MAX_RETRIES,
+                MANAGED_IDENTITY_RETRY_DELAY,
+                MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
+            );
+            networkClientHelper = new HttpClientWithRetries(
+                networkClient,
+                linearRetryPolicy
+            );
+        }
+
+        super(logger, nodeStorage, networkClientHelper, cryptoProvider);
 
         this.identityEndpoint = identityEndpoint;
         this.identityHeader = identityHeader;
@@ -66,6 +85,7 @@ export class ServiceFabric extends BaseManagedIdentitySource {
         nodeStorage: NodeStorage,
         networkClient: INetworkModule,
         cryptoProvider: CryptoProvider,
+        disableInternalRetries: boolean,
         managedIdentityId: ManagedIdentityId
     ): ServiceFabric | null {
         const [identityEndpoint, identityHeader, identityServerThumbprint] =
@@ -107,6 +127,7 @@ export class ServiceFabric extends BaseManagedIdentitySource {
             nodeStorage,
             networkClient,
             cryptoProvider,
+            disableInternalRetries,
             identityEndpoint,
             identityHeader
         );

--- a/lib/msal-node/src/config/Configuration.ts
+++ b/lib/msal-node/src/config/Configuration.ts
@@ -20,13 +20,6 @@ import { HttpClient } from "../network/HttpClient.js";
 import http from "http";
 import https from "https";
 import { ManagedIdentityId } from "./ManagedIdentityId.js";
-import {
-    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
-    MANAGED_IDENTITY_MAX_RETRIES,
-    MANAGED_IDENTITY_RETRY_DELAY,
-} from "../utils/Constants.js";
-import { LinearRetryPolicy } from "../retry/LinearRetryPolicy.js";
-import { HttpClientWithRetries } from "../network/HttpClientWithRetries.js";
 import { NodeAuthError } from "../error/NodeAuthError.js";
 
 /**
@@ -251,6 +244,7 @@ export type ManagedIdentityNodeConfiguration = {
     system: Required<
         Pick<NodeSystemOptions, "loggerOptions" | "networkClient">
     >;
+    disableInternalRetries: boolean;
 };
 
 export function buildManagedIdentityConfiguration({
@@ -276,24 +270,12 @@ export function buildManagedIdentityConfiguration({
         );
     }
 
-    // wrap the network client with a retry policy if the developer has not disabled the option to do so
-    if (!system?.disableInternalRetries) {
-        const linearRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
-            MANAGED_IDENTITY_MAX_RETRIES,
-            MANAGED_IDENTITY_RETRY_DELAY,
-            MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
-        );
-        networkClient = new HttpClientWithRetries(
-            networkClient,
-            linearRetryPolicy
-        );
-    }
-
     return {
         managedIdentityId: managedIdentityId,
         system: {
             loggerOptions,
             networkClient,
         },
+        disableInternalRetries: system?.disableInternalRetries || false,
     };
 }

--- a/lib/msal-node/src/config/ManagedIdentityRequestParameters.ts
+++ b/lib/msal-node/src/config/ManagedIdentityRequestParameters.ts
@@ -4,7 +4,14 @@
  */
 
 import { RequestParameterBuilder, UrlString } from "@azure/msal-common/node";
-import { HttpMethod } from "../utils/Constants.js";
+import {
+    HttpMethod,
+    MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON,
+    MANAGED_IDENTITY_MAX_RETRIES,
+    MANAGED_IDENTITY_RETRY_DELAY,
+    RetryPolicies,
+} from "../utils/Constants.js";
+import { LinearRetryPolicy } from "../retry/LinearRetryPolicy.js";
 
 export class ManagedIdentityRequestParameters {
     private _baseEndpoint: string;
@@ -12,13 +19,25 @@ export class ManagedIdentityRequestParameters {
     public headers: Record<string, string>;
     public bodyParameters: Record<string, string>;
     public queryParameters: Record<string, string>;
+    public retryPolicy: RetryPolicies;
 
-    constructor(httpMethod: HttpMethod, endpoint: string) {
+    constructor(
+        httpMethod: HttpMethod,
+        endpoint: string,
+        retryPolicy?: RetryPolicies
+    ) {
         this.httpMethod = httpMethod;
         this._baseEndpoint = endpoint;
         this.headers = {} as Record<string, string>;
         this.bodyParameters = {} as Record<string, string>;
         this.queryParameters = {} as Record<string, string>;
+
+        const defaultRetryPolicy: LinearRetryPolicy = new LinearRetryPolicy(
+            MANAGED_IDENTITY_MAX_RETRIES,
+            MANAGED_IDENTITY_RETRY_DELAY,
+            MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON
+        );
+        this.retryPolicy = retryPolicy || defaultRetryPolicy;
     }
 
     public computeUri(): string {

--- a/lib/msal-node/src/utils/Constants.ts
+++ b/lib/msal-node/src/utils/Constants.ts
@@ -4,6 +4,7 @@
  */
 
 import { HttpStatus } from "@azure/msal-common/node";
+import { LinearRetryPolicy } from "../retry/LinearRetryPolicy.js";
 
 // MSI Constants. Docs for MSI are available here https://docs.microsoft.com/azure/app-service/overview-managed-identity
 export const AUTHORIZATION_HEADER_NAME: string = "Authorization";
@@ -178,3 +179,9 @@ export const MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON = [
     HttpStatus.SERVICE_UNAVAILABLE,
     HttpStatus.GATEWAY_TIMEOUT,
 ];
+
+/**
+ * Retry Policy Types
+ * TODO: add IMDS retry policy
+ */
+export type RetryPolicies = LinearRetryPolicy; // | ImdsRetryPolicy;

--- a/lib/msal-node/src/utils/Constants.ts
+++ b/lib/msal-node/src/utils/Constants.ts
@@ -182,6 +182,5 @@ export const MANAGED_IDENTITY_HTTP_STATUS_CODES_TO_RETRY_ON = [
 
 /**
  * Retry Policy Types
- * TODO: add IMDS retry policy
  */
-export type RetryPolicies = LinearRetryPolicy; // | ImdsRetryPolicy;
+export type RetryPolicies = LinearRetryPolicy;


### PR DESCRIPTION
The same retry policy was previously being used for all Managed Identity sources and requests.

The retry policy will now be based on the Managed Identity source, and therefore will be per-request.

Future Work: Create an IMDS retry policy to address [this bug](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4998).