### PR TITLE
New resetInProgressEvent method to reset event to None after handleRedirectPromise completes

### DIFF
--- a/change/@azure-msal-angular-ecec97fd-ef4a-434a-acbb-42aae92467b7.json
+++ b/change/@azure-msal-angular-ecec97fd-ef4a-434a-acbb-42aae92467b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added resetInProgressEvent function to reset event after handleRedirectPromise is called",
+  "packageName": "@azure/msal-angular",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-angular-ecec97fd-ef4a-434a-acbb-42aae92467b7.json
+++ b/change/@azure-msal-angular-ecec97fd-ef4a-434a-acbb-42aae92467b7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "added resetInProgressEvent function to reset event after handleRedirectPromise is called",
+  "comment": "added resetInProgressEvent function to reset event after handleRedirectPromise is called #7682",
   "packageName": "@azure/msal-angular",
   "email": "lalimasharda@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-angular/karma.conf.js
+++ b/lib/msal-angular/karma.conf.js
@@ -18,7 +18,8 @@ module.exports = function (config) {
             jasmine: {
                 failSpecWithNoExpectations: true
             },
-            clearContext: false // leave Jasmine Spec Runner output visible in browser
+            clearContext: false, // leave Jasmine Spec Runner output visible in browser
+            captureConsole: true // turns on console logging for test debugging
         },
         coverageIstanbulReporter: {
             dir: require("path").join(__dirname, "./coverage"),

--- a/lib/msal-angular/src/msal.broadcast.service.spec.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.spec.ts
@@ -443,4 +443,32 @@ describe("MsalBroadcastService", () => {
       InteractionType.Redirect
     );
   });
+
+  it("automatically sets inProgress to None when handleRedirectPromise returns without emitting HANDLE_REDIRECT_END", (done) => {
+    const expectedInProgress = [
+      InteractionStatus.Startup,
+      InteractionStatus.HandleRedirect,
+      InteractionStatus.None,
+    ];
+    let index = 0;
+
+    subscription = broadcastService.inProgress$.subscribe((result) => {
+      expect(result).toEqual(expectedInProgress[index]);
+      if (index === expectedInProgress.length - 1) {
+        done();
+      } else if (
+        expectedInProgress[index] === InteractionStatus.HandleRedirect
+      ) {
+        index++;
+        broadcastService.resetInProgressEvent();
+      } else {
+        index++;
+      }
+    });
+
+    eventHandler.emitEvent(
+      EventType.HANDLE_REDIRECT_START,
+      InteractionType.Redirect
+    );
+  });
 });

--- a/lib/msal-angular/src/msal.broadcast.service.spec.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.spec.ts
@@ -40,6 +40,7 @@ function initializeMsal(providers: any[] = []) {
       }),
     ],
     providers: [MsalBroadcastService, ...providers],
+    teardown: { destroyAfterEach: false },
   });
   broadcastService = TestBed.inject(MsalBroadcastService);
 }

--- a/lib/msal-angular/src/msal.broadcast.service.spec.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.spec.ts
@@ -444,10 +444,9 @@ describe("MsalBroadcastService", () => {
     );
   });
 
-  it("automatically sets inProgress to None when handleRedirectPromise returns without emitting HANDLE_REDIRECT_END", (done) => {
+  it("automatically sets inProgress to None when handleRedirectPromise returns without emitting an event", (done) => {
     const expectedInProgress = [
       InteractionStatus.Startup,
-      InteractionStatus.HandleRedirect,
       InteractionStatus.None,
     ];
     let index = 0;
@@ -456,9 +455,7 @@ describe("MsalBroadcastService", () => {
       expect(result).toEqual(expectedInProgress[index]);
       if (index === expectedInProgress.length - 1) {
         done();
-      } else if (
-        expectedInProgress[index] === InteractionStatus.HandleRedirect
-      ) {
+      } else if (expectedInProgress[index] === InteractionStatus.Startup) {
         index++;
         broadcastService.resetInProgressEvent();
       } else {
@@ -467,7 +464,7 @@ describe("MsalBroadcastService", () => {
     });
 
     eventHandler.emitEvent(
-      EventType.HANDLE_REDIRECT_START,
+      EventType.INITIALIZE_START,
       InteractionType.Redirect
     );
   });

--- a/lib/msal-angular/src/msal.broadcast.service.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.ts
@@ -76,6 +76,8 @@ export class MsalBroadcastService {
    * Resets inProgress state to None
    */
   resetInProgressEvent(): void {
-    this._inProgress.next(InteractionStatus.None);
+    if (this._inProgress.value === InteractionStatus.Startup) {
+      this._inProgress.next(InteractionStatus.None);
+    }
   }
 }

--- a/lib/msal-angular/src/msal.broadcast.service.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.ts
@@ -71,4 +71,11 @@ export class MsalBroadcastService {
       }
     });
   }
+
+  /**
+   * Resets inProgress state to None
+   */
+  resetInProgressEvent(): void {
+    this._inProgress.next(InteractionStatus.None);
+  }
 }

--- a/lib/msal-angular/src/msal.guard.spec.ts
+++ b/lib/msal-angular/src/msal.guard.spec.ts
@@ -68,6 +68,7 @@ function initializeMsal(providers: any[] = []) {
       RouterTestingModule.withRoutes([]),
     ],
     providers: [MsalGuard, MsalService, MsalBroadcastService, ...providers],
+    teardown: { destroyAfterEach: false },
   });
 
   authService = TestBed.inject(MsalService);

--- a/lib/msal-angular/src/msal.interceptor.spec.ts
+++ b/lib/msal-angular/src/msal.interceptor.spec.ts
@@ -124,6 +124,7 @@ function initializeMsal() {
       },
       Location,
     ],
+    teardown: { destroyAfterEach: false },
   });
 
   interceptor = TestBed.inject(MsalInterceptor);

--- a/lib/msal-angular/src/msal.navigation.client.spec.ts
+++ b/lib/msal-angular/src/msal.navigation.client.spec.ts
@@ -44,6 +44,7 @@ describe("MsalCustomNaviationClient", () => {
         MsalService,
         MsalGuard,
       ],
+      teardown: { destroyAfterEach: false },
     });
     authService = TestBed.inject(MsalService);
     navigationClient = TestBed.inject(MsalCustomNavigationClient);

--- a/lib/msal-angular/src/msal.redirect.component.spec.ts
+++ b/lib/msal-angular/src/msal.redirect.component.spec.ts
@@ -27,6 +27,7 @@ function initializeMsal() {
     declarations: [MsalRedirectComponent],
     imports: [MsalModule.forRoot(MSALInstanceFactory(), null, null)],
     providers: [],
+    teardown: { destroyAfterEach: false },
   });
 
   authService = TestBed.inject(MsalService);

--- a/lib/msal-angular/src/msal.service.spec.ts
+++ b/lib/msal-angular/src/msal.service.spec.ts
@@ -2,12 +2,14 @@ import { TestBed } from "@angular/core/testing";
 import {
   AuthenticationResult,
   AuthError,
+  InteractionStatus,
   InteractionType,
   Logger,
   PublicClientApplication,
   SilentRequest,
 } from "@azure/msal-browser";
 import { MsalModule, MsalBroadcastService, MsalService } from "./public-api";
+import { takeLast } from "rxjs/operators";
 
 let authService: MsalService;
 let broadcastService: MsalBroadcastService;
@@ -351,10 +353,13 @@ describe("MsalService", () => {
   });
 
   describe("handleRedirectObservable", () => {
-    it("success", (done) => {
+    it("success and resets inProgress event to none", (done) => {
       const sampleAccessToken = {
         accessToken: "123abc",
       };
+
+      //@ts-ignore
+      broadcastService._inProgress.next(InteractionStatus.Startup);
 
       spyOn(PublicClientApplication.prototype, "initialize").and.returnValue(
         Promise.resolve()
@@ -380,12 +385,18 @@ describe("MsalService", () => {
           expect(
             PublicClientApplication.prototype.handleRedirectPromise
           ).toHaveBeenCalled();
+          broadcastService.inProgress$.subscribe((result) => {
+            expect(result).toBe(InteractionStatus.None);
+          });
           done();
         });
     });
 
-    it("failure", (done) => {
+    it("failure and also resets inProgress event to none", (done) => {
       const sampleError = new AuthError("123", "message");
+
+      //@ts-ignore
+      broadcastService._inProgress.next(InteractionStatus.Startup);
 
       spyOn(PublicClientApplication.prototype, "initialize").and.returnValue(
         Promise.resolve()
@@ -409,6 +420,10 @@ describe("MsalService", () => {
           expect(
             PublicClientApplication.prototype.handleRedirectPromise
           ).toHaveBeenCalled();
+          broadcastService.inProgress$.pipe(takeLast(1)).subscribe((result) => {
+            console.log("failure result", result);
+            expect(result).toBe(InteractionStatus.None);
+          });
           done();
         },
       });

--- a/lib/msal-angular/src/msal.service.spec.ts
+++ b/lib/msal-angular/src/msal.service.spec.ts
@@ -30,6 +30,7 @@ function initializeMsal() {
       }),
     ],
     providers: [MsalService, MsalBroadcastService],
+    teardown: { destroyAfterEach: false },
   });
 
   authService = TestBed.inject(MsalService);
@@ -198,7 +199,7 @@ describe("MsalService", () => {
 
       authService.ssoSilent(request).subscribe({
         error: (error: AuthError) => {
-          expect(error.message).toBe(sampleError.message);
+          expect(error.errorMessage).toBe(sampleError.errorMessage);
           expect(
             PublicClientApplication.prototype.ssoSilent
           ).toHaveBeenCalledWith(request);
@@ -259,7 +260,7 @@ describe("MsalService", () => {
 
       authService.acquireTokenSilent(request).subscribe({
         error: (error: AuthError) => {
-          expect(error.message).toBe(sampleError.message);
+          expect(error.errorMessage).toBe(sampleError.errorMessage);
           expect(
             PublicClientApplication.prototype.acquireTokenSilent
           ).toHaveBeenCalledWith(request);
@@ -339,7 +340,7 @@ describe("MsalService", () => {
 
       authService.acquireTokenPopup(request).subscribe({
         error: (error: AuthError) => {
-          expect(error.message).toBe(sampleError.message);
+          expect(error.errorMessage).toBe(sampleError.errorMessage);
           expect(
             PublicClientApplication.prototype.acquireTokenPopup
           ).toHaveBeenCalledWith(request);

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -16,6 +16,7 @@ import {
   SsoSilentRequest,
   Logger,
   WrapperSKU,
+  AuthError,
 } from "@azure/msal-browser";
 import { Observable, from } from "rxjs";
 import { IMsalService } from "./IMsalService";
@@ -61,11 +62,8 @@ export class MsalService implements IMsalService {
         .then(() =>
           this.instance.handleRedirectPromise(hash || this.redirectHash)
         )
-        .catch((error) => {
-          this.logger.error(
-            "Error while executing handleRedirectPromise",
-            error
-          );
+        .catch((error: AuthError) => {
+          this.logger.error("Error while executing handleRedirectPromise");
           throw error; // Rethrow the error to ensure the return type matches
         })
         .finally(() => {

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -16,7 +16,6 @@ import {
   SsoSilentRequest,
   Logger,
   WrapperSKU,
-  AuthError,
 } from "@azure/msal-browser";
 import { Observable, from } from "rxjs";
 import { IMsalService } from "./IMsalService";

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Inject, Injectable } from "@angular/core";
+import { Inject, Injectable, Injector } from "@angular/core";
 import { Location } from "@angular/common";
 import {
   IPublicClientApplication,
@@ -21,6 +21,7 @@ import { Observable, from } from "rxjs";
 import { IMsalService } from "./IMsalService";
 import { name, version } from "./packageMetadata";
 import { MSAL_INSTANCE } from "./constants";
+import { MsalBroadcastService } from "./msal.broadcast.service";
 
 @Injectable()
 export class MsalService implements IMsalService {
@@ -29,7 +30,8 @@ export class MsalService implements IMsalService {
 
   constructor(
     @Inject(MSAL_INSTANCE) public instance: IPublicClientApplication,
-    private location: Location
+    private location: Location,
+    private injector: Injector
   ) {
     const hash = this.location.path(true).split("#").pop();
     if (hash) {
@@ -59,6 +61,17 @@ export class MsalService implements IMsalService {
         .then(() =>
           this.instance.handleRedirectPromise(hash || this.redirectHash)
         )
+        .catch((error) => {
+          this.logger.error(
+            "Error while executing handleRedirectPromise",
+            error
+          );
+          throw error; // Rethrow the error to ensure the return type matches
+        })
+        .finally(() => {
+          // update inProgress state to none
+          this.injector.get(MsalBroadcastService).resetInProgressEvent();
+        })
     );
   }
   loginPopup(request?: PopupRequest): Observable<AuthenticationResult> {

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -62,10 +62,6 @@ export class MsalService implements IMsalService {
         .then(() =>
           this.instance.handleRedirectPromise(hash || this.redirectHash)
         )
-        .catch((error: AuthError) => {
-          this.logger.error("Error while executing handleRedirectPromise");
-          throw error; // Rethrow the error to ensure the return type matches
-        })
         .finally(() => {
           // update inProgress state to none
           this.injector.get(MsalBroadcastService).resetInProgressEvent();

--- a/package-lock.json
+++ b/package-lock.json
@@ -54327,8 +54327,8 @@
                 "@angular/platform-browser": "^19.1.0",
                 "@angular/platform-browser-dynamic": "^19.1.0",
                 "@angular/router": "^19.1.0",
-                "@azure/msal-angular": "file:../../../lib/msal-angular/dist/azure-msal-angular-4.0.8.tgz",
-                "@azure/msal-browser": "file:../../../lib/msal-browser",
+                "@azure/msal-angular": "^4.0.0",
+                "@azure/msal-browser": "^4.0.0",
                 "rxjs": "~7.8.0",
                 "tslib": "^2.3.0",
                 "zone.js": "~0.15.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55204,19 +55204,6 @@
                 "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
-        "samples/msal-angular-samples/angular-standalone-sample/node_modules/@azure/msal-angular": {
-            "version": "4.0.8",
-            "resolved": "file:lib/msal-angular/dist/azure-msal-angular-4.0.8.tgz",
-            "integrity": "sha512-TRI4YEzwBfMnFDzn8x6YVqOm2hLP1Cb5cFE0mwTu3+xVViuB3hx8F76/39K0HzIK3Bckya9izbiupjVrm6z4zg==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.3.0"
-            },
-            "peerDependencies": {
-                "@azure/msal-browser": "^4.9.0",
-                "rxjs": "^7.0.0"
-            }
-        },
         "samples/msal-angular-samples/angular-standalone-sample/node_modules/@babel/core": {
             "version": "7.26.0",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44259,9 +44259,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.5.11",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.11.tgz",
-            "integrity": "sha512-4mVdhLkZ0vpqZLGJhNm+X1n7juqXApEMGlUXcOQawA45UmpxivOYaMBkI/Js3FlBsNA8hCgEnX5X04moFitSGw==",
+            "version": "4.5.12",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.12.tgz",
+            "integrity": "sha512-qrMwavANtSz91nDy3zEiUHMtL09x0mniQsSMvDkNxuCBM1W5vriJ22hEmwTth6DhLSWsZnHBT0yHFAQXt6efGA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -54327,8 +54327,8 @@
                 "@angular/platform-browser": "^19.1.0",
                 "@angular/platform-browser-dynamic": "^19.1.0",
                 "@angular/router": "^19.1.0",
-                "@azure/msal-angular": "^4.0.0",
-                "@azure/msal-browser": "^4.0.0",
+                "@azure/msal-angular": "file:../../../lib/msal-angular/dist/azure-msal-angular-4.0.8.tgz",
+                "@azure/msal-browser": "file:../../../lib/msal-browser",
                 "rxjs": "~7.8.0",
                 "tslib": "^2.3.0",
                 "zone.js": "~0.15.0"
@@ -55202,6 +55202,19 @@
                 "@angular/core": "19.1.3",
                 "@angular/platform-browser": "19.1.3",
                 "rxjs": "^6.5.3 || ^7.4.0"
+            }
+        },
+        "samples/msal-angular-samples/angular-standalone-sample/node_modules/@azure/msal-angular": {
+            "version": "4.0.8",
+            "resolved": "file:lib/msal-angular/dist/azure-msal-angular-4.0.8.tgz",
+            "integrity": "sha512-TRI4YEzwBfMnFDzn8x6YVqOm2hLP1Cb5cFE0mwTu3+xVViuB3hx8F76/39K0HzIK3Bckya9izbiupjVrm6z4zg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "peerDependencies": {
+                "@azure/msal-browser": "^4.9.0",
+                "rxjs": "^7.0.0"
             }
         },
         "samples/msal-angular-samples/angular-standalone-sample/node_modules/@babel/core": {


### PR DESCRIPTION
This PR fixes a bug in msal-angular where inProgress event does not get reset to None after handleRedirectPromise() completes.

Addresses issue #7663 