### PR TITLE
Fix a bug in handleRedirectPromise when invoked after logoutRedirect

### DIFF
--- a/change/@azure-msal-browser-89e5a8e4-9268-4c87-8e68-a8d783abd163.json
+++ b/change/@azure-msal-browser-89e5a8e4-9268-4c87-8e68-a8d783abd163.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fix a bug in handleRedirectPromise when invoked after logoutRedirect #7680",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -38,7 +38,10 @@ import {
     TokenKeys,
 } from "@azure/msal-common/browser";
 import { CacheOptions } from "../config/Configuration.js";
-import { BrowserAuthErrorCodes, createBrowserAuthError, } from "../error/BrowserAuthError.js";
+import {
+    BrowserAuthErrorCodes,
+    createBrowserAuthError,
+} from "../error/BrowserAuthError.js";
 import {
     BrowserCacheLocation,
     InMemoryCacheKeys,
@@ -1194,13 +1197,19 @@ export class BrowserCacheManager extends CacheManager {
         }
     }
 
-    getInteractionInProgress(): { clientId: string, type: INTERACTION_TYPE } | null {
+    getInteractionInProgress(): {
+        clientId: string;
+        type: INTERACTION_TYPE;
+    } | null {
         const key = `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`;
         const value = this.getTemporaryCache(key, false);
         return value ? JSON.parse(value) : null;
     }
 
-    setInteractionInProgress(inProgress: boolean, type: INTERACTION_TYPE = INTERACTION_TYPE.SIGNIN): void {
+    setInteractionInProgress(
+        inProgress: boolean,
+        type: INTERACTION_TYPE = INTERACTION_TYPE.SIGNIN
+    ): void {
         // Ensure we don't overwrite interaction in progress for a different clientId
         const key = `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`;
         if (inProgress) {
@@ -1210,7 +1219,11 @@ export class BrowserCacheManager extends CacheManager {
                 );
             } else {
                 // No interaction is in progress
-                this.setTemporaryCache(key, JSON.stringify({ clientId: this.clientId, type } ), false);
+                this.setTemporaryCache(
+                    key,
+                    JSON.stringify({ clientId: this.clientId, type }),
+                    false
+                );
             }
         } else if (
             !inProgress &&

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -4,49 +4,47 @@
  */
 
 import {
-    Constants,
-    PersistentCacheKeys,
-    StringUtils,
-    ICrypto,
-    AccountEntity,
-    IdTokenEntity,
     AccessTokenEntity,
-    RefreshTokenEntity,
-    AppMetadataEntity,
-    CacheManager,
-    ServerTelemetryEntity,
-    ThrottlingEntity,
-    Logger,
-    AuthorityMetadataEntity,
-    DEFAULT_CRYPTO_IMPLEMENTATION,
+    AccountEntity,
     AccountInfo,
     ActiveAccountFilters,
-    TokenKeys,
-    CredentialType,
-    CacheRecord,
+    AppMetadataEntity,
     AuthenticationScheme,
-    createClientAuthError,
-    ClientAuthErrorCodes,
-    PerformanceEvents,
-    IPerformanceClient,
-    StaticAuthorityOptions,
-    CacheHelpers,
-    StoreInCache,
+    AuthorityMetadataEntity,
     CacheError,
-    invokeAsync,
-    TimeUtils,
+    CacheHelpers,
+    CacheManager,
+    CacheRecord,
+    ClientAuthErrorCodes,
     CommonAuthorizationUrlRequest,
+    Constants,
+    createClientAuthError,
+    CredentialType,
+    DEFAULT_CRYPTO_IMPLEMENTATION,
+    ICrypto,
+    IdTokenEntity,
+    invokeAsync,
+    IPerformanceClient,
+    Logger,
+    PerformanceEvents,
+    PersistentCacheKeys,
+    RefreshTokenEntity,
+    ServerTelemetryEntity,
+    StaticAuthorityOptions,
+    StoreInCache,
+    StringUtils,
+    ThrottlingEntity,
+    TimeUtils,
+    TokenKeys,
 } from "@azure/msal-common/browser";
 import { CacheOptions } from "../config/Configuration.js";
-import {
-    createBrowserAuthError,
-    BrowserAuthErrorCodes,
-} from "../error/BrowserAuthError.js";
+import { BrowserAuthErrorCodes, createBrowserAuthError, } from "../error/BrowserAuthError.js";
 import {
     BrowserCacheLocation,
-    TemporaryCacheKeys,
     InMemoryCacheKeys,
+    INTERACTION_TYPE,
     StaticCacheKeys,
+    TemporaryCacheKeys,
 } from "../utils/BrowserConstants.js";
 import { LocalStorage } from "./LocalStorage.js";
 import { SessionStorage } from "./SessionStorage.js";
@@ -1187,7 +1185,7 @@ export class BrowserCacheManager extends CacheManager {
     }
 
     isInteractionInProgress(matchClientId?: boolean): boolean {
-        const clientId = this.getInteractionInProgress();
+        const clientId = this.getInteractionInProgress()?.clientId;
 
         if (matchClientId) {
             return clientId === this.clientId;
@@ -1196,12 +1194,13 @@ export class BrowserCacheManager extends CacheManager {
         }
     }
 
-    getInteractionInProgress(): string | null {
+    getInteractionInProgress(): { clientId: string, type: INTERACTION_TYPE } | null {
         const key = `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`;
-        return this.getTemporaryCache(key, false);
+        const value = this.getTemporaryCache(key, false);
+        return value ? JSON.parse(value) : null;
     }
 
-    setInteractionInProgress(inProgress: boolean): void {
+    setInteractionInProgress(inProgress: boolean, type: INTERACTION_TYPE = INTERACTION_TYPE.SIGNIN): void {
         // Ensure we don't overwrite interaction in progress for a different clientId
         const key = `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`;
         if (inProgress) {
@@ -1211,11 +1210,11 @@ export class BrowserCacheManager extends CacheManager {
                 );
             } else {
                 // No interaction is in progress
-                this.setTemporaryCache(key, this.clientId, false);
+                this.setTemporaryCache(key, JSON.stringify({ clientId: this.clientId, type } ), false);
             }
         } else if (
             !inProgress &&
-            this.getInteractionInProgress() === this.clientId
+            this.getInteractionInProgress()?.clientId === this.clientId
         ) {
             this.removeTemporaryItem(key);
         }

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -444,7 +444,8 @@ export class StandardController implements IController {
             return null;
         }
 
-        const interactionType = this.browserStorage.getInteractionInProgress()?.type;
+        const interactionType =
+            this.browserStorage.getInteractionInProgress()?.type;
         if (interactionType === INTERACTION_TYPE.SIGNOUT) {
             this.logger.verbose(
                 "handleRedirectPromise removing interaction_in_progress flag and returning null after sign-out"
@@ -672,7 +673,10 @@ export class StandardController implements IController {
         const isLoggedIn = this.getAllAccounts().length > 0;
         try {
             BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
-            this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNIN);
+            this.browserStorage.setInteractionInProgress(
+                true,
+                INTERACTION_TYPE.SIGNIN
+            );
 
             if (isLoggedIn) {
                 this.eventHandler.emitEvent(
@@ -783,7 +787,10 @@ export class StandardController implements IController {
         try {
             this.logger.verbose("acquireTokenPopup called", correlationId);
             preflightCheck(this.initialized, atPopupMeasurement);
-            this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNIN);
+            this.browserStorage.setInteractionInProgress(
+                true,
+                INTERACTION_TYPE.SIGNIN
+            );
         } catch (e) {
             // Since this function is syncronous we need to reject
             return Promise.reject(e);
@@ -1364,7 +1371,10 @@ export class StandardController implements IController {
     async logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void> {
         const correlationId = this.getRequestCorrelationId(logoutRequest);
         BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
-        this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNOUT);
+        this.browserStorage.setInteractionInProgress(
+            true,
+            INTERACTION_TYPE.SIGNOUT
+        );
 
         const redirectClient = this.createRedirectClient(correlationId);
         return redirectClient.logout(logoutRequest);
@@ -1378,7 +1388,10 @@ export class StandardController implements IController {
         try {
             const correlationId = this.getRequestCorrelationId(logoutRequest);
             BrowserUtils.preflightCheck(this.initialized);
-            this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNOUT);
+            this.browserStorage.setInteractionInProgress(
+                true,
+                INTERACTION_TYPE.SIGNOUT
+            );
 
             const popupClient = this.createPopupClient(correlationId);
             return popupClient.logout(logoutRequest).finally(() => {

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1371,6 +1371,10 @@ export class StandardController implements IController {
     async logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void> {
         const correlationId = this.getRequestCorrelationId(logoutRequest);
         BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
+        this.browserStorage.setInteractionInProgress(
+            true,
+            INTERACTION_TYPE.SIGNOUT
+        );
 
         const redirectClient = this.createRedirectClient(correlationId);
         return redirectClient.logout(logoutRequest);

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -45,6 +45,7 @@ import {
     DEFAULT_REQUEST,
     BrowserConstants,
     iFrameRenewalPolicies,
+    INTERACTION_TYPE,
 } from "../utils/BrowserConstants.js";
 import * as BrowserUtils from "../utils/BrowserUtils.js";
 import { RedirectRequest } from "../request/RedirectRequest.js";
@@ -443,6 +444,15 @@ export class StandardController implements IController {
             return null;
         }
 
+        const interactionType = this.browserStorage.getInteractionInProgress()?.type;
+        if (interactionType === INTERACTION_TYPE.SIGNOUT) {
+            this.logger.verbose(
+                "handleRedirectPromise removing interaction_in_progress flag and returning null after sign-out"
+            );
+            this.browserStorage.setInteractionInProgress(false);
+            return Promise.resolve(null);
+        }
+
         const loggedInAccounts = this.getAllAccounts();
         const platformBrokerRequest: NativeTokenRequest | null =
             this.browserStorage.getCachedNativeRequest();
@@ -455,63 +465,68 @@ export class StandardController implements IController {
             ) &&
             this.nativeExtensionProvider &&
             !hash;
-        let rootMeasurement = this.performanceClient.startMeasurement(
-            PerformanceEvents.AcquireTokenRedirect,
-            platformBrokerRequest?.correlationId || ""
-        );
+        let rootMeasurement: InProgressPerformanceEvent;
         this.eventHandler.emitEvent(
             EventType.HANDLE_REDIRECT_START,
             InteractionType.Redirect
         );
 
         let redirectResponse: Promise<AuthenticationResult | null>;
-        if (useNative && this.nativeExtensionProvider) {
-            this.logger.trace(
-                "handleRedirectPromise - acquiring token from native platform"
-            );
-            const nativeClient = new NativeInteractionClient(
-                this.config,
-                this.browserStorage,
-                this.browserCrypto,
-                this.logger,
-                this.eventHandler,
-                this.navigationClient,
-                ApiId.handleRedirectPromise,
-                this.performanceClient,
-                this.nativeExtensionProvider,
-                platformBrokerRequest.accountId,
-                this.nativeInternalStorage,
-                platformBrokerRequest.correlationId
-            );
+        try {
+            if (useNative && this.nativeExtensionProvider) {
+                rootMeasurement = this.performanceClient.startMeasurement(
+                    PerformanceEvents.AcquireTokenRedirect,
+                    platformBrokerRequest?.correlationId || ""
+                );
+                this.logger.trace(
+                    "handleRedirectPromise - acquiring token from native platform"
+                );
+                const nativeClient = new NativeInteractionClient(
+                    this.config,
+                    this.browserStorage,
+                    this.browserCrypto,
+                    this.logger,
+                    this.eventHandler,
+                    this.navigationClient,
+                    ApiId.handleRedirectPromise,
+                    this.performanceClient,
+                    this.nativeExtensionProvider,
+                    platformBrokerRequest.accountId,
+                    this.nativeInternalStorage,
+                    platformBrokerRequest.correlationId
+                );
 
-            redirectResponse = invokeAsync(
-                nativeClient.handleRedirectPromise.bind(nativeClient),
-                PerformanceEvents.HandleNativeRedirectPromiseMeasurement,
-                this.logger,
-                this.performanceClient,
-                rootMeasurement.event.correlationId
-            )(this.performanceClient, rootMeasurement.event.correlationId);
-        } else {
-            const [standardRequest, codeVerifier] =
-                this.browserStorage.getCachedRequest();
-            const correlationId = standardRequest.correlationId;
-            // Reset rootMeasurement now that we have correlationId
-            rootMeasurement.discard();
-            rootMeasurement = this.performanceClient.startMeasurement(
-                PerformanceEvents.AcquireTokenRedirect,
-                correlationId
-            );
-            this.logger.trace(
-                "handleRedirectPromise - acquiring token from web flow"
-            );
-            const redirectClient = this.createRedirectClient(correlationId);
-            redirectResponse = invokeAsync(
-                redirectClient.handleRedirectPromise.bind(redirectClient),
-                PerformanceEvents.HandleRedirectPromiseMeasurement,
-                this.logger,
-                this.performanceClient,
-                rootMeasurement.event.correlationId
-            )(hash, standardRequest, codeVerifier, rootMeasurement);
+                redirectResponse = invokeAsync(
+                    nativeClient.handleRedirectPromise.bind(nativeClient),
+                    PerformanceEvents.HandleNativeRedirectPromiseMeasurement,
+                    this.logger,
+                    this.performanceClient,
+                    rootMeasurement.event.correlationId
+                )(this.performanceClient, rootMeasurement.event.correlationId);
+            } else {
+                const [standardRequest, codeVerifier] =
+                    this.browserStorage.getCachedRequest();
+                const correlationId = standardRequest.correlationId;
+                // Reset rootMeasurement now that we have correlationId
+                rootMeasurement = this.performanceClient.startMeasurement(
+                    PerformanceEvents.AcquireTokenRedirect,
+                    correlationId
+                );
+                this.logger.trace(
+                    "handleRedirectPromise - acquiring token from web flow"
+                );
+                const redirectClient = this.createRedirectClient(correlationId);
+                redirectResponse = invokeAsync(
+                    redirectClient.handleRedirectPromise.bind(redirectClient),
+                    PerformanceEvents.HandleRedirectPromiseMeasurement,
+                    this.logger,
+                    this.performanceClient,
+                    rootMeasurement.event.correlationId
+                )(hash, standardRequest, codeVerifier, rootMeasurement);
+            }
+        } catch (e) {
+            this.browserStorage.resetRequestCache();
+            throw e;
         }
 
         return redirectResponse
@@ -657,7 +672,7 @@ export class StandardController implements IController {
         const isLoggedIn = this.getAllAccounts().length > 0;
         try {
             BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
-            this.browserStorage.setInteractionInProgress(true);
+            this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNIN);
 
             if (isLoggedIn) {
                 this.eventHandler.emitEvent(
@@ -768,7 +783,7 @@ export class StandardController implements IController {
         try {
             this.logger.verbose("acquireTokenPopup called", correlationId);
             preflightCheck(this.initialized, atPopupMeasurement);
-            this.browserStorage.setInteractionInProgress(true);
+            this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNIN);
         } catch (e) {
             // Since this function is syncronous we need to reject
             return Promise.reject(e);
@@ -1349,7 +1364,7 @@ export class StandardController implements IController {
     async logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void> {
         const correlationId = this.getRequestCorrelationId(logoutRequest);
         BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
-        this.browserStorage.setInteractionInProgress(true);
+        this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNOUT);
 
         const redirectClient = this.createRedirectClient(correlationId);
         return redirectClient.logout(logoutRequest);
@@ -1363,7 +1378,7 @@ export class StandardController implements IController {
         try {
             const correlationId = this.getRequestCorrelationId(logoutRequest);
             BrowserUtils.preflightCheck(this.initialized);
-            this.browserStorage.setInteractionInProgress(true);
+            this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNOUT);
 
             const popupClient = this.createPopupClient(correlationId);
             return popupClient.logout(logoutRequest).finally(() => {

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1371,10 +1371,6 @@ export class StandardController implements IController {
     async logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void> {
         const correlationId = this.getRequestCorrelationId(logoutRequest);
         BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
-        this.browserStorage.setInteractionInProgress(
-            true,
-            INTERACTION_TYPE.SIGNOUT
-        );
 
         const redirectClient = this.createRedirectClient(correlationId);
         return redirectClient.logout(logoutRequest);

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -743,7 +743,7 @@ export class RedirectClient extends StandardInteractionClient {
                     if (!this.browserStorage.getInteractionInProgress()) {
                         this.browserStorage.setInteractionInProgress(
                             true,
-                            INTERACTION_TYPE.SIGNIN
+                            INTERACTION_TYPE.SIGNOUT
                         );
                     }
                     await this.navigationClient.navigateExternal(
@@ -763,7 +763,7 @@ export class RedirectClient extends StandardInteractionClient {
                 if (!this.browserStorage.getInteractionInProgress()) {
                     this.browserStorage.setInteractionInProgress(
                         true,
-                        INTERACTION_TYPE.SIGNIN
+                        INTERACTION_TYPE.SIGNOUT
                     );
                 }
                 await this.navigationClient.navigateExternal(

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -741,7 +741,10 @@ export class RedirectClient extends StandardInteractionClient {
                     );
                     // Ensure interaction is in progress
                     if (!this.browserStorage.getInteractionInProgress()) {
-                        this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNIN);
+                        this.browserStorage.setInteractionInProgress(
+                            true,
+                            INTERACTION_TYPE.SIGNIN
+                        );
                     }
                     await this.navigationClient.navigateExternal(
                         logoutUri,
@@ -758,7 +761,10 @@ export class RedirectClient extends StandardInteractionClient {
             } else {
                 // Ensure interaction is in progress
                 if (!this.browserStorage.getInteractionInProgress()) {
-                    this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNIN);
+                    this.browserStorage.setInteractionInProgress(
+                        true,
+                        INTERACTION_TYPE.SIGNIN
+                    );
                 }
                 await this.navigationClient.navigateExternal(
                     logoutUri,

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -24,6 +24,7 @@ import {
 import { StandardInteractionClient } from "./StandardInteractionClient.js";
 import {
     ApiId,
+    INTERACTION_TYPE,
     InteractionType,
     TemporaryCacheKeys,
 } from "../utils/BrowserConstants.js";
@@ -740,7 +741,7 @@ export class RedirectClient extends StandardInteractionClient {
                     );
                     // Ensure interaction is in progress
                     if (!this.browserStorage.getInteractionInProgress()) {
-                        this.browserStorage.setInteractionInProgress(true);
+                        this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNIN);
                     }
                     await this.navigationClient.navigateExternal(
                         logoutUri,
@@ -757,7 +758,7 @@ export class RedirectClient extends StandardInteractionClient {
             } else {
                 // Ensure interaction is in progress
                 if (!this.browserStorage.getInteractionInProgress()) {
-                    this.browserStorage.setInteractionInProgress(true);
+                    this.browserStorage.setInteractionInProgress(true, INTERACTION_TYPE.SIGNIN);
                 }
                 await this.navigationClient.navigateExternal(
                     logoutUri,

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -74,6 +74,13 @@ export const HTTP_REQUEST_TYPE = {
 export type HTTP_REQUEST_TYPE =
     (typeof HTTP_REQUEST_TYPE)[keyof typeof HTTP_REQUEST_TYPE];
 
+export const INTERACTION_TYPE = {
+    SIGNIN: "signin",
+    SIGNOUT: "signout",
+} as const;
+export type INTERACTION_TYPE =
+    (typeof INTERACTION_TYPE)[keyof typeof INTERACTION_TYPE];
+
 /**
  * Temporary cache keys for MSAL, deleted after any request.
  */

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -115,6 +115,7 @@ import {
     buildIdToken,
     TestTimeUtils,
 } from "msal-test-utils";
+import { INTERACTION_TYPE } from "../../src/utils/BrowserConstants.js";
 
 const cacheConfig = {
     temporaryCacheLocation: BrowserCacheLocation.SessionStorage,
@@ -1092,7 +1093,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             );
             window.sessionStorage.setItem(
                 `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`,
-                TEST_CONFIG.MSAL_CLIENT_ID
+                JSON.stringify({ clientId: TEST_CONFIG.MSAL_CLIENT_ID, type: INTERACTION_TYPE.SIGNIN })
             );
             jest.spyOn(
                 BrowserCacheManager.prototype,
@@ -1247,7 +1248,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             window.sessionStorage.setItem(
                 `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`,
-                TEST_CONFIG.MSAL_CLIENT_ID
+                JSON.stringify({ clientId: TEST_CONFIG.MSAL_CLIENT_ID, type: INTERACTION_TYPE.SIGNIN })
             );
             pca.handleRedirectPromise();
         });
@@ -1276,6 +1277,51 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             await pca.handleRedirectPromise();
             expect(emitSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("removes interaction_in_progress and returns null after sign-out", async () => {
+            pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                },
+            });
+            await pca.initialize();
+
+            window.sessionStorage.setItem(
+                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`,
+                JSON.stringify({ clientId: TEST_CONFIG.MSAL_CLIENT_ID, type: INTERACTION_TYPE.SIGNOUT })
+            );
+            const res = await pca.handleRedirectPromise();
+            expect(res).toBeNull();
+            expect(
+                // @ts-ignore
+                pca.controller.browserStorage.getInteractionInProgress()
+            ).toBeFalsy();
+        });
+
+        it("removes interaction_in_progress and throws after sign-in when there are no tokens in cache", async () => {
+            pca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                },
+            });
+            await pca.initialize();
+
+            window.sessionStorage.setItem(
+                `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`,
+                JSON.stringify({ clientId: TEST_CONFIG.MSAL_CLIENT_ID, type: INTERACTION_TYPE.SIGNIN })
+            );
+            try {
+                await pca.handleRedirectPromise();
+                throw "Unexpected code path";
+            } catch (e) {
+                // @ts-ignore
+                expect(e.errorCode).toEqual("no_token_request_cache_error");
+            }
+            expect(
+                // @ts-ignore
+                pca.controller.browserStorage.getInteractionInProgress()
+            ).toBeFalsy();
         });
     });
     describe("OIDC Protocol Mode tests", () => {

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1093,7 +1093,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             );
             window.sessionStorage.setItem(
                 `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`,
-                JSON.stringify({ clientId: TEST_CONFIG.MSAL_CLIENT_ID, type: INTERACTION_TYPE.SIGNIN })
+                JSON.stringify({
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    type: INTERACTION_TYPE.SIGNIN,
+                })
             );
             jest.spyOn(
                 BrowserCacheManager.prototype,
@@ -1248,7 +1251,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             window.sessionStorage.setItem(
                 `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`,
-                JSON.stringify({ clientId: TEST_CONFIG.MSAL_CLIENT_ID, type: INTERACTION_TYPE.SIGNIN })
+                JSON.stringify({
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    type: INTERACTION_TYPE.SIGNIN,
+                })
             );
             pca.handleRedirectPromise();
         });
@@ -1289,7 +1295,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             window.sessionStorage.setItem(
                 `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`,
-                JSON.stringify({ clientId: TEST_CONFIG.MSAL_CLIENT_ID, type: INTERACTION_TYPE.SIGNOUT })
+                JSON.stringify({
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    type: INTERACTION_TYPE.SIGNOUT,
+                })
             );
             const res = await pca.handleRedirectPromise();
             expect(res).toBeNull();
@@ -1309,7 +1318,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             window.sessionStorage.setItem(
                 `${Constants.CACHE_PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`,
-                JSON.stringify({ clientId: TEST_CONFIG.MSAL_CLIENT_ID, type: INTERACTION_TYPE.SIGNIN })
+                JSON.stringify({
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    type: INTERACTION_TYPE.SIGNIN,
+                })
             );
             try {
                 await pca.handleRedirectPromise();


### PR DESCRIPTION
- Add interaction type to "interaction_in_progress" temporary key to return from "handleRedirectPromise" early if invoked after signout. This fixes a bug with the login flow being blocked after user logs out and improves sign-out perf.
- Add try-catch block to the first parst of "handleRedirectPromise" to make sure users can recover from "no_token_request_cache_error" if session storage gets cleared during page navigation.
- Simplify redirect telemetry instrumentation.