### PR TITLE
Updates to beachball and change types for msal-v5

### DIFF
--- a/.beachballrc
+++ b/.beachballrc
@@ -1,5 +1,5 @@
 {
-    "branch": "dev",
+    "branch": "msal-v5",
     "access": "public",
     "changehint": "Need to run the following command before merging this PR: npm run beachball:change",
     "scope": [

--- a/.github/workflows/beachball-bump.yml
+++ b/.github/workflows/beachball-bump.yml
@@ -6,6 +6,7 @@ on:
     types: [closed]
     branches:
       - dev
+      - msal-v5
 
 concurrency:
   group: beachball-bump

--- a/.github/workflows/beachball-check.yml
+++ b/.github/workflows/beachball-check.yml
@@ -6,6 +6,7 @@ on:
     pull_request:
         branches:
             - dev
+            - msal-v5
 
 concurrency:
     group: beachball-${{github.ref}}

--- a/change/@azure-msal-angular-a07ba1ae-db65-4e84-8460-6c98c66c64b9.json
+++ b/change/@azure-msal-angular-a07ba1ae-db65-4e84-8460-6c98c66c64b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v5 updates #7647",
+  "packageName": "@azure/msal-angular",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-browser-73987da3-98b5-47d9-b22e-9de7e2b11b2b.json
+++ b/change/@azure-msal-browser-73987da3-98b5-47d9-b22e-9de7e2b11b2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v5 updates #7647",
+  "packageName": "@azure/msal-browser",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-common-56d5d66d-90dc-4b35-bad3-fe0d837611f1.json
+++ b/change/@azure-msal-common-56d5d66d-90dc-4b35-bad3-fe0d837611f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v5 updates #7647",
+  "packageName": "@azure/msal-common",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-node-d75fe444-929b-40f9-a64d-0fd83cc72d33.json
+++ b/change/@azure-msal-node-d75fe444-929b-40f9-a64d-0fd83cc72d33.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v5 updates #7647",
+  "packageName": "@azure/msal-node",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-react-02fc1c0d-b15d-414d-88a7-a2e6e04b84a6.json
+++ b/change/@azure-msal-react-02fc1c0d-b15d-414d-88a7-a2e6e04b84a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow major change types for v5 updates #7647",
+  "packageName": "@azure/msal-react",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -34,9 +34,7 @@
   },
   "typings": "./dist/azure-msal-angular.d.ts",
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.1.5",

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -43,9 +43,7 @@
     "node": ">=0.8.0"
   },
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "directories": {
     "test": "test"

--- a/lib/msal-common/package.json
+++ b/lib/msal-common/package.json
@@ -91,9 +91,7 @@
     "apiExtractor": "api-extractor run"
   },
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -59,9 +59,7 @@
     "apiExtractor": "api-extractor run"
   },
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.43.4",

--- a/lib/msal-react/package.json
+++ b/lib/msal-react/package.json
@@ -38,9 +38,7 @@
     "node": ">=10"
   },
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
+    "disallowedChangeTypes": []
   },
   "scripts": {
     "build": "rollup -c --strictDeprecations --bundleConfigAsCjs",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,8 @@
         "doc:deploy": "gh-pages -d ref -a -e ref",
         "beachball:check": "beachball check --branch origin/msal-v5",
         "beachball:change": "beachball change --branch origin/msal-v5",
-        "beachball:bump": "beachball bump --branch origin/msal-v5 --bumpDeps false && node release-scripts/updateVersion.js",
         "beachball:bump:alpha": "beachball bump --branch origin/msal-v5 --bumpDeps false --prerelease-prefix alpha",
         "beachball:bump:beta": "beachball bump --branch origin/msal-v5 --bumpDeps false --prerelease-prefix beta",
-        "beachball:bump:official": "beachball bump --branch origin/msal-v5",
         "beachball:release": "node ./.github/create-releases.js"
     },
     "workspaces": [

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
         "doc": "npm run doc:generate && npm run doc:deploy",
         "doc:generate": "rimraf ./ref/* && typedoc",
         "doc:deploy": "gh-pages -d ref -a -e ref",
-        "beachball:check": "beachball check --branch origin/dev",
-        "beachball:change": "beachball change --branch origin/dev",
-        "beachball:bump": "beachball bump --branch origin/dev --bumpDeps false && node release-scripts/updateVersion.js",
-        "beachball:bump:alpha": "beachball bump --branch origin/dev --bumpDeps false --prerelease-prefix alpha",
-        "beachball:bump:beta": "beachball bump --branch origin/dev --bumpDeps false --prerelease-prefix beta",
-        "beachball:bump:official": "beachball bump --branch origin/dev",
+        "beachball:check": "beachball check --branch origin/msal-v5",
+        "beachball:change": "beachball change --branch origin/msal-v5",
+        "beachball:bump": "beachball bump --branch origin/msal-v5 --bumpDeps false && node release-scripts/updateVersion.js",
+        "beachball:bump:alpha": "beachball bump --branch origin/msal-v5 --bumpDeps false --prerelease-prefix alpha",
+        "beachball:bump:beta": "beachball bump --branch origin/msal-v5 --bumpDeps false --prerelease-prefix beta",
+        "beachball:bump:official": "beachball bump --branch origin/msal-v5",
         "beachball:release": "node ./.github/create-releases.js"
     },
     "workspaces": [


### PR DESCRIPTION
This PR:
- Sets root branch to msal-v5 in .beachballrc
- Updates to msal-v5 branch for beachball checks and bumps
- Allows major change types for v5
- Updates beachball commands in package.json for msal-v5 branch