### PR TITLE
Broker Connection Event v5

### DIFF
--- a/change/@azure-msal-browser-9abd21db-9805-4114-a50c-7db475f5acbd.json
+++ b/change/@azure-msal-browser-9abd21db-9805-4114-a50c-7db475f5acbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add BrokerConnectionEvent to exports",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -169,6 +169,13 @@ function blockRedirectInIframe(allowRedirectInIframe: boolean): void;
 // @public
 function blockReloadInHiddenIframes(): void;
 
+// Warning: (ae-missing-release-tag) "BrokerConnectionEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type BrokerConnectionEvent = {
+    pairwiseBrokerOrigin: string;
+};
+
 // Warning: (ae-missing-release-tag) "BrowserAuthError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -555,7 +562,7 @@ export class EventMessageUtils {
 // Warning: (ae-missing-release-tag) "EventPayload" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type EventPayload = AccountInfo | PopupRequest | RedirectRequest | SilentRequest | SsoSilentRequest | EndSessionRequest | AuthenticationResult | PopupEvent | null;
+export type EventPayload = AccountInfo | PopupRequest | RedirectRequest | SilentRequest | SsoSilentRequest | EndSessionRequest | AuthenticationResult | PopupEvent | BrokerConnectionEvent | null;
 
 // Warning: (ae-missing-release-tag) "EventType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "EventType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -588,6 +595,7 @@ export const EventType: {
     readonly LOGOUT_FAILURE: "msal:logoutFailure";
     readonly LOGOUT_END: "msal:logoutEnd";
     readonly RESTORE_FROM_BFCACHE: "msal:restoreFromBFCache";
+    readonly BROKER_CONNECTION_ESTABLISHED: "msal:brokerConnectionEstablished";
 };
 
 // @public (undocumented)

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -28,6 +28,16 @@ export type PopupEvent = {
     popupWindow: Window;
 };
 
+/**
+ * Payload for the BrokerConnectionEstablished event
+ */
+export type BrokerConnectionEvent = {
+    /**
+     * The origin of the broker that is connected to the client
+     */
+    pairwiseBrokerOrigin: string;
+};
+
 export type EventPayload =
     | AccountInfo
     | PopupRequest
@@ -37,6 +47,7 @@ export type EventPayload =
     | EndSessionRequest
     | AuthenticationResult
     | PopupEvent
+    | BrokerConnectionEvent
     | null;
 
 export type EventError = AuthError | Error | null;

--- a/lib/msal-browser/src/event/EventType.ts
+++ b/lib/msal-browser/src/event/EventType.ts
@@ -30,5 +30,6 @@ export const EventType = {
     LOGOUT_FAILURE: "msal:logoutFailure",
     LOGOUT_END: "msal:logoutEnd",
     RESTORE_FROM_BFCACHE: "msal:restoreFromBFCache",
+    BROKER_CONNECTION_ESTABLISHED: "msal:brokerConnectionEstablished",
 } as const;
 export type EventType = (typeof EventType)[keyof typeof EventType];

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -80,6 +80,7 @@ export {
     EventCallbackFunction,
     EventMessageUtils,
     PopupEvent,
+    BrokerConnectionEvent,
 } from "./event/EventMessage.js";
 export { EventType } from "./event/EventType.js";
 export { EventHandler } from "./event/EventHandler.js";


### PR DESCRIPTION
Adds BrokerConnectionEstablished event to the available events. This will be emitted in pairwise brokering scenarios.