### PR TITLE
Reset msal instance before running each test in msal.service.spec.ts

### DIFF
--- a/lib/msal-angular/src/msal.navigation.client.spec.ts
+++ b/lib/msal-angular/src/msal.navigation.client.spec.ts
@@ -26,7 +26,7 @@ const msalInstance = new PublicClientApplication({
 });
 
 describe("MsalCustomNaviationClient", () => {
-  beforeAll(() => {
+  beforeEach(() => {
     TestBed.resetTestingModule();
 
     TestBed.configureTestingModule({

--- a/lib/msal-angular/src/msal.redirect.component.spec.ts
+++ b/lib/msal-angular/src/msal.redirect.component.spec.ts
@@ -35,7 +35,7 @@ function initializeMsal() {
 }
 
 describe("MsalRedirectComponent", () => {
-  beforeAll(initializeMsal);
+  beforeEach(initializeMsal);
 
   it("calls handleRedirectObservable on ngInit", (done) => {
     const sampleAccessToken = {

--- a/lib/msal-angular/src/msal.service.spec.ts
+++ b/lib/msal-angular/src/msal.service.spec.ts
@@ -40,7 +40,7 @@ function initializeMsal() {
 }
 
 describe("MsalService", () => {
-  beforeAll(initializeMsal);
+  beforeEach(initializeMsal);
 
   describe("loginPopup", () => {
     it("success", (done) => {


### PR DESCRIPTION
- prevents events from leaking between tests by resetting the msal instance before each test