### PR TITLE
encodeURIComponent during QS generation

### DIFF
--- a/change/@azure-msal-common-057c3170-8c50-4695-bfb0-876cc6b0c419.json
+++ b/change/@azure-msal-common-057c3170-8c50-4695-bfb0-876cc6b0c419.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "encodeURIComponent during QS generation",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-01d4e500-04b2-448b-a836-44f80546e11b.json
+++ b/change/@azure-msal-node-01d4e500-04b2-448b-a836-44f80546e11b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Test changes",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -58,7 +58,7 @@ export function instrumentBrokerParams(
 export function addResponseTypeCode(parameters: Map<string, string>): void {
     parameters.set(
         AADServerParamKeys.RESPONSE_TYPE,
-        encodeURIComponent(Constants.CODE_RESPONSE_TYPE)
+        Constants.CODE_RESPONSE_TYPE
     );
 }
 
@@ -70,9 +70,7 @@ export function addResponseTypeForTokenAndIdToken(
 ): void {
     parameters.set(
         AADServerParamKeys.RESPONSE_TYPE,
-        encodeURIComponent(
-            `${Constants.TOKEN_RESPONSE_TYPE} ${Constants.ID_TOKEN_RESPONSE_TYPE}`
-        )
+        `${Constants.TOKEN_RESPONSE_TYPE} ${Constants.ID_TOKEN_RESPONSE_TYPE}`
     );
 }
 
@@ -86,7 +84,7 @@ export function addResponseMode(
 ): void {
     parameters.set(
         AADServerParamKeys.RESPONSE_MODE,
-        encodeURIComponent(responseMode ? responseMode : ResponseMode.QUERY)
+        responseMode ? responseMode : ResponseMode.QUERY
     );
 }
 
@@ -94,7 +92,7 @@ export function addResponseMode(
  * Add flag to indicate STS should attempt to use WAM if available
  */
 export function addNativeBroker(parameters: Map<string, string>): void {
-    parameters.set(AADServerParamKeys.NATIVE_BROKER, encodeURIComponent("1"));
+    parameters.set(AADServerParamKeys.NATIVE_BROKER, "1");
 }
 
 /**
@@ -120,10 +118,7 @@ export function addScopes(
         ? [...(scopes || []), ...defaultScopes]
         : scopes || [];
     const scopeSet = new ScopeSet(requestScopes);
-    parameters.set(
-        AADServerParamKeys.SCOPE,
-        encodeURIComponent(scopeSet.printScopes())
-    );
+    parameters.set(AADServerParamKeys.SCOPE, scopeSet.printScopes());
 }
 
 /**
@@ -134,7 +129,7 @@ export function addClientId(
     parameters: Map<string, string>,
     clientId: string
 ): void {
-    parameters.set(AADServerParamKeys.CLIENT_ID, encodeURIComponent(clientId));
+    parameters.set(AADServerParamKeys.CLIENT_ID, clientId);
 }
 
 /**
@@ -145,10 +140,7 @@ export function addRedirectUri(
     parameters: Map<string, string>,
     redirectUri: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.REDIRECT_URI,
-        encodeURIComponent(redirectUri)
-    );
+    parameters.set(AADServerParamKeys.REDIRECT_URI, redirectUri);
 }
 
 /**
@@ -159,10 +151,7 @@ export function addPostLogoutRedirectUri(
     parameters: Map<string, string>,
     redirectUri: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.POST_LOGOUT_URI,
-        encodeURIComponent(redirectUri)
-    );
+    parameters.set(AADServerParamKeys.POST_LOGOUT_URI, redirectUri);
 }
 
 /**
@@ -173,10 +162,7 @@ export function addIdTokenHint(
     parameters: Map<string, string>,
     idTokenHint: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.ID_TOKEN_HINT,
-        encodeURIComponent(idTokenHint)
-    );
+    parameters.set(AADServerParamKeys.ID_TOKEN_HINT, idTokenHint);
 }
 
 /**
@@ -187,10 +173,7 @@ export function addDomainHint(
     parameters: Map<string, string>,
     domainHint: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.DOMAIN_HINT,
-        encodeURIComponent(domainHint)
-    );
+    parameters.set(AADServerParamKeys.DOMAIN_HINT, domainHint);
 }
 
 /**
@@ -201,10 +184,7 @@ export function addLoginHint(
     parameters: Map<string, string>,
     loginHint: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.LOGIN_HINT,
-        encodeURIComponent(loginHint)
-    );
+    parameters.set(AADServerParamKeys.LOGIN_HINT, loginHint);
 }
 
 /**
@@ -215,10 +195,7 @@ export function addCcsUpn(
     parameters: Map<string, string>,
     loginHint: string
 ): void {
-    parameters.set(
-        HeaderNames.CCS_HEADER,
-        encodeURIComponent(`UPN:${loginHint}`)
-    );
+    parameters.set(HeaderNames.CCS_HEADER, `UPN:${loginHint}`);
 }
 
 /**
@@ -231,7 +208,7 @@ export function addCcsOid(
 ): void {
     parameters.set(
         HeaderNames.CCS_HEADER,
-        encodeURIComponent(`Oid:${clientInfo.uid}@${clientInfo.utid}`)
+        `Oid:${clientInfo.uid}@${clientInfo.utid}`
     );
 }
 
@@ -240,7 +217,7 @@ export function addCcsOid(
  * @param sid
  */
 export function addSid(parameters: Map<string, string>, sid: string): void {
-    parameters.set(AADServerParamKeys.SID, encodeURIComponent(sid));
+    parameters.set(AADServerParamKeys.SID, sid);
 }
 
 /**
@@ -263,7 +240,7 @@ export function addClaims(
             ClientConfigurationErrorCodes.invalidClaims
         );
     }
-    parameters.set(AADServerParamKeys.CLAIMS, encodeURIComponent(mergedClaims));
+    parameters.set(AADServerParamKeys.CLAIMS, mergedClaims);
 }
 
 /**
@@ -274,10 +251,7 @@ export function addCorrelationId(
     parameters: Map<string, string>,
     correlationId: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.CLIENT_REQUEST_ID,
-        encodeURIComponent(correlationId)
-    );
+    parameters.set(AADServerParamKeys.CLIENT_REQUEST_ID, correlationId);
 }
 
 /**
@@ -324,7 +298,7 @@ export function addPrompt(
     parameters: Map<string, string>,
     prompt: string
 ): void {
-    parameters.set(`${AADServerParamKeys.PROMPT}`, encodeURIComponent(prompt));
+    parameters.set(AADServerParamKeys.PROMPT, prompt);
 }
 
 /**
@@ -333,7 +307,7 @@ export function addPrompt(
  */
 export function addState(parameters: Map<string, string>, state: string): void {
     if (state) {
-        parameters.set(AADServerParamKeys.STATE, encodeURIComponent(state));
+        parameters.set(AADServerParamKeys.STATE, state);
     }
 }
 
@@ -342,7 +316,7 @@ export function addState(parameters: Map<string, string>, state: string): void {
  * @param nonce
  */
 export function addNonce(parameters: Map<string, string>, nonce: string): void {
-    parameters.set(AADServerParamKeys.NONCE, encodeURIComponent(nonce));
+    parameters.set(AADServerParamKeys.NONCE, nonce);
 }
 
 /**
@@ -357,13 +331,10 @@ export function addCodeChallengeParams(
     codeChallengeMethod?: string
 ): void {
     if (codeChallenge && codeChallengeMethod) {
-        parameters.set(
-            AADServerParamKeys.CODE_CHALLENGE,
-            encodeURIComponent(codeChallenge)
-        );
+        parameters.set(AADServerParamKeys.CODE_CHALLENGE, codeChallenge);
         parameters.set(
             AADServerParamKeys.CODE_CHALLENGE_METHOD,
-            encodeURIComponent(codeChallengeMethod)
+            codeChallengeMethod
         );
     } else {
         throw createClientConfigurationError(
@@ -380,7 +351,7 @@ export function addAuthorizationCode(
     parameters: Map<string, string>,
     code: string
 ): void {
-    parameters.set(AADServerParamKeys.CODE, encodeURIComponent(code));
+    parameters.set(AADServerParamKeys.CODE, code);
 }
 
 /**
@@ -391,7 +362,7 @@ export function addDeviceCode(
     parameters: Map<string, string>,
     code: string
 ): void {
-    parameters.set(AADServerParamKeys.DEVICE_CODE, encodeURIComponent(code));
+    parameters.set(AADServerParamKeys.DEVICE_CODE, code);
 }
 
 /**
@@ -402,10 +373,7 @@ export function addRefreshToken(
     parameters: Map<string, string>,
     refreshToken: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.REFRESH_TOKEN,
-        encodeURIComponent(refreshToken)
-    );
+    parameters.set(AADServerParamKeys.REFRESH_TOKEN, refreshToken);
 }
 
 /**
@@ -416,10 +384,7 @@ export function addCodeVerifier(
     parameters: Map<string, string>,
     codeVerifier: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.CODE_VERIFIER,
-        encodeURIComponent(codeVerifier)
-    );
+    parameters.set(AADServerParamKeys.CODE_VERIFIER, codeVerifier);
 }
 
 /**
@@ -430,10 +395,7 @@ export function addClientSecret(
     parameters: Map<string, string>,
     clientSecret: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.CLIENT_SECRET,
-        encodeURIComponent(clientSecret)
-    );
+    parameters.set(AADServerParamKeys.CLIENT_SECRET, clientSecret);
 }
 
 /**
@@ -445,10 +407,7 @@ export function addClientAssertion(
     clientAssertion: string
 ): void {
     if (clientAssertion) {
-        parameters.set(
-            AADServerParamKeys.CLIENT_ASSERTION,
-            encodeURIComponent(clientAssertion)
-        );
+        parameters.set(AADServerParamKeys.CLIENT_ASSERTION, clientAssertion);
     }
 }
 
@@ -463,7 +422,7 @@ export function addClientAssertionType(
     if (clientAssertionType) {
         parameters.set(
             AADServerParamKeys.CLIENT_ASSERTION_TYPE,
-            encodeURIComponent(clientAssertionType)
+            clientAssertionType
         );
     }
 }
@@ -476,10 +435,7 @@ export function addOboAssertion(
     parameters: Map<string, string>,
     oboAssertion: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.OBO_ASSERTION,
-        encodeURIComponent(oboAssertion)
-    );
+    parameters.set(AADServerParamKeys.OBO_ASSERTION, oboAssertion);
 }
 
 /**
@@ -490,10 +446,7 @@ export function addRequestTokenUse(
     parameters: Map<string, string>,
     tokenUse: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.REQUESTED_TOKEN_USE,
-        encodeURIComponent(tokenUse)
-    );
+    parameters.set(AADServerParamKeys.REQUESTED_TOKEN_USE, tokenUse);
 }
 
 /**
@@ -504,10 +457,7 @@ export function addGrantType(
     parameters: Map<string, string>,
     grantType: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.GRANT_TYPE,
-        encodeURIComponent(grantType)
-    );
+    parameters.set(AADServerParamKeys.GRANT_TYPE, grantType);
 }
 
 /**
@@ -582,10 +532,7 @@ export function addUsername(
     parameters: Map<string, string>,
     username: string
 ): void {
-    parameters.set(
-        PasswordGrantConstants.username,
-        encodeURIComponent(username)
-    );
+    parameters.set(PasswordGrantConstants.username, username);
 }
 
 /**
@@ -596,10 +543,7 @@ export function addPassword(
     parameters: Map<string, string>,
     password: string
 ): void {
-    parameters.set(
-        PasswordGrantConstants.password,
-        encodeURIComponent(password)
-    );
+    parameters.set(PasswordGrantConstants.password, password);
 }
 
 /**
@@ -612,10 +556,7 @@ export function addPopToken(
 ): void {
     if (cnfString) {
         parameters.set(AADServerParamKeys.TOKEN_TYPE, AuthenticationScheme.POP);
-        parameters.set(
-            AADServerParamKeys.REQ_CNF,
-            encodeURIComponent(cnfString)
-        );
+        parameters.set(AADServerParamKeys.REQ_CNF, cnfString);
     }
 }
 
@@ -628,10 +569,7 @@ export function addSshJwk(
 ): void {
     if (sshJwkString) {
         parameters.set(AADServerParamKeys.TOKEN_TYPE, AuthenticationScheme.SSH);
-        parameters.set(
-            AADServerParamKeys.REQ_CNF,
-            encodeURIComponent(sshJwkString)
-        );
+        parameters.set(AADServerParamKeys.REQ_CNF, sshJwkString);
     }
 }
 
@@ -670,10 +608,7 @@ export function addLogoutHint(
     parameters: Map<string, string>,
     logoutHint: string
 ): void {
-    parameters.set(
-        AADServerParamKeys.LOGOUT_HINT,
-        encodeURIComponent(logoutHint)
-    );
+    parameters.set(AADServerParamKeys.LOGOUT_HINT, logoutHint);
 }
 
 export function addBrokerParameters(
@@ -682,15 +617,12 @@ export function addBrokerParameters(
     brokerRedirectUri: string
 ): void {
     if (!parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)) {
-        parameters.set(
-            AADServerParamKeys.BROKER_CLIENT_ID,
-            encodeURIComponent(brokerClientId)
-        );
+        parameters.set(AADServerParamKeys.BROKER_CLIENT_ID, brokerClientId);
     }
     if (!parameters.has(AADServerParamKeys.BROKER_REDIRECT_URI)) {
         parameters.set(
             AADServerParamKeys.BROKER_REDIRECT_URI,
-            encodeURIComponent(brokerRedirectUri)
+            brokerRedirectUri
         );
     }
 }

--- a/lib/msal-common/src/utils/UrlUtils.ts
+++ b/lib/msal-common/src/utils/UrlUtils.ts
@@ -67,7 +67,7 @@ export function mapToQueryString(parameters: Map<string, string>): string {
     const queryParameterArray: Array<string> = new Array<string>();
 
     parameters.forEach((value, key) => {
-        queryParameterArray.push(`${key}=${value}`);
+        queryParameterArray.push(`${key}=${encodeURIComponent(value)}`);
     });
 
     return queryParameterArray.join("&");

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -844,7 +844,11 @@ describe("AuthorizationCodeClient unit tests", () => {
             ).toBe(true);
             expect(
                 returnVal.includes(
-                    `${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`
+                    `${
+                        AADServerParamKeys.X_MS_LIB_CAPABILITY
+                    }=${encodeURIComponent(
+                        ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE
+                    )}`
                 )
             ).toBe(true);
         });
@@ -1025,7 +1029,11 @@ describe("AuthorizationCodeClient unit tests", () => {
             ).toBe(true);
             expect(
                 returnVal.includes(
-                    `${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`
+                    `${
+                        AADServerParamKeys.X_MS_LIB_CAPABILITY
+                    }=${encodeURIComponent(
+                        ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE
+                    )}`
                 )
             ).toBe(true);
         });

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -519,7 +519,11 @@ describe("RefreshTokenClient unit tests", () => {
             ).toBe(true);
             expect(
                 result.includes(
-                    `${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`
+                    `${
+                        AADServerParamKeys.X_MS_LIB_CAPABILITY
+                    }=${encodeURIComponent(
+                        ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE
+                    )}`
                 )
             ).toBe(true);
         });
@@ -781,7 +785,11 @@ describe("RefreshTokenClient unit tests", () => {
             ).toBe(true);
             expect(
                 result.includes(
-                    `${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`
+                    `${
+                        AADServerParamKeys.X_MS_LIB_CAPABILITY
+                    }=${encodeURIComponent(
+                        ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE
+                    )}`
                 )
             ).toBe(true);
         });
@@ -899,7 +907,11 @@ describe("RefreshTokenClient unit tests", () => {
             ).toBe(true);
             expect(
                 result.includes(
-                    `${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`
+                    `${
+                        AADServerParamKeys.X_MS_LIB_CAPABILITY
+                    }=${encodeURIComponent(
+                        ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE
+                    )}`
                 )
             ).toBe(true);
         });

--- a/lib/msal-node/test/client/ClientTestUtils.ts
+++ b/lib/msal-node/test/client/ClientTestUtils.ts
@@ -526,7 +526,9 @@ export const checkMockedNetworkRequest = (
     if (checks.msLibraryCapability !== undefined) {
         expect(
             returnVal.includes(
-                `${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE}`
+                `${AADServerParamKeys.X_MS_LIB_CAPABILITY}=${encodeURIComponent(
+                    ThrottlingConstants.X_MS_LIB_CAPABILITY_VALUE
+                )}`
             )
         ).toBe(checks.msLibraryCapability);
     }

--- a/lib/msal-node/test/client/ManagedIdentitySources/AzureArc.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/AzureArc.spec.ts
@@ -236,7 +236,9 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                         ManagedIdentityEnvironmentVariableNames
                             .IDENTITY_ENDPOINT
                     ]
-                }?api-version=${ARC_API_VERSION}&resource=${MANAGED_IDENTITY_RESOURCE_BASE}`,
+                }?api-version=${ARC_API_VERSION}&resource=${encodeURIComponent(
+                    MANAGED_IDENTITY_RESOURCE_BASE
+                )}`,
                 {
                     headers: {
                         Authorization:


### PR DESCRIPTION
We encode all parameters added to the request URI, however, with the introduction of EAR this will cause problems as the request parameters are sent over form post, not QS. This PR moves the encode step to happen during QS generation instead of during parameter addition to support both use cases.