### PR TITLE
Follow up on JS WAM-Edge integration work

### DIFF
--- a/change/@azure-msal-browser-f6b2148c-0385-42b2-bc5d-058c8b3f12ec.json
+++ b/change/@azure-msal-browser-f6b2148c-0385-42b2-bc5d-058c8b3f12ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "updated naming for PlatformAuth request and response objects and added new type for DOM extraParameters #7759",
+  "packageName": "@azure/msal-browser",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/broker/nativeBroker/IPlatformAuthHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/IPlatformAuthHandler.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { PlatformBrokerRequest } from "./PlatformBrokerRequest.js";
-import { PlatformBrokerResponse } from "./PlatformBrokerResponse.js";
+import { PlatformAuthRequest } from "./PlatformAuthRequest.js";
+import { PlatformAuthResponse } from "./PlatformAuthResponse.js";
 
 /**
  * Interface for the Platform Broker Handlers
@@ -13,7 +13,5 @@ export interface IPlatformAuthHandler {
     getExtensionId(): string | undefined;
     getExtensionVersion(): string | undefined;
     getExtensionName(): string | undefined;
-    sendMessage(
-        request: PlatformBrokerRequest
-    ): Promise<PlatformBrokerResponse>;
+    sendMessage(request: PlatformAuthRequest): Promise<PlatformAuthResponse>;
 }

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
@@ -11,14 +11,15 @@ import {
     StringDict,
 } from "@azure/msal-common/browser";
 import {
-    PlatformBrokerRequest,
+    DOMExtraParameters,
+    PlatformAuthRequest,
     PlatformDOMTokenRequest,
-} from "./PlatformBrokerRequest.js";
+} from "./PlatformAuthRequest.js";
 import { PlatformAuthConstants } from "../../utils/BrowserConstants.js";
 import {
-    PlatformBrokerResponse,
+    PlatformAuthResponse,
     PlatformDOMTokenResponse,
-} from "./PlatformBrokerResponse.js";
+} from "./PlatformAuthResponse.js";
 import { createNativeAuthError } from "../../error/NativeAuthError.js";
 import { IPlatformAuthHandler } from "./IPlatformAuthHandler.js";
 
@@ -91,8 +92,8 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
      * @returns
      */
     async sendMessage(
-        request: PlatformBrokerRequest
-    ): Promise<PlatformBrokerResponse> {
+        request: PlatformAuthRequest
+    ): Promise<PlatformAuthResponse> {
         this.logger.trace(
             this.platformAuthType + " - Sending request to browser DOM API"
         );
@@ -115,7 +116,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
     }
 
     private initializePlatformDOMRequest(
-        request: PlatformBrokerRequest
+        request: PlatformAuthRequest
     ): PlatformDOMTokenRequest {
         this.logger.trace(
             this.platformAuthType + " - initializeNativeDOMRequest called"
@@ -135,8 +136,8 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
             ...remainingProperties
         } = request;
 
-        const validExtraParameters =
-            this.stringifyExtraParameters(remainingProperties);
+        const validExtraParameters: DOMExtraParameters =
+            this.getDOMExtraParams(remainingProperties);
 
         const platformDOMRequest: PlatformDOMTokenRequest = {
             accountId: accountId,
@@ -158,7 +159,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
 
     private validatePlatformBrokerResponse(
         response: object
-    ): PlatformBrokerResponse {
+    ): PlatformAuthResponse {
         if (response.hasOwnProperty("isSuccess")) {
             if (
                 response.hasOwnProperty("accessToken") &&
@@ -207,11 +208,11 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
 
     private convertToPlatformBrokerResponse(
         response: PlatformDOMTokenResponse
-    ): PlatformBrokerResponse {
+    ): PlatformAuthResponse {
         this.logger.trace(
             this.platformAuthType + " - convertToNativeResponse called"
         );
-        const nativeResponse: PlatformBrokerResponse = {
+        const nativeResponse: PlatformAuthResponse = {
             access_token: response.accessToken,
             id_token: response.idToken,
             client_info: response.clientInfo,
@@ -227,15 +228,21 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         return nativeResponse;
     }
 
-    private stringifyExtraParameters(
+    private getDOMExtraParams(
         extraParameters: Record<string, unknown>
-    ): StringDict {
-        return Object.entries(extraParameters).reduce(
+    ): DOMExtraParameters {
+        const stringifiedParams = Object.entries(extraParameters).reduce(
             (record, [key, value]) => {
                 record[key] = String(value);
                 return record;
             },
             {} as StringDict
         );
+
+        const validExtraParams: DOMExtraParameters = {
+            ...stringifiedParams,
+        };
+
+        return validExtraParams;
     }
 }

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthExtensionHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthExtensionHandler.ts
@@ -19,15 +19,15 @@ import {
 import {
     NativeExtensionRequest,
     NativeExtensionRequestBody,
-    PlatformBrokerRequest,
-} from "./PlatformBrokerRequest.js";
+    PlatformAuthRequest,
+} from "./PlatformAuthRequest.js";
 import { createNativeAuthError } from "../../error/NativeAuthError.js";
 import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
 } from "../../error/BrowserAuthError.js";
 import { createNewGuid } from "../../crypto/BrowserCrypto.js";
-import { PlatformBrokerResponse } from "./PlatformBrokerResponse.js";
+import { PlatformAuthResponse } from "./PlatformAuthResponse.js";
 import { IPlatformAuthHandler } from "./IPlatformAuthHandler.js";
 
 type ResponseResolvers<T> = {
@@ -77,8 +77,8 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      * @param request
      */
     async sendMessage(
-        request: PlatformBrokerRequest
-    ): Promise<PlatformBrokerResponse> {
+        request: PlatformAuthRequest
+    ): Promise<PlatformAuthResponse> {
         this.logger.trace(this.platformAuthType + " - sendMessage called.");
 
         // fall back to native calls
@@ -109,7 +109,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
             this.resolvers.set(req.responseId, { resolve, reject });
         });
 
-        const validatedResponse: PlatformBrokerResponse =
+        const validatedResponse: PlatformAuthResponse =
             this.validatePlatformBrokerResponse(response);
 
         return validatedResponse;
@@ -382,7 +382,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      */
     private validatePlatformBrokerResponse(
         response: object
-    ): PlatformBrokerResponse {
+    ): PlatformAuthResponse {
         if (
             response.hasOwnProperty("access_token") &&
             response.hasOwnProperty("id_token") &&
@@ -391,7 +391,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
             response.hasOwnProperty("scope") &&
             response.hasOwnProperty("expires_in")
         ) {
-            return response as PlatformBrokerResponse;
+            return response as PlatformAuthResponse;
         } else {
             throw createAuthError(
                 AuthErrorCodes.unexpectedError,

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
@@ -122,7 +122,7 @@ export function isDomEnabledForPlatformAuth(): boolean {
  * @param platformAuthProvider
  * @param authenticationScheme
  */
-export function isBrokerAvailable(
+export function isPlatformAuthAllowed(
     config: BrowserConfiguration,
     logger: Logger,
     platformAuthProvider?: IPlatformAuthHandler,

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
@@ -9,7 +9,7 @@ import { StoreInCache, StringDict } from "@azure/msal-common/browser";
 /**
  * Token request which native broker will use to acquire tokens
  */
-export type PlatformBrokerRequest = {
+export type PlatformAuthRequest = {
     accountId: string; // WAM specific account id used for identification of WAM account. This can be any broker-id eventually
     clientId: string;
     authority: string;
@@ -40,7 +40,7 @@ export type PlatformBrokerRequest = {
  */
 export type NativeExtensionRequestBody = {
     method: NativeExtensionMethod;
-    request?: PlatformBrokerRequest;
+    request?: PlatformAuthRequest;
 };
 
 /**
@@ -69,7 +69,25 @@ export type PlatformDOMTokenRequest = {
      * "prompt", "nonce", "claims", "loginHint", "instanceAware", "windowTitleSubstring", "extendedExpiryToken", "storeInCache",
      * ProofOfPossessionParams: "reqCnf", "keyId", "tokenType", "shrClaims", "shrNonce", "resourceRequestMethod", "resourceRequestUri", "signPopToken"
      */
-    extraParameters?: StringDict;
+    extraParameters?: DOMExtraParameters;
     embeddedClientId?: string;
     storeInCache?: StoreInCache; // Object of booleans indicating whether to store tokens in the cache or not (default is true)
+};
+
+export type DOMExtraParameters = StringDict & {
+    prompt?: string;
+    nonce?: string;
+    claims?: string;
+    loginHint?: string;
+    instanceAware?: string;
+    windowTitleSubstring?: string;
+    extendedExpiryToken?: string;
+    reqCnf?: string;
+    keyId?: string;
+    tokenType?: string;
+    shrClaims?: string;
+    shrNonce?: string;
+    resourceRequestMethod?: string;
+    resourceRequestUri?: string;
+    signPopToken?: string; // Set to true only if token request deos not contain a PoP keyId
 };

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthResponse.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthResponse.ts
@@ -15,7 +15,7 @@ export type NativeAccountInfo = {
 /**
  * Token response returned by Native Platform
  */
-export type PlatformBrokerResponse = {
+export type PlatformAuthResponse = {
     access_token: string;
     account: NativeAccountInfo;
     client_info: string;

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -53,7 +53,7 @@ import { LocalStorage } from "./LocalStorage.js";
 import { SessionStorage } from "./SessionStorage.js";
 import { MemoryStorage } from "./MemoryStorage.js";
 import { IWindowStorage } from "./IWindowStorage.js";
-import { PlatformBrokerRequest } from "../broker/nativeBroker/PlatformBrokerRequest.js";
+import { PlatformAuthRequest } from "../broker/nativeBroker/PlatformAuthRequest.js";
 import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import { SilentRequest } from "../request/SilentRequest.js";
 import { SsoSilentRequest } from "../request/SsoSilentRequest.js";
@@ -1162,7 +1162,7 @@ export class BrowserCacheManager extends CacheManager {
     /**
      * Gets cached native request for redirect flows
      */
-    getCachedNativeRequest(): PlatformBrokerRequest | null {
+    getCachedNativeRequest(): PlatformAuthRequest | null {
         this.logger.trace("BrowserCacheManager.getCachedNativeRequest called");
         const cachedRequest = this.getTemporaryCache(
             TemporaryCacheKeys.NATIVE_REQUEST,
@@ -1177,7 +1177,7 @@ export class BrowserCacheManager extends CacheManager {
 
         const parsedRequest = this.validateAndParseJson(
             cachedRequest
-        ) as PlatformBrokerRequest;
+        ) as PlatformAuthRequest;
         if (!parsedRequest) {
             this.logger.error(
                 "BrowserCacheManager.getCachedNativeRequest: Unable to parse native request"

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -76,7 +76,7 @@ import {
     BrowserAuthErrorCodes,
 } from "../error/BrowserAuthError.js";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest.js";
-import { PlatformBrokerRequest } from "../broker/nativeBroker/PlatformBrokerRequest.js";
+import { PlatformAuthRequest } from "../broker/nativeBroker/PlatformAuthRequest.js";
 import { StandardOperatingContext } from "../operatingcontext/StandardOperatingContext.js";
 import { BaseOperatingContext } from "../operatingcontext/BaseOperatingContext.js";
 import { IController } from "./IController.js";
@@ -471,7 +471,7 @@ export class StandardController implements IController {
         }
 
         const loggedInAccounts = this.getAllAccounts();
-        const platformBrokerRequest: PlatformBrokerRequest | null =
+        const platformBrokerRequest: PlatformAuthRequest | null =
             this.browserStorage.getCachedNativeRequest();
         const useNative =
             platformBrokerRequest && this.platformAuthProvider && !hash;

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -88,7 +88,7 @@ import { InitializeApplicationRequest } from "../request/InitializeApplicationRe
 import { generatePkceCodes } from "../crypto/PkceGenerator.js";
 import {
     getPlatformAuthProvider,
-    isBrokerAvailable,
+    isPlatformAuthAllowed,
 } from "../broker/nativeBroker/PlatformAuthProvider.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 import { collectInstanceStats } from "../utils/MsalFrameStatsUtils.js";
@@ -1614,7 +1614,7 @@ export class StandardController implements IController {
         }
 
         if (
-            !isBrokerAvailable(
+            !isPlatformAuthAllowed(
                 this.config,
                 this.logger,
                 this.platformAuthProvider,
@@ -2298,7 +2298,7 @@ export class StandardController implements IController {
     ): Promise<AuthenticationResult> {
         // if the cache policy is set to access_token only, we should not be hitting the native layer yet
         if (
-            isBrokerAvailable(
+            isPlatformAuthAllowed(
                 this.config,
                 this.logger,
                 this.platformAuthProvider,

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -50,14 +50,11 @@ import {
     BrowserConstants,
     CacheLookupPolicy,
 } from "../utils/BrowserConstants.js";
-import {
-    PlatformBrokerRequest,
-    PlatformDOMTokenRequest,
-} from "../broker/nativeBroker/PlatformBrokerRequest.js";
+import { PlatformAuthRequest } from "../broker/nativeBroker/PlatformAuthRequest.js";
 import {
     MATS,
-    PlatformBrokerResponse,
-} from "../broker/nativeBroker/PlatformBrokerResponse.js";
+    PlatformAuthResponse,
+} from "../broker/nativeBroker/PlatformAuthResponse.js";
 import {
     NativeAuthError,
     NativeAuthErrorCodes,
@@ -138,12 +135,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
 
     /**
      * Adds SKUs to request extra query parameters
-     * @param request {PlatformBrokerRequest}
+     * @param request {PlatformAuthRequest}
      * @private
      */
-    private addRequestSKUs(
-        request: PlatformBrokerRequest | PlatformDOMTokenRequest
-    ): void {
+    private addRequestSKUs(request: PlatformAuthRequest): void {
         request.extraParameters = {
             ...request.extraParameters,
             [AADServerParamKeys.X_CLIENT_EXTRA_SKU]: this.skus,
@@ -204,7 +199,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 );
             }
 
-            const validatedResponse: PlatformBrokerResponse =
+            const validatedResponse: PlatformAuthResponse =
                 await this.platformAuthProvider.sendMessage(nativeRequest);
 
             return await this.handleNativeResponse(
@@ -245,7 +240,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      * @returns CommonSilentFlowRequest
      */
     private createSilentCacheRequest(
-        request: PlatformBrokerRequest,
+        request: PlatformAuthRequest,
         cachedAccount: AccountInfo
     ): CommonSilentFlowRequest {
         return {
@@ -265,7 +260,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      */
     protected async acquireTokensFromCache(
         nativeAccountId: string,
-        request: PlatformBrokerRequest
+        request: PlatformAuthRequest
     ): Promise<AuthenticationResult> {
         if (!nativeAccountId) {
             this.logger.warning(
@@ -414,7 +409,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             this.logger.verbose(
                 "NativeInteractionClient - handleRedirectPromise sending message to native broker."
             );
-            const response: PlatformBrokerResponse =
+            const response: PlatformAuthResponse =
                 await this.platformAuthProvider.sendMessage(request);
             const authResult = await this.handleNativeResponse(
                 response,
@@ -447,8 +442,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      * @param reqTimestamp
      */
     protected async handleNativeResponse(
-        response: PlatformBrokerResponse,
-        request: PlatformBrokerRequest,
+        response: PlatformAuthResponse,
+        request: PlatformAuthRequest,
         reqTimestamp: number
     ): Promise<AuthenticationResult> {
         this.logger.trace(
@@ -541,7 +536,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      * @returns
      */
     protected createHomeAccountIdentifier(
-        response: PlatformBrokerResponse,
+        response: PlatformAuthResponse,
         idTokenClaims: TokenClaims
     ): string {
         // Save account in browser storage
@@ -574,8 +569,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      * @param response
      */
     async generatePopAccessToken(
-        response: PlatformBrokerResponse,
-        request: PlatformBrokerRequest
+        response: PlatformAuthResponse,
+        request: PlatformAuthRequest
     ): Promise<string> {
         if (
             request.tokenType === AuthenticationScheme.POP &&
@@ -633,8 +628,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      * @returns
      */
     protected async generateAuthenticationResult(
-        response: PlatformBrokerResponse,
-        request: PlatformBrokerRequest,
+        response: PlatformAuthResponse,
+        request: PlatformAuthRequest,
         idTokenClaims: TokenClaims,
         accountEntity: AccountEntity,
         authority: string,
@@ -737,8 +732,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      * @param reqTimestamp
      */
     cacheNativeTokens(
-        response: PlatformBrokerResponse,
-        request: PlatformBrokerRequest,
+        response: PlatformAuthResponse,
+        request: PlatformAuthRequest,
         homeAccountIdentifier: string,
         idTokenClaims: TokenClaims,
         responseAccessToken: string,
@@ -882,7 +877,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      */
     protected async initializeNativeRequest(
         request: PopupRequest | SsoSilentRequest
-    ): Promise<PlatformBrokerRequest> {
+    ): Promise<PlatformAuthRequest> {
         this.logger.trace(
             "NativeInteractionClient - initializeNativeRequest called"
         );
@@ -894,7 +889,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         const scopeSet = new ScopeSet(scopes || []);
         scopeSet.appendScopes(OIDC_DEFAULT_SCOPES);
 
-        const validatedRequest: PlatformBrokerRequest = {
+        const validatedRequest: PlatformAuthRequest = {
             ...remainingProperties,
             accountId: this.accountId,
             clientId: this.config.auth.clientId,
@@ -1027,12 +1022,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
 
     /**
      * Handles extra broker request parameters
-     * @param request {PlatformBrokerRequest}
+     * @param request {PlatformAuthRequest}
      * @private
      */
-    private handleExtraBrokerParams(
-        request: PlatformBrokerRequest | PlatformDOMTokenRequest
-    ): void {
+    private handleExtraBrokerParams(request: PlatformAuthRequest): void {
         const hasExtraBrokerParams =
             request.extraParameters &&
             request.extraParameters.hasOwnProperty(

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -45,7 +45,7 @@ import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import * as ResponseHandler from "../response/ResponseHandler.js";
 import * as Authorize from "../protocol/Authorize.js";
 import { generatePkceCodes } from "../crypto/PkceGenerator.js";
-import { isBrokerAvailable } from "../broker/nativeBroker/PlatformAuthProvider.js";
+import { isPlatformAuthAllowed } from "../broker/nativeBroker/PlatformAuthProvider.js";
 import { generateEarKey } from "../crypto/BrowserCrypto.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 
@@ -223,7 +223,7 @@ export class PopupClient extends StandardInteractionClient {
             BrowserUtils.preconnect(validRequest.authority);
         }
 
-        const isPlatformBroker = isBrokerAvailable(
+        const isPlatformBroker = isPlatformAuthAllowed(
             this.config,
             this.logger,
             this.platformAuthProvider,

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -46,7 +46,7 @@ import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import * as ResponseHandler from "../response/ResponseHandler.js";
 import * as Authorize from "../protocol/Authorize.js";
 import { generatePkceCodes } from "../crypto/PkceGenerator.js";
-import { isBrokerAvailable } from "../broker/nativeBroker/PlatformAuthProvider.js";
+import { isPlatformAuthAllowed } from "../broker/nativeBroker/PlatformAuthProvider.js";
 import { generateEarKey } from "../crypto/BrowserCrypto.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 
@@ -108,7 +108,7 @@ export class RedirectClient extends StandardInteractionClient {
             this.correlationId
         )(request, InteractionType.Redirect);
 
-        validRequest.platformBroker = isBrokerAvailable(
+        validRequest.platformBroker = isPlatformAuthAllowed(
             this.config,
             this.logger,
             this.platformAuthProvider,

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -41,7 +41,7 @@ import * as BrowserUtils from "../utils/BrowserUtils.js";
 import * as ResponseHandler from "../response/ResponseHandler.js";
 import * as Authorize from "../protocol/Authorize.js";
 import { generatePkceCodes } from "../crypto/PkceGenerator.js";
-import { isBrokerAvailable } from "../broker/nativeBroker/PlatformAuthProvider.js";
+import { isPlatformAuthAllowed } from "../broker/nativeBroker/PlatformAuthProvider.js";
 import { generateEarKey } from "../crypto/BrowserCrypto.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 
@@ -123,7 +123,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             this.performanceClient,
             request.correlationId
         )(inputRequest, InteractionType.Silent);
-        silentRequest.platformBroker = isBrokerAvailable(
+        silentRequest.platformBroker = isPlatformAuthAllowed(
             this.config,
             this.logger,
             this.platformAuthProvider,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -6263,8 +6263,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     .spyOn(SilentIframeClient.prototype, "acquireToken")
                     .mockImplementation();
 
-                const isBrokerAvailableSpy = jest
-                    .spyOn(PlatformAuthProvider, "isBrokerAvailable")
+                const isPlatformAuthAllowedSpy = jest
+                    .spyOn(PlatformAuthProvider, "isPlatformAuthAllowed")
                     .mockReturnValue(true);
                 const nativeAcquireTokenSpy: jest.SpyInstance = jest
                     .spyOn(
@@ -6294,7 +6294,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(0);
 
                 nativeAcquireTokenSpy.mockRestore();
-                isBrokerAvailableSpy.mockRestore();
+                isPlatformAuthAllowedSpy.mockRestore();
             });
 
             it("Calls SilentRefreshClient.acquireToken, and does not call SilentCacheClient.acquireToken or SilentIframeClient.acquireToken if refresh token is expired when CacheLookupPolicy is set to RefreshToken", async () => {
@@ -6339,8 +6339,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
                 const cacheAccount = testAccount;
                 cacheAccount.nativeAccountId = "nativeAccountId";
-                const isBrokerAvailableSpy = jest
-                    .spyOn(PlatformAuthProvider, "isBrokerAvailable")
+                const isPlatformAuthAllowedSpy = jest
+                    .spyOn(PlatformAuthProvider, "isPlatformAuthAllowed")
                     .mockReturnValue(true);
                 testAccount.nativeAccountId = "nativeAccountId";
 
@@ -6363,7 +6363,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(silentIframeSpy).toHaveBeenCalledTimes(0);
                 expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(0);
                 nativeAcquireTokenSpy.mockRestore();
-                isBrokerAvailableSpy.mockRestore();
+                isPlatformAuthAllowedSpy.mockRestore();
             });
 
             it("Calls SilentRefreshClient.acquireToken, and does not call SilentCacheClient.acquireToken or SilentIframeClient.acquireToken if refresh token is expired when CacheLookupPolicy is set to RefreshToken", async () => {

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -30,7 +30,6 @@ import {
     CacheHelpers,
     CacheManager,
     ClientAuthErrorCodes,
-    CommonAuthorizationCodeRequest,
     CommonAuthorizationUrlRequest,
     CommonSilentFlowRequest,
     Constants,
@@ -76,7 +75,6 @@ import { NavigationOptions } from "../../src/navigation/NavigationOptions.js";
 import { EventMessage } from "../../src/event/EventMessage.js";
 import { EventHandler } from "../../src/event/EventHandler.js";
 import { SilentIframeClient } from "../../src/interaction_client/SilentIframeClient.js";
-import { base64Encode } from "../../src/encode/Base64Encode.js";
 import { FetchClient } from "../../src/network/FetchClient.js";
 import {
     BrowserAuthError,
@@ -98,7 +96,7 @@ import { BrowserCacheManager } from "../../src/cache/BrowserCacheManager.js";
 import { PlatformAuthExtensionHandler } from "../../src/broker/nativeBroker/PlatformAuthExtensionHandler.js";
 import * as PlatformAuthProvider from "../../src/broker/nativeBroker/PlatformAuthProvider.js";
 import { PlatformAuthInteractionClient } from "../../src/interaction_client/PlatformAuthInteractionClient.js";
-import { PlatformBrokerRequest } from "../../src/broker/nativeBroker/PlatformBrokerRequest.js";
+import { PlatformAuthRequest } from "../../src/broker/nativeBroker/PlatformAuthRequest.js";
 import { NativeAuthError } from "../../src/error/NativeAuthError.js";
 import { StandardController } from "../../src/controllers/StandardController.js";
 import { AuthenticationResult } from "../../src/response/AuthenticationResult.js";
@@ -117,9 +115,7 @@ import {
     TestTimeUtils,
 } from "msal-test-utils";
 import { INTERACTION_TYPE } from "../../src/utils/BrowserConstants.js";
-import { BaseOperatingContext } from "../../src/operatingcontext/BaseOperatingContext.js";
 import { PlatformAuthDOMHandler } from "../../src/broker/nativeBroker/PlatformAuthDOMHandler.js";
-import { config } from "process";
 
 const cacheConfig = {
     temporaryCacheLocation: BrowserCacheLocation.SessionStorage,
@@ -884,7 +880,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 "isInteractionInProgress"
             ).mockReturnValue(true);
 
-            const nativeRequest: PlatformBrokerRequest = {
+            const nativeRequest: PlatformAuthRequest = {
                 authority: TEST_CONFIG.validAuthority,
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
@@ -1003,7 +999,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     "getCachedRequest"
                 ).mockReturnValue([testRequest, TEST_CONFIG.TEST_VERIFIER]);
 
-                const nativeRequest: PlatformBrokerRequest = {
+                const nativeRequest: PlatformAuthRequest = {
                     authority: TEST_CONFIG.validAuthority,
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                     scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),
@@ -1046,7 +1042,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             //@ts-ignore
             pca.controller.browserStorage.setInteractionInProgress(true);
 
-            const nativeRequest: PlatformBrokerRequest = {
+            const nativeRequest: PlatformAuthRequest = {
                 authority: TEST_CONFIG.validAuthority,
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 scope: TEST_CONFIG.DEFAULT_SCOPES.join(" "),

--- a/lib/msal-browser/test/broker/PlatformAuthDOMHandler.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthDOMHandler.spec.ts
@@ -7,14 +7,13 @@ import {
 import { PlatformAuthConstants } from "../../src/utils/BrowserConstants.js";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils.js";
 import { PlatformAuthDOMHandler } from "../../src/broker/nativeBroker/PlatformAuthDOMHandler.js";
-import { get } from "http";
-import { PlatformBrokerResponse } from "../../src/broker/nativeBroker/PlatformBrokerResponse.js";
+import { PlatformAuthResponse } from "../../src/broker/nativeBroker/PlatformAuthResponse.js";
 import {
     TEST_CONFIG,
     TEST_TOKENS,
     TEST_URIS,
 } from "../utils/StringConstants.js";
-import { PlatformBrokerRequest } from "../../src/broker/nativeBroker/PlatformBrokerRequest.js";
+import { PlatformAuthRequest } from "../../src/broker/nativeBroker/PlatformAuthRequest.js";
 import { NativeAuthError } from "../../src/error/NativeAuthError.js";
 
 describe("PlatformAuthDOMHandler tests", () => {
@@ -136,7 +135,7 @@ describe("PlatformAuthDOMHandler tests", () => {
             getSupportedContractsMock.mockResolvedValue([
                 PlatformAuthConstants.PLATFORM_DOM_APIS,
             ]);
-            const testRequest: PlatformBrokerRequest = {
+            const testRequest: PlatformAuthRequest = {
                 accountId: "test-id",
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 authority: TEST_CONFIG.validAuthority,
@@ -167,7 +166,7 @@ describe("PlatformAuthDOMHandler tests", () => {
                 },
                 extendedLifetimeToken: true,
             };
-            const validatedResponse: PlatformBrokerResponse = {
+            const validatedResponse: PlatformAuthResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 account: {
                     id: "test-id",
@@ -202,7 +201,7 @@ describe("PlatformAuthDOMHandler tests", () => {
             getSupportedContractsMock.mockResolvedValue([
                 PlatformAuthConstants.PLATFORM_DOM_APIS,
             ]);
-            const testRequest: PlatformBrokerRequest = {
+            const testRequest: PlatformAuthRequest = {
                 accountId: "test-id",
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 authority: TEST_CONFIG.validAuthority,
@@ -259,7 +258,7 @@ describe("PlatformAuthDOMHandler tests", () => {
             getSupportedContractsMock.mockResolvedValue([
                 PlatformAuthConstants.PLATFORM_DOM_APIS,
             ]);
-            const testRequest: PlatformBrokerRequest = {
+            const testRequest: PlatformAuthRequest = {
                 accountId: "test-id",
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 authority: TEST_CONFIG.validAuthority,
@@ -305,7 +304,7 @@ describe("PlatformAuthDOMHandler tests", () => {
             getSupportedContractsMock.mockResolvedValue([
                 PlatformAuthConstants.PLATFORM_DOM_APIS,
             ]);
-            const testRequest: PlatformBrokerRequest = {
+            const testRequest: PlatformAuthRequest = {
                 accountId: "test-id",
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 authority: TEST_CONFIG.validAuthority,
@@ -364,14 +363,17 @@ describe("PlatformAuthDOMHandler tests", () => {
                     performanceClient,
                     "test-correlation-id"
                 );
-            const testRequest: PlatformBrokerRequest = {
+            const testRequest: PlatformAuthRequest = {
                 accountId: "test-id",
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 authority: TEST_CONFIG.validAuthority,
                 redirectUri: TEST_URIS.TEST_REDIR_URI,
                 scope: "read openid",
                 correlationId: TEST_CONFIG.CORRELATION_ID,
-                windowTitleSubstring: "",
+                windowTitleSubstring: "test-window-substring",
+                prompt: "login",
+                nonce: "test-nonce",
+                claims: "test-claims",
                 extraParameters: {
                     extendedExpiryToken: "true",
                 },
@@ -390,7 +392,10 @@ describe("PlatformAuthDOMHandler tests", () => {
                 isSecurityTokenService: false,
                 extraParameters: {
                     extendedExpiryToken: "true",
-                    windowTitleSubstring: "",
+                    windowTitleSubstring: "test-window-substring",
+                    prompt: "login",
+                    nonce: "test-nonce",
+                    claims: "test-claims",
                 },
                 redirectUri: testRequest.redirectUri,
                 scope: testRequest.scope,

--- a/lib/msal-browser/test/broker/PlatformAuthDOMHandler.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthDOMHandler.spec.ts
@@ -3,6 +3,7 @@ import {
     AuthErrorCodes,
     IPerformanceClient,
     Logger,
+    PromptValue,
 } from "@azure/msal-common/browser";
 import { PlatformAuthConstants } from "../../src/utils/BrowserConstants.js";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils.js";
@@ -15,6 +16,7 @@ import {
 } from "../utils/StringConstants.js";
 import { PlatformAuthRequest } from "../../src/broker/nativeBroker/PlatformAuthRequest.js";
 import { NativeAuthError } from "../../src/error/NativeAuthError.js";
+import { sign } from "crypto";
 
 describe("PlatformAuthDOMHandler tests", () => {
     let performanceClient: IPerformanceClient;
@@ -458,6 +460,40 @@ describe("PlatformAuthDOMHandler tests", () => {
                 state: "",
                 extendedLifetimeToken: true,
             });
+        });
+    });
+
+    describe("getDOMExtraParams tests", () => {});
+    it("should return a valid DOMExtraParameters object", async () => {
+        getSupportedContractsMock.mockResolvedValue([
+            PlatformAuthConstants.PLATFORM_DOM_APIS,
+        ]);
+        const platformAuthDOMHandler =
+            await PlatformAuthDOMHandler.createProvider(
+                logger,
+                performanceClient,
+                "test-correlation-id"
+            );
+        const testExtraParameters = {
+            prompt: PromptValue.NONE,
+            nonce: "test-nonce",
+            claims: "test-claims",
+            instanceAware: true,
+            windowTitleSubstring: "test-window-substring",
+            extendedExpiryToken: true,
+            signPopToken: true,
+        };
+        const domExtraParams =
+            //@ts-ignore
+            platformAuthDOMHandler.getDOMExtraParams(testExtraParameters);
+        expect(domExtraParams).toEqual({
+            prompt: "none",
+            nonce: "test-nonce",
+            claims: "test-claims",
+            instanceAware: "true",
+            windowTitleSubstring: "test-window-substring",
+            extendedExpiryToken: "true",
+            signPopToken: "true",
         });
     });
 });

--- a/lib/msal-browser/test/broker/PlatformAuthDOMHandler.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthDOMHandler.spec.ts
@@ -376,8 +376,60 @@ describe("PlatformAuthDOMHandler tests", () => {
                 prompt: "login",
                 nonce: "test-nonce",
                 claims: "test-claims",
+                extendedExpiryToken: true,
+            };
+            const platformDOMRequest =
+                //@ts-ignore
+                platformAuthDOMHandler.initializePlatformDOMRequest(
+                    testRequest
+                );
+            expect(platformDOMRequest).toEqual({
+                accountId: testRequest.accountId,
+                brokerId: PlatformAuthConstants.MICROSOFT_ENTRA_BROKERID,
+                authority: testRequest.authority,
+                clientId: testRequest.clientId,
+                correlationId: testRequest.correlationId,
+                isSecurityTokenService: false,
                 extraParameters: {
+                    windowTitleSubstring: "test-window-substring",
                     extendedExpiryToken: "true",
+                    prompt: "login",
+                    nonce: "test-nonce",
+                    claims: "test-claims",
+                },
+                redirectUri: testRequest.redirectUri,
+                scope: testRequest.scope,
+                state: undefined,
+                storeInCache: undefined,
+                embeddedClientId: undefined,
+            });
+        });
+
+        it("returned DOM request object should include user input extra parameters", async () => {
+            getSupportedContractsMock.mockResolvedValue([
+                PlatformAuthConstants.PLATFORM_DOM_APIS,
+            ]);
+            const platformAuthDOMHandler =
+                await PlatformAuthDOMHandler.createProvider(
+                    logger,
+                    performanceClient,
+                    "test-correlation-id"
+                );
+            const testRequest: PlatformAuthRequest = {
+                accountId: "test-id",
+                clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                authority: TEST_CONFIG.validAuthority,
+                redirectUri: TEST_URIS.TEST_REDIR_URI,
+                scope: "read openid",
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                windowTitleSubstring: "test-window-substring",
+                prompt: "login",
+                nonce: "test-nonce",
+                claims: "test-claims",
+                extendedExpiryToken: true,
+                extraParameters: {
+                    customUserInput1: "test-user-input1",
+                    customUserInput2: "test-user-input2",
                 },
             };
             const platformDOMRequest =
@@ -393,11 +445,13 @@ describe("PlatformAuthDOMHandler tests", () => {
                 correlationId: testRequest.correlationId,
                 isSecurityTokenService: false,
                 extraParameters: {
-                    extendedExpiryToken: "true",
                     windowTitleSubstring: "test-window-substring",
+                    extendedExpiryToken: "true",
                     prompt: "login",
                     nonce: "test-nonce",
                     claims: "test-claims",
+                    customUserInput1: "test-user-input1",
+                    customUserInput2: "test-user-input2",
                 },
                 redirectUri: testRequest.redirectUri,
                 scope: testRequest.scope,

--- a/lib/msal-browser/test/broker/PlatformAuthExtensionHandler.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthExtensionHandler.spec.ts
@@ -15,13 +15,12 @@ import { NativeExtensionMethod } from "../../src/utils/BrowserConstants.js";
 import { NativeAuthError } from "../../src/error/NativeAuthError.js";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils.js";
 import { CryptoOps } from "../../src/crypto/CryptoOps.js";
-import { mock } from "node:test";
-import { PlatformBrokerRequest } from "../../src/broker/nativeBroker/PlatformBrokerRequest.js";
+import { PlatformAuthRequest } from "../../src/broker/nativeBroker/PlatformAuthRequest.js";
 import { TEST_CONFIG, TEST_URIS } from "../utils/StringConstants.js";
 
 let performanceClient: IPerformanceClient;
 
-const TEST_REQUEST: PlatformBrokerRequest = {
+const TEST_REQUEST: PlatformAuthRequest = {
     accountId: "test-account-id",
     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
     authority: TEST_CONFIG.validAuthority,

--- a/lib/msal-browser/test/broker/PlatformAuthProvider.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthProvider.spec.ts
@@ -204,7 +204,7 @@ describe("PlatformAuthProvider tests", () => {
         });
     });
 
-    describe("isBrokerAvailable", () => {
+    describe("isPlatformAuthAllowed", () => {
         let config: BrowserConfiguration;
         beforeEach(() => {
             config = buildConfiguration(
@@ -224,7 +224,7 @@ describe("PlatformAuthProvider tests", () => {
 
         it("returns false when config is not set to enable paltform broker", () => {
             config.system.allowPlatformBroker = false;
-            const result = PlatformAuthProvider.isBrokerAvailable(
+            const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,
                 new PlatformAuthDOMHandler(
@@ -238,7 +238,7 @@ describe("PlatformAuthProvider tests", () => {
         });
 
         it("returns false when platform auth provider is not initialized", () => {
-            const result = PlatformAuthProvider.isBrokerAvailable(
+            const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,
                 undefined,
@@ -247,7 +247,7 @@ describe("PlatformAuthProvider tests", () => {
             expect(result).toBe(false);
         });
         it("returns false when authentication scheme is not supported", () => {
-            const result = PlatformAuthProvider.isBrokerAvailable(
+            const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,
                 new PlatformAuthDOMHandler(
@@ -261,7 +261,7 @@ describe("PlatformAuthProvider tests", () => {
         });
 
         it("returns true when platform auth provider is initialized and authentication scheme is supported", () => {
-            const result = PlatformAuthProvider.isBrokerAvailable(
+            const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,
                 new PlatformAuthDOMHandler(

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -48,6 +48,7 @@ import { version } from "../../src/packageMetadata.js";
 import { BrowserConstants } from "../../src/utils/BrowserConstants.js";
 import * as NativeStatusCodes from "../../src/broker/nativeBroker/NativeStatusCodes.js";
 import { PlatformAuthResponse } from "../../src/broker/nativeBroker/PlatformAuthResponse.js";
+import { PlatformAuthDOMHandler } from "../../src/broker/nativeBroker/PlatformAuthDOMHandler.js";
 
 const MOCK_WAM_RESPONSE: PlatformAuthResponse = {
     access_token: TEST_TOKENS.ACCESS_TOKEN,
@@ -113,7 +114,8 @@ const testAccessTokenEntity: AccessTokenEntity = {
 
 describe("PlatformAuthInteractionClient Tests", () => {
     let pca: PublicClientApplication;
-    let nativeInteractionClient: PlatformAuthInteractionClient;
+    let platformAuthInteractionClient: PlatformAuthInteractionClient;
+    let platformAuthDOMHandler: PlatformAuthDOMHandler;
 
     let browserCacheManager: BrowserCacheManager;
     let internalStorage: BrowserCacheManager;
@@ -160,7 +162,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             getDefaultPerformanceClient()
         );
 
-        nativeInteractionClient = new PlatformAuthInteractionClient(
+        platformAuthInteractionClient = new PlatformAuthInteractionClient(
             // @ts-ignore
             pca.config,
             // @ts-ignore
@@ -223,7 +225,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
         });
 
         it("Tokens found in cache", async () => {
-            const response = await nativeInteractionClient.acquireToken({
+            const response = await platformAuthInteractionClient.acquireToken({
                 scopes: TEST_CONFIG.DEFAULT_SCOPES,
             });
             expect(response.accessToken).toEqual(testAccessTokenEntity.secret);
@@ -240,14 +242,65 @@ describe("PlatformAuthInteractionClient Tests", () => {
     });
 
     describe("acquireToken Tests", () => {
-        it("acquires token successfully", async () => {
+        it("Extension: acquires token successfully", async () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
-            const response = await nativeInteractionClient.acquireToken({
+            const response = await platformAuthInteractionClient.acquireToken({
+                scopes: ["User.Read"],
+            });
+            expect(response.accessToken).toEqual(
+                MOCK_WAM_RESPONSE.access_token
+            );
+            expect(response.idToken).toEqual(MOCK_WAM_RESPONSE.id_token);
+            expect(response.uniqueId).toEqual(ID_TOKEN_CLAIMS.oid);
+            expect(response.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
+            expect(response.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
+            expect(response.authority).toEqual(TEST_CONFIG.validAuthority);
+            expect(response.scopes).toContain(MOCK_WAM_RESPONSE.scope);
+            expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
+            expect(response.account).toEqual(TEST_ACCOUNT_INFO);
+            expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
+        });
+
+        it("DOM API: acquires token successfully", async () => {
+            platformAuthDOMHandler = new PlatformAuthDOMHandler(
+                pca.getLogger(),
+                getDefaultPerformanceClient(),
+                "test-correlation-id"
+            );
+
+            const testInterctionClient = new PlatformAuthInteractionClient(
+                // @ts-ignore
+                pca.config,
+                // @ts-ignore
+                pca.browserStorage,
+                // @ts-ignore
+                pca.browserCrypto,
+                pca.getLogger(),
+                // @ts-ignore
+                pca.eventHandler,
+                // @ts-ignore
+                pca.navigationClient,
+                ApiId.acquireTokenRedirect,
+                perfClient,
+                platformAuthDOMHandler,
+                "nativeAccountId",
+                // @ts-ignore
+                pca.nativeInternalStorage,
+                RANDOM_TEST_GUID
+            );
+
+            jest.spyOn(
+                PlatformAuthDOMHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+            const response = await testInterctionClient.acquireToken({
                 scopes: ["User.Read"],
             });
             expect(response.accessToken).toEqual(
@@ -271,7 +324,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE_STRING_EXPIRES_IN);
             });
-            const response = await nativeInteractionClient.acquireToken({
+            const response = await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
             });
             expect(response.accessToken).toEqual(
@@ -294,7 +347,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
         });
 
         it("throws if prompt: select_account", (done) => {
-            nativeInteractionClient
+            platformAuthInteractionClient
                 .acquireToken({
                     scopes: ["User.Read"],
                     prompt: PromptValue.SELECT_ACCOUNT,
@@ -311,7 +364,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
         });
 
         it("throws if prompt: create", (done) => {
-            nativeInteractionClient
+            platformAuthInteractionClient
                 .acquireToken({
                     scopes: ["User.Read"],
                     prompt: PromptValue.CREATE,
@@ -334,7 +387,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
-            const response = await nativeInteractionClient.acquireToken({
+            const response = await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
                 prompt: PromptValue.NONE,
             });
@@ -359,7 +412,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
-            const response = await nativeInteractionClient.acquireToken({
+            const response = await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
                 prompt: PromptValue.CONSENT,
             });
@@ -384,7 +437,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
-            const response = await nativeInteractionClient.acquireToken({
+            const response = await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
                 prompt: PromptValue.LOGIN,
             });
@@ -432,7 +485,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(mockWamResponse);
             });
-            nativeInteractionClient
+            platformAuthInteractionClient
                 .acquireToken({
                     scopes: ["User.Read"],
                 })
@@ -481,7 +534,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(mockWamResponse);
             });
-            nativeInteractionClient
+            platformAuthInteractionClient
                 .acquireToken({
                     scopes: ["User.Read"],
                 })
@@ -525,7 +578,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 return Promise.resolve(mockWamResponse);
             });
 
-            nativeInteractionClient
+            platformAuthInteractionClient
                 .acquireToken({
                     scopes: ["User.Read"],
                     redirectUri: "localhost",
@@ -666,7 +719,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 );
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
-            await nativeInteractionClient.acquireToken({
+            await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
             });
         });
@@ -691,7 +744,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 "getExtensionVersion"
             ).mockReturnValue("1.0.2");
 
-            nativeInteractionClient = new PlatformAuthInteractionClient(
+            platformAuthInteractionClient = new PlatformAuthInteractionClient(
                 // @ts-ignore
                 pca.config,
                 // @ts-ignore
@@ -712,7 +765,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 RANDOM_TEST_GUID
             );
 
-            await nativeInteractionClient.acquireToken({
+            await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
             });
         });
@@ -737,7 +790,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 "getExtensionVersion"
             ).mockReturnValue("2.3.4");
 
-            nativeInteractionClient = new PlatformAuthInteractionClient(
+            platformAuthInteractionClient = new PlatformAuthInteractionClient(
                 // @ts-ignore
                 pca.config,
                 // @ts-ignore
@@ -758,7 +811,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 RANDOM_TEST_GUID
             );
 
-            await nativeInteractionClient.acquireToken({
+            await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
             });
         });
@@ -771,7 +824,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
 
-            await nativeInteractionClient.acquireToken({
+            await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
             });
             expect(
@@ -797,7 +850,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 );
             });
             try {
-                await nativeInteractionClient.acquireToken({
+                await platformAuthInteractionClient.acquireToken({
                     scopes: ["User.Read"],
                 });
             } catch (e) {}
@@ -838,7 +891,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 );
 
             try {
-                await nativeInteractionClient.acquireToken({
+                await platformAuthInteractionClient.acquireToken({
                     scopes: ["User.Read"],
                 });
             } catch (e) {}
@@ -855,7 +908,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 nativeBrokerErrorCode: "test_native_error_code",
             });
 
-            await nativeInteractionClient.acquireToken({
+            await platformAuthInteractionClient.acquireToken({
                 scopes: ["User.Read"],
             });
             expect(
@@ -882,12 +935,13 @@ describe("PlatformAuthInteractionClient Tests", () => {
             });
 
             it("does not store idToken if storeInCache.idToken = false", async () => {
-                const response = await nativeInteractionClient.acquireToken({
-                    scopes: ["User.Read"],
-                    storeInCache: {
-                        idToken: false,
-                    },
-                });
+                const response =
+                    await platformAuthInteractionClient.acquireToken({
+                        scopes: ["User.Read"],
+                        storeInCache: {
+                            idToken: false,
+                        },
+                    });
                 expect(response.accessToken).toEqual(
                     MOCK_WAM_RESPONSE.access_token
                 );
@@ -907,12 +961,13 @@ describe("PlatformAuthInteractionClient Tests", () => {
             });
 
             it("does not store accessToken if storeInCache.accessToken = false", async () => {
-                const response = await nativeInteractionClient.acquireToken({
-                    scopes: ["User.Read"],
-                    storeInCache: {
-                        accessToken: false,
-                    },
-                });
+                const response =
+                    await platformAuthInteractionClient.acquireToken({
+                        scopes: ["User.Read"],
+                        storeInCache: {
+                            accessToken: false,
+                        },
+                    });
                 expect(response.accessToken).toEqual(
                     MOCK_WAM_RESPONSE.access_token
                 );
@@ -932,12 +987,13 @@ describe("PlatformAuthInteractionClient Tests", () => {
             });
 
             it("does not store refreshToken if storeInCache.refreshToken = false", async () => {
-                const response = await nativeInteractionClient.acquireToken({
-                    scopes: ["User.Read"],
-                    storeInCache: {
-                        refreshToken: false,
-                    },
-                });
+                const response =
+                    await platformAuthInteractionClient.acquireToken({
+                        scopes: ["User.Read"],
+                        storeInCache: {
+                            refreshToken: false,
+                        },
+                    });
                 expect(response.accessToken).toEqual(
                     MOCK_WAM_RESPONSE.access_token
                 );
@@ -974,7 +1030,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
-            nativeInteractionClient.acquireTokenRedirect(
+            platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                 },
@@ -1002,7 +1058,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 pca.removePerformanceCallback(callbackId);
                 done();
             });
-            nativeInteractionClient.acquireTokenRedirect(
+            platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                 },
@@ -1022,7 +1078,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                     )
                 );
             });
-            nativeInteractionClient
+            platformAuthInteractionClient
                 .acquireTokenRedirect(
                     { scopes: ["User.Read"] },
                     perfMeasurement
@@ -1051,7 +1107,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 );
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
-            nativeInteractionClient.acquireTokenRedirect(
+            platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                 },
@@ -1086,7 +1142,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                     new NativeAuthError("test_native_error_code")
                 );
             });
-            nativeInteractionClient.acquireTokenRedirect(
+            platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                 },
@@ -1129,7 +1185,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 );
 
             try {
-                await nativeInteractionClient.acquireTokenRedirect(
+                await platformAuthInteractionClient.acquireTokenRedirect(
                     {
                         scopes: ["User.Read"],
                     },
@@ -1150,7 +1206,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 nativeBrokerErrorCode: "test_native_error_code",
             });
 
-            await nativeInteractionClient.acquireTokenRedirect(
+            await platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                 },
@@ -1158,7 +1214,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             );
             // @ts-ignore
             pca.browserStorage.setInteractionInProgress(true);
-            await nativeInteractionClient.handleRedirectPromise();
+            await platformAuthInteractionClient.handleRedirectPromise();
 
             expect(
                 JSON.parse(
@@ -1184,7 +1240,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 expect(request.onRedirectNavigate).toBeUndefined();
                 done();
             });
-            nativeInteractionClient.acquireTokenRedirect(
+            platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                     onRedirectNavigate: (url: string) => {
@@ -1213,14 +1269,14 @@ describe("PlatformAuthInteractionClient Tests", () => {
             });
             // @ts-ignore
             pca.browserStorage.setInteractionInProgress(true);
-            await nativeInteractionClient.acquireTokenRedirect(
+            await platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                 },
                 perfMeasurement
             );
             const response =
-                await nativeInteractionClient.handleRedirectPromise();
+                await platformAuthInteractionClient.handleRedirectPromise();
             expect(response).not.toBe(null);
 
             const testTokenResponse: AuthenticationResult = {
@@ -1264,7 +1320,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             );
             // @ts-ignore
             pca.browserStorage.setInteractionInProgress(true);
-            await nativeInteractionClient.acquireTokenRedirect(
+            await platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                     prompt: "login",
@@ -1272,7 +1328,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 perfMeasurement
             );
             const response =
-                await nativeInteractionClient.handleRedirectPromise();
+                await platformAuthInteractionClient.handleRedirectPromise();
             expect(response).not.toBe(null);
 
             const testTokenResponse: AuthenticationResult = {
@@ -1310,14 +1366,14 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
-            await nativeInteractionClient.acquireTokenRedirect(
+            await platformAuthInteractionClient.acquireTokenRedirect(
                 {
                     scopes: ["User.Read"],
                 },
                 perfMeasurement
             );
             const response =
-                await nativeInteractionClient.handleRedirectPromise();
+                await platformAuthInteractionClient.handleRedirectPromise();
             expect(response).toBe(null);
         });
 
@@ -1325,7 +1381,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             // @ts-ignore
             pca.browserStorage.setInteractionInProgress(true);
             const response =
-                await nativeInteractionClient.handleRedirectPromise();
+                await platformAuthInteractionClient.handleRedirectPromise();
             expect(response).toBe(null);
         });
     });
@@ -1334,7 +1390,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
         it("pick up default params", async () => {
             const nativeRequest =
                 // @ts-ignore
-                await nativeInteractionClient.initializeNativeRequest({
+                await platformAuthInteractionClient.initializeNativeRequest({
                     scopes: ["User.Read"],
                     prompt: PromptValue.LOGIN,
                 });
@@ -1346,7 +1402,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
         it("pick up broker extra query parameters", async () => {
             const nativeRequest =
                 // @ts-ignore
-                await nativeInteractionClient.initializeNativeRequest({
+                await platformAuthInteractionClient.initializeNativeRequest({
                     scopes: ["User.Read"],
                     prompt: PromptValue.LOGIN,
                     redirectUri: "localhost",
@@ -1367,6 +1423,29 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(nativeRequest.redirectUri).toEqual(
                 "https://broker_redirect_uri.com"
             );
+        });
+
+        it("pick up user input extra query parameters", async () => {
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthInteractionClient.initializeNativeRequest({
+                    scopes: ["User.Read"],
+                    prompt: PromptValue.LOGIN,
+                    redirectUri: "localhost",
+                    extraQueryParameters: {
+                        userEQP1: "customUserParam1",
+                        userEQP2: "customUserParam2",
+                    },
+                });
+
+            expect(nativeRequest.clientId).toEqual(TEST_CONFIG.MSAL_CLIENT_ID);
+            expect(nativeRequest.extraParameters!["userEQP1"]).toEqual(
+                "customUserParam1"
+            );
+            expect(nativeRequest.extraParameters!["userEQP2"]).toEqual(
+                "customUserParam2"
+            );
+            expect(nativeRequest.redirectUri).toEqual("localhost");
         });
     });
 });

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -266,6 +266,44 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
         });
 
+        it("Extension: token request contains user input extra params", async () => {
+            const sendMessageSpy = jest
+                .spyOn(PlatformAuthExtensionHandler.prototype, "sendMessage")
+                .mockImplementation((): Promise<PlatformAuthResponse> => {
+                    return Promise.resolve(MOCK_WAM_RESPONSE);
+                });
+            const response = await platformAuthInteractionClient.acquireToken({
+                scopes: ["User.Read"],
+                extraQueryParameters: {
+                    testQP1: "testQP1",
+                    testQP2: "testQP2",
+                },
+            });
+
+            expect(sendMessageSpy).toHaveProperty(
+                "mock.calls[0][0].extraParameters",
+                {
+                    telemetry: "MATS",
+                    testQP1: "testQP1",
+                    testQP2: "testQP2",
+                    "x-client-xtra-sku": `${BrowserConstants.MSAL_SKU}|${version},|,|,|`,
+                }
+            );
+
+            expect(response.accessToken).toEqual(
+                MOCK_WAM_RESPONSE.access_token
+            );
+            expect(response.idToken).toEqual(MOCK_WAM_RESPONSE.id_token);
+            expect(response.uniqueId).toEqual(ID_TOKEN_CLAIMS.oid);
+            expect(response.tenantId).toEqual(ID_TOKEN_CLAIMS.tid);
+            expect(response.idTokenClaims).toEqual(ID_TOKEN_CLAIMS);
+            expect(response.authority).toEqual(TEST_CONFIG.validAuthority);
+            expect(response.scopes).toContain(MOCK_WAM_RESPONSE.scope);
+            expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
+            expect(response.account).toEqual(TEST_ACCOUNT_INFO);
+            expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
+        });
+
         it("DOM API: acquires token successfully", async () => {
             platformAuthDOMHandler = new PlatformAuthDOMHandler(
                 pca.getLogger(),
@@ -294,15 +332,28 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 RANDOM_TEST_GUID
             );
 
-            jest.spyOn(
-                PlatformAuthDOMHandler.prototype,
-                "sendMessage"
-            ).mockImplementation((): Promise<PlatformAuthResponse> => {
-                return Promise.resolve(MOCK_WAM_RESPONSE);
-            });
+            const sendMessageSpy = jest
+                .spyOn(PlatformAuthDOMHandler.prototype, "sendMessage")
+                .mockImplementation((): Promise<PlatformAuthResponse> => {
+                    return Promise.resolve(MOCK_WAM_RESPONSE);
+                });
             const response = await testInterctionClient.acquireToken({
                 scopes: ["User.Read"],
+                extraQueryParameters: {
+                    testQP1: "testQP1",
+                    testQP2: "testQP2",
+                },
             });
+
+            expect(sendMessageSpy).toHaveProperty(
+                "mock.calls[0][0].extraParameters",
+                {
+                    telemetry: "MATS",
+                    testQP1: "testQP1",
+                    testQP2: "testQP2",
+                    "x-client-xtra-sku": `${BrowserConstants.MSAL_SKU}|${version},|,|,|`,
+                }
+            );
             expect(response.accessToken).toEqual(
                 MOCK_WAM_RESPONSE.access_token
             );

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -14,12 +14,8 @@ import {
     CredentialType,
     TimeUtils,
     CacheManager,
-    Logger,
-    CacheRecord,
-    AADServerParamKeys,
     IPerformanceClient,
     InProgressPerformanceEvent,
-    PerformanceEvents,
 } from "@azure/msal-common";
 import { PlatformAuthExtensionHandler } from "../../src/broker/nativeBroker/PlatformAuthExtensionHandler.js";
 import { ApiId } from "../../src/utils/BrowserConstants.js";
@@ -39,15 +35,11 @@ import {
     NativeAuthErrorCodes,
     NativeAuthErrorMessages,
 } from "../../src/error/NativeAuthError.js";
-import {
-    NativeExtensionRequestBody,
-    PlatformBrokerRequest,
-} from "../../src/broker/nativeBroker/PlatformBrokerRequest.js";
+import { PlatformAuthRequest } from "../../src/broker/nativeBroker/PlatformAuthRequest.js";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils.js";
 import { BrowserCacheManager } from "../../src/cache/BrowserCacheManager.js";
 import {
     BrowserPerformanceClient,
-    IPublicClientApplication,
     PopupRequest,
     SsoSilentRequest,
 } from "../../src/index.js";
@@ -55,9 +47,9 @@ import { buildAccountFromIdTokenClaims, buildIdToken } from "msal-test-utils";
 import { version } from "../../src/packageMetadata.js";
 import { BrowserConstants } from "../../src/utils/BrowserConstants.js";
 import * as NativeStatusCodes from "../../src/broker/nativeBroker/NativeStatusCodes.js";
-import { PlatformBrokerResponse } from "../../src/broker/nativeBroker/PlatformBrokerResponse.js";
+import { PlatformAuthResponse } from "../../src/broker/nativeBroker/PlatformAuthResponse.js";
 
-const MOCK_WAM_RESPONSE: PlatformBrokerResponse = {
+const MOCK_WAM_RESPONSE: PlatformAuthResponse = {
     access_token: TEST_TOKENS.ACCESS_TOKEN,
     id_token: TEST_TOKENS.IDTOKEN_V2,
     scope: "User.Read",
@@ -72,7 +64,7 @@ const MOCK_WAM_RESPONSE: PlatformBrokerResponse = {
     state: "",
 };
 
-const MOCK_WAM_RESPONSE_STRING_EXPIRES_IN: PlatformBrokerResponse = {
+const MOCK_WAM_RESPONSE_STRING_EXPIRES_IN: PlatformAuthResponse = {
     access_token: TEST_TOKENS.ACCESS_TOKEN,
     id_token: TEST_TOKENS.IDTOKEN_V2,
     scope: "User.Read",
@@ -252,7 +244,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
             const response = await nativeInteractionClient.acquireToken({
@@ -276,7 +268,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE_STRING_EXPIRES_IN);
             });
             const response = await nativeInteractionClient.acquireToken({
@@ -339,7 +331,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
             const response = await nativeInteractionClient.acquireToken({
@@ -364,7 +356,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
             const response = await nativeInteractionClient.acquireToken({
@@ -389,7 +381,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
             const response = await nativeInteractionClient.acquireToken({
@@ -414,7 +406,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             const raw_client_info =
                 "eyJ1aWQiOiAiMDAwMDAwMDAtMDAwMC0wMDAwLTY2ZjMtMzMzMmVjYTdlYTgxIiwgInV0aWQiOiIzMzM4MDQwZC02YzY3LTRjNWItYjExMi0zNmEzMDRiNjZkYWQifQ==";
 
-            const mockWamResponse: PlatformBrokerResponse = {
+            const mockWamResponse: PlatformAuthResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2_ALT,
                 scope: "User.Read",
@@ -437,7 +429,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(mockWamResponse);
             });
             nativeInteractionClient
@@ -463,7 +455,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             const raw_client_info =
                 "eyJ1aWQiOiAiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwgInV0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcifQ==";
 
-            const mockWamResponse: PlatformBrokerResponse = {
+            const mockWamResponse: PlatformAuthResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2_ALT,
                 scope: "User.Read",
@@ -486,7 +478,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(mockWamResponse);
             });
             nativeInteractionClient
@@ -506,7 +498,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             const raw_client_info =
                 "eyJ1aWQiOiAiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwgInV0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcifQ==";
 
-            const mockWamResponse: PlatformBrokerResponse = {
+            const mockWamResponse: PlatformAuthResponse = {
                 access_token: TEST_TOKENS.ACCESS_TOKEN,
                 id_token: TEST_TOKENS.IDTOKEN_V2_ALT,
                 scope: "User.Read",
@@ -529,7 +521,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(mockWamResponse);
             });
 
@@ -563,7 +555,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
             ).mockImplementation(
-                (nativeRequest): Promise<PlatformBrokerResponse> => {
+                (nativeRequest): Promise<PlatformAuthResponse> => {
                     expect(nativeRequest && nativeRequest.prompt).toBe(
                         PromptValue.NONE
                     );
@@ -616,7 +608,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
             ).mockImplementation(
-                (nativeRequest): Promise<PlatformBrokerResponse> => {
+                (nativeRequest): Promise<PlatformAuthResponse> => {
                     expect(nativeRequest && nativeRequest.prompt).toBe(
                         PromptValue.NONE
                     );
@@ -668,7 +660,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((request): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((request): Promise<PlatformAuthResponse> => {
                 expect(request?.extraParameters!["x-client-xtra-sku"]).toEqual(
                     `${BrowserConstants.MSAL_SKU}|${version},|,|,|`
                 );
@@ -683,7 +675,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((request): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((request): Promise<PlatformAuthResponse> => {
                 expect(request.extraParameters!["x-client-xtra-sku"]).toEqual(
                     `${BrowserConstants.MSAL_SKU}|${version},|,chrome|1.0.2,|`
                 );
@@ -729,7 +721,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((request): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((request): Promise<PlatformAuthResponse> => {
                 expect(request.extraParameters!["x-client-xtra-sku"]).toEqual(
                     `${BrowserConstants.MSAL_SKU}|${version},|,unknown|2.3.4,|`
                 );
@@ -775,7 +767,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((message): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((message): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
 
@@ -799,7 +791,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((message): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((message): Promise<PlatformAuthResponse> => {
                 return Promise.reject(
                     new NativeAuthError("test_native_error_code")
                 );
@@ -829,7 +821,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 .mockImplementation();
             sendMessageStub
                 .mockImplementationOnce(
-                    (message): Promise<PlatformBrokerResponse> => {
+                    (message): Promise<PlatformAuthResponse> => {
                         return Promise.reject(
                             new NativeAuthError(
                                 "test_native_error_code",
@@ -840,7 +832,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                     }
                 )
                 .mockImplementationOnce(
-                    (message): Promise<PlatformBrokerResponse> => {
+                    (message): Promise<PlatformAuthResponse> => {
                         return Promise.resolve(MOCK_WAM_RESPONSE);
                     }
                 );
@@ -979,7 +971,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
             nativeInteractionClient.acquireTokenRedirect(
@@ -1001,7 +993,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
             const callbackId = pca.addPerformanceCallback((events) => {
@@ -1022,7 +1014,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.reject(
                     new NativeAuthError(
                         "ContentError",
@@ -1053,7 +1045,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((request): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((request): Promise<PlatformAuthResponse> => {
                 expect(request.extraParameters!["x-client-xtra-sku"]).toEqual(
                     `${BrowserConstants.MSAL_SKU}|${version},|,|,|`
                 );
@@ -1089,7 +1081,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((message): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((message): Promise<PlatformAuthResponse> => {
                 return Promise.reject(
                     new NativeAuthError("test_native_error_code")
                 );
@@ -1115,7 +1107,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             );
             sendMessageStub
                 .mockImplementationOnce(
-                    (message): Promise<PlatformBrokerResponse> => {
+                    (message): Promise<PlatformAuthResponse> => {
                         return Promise.reject(
                             new NativeAuthError(
                                 "test_native_error_code",
@@ -1126,12 +1118,12 @@ describe("PlatformAuthInteractionClient Tests", () => {
                     }
                 )
                 .mockImplementationOnce(
-                    (message): Promise<PlatformBrokerResponse> => {
+                    (message): Promise<PlatformAuthResponse> => {
                         return Promise.resolve(MOCK_WAM_RESPONSE);
                     }
                 )
                 .mockImplementationOnce(
-                    (message): Promise<PlatformBrokerResponse> => {
+                    (message): Promise<PlatformAuthResponse> => {
                         return Promise.resolve(MOCK_WAM_RESPONSE);
                     }
                 );
@@ -1216,7 +1208,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
             // @ts-ignore
@@ -1264,8 +1256,8 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 "sendMessage"
             ).mockImplementation(
                 (
-                    request: PlatformBrokerRequest
-                ): Promise<PlatformBrokerResponse> => {
+                    request: PlatformAuthRequest
+                ): Promise<PlatformAuthResponse> => {
                     expect(request && request.prompt).toBe(undefined);
                     return Promise.resolve(MOCK_WAM_RESPONSE);
                 }
@@ -1315,7 +1307,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"
-            ).mockImplementation((): Promise<PlatformBrokerResponse> => {
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.resolve(MOCK_WAM_RESPONSE);
             });
             await nativeInteractionClient.acquireTokenRedirect(

--- a/lib/msal-browser/test/utils/StringConstants.ts
+++ b/lib/msal-browser/test/utils/StringConstants.ts
@@ -16,7 +16,6 @@ import { version } from "../../src/packageMetadata.js";
 import { base64Decode, base64DecToArr } from "../../src/encode/Base64Decode.js";
 import { urlEncodeArr } from "../../src/encode/Base64Encode.js";
 import { AuthenticationResult } from "../../src/response/AuthenticationResult.js";
-import { PlatformDOMTokenResponse } from "../../src/broker/nativeBroker/PlatformBrokerResponse.js";
 
 /**
  * This file contains the string constants used by the test classes.


### PR DESCRIPTION
Addresses some of the feedback from last PR:
1. Adding a type for the extra parameters is DOM request
2. Updating naming from Native/NativeBroker to `PlatformAuth`