### PR TITLE
Support web fallback

### DIFF
--- a/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
+++ b/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
@@ -127,9 +127,5 @@ export class CustomAuthPublicClientApplication
                 `The authority URL '${config.auth?.authority}' is not a CIAM authority.`,
             );
         }
-
-        if (!config.customAuth.challengeTypes || !config.customAuth.challengeTypes.includes(ChallengeType.REDIRECT)) {
-            config.customAuth.challengeTypes?.push(ChallengeType.REDIRECT);
-        }
     }
 }

--- a/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
+++ b/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Constants, PublicClientApplication } from "@azure/msal-browser";
+import { PublicClientApplication } from "@azure/msal-browser";
 import { GetAccountResult } from "./get_account/auth_flow/result/GetAccountResult.js";
 import { SignInResult } from "./sign_in/auth_flow/result/SignInResult.js";
 import { SignUpResult } from "./sign_up/auth_flow/result/SignUpResult.js";
@@ -20,7 +20,6 @@ import {
     InvalidConfigurationError,
     MissingConfiguration,
 } from "./core/error/InvalidConfigurationError.js";
-import { StringUtils } from "./core/utils/StringUtils.js";
 import { ChallengeType } from "./CustomAuthConstants.js";
 
 export class CustomAuthPublicClientApplication
@@ -113,19 +112,6 @@ export class CustomAuthPublicClientApplication
             throw new InvalidConfigurationError(MissingConfiguration, "The configuration is missing.");
         }
 
-        try {
-            CustomAuthPublicClientApplication.validateAuthorityURL(config);
-            CustomAuthPublicClientApplication.validateChallengeTypes(config);
-        } catch (error) {
-            throw error;
-        }
-    }
-
-    /**
-     * Validates the authority URL is a vaild CIAM authority.
-     * @param config - The configuration object for the PublicClientApplication.
-     */
-    private static validateAuthorityURL(config: CustomAuthConfiguration) {
         if (!config.auth?.authority) {
             throw new InvalidConfigurationError(
                 InvalidAuthority,
@@ -133,21 +119,6 @@ export class CustomAuthPublicClientApplication
             );
         }
 
-        const trimmedAuthority = StringUtils.trimSlashes(config.auth.authority);
-
-        if (!trimmedAuthority.endsWith(Constants.CIAM_AUTH_URL)) {
-            throw new InvalidConfigurationError(
-                InvalidAuthority,
-                `The authority URL '${config.auth?.authority}' is not a CIAM authority.`,
-            );
-        }
-    }
-
-    /**
-     * Validates the challenge types in the configuration are valid.
-     * @param config - The configuration object for the PublicClientApplication.
-     */
-    private static validateChallengeTypes(config: CustomAuthConfiguration) {
         const challengeTypes = config.customAuth.challengeTypes;
 
         if (!!challengeTypes && challengeTypes.length > 0) {

--- a/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
+++ b/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
@@ -149,7 +149,6 @@ export class CustomAuthPublicClientApplication
      */
     private static validateChallengeTypes(config: CustomAuthConfiguration) {
         const challengeTypes = config.customAuth.challengeTypes;
-        let invalidChallengeType = false;
 
         if (!!challengeTypes && challengeTypes.length > 0) {
             challengeTypes.forEach((challengeType) => {
@@ -159,16 +158,12 @@ export class CustomAuthPublicClientApplication
                     lowerCaseChallengeType !== ChallengeType.OOB &&
                     lowerCaseChallengeType !== ChallengeType.REDIRECT
                 ) {
-                    invalidChallengeType = true;
-                    return;
+                    throw new InvalidConfigurationError(
+                        InvalidChallengeType,
+                        `Challenge type ${challengeType} in the configuration are not valid. Supported challenge types are ${Object.values(ChallengeType)}`,
+                    );
                 }
             });
-        }
-        if (invalidChallengeType) {
-            throw new InvalidConfigurationError(
-                InvalidChallengeType,
-                `One or more challenge types in the configuration are not valid. Supported challenge types are ${Object.values(ChallengeType)}`,
-            );
         }
     }
 }

--- a/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
+++ b/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
@@ -20,7 +20,6 @@ import {
     MissingConfiguration,
 } from "./core/error/InvalidConfigurationError.js";
 import { StringUtils } from "./core/utils/StringUtils.js";
-import { ChallengeType } from "./CustomAuthConstants.js";
 
 export class CustomAuthPublicClientApplication
     extends PublicClientApplication

--- a/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
+++ b/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
@@ -16,10 +16,12 @@ import { CustomAuthOperatingContext } from "./operating_context/CustomAuthOperat
 import { ResetPasswordStartResult } from "./reset_password/auth_flow/result/ResetPasswordStartResult.js";
 import {
     InvalidAuthority,
+    InvalidChallengeType,
     InvalidConfigurationError,
     MissingConfiguration,
 } from "./core/error/InvalidConfigurationError.js";
 import { StringUtils } from "./core/utils/StringUtils.js";
+import { ChallengeType } from "./CustomAuthConstants.js";
 
 export class CustomAuthPublicClientApplication
     extends PublicClientApplication
@@ -111,6 +113,19 @@ export class CustomAuthPublicClientApplication
             throw new InvalidConfigurationError(MissingConfiguration, "The configuration is missing.");
         }
 
+        try {
+            CustomAuthPublicClientApplication.ensureValidAuthorityURL(config);
+            CustomAuthPublicClientApplication.validateChallengeTypes(config);
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Validates the authority URL is a vaild CIAM authority.
+     * @param config - The configuration object for the PublicClientApplication.
+     */
+    private static ensureValidAuthorityURL(config: CustomAuthConfiguration) {
         if (!config.auth?.authority) {
             throw new InvalidConfigurationError(
                 InvalidAuthority,
@@ -124,6 +139,35 @@ export class CustomAuthPublicClientApplication
             throw new InvalidConfigurationError(
                 InvalidAuthority,
                 `The authority URL '${config.auth?.authority}' is not a CIAM authority.`,
+            );
+        }
+    }
+
+    /**
+     * Validates the challenge types in the configuration are valid.
+     * @param config - The configuration object for the PublicClientApplication.
+     */
+    private static validateChallengeTypes(config: CustomAuthConfiguration) {
+        const challengeTypes = config.customAuth.challengeTypes;
+        let invalidChallengeType = false;
+
+        if (!!challengeTypes && challengeTypes.length > 0) {
+            challengeTypes.forEach((challengeType) => {
+                const lowerCaseChallengeType = challengeType.toLowerCase();
+                if (
+                    lowerCaseChallengeType !== ChallengeType.PASSWORD &&
+                    lowerCaseChallengeType !== ChallengeType.OOB &&
+                    lowerCaseChallengeType !== ChallengeType.REDIRECT
+                ) {
+                    invalidChallengeType = true;
+                }
+            });
+        }
+
+        if (invalidChallengeType) {
+            throw new InvalidConfigurationError(
+                InvalidChallengeType,
+                `One or more challenge types in the configuration are not valid. Supported challenge types are ${Object.values(ChallengeType)}`,
             );
         }
     }

--- a/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
+++ b/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
@@ -114,7 +114,7 @@ export class CustomAuthPublicClientApplication
         }
 
         try {
-            CustomAuthPublicClientApplication.ensureValidAuthorityURL(config);
+            CustomAuthPublicClientApplication.validateAuthorityURL(config);
             CustomAuthPublicClientApplication.validateChallengeTypes(config);
         } catch (error) {
             throw error;
@@ -125,7 +125,7 @@ export class CustomAuthPublicClientApplication
      * Validates the authority URL is a vaild CIAM authority.
      * @param config - The configuration object for the PublicClientApplication.
      */
-    private static ensureValidAuthorityURL(config: CustomAuthConfiguration) {
+    private static validateAuthorityURL(config: CustomAuthConfiguration) {
         if (!config.auth?.authority) {
             throw new InvalidConfigurationError(
                 InvalidAuthority,
@@ -160,10 +160,10 @@ export class CustomAuthPublicClientApplication
                     lowerCaseChallengeType !== ChallengeType.REDIRECT
                 ) {
                     invalidChallengeType = true;
+                    return;
                 }
             });
         }
-
         if (invalidChallengeType) {
             throw new InvalidConfigurationError(
                 InvalidChallengeType,

--- a/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
+++ b/lib/msal-custom-auth/src/CustomAuthPublicClientApplication.ts
@@ -20,6 +20,7 @@ import {
     MissingConfiguration,
 } from "./core/error/InvalidConfigurationError.js";
 import { StringUtils } from "./core/utils/StringUtils.js";
+import { ChallengeType } from "./CustomAuthConstants.js";
 
 export class CustomAuthPublicClientApplication
     extends PublicClientApplication
@@ -125,6 +126,10 @@ export class CustomAuthPublicClientApplication
                 InvalidAuthority,
                 `The authority URL '${config.auth?.authority}' is not a CIAM authority.`,
             );
+        }
+
+        if (!config.customAuth.challengeTypes || !config.customAuth.challengeTypes.includes(ChallengeType.REDIRECT)) {
+            config.customAuth.challengeTypes?.push(ChallengeType.REDIRECT);
         }
     }
 }

--- a/lib/msal-custom-auth/src/ICustomAuthPublicClientApplication.ts
+++ b/lib/msal-custom-auth/src/ICustomAuthPublicClientApplication.ts
@@ -8,8 +8,9 @@ import { SignInResult } from "./sign_in/auth_flow/result/SignInResult.js";
 import { SignUpResult } from "./sign_up/auth_flow/result/SignUpResult.js";
 import { AccountRetrievalInputs, ResetPasswordInputs, SignInInputs, SignUpInputs } from "./CustomAuthActionInputs.js";
 import { ResetPasswordStartResult } from "./reset_password/auth_flow/result/ResetPasswordStartResult.js";
+import { IPublicClientApplication } from "@azure/msal-browser";
 
-export interface ICustomAuthPublicClientApplication {
+export interface ICustomAuthPublicClientApplication extends IPublicClientApplication {
     /**
      * Gets the current account from the cache.
      * @param {AccountRetrievalInputs} accountRetrievalInputs - Inputs for getting the current cached account

--- a/lib/msal-custom-auth/src/core/error/InvalidConfigurationError.ts
+++ b/lib/msal-custom-auth/src/core/error/InvalidConfigurationError.ts
@@ -15,3 +15,4 @@ export class InvalidConfigurationError extends CustomAuthError {
 export const MissingConfiguration = "missing_configuration";
 export const InvalidAuthority = "invalid_authority";
 export const InvalidAuthApiProxyDomain = "invalid_auth_api_proxy_domain";
+export const InvalidChallengeType = "invalid_challenge_type";

--- a/lib/msal-custom-auth/src/core/interaction_client/CustomAuthInteractionClientBase.ts
+++ b/lib/msal-custom-auth/src/core/interaction_client/CustomAuthInteractionClientBase.ts
@@ -61,7 +61,7 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
             return configuredChallengeTypes.join(" ");
         }
 
-        return `${ChallengeType.PASSWORD} ${ChallengeType.OOB} ${ChallengeType.REDIRECT}`;
+        return `${ChallengeType.REDIRECT}`;
     }
 
     protected getScopes(scopes: string[] | undefined): string[] {

--- a/lib/msal-custom-auth/src/core/interaction_client/CustomAuthInteractionClientBase.ts
+++ b/lib/msal-custom-auth/src/core/interaction_client/CustomAuthInteractionClientBase.ts
@@ -54,14 +54,11 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
     }
 
     protected getChallengeTypes(configuredChallengeTypes: string[] | undefined): string {
-        if (!!configuredChallengeTypes && configuredChallengeTypes.length > 0) {
-            if (!configuredChallengeTypes.includes(ChallengeType.REDIRECT)) {
-                configuredChallengeTypes.push(ChallengeType.REDIRECT);
-            }
-            return configuredChallengeTypes.join(" ");
+        const challengeType = configuredChallengeTypes ?? [];
+        if (!challengeType.some((type) => type.toLowerCase() === ChallengeType.REDIRECT)) {
+            challengeType.push(ChallengeType.REDIRECT);
         }
-
-        return `${ChallengeType.REDIRECT}`;
+        return challengeType.join(" ");
     }
 
     protected getScopes(scopes: string[] | undefined): string[] {

--- a/lib/msal-custom-auth/src/core/interaction_client/CustomAuthInteractionClientBase.ts
+++ b/lib/msal-custom-auth/src/core/interaction_client/CustomAuthInteractionClientBase.ts
@@ -55,6 +55,9 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
 
     protected getChallengeTypes(configuredChallengeTypes: string[] | undefined): string {
         if (!!configuredChallengeTypes && configuredChallengeTypes.length > 0) {
+            if (!configuredChallengeTypes.includes(ChallengeType.REDIRECT)) {
+                configuredChallengeTypes.push(ChallengeType.REDIRECT);
+            }
             return configuredChallengeTypes.join(" ");
         }
 

--- a/lib/msal-custom-auth/src/reset_password/auth_flow/error_type/ResetPasswordError.ts
+++ b/lib/msal-custom-auth/src/reset_password/auth_flow/error_type/ResetPasswordError.ts
@@ -33,10 +33,10 @@ export class ResetPasswordError extends AuthFlowErrorBase {
     }
 
     /**
-     * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the challenge type is redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if client app doesn't support the challenge type configured in Entra, "loginPopup" function is required to continue the operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -73,20 +73,20 @@ export class ResetPasswordSubmitCodeError extends AuthFlowErrorBase {
     }
 
     /**
-     * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the challenge type is redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if client app doesn't support the challenge type configured in Entra, "loginPopup" function is required to continue the operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }
 
 export class ResetPasswordResendCodeError extends AuthFlowErrorBase {
     /**
-     * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the challenge type is redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if client app doesn't support the challenge type configured in Entra, "loginPopup" function is required to continue the operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/reset_password/auth_flow/error_type/ResetPasswordError.ts
+++ b/lib/msal-custom-auth/src/reset_password/auth_flow/error_type/ResetPasswordError.ts
@@ -36,7 +36,7 @@ export class ResetPasswordError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if client app doesn't support the challenge type configured in Entra, "loginPopup" function is required to continue the operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -76,7 +76,7 @@ export class ResetPasswordSubmitCodeError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if client app doesn't support the challenge type configured in Entra, "loginPopup" function is required to continue the operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -86,7 +86,7 @@ export class ResetPasswordResendCodeError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if client app doesn't support the challenge type configured in Entra, "loginPopup" function is required to continue the operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/reset_password/auth_flow/error_type/ResetPasswordError.ts
+++ b/lib/msal-custom-auth/src/reset_password/auth_flow/error_type/ResetPasswordError.ts
@@ -36,7 +36,7 @@ export class ResetPasswordError extends AuthFlowErrorBase {
      * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the challenge type is redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -76,7 +76,7 @@ export class ResetPasswordSubmitCodeError extends AuthFlowErrorBase {
      * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the challenge type is redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -86,7 +86,7 @@ export class ResetPasswordResendCodeError extends AuthFlowErrorBase {
      * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the challenge type is redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/reset_password/interaction_client/ResetPasswordClient.ts
+++ b/lib/msal-custom-auth/src/reset_password/interaction_client/ResetPasswordClient.ts
@@ -115,7 +115,7 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
 
         const challengeRequest: ResetPasswordChallengeRequest = {
             continuation_token: parameters.continuationToken,
-            challenge_type: parameters.challengeType.join(" "),
+            challenge_type: this.getChallengeTypes(parameters.challengeType),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
         };

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/error_type/SignInError.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/error_type/SignInError.ts
@@ -40,10 +40,10 @@ export class SignInError extends AuthFlowErrorBase {
     }
 
     /**
-     * Checks if challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the error is due to the challenge type being redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -70,10 +70,10 @@ export class SignInSubmitCodeError extends AuthFlowErrorBase {
 
 export class SignInResendCodeError extends AuthFlowErrorBase {
     /**
-     * Checks if challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the error is due to the challenge type being redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/error_type/SignInError.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/error_type/SignInError.ts
@@ -43,7 +43,7 @@ export class SignInError extends AuthFlowErrorBase {
      * Checks if challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the error is due to the challenge type being redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -73,7 +73,7 @@ export class SignInResendCodeError extends AuthFlowErrorBase {
      * Checks if challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the error is due to the challenge type being redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/sign_in/auth_flow/error_type/SignInError.ts
+++ b/lib/msal-custom-auth/src/sign_in/auth_flow/error_type/SignInError.ts
@@ -43,7 +43,7 @@ export class SignInError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -73,7 +73,7 @@ export class SignInResendCodeError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/sign_in/interaction_client/SignInClient.ts
+++ b/lib/msal-custom-auth/src/sign_in/interaction_client/SignInClient.ts
@@ -98,7 +98,7 @@ export class SignInClient extends CustomAuthInteractionClientBase {
         this.logger.verbose("Calling initiate endpoint for sign in.", parameters.correlationId);
 
         const initReq: SignInInitiateRequest = {
-            challenge_type: parameters.challengeType.join(" "),
+            challenge_type: this.getChallengeTypes(parameters.challengeType),
             username: parameters.username,
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
@@ -130,7 +130,7 @@ export class SignInClient extends CustomAuthInteractionClientBase {
         const telemetryManager = this.initializeServerTelemetryManager(apiId);
 
         const challengeReq: SignInChallengeRequest = {
-            challenge_type: parameters.challengeType.join(" "),
+            challenge_type: this.getChallengeTypes(parameters.challengeType),
             continuation_token: parameters.continuationToken ?? "",
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/error_type/SignUpError.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/error_type/SignUpError.ts
@@ -58,7 +58,7 @@ export class SignUpError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -76,7 +76,7 @@ export class SignUpSubmitPasswordError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -94,7 +94,7 @@ export class SignUpSubmitCodeError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -120,7 +120,7 @@ export class SignUpSubmitAttributesError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -130,7 +130,7 @@ export class SignUpResendCodeError extends AuthFlowErrorBase {
      * Check if client app supports the challenge type configured in Entra.
      * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isFallbackRequired(): boolean {
+    isRedirectRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/error_type/SignUpError.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/error_type/SignUpError.ts
@@ -55,10 +55,10 @@ export class SignUpError extends AuthFlowErrorBase {
     }
 
     /**
-     * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the challenge type is redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -73,10 +73,10 @@ export class SignUpSubmitPasswordError extends AuthFlowErrorBase {
     }
 
     /**
-     * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the challenge type is redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -91,10 +91,10 @@ export class SignUpSubmitCodeError extends AuthFlowErrorBase {
     }
 
     /**
-     * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the challenge type is redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -117,20 +117,20 @@ export class SignUpSubmitAttributesError extends AuthFlowErrorBase {
     }
 
     /**
-     * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the challenge type is redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }
 
 export class SignUpResendCodeError extends AuthFlowErrorBase {
     /**
-     * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
-     * @returns {boolean} True if the challenge type is redirect, false otherwise.
+     * Check if client app supports the challenge type configured in Entra.
+     * @returns {boolean} True if "loginPopup" function is required to continue sthe operation.
      */
-    isRedirectionRequired(): boolean {
+    isFallbackRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/sign_up/auth_flow/error_type/SignUpError.ts
+++ b/lib/msal-custom-auth/src/sign_up/auth_flow/error_type/SignUpError.ts
@@ -58,7 +58,7 @@ export class SignUpError extends AuthFlowErrorBase {
      * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the challenge type is redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -76,7 +76,7 @@ export class SignUpSubmitPasswordError extends AuthFlowErrorBase {
      * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the challenge type is redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -94,7 +94,7 @@ export class SignUpSubmitCodeError extends AuthFlowErrorBase {
      * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the challenge type is redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -120,7 +120,7 @@ export class SignUpSubmitAttributesError extends AuthFlowErrorBase {
      * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the challenge type is redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }
@@ -130,7 +130,7 @@ export class SignUpResendCodeError extends AuthFlowErrorBase {
      * Checks if the challenge type is redirect (authentication method is not supported by by Microsoft Entra)
      * @returns {boolean} True if the challenge type is redirect, false otherwise.
      */
-    isRedirect(): boolean {
+    isRedirectionRequired(): boolean {
         return this.isRedirectError();
     }
 }

--- a/lib/msal-custom-auth/src/sign_up/interaction_client/SignUpClient.ts
+++ b/lib/msal-custom-auth/src/sign_up/interaction_client/SignUpClient.ts
@@ -208,7 +208,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
 
         const challengeRequest: SignUpChallengeRequest = {
             continuation_token: parameters.continuationToken ?? "",
-            challenge_type: parameters.challengeType.join(" "),
+            challenge_type: this.getChallengeTypes(parameters.challengeType),
             telemetryManager,
             correlationId: parameters.correlationId,
         };
@@ -327,7 +327,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
             // Call the challenge endpoint to ensure the password challenge type is supported.
             const challengeRequest: SignUpChallengeRequest = {
                 continuation_token: continuationToken,
-                challenge_type: requestParams.challengeType.join(" "),
+                challenge_type: this.getChallengeTypes(requestParams.challengeType),
                 telemetryManager,
                 correlationId,
             };

--- a/lib/msal-custom-auth/test/CustomAuthPublicClientApplication.spec.ts
+++ b/lib/msal-custom-auth/test/CustomAuthPublicClientApplication.spec.ts
@@ -51,7 +51,7 @@ describe("CustomAuthPublicClientApplication", () => {
             const invalidConfig = {
                 auth: { authority: customAuthConfig.auth.authority },
                 customAuth: {
-                    challengeTypes: ["invalid-challenge-type"],
+                    challengeTypes: ["invalid-challenge-type", "oob"],
                 },
             };
 

--- a/lib/msal-custom-auth/test/CustomAuthPublicClientApplication.spec.ts
+++ b/lib/msal-custom-auth/test/CustomAuthPublicClientApplication.spec.ts
@@ -47,6 +47,19 @@ describe("CustomAuthPublicClientApplication", () => {
             );
         });
 
+        it("should throw an error if challenge type is invalid", async () => {
+            const invalidConfig = {
+                auth: { authority: customAuthConfig.auth.authority },
+                customAuth: {
+                    challengeTypes: ["invalid-challenge-type"],
+                },
+            };
+
+            await expect(CustomAuthPublicClientApplication.create(invalidConfig as any)).rejects.toThrow(
+                InvalidConfigurationError,
+            );
+        });
+
         it("should create an instance if the config is valid", async () => {
             const app = await CustomAuthPublicClientApplication.create(customAuthConfig);
 

--- a/lib/msal-custom-auth/test/CustomAuthPublicClientApplication.spec.ts
+++ b/lib/msal-custom-auth/test/CustomAuthPublicClientApplication.spec.ts
@@ -36,17 +36,6 @@ describe("CustomAuthPublicClientApplication", () => {
             );
         });
 
-        it("should throw an error if the authority is not a CIAM authority", async () => {
-            const invalidConfig = {
-                auth: { authority: "https://invalid.example.com" },
-                customAuth: {},
-            };
-
-            await expect(CustomAuthPublicClientApplication.create(invalidConfig as any)).rejects.toThrow(
-                InvalidConfigurationError,
-            );
-        });
-
         it("should throw an error if challenge type is invalid", async () => {
             const invalidConfig = {
                 auth: { authority: customAuthConfig.auth.authority },

--- a/lib/msal-custom-auth/test/controller/CustomAuthStandardController.spec.ts
+++ b/lib/msal-custom-auth/test/controller/CustomAuthStandardController.spec.ts
@@ -209,7 +209,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignInResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isRedirect()).toEqual(true);
+            expect(result.error?.isRedirectionRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
     });
@@ -289,7 +289,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignUpResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isRedirect()).toEqual(true);
+            expect(result.error?.isRedirectionRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 
@@ -309,7 +309,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignUpResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isRedirect()).toEqual(true);
+            expect(result.error?.isRedirectionRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 
@@ -393,7 +393,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(ResetPasswordStartResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isRedirect()).toEqual(true);
+            expect(result.error?.isRedirectionRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 

--- a/lib/msal-custom-auth/test/controller/CustomAuthStandardController.spec.ts
+++ b/lib/msal-custom-auth/test/controller/CustomAuthStandardController.spec.ts
@@ -209,7 +209,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignInResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isFallbackRequired()).toEqual(true);
+            expect(result.error?.isRedirectRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
     });
@@ -289,7 +289,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignUpResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isFallbackRequired()).toEqual(true);
+            expect(result.error?.isRedirectRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 
@@ -309,7 +309,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignUpResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isFallbackRequired()).toEqual(true);
+            expect(result.error?.isRedirectRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 
@@ -393,7 +393,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(ResetPasswordStartResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isFallbackRequired()).toEqual(true);
+            expect(result.error?.isRedirectRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 

--- a/lib/msal-custom-auth/test/controller/CustomAuthStandardController.spec.ts
+++ b/lib/msal-custom-auth/test/controller/CustomAuthStandardController.spec.ts
@@ -209,7 +209,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignInResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isRedirectionRequired()).toEqual(true);
+            expect(result.error?.isFallbackRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
     });
@@ -289,7 +289,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignUpResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isRedirectionRequired()).toEqual(true);
+            expect(result.error?.isFallbackRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 
@@ -309,7 +309,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(SignUpResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isRedirectionRequired()).toEqual(true);
+            expect(result.error?.isFallbackRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 
@@ -393,7 +393,7 @@ describe("CustomAuthStandardController", () => {
             expect(result).toBeInstanceOf(ResetPasswordStartResult);
             expect(result.error).toBeDefined();
             expect(result.error?.errorData).toBeDefined();
-            expect(result.error?.isRedirectionRequired()).toEqual(true);
+            expect(result.error?.isFallbackRequired()).toEqual(true);
             expect(result.isFailed()).toBe(true);
         });
 

--- a/lib/msal-custom-auth/test/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/ResetPassword.spec.ts
@@ -227,7 +227,7 @@ describe("Reset password", () => {
         expect(startResult).toBeInstanceOf(ResetPasswordStartResult);
         expect(startResult.error).toBeDefined();
         expect(startResult.isFailed()).toBe(true);
-        expect(startResult.error?.isRedirectionRequired()).toBe(true);
+        expect(startResult.error?.isFallbackRequired()).toBe(true);
     });
 
     it("should reset password failed if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/ResetPassword.spec.ts
@@ -227,7 +227,7 @@ describe("Reset password", () => {
         expect(startResult).toBeInstanceOf(ResetPasswordStartResult);
         expect(startResult.error).toBeDefined();
         expect(startResult.isFailed()).toBe(true);
-        expect(startResult.error?.isRedirect()).toBe(true);
+        expect(startResult.error?.isRedirectionRequired()).toBe(true);
     });
 
     it("should reset password failed if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/ResetPassword.spec.ts
@@ -227,7 +227,7 @@ describe("Reset password", () => {
         expect(startResult).toBeInstanceOf(ResetPasswordStartResult);
         expect(startResult.error).toBeDefined();
         expect(startResult.isFailed()).toBe(true);
-        expect(startResult.error?.isFallbackRequired()).toBe(true);
+        expect(startResult.error?.isRedirectRequired()).toBe(true);
     });
 
     it("should reset password failed if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/integration_tests/SignIn.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/SignIn.spec.ts
@@ -282,7 +282,7 @@ describe("Sign in", () => {
         expect(signInResult).toBeInstanceOf(SignInResult);
         expect(signInResult.error).toBeDefined();
         expect(signInResult.isFailed()).toBe(true);
-        expect(signInResult.error?.isRedirect()).toBe(true);
+        expect(signInResult.error?.isRedirectionRequired()).toBe(true);
     });
 
     it("should sign in failed with error if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/integration_tests/SignIn.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/SignIn.spec.ts
@@ -282,7 +282,7 @@ describe("Sign in", () => {
         expect(signInResult).toBeInstanceOf(SignInResult);
         expect(signInResult.error).toBeDefined();
         expect(signInResult.isFailed()).toBe(true);
-        expect(signInResult.error?.isFallbackRequired()).toBe(true);
+        expect(signInResult.error?.isRedirectRequired()).toBe(true);
     });
 
     it("should sign in failed with error if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/integration_tests/SignIn.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/SignIn.spec.ts
@@ -282,7 +282,7 @@ describe("Sign in", () => {
         expect(signInResult).toBeInstanceOf(SignInResult);
         expect(signInResult.error).toBeDefined();
         expect(signInResult.isFailed()).toBe(true);
-        expect(signInResult.error?.isRedirectionRequired()).toBe(true);
+        expect(signInResult.error?.isFallbackRequired()).toBe(true);
     });
 
     it("should sign in failed with error if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/integration_tests/SignUp.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/SignUp.spec.ts
@@ -616,7 +616,7 @@ describe("Sign up", () => {
         expect(startResult).toBeInstanceOf(SignUpResult);
         expect(startResult.error).toBeDefined();
         expect(startResult.isFailed()).toBe(true);
-        expect(startResult.error?.isRedirectionRequired()).toBe(true);
+        expect(startResult.error?.isFallbackRequired()).toBe(true);
     });
 
     it("should sign up failed if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/integration_tests/SignUp.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/SignUp.spec.ts
@@ -616,7 +616,7 @@ describe("Sign up", () => {
         expect(startResult).toBeInstanceOf(SignUpResult);
         expect(startResult.error).toBeDefined();
         expect(startResult.isFailed()).toBe(true);
-        expect(startResult.error?.isRedirect()).toBe(true);
+        expect(startResult.error?.isRedirectionRequired()).toBe(true);
     });
 
     it("should sign up failed if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/integration_tests/SignUp.spec.ts
+++ b/lib/msal-custom-auth/test/integration_tests/SignUp.spec.ts
@@ -616,7 +616,7 @@ describe("Sign up", () => {
         expect(startResult).toBeInstanceOf(SignUpResult);
         expect(startResult.error).toBeDefined();
         expect(startResult.isFailed()).toBe(true);
-        expect(startResult.error?.isFallbackRequired()).toBe(true);
+        expect(startResult.error?.isRedirectRequired()).toBe(true);
     });
 
     it("should sign up failed if the given user is not found", async () => {

--- a/lib/msal-custom-auth/test/reset_password/auth_flow/error_type/ResetPasswordError.spec.ts
+++ b/lib/msal-custom-auth/test/reset_password/auth_flow/error_type/ResetPasswordError.spec.ts
@@ -49,7 +49,7 @@ describe("ResetPasswordError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordError(error);
-        expect(resetPasswordError.isRedirect()).toBe(true);
+        expect(resetPasswordError.isRedirectionRequired()).toBe(true);
     });
 });
 
@@ -101,7 +101,7 @@ describe("ResetPasswordSubmitCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordSubmitCodeError(error);
-        expect(resetPasswordError.isRedirect()).toBe(true);
+        expect(resetPasswordError.isRedirectionRequired()).toBe(true);
     });
 });
 
@@ -109,6 +109,6 @@ describe("ResetPasswordResendCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordResendCodeError(error);
-        expect(resetPasswordError.isRedirect()).toBe(true);
+        expect(resetPasswordError.isRedirectionRequired()).toBe(true);
     });
 });

--- a/lib/msal-custom-auth/test/reset_password/auth_flow/error_type/ResetPasswordError.spec.ts
+++ b/lib/msal-custom-auth/test/reset_password/auth_flow/error_type/ResetPasswordError.spec.ts
@@ -49,7 +49,7 @@ describe("ResetPasswordError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordError(error);
-        expect(resetPasswordError.isFallbackRequired()).toBe(true);
+        expect(resetPasswordError.isRedirectRequired()).toBe(true);
     });
 });
 
@@ -101,7 +101,7 @@ describe("ResetPasswordSubmitCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordSubmitCodeError(error);
-        expect(resetPasswordError.isFallbackRequired()).toBe(true);
+        expect(resetPasswordError.isRedirectRequired()).toBe(true);
     });
 });
 
@@ -109,6 +109,6 @@ describe("ResetPasswordResendCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordResendCodeError(error);
-        expect(resetPasswordError.isFallbackRequired()).toBe(true);
+        expect(resetPasswordError.isRedirectRequired()).toBe(true);
     });
 });

--- a/lib/msal-custom-auth/test/reset_password/auth_flow/error_type/ResetPasswordError.spec.ts
+++ b/lib/msal-custom-auth/test/reset_password/auth_flow/error_type/ResetPasswordError.spec.ts
@@ -49,7 +49,7 @@ describe("ResetPasswordError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordError(error);
-        expect(resetPasswordError.isRedirectionRequired()).toBe(true);
+        expect(resetPasswordError.isFallbackRequired()).toBe(true);
     });
 });
 
@@ -101,7 +101,7 @@ describe("ResetPasswordSubmitCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordSubmitCodeError(error);
-        expect(resetPasswordError.isRedirectionRequired()).toBe(true);
+        expect(resetPasswordError.isFallbackRequired()).toBe(true);
     });
 });
 
@@ -109,6 +109,6 @@ describe("ResetPasswordResendCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const resetPasswordError = new ResetPasswordResendCodeError(error);
-        expect(resetPasswordError.isRedirectionRequired()).toBe(true);
+        expect(resetPasswordError.isFallbackRequired()).toBe(true);
     });
 });

--- a/lib/msal-custom-auth/test/sign_in/auth_flow/error_type/SignInError.spec.ts
+++ b/lib/msal-custom-auth/test/sign_in/auth_flow/error_type/SignInError.spec.ts
@@ -54,7 +54,7 @@ describe("SignInError", () => {
     it("should return true for isRedirect when error is an instance of RedirectError", () => {
         const redirectError = new RedirectError(mockErrorData as any);
         const signInError = new SignInError(redirectError as any);
-        expect(signInError.isRedirect()).toBe(true);
+        expect(signInError.isRedirectionRequired()).toBe(true);
     });
 
     it("should return false for all methods when error data does not match any condition", () => {
@@ -65,7 +65,7 @@ describe("SignInError", () => {
         expect(signInError.isInvalidUsername()).toBe(false);
         expect(signInError.isPasswordIncorrect()).toBe(false);
         expect(signInError.isUnsupportedChallengeType()).toBe(false);
-        expect(signInError.isRedirect()).toBe(false);
+        expect(signInError.isRedirectionRequired()).toBe(false);
     });
 });
 

--- a/lib/msal-custom-auth/test/sign_in/auth_flow/error_type/SignInError.spec.ts
+++ b/lib/msal-custom-auth/test/sign_in/auth_flow/error_type/SignInError.spec.ts
@@ -54,7 +54,7 @@ describe("SignInError", () => {
     it("should return true for isRedirect when error is an instance of RedirectError", () => {
         const redirectError = new RedirectError(mockErrorData as any);
         const signInError = new SignInError(redirectError as any);
-        expect(signInError.isRedirectionRequired()).toBe(true);
+        expect(signInError.isFallbackRequired()).toBe(true);
     });
 
     it("should return false for all methods when error data does not match any condition", () => {
@@ -65,7 +65,7 @@ describe("SignInError", () => {
         expect(signInError.isInvalidUsername()).toBe(false);
         expect(signInError.isPasswordIncorrect()).toBe(false);
         expect(signInError.isUnsupportedChallengeType()).toBe(false);
-        expect(signInError.isRedirectionRequired()).toBe(false);
+        expect(signInError.isFallbackRequired()).toBe(false);
     });
 });
 

--- a/lib/msal-custom-auth/test/sign_in/auth_flow/error_type/SignInError.spec.ts
+++ b/lib/msal-custom-auth/test/sign_in/auth_flow/error_type/SignInError.spec.ts
@@ -54,7 +54,7 @@ describe("SignInError", () => {
     it("should return true for isRedirect when error is an instance of RedirectError", () => {
         const redirectError = new RedirectError(mockErrorData as any);
         const signInError = new SignInError(redirectError as any);
-        expect(signInError.isFallbackRequired()).toBe(true);
+        expect(signInError.isRedirectRequired()).toBe(true);
     });
 
     it("should return false for all methods when error data does not match any condition", () => {
@@ -65,7 +65,7 @@ describe("SignInError", () => {
         expect(signInError.isInvalidUsername()).toBe(false);
         expect(signInError.isPasswordIncorrect()).toBe(false);
         expect(signInError.isUnsupportedChallengeType()).toBe(false);
-        expect(signInError.isFallbackRequired()).toBe(false);
+        expect(signInError.isRedirectRequired()).toBe(false);
     });
 });
 

--- a/lib/msal-custom-auth/test/sign_up/auth_flow/error_type/SignUpError.spec.ts
+++ b/lib/msal-custom-auth/test/sign_up/auth_flow/error_type/SignUpError.spec.ts
@@ -80,7 +80,7 @@ describe("SignUpError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpError(error);
-        expect(signUpError.isFallbackRequired()).toBe(true);
+        expect(signUpError.isRedirectRequired()).toBe(true);
     });
 });
 
@@ -110,7 +110,7 @@ describe("SignUpSubmitPasswordError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitPasswordError(error);
-        expect(signUpError.isFallbackRequired()).toBe(true);
+        expect(signUpError.isRedirectRequired()).toBe(true);
     });
 });
 
@@ -134,7 +134,7 @@ describe("SignUpSubmitCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitCodeError(error);
-        expect(signUpError.isFallbackRequired()).toBe(true);
+        expect(signUpError.isRedirectRequired()).toBe(true);
     });
 });
 
@@ -160,7 +160,7 @@ describe("SignUpSubmitAttributesError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitAttributesError(error);
-        expect(signUpError.isFallbackRequired()).toBe(true);
+        expect(signUpError.isRedirectRequired()).toBe(true);
     });
 });
 
@@ -168,6 +168,6 @@ describe("SignUpResendCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpResendCodeError(error);
-        expect(signUpError.isFallbackRequired()).toBe(true);
+        expect(signUpError.isRedirectRequired()).toBe(true);
     });
 });

--- a/lib/msal-custom-auth/test/sign_up/auth_flow/error_type/SignUpError.spec.ts
+++ b/lib/msal-custom-auth/test/sign_up/auth_flow/error_type/SignUpError.spec.ts
@@ -80,7 +80,7 @@ describe("SignUpError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpError(error);
-        expect(signUpError.isRedirectionRequired()).toBe(true);
+        expect(signUpError.isFallbackRequired()).toBe(true);
     });
 });
 
@@ -110,7 +110,7 @@ describe("SignUpSubmitPasswordError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitPasswordError(error);
-        expect(signUpError.isRedirectionRequired()).toBe(true);
+        expect(signUpError.isFallbackRequired()).toBe(true);
     });
 });
 
@@ -134,7 +134,7 @@ describe("SignUpSubmitCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitCodeError(error);
-        expect(signUpError.isRedirectionRequired()).toBe(true);
+        expect(signUpError.isFallbackRequired()).toBe(true);
     });
 });
 
@@ -160,7 +160,7 @@ describe("SignUpSubmitAttributesError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitAttributesError(error);
-        expect(signUpError.isRedirectionRequired()).toBe(true);
+        expect(signUpError.isFallbackRequired()).toBe(true);
     });
 });
 
@@ -168,6 +168,6 @@ describe("SignUpResendCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpResendCodeError(error);
-        expect(signUpError.isRedirectionRequired()).toBe(true);
+        expect(signUpError.isFallbackRequired()).toBe(true);
     });
 });

--- a/lib/msal-custom-auth/test/sign_up/auth_flow/error_type/SignUpError.spec.ts
+++ b/lib/msal-custom-auth/test/sign_up/auth_flow/error_type/SignUpError.spec.ts
@@ -80,7 +80,7 @@ describe("SignUpError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpError(error);
-        expect(signUpError.isRedirect()).toBe(true);
+        expect(signUpError.isRedirectionRequired()).toBe(true);
     });
 });
 
@@ -110,7 +110,7 @@ describe("SignUpSubmitPasswordError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitPasswordError(error);
-        expect(signUpError.isRedirect()).toBe(true);
+        expect(signUpError.isRedirectionRequired()).toBe(true);
     });
 });
 
@@ -134,7 +134,7 @@ describe("SignUpSubmitCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitCodeError(error);
-        expect(signUpError.isRedirect()).toBe(true);
+        expect(signUpError.isRedirectionRequired()).toBe(true);
     });
 });
 
@@ -160,7 +160,7 @@ describe("SignUpSubmitAttributesError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpSubmitAttributesError(error);
-        expect(signUpError.isRedirect()).toBe(true);
+        expect(signUpError.isRedirectionRequired()).toBe(true);
     });
 });
 
@@ -168,6 +168,6 @@ describe("SignUpResendCodeError", () => {
     it("should correctly identify redirect error", () => {
         const error = new RedirectError("Redirecting...");
         const signUpError = new SignUpResendCodeError(error);
-        expect(signUpError.isRedirect()).toBe(true);
+        expect(signUpError.isRedirectionRequired()).toBe(true);
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -44500,11 +44500,10 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.5.11",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.11.tgz",
-            "integrity": "sha512-4mVdhLkZ0vpqZLGJhNm+X1n7juqXApEMGlUXcOQawA45UmpxivOYaMBkI/Js3FlBsNA8hCgEnX5X04moFitSGw==",
+            "version": "4.5.13",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.13.tgz",
+            "integrity": "sha512-Hgp8IF/yZDzKsN1hQWOuQZbrKiaFsbQud+07jJ8h9m9PaHWkpvZ5u55Xw5yYjWRXwRQ4jwFlJvY7T7FUJG9MCA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "esbuild": "^0.18.10",


### PR DESCRIPTION
This PR is to add support for web fallback for (sign-up, sign-in, reset password) flows. 
1. Existing code already check during those flows if challenge types is `redirect `only. In this case, user could check this condition from state, and handle it.
2. By default, user could reuse the built-in `popUpLogin` from MSAL JS to continue to flow with a pop up interactively.
3. Make sure challenge type at least contains `redirect`.