### PR TITLE
Update Error handling and log pii info

### DIFF
--- a/lib/msal-custom-auth/src/CustomAuthConstants.ts
+++ b/lib/msal-custom-auth/src/CustomAuthConstants.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Constants } from "@azure/msal-common";
+import { Constants } from "@azure/msal-browser";
 import { version } from "./packageMetadata.js";
 
 export const GrantType = {

--- a/lib/msal-custom-auth/src/controller/CustomAuthStandardController.ts
+++ b/lib/msal-custom-auth/src/controller/CustomAuthStandardController.ts
@@ -139,7 +139,7 @@ export class CustomAuthStandardController extends StandardController implements 
 
             throw new NoCachedAccountFoundError(correlationId);
         } catch (error) {
-            this.logger.error(`An error occurred during getting current account: ${error}`);
+            this.logger.errorPii(`An error occurred during getting current account: ${error}`);
 
             return GetAccountResult.createWithError(error);
         }
@@ -244,7 +244,7 @@ export class CustomAuthStandardController extends StandardController implements 
 
             throw new UnexpectedError("Unknow sign-in result type");
         } catch (error) {
-            this.logger.error(`An error occurred during starting sign-in: ${error}`);
+            this.logger.errorPii(`An error occurred during starting sign-in: ${error}`);
 
             return SignInResult.createWithError(error);
         }
@@ -323,7 +323,7 @@ export class CustomAuthStandardController extends StandardController implements 
 
             throw new UnexpectedError("Unknown sign-up result type");
         } catch (error) {
-            this.logger.error(`An error occurred during starting sign-up: ${error}`);
+            this.logger.errorPii(`An error occurred during starting sign-up: ${error}`);
 
             return SignUpResult.createWithError(error);
         }
@@ -368,7 +368,7 @@ export class CustomAuthStandardController extends StandardController implements 
                 ),
             );
         } catch (error) {
-            this.logger.error(`An error occurred during starting reset-password: ${error}`);
+            this.logger.errorPii(`An error occurred during starting reset-password: ${error}`);
 
             return ResetPasswordStartResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/controller/CustomAuthStandardController.ts
+++ b/lib/msal-custom-auth/src/controller/CustomAuthStandardController.ts
@@ -116,15 +116,14 @@ export class CustomAuthStandardController extends StandardController implements 
      * @returns - A promise that resolves to GetAccountResult
      */
     getCurrentAccount(accountRetrievalInputs?: AccountRetrievalInputs): GetAccountResult {
+        const correlationId = this.getCorrelationId(accountRetrievalInputs);
         try {
-            const correlationId = this.getCorrelationId(accountRetrievalInputs);
-
-            this.logger.info("Getting current account data.");
+            this.logger.info("Getting current account data.", correlationId);
 
             const account = this.cacheClient.getCurrentAccount(correlationId);
 
             if (account) {
-                this.logger.info("Account data found.");
+                this.logger.info("Account data found.", correlationId);
 
                 return new GetAccountResult(
                     new CustomAuthAccountData(
@@ -139,7 +138,7 @@ export class CustomAuthStandardController extends StandardController implements 
 
             throw new NoCachedAccountFoundError(correlationId);
         } catch (error) {
-            this.logger.errorPii(`An error occurred during getting current account: ${error}`);
+            this.logger.errorPii(`An error occurred during getting current account: ${error}`, correlationId);
 
             return GetAccountResult.createWithError(error);
         }
@@ -151,10 +150,10 @@ export class CustomAuthStandardController extends StandardController implements 
      * @returns The result of the operation.
      */
     async signIn(signInInputs: SignInInputs): Promise<SignInResult> {
-        try {
-            ArgumentValidator.ensureArgumentIsNotNullOrUndefined("signInInputs", signInInputs);
+        const correlationId = this.getCorrelationId(signInInputs);
 
-            const correlationId = this.getCorrelationId(signInInputs);
+        try {
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined("signInInputs", signInInputs, correlationId);
 
             this.ensureUsernameValid("signInInputs.username", signInInputs.username, correlationId);
             this.ensureUserNotSignedIn(correlationId);
@@ -168,15 +167,18 @@ export class CustomAuthStandardController extends StandardController implements 
                 password: signInInputs.password,
             };
 
-            this.logger.info(`Starting sign-in flow ${!!signInInputs.password ? "with" : "without"} password.`);
+            this.logger.info(
+                `Starting sign-in flow ${!!signInInputs.password ? "with" : "without"} password.`,
+                correlationId,
+            );
 
             const startResult = await this.signInClient.start(signInStartParams);
 
-            this.logger.info("Sign-in flow started.");
+            this.logger.info("Sign-in flow started.", correlationId);
 
             if (startResult instanceof SignInCodeSendResult) {
                 // require code
-                this.logger.info("Code required for sign-in.");
+                this.logger.info("Code required for sign-in.", correlationId);
 
                 return new SignInResult(
                     new SignInCodeRequired(
@@ -193,10 +195,13 @@ export class CustomAuthStandardController extends StandardController implements 
                 );
             } else if (startResult instanceof SignInPasswordRequiredResult) {
                 // require password
-                this.logger.info("Password required for sign-in.");
+                this.logger.info("Password required for sign-in.", correlationId);
 
                 if (!signInInputs.password) {
-                    this.logger.info("Password required but not provided. Returning password required state.");
+                    this.logger.info(
+                        "Password required but not provided. Returning password required state.",
+                        correlationId,
+                    );
 
                     return new SignInResult(
                         new SignInPasswordRequired(
@@ -212,7 +217,7 @@ export class CustomAuthStandardController extends StandardController implements 
                     );
                 }
 
-                this.logger.info("Submitting password for sign-in.");
+                this.logger.info("Submitting password for sign-in.", correlationId);
 
                 // if the password is provided, then try to get token silently.
                 const submitPasswordParams: SignInSubmitPasswordParams = {
@@ -227,7 +232,7 @@ export class CustomAuthStandardController extends StandardController implements 
 
                 const completedResult = await this.signInClient.submitPassword(submitPasswordParams);
 
-                this.logger.info("Sign-in flow completed.");
+                this.logger.info("Sign-in flow completed.", correlationId);
 
                 const accountInfo = new CustomAuthAccountData(
                     completedResult.authenticationResult.account,
@@ -240,11 +245,11 @@ export class CustomAuthStandardController extends StandardController implements 
                 return new SignInResult(new SignInCompleted(), accountInfo);
             }
 
-            this.logger.error("Unexpected sign-in result type. Returning error.");
+            this.logger.error("Unexpected sign-in result type. Returning error.", correlationId);
 
-            throw new UnexpectedError("Unknow sign-in result type");
+            throw new UnexpectedError("Unknow sign-in result type", correlationId);
         } catch (error) {
-            this.logger.errorPii(`An error occurred during starting sign-in: ${error}`);
+            this.logger.errorPii(`An error occurred during starting sign-in: ${error}`, correlationId);
 
             return SignInResult.createWithError(error);
         }
@@ -256,10 +261,10 @@ export class CustomAuthStandardController extends StandardController implements 
      * @returns The result of the operation
      */
     async signUp(signUpInputs: SignUpInputs): Promise<SignUpResult> {
-        try {
-            ArgumentValidator.ensureArgumentIsNotNullOrUndefined("signUpInputs", signUpInputs);
+        const correlationId = this.getCorrelationId(signUpInputs);
 
-            const correlationId = this.getCorrelationId(signUpInputs);
+        try {
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined("signUpInputs", signUpInputs, correlationId);
 
             this.ensureUsernameValid("signUpInputs.username", signUpInputs.username, correlationId);
             this.ensureUserNotSignedIn(correlationId);
@@ -270,6 +275,7 @@ export class CustomAuthStandardController extends StandardController implements 
                         ? ` with ${!!signUpInputs.attributes ? "password and attributes" : "password"}`
                         : ""
                 }.`,
+                correlationId,
             );
 
             const startResult = await this.signUpClient.start({
@@ -281,11 +287,11 @@ export class CustomAuthStandardController extends StandardController implements 
                 attributes: signUpInputs.attributes?.toRecord(),
             });
 
-            this.logger.info("Sign-up flow started.");
+            this.logger.info("Sign-up flow started.", correlationId);
 
             if (startResult instanceof SignUpCodeRequiredResult) {
                 // Code required
-                this.logger.info("Code required for sign-up.");
+                this.logger.info("Code required for sign-up.", correlationId);
 
                 return new SignUpResult(
                     new SignUpCodeRequired(
@@ -303,7 +309,7 @@ export class CustomAuthStandardController extends StandardController implements 
                 );
             } else if (startResult instanceof SignUpPasswordRequiredResult) {
                 // Password required
-                this.logger.info("Password required for sign-up.");
+                this.logger.info("Password required for sign-up.", correlationId);
 
                 return new SignUpResult(
                     new SignUpPasswordRequired(
@@ -319,11 +325,11 @@ export class CustomAuthStandardController extends StandardController implements 
                 );
             }
 
-            this.logger.error("Unexpected sign-up result type. Returning error.");
+            this.logger.error("Unexpected sign-up result type. Returning error.", correlationId);
 
-            throw new UnexpectedError("Unknown sign-up result type");
+            throw new UnexpectedError("Unknown sign-up result type", correlationId);
         } catch (error) {
-            this.logger.errorPii(`An error occurred during starting sign-up: ${error}`);
+            this.logger.errorPii(`An error occurred during starting sign-up: ${error}`, correlationId);
 
             return SignUpResult.createWithError(error);
         }
@@ -335,15 +341,19 @@ export class CustomAuthStandardController extends StandardController implements 
      * @returns The result of the operation.
      */
     async resetPassword(resetPasswordInputs: ResetPasswordInputs): Promise<ResetPasswordStartResult> {
-        try {
-            ArgumentValidator.ensureArgumentIsNotNullOrUndefined("resetPasswordInputs", resetPasswordInputs);
+        const correlationId = this.getCorrelationId(resetPasswordInputs);
 
-            const correlationId = this.getCorrelationId(resetPasswordInputs);
+        try {
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                "resetPasswordInputs",
+                resetPasswordInputs,
+                correlationId,
+            );
 
             this.ensureUsernameValid("resetPasswordInputs.username", resetPasswordInputs.username, correlationId);
             this.ensureUserNotSignedIn(correlationId);
 
-            this.logger.info("Starting password-reset flow.");
+            this.logger.info("Starting password-reset flow.", correlationId);
 
             const startResult = await this.resetPasswordClient.start({
                 clientId: this.customAuthConfig.auth.clientId,
@@ -352,7 +362,7 @@ export class CustomAuthStandardController extends StandardController implements 
                 username: resetPasswordInputs.username,
             });
 
-            this.logger.info("Password-reset flow started.");
+            this.logger.info("Password-reset flow started.", correlationId);
 
             return new ResetPasswordStartResult(
                 new ResetPasswordCodeRequired(
@@ -368,7 +378,7 @@ export class CustomAuthStandardController extends StandardController implements 
                 ),
             );
         } catch (error) {
-            this.logger.errorPii(`An error occurred during starting reset-password: ${error}`);
+            this.logger.errorPii(`An error occurred during starting reset-password: ${error}`, correlationId);
 
             return ResetPasswordStartResult.createWithError(error);
         }
@@ -385,7 +395,7 @@ export class CustomAuthStandardController extends StandardController implements 
 
     private ensureUsernameValid(usernameParamName: string, username: string, correlationId: string): void {
         if (!this.isUsernameValid(username)) {
-            this.logger.error("Invalid username is provided.");
+            this.logger.error("Invalid username is provided.", correlationId);
 
             throw new InvalidArgumentError(usernameParamName, correlationId);
         }
@@ -397,7 +407,7 @@ export class CustomAuthStandardController extends StandardController implements 
         });
 
         if (account && !!account.data) {
-            this.logger.error("User has already signed in.");
+            this.logger.error("User has already signed in.", correlationId);
 
             throw new UserAlreadySignedInError(correlationId);
         }

--- a/lib/msal-custom-auth/src/core/auth_flow/AuthFlowResultBase.ts
+++ b/lib/msal-custom-auth/src/core/auth_flow/AuthFlowResultBase.ts
@@ -44,9 +44,7 @@ export abstract class AuthFlowResultBase<
         if (error instanceof CustomAuthError) {
             return error;
         } else if (error instanceof AuthError) {
-            const errorCode = error.errorCode;
-            const errorMessage = error.subError ? `${error.errorMessage} - ${error.subError}` : error.errorMessage;
-            return new MsalCustomAuthError(errorCode, errorMessage, error.correlationId);
+            return new MsalCustomAuthError(error.errorCode, error.errorMessage, error.subError, error.correlationId);
         } else {
             return new UnexpectedError(error);
         }

--- a/lib/msal-custom-auth/src/core/auth_flow/AuthFlowResultBase.ts
+++ b/lib/msal-custom-auth/src/core/auth_flow/AuthFlowResultBase.ts
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { AuthError } from "@azure/msal-browser";
 import { CustomAuthError } from "../error/CustomAuthError.js";
+import { MsalCustomAuthError } from "../error/MsalCustomAuthError.js";
 import { UnexpectedError } from "../error/UnexpectedError.js";
 import { AuthFlowErrorBase } from "./AuthFlowErrorBase.js";
 import { AuthFlowStateBase } from "./AuthFlowStateBase.js";
@@ -39,6 +41,14 @@ export abstract class AuthFlowResultBase<
      * @returns The auth error.
      */
     protected static createErrorData(error: unknown): CustomAuthError {
-        return error instanceof CustomAuthError ? error : new UnexpectedError(error);
+        if (error instanceof CustomAuthError) {
+            return error;
+        } else if (error instanceof AuthError) {
+            const errorCode = error.errorCode;
+            const errorMessage = error.subError ? `${error.errorMessage} - ${error.subError}` : error.errorMessage;
+            return new MsalCustomAuthError(errorCode, errorMessage, error.correlationId);
+        } else {
+            return new UnexpectedError(error);
+        }
     }
 }

--- a/lib/msal-custom-auth/src/core/auth_flow/AuthFlowStateHandlerBase.ts
+++ b/lib/msal-custom-auth/src/core/auth_flow/AuthFlowStateHandlerBase.ts
@@ -23,12 +23,12 @@ export abstract class AuthFlowStateHandlerBase {
         protected continuationToken?: string,
     ) {
         ArgumentValidator.ensureArgumentIsNotEmptyString("correlationId", correlationId);
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("logger", logger);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("logger", logger, correlationId);
     }
 
     protected ensureCodeIsValid(code: string, codeLength: number): void {
         if (!code || code.length !== codeLength) {
-            this.logger.error("Code parameter is not provided or invalid for authentication flow.");
+            this.logger.error("Code parameter is not provided or invalid for authentication flow.", this.correlationId);
 
             throw new InvalidArgumentError("code", this.correlationId);
         }
@@ -36,7 +36,7 @@ export abstract class AuthFlowStateHandlerBase {
 
     protected ensurePasswordIsNotEmpty(password: string): void {
         if (!password) {
-            this.logger.error("Password parameter is not provided for authentication flow.");
+            this.logger.error("Password parameter is not provided for authentication flow.", this.correlationId);
 
             throw new InvalidArgumentError("password", this.correlationId);
         }

--- a/lib/msal-custom-auth/src/core/error/MsalCustomAuthError.ts
+++ b/lib/msal-custom-auth/src/core/error/MsalCustomAuthError.ts
@@ -1,11 +1,7 @@
 import { CustomAuthError } from "./CustomAuthError.js";
 
 export class MsalCustomAuthError extends CustomAuthError {
-    constructor(
-        public error: string,
-        public errorDescription?: string,
-        public correlationId?: string,
-    ) {
+    constructor(error: string, errorDescription?: string, correlationId?: string) {
         super(error, errorDescription, correlationId);
 
         Object.setPrototypeOf(this, MsalCustomAuthError.prototype);

--- a/lib/msal-custom-auth/src/core/error/MsalCustomAuthError.ts
+++ b/lib/msal-custom-auth/src/core/error/MsalCustomAuthError.ts
@@ -1,9 +1,13 @@
+import { Constants } from "@azure/msal-browser";
 import { CustomAuthError } from "./CustomAuthError.js";
 
 export class MsalCustomAuthError extends CustomAuthError {
-    constructor(error: string, errorDescription?: string, correlationId?: string) {
-        super(error, errorDescription, correlationId);
+    subError: string | undefined;
 
+    constructor(error: string, errorDescription?: string, subError?: string, correlationId?: string) {
+        super(error, errorDescription, correlationId);
         Object.setPrototypeOf(this, MsalCustomAuthError.prototype);
+
+        this.subError = subError || Constants.EMPTY_STRING;
     }
 }

--- a/lib/msal-custom-auth/src/core/error/MsalCustomAuthError.ts
+++ b/lib/msal-custom-auth/src/core/error/MsalCustomAuthError.ts
@@ -1,0 +1,13 @@
+import { CustomAuthError } from "./CustomAuthError.js";
+
+export class MsalCustomAuthError extends CustomAuthError {
+    constructor(
+        public error: string,
+        public errorDescription?: string,
+        public correlationId?: string,
+    ) {
+        super(error, errorDescription, correlationId);
+
+        Object.setPrototypeOf(this, MsalCustomAuthError.prototype);
+    }
+}

--- a/lib/msal-custom-auth/src/core/interaction_client/CustomAuthInteractionClientBase.ts
+++ b/lib/msal-custom-auth/src/core/interaction_client/CustomAuthInteractionClientBase.ts
@@ -18,7 +18,7 @@ import {
     SsoSilentRequest,
     StandardInteractionClient,
 } from "@azure/msal-browser";
-import { Constants, ICrypto } from "@azure/msal-common";
+import { Constants, ICrypto } from "@azure/msal-browser";
 import { ICustomAuthApiClient } from "../network_client/custom_auth_api/ICustomAuthApiClient.js";
 import { ArgumentValidator } from "../utils/ArgumentValidator.js";
 import { MethodNotImplementedError } from "../error/MethodNotImplementedError.js";

--- a/lib/msal-custom-auth/src/core/network_client/http_client/FetchHttpClient.ts
+++ b/lib/msal-custom-auth/src/core/network_client/http_client/FetchHttpClient.ts
@@ -15,7 +15,7 @@ export class FetchHttpClient implements IHttpClient {
 
     async sendAsync(url: string | URL, options: RequestInit, correlationId: string): Promise<Response> {
         try {
-            this.logger.trace(`Sending request to ${url}`, correlationId);
+            this.logger.tracePii(`Sending request to ${url}`, correlationId);
 
             const startTime = performance.now();
 
@@ -23,14 +23,14 @@ export class FetchHttpClient implements IHttpClient {
 
             const endTime = performance.now();
 
-            this.logger.trace(
+            this.logger.tracePii(
                 `Request to '${url}' completed in ${endTime - startTime}ms with status code ${response.status}`,
                 correlationId,
             );
 
             return response;
         } catch (e) {
-            this.logger.error(`Failed to send request to ${url}: ${e}`, correlationId);
+            this.logger.errorPii(`Failed to send request to ${url}: ${e}`, correlationId);
 
             if (!window.navigator.onLine) {
                 throw new HttpError(NoNetworkConnectivity, `No network connectivity: ${e}`, correlationId);

--- a/lib/msal-custom-auth/src/get_account/auth_flow/CustomAuthAccountData.ts
+++ b/lib/msal-custom-auth/src/get_account/auth_flow/CustomAuthAccountData.ts
@@ -66,7 +66,7 @@ export class CustomAuthAccountData {
 
             return new SignOutResult();
         } catch (error) {
-            this.logger.error(`An error occurred during sign out: ${error}`, this.correlationId);
+            this.logger.errorPii(`An error occurred during sign out: ${error}`, this.correlationId);
 
             return SignOutResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/reset_password/auth_flow/state_handler/ResetPasswordCodeRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/reset_password/auth_flow/state_handler/ResetPasswordCodeRequiredStateHandler.ts
@@ -50,7 +50,7 @@ export class ResetPasswordCodeRequiredStateHandler extends ResetPasswordStateHan
         try {
             this.ensureCodeIsValid(code, this.codeLength);
 
-            this.logger.info("Submitting code for password reset.");
+            this.logger.info("Submitting code for password reset.", this.correlationId);
 
             const result = await this.resetPasswordClient.submitCode({
                 clientId: this.config.auth.clientId,
@@ -61,7 +61,7 @@ export class ResetPasswordCodeRequiredStateHandler extends ResetPasswordStateHan
                 username: this.username,
             });
 
-            this.logger.info("Code is submitted for password reset.");
+            this.logger.info("Code is submitted for password reset.", this.correlationId);
 
             return new ResetPasswordSubmitCodeResult(
                 new ResetPasswordPasswordRequired(
@@ -76,7 +76,7 @@ export class ResetPasswordCodeRequiredStateHandler extends ResetPasswordStateHan
                 ),
             );
         } catch (error) {
-            this.logger.errorPii(`Failed to submit code for password reset. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit code for password reset. Error: ${error}.`, this.correlationId);
 
             return ResetPasswordSubmitCodeResult.createWithError(error);
         }
@@ -88,7 +88,7 @@ export class ResetPasswordCodeRequiredStateHandler extends ResetPasswordStateHan
      */
     async resendCode(): Promise<ResetPasswordResendCodeResult> {
         try {
-            this.logger.info("Resending code for password reset.");
+            this.logger.info("Resending code for password reset.", this.correlationId);
 
             const result = await this.resetPasswordClient.resendCode({
                 clientId: this.config.auth.clientId,
@@ -98,7 +98,7 @@ export class ResetPasswordCodeRequiredStateHandler extends ResetPasswordStateHan
                 continuationToken: this.continuationToken ?? "",
             });
 
-            this.logger.info("Code is resent for password reset.");
+            this.logger.info("Code is resent for password reset.", this.correlationId);
 
             return new ResetPasswordResendCodeResult(
                 new ResetPasswordCodeRequired(
@@ -114,7 +114,7 @@ export class ResetPasswordCodeRequiredStateHandler extends ResetPasswordStateHan
                 ),
             );
         } catch (error) {
-            this.logger.errorPii(`Failed to resend code for password reset. Error: ${error}.`);
+            this.logger.errorPii(`Failed to resend code for password reset. Error: ${error}.`, this.correlationId);
 
             return ResetPasswordResendCodeResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/reset_password/auth_flow/state_handler/ResetPasswordCodeRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/reset_password/auth_flow/state_handler/ResetPasswordCodeRequiredStateHandler.ts
@@ -76,7 +76,7 @@ export class ResetPasswordCodeRequiredStateHandler extends ResetPasswordStateHan
                 ),
             );
         } catch (error) {
-            this.logger.error(`Failed to submit code for password reset. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit code for password reset. Error: ${error}.`);
 
             return ResetPasswordSubmitCodeResult.createWithError(error);
         }
@@ -114,7 +114,7 @@ export class ResetPasswordCodeRequiredStateHandler extends ResetPasswordStateHan
                 ),
             );
         } catch (error) {
-            this.logger.error(`Failed to resend code for password reset. Error: ${error}.`);
+            this.logger.errorPii(`Failed to resend code for password reset. Error: ${error}.`);
 
             return ResetPasswordResendCodeResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/reset_password/auth_flow/state_handler/ResetPasswordPasswordRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/reset_password/auth_flow/state_handler/ResetPasswordPasswordRequiredStateHandler.ts
@@ -47,7 +47,7 @@ export class ResetPasswordPasswordRequiredStateHandler extends ResetPasswordStat
         try {
             this.ensurePasswordIsNotEmpty(password);
 
-            this.logger.info("Submitting new password for password reset.");
+            this.logger.info("Submitting new password for password reset.", this.correlationId);
 
             const result = await this.resetPasswordClient.submitNewPassword({
                 clientId: this.config.auth.clientId,
@@ -58,7 +58,7 @@ export class ResetPasswordPasswordRequiredStateHandler extends ResetPasswordStat
                 username: this.username,
             });
 
-            this.logger.info("New password is submitted for sign-up.");
+            this.logger.info("New password is submitted for sign-up.", this.correlationId);
 
             return new ResetPasswordSubmitPasswordResult(
                 new ResetPasswordCompleted(
@@ -72,7 +72,7 @@ export class ResetPasswordPasswordRequiredStateHandler extends ResetPasswordStat
                 ),
             );
         } catch (error) {
-            this.logger.errorPii(`Failed to submit password for password reset. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit password for password reset. Error: ${error}.`, this.correlationId);
 
             return ResetPasswordSubmitPasswordResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/reset_password/auth_flow/state_handler/ResetPasswordPasswordRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/reset_password/auth_flow/state_handler/ResetPasswordPasswordRequiredStateHandler.ts
@@ -72,7 +72,7 @@ export class ResetPasswordPasswordRequiredStateHandler extends ResetPasswordStat
                 ),
             );
         } catch (error) {
-            this.logger.error(`Failed to submit password for password reset. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit password for password reset. Error: ${error}.`);
 
             return ResetPasswordSubmitPasswordResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/reset_password/interaction_client/ResetPasswordClient.ts
+++ b/lib/msal-custom-auth/src/reset_password/interaction_client/ResetPasswordClient.ts
@@ -41,7 +41,8 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
      * @returns The result of password reset start operation.
      */
     async start(parameters: ResetPasswordStartParams): Promise<ResetPasswordCodeRequiredResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        const correlationId = parameters.correlationId;
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, correlationId);
 
         const apiId = PublicApiId.PASSWORD_RESET_START;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -49,20 +50,20 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
         const startRequest: ResetPasswordStartRequest = {
             challenge_type: this.getChallengeTypes(parameters.challengeType),
             username: parameters.username,
-            correlationId: parameters.correlationId,
+            correlationId: correlationId,
             telemetryManager: telemetryManager,
         };
 
-        this.logger.info("Calling start endpoint for password reset flow.");
+        this.logger.info("Calling start endpoint for password reset flow.", correlationId);
 
         const startResponse = await this.customAuthApiClient.resetPasswordApi.start(startRequest);
 
-        this.logger.verbose("Start endpoint for password reset returned successfully.");
+        this.logger.verbose("Start endpoint for password reset returned successfully.", correlationId);
 
         const challengeRequest: ResetPasswordChallengeRequest = {
             continuation_token: startResponse.continuation_token ?? "",
             challenge_type: this.getChallengeTypes(parameters.challengeType),
-            correlationId: parameters.correlationId,
+            correlationId: correlationId,
             telemetryManager: telemetryManager,
         };
 
@@ -75,8 +76,9 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
      * @returns The result of submitting the code for password reset.
      */
     async submitCode(parameters: ResetPasswordSubmitCodeParams): Promise<ResetPasswordPasswordRequiredResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
-        ArgumentValidator.ensureArgumentIsNotEmptyString("parameters.code", parameters.code, parameters.correlationId);
+        const correlationId = parameters.correlationId;
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, correlationId);
+        ArgumentValidator.ensureArgumentIsNotEmptyString("parameters.code", parameters.code, correlationId);
 
         const apiId = PublicApiId.PASSWORD_RESET_SUBMIT_CODE;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -84,15 +86,18 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
         const continueRequest: ResetPasswordContinueRequest = {
             continuation_token: parameters.continuationToken,
             oob: parameters.code,
-            correlationId: parameters.correlationId,
+            correlationId: correlationId,
             telemetryManager: telemetryManager,
         };
 
-        this.logger.info("Calling continue endpoint with code for password reset.");
+        this.logger.info("Calling continue endpoint with code for password reset.", correlationId);
 
         const response = await this.customAuthApiClient.resetPasswordApi.continueWithCode(continueRequest);
 
-        this.logger.info("Continue endpoint called successfully with code for password reset.");
+        this.logger.info(
+            "Continue endpoint called successfully with code for password reset.",
+            response.correlation_id,
+        );
 
         return new ResetPasswordPasswordRequiredResult(response.correlation_id, response.continuation_token ?? "");
     }
@@ -103,7 +108,7 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
      * @returns The result of resending the code for password reset.
      */
     async resendCode(parameters: ResetPasswordResendCodeParams): Promise<ResetPasswordCodeRequiredResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
 
         const apiId = PublicApiId.PASSWORD_RESET_RESEND_CODE;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -124,11 +129,13 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
      * @returns The result of submitting the new password for password reset.
      */
     async submitNewPassword(parameters: ResetPasswordSubmitNewPasswordParams): Promise<ResetPasswordCompletedResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        const correlationId = parameters.correlationId;
+
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, correlationId);
         ArgumentValidator.ensureArgumentIsNotEmptyString(
             "parameters.newPassword",
             parameters.newPassword,
-            parameters.correlationId,
+            correlationId,
         );
 
         const apiId = PublicApiId.PASSWORD_RESET_SUBMIT_PASSWORD;
@@ -137,20 +144,20 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
         const submitRequest: ResetPasswordSubmitRequest = {
             continuation_token: parameters.continuationToken,
             new_password: parameters.newPassword,
-            correlationId: parameters.correlationId,
+            correlationId: correlationId,
             telemetryManager: telemetryManager,
         };
 
-        this.logger.info("Calling submit endpoint with new password for password reset.");
+        this.logger.info("Calling submit endpoint with new password for password reset.", correlationId);
 
         const submitResponse = await this.customAuthApiClient.resetPasswordApi.submitNewPassword(submitRequest);
 
-        this.logger.info("Submit endpoint called successfully with new password for password reset.");
+        this.logger.info("Submit endpoint called successfully with new password for password reset.", correlationId);
 
         return this.performPollCompletionRequest(
             submitResponse.continuation_token ?? "",
             submitResponse.poll_interval,
-            parameters.correlationId,
+            correlationId,
             telemetryManager,
         );
     }
@@ -158,15 +165,16 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
     private async performChallengeRequest(
         request: ResetPasswordChallengeRequest,
     ): Promise<ResetPasswordCodeRequiredResult> {
-        this.logger.info("Calling challenge endpoint for password reset flow.");
+        const correlationId = request.correlationId;
+        this.logger.info("Calling challenge endpoint for password reset flow.", correlationId);
 
         const response = await this.customAuthApiClient.resetPasswordApi.requestChallenge(request);
 
-        this.logger.info("Challenge endpoint for password reset returned successfully.");
+        this.logger.info("Challenge endpoint for password reset returned successfully.", correlationId);
 
         if (response.challenge_type === ChallengeType.OOB) {
             // Code is required
-            this.logger.info("Code is required for password reset flow.");
+            this.logger.info("Code is required for password reset flow.", correlationId);
 
             return new ResetPasswordCodeRequiredResult(
                 response.correlation_id,
@@ -180,12 +188,13 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
 
         this.logger.error(
             `Unsupported challenge type '${response.challenge_type}' returned from challenge endpoint for password reset.`,
+            correlationId,
         );
 
         throw new CustomAuthApiError(
             CustomAuthApiErrorCode.UNSUPPORTED_CHALLENGE_TYPE,
             `Unsupported challenge type '${response.challenge_type}'.`,
-            response.correlation_id,
+            correlationId,
         );
     }
 
@@ -204,11 +213,11 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
                 telemetryManager: telemetryManager,
             };
 
-            this.logger.info("Calling the poll completion endpoint for password reset flow.");
+            this.logger.info("Calling the poll completion endpoint for password reset flow.", correlationId);
 
             const pollResponse = await this.customAuthApiClient.resetPasswordApi.pollCompletion(pollRequest);
 
-            this.logger.info("Poll completion endpoint for password reset returned successfully.");
+            this.logger.info("Poll completion endpoint for password reset returned successfully.", correlationId);
 
             if (pollResponse.status === ResetPasswordPollStatus.SUCCEEDED) {
                 return new ResetPasswordCompletedResult(
@@ -225,12 +234,13 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
 
             this.logger.info(
                 `Poll completion endpoint for password reset is not started or in progress, waiting ${pollInterval} seconds for next check.`,
+                correlationId,
             );
 
             await this.delay(pollInterval * 1000);
         }
 
-        this.logger.error("Password reset flow has timed out.");
+        this.logger.error("Password reset flow has timed out.", correlationId);
 
         throw new CustomAuthApiError(
             CustomAuthApiErrorCode.PASSWORD_RESET_TIMEOUT,

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInCodeRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInCodeRequiredStateHandler.ts
@@ -68,7 +68,7 @@ export class SignInCodeRequiredStateHandler extends SignInStateHandler {
 
             return new SignInSubmitCodeResult(new SignInCompleted(), accountInfo);
         } catch (error) {
-            this.logger.error(`Failed to submit code for sign-in. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit code for sign-in. Error: ${error}.`);
 
             return SignInSubmitCodeResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInCodeRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInCodeRequiredStateHandler.ts
@@ -52,11 +52,11 @@ export class SignInCodeRequiredStateHandler extends SignInStateHandler {
                 username: this.username,
             };
 
-            this.logger.info("Submitting code for sign-in.");
+            this.logger.info("Submitting code for sign-in.", this.correlationId);
 
             const completedResult = await this.signInClient.submitCode(submitCodeParams);
 
-            this.logger.info("Code submitted for sign-in.");
+            this.logger.info("Code submitted for sign-in.", this.correlationId);
 
             const accountInfo = new CustomAuthAccountData(
                 completedResult.authenticationResult.account,
@@ -68,7 +68,7 @@ export class SignInCodeRequiredStateHandler extends SignInStateHandler {
 
             return new SignInSubmitCodeResult(new SignInCompleted(), accountInfo);
         } catch (error) {
-            this.logger.errorPii(`Failed to submit code for sign-in. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit code for sign-in. Error: ${error}.`, this.correlationId);
 
             return SignInSubmitCodeResult.createWithError(error);
         }
@@ -88,11 +88,11 @@ export class SignInCodeRequiredStateHandler extends SignInStateHandler {
                 username: this.username,
             };
 
-            this.logger.info("Resending code for sign-in.");
+            this.logger.info("Resending code for sign-in.", this.correlationId);
 
             const result = await this.signInClient.resendCode(submitCodeParams);
 
-            this.logger.info("Code resent for sign-in.");
+            this.logger.info("Code resent for sign-in.", this.correlationId);
 
             return new SignInResendCodeResult(
                 new SignInCodeRequired(

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInContinuationStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInContinuationStateHandler.ts
@@ -47,11 +47,11 @@ export class SignInContinuationStateHandler extends SignInStateHandler {
                 signInScenario: this.signInScenario,
             };
 
-            this.logger.info("Signing in with continuation token.");
+            this.logger.info("Signing in with continuation token.", this.correlationId);
 
             const completedResult = await this.signInClient.signInWithContinuationToken(continuationTokenParams);
 
-            this.logger.info("Signed in with continuation token.");
+            this.logger.info("Signed in with continuation token.", this.correlationId);
 
             const accountInfo = new CustomAuthAccountData(
                 completedResult.authenticationResult.account,
@@ -63,7 +63,7 @@ export class SignInContinuationStateHandler extends SignInStateHandler {
 
             return new SignInResult(new SignInCompleted(), accountInfo);
         } catch (error) {
-            this.logger.errorPii(`Failed to sign in with continuation token. Error: ${error}.`);
+            this.logger.errorPii(`Failed to sign in with continuation token. Error: ${error}.`, this.correlationId);
 
             return SignInResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInContinuationStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInContinuationStateHandler.ts
@@ -63,7 +63,7 @@ export class SignInContinuationStateHandler extends SignInStateHandler {
 
             return new SignInResult(new SignInCompleted(), accountInfo);
         } catch (error) {
-            this.logger.error(`Failed to sign in with continuation token. Error: ${error}.`);
+            this.logger.errorPii(`Failed to sign in with continuation token. Error: ${error}.`);
 
             return SignInResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInPasswordRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInPasswordRequiredStateHandler.ts
@@ -65,7 +65,7 @@ export class SignInPasswordRequiredStateHandler extends SignInStateHandler {
 
             return new SignInSubmitPasswordResult(new SignInCompleted(), accountInfo);
         } catch (error) {
-            this.logger.error(`Failed to sign in after submitting password. Error: ${error}.`);
+            this.logger.errorPii(`Failed to sign in after submitting password. Error: ${error}.`);
 
             return SignInSubmitPasswordResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInPasswordRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/state_handler/SignInPasswordRequiredStateHandler.ts
@@ -49,11 +49,11 @@ export class SignInPasswordRequiredStateHandler extends SignInStateHandler {
                 username: this.username,
             };
 
-            this.logger.info("Submitting password for sign-in.");
+            this.logger.info("Submitting password for sign-in.", this.correlationId);
 
             const completedResult = await this.signInClient.submitPassword(submitPasswordParams);
 
-            this.logger.info("Password submitted for sign-in.");
+            this.logger.info("Password submitted for sign-in.", this.correlationId);
 
             const accountInfo = new CustomAuthAccountData(
                 completedResult.authenticationResult.account,
@@ -65,7 +65,7 @@ export class SignInPasswordRequiredStateHandler extends SignInStateHandler {
 
             return new SignInSubmitPasswordResult(new SignInCompleted(), accountInfo);
         } catch (error) {
-            this.logger.errorPii(`Failed to sign in after submitting password. Error: ${error}.`);
+            this.logger.errorPii(`Failed to sign in after submitting password. Error: ${error}.`, this.correlationId);
 
             return SignInSubmitPasswordResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_in/interaction_client/SignInClient.ts
+++ b/lib/msal-custom-auth/src/sign_in/interaction_client/SignInClient.ts
@@ -88,14 +88,14 @@ export class SignInClient extends CustomAuthInteractionClientBase {
      * @returns The result of the sign-in start operation.
      */
     async start(parameters: SignInStartParams): Promise<SignInPasswordRequiredResult | SignInCodeSendResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
 
         const apiId = !parameters.password
             ? PublicApiId.SIGN_IN_WITH_CODE_START
             : PublicApiId.SIGN_IN_WITH_PASSWORD_START;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
 
-        this.logger.info("Calling initiate endpoint for sign in.");
+        this.logger.info("Calling initiate endpoint for sign in.", parameters.correlationId);
 
         const initReq: SignInInitiateRequest = {
             challenge_type: parameters.challengeType.join(" "),
@@ -106,7 +106,7 @@ export class SignInClient extends CustomAuthInteractionClientBase {
 
         const initiateResponse = await this.customAuthApiClient.signInApi.initiate(initReq);
 
-        this.logger.info("Initiate endpoint called for sign in.");
+        this.logger.info("Initiate endpoint called for sign in.", parameters.correlationId);
 
         const challengeReq: SignInChallengeRequest = {
             challenge_type: this.getChallengeTypes(parameters.challengeType),
@@ -124,7 +124,7 @@ export class SignInClient extends CustomAuthInteractionClientBase {
      * @returns The result of the sign-in resend code action.
      */
     async resendCode(parameters: SignInResendCodeParams): Promise<SignInCodeSendResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
 
         const apiId = PublicApiId.SIGN_IN_RESEND_CODE;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -139,7 +139,10 @@ export class SignInClient extends CustomAuthInteractionClientBase {
         const result = await this.performChallengeRequest(challengeReq);
 
         if (result instanceof SignInPasswordRequiredResult) {
-            this.logger.error("Resend code operation failed due to the challenge type 'password' is not supported.");
+            this.logger.error(
+                "Resend code operation failed due to the challenge type 'password' is not supported.",
+                parameters.correlationId,
+            );
 
             throw new CustomAuthApiError(
                 CustomAuthApiErrorCode.UNSUPPORTED_CHALLENGE_TYPE,
@@ -157,7 +160,7 @@ export class SignInClient extends CustomAuthInteractionClientBase {
      * @returns The result of the sign-in submit code action.
      */
     async submitCode(parameters: SignInSubmitCodeParams): Promise<SignInCompletedResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
         ArgumentValidator.ensureArgumentIsNotEmptyString("parameters.code", parameters.code, parameters.correlationId);
 
         const apiId = PublicApiId.SIGN_IN_SUBMIT_CODE;
@@ -181,7 +184,7 @@ export class SignInClient extends CustomAuthInteractionClientBase {
      * @returns The result of the sign-in submit password action.
      */
     async submitPassword(parameters: SignInSubmitPasswordParams): Promise<SignInCompletedResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
         ArgumentValidator.ensureArgumentIsNotEmptyString(
             "parameters.password",
             parameters.password,
@@ -212,7 +215,7 @@ export class SignInClient extends CustomAuthInteractionClientBase {
      * @returns The result of the sign-in complete action.
      */
     async signInWithContinuationToken(parameters: SignInContinuationTokenParams): Promise<SignInCompletedResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
 
         const apiId = this.getPublicApiIdBySignInScenario(parameters.signInScenario, parameters.correlationId);
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -238,12 +241,12 @@ export class SignInClient extends CustomAuthInteractionClientBase {
         tokenEndpointCaller: () => Promise<SignInTokenResponse>,
         requestScopes: string[],
     ): Promise<SignInCompletedResult> {
-        this.logger.info("Calling token endpoint for sign in.");
+        this.logger.info("Calling token endpoint for sign in.", this.correlationId);
 
         const requestTimestamp = Math.round(new Date().getTime() / 1000.0);
         const tokenResponse = await tokenEndpointCaller();
 
-        this.logger.info("Token endpoint called for sign in.");
+        this.logger.info("Token endpoint called for sign in.", this.correlationId);
 
         // Save tokens and create authentication result.
         const result = await this.tokenResponseHandler.handleServerTokenResponse(
@@ -268,15 +271,15 @@ export class SignInClient extends CustomAuthInteractionClientBase {
     private async performChallengeRequest(
         request: SignInChallengeRequest,
     ): Promise<SignInPasswordRequiredResult | SignInCodeSendResult> {
-        this.logger.info("Calling challenge endpoint for sign in.");
+        this.logger.info("Calling challenge endpoint for sign in.", request.correlationId);
 
         const challengeResponse = await this.customAuthApiClient.signInApi.requestChallenge(request);
 
-        this.logger.info("Challenge endpoint called for sign in.");
+        this.logger.info("Challenge endpoint called for sign in.", request.correlationId);
 
         if (challengeResponse.challenge_type === ChallengeType.OOB) {
             // Code is required
-            this.logger.info("Challenge type is oob for sign in.");
+            this.logger.info("Challenge type is oob for sign in.", request.correlationId);
 
             return new SignInCodeSendResult(
                 challengeResponse.correlation_id,
@@ -290,7 +293,7 @@ export class SignInClient extends CustomAuthInteractionClientBase {
 
         if (challengeResponse.challenge_type === ChallengeType.PASSWORD) {
             // Password is required
-            this.logger.info("Challenge type is password for sign in.");
+            this.logger.info("Challenge type is password for sign in.", request.correlationId);
 
             return new SignInPasswordRequiredResult(
                 challengeResponse.correlation_id,
@@ -298,7 +301,10 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             );
         }
 
-        this.logger.error(`Unsupported challenge type '${challengeResponse.challenge_type}' for sign in.`);
+        this.logger.error(
+            `Unsupported challenge type '${challengeResponse.challenge_type}' for sign in.`,
+            request.correlationId,
+        );
 
         throw new CustomAuthApiError(
             CustomAuthApiErrorCode.UNSUPPORTED_CHALLENGE_TYPE,

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpAttributesRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpAttributesRequiredStateHandler.ts
@@ -48,7 +48,7 @@ export class SignUpAttributesRequiredStateHandler extends SignUpStateHandler {
      */
     async submitAttributes(attributes: UserAccountAttributes): Promise<SignUpSubmitAttributesResult> {
         if (!attributes || Object.keys(attributes.toRecord()).length === 0) {
-            this.logger.error("Attributes are required for sign-up.");
+            this.logger.error("Attributes are required for sign-up.", this.correlationId);
 
             return Promise.resolve(
                 SignUpSubmitAttributesResult.createWithError(
@@ -58,7 +58,7 @@ export class SignUpAttributesRequiredStateHandler extends SignUpStateHandler {
         }
 
         try {
-            this.logger.info("Submitting attributes for sign-up.");
+            this.logger.info("Submitting attributes for sign-up.", this.correlationId);
 
             const result = await this.signUpClient.submitAttributes({
                 clientId: this.config.auth.clientId,
@@ -69,11 +69,11 @@ export class SignUpAttributesRequiredStateHandler extends SignUpStateHandler {
                 username: this.username,
             });
 
-            this.logger.info("Password submitted for sign-up.");
+            this.logger.info("Password submitted for sign-up.", this.correlationId);
 
             if (result instanceof SignUpCodeRequiredResult) {
                 // Code required
-                this.logger.info("Code required for sign-up.");
+                this.logger.info("Code required for sign-up.", this.correlationId);
 
                 return new SignUpSubmitAttributesResult(
                     new SignUpCodeRequired(
@@ -91,7 +91,7 @@ export class SignUpAttributesRequiredStateHandler extends SignUpStateHandler {
                 );
             } else if (result instanceof SignUpPasswordRequiredResult) {
                 // Password required
-                this.logger.info("Password required for sign-up.");
+                this.logger.info("Password required for sign-up.", this.correlationId);
 
                 return new SignUpSubmitAttributesResult(
                     new SignUpPasswordRequired(
@@ -107,7 +107,7 @@ export class SignUpAttributesRequiredStateHandler extends SignUpStateHandler {
                 );
             } else if (result instanceof SignUpCompletedResult) {
                 // Sign-up completed
-                this.logger.info("Sign-up completed.");
+                this.logger.info("Sign-up completed.", this.correlationId);
 
                 return new SignUpSubmitAttributesResult(
                     new SignUpCompleted(
@@ -122,9 +122,11 @@ export class SignUpAttributesRequiredStateHandler extends SignUpStateHandler {
                 );
             }
 
-            return SignUpSubmitAttributesResult.createWithError(new UnexpectedError("Unknown sign-up result type."));
+            return SignUpSubmitAttributesResult.createWithError(
+                new UnexpectedError("Unknown sign-up result type.", this.correlationId),
+            );
         } catch (error) {
-            this.logger.errorPii(`Failed to submit attributes for sign up. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit attributes for sign up. Error: ${error}.`, this.correlationId);
 
             return SignUpSubmitAttributesResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpAttributesRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpAttributesRequiredStateHandler.ts
@@ -124,7 +124,7 @@ export class SignUpAttributesRequiredStateHandler extends SignUpStateHandler {
 
             return SignUpSubmitAttributesResult.createWithError(new UnexpectedError("Unknown sign-up result type."));
         } catch (error) {
-            this.logger.error(`Failed to submit attributes for sign up. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit attributes for sign up. Error: ${error}.`);
 
             return SignUpSubmitAttributesResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpCodeRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpCodeRequiredStateHandler.ts
@@ -115,7 +115,7 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
 
             return SignUpSubmitCodeResult.createWithError(new UnexpectedError("Unknown sign-up result type."));
         } catch (error) {
-            this.logger.error(`Failed to submit code for sign up. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit code for sign up. Error: ${error}.`);
 
             return SignUpSubmitCodeResult.createWithError(error);
         }
@@ -154,7 +154,7 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
                 ),
             );
         } catch (error) {
-            this.logger.error(`Failed to resend code for sign up. Error: ${error}.`);
+            this.logger.errorPii(`Failed to resend code for sign up. Error: ${error}.`);
 
             return SignUpResendCodeResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpCodeRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpCodeRequiredStateHandler.ts
@@ -50,7 +50,7 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
         try {
             this.ensureCodeIsValid(code, this.codeLength);
 
-            this.logger.info("Submitting code for sign-up.");
+            this.logger.info("Submitting code for sign-up.", this.correlationId);
 
             const result = await this.signUpClient.submitCode({
                 clientId: this.config.auth.clientId,
@@ -61,11 +61,11 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
                 username: this.username,
             });
 
-            this.logger.info("Code submitted for sign-up.");
+            this.logger.info("Code submitted for sign-up.", this.correlationId);
 
             if (result instanceof SignUpPasswordRequiredResult) {
                 // Password required
-                this.logger.info("Password required for sign-up.");
+                this.logger.info("Password required for sign-up.", this.correlationId);
 
                 return new SignUpSubmitCodeResult(
                     new SignUpPasswordRequired(
@@ -81,7 +81,7 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
                 );
             } else if (result instanceof SignUpAttributesRequiredResult) {
                 // Attributes required
-                this.logger.info("Attributes required for sign-up.");
+                this.logger.info("Attributes required for sign-up.", this.correlationId);
 
                 return new SignUpSubmitCodeResult(
                     new SignUpAttributesRequired(
@@ -98,7 +98,7 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
                 );
             } else if (result instanceof SignUpCompletedResult) {
                 // Sign-up completed
-                this.logger.info("Sign-up completed.");
+                this.logger.info("Sign-up completed.", this.correlationId);
 
                 return new SignUpSubmitCodeResult(
                     new SignUpCompleted(
@@ -113,9 +113,11 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
                 );
             }
 
-            return SignUpSubmitCodeResult.createWithError(new UnexpectedError("Unknown sign-up result type."));
+            return SignUpSubmitCodeResult.createWithError(
+                new UnexpectedError("Unknown sign-up result type.", this.correlationId),
+            );
         } catch (error) {
-            this.logger.errorPii(`Failed to submit code for sign up. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit code for sign up. Error: ${error}.`, this.correlationId);
 
             return SignUpSubmitCodeResult.createWithError(error);
         }
@@ -127,7 +129,7 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
      */
     async resendCode(): Promise<SignUpResendCodeResult> {
         try {
-            this.logger.info("Resending code for sign-up.");
+            this.logger.info("Resending code for sign-up.", this.correlationId);
 
             const result = await this.signUpClient.resendCode({
                 clientId: this.config.auth.clientId,
@@ -137,7 +139,7 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
                 continuationToken: this.continuationToken ?? "",
             });
 
-            this.logger.info("Code resent for sign-up.");
+            this.logger.info("Code resent for sign-up.", this.correlationId);
 
             return new SignUpResendCodeResult(
                 new SignUpCodeRequired(
@@ -154,7 +156,7 @@ export class SignUpCodeRequiredStateHandler extends SignUpStateHandler {
                 ),
             );
         } catch (error) {
-            this.logger.errorPii(`Failed to resend code for sign up. Error: ${error}.`);
+            this.logger.errorPii(`Failed to resend code for sign up. Error: ${error}.`, this.correlationId);
 
             return SignUpResendCodeResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpPasswordRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpPasswordRequiredStateHandler.ts
@@ -95,7 +95,7 @@ export class SignUpPasswordRequiredStateHandler extends SignUpStateHandler {
 
             return SignUpSubmitPasswordResult.createWithError(new UnexpectedError("Unknown sign-up result type."));
         } catch (error) {
-            this.logger.error(`Failed to submit password for sign up. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit password for sign up. Error: ${error}.`);
 
             return SignUpSubmitPasswordResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpPasswordRequiredStateHandler.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/state_handler/SignUpPasswordRequiredStateHandler.ts
@@ -28,7 +28,7 @@ export class SignUpPasswordRequiredStateHandler extends SignUpStateHandler {
         try {
             this.ensurePasswordIsNotEmpty(password);
 
-            this.logger.info("Submitting password for sign-up.");
+            this.logger.info("Submitting password for sign-up.", this.correlationId);
 
             const result = await this.signUpClient.submitPassword({
                 clientId: this.config.auth.clientId,
@@ -39,11 +39,11 @@ export class SignUpPasswordRequiredStateHandler extends SignUpStateHandler {
                 username: this.username,
             });
 
-            this.logger.info("Password submitted for sign-up.");
+            this.logger.info("Password submitted for sign-up.", this.correlationId);
 
             if (result instanceof SignUpCodeRequiredResult) {
                 // Code required
-                this.logger.info("Code required for sign-up.");
+                this.logger.info("Code required for sign-up.", this.correlationId);
 
                 return new SignUpSubmitPasswordResult(
                     new SignUpCodeRequired(
@@ -61,7 +61,7 @@ export class SignUpPasswordRequiredStateHandler extends SignUpStateHandler {
                 );
             } else if (result instanceof SignUpAttributesRequiredResult) {
                 // Attributes required
-                this.logger.info("Attributes required for sign-up.");
+                this.logger.info("Attributes required for sign-up.", this.correlationId);
 
                 return new SignUpSubmitPasswordResult(
                     new SignUpAttributesRequired(
@@ -78,7 +78,7 @@ export class SignUpPasswordRequiredStateHandler extends SignUpStateHandler {
                 );
             } else if (result instanceof SignUpCompletedResult) {
                 // Sign-up completed
-                this.logger.info("Sign-up completed.");
+                this.logger.info("Sign-up completed.", this.correlationId);
 
                 return new SignUpSubmitPasswordResult(
                     new SignUpCompleted(
@@ -93,9 +93,11 @@ export class SignUpPasswordRequiredStateHandler extends SignUpStateHandler {
                 );
             }
 
-            return SignUpSubmitPasswordResult.createWithError(new UnexpectedError("Unknown sign-up result type."));
+            return SignUpSubmitPasswordResult.createWithError(
+                new UnexpectedError("Unknown sign-up result type.", this.correlationId),
+            );
         } catch (error) {
-            this.logger.errorPii(`Failed to submit password for sign up. Error: ${error}.`);
+            this.logger.errorPii(`Failed to submit password for sign up. Error: ${error}.`, this.correlationId);
 
             return SignUpSubmitPasswordResult.createWithError(error);
         }

--- a/lib/msal-custom-auth/src/sign_up/interaction_client/SignUpClient.ts
+++ b/lib/msal-custom-auth/src/sign_up/interaction_client/SignUpClient.ts
@@ -45,7 +45,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
      * @returns The result of the sign up start action.
      */
     async start(parameters: SignUpStartParams): Promise<SignUpPasswordRequiredResult | SignUpCodeRequiredResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
 
         const apiId = !parameters.password ? PublicApiId.SIGN_UP_START : PublicApiId.SIGN_UP_WITH_PASSWORD_START;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -59,11 +59,11 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
             correlationId: parameters.correlationId,
         };
 
-        this.logger.info("Calling start endpoint for sign up.");
+        this.logger.info("Calling start endpoint for sign up.", parameters.correlationId);
 
         const startResponse = await this.customAuthApiClient.signUpApi.start(startRequest);
 
-        this.logger.info("Start endpoint called for sign up.");
+        this.logger.info("Start endpoint called for sign up.", parameters.correlationId);
 
         const challengeRequest: SignUpChallengeRequest = {
             continuation_token: startResponse.continuation_token ?? "",
@@ -83,7 +83,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
     async submitCode(
         parameters: SignUpSubmitCodeParams,
     ): Promise<SignUpCompletedResult | SignUpPasswordRequiredResult | SignUpAttributesRequiredResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
 
         const apiId = PublicApiId.SIGN_UP_SUBMIT_CODE;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -122,7 +122,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
     async submitPassword(
         parameter: SignUpSubmitPasswordParams,
     ): Promise<SignUpCompletedResult | SignUpCodeRequiredResult | SignUpAttributesRequiredResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameter", parameter);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameter", parameter, parameter.correlationId);
 
         const apiId = PublicApiId.SIGN_UP_SUBMIT_PASSWORD;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -161,7 +161,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
     async submitAttributes(
         parameter: SignUpSubmitUserAttributesParams,
     ): Promise<SignUpCompletedResult | SignUpPasswordRequiredResult | SignUpCodeRequiredResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameter", parameter);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameter", parameter, parameter.correlationId);
 
         const apiId = PublicApiId.SIGN_UP_SUBMIT_ATTRIBUTES;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -201,7 +201,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
      * @returns The result of the sign up resend code action.
      */
     async resendCode(parameters: SignUpResendCodeParams): Promise<SignUpCodeRequiredResult> {
-        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters);
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined("parameters", parameters, parameters.correlationId);
 
         const apiId = PublicApiId.SIGN_UP_RESEND_CODE;
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
@@ -229,15 +229,15 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
     private async performChallengeRequest(
         request: SignUpChallengeRequest,
     ): Promise<SignUpPasswordRequiredResult | SignUpCodeRequiredResult> {
-        this.logger.info("Calling challenge endpoint for sign up.");
+        this.logger.info("Calling challenge endpoint for sign up.", request.correlationId);
 
         const challengeResponse = await this.customAuthApiClient.signUpApi.requestChallenge(request);
 
-        this.logger.info("Challenge endpoint called for sign up.");
+        this.logger.info("Challenge endpoint called for sign up.", request.correlationId);
 
         if (challengeResponse.challenge_type === ChallengeType.OOB) {
             // Code is required
-            this.logger.info("Challenge type is oob for sign up.");
+            this.logger.info("Challenge type is oob for sign up.", request.correlationId);
 
             return new SignUpCodeRequiredResult(
                 challengeResponse.correlation_id,
@@ -252,7 +252,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
 
         if (challengeResponse.challenge_type === ChallengeType.PASSWORD) {
             // Password is required
-            this.logger.info("Challenge type is password for sign up.");
+            this.logger.info("Challenge type is password for sign up.", request.correlationId);
 
             return new SignUpPasswordRequiredResult(
                 challengeResponse.correlation_id,
@@ -260,7 +260,10 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
             );
         }
 
-        this.logger.error(`Unsupported challenge type '${challengeResponse.challenge_type}' for sign up.`);
+        this.logger.error(
+            `Unsupported challenge type '${challengeResponse.challenge_type}' for sign up.`,
+            request.correlationId,
+        );
 
         throw new CustomAuthApiError(
             CustomAuthApiErrorCode.UNSUPPORTED_CHALLENGE_TYPE,
@@ -278,12 +281,12 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
     ): Promise<
         SignUpCompletedResult | SignUpPasswordRequiredResult | SignUpCodeRequiredResult | SignUpAttributesRequiredResult
     > {
-        this.logger.info(`${callerName} is calling continue endpoint for sign up.`);
+        this.logger.info(`${callerName} is calling continue endpoint for sign up.`, requestCorrelationId);
 
         try {
             const response = await responseGetter();
 
-            this.logger.info(`Continue endpoint called by ${callerName} for sign up.`);
+            this.logger.info(`Continue endpoint called by ${callerName} for sign up.`, requestCorrelationId);
 
             return new SignUpCompletedResult(requestCorrelationId, response.continuation_token ?? "");
         } catch (error) {
@@ -295,7 +298,10 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
                     telemetryManager,
                 );
             } else {
-                this.logger.errorPii(`${callerName} is failed to call continue endpoint for sign up. Error: ${error}`);
+                this.logger.errorPii(
+                    `${callerName} is failed to call continue endpoint for sign up. Error: ${error}`,
+                    requestCorrelationId,
+                );
 
                 throw new UnexpectedError(error, requestCorrelationId);
             }

--- a/lib/msal-custom-auth/src/sign_up/interaction_client/SignUpClient.ts
+++ b/lib/msal-custom-auth/src/sign_up/interaction_client/SignUpClient.ts
@@ -295,7 +295,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
                     telemetryManager,
                 );
             } else {
-                this.logger.error(`${callerName} is failed to call continue endpoint for sign up. Error: ${error}`);
+                this.logger.errorPii(`${callerName} is failed to call continue endpoint for sign up. Error: ${error}`);
 
                 throw new UnexpectedError(error, requestCorrelationId);
             }

--- a/lib/msal-custom-auth/test/core/network_client/custom_auth_api/CustomAuthApiClient.spec.ts
+++ b/lib/msal-custom-auth/test/core/network_client/custom_auth_api/CustomAuthApiClient.spec.ts
@@ -11,6 +11,7 @@ describe("CustomAuthApiClient", () => {
             verbose: jest.fn(),
             info: jest.fn(),
             error: jest.fn(),
+            errorPii: jest.fn(),
         } as unknown as jest.Mocked<Logger>;
         customAuthApiClient = new CustomAuthApiClient("https://test.com", "client_id", new FetchHttpClient(mockLogger));
     });

--- a/lib/msal-custom-auth/test/core/network_client/http_client/FetchClient.spec.ts
+++ b/lib/msal-custom-auth/test/core/network_client/http_client/FetchClient.spec.ts
@@ -1,5 +1,6 @@
 import { Logger } from "@azure/msal-browser";
 import { FetchHttpClient } from "../../../../src/core/network_client/http_client/FetchHttpClient.js";
+import { trace } from "console";
 
 class MockResponse {
     public readonly status: number;
@@ -26,6 +27,8 @@ describe("FetchHttpClient", () => {
         info: jest.fn(),
         error: jest.fn(),
         trace: jest.fn(),
+        errorPii: jest.fn(),
+        tracePii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     beforeEach(() => {

--- a/lib/msal-custom-auth/test/get_account/auth_flow/CustomAuthAccountData.spec.ts
+++ b/lib/msal-custom-auth/test/get_account/auth_flow/CustomAuthAccountData.spec.ts
@@ -13,7 +13,6 @@ import { SignOutError } from "../../../src/get_account/auth_flow/error_type/GetA
 import { IdTokenClaims } from "../../../../msal-common/dist/exports-common.js";
 import { GetAccessTokenState } from "../../../src/core/auth_flow/AuthFlowStateBase.js";
 import { MsalCustomAuthError } from "../../../src/core/error/MsalCustomAuthError.js";
-import { error } from "console";
 
 describe("CustomAuthAccountData", () => {
     let mockAccount: AccountInfo;
@@ -200,7 +199,8 @@ describe("CustomAuthAccountData", () => {
             (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(mockAccount);
             const errorCode = InteractionRequiredAuthErrorCodes.refreshTokenExpired;
             const errorMessage = "Refresh token has expired.";
-            const mockRefreshTokenExpiredError = new InteractionRequiredAuthError(errorCode, errorMessage);
+            const subError = "Refresh token has expired, can not use it to get a new access token.";
+            const mockRefreshTokenExpiredError = new InteractionRequiredAuthError(errorCode, errorMessage, subError);
             (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(mockRefreshTokenExpiredError);
 
             const accountData = new CustomAuthAccountData(
@@ -217,8 +217,11 @@ describe("CustomAuthAccountData", () => {
             expect(response.state?.type).toEqual(GetAccessTokenState.Failed);
             expect(response.error?.errorData).toEqual(mockRefreshTokenExpiredError);
             expect(response.error?.errorData).toBeInstanceOf(MsalCustomAuthError);
-            expect(response.error?.errorData.error).toEqual(errorCode);
-            expect(response.error?.errorData.errorDescription).toEqual(errorMessage);
+
+            const msalError = response.error?.errorData as MsalCustomAuthError;
+            expect(msalError.error).toEqual(errorCode);
+            expect(msalError.errorDescription).toEqual(errorMessage);
+            expect(msalError.subError).toEqual(subError);
         });
     });
 });

--- a/lib/msal-custom-auth/test/get_account/auth_flow/CustomAuthAccountData.spec.ts
+++ b/lib/msal-custom-auth/test/get_account/auth_flow/CustomAuthAccountData.spec.ts
@@ -1,4 +1,10 @@
-import { AccountInfo, AuthenticationResult, Logger } from "@azure/msal-browser";
+import {
+    AccountInfo,
+    AuthenticationResult,
+    Logger,
+    InteractionRequiredAuthError,
+    InteractionRequiredAuthErrorCodes,
+} from "@azure/msal-browser";
 import { CustomAuthBrowserConfiguration } from "../../../src/configuration/CustomAuthConfiguration.js";
 import { CustomAuthSilentCacheClient } from "../../../src/get_account/interaction_client/CustomAuthSilentCacheClient.js";
 import { CustomAuthAccountData } from "../../../src/get_account/auth_flow/CustomAuthAccountData.js";
@@ -6,7 +12,8 @@ import { SignOutResult } from "../../../src/get_account/auth_flow/result/SignOut
 import { SignOutError } from "../../../src/get_account/auth_flow/error_type/GetAccountError.js";
 import { IdTokenClaims } from "../../../../msal-common/dist/exports-common.js";
 import { GetAccessTokenState } from "../../../src/core/auth_flow/AuthFlowStateBase.js";
-import { CustomAuthError } from "../../../src/core/error/CustomAuthError.js";
+import { MsalCustomAuthError } from "../../../src/core/error/MsalCustomAuthError.js";
+import { error } from "console";
 
 describe("CustomAuthAccountData", () => {
     let mockAccount: AccountInfo;
@@ -45,7 +52,11 @@ describe("CustomAuthAccountData", () => {
             correlationId: correlationId,
         } as AuthenticationResult;
 
-        mockConfig = {} as CustomAuthBrowserConfiguration; // Mock as needed
+        mockConfig = {
+            auth: {
+                authority: "test-authority",
+            },
+        } as CustomAuthBrowserConfiguration; // Mock as needed
         mockCacheClient = {
             acquireToken: jest.fn(),
             getCurrentAccount: jest.fn(),
@@ -54,6 +65,7 @@ describe("CustomAuthAccountData", () => {
         mockLogger = {
             info: jest.fn(),
             error: jest.fn(),
+            errorPii: jest.fn(),
         } as unknown as Logger;
     });
 
@@ -97,7 +109,7 @@ describe("CustomAuthAccountData", () => {
             );
             const result = await accountData.signOut();
 
-            expect(mockLogger.error).toHaveBeenCalledWith(
+            expect(mockLogger.errorPii).toHaveBeenCalledWith(
                 `An error occurred during sign out: ${error}`,
                 "test-correlation-id",
             );
@@ -186,12 +198,10 @@ describe("CustomAuthAccountData", () => {
 
         it("should return GetAccessTokenError if there is an error when aquire tokens", async () => {
             (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(mockAccount);
-            const mockGetAccessTokenError = new CustomAuthError(
-                "get_access_token_failed",
-                "Get access token failed.",
-                correlationId,
-            );
-            (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(mockGetAccessTokenError);
+            const errorCode = InteractionRequiredAuthErrorCodes.refreshTokenExpired;
+            const errorMessage = "Refresh token has expired.";
+            const mockRefreshTokenExpiredError = new InteractionRequiredAuthError(errorCode, errorMessage);
+            (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(mockRefreshTokenExpiredError);
 
             const accountData = new CustomAuthAccountData(
                 mockAccount,
@@ -205,7 +215,10 @@ describe("CustomAuthAccountData", () => {
 
             expect(response).toBeDefined();
             expect(response.state?.type).toEqual(GetAccessTokenState.Failed);
-            expect(response.error?.errorData).toEqual(mockGetAccessTokenError);
+            expect(response.error?.errorData).toEqual(mockRefreshTokenExpiredError);
+            expect(response.error?.errorData).toBeInstanceOf(MsalCustomAuthError);
+            expect(response.error?.errorData.error).toEqual(errorCode);
+            expect(response.error?.errorData.errorDescription).toEqual(errorMessage);
         });
     });
 });

--- a/lib/msal-custom-auth/test/reset_password/auth_flow/state_handler/ResetPasswordCodeRequiredStateHandler.spec.ts
+++ b/lib/msal-custom-auth/test/reset_password/auth_flow/state_handler/ResetPasswordCodeRequiredStateHandler.spec.ts
@@ -31,6 +31,7 @@ describe("ResetPasswordCodeRequiredStateHandler", () => {
     const mockLogger = {
         info: jest.fn(),
         error: jest.fn(),
+        errorPii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";

--- a/lib/msal-custom-auth/test/reset_password/auth_flow/state_handler/ResetPasswordPasswordRequiredStateHandler.spec.ts
+++ b/lib/msal-custom-auth/test/reset_password/auth_flow/state_handler/ResetPasswordPasswordRequiredStateHandler.spec.ts
@@ -26,6 +26,7 @@ describe("ResetPasswordPasswordRequiredStateHandler", () => {
     const mockLogger = {
         info: jest.fn(),
         error: jest.fn(),
+        errorPii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";

--- a/lib/msal-custom-auth/test/reset_password/interaction_client/ResetPasswordClient.spec.ts
+++ b/lib/msal-custom-auth/test/reset_password/interaction_client/ResetPasswordClient.spec.ts
@@ -123,6 +123,7 @@ describe("ResetPasswordClient", () => {
             verbose: jest.fn(),
             info: jest.fn(),
             error: jest.fn(),
+            errorPii: jest.fn(),
         } as unknown as jest.Mocked<Logger>;
         mockLogger.clone.mockReturnValue(mockLogger);
 

--- a/lib/msal-custom-auth/test/sign_in/auth_flow/state_handler/SignInCodeRequiredStateHandler.spec.ts
+++ b/lib/msal-custom-auth/test/sign_in/auth_flow/state_handler/SignInCodeRequiredStateHandler.spec.ts
@@ -33,6 +33,7 @@ describe("SignInCodeRequiredStateHandler", () => {
     const mockLogger = {
         info: jest.fn(),
         error: jest.fn(),
+        errorPii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";

--- a/lib/msal-custom-auth/test/sign_in/auth_flow/state_handler/SignInContinuationStateHandler.spec.ts
+++ b/lib/msal-custom-auth/test/sign_in/auth_flow/state_handler/SignInContinuationStateHandler.spec.ts
@@ -22,6 +22,7 @@ describe("SignInContinuationStateHandler", () => {
     const mockLogger = {
         info: jest.fn(),
         error: jest.fn(),
+        errorPii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     const mockCacheClient = {} as unknown as jest.Mocked<CustomAuthSilentCacheClient>;

--- a/lib/msal-custom-auth/test/sign_in/auth_flow/state_handler/SignInPasswordRequiredStateHandler.spec.ts
+++ b/lib/msal-custom-auth/test/sign_in/auth_flow/state_handler/SignInPasswordRequiredStateHandler.spec.ts
@@ -23,6 +23,7 @@ describe("SignInPasswordRequiredStateHandler", () => {
     const mockLogger = {
         info: jest.fn(),
         error: jest.fn(),
+        errorPii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     const mockCacheClient = {} as unknown as jest.Mocked<CustomAuthSilentCacheClient>;

--- a/lib/msal-custom-auth/test/sign_in/interation_client/SignInClient.spec.ts
+++ b/lib/msal-custom-auth/test/sign_in/interation_client/SignInClient.spec.ts
@@ -96,6 +96,7 @@ describe("SignInClient", () => {
             clone: jest.fn(),
             verbose: jest.fn(),
             info: jest.fn(),
+            errorPii: jest.fn(),
         } as unknown as jest.Mocked<Logger>;
         mockLogger.clone.mockReturnValue(mockLogger);
 

--- a/lib/msal-custom-auth/test/sign_up/auth_flow/state_handler/SignUpAttributesRequiredStateHandler.spec.ts
+++ b/lib/msal-custom-auth/test/sign_up/auth_flow/state_handler/SignUpAttributesRequiredStateHandler.spec.ts
@@ -29,6 +29,7 @@ describe("SignUpAttributesRequiredStateHandler", () => {
     const mockLogger = {
         info: jest.fn(),
         error: jest.fn(),
+        errorPii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";

--- a/lib/msal-custom-auth/test/sign_up/auth_flow/state_handler/SignUpCodeRequiredStateHandler.spec.ts
+++ b/lib/msal-custom-auth/test/sign_up/auth_flow/state_handler/SignUpCodeRequiredStateHandler.spec.ts
@@ -32,6 +32,7 @@ describe("SignUpCodeRequiredStateHandler", () => {
     const mockLogger = {
         info: jest.fn(),
         error: jest.fn(),
+        errorPii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";

--- a/lib/msal-custom-auth/test/sign_up/auth_flow/state_handler/SignUpPasswordRequiredStateHandler.spec.ts
+++ b/lib/msal-custom-auth/test/sign_up/auth_flow/state_handler/SignUpPasswordRequiredStateHandler.spec.ts
@@ -29,6 +29,7 @@ describe("SignUpPasswordRequiredStateHandler", () => {
     const mockLogger = {
         info: jest.fn(),
         error: jest.fn(),
+        errorPii: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";

--- a/lib/msal-custom-auth/test/sign_up/interaction_client/SignUpClient.spec.ts
+++ b/lib/msal-custom-auth/test/sign_up/interaction_client/SignUpClient.spec.ts
@@ -97,6 +97,7 @@ describe("SignUpClient", () => {
             verbose: jest.fn(),
             info: jest.fn(),
             error: jest.fn(),
+            errorPii: jest.fn(),
         } as unknown as jest.Mocked<Logger>;
         mockLogger.clone.mockReturnValue(mockLogger);
 


### PR DESCRIPTION
This PR is to update
1. Error handling: when function throws error, we create `AuthenticationResult` with error object and state. This updates when error is `AuthError`, i.e. error comes from msal-browser, wraps it with `MsalCustomAuthError` owned by custom auth
2. Pii info: Wrap logs/errors which potentially contains pii data with *pii logger method. 
    3. Set up piiLoggingEnabled = true to trigger pii callback. Default is false.
    4. pii callback is to give user options how they want to handle pii info. By setting `config.system.loggerOptions.loggerCallback` with a callback function to overwrite. Default is not set loggerCallback.
3. Update correlation id to all logs occurrences 