### PR TITLE
Fix ATS request deduplication for pairwise broker requests

### DIFF
--- a/change/@azure-msal-browser-ff22c8e9-d56a-4cee-a010-bc0e2d00ce5a.json
+++ b/change/@azure-msal-browser-ff22c8e9-d56a-4cee-a010-bc0e2d00ce5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix acquireTokenSilent deduplication for pairwise broker requests",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-46041a7e-4da2-4a81-93d9-1b2be924772e.json
+++ b/change/@azure-msal-common-46041a7e-4da2-4a81-93d9-1b2be924772e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add embeddedClientId to RequestThumbprint",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1341,7 +1341,6 @@ export type PopupPosition = {
 export type PopupRequest = Partial<Omit<CommonAuthorizationUrlRequest, "responseMode" | "scopes" | "codeChallenge" | "codeChallengeMethod" | "requestedClaimsHash" | "platformBroker">> & {
     scopes: Array<string>;
     popupWindowAttributes?: PopupWindowAttributes;
-    tokenBodyParameters?: StringDict;
     popupWindowParent?: Window;
 };
 
@@ -1600,7 +1599,6 @@ export type RedirectRequest = Partial<Omit<CommonAuthorizationUrlRequest, "respo
     scopes: Array<string>;
     redirectStartPage?: string;
     onRedirectNavigate?: (url: string) => boolean | void;
-    tokenBodyParameters?: StringDict;
 };
 
 // Warning: (ae-missing-release-tag) "replaceHash" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1679,7 +1677,6 @@ export type SilentRequest = Omit<CommonSilentFlowRequest, "authority" | "correla
     cacheLookupPolicy?: CacheLookupPolicy;
     prompt?: string;
     state?: string;
-    tokenBodyParameters?: StringDict;
 };
 
 // Warning: (ae-missing-release-tag) "spaCodeAndNativeAccountIdPresent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1690,9 +1687,7 @@ const spaCodeAndNativeAccountIdPresent = "spa_code_and_nativeAccountId_present";
 // Warning: (ae-missing-release-tag) "SsoSilentRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export type SsoSilentRequest = Partial<Omit<CommonAuthorizationUrlRequest, "responseMode" | "codeChallenge" | "codeChallengeMethod" | "requestedClaimsHash" | "platformBroker">> & {
-    tokenBodyParameters?: StringDict;
-};
+export type SsoSilentRequest = Partial<Omit<CommonAuthorizationUrlRequest, "responseMode" | "codeChallenge" | "codeChallengeMethod" | "requestedClaimsHash" | "platformBroker">>;
 
 // Warning: (ae-missing-release-tag) "stateInteractionTypeMismatch" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1959,7 +1959,7 @@ export class StandardController implements IController {
         }
         atsMeasurement.add({ accountType: getAccountType(account) });
 
-        return this.getDedupedSilentRequest(request, account, correlationId)
+        return this.acquireTokenSilentDeduped(request, account, correlationId)
             .then((result) => {
                 atsMeasurement.end({
                     success: true,
@@ -1997,7 +1997,7 @@ export class StandardController implements IController {
      * @param correlationId
      * @returns
      */
-    private async getDedupedSilentRequest(
+    private async acquireTokenSilentDeduped(
         request: SilentRequest,
         account: AccountInfo,
         correlationId: string

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1959,11 +1959,7 @@ export class StandardController implements IController {
         }
         atsMeasurement.add({ accountType: getAccountType(account) });
 
-        return await this.getDedupedSilentRequest(
-            request,
-            account,
-            correlationId
-        )
+        return this.getDedupedSilentRequest(request, account, correlationId)
             .then((result) => {
                 atsMeasurement.end({
                     success: true,

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -20,7 +20,7 @@ import {
     BaseAuthRequest,
     PromptValue,
     InProgressPerformanceEvent,
-    RequestThumbprint,
+    getRequestThumbprint,
     AccountEntity,
     invokeAsync,
     createClientAuthError,
@@ -1959,19 +1959,15 @@ export class StandardController implements IController {
         }
         atsMeasurement.add({ accountType: getAccountType(account) });
 
-        const thumbprint: RequestThumbprint = {
-            clientId: this.config.auth.clientId,
-            authority: request.authority || Constants.EMPTY_STRING,
-            scopes: request.scopes,
-            homeAccountIdentifier: account.homeAccountId,
-            claims: request.claims,
-            authenticationScheme: request.authenticationScheme,
-            resourceRequestMethod: request.resourceRequestMethod,
-            resourceRequestUri: request.resourceRequestUri,
-            shrClaims: request.shrClaims,
-            sshKid: request.sshKid,
-            shrOptions: request.shrOptions,
-        };
+        const thumbprint = getRequestThumbprint(
+            this.config.auth.clientId,
+            {
+                ...request,
+                authority: request.authority || this.config.auth.authority,
+                correlationId: correlationId,
+            },
+            account.homeAccountId
+        );
         const silentRequestKey = JSON.stringify(thumbprint);
 
         const cachedResponse =
@@ -2032,6 +2028,7 @@ export class StandardController implements IController {
             return {
                 ...(await cachedResponse),
                 state: request.state,
+                correlationId: correlationId
             };
         }
     }

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1959,6 +1959,53 @@ export class StandardController implements IController {
         }
         atsMeasurement.add({ accountType: getAccountType(account) });
 
+        return await this.getDedupedSilentRequest(
+            request,
+            account,
+            correlationId
+        )
+            .then((result) => {
+                atsMeasurement.end({
+                    success: true,
+                    fromCache: result.fromCache,
+                    isNativeBroker: result.fromNativeBroker,
+                    accessTokenSize: result.accessToken.length,
+                    idTokenSize: result.idToken.length,
+                });
+                return {
+                    ...result,
+                    state: request.state,
+                    correlationId: correlationId, // Ensures PWB scenarios can correctly match request to response
+                };
+            })
+            .catch((error: Error) => {
+                if (error instanceof AuthError) {
+                    // Ensures PWB scenarios can correctly match request to response
+                    error.setCorrelationId(correlationId);
+                }
+
+                atsMeasurement.end(
+                    {
+                        success: false,
+                    },
+                    error
+                );
+                throw error;
+            });
+    }
+
+    /**
+     * Checks if identical request is already in flight and returns reference to the existing promise or fires off a new one if this is the first
+     * @param request
+     * @param account
+     * @param correlationId
+     * @returns
+     */
+    private async getDedupedSilentRequest(
+        request: SilentRequest,
+        account: AccountInfo,
+        correlationId: string
+    ): Promise<AuthenticationResult> {
         const thumbprint = getRequestThumbprint(
             this.config.auth.clientId,
             {
@@ -1970,15 +2017,17 @@ export class StandardController implements IController {
         );
         const silentRequestKey = JSON.stringify(thumbprint);
 
-        const cachedResponse =
+        const inProgressRequest =
             this.activeSilentTokenRequests.get(silentRequestKey);
-        if (typeof cachedResponse === "undefined") {
+
+        if (typeof inProgressRequest === "undefined") {
             this.logger.verbose(
                 "acquireTokenSilent called for the first time, storing active request",
                 correlationId
             );
+            this.performanceClient.addFields({ deduped: false }, correlationId);
 
-            const response = invokeAsync(
+            const activeRequest = invokeAsync(
                 this.acquireTokenSilentAsync.bind(this),
                 PerformanceEvents.AcquireTokenSilentAsync,
                 this.logger,
@@ -1990,46 +2039,19 @@ export class StandardController implements IController {
                     correlationId,
                 },
                 account
-            )
-                .then((result) => {
-                    this.activeSilentTokenRequests.delete(silentRequestKey);
-                    atsMeasurement.end({
-                        success: true,
-                        fromCache: result.fromCache,
-                        isNativeBroker: result.fromNativeBroker,
-                        cacheLookupPolicy: request.cacheLookupPolicy,
-                        accessTokenSize: result.accessToken.length,
-                        idTokenSize: result.idToken.length,
-                    });
-                    return result;
-                })
-                .catch((error: Error) => {
-                    this.activeSilentTokenRequests.delete(silentRequestKey);
-                    atsMeasurement.end(
-                        {
-                            success: false,
-                        },
-                        error
-                    );
-                    throw error;
-                });
-            this.activeSilentTokenRequests.set(silentRequestKey, response);
-            return {
-                ...(await response),
-                state: request.state,
-            };
+            );
+            this.activeSilentTokenRequests.set(silentRequestKey, activeRequest);
+
+            return activeRequest.finally(() => {
+                this.activeSilentTokenRequests.delete(silentRequestKey);
+            });
         } else {
             this.logger.verbose(
                 "acquireTokenSilent has been called previously, returning the result from the first call",
                 correlationId
             );
-            // Discard measurements for memoized calls, as they are usually only a couple of ms and will artificially deflate metrics
-            atsMeasurement.discard();
-            return {
-                ...(await cachedResponse),
-                state: request.state,
-                correlationId: correlationId
-            };
+            this.performanceClient.addFields({ deduped: true }, correlationId);
+            return inProgressRequest;
         }
     }
 

--- a/lib/msal-browser/src/request/PopupRequest.ts
+++ b/lib/msal-browser/src/request/PopupRequest.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-    CommonAuthorizationUrlRequest,
-    StringDict,
-} from "@azure/msal-common/browser";
+import { CommonAuthorizationUrlRequest } from "@azure/msal-common/browser";
 import { PopupWindowAttributes } from "./PopupWindowAttributes.js";
 
 /**

--- a/lib/msal-browser/src/request/PopupRequest.ts
+++ b/lib/msal-browser/src/request/PopupRequest.ts
@@ -51,6 +51,5 @@ export type PopupRequest = Partial<
 > & {
     scopes: Array<string>;
     popupWindowAttributes?: PopupWindowAttributes;
-    tokenBodyParameters?: StringDict;
     popupWindowParent?: Window;
 };

--- a/lib/msal-browser/src/request/RedirectRequest.ts
+++ b/lib/msal-browser/src/request/RedirectRequest.ts
@@ -55,5 +55,4 @@ export type RedirectRequest = Partial<
      * Set onRedirectNavigate in Configuration instead.
      */
     onRedirectNavigate?: (url: string) => boolean | void;
-    tokenBodyParameters?: StringDict;
 };

--- a/lib/msal-browser/src/request/RedirectRequest.ts
+++ b/lib/msal-browser/src/request/RedirectRequest.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-    CommonAuthorizationUrlRequest,
-    StringDict,
-} from "@azure/msal-common/browser";
+import { CommonAuthorizationUrlRequest } from "@azure/msal-common/browser";
 
 /**
  * RedirectRequest: Request object passed by user to retrieve a Code from the

--- a/lib/msal-browser/src/request/SilentRequest.ts
+++ b/lib/msal-browser/src/request/SilentRequest.ts
@@ -46,5 +46,4 @@ export type SilentRequest = Omit<
     cacheLookupPolicy?: CacheLookupPolicy;
     prompt?: string;
     state?: string;
-    tokenBodyParameters?: StringDict;
 };

--- a/lib/msal-browser/src/request/SsoSilentRequest.ts
+++ b/lib/msal-browser/src/request/SsoSilentRequest.ts
@@ -42,6 +42,4 @@ export type SsoSilentRequest = Partial<
         | "requestedClaimsHash"
         | "platformBroker"
     >
-> & {
-    tokenBodyParameters?: StringDict;
-};
+>;

--- a/lib/msal-browser/src/request/SsoSilentRequest.ts
+++ b/lib/msal-browser/src/request/SsoSilentRequest.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-    CommonAuthorizationUrlRequest,
-    StringDict,
-} from "@azure/msal-common/browser";
+import { CommonAuthorizationUrlRequest } from "@azure/msal-common/browser";
 
 /**
  * Request object passed by user to ssoSilent to retrieve a Code from the server (first leg of authorization code grant flow)

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -3978,7 +3978,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const response = await pca.acquireTokenSilent({
                 scopes: ["User.Read"],
                 account: testAccount,
-                correlationId: RANDOM_TEST_GUID
+                correlationId: RANDOM_TEST_GUID,
             });
 
             expect(response).toEqual(testTokenResponse);
@@ -4037,7 +4037,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const silentRequest = {
                 scopes: ["User.Read"],
                 account: testAccount,
-                correlationId: RANDOM_TEST_GUID
+                correlationId: RANDOM_TEST_GUID,
             };
             const response = await pca.acquireTokenSilent(silentRequest);
 
@@ -4142,7 +4142,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
-                correlationId: RANDOM_TEST_GUID
+                correlationId: RANDOM_TEST_GUID,
             });
             expect(response?.idToken).not.toBeNull();
             expect(response).toEqual(testTokenResponse);
@@ -4232,7 +4232,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
-                correlationId: RANDOM_TEST_GUID
+                correlationId: RANDOM_TEST_GUID,
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -4282,7 +4282,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
-                correlationId: RANDOM_TEST_GUID
+                correlationId: RANDOM_TEST_GUID,
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -4331,7 +4331,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
-                correlationId: RANDOM_TEST_GUID
+                correlationId: RANDOM_TEST_GUID,
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -4415,8 +4415,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             };
 
             const silentRequest1 = pca.acquireTokenSilent(tokenRequest);
-            const silentRequest2 = pca.acquireTokenSilent({...tokenRequest, correlationId: "test-correlationId2"});
-            const silentRequest3 = pca.acquireTokenSilent({...tokenRequest, correlationId: "test-correlationId3"});
+            const silentRequest2 = pca.acquireTokenSilent({
+                ...tokenRequest,
+                correlationId: "test-correlationId2",
+            });
+            const silentRequest3 = pca.acquireTokenSilent({
+                ...tokenRequest,
+                correlationId: "test-correlationId3",
+            });
             const parallelResponse = await Promise.all([
                 silentRequest1,
                 silentRequest2,
@@ -4427,8 +4433,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(atsSpy).toHaveBeenCalledTimes(1);
             expect(silentATStub).toHaveBeenCalledTimes(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);
-            expect(parallelResponse[1]).toEqual({...testTokenResponse, correlationId: "test-correlationId2"});
-            expect(parallelResponse[2]).toEqual({...testTokenResponse, correlationId: "test-correlationId3"});
+            expect(parallelResponse[1]).toEqual({
+                ...testTokenResponse,
+                correlationId: "test-correlationId2",
+            });
+            expect(parallelResponse[2]).toEqual({
+                ...testTokenResponse,
+                correlationId: "test-correlationId3",
+            });
             expect(parallelResponse).toHaveLength(3);
         });
 
@@ -4524,8 +4536,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             };
 
             const silentRequest1 = pca.acquireTokenSilent(tokenRequest);
-            const silentRequest2 = pca.acquireTokenSilent({...tokenRequest, correlationId: "test-correlationId2"});
-            const silentRequest3 = pca.acquireTokenSilent({...tokenRequest, correlationId: "test-correlationId3"});
+            const silentRequest2 = pca.acquireTokenSilent({
+                ...tokenRequest,
+                correlationId: "test-correlationId2",
+            });
+            const silentRequest3 = pca.acquireTokenSilent({
+                ...tokenRequest,
+                correlationId: "test-correlationId3",
+            });
             const parallelResponse = await Promise.all([
                 silentRequest1,
                 silentRequest2,
@@ -4536,8 +4554,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(atsSpy).toHaveBeenCalledTimes(1);
             expect(silentATStub).toHaveBeenCalledTimes(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);
-            expect(parallelResponse[1]).toEqual({...testTokenResponse, correlationId: "test-correlationId2"});
-            expect(parallelResponse[2]).toEqual({...testTokenResponse, correlationId: "test-correlationId3"});
+            expect(parallelResponse[1]).toEqual({
+                ...testTokenResponse,
+                correlationId: "test-correlationId2",
+            });
+            expect(parallelResponse[2]).toEqual({
+                ...testTokenResponse,
+                correlationId: "test-correlationId3",
+            });
             expect(parallelResponse).toHaveLength(3);
         });
 
@@ -5069,7 +5093,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 authority: TEST_CONFIG.validAuthority,
                 correlationId: "test-correlationId1",
                 forceRefresh: false,
-            }
+            };
             const tokenRequest1: CommonSilentFlowRequest = {
                 ...baseRequest,
                 embeddedClientId: "embeddedApp1",
@@ -5084,11 +5108,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const silentRequest1 = pca.acquireTokenSilent(tokenRequest1);
             const silentRequest2 = pca.acquireTokenSilent(tokenRequest1);
             const silentRequest3 = pca.acquireTokenSilent(tokenRequest2);
-            await Promise.all([
-                silentRequest1,
-                silentRequest2,
-                silentRequest3,
-            ]);
+            await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
 
             expect(silentATStub).toHaveBeenCalledWith(tokenRequest1);
             expect(silentATStub).toHaveBeenCalledWith(tokenRequest2);
@@ -5253,25 +5273,34 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const silentRequest1 = pca.acquireTokenSilent({
                 scopes: ["Scope1"],
                 account: testAccount,
-                correlationId: "test-correlationId1"
+                correlationId: "test-correlationId1",
             });
             const silentRequest2 = pca.acquireTokenSilent({
                 scopes: ["Scope2"],
                 account: testAccount,
-                correlationId: "test-correlationId2"
+                correlationId: "test-correlationId2",
             });
             const silentRequest3 = pca.acquireTokenSilent({
                 scopes: ["Scope3"],
                 account: testAccount,
-                correlationId: "test-correlationId3"
+                correlationId: "test-correlationId3",
             });
             await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
             expect(iframeMock).toHaveBeenCalledTimes(1);
             expect(rtMockFirstCalledTimes).toEqual(3);
             expect(rtMockSecond).toHaveBeenCalledTimes(2);
-            expect(await silentRequest1).toEqual({...testTokenResponse, correlationId: "test-correlationId1"});
-            expect(await silentRequest2).toEqual({...testTokenResponse, correlationId: "test-correlationId2"});
-            expect(await silentRequest3).toEqual({...testTokenResponse, correlationId: "test-correlationId3"});
+            expect(await silentRequest1).toEqual({
+                ...testTokenResponse,
+                correlationId: "test-correlationId1",
+            });
+            expect(await silentRequest2).toEqual({
+                ...testTokenResponse,
+                correlationId: "test-correlationId2",
+            });
+            expect(await silentRequest3).toEqual({
+                ...testTokenResponse,
+                correlationId: "test-correlationId3",
+            });
         });
 
         it("throws RT renewal error if other in progress iframe renewal throws", async () => {
@@ -5815,7 +5844,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     scopes: ["openid"],
                     account: testAccount,
                     cacheLookupPolicy: CacheLookupPolicy.Default,
-                    correlationId: RANDOM_TEST_GUID
+                    correlationId: RANDOM_TEST_GUID,
                 });
                 expect(response).toEqual(testTokenResponse);
                 expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -5842,7 +5871,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     scopes: ["openid"],
                     account: testAccount,
                     cacheLookupPolicy: CacheLookupPolicy.Default,
-                    correlationId: RANDOM_TEST_GUID
+                    correlationId: RANDOM_TEST_GUID,
                 });
                 expect(response).toEqual(testTokenResponse);
                 expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -5936,7 +5965,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     scopes: ["openid"],
                     account: testAccount,
                     cacheLookupPolicy: CacheLookupPolicy.RefreshTokenAndNetwork,
-                    correlationId: RANDOM_TEST_GUID
+                    correlationId: RANDOM_TEST_GUID,
                 });
                 expect(response).toEqual(testTokenResponse);
                 expect(silentCacheSpy).toHaveBeenCalledTimes(0);
@@ -5959,7 +5988,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     scopes: ["openid"],
                     account: testAccount,
                     cacheLookupPolicy: CacheLookupPolicy.Skip,
-                    correlationId: RANDOM_TEST_GUID
+                    correlationId: RANDOM_TEST_GUID,
                 });
                 expect(response).toEqual(testTokenResponse);
                 expect(silentCacheSpy).toHaveBeenCalledTimes(0);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -3978,6 +3978,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const response = await pca.acquireTokenSilent({
                 scopes: ["User.Read"],
                 account: testAccount,
+                correlationId: RANDOM_TEST_GUID
             });
 
             expect(response).toEqual(testTokenResponse);
@@ -4036,6 +4037,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const silentRequest = {
                 scopes: ["User.Read"],
                 account: testAccount,
+                correlationId: RANDOM_TEST_GUID
             };
             const response = await pca.acquireTokenSilent(silentRequest);
 
@@ -4140,6 +4142,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
+                correlationId: RANDOM_TEST_GUID
             });
             expect(response?.idToken).not.toBeNull();
             expect(response).toEqual(testTokenResponse);
@@ -4229,6 +4232,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
+                correlationId: RANDOM_TEST_GUID
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -4278,6 +4282,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
+                correlationId: RANDOM_TEST_GUID
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -4326,6 +4331,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["openid"],
                 account: testAccount,
                 state: "test-state",
+                correlationId: RANDOM_TEST_GUID
             });
             expect(response).toEqual(testTokenResponse);
             expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -4409,8 +4415,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             };
 
             const silentRequest1 = pca.acquireTokenSilent(tokenRequest);
-            const silentRequest2 = pca.acquireTokenSilent(tokenRequest);
-            const silentRequest3 = pca.acquireTokenSilent(tokenRequest);
+            const silentRequest2 = pca.acquireTokenSilent({...tokenRequest, correlationId: "test-correlationId2"});
+            const silentRequest3 = pca.acquireTokenSilent({...tokenRequest, correlationId: "test-correlationId3"});
             const parallelResponse = await Promise.all([
                 silentRequest1,
                 silentRequest2,
@@ -4421,8 +4427,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(atsSpy).toHaveBeenCalledTimes(1);
             expect(silentATStub).toHaveBeenCalledTimes(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);
-            expect(parallelResponse[1]).toEqual(testTokenResponse);
-            expect(parallelResponse[2]).toEqual(testTokenResponse);
+            expect(parallelResponse[1]).toEqual({...testTokenResponse, correlationId: "test-correlationId2"});
+            expect(parallelResponse[2]).toEqual({...testTokenResponse, correlationId: "test-correlationId3"});
             expect(parallelResponse).toHaveLength(3);
         });
 
@@ -4518,8 +4524,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             };
 
             const silentRequest1 = pca.acquireTokenSilent(tokenRequest);
-            const silentRequest2 = pca.acquireTokenSilent(tokenRequest);
-            const silentRequest3 = pca.acquireTokenSilent(tokenRequest);
+            const silentRequest2 = pca.acquireTokenSilent({...tokenRequest, correlationId: "test-correlationId2"});
+            const silentRequest3 = pca.acquireTokenSilent({...tokenRequest, correlationId: "test-correlationId3"});
             const parallelResponse = await Promise.all([
                 silentRequest1,
                 silentRequest2,
@@ -4530,8 +4536,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(atsSpy).toHaveBeenCalledTimes(1);
             expect(silentATStub).toHaveBeenCalledTimes(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);
-            expect(parallelResponse[1]).toEqual(testTokenResponse);
-            expect(parallelResponse[2]).toEqual(testTokenResponse);
+            expect(parallelResponse[1]).toEqual({...testTokenResponse, correlationId: "test-correlationId2"});
+            expect(parallelResponse[2]).toEqual({...testTokenResponse, correlationId: "test-correlationId3"});
             expect(parallelResponse).toHaveLength(3);
         });
 
@@ -5000,6 +5006,95 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentATStub).toHaveBeenCalledTimes(8);
         });
 
+        it("makes network requests for identical requests for different embedded apps when acquireTokenSilent is called in parallel", async () => {
+            const testServerTokenResponse = {
+                token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,
+                scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
+                expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+                ext_expires_in: TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN,
+                access_token: TEST_TOKENS.ACCESS_TOKEN,
+                refresh_token: TEST_TOKENS.REFRESH_TOKEN,
+                id_token: TEST_TOKENS.IDTOKEN_V2,
+            };
+            const testIdTokenClaims: TokenClaims = {
+                ver: "2.0",
+                iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                name: "Abe Lincoln",
+                preferred_username: "AbeLi@microsoft.com",
+                oid: "00000000-0000-0000-66f3-3332eca7ea81",
+                tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                nonce: "123523",
+            };
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || "",
+            };
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testIdTokenClaims.oid || "",
+                tenantId: testIdTokenClaims.tid || "",
+                scopes: [...TEST_CONFIG.DEFAULT_SCOPES, "User.Read"],
+                idToken: testServerTokenResponse.id_token,
+                idTokenClaims: testIdTokenClaims,
+                accessToken: testServerTokenResponse.access_token,
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: new Date(
+                    Date.now() + testServerTokenResponse.expires_in * 1000
+                ),
+                account: testAccount,
+                tokenType: AuthenticationScheme.BEARER,
+            };
+            jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                RANDOM_TEST_GUID
+            );
+            jest.spyOn(CryptoOps.prototype, "hashString").mockResolvedValue(
+                TEST_CRYPTO_VALUES.TEST_SHA256_HASH
+            );
+            const silentATStub: jest.SpyInstance = jest
+                .spyOn(
+                    RefreshTokenClient.prototype,
+                    "acquireTokenByRefreshToken"
+                )
+                .mockResolvedValue(testTokenResponse);
+            // Beaerer requests
+            const baseRequest = {
+                scopes: ["User.Read"],
+                account: testAccount,
+                authenticationScheme: AuthenticationScheme.BEARER,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: "test-correlationId1",
+                forceRefresh: false,
+            }
+            const tokenRequest1: CommonSilentFlowRequest = {
+                ...baseRequest,
+                embeddedClientId: "embeddedApp1",
+                correlationId: "test-correlationId1",
+            };
+            const tokenRequest2: CommonSilentFlowRequest = {
+                ...baseRequest,
+                embeddedClientId: "embeddedApp2",
+                correlationId: "test-correlationId2",
+            };
+
+            const silentRequest1 = pca.acquireTokenSilent(tokenRequest1);
+            const silentRequest2 = pca.acquireTokenSilent(tokenRequest1);
+            const silentRequest3 = pca.acquireTokenSilent(tokenRequest2);
+            await Promise.all([
+                silentRequest1,
+                silentRequest2,
+                silentRequest3,
+            ]);
+
+            expect(silentATStub).toHaveBeenCalledWith(tokenRequest1);
+            expect(silentATStub).toHaveBeenCalledWith(tokenRequest2);
+            expect(silentATStub).toHaveBeenCalledTimes(2);
+        });
+
         it("throws error that SilentFlowClient.acquireToken() throws", async () => {
             const testError: AuthError = new AuthError(
                 "create_login_url_error",
@@ -5158,22 +5253,25 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const silentRequest1 = pca.acquireTokenSilent({
                 scopes: ["Scope1"],
                 account: testAccount,
+                correlationId: "test-correlationId1"
             });
             const silentRequest2 = pca.acquireTokenSilent({
                 scopes: ["Scope2"],
                 account: testAccount,
+                correlationId: "test-correlationId2"
             });
             const silentRequest3 = pca.acquireTokenSilent({
                 scopes: ["Scope3"],
                 account: testAccount,
+                correlationId: "test-correlationId3"
             });
             await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
             expect(iframeMock).toHaveBeenCalledTimes(1);
             expect(rtMockFirstCalledTimes).toEqual(3);
             expect(rtMockSecond).toHaveBeenCalledTimes(2);
-            expect(await silentRequest1).toEqual(testTokenResponse);
-            expect(await silentRequest2).toEqual(testTokenResponse);
-            expect(await silentRequest3).toEqual(testTokenResponse);
+            expect(await silentRequest1).toEqual({...testTokenResponse, correlationId: "test-correlationId1"});
+            expect(await silentRequest2).toEqual({...testTokenResponse, correlationId: "test-correlationId2"});
+            expect(await silentRequest3).toEqual({...testTokenResponse, correlationId: "test-correlationId3"});
         });
 
         it("throws RT renewal error if other in progress iframe renewal throws", async () => {
@@ -5717,6 +5815,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     scopes: ["openid"],
                     account: testAccount,
                     cacheLookupPolicy: CacheLookupPolicy.Default,
+                    correlationId: RANDOM_TEST_GUID
                 });
                 expect(response).toEqual(testTokenResponse);
                 expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -5743,6 +5842,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     scopes: ["openid"],
                     account: testAccount,
                     cacheLookupPolicy: CacheLookupPolicy.Default,
+                    correlationId: RANDOM_TEST_GUID
                 });
                 expect(response).toEqual(testTokenResponse);
                 expect(silentCacheSpy).toHaveBeenCalledTimes(1);
@@ -5836,6 +5936,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     scopes: ["openid"],
                     account: testAccount,
                     cacheLookupPolicy: CacheLookupPolicy.RefreshTokenAndNetwork,
+                    correlationId: RANDOM_TEST_GUID
                 });
                 expect(response).toEqual(testTokenResponse);
                 expect(silentCacheSpy).toHaveBeenCalledTimes(0);
@@ -5858,6 +5959,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     scopes: ["openid"],
                     account: testAccount,
                     cacheLookupPolicy: CacheLookupPolicy.Skip,
+                    correlationId: RANDOM_TEST_GUID
                 });
                 expect(response).toEqual(testTokenResponse);
                 expect(silentCacheSpy).toHaveBeenCalledTimes(0);

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -602,6 +602,7 @@ export type BaseAuthRequest = {
     azureCloudOptions?: AzureCloudOptions;
     requestedClaimsHash?: string;
     maxAge?: number;
+    tokenBodyParameters?: StringDict;
     tokenQueryParameters?: StringDict;
     storeInCache?: StoreInCache;
     scenarioId?: string;
@@ -1527,7 +1528,6 @@ export type CommonAuthorizationCodeRequest = BaseAuthRequest & {
     code: string;
     redirectUri: string;
     codeVerifier?: string;
-    tokenBodyParameters?: StringDict;
     enableSpaAuthorizationCode?: boolean;
     clientInfo?: string;
     ccsCredential?: CcsCredential;
@@ -1565,7 +1565,7 @@ export type CommonClientCredentialRequest = BaseAuthRequest & {
 // Warning: (ae-missing-release-tag) "CommonDeviceCodeRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export type CommonDeviceCodeRequest = Omit<BaseAuthRequest, "tokenQueryParameters"> & {
+export type CommonDeviceCodeRequest = Omit<BaseAuthRequest, "tokenQueryParameters" | "tokenBodyParameters"> & {
     deviceCodeCallback: (response: DeviceCodeResponse) => void;
     cancel?: boolean;
     timeout?: number;
@@ -1600,7 +1600,6 @@ export type CommonRefreshTokenRequest = BaseAuthRequest & {
     refreshToken: string;
     ccsCredential?: CcsCredential;
     forceCache?: boolean;
-    tokenBodyParameters?: StringDict;
     redirectUri?: string;
 };
 
@@ -1611,7 +1610,6 @@ export type CommonSilentFlowRequest = BaseAuthRequest & {
     account: AccountInfo;
     forceRefresh: boolean;
     redirectUri?: string;
-    tokenBodyParameters?: StringDict;
     refreshTokenExpirationOffsetSeconds?: number;
 };
 
@@ -2014,6 +2012,11 @@ function getDeserializedResponse(responseString: string): ServerAuthorizationCod
 //
 // @public
 function getJWSPayload(authToken: string): string;
+
+// Warning: (ae-missing-release-tag) "getRequestThumbprint" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function getRequestThumbprint(clientId: string, request: BaseAuthRequest, homeAccountId?: string): RequestThumbprint;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "getTenantIdFromIdTokenClaims" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3496,6 +3499,7 @@ export type RequestThumbprint = {
     shrClaims?: string;
     sshKid?: string;
     shrOptions?: ShrOptions;
+    embeddedClientId?: string;
 };
 
 // Warning: (ae-missing-release-tag) "RESPONSE_MODE" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4282,14 +4286,14 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/cache/utils/CacheTypes.ts:94:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
 // src/client/AuthorizationCodeClient.ts:228:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:229:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:307:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:507:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:763:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:823:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:298:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:498:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:754:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:814:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:193:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:286:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:287:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:346:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:338:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/SilentFlowClient.ts:172:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/ClientConfiguration.ts:50:5 - (ae-forgotten-export) The symbol "ClientCredentials" needs to be exported by the entry point index.d.ts
 // src/config/ClientConfiguration.ts:51:5 - (ae-forgotten-export) The symbol "LibraryInfo" needs to be exported by the entry point index.d.ts

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -33,7 +33,6 @@ import { UrlString } from "../url/UrlString.js";
 import { ServerAuthorizationCodeResponse } from "../response/ServerAuthorizationCodeResponse.js";
 import { CommonEndSessionRequest } from "../request/CommonEndSessionRequest.js";
 import { PopTokenGenerator } from "../crypto/PopTokenGenerator.js";
-import { RequestThumbprint } from "../network/RequestThumbprint.js";
 import { AuthorizationCodePayload } from "../response/AuthorizationCodePayload.js";
 import * as TimeUtils from "../utils/TimeUtils.js";
 import { AccountInfo } from "../account/AccountInfo.js";
@@ -52,6 +51,7 @@ import { PerformanceEvents } from "../telemetry/performance/PerformanceEvent.js"
 import { invokeAsync } from "../utils/FunctionWrappers.js";
 import { ClientAssertion } from "../account/ClientCredentials.js";
 import { getClientAssertion } from "../utils/ClientAssertionUtils.js";
+import { getRequestThumbprint } from "../network/RequestThumbprint.js";
 
 /**
  * Oauth2.0 Authorization Code client
@@ -272,19 +272,10 @@ export class AuthorizationCodeClient extends BaseClient {
             ccsCredential || request.ccsCredential
         );
 
-        const thumbprint: RequestThumbprint = {
-            clientId:
-                request.tokenBodyParameters?.clientId ||
-                this.config.authOptions.clientId,
-            authority: authority.canonicalAuthority,
-            scopes: request.scopes,
-            claims: request.claims,
-            authenticationScheme: request.authenticationScheme,
-            resourceRequestMethod: request.resourceRequestMethod,
-            resourceRequestUri: request.resourceRequestUri,
-            shrClaims: request.shrClaims,
-            sshKid: request.sshKid,
-        };
+        const thumbprint = getRequestThumbprint(
+            this.config.authOptions.clientId,
+            request
+        );
 
         return invokeAsync(
             this.executePostToTokenEndpoint.bind(this),

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -23,7 +23,6 @@ import { ResponseHandler } from "../response/ResponseHandler.js";
 import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import { PopTokenGenerator } from "../crypto/PopTokenGenerator.js";
 import { StringUtils } from "../utils/StringUtils.js";
-import { RequestThumbprint } from "../network/RequestThumbprint.js";
 import { NetworkResponse } from "../network/NetworkResponse.js";
 import { CommonSilentFlowRequest } from "../request/CommonSilentFlowRequest.js";
 import {
@@ -50,6 +49,7 @@ import { invoke, invokeAsync } from "../utils/FunctionWrappers.js";
 import { generateCredentialKey } from "../cache/utils/CacheHelpers.js";
 import { ClientAssertion } from "../account/ClientCredentials.js";
 import { getClientAssertion } from "../utils/ClientAssertionUtils.js";
+import { getRequestThumbprint } from "../network/RequestThumbprint.js";
 
 const DEFAULT_REFRESH_TOKEN_EXPIRATION_OFFSET_SECONDS = 300; // 5 Minutes
 
@@ -311,19 +311,11 @@ export class RefreshTokenClient extends BaseClient {
         const headers: Record<string, string> = this.createTokenRequestHeaders(
             request.ccsCredential
         );
-        const thumbprint: RequestThumbprint = {
-            clientId:
-                request.tokenBodyParameters?.clientId ||
-                this.config.authOptions.clientId,
-            authority: authority.canonicalAuthority,
-            scopes: request.scopes,
-            claims: request.claims,
-            authenticationScheme: request.authenticationScheme,
-            resourceRequestMethod: request.resourceRequestMethod,
-            resourceRequestUri: request.resourceRequestUri,
-            shrClaims: request.shrClaims,
-            sshKid: request.sshKid,
-        };
+
+        const thumbprint = getRequestThumbprint(
+            this.config.authOptions.clientId,
+            request
+        );
 
         return invokeAsync(
             this.executePostToTokenEndpoint.bind(this),

--- a/lib/msal-common/src/exports-common.ts
+++ b/lib/msal-common/src/exports-common.ts
@@ -93,7 +93,10 @@ export {
 } from "./network/INetworkModule.js";
 export { NetworkResponse } from "./network/NetworkResponse.js";
 export { ThrottlingUtils } from "./network/ThrottlingUtils.js";
-export { RequestThumbprint } from "./network/RequestThumbprint.js";
+export {
+    RequestThumbprint,
+    getRequestThumbprint,
+} from "./network/RequestThumbprint.js";
 export { IUri } from "./url/IUri.js";
 export { UrlString } from "./url/UrlString.js";
 export {

--- a/lib/msal-common/src/network/RequestThumbprint.ts
+++ b/lib/msal-common/src/network/RequestThumbprint.ts
@@ -4,6 +4,7 @@
  */
 
 import { ShrOptions } from "../crypto/SignedHttpRequest.js";
+import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
 import { AuthenticationScheme } from "../utils/Constants.js";
 
 /**
@@ -21,4 +22,26 @@ export type RequestThumbprint = {
     shrClaims?: string;
     sshKid?: string;
     shrOptions?: ShrOptions;
+    embeddedClientId?: string;
 };
+
+export function getRequestThumbprint(
+    clientId: string,
+    request: BaseAuthRequest,
+    homeAccountId?: string
+): RequestThumbprint {
+    return {
+        clientId: clientId,
+        authority: request.authority,
+        scopes: request.scopes,
+        homeAccountIdentifier: homeAccountId,
+        claims: request.claims,
+        authenticationScheme: request.authenticationScheme,
+        resourceRequestMethod: request.resourceRequestMethod,
+        resourceRequestUri: request.resourceRequestUri,
+        shrClaims: request.shrClaims,
+        sshKid: request.sshKid,
+        embeddedClientId:
+            request.embeddedClientId || request.tokenBodyParameters?.clientId,
+    };
+}

--- a/lib/msal-common/src/network/ThrottlingUtils.ts
+++ b/lib/msal-common/src/network/ThrottlingUtils.ts
@@ -12,7 +12,10 @@ import {
 } from "../utils/Constants.js";
 import { CacheManager } from "../cache/CacheManager.js";
 import { ServerError } from "../error/ServerError.js";
-import { RequestThumbprint } from "./RequestThumbprint.js";
+import {
+    getRequestThumbprint,
+    RequestThumbprint,
+} from "./RequestThumbprint.js";
 import { ThrottlingEntity } from "../cache/entities/ThrottlingEntity.js";
 import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
 
@@ -137,19 +140,11 @@ export class ThrottlingUtils {
         request: BaseAuthRequest,
         homeAccountIdentifier?: string
     ): void {
-        const thumbprint: RequestThumbprint = {
-            clientId: clientId,
-            authority: request.authority,
-            scopes: request.scopes,
-            homeAccountIdentifier: homeAccountIdentifier,
-            claims: request.claims,
-            authenticationScheme: request.authenticationScheme,
-            resourceRequestMethod: request.resourceRequestMethod,
-            resourceRequestUri: request.resourceRequestUri,
-            shrClaims: request.shrClaims,
-            sshKid: request.sshKid,
-        };
-
+        const thumbprint = getRequestThumbprint(
+            clientId,
+            request,
+            homeAccountIdentifier
+        );
         const key = this.generateThrottlingStorageKey(thumbprint);
         cacheManager.removeItem(key);
     }

--- a/lib/msal-common/src/request/BaseAuthRequest.ts
+++ b/lib/msal-common/src/request/BaseAuthRequest.ts
@@ -26,6 +26,7 @@ import { ShrOptions } from "../crypto/SignedHttpRequest.js";
  * - azureCloudOptions       - Convenience string enums for users to provide public/sovereign cloud ids
  * - requestedClaimsHash     - SHA 256 hash string of the requested claims string, used as part of an access token cache key so tokens can be filtered by requested claims
  * - tokenQueryParameters    - String to string map of custom query parameters added to the /token call
+ * - tokenBodyParameters     - String to string map of custom parameters added to the body of the /token call
  * - storeInCache            - Object containing boolean values indicating whether to store tokens in the cache or not (default is true)
  * - scenarioId              - Scenario id to track custom user prompts
  * - popKid                  - Key ID to identify the public key for PoP token request
@@ -47,6 +48,7 @@ export type BaseAuthRequest = {
     azureCloudOptions?: AzureCloudOptions;
     requestedClaimsHash?: string;
     maxAge?: number;
+    tokenBodyParameters?: StringDict;
     tokenQueryParameters?: StringDict;
     storeInCache?: StoreInCache;
     scenarioId?: string;

--- a/lib/msal-common/src/request/CommonAuthorizationCodeRequest.ts
+++ b/lib/msal-common/src/request/CommonAuthorizationCodeRequest.ts
@@ -4,7 +4,6 @@
  */
 
 import { BaseAuthRequest } from "./BaseAuthRequest.js";
-import { StringDict } from "../utils/MsalTypes.js";
 import { CcsCredential } from "../account/CcsCredential.js";
 
 /**
@@ -26,7 +25,6 @@ export type CommonAuthorizationCodeRequest = BaseAuthRequest & {
     code: string;
     redirectUri: string;
     codeVerifier?: string;
-    tokenBodyParameters?: StringDict;
     enableSpaAuthorizationCode?: boolean;
     clientInfo?: string;
     ccsCredential?: CcsCredential;

--- a/lib/msal-common/src/request/CommonDeviceCodeRequest.ts
+++ b/lib/msal-common/src/request/CommonDeviceCodeRequest.ts
@@ -22,7 +22,7 @@ import { BaseAuthRequest } from "./BaseAuthRequest.js";
 // export type CommonDeviceCodeRequest = BaseAuthRequest &  {
 export type CommonDeviceCodeRequest = Omit<
     BaseAuthRequest,
-    "tokenQueryParameters"
+    "tokenQueryParameters" | "tokenBodyParameters"
 > & {
     deviceCodeCallback: (response: DeviceCodeResponse) => void;
     cancel?: boolean;

--- a/lib/msal-common/src/request/CommonRefreshTokenRequest.ts
+++ b/lib/msal-common/src/request/CommonRefreshTokenRequest.ts
@@ -5,7 +5,6 @@
 
 import { BaseAuthRequest } from "./BaseAuthRequest.js";
 import { CcsCredential } from "../account/CcsCredential.js";
-import { StringDict } from "../utils/MsalTypes.js";
 
 /**
  * CommonRefreshTokenRequest
@@ -23,6 +22,5 @@ export type CommonRefreshTokenRequest = BaseAuthRequest & {
     refreshToken: string;
     ccsCredential?: CcsCredential;
     forceCache?: boolean;
-    tokenBodyParameters?: StringDict;
     redirectUri?: string;
 };

--- a/lib/msal-common/src/request/CommonSilentFlowRequest.ts
+++ b/lib/msal-common/src/request/CommonSilentFlowRequest.ts
@@ -4,7 +4,6 @@
  */
 
 import { AccountInfo } from "../account/AccountInfo.js";
-import { StringDict } from "../utils/MsalTypes.js";
 import { BaseAuthRequest } from "./BaseAuthRequest.js";
 
 /**
@@ -26,8 +25,6 @@ export type CommonSilentFlowRequest = BaseAuthRequest & {
     forceRefresh: boolean;
     /** RedirectUri registered on the app registration - only required in brokering scenarios */
     redirectUri?: string;
-    /** Key value pairs to include on the POST body to the /token endpoint */
-    tokenBodyParameters?: StringDict;
     /** If refresh token will expire within the configured value, consider it already expired. Used to pre-emptively invoke interaction when cached refresh token is close to expiry. */
     refreshTokenExpirationOffsetSeconds?: number;
 };


### PR DESCRIPTION
acquireTokenSilent deduplicates identical requests fired off in parallel. This logic has 2 bugs that may result in broker_timeout errors in PWB flows.

1. Request thumbprint used for deduplication does not take embeddedClientId into account, resulting in 2 requests originating from different child apps being incorrectly deduped.
2. CorrelationId is shared for deduped requests, preventing embedded apps from resolving the promise upon receiving the response from the broker.

This PR addresses both of these issues and enables telemetry collection for deduped requests (will need to filter these out in our dashboards/queries)