### PR TITLE
[v5] Move MSAL Common requests to MSAL Node

### DIFF
--- a/change/@azure-msal-common-df261a30-c9c7-4779-97dd-3645f685fa2b.json
+++ b/change/@azure-msal-common-df261a30-c9c7-4779-97dd-3645f685fa2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Move requests from MSAL Common to MSAL Node #7790",
+  "packageName": "@azure/msal-common",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-f766537e-8df2-45d7-8956-fed864ca8cfd.json
+++ b/change/@azure-msal-node-f766537e-8df2-45d7-8956-fed864ca8cfd.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Move requests from MSAL Common to MSAL Node #7790",
+  "packageName": "@azure/msal-node",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1526,25 +1526,6 @@ export type CommonAuthorizationUrlRequest = BaseAuthRequest & {
     platformBroker?: boolean;
 };
 
-// Warning: (ae-missing-release-tag) "CommonClientCredentialRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
-export type CommonClientCredentialRequest = BaseAuthRequest & {
-    skipCache?: boolean;
-    azureRegion?: AzureRegion;
-    clientAssertion?: ClientAssertion;
-};
-
-// Warning: (ae-missing-release-tag) "CommonDeviceCodeRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
-export type CommonDeviceCodeRequest = Omit<BaseAuthRequest, "tokenQueryParameters" | "tokenBodyParameters"> & {
-    deviceCodeCallback: (response: DeviceCodeResponse) => void;
-    cancel?: boolean;
-    timeout?: number;
-    extraQueryParameters?: StringDict;
-};
-
 // Warning: (ae-missing-release-tag) "CommonEndSessionRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -1556,14 +1537,6 @@ export type CommonEndSessionRequest = {
     state?: string;
     logoutHint?: string;
     extraQueryParameters?: StringDict;
-};
-
-// Warning: (ae-missing-release-tag) "CommonOnBehalfOfRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
-export type CommonOnBehalfOfRequest = BaseAuthRequest & {
-    oboAssertion: string;
-    skipCache?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "CommonRefreshTokenRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1584,14 +1557,6 @@ export type CommonSilentFlowRequest = BaseAuthRequest & {
     forceRefresh: boolean;
     redirectUri?: string;
     refreshTokenExpirationOffsetSeconds?: number;
-};
-
-// Warning: (ae-missing-release-tag) "CommonUsernamePasswordRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
-export type CommonUsernamePasswordRequest = BaseAuthRequest & {
-    username: string;
-    password: string;
 };
 
 // Warning: (ae-missing-release-tag) "consentRequired" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/lib/msal-common/src/exports-node-only.ts
+++ b/lib/msal-common/src/exports-node-only.ts
@@ -17,7 +17,6 @@ export { ICachePlugin } from "./cache/interface/ICachePlugin.js";
 export { TokenCacheContext } from "./cache/persistence/TokenCacheContext.js";
 export { ISerializableTokenCache } from "./cache/interface/ISerializableTokenCache.js";
 export { CommonOnBehalfOfRequest } from "./request/CommonOnBehalfOfRequest.js";
-export { CommonDeviceCodeRequest } from "./request/CommonDeviceCodeRequest.js";
 export { CommonUsernamePasswordRequest } from "./request/CommonUsernamePasswordRequest.js";
 export { NativeRequest } from "./request/NativeRequest.js";
 export { NativeSignOutRequest } from "./request/NativeSignOutRequest.js";

--- a/lib/msal-common/src/exports-node-only.ts
+++ b/lib/msal-common/src/exports-node-only.ts
@@ -16,7 +16,6 @@ export { INativeBrokerPlugin } from "./broker/nativeBroker/INativeBrokerPlugin.j
 export { ICachePlugin } from "./cache/interface/ICachePlugin.js";
 export { TokenCacheContext } from "./cache/persistence/TokenCacheContext.js";
 export { ISerializableTokenCache } from "./cache/interface/ISerializableTokenCache.js";
-export { CommonOnBehalfOfRequest } from "./request/CommonOnBehalfOfRequest.js";
 export { CommonUsernamePasswordRequest } from "./request/CommonUsernamePasswordRequest.js";
 export { NativeRequest } from "./request/NativeRequest.js";
 export { NativeSignOutRequest } from "./request/NativeSignOutRequest.js";

--- a/lib/msal-common/src/exports-node-only.ts
+++ b/lib/msal-common/src/exports-node-only.ts
@@ -16,7 +16,6 @@ export { INativeBrokerPlugin } from "./broker/nativeBroker/INativeBrokerPlugin.j
 export { ICachePlugin } from "./cache/interface/ICachePlugin.js";
 export { TokenCacheContext } from "./cache/persistence/TokenCacheContext.js";
 export { ISerializableTokenCache } from "./cache/interface/ISerializableTokenCache.js";
-export { CommonUsernamePasswordRequest } from "./request/CommonUsernamePasswordRequest.js";
 export { NativeRequest } from "./request/NativeRequest.js";
 export { NativeSignOutRequest } from "./request/NativeSignOutRequest.js";
 export {

--- a/lib/msal-common/src/exports-node-only.ts
+++ b/lib/msal-common/src/exports-node-only.ts
@@ -16,7 +16,6 @@ export { INativeBrokerPlugin } from "./broker/nativeBroker/INativeBrokerPlugin.j
 export { ICachePlugin } from "./cache/interface/ICachePlugin.js";
 export { TokenCacheContext } from "./cache/persistence/TokenCacheContext.js";
 export { ISerializableTokenCache } from "./cache/interface/ISerializableTokenCache.js";
-export { CommonClientCredentialRequest } from "./request/CommonClientCredentialRequest.js";
 export { CommonOnBehalfOfRequest } from "./request/CommonOnBehalfOfRequest.js";
 export { CommonDeviceCodeRequest } from "./request/CommonDeviceCodeRequest.js";
 export { CommonUsernamePasswordRequest } from "./request/CommonUsernamePasswordRequest.js";

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -25,11 +25,14 @@ import { AuthorizationCodePayload } from '@azure/msal-common/node';
 import { AuthorizeResponse } from '@azure/msal-common/node';
 import { AzureCloudInstance } from '@azure/msal-common/node';
 import { AzureCloudOptions } from '@azure/msal-common/node';
+import { AzureRegion } from '@azure/msal-common';
 import { AzureRegionConfiguration } from '@azure/msal-common/node';
-import { BaseAuthRequest } from '@azure/msal-common/node';
+import { BaseAuthRequest } from '@azure/msal-common';
+import { BaseAuthRequest as BaseAuthRequest_2 } from '@azure/msal-common/node';
 import { BaseClient } from '@azure/msal-common/node';
 import { CacheManager } from '@azure/msal-common/node';
 import { CacheOutcome } from '@azure/msal-common/node';
+import { ClientAssertion as ClientAssertion_2 } from '@azure/msal-common';
 import { ClientAssertionCallback } from '@azure/msal-common/node';
 import { ClientAuthError } from '@azure/msal-common/node';
 import { ClientAuthErrorCodes } from '@azure/msal-common/node';
@@ -38,13 +41,10 @@ import { ClientConfigurationError } from '@azure/msal-common/node';
 import { ClientConfigurationErrorCodes } from '@azure/msal-common/node';
 import { CommonAuthorizationCodeRequest } from '@azure/msal-common/node';
 import { CommonAuthorizationUrlRequest } from '@azure/msal-common/node';
-import { CommonClientCredentialRequest } from '@azure/msal-common/node';
-import { CommonDeviceCodeRequest } from '@azure/msal-common/node';
-import { CommonOnBehalfOfRequest } from '@azure/msal-common/node';
 import { CommonRefreshTokenRequest } from '@azure/msal-common/node';
 import { CommonSilentFlowRequest } from '@azure/msal-common/node';
-import { CommonUsernamePasswordRequest } from '@azure/msal-common/node';
-import { DeviceCodeResponse } from '@azure/msal-common/node';
+import { DeviceCodeResponse } from '@azure/msal-common';
+import { DeviceCodeResponse as DeviceCodeResponse_2 } from '@azure/msal-common/node';
 import http from 'http';
 import https from 'https';
 import { IAppTokenProvider } from '@azure/msal-common/node';
@@ -73,6 +73,7 @@ import { ServerError } from '@azure/msal-common/node';
 import { ServerTelemetryEntity } from '@azure/msal-common/node';
 import { ServerTelemetryManager } from '@azure/msal-common/node';
 import { StaticAuthorityOptions } from '@azure/msal-common/node';
+import { StringDict } from '@azure/msal-common';
 import { ThrottlingEntity } from '@azure/msal-common/node';
 import { TokenCacheContext } from '@azure/msal-common/node';
 import { TokenKeys } from '@azure/msal-common/node';
@@ -148,7 +149,7 @@ export abstract class ClientApplication {
     getAuthCodeUrl(request: AuthorizationUrlRequest): Promise<string>;
     getLogger(): Logger;
     getTokenCache(): TokenCache;
-    protected initializeBaseRequest(authRequest: Partial<BaseAuthRequest>): Promise<BaseAuthRequest>;
+    protected initializeBaseRequest(authRequest: Partial<BaseAuthRequest_2>): Promise<BaseAuthRequest_2>;
     protected initializeServerTelemetryManager(apiId: number, correlationId: string, forceRefresh?: boolean): ServerTelemetryManager;
     protected logger: Logger;
     setLogger(logger: Logger): void;
@@ -180,6 +181,7 @@ export { ClientConfigurationErrorCodes }
 // @public
 export class ClientCredentialClient extends BaseClient {
     constructor(configuration: ClientConfiguration, appTokenProvider?: IAppTokenProvider);
+    // Warning: (ae-forgotten-export) The symbol "CommonClientCredentialRequest" needs to be exported by the entry point index.d.ts
     acquireToken(request: CommonClientCredentialRequest): Promise<AuthenticationResult | null>;
     getCachedAuthenticationResult(request: CommonClientCredentialRequest, config: ClientConfiguration | ManagedIdentityConfiguration, cryptoUtils: ICrypto, authority: Authority, cacheManager: CacheManager, serverTelemetryManager?: ServerTelemetryManager | null): Promise<[AuthenticationResult | null, CacheOutcome]>;
 }
@@ -236,6 +238,7 @@ class Deserializer {
 // @public
 export class DeviceCodeClient extends BaseClient {
     constructor(configuration: ClientConfiguration);
+    // Warning: (ae-forgotten-export) The symbol "CommonDeviceCodeRequest" needs to be exported by the entry point index.d.ts
     acquireToken(request: CommonDeviceCodeRequest): Promise<AuthenticationResult | null>;
     createExtraQueryParameters(request: CommonDeviceCodeRequest): string;
 }
@@ -243,7 +246,7 @@ export class DeviceCodeClient extends BaseClient {
 // @public
 export type DeviceCodeRequest = Partial<Omit<CommonDeviceCodeRequest, "scopes" | "deviceCodeCallback" | "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "storeInCache">> & {
     scopes: Array<string>;
-    deviceCodeCallback: (response: DeviceCodeResponse) => void;
+    deviceCodeCallback: (response: DeviceCodeResponse_2) => void;
 };
 
 // @public
@@ -456,6 +459,7 @@ export type NodeTelemetryOptions = {
 // @public
 export class OnBehalfOfClient extends BaseClient {
     constructor(configuration: ClientConfiguration);
+    // Warning: (ae-forgotten-export) The symbol "CommonOnBehalfOfRequest" needs to be exported by the entry point index.d.ts
     acquireToken(request: CommonOnBehalfOfRequest): Promise<AuthenticationResult | null>;
 }
 
@@ -599,6 +603,7 @@ export { TokenCacheContext }
 // @public @deprecated
 export class UsernamePasswordClient extends BaseClient {
     constructor(configuration: ClientConfiguration);
+    // Warning: (ae-forgotten-export) The symbol "CommonUsernamePasswordRequest" needs to be exported by the entry point index.d.ts
     acquireToken(request: CommonUsernamePasswordRequest): Promise<AuthenticationResult | null>;
 }
 

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -19,7 +19,6 @@ import {
     CommonRefreshTokenRequest,
     CommonAuthorizationCodeRequest,
     CommonAuthorizationUrlRequest,
-    CommonUsernamePasswordRequest,
     AuthenticationScheme,
     ResponseMode,
     AuthorityOptions,
@@ -54,6 +53,7 @@ import { RefreshTokenRequest } from "../request/RefreshTokenRequest.js";
 import { SilentFlowRequest } from "../request/SilentFlowRequest.js";
 import { version, name } from "../packageMetadata.js";
 import { UsernamePasswordRequest } from "../request/UsernamePasswordRequest.js";
+import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePasswordRequest.js";
 import { NodeAuthError } from "../error/NodeAuthError.js";
 import { UsernamePasswordClient } from "./UsernamePasswordClient.js";
 import { getAuthCodeRequestUrl } from "../protocol/Authorize.js";

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -13,7 +13,6 @@ import {
     CacheOutcome,
     ClientAuthErrorCodes,
     ClientConfiguration,
-    CommonClientCredentialRequest,
     Constants,
     CredentialFilter,
     CredentialType,
@@ -40,6 +39,7 @@ import {
     ManagedIdentityConfiguration,
     ManagedIdentityNodeConfiguration,
 } from "../config/Configuration.js";
+import { CommonClientCredentialRequest } from "../request/CommonClientCredentialRequest.js";
 
 /**
  * OAuth2.0 client credential grant

--- a/lib/msal-node/src/client/ConfidentialClientApplication.ts
+++ b/lib/msal-node/src/client/ConfidentialClientApplication.ts
@@ -15,7 +15,6 @@ import {
     MSAL_FORCE_REGION,
 } from "../utils/Constants.js";
 import {
-    CommonOnBehalfOfRequest,
     AuthenticationResult,
     AzureRegionConfiguration,
     AuthError,
@@ -31,6 +30,7 @@ import {
 } from "@azure/msal-common/node";
 import { IConfidentialClientApplication } from "./IConfidentialClientApplication.js";
 import { OnBehalfOfRequest } from "../request/OnBehalfOfRequest.js";
+import { CommonOnBehalfOfRequest } from "../request/CommonOnBehalfOfRequest.js";
 import { CommonClientCredentialRequest } from "../request/CommonClientCredentialRequest.js";
 import { ClientCredentialRequest } from "../request/ClientCredentialRequest.js";
 import { ClientCredentialClient } from "./ClientCredentialClient.js";

--- a/lib/msal-node/src/client/ConfidentialClientApplication.ts
+++ b/lib/msal-node/src/client/ConfidentialClientApplication.ts
@@ -15,7 +15,6 @@ import {
     MSAL_FORCE_REGION,
 } from "../utils/Constants.js";
 import {
-    CommonClientCredentialRequest,
     CommonOnBehalfOfRequest,
     AuthenticationResult,
     AzureRegionConfiguration,
@@ -32,6 +31,7 @@ import {
 } from "@azure/msal-common/node";
 import { IConfidentialClientApplication } from "./IConfidentialClientApplication.js";
 import { OnBehalfOfRequest } from "../request/OnBehalfOfRequest.js";
+import { CommonClientCredentialRequest } from "../request/CommonClientCredentialRequest.js";
 import { ClientCredentialRequest } from "../request/ClientCredentialRequest.js";
 import { ClientCredentialClient } from "./ClientCredentialClient.js";
 import { OnBehalfOfClient } from "./OnBehalfOfClient.js";

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -9,7 +9,6 @@ import {
     BaseClient,
     ClientAuthErrorCodes,
     ClientConfiguration,
-    CommonDeviceCodeRequest,
     Constants,
     DeviceCodeResponse,
     GrantType,
@@ -25,6 +24,7 @@ import {
     createAuthError,
     createClientAuthError,
 } from "@azure/msal-common/node";
+import { CommonDeviceCodeRequest } from "../request/CommonDeviceCodeRequest.js";
 
 /**
  * OAuth2.0 Device code client

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -16,7 +16,6 @@ import {
     CacheOutcome,
     ClientAuthErrorCodes,
     ClientConfiguration,
-    CommonOnBehalfOfRequest,
     Constants,
     createClientAuthError,
     CredentialFilter,
@@ -35,6 +34,7 @@ import {
     UrlUtils,
 } from "@azure/msal-common/node";
 import { EncodingUtils } from "../utils/EncodingUtils.js";
+import { CommonOnBehalfOfRequest } from "../request/CommonOnBehalfOfRequest.js";
 
 /**
  * On-Behalf-Of client

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -10,7 +10,6 @@ import {
 } from "../utils/Constants.js";
 import {
     AuthenticationResult,
-    CommonDeviceCodeRequest,
     AuthError,
     ResponseMode,
     OIDC_DEFAULT_SCOPES,
@@ -29,6 +28,7 @@ import { Configuration } from "../config/Configuration.js";
 import { ClientApplication } from "./ClientApplication.js";
 import { IPublicClientApplication } from "./IPublicClientApplication.js";
 import { DeviceCodeRequest } from "../request/DeviceCodeRequest.js";
+import { CommonDeviceCodeRequest } from "../request/CommonDeviceCodeRequest.js";
 import { AuthorizationUrlRequest } from "../request/AuthorizationUrlRequest.js";
 import { AuthorizationCodeRequest } from "../request/AuthorizationCodeRequest.js";
 import { InteractiveRequest } from "../request/InteractiveRequest.js";

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -10,7 +10,6 @@ import {
     CcsCredentialType,
     ClientAssertion,
     ClientConfiguration,
-    CommonUsernamePasswordRequest,
     GrantType,
     NetworkResponse,
     OAuthResponseType,
@@ -24,6 +23,7 @@ import {
     UrlUtils,
     getClientAssertion,
 } from "@azure/msal-common/node";
+import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePasswordRequest.js";
 
 /**
  * Oauth2.0 Password grant client

--- a/lib/msal-node/src/request/ClientCredentialRequest.ts
+++ b/lib/msal-node/src/request/ClientCredentialRequest.ts
@@ -3,13 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import {
-    ClientAssertionCallback,
-    CommonClientCredentialRequest,
-} from "@azure/msal-common/node";
+import { ClientAssertionCallback } from "@azure/msal-common/node";
+import { CommonClientCredentialRequest } from "./CommonClientCredentialRequest.js";
 
 /**
- * CommonClientCredentialRequest
+ * ClientCredentialRequest
  * - scopes                  - Array of scopes the application is requesting access to. Typically contains only the .default scope for a single resource. See: https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc#the-default-scope
  * - authority               - URL of the authority, the security token service (STS) from which MSAL will acquire tokens.
  * - correlationId           - Unique GUID set per request to trace a request end-to-end for telemetry purposes.

--- a/lib/msal-node/src/request/CommonClientCredentialRequest.ts
+++ b/lib/msal-node/src/request/CommonClientCredentialRequest.ts
@@ -3,9 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { BaseAuthRequest } from "./BaseAuthRequest.js";
-import { AzureRegion } from "../authority/AzureRegion.js";
-import { ClientAssertion } from "../account/ClientCredentials.js";
+import {
+    BaseAuthRequest,
+    AzureRegion,
+    ClientAssertion,
+} from "@azure/msal-common";
 
 /**
  * CommonClientCredentialRequest

--- a/lib/msal-node/src/request/CommonDeviceCodeRequest.ts
+++ b/lib/msal-node/src/request/CommonDeviceCodeRequest.ts
@@ -3,9 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { DeviceCodeResponse } from "../response/DeviceCodeResponse.js";
-import { StringDict } from "../utils/MsalTypes.js";
-import { BaseAuthRequest } from "./BaseAuthRequest.js";
+import {
+    DeviceCodeResponse,
+    StringDict,
+    BaseAuthRequest,
+} from "@azure/msal-common";
 
 /**
  * Parameters for Oauth2 device code flow.

--- a/lib/msal-node/src/request/CommonOnBehalfOfRequest.ts
+++ b/lib/msal-node/src/request/CommonOnBehalfOfRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BaseAuthRequest } from "./BaseAuthRequest.js";
+import { BaseAuthRequest } from "@azure/msal-common";
 
 /**
  * - scopes                  - Array of scopes the application is requesting access to.

--- a/lib/msal-node/src/request/CommonUsernamePasswordRequest.ts
+++ b/lib/msal-node/src/request/CommonUsernamePasswordRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BaseAuthRequest } from "./BaseAuthRequest.js";
+import { BaseAuthRequest } from "@azure/msal-common";
 
 /**
  * CommonUsernamePassword parameters passed by the user to retrieve credentials

--- a/lib/msal-node/src/request/DeviceCodeRequest.ts
+++ b/lib/msal-node/src/request/DeviceCodeRequest.ts
@@ -3,10 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import {
-    CommonDeviceCodeRequest,
-    DeviceCodeResponse,
-} from "@azure/msal-common/node";
+import { DeviceCodeResponse } from "@azure/msal-common/node";
+import { CommonDeviceCodeRequest } from "./CommonDeviceCodeRequest.js";
 
 /**
  * Parameters for Oauth2 device code flow.

--- a/lib/msal-node/src/request/ManagedIdentityRequest.ts
+++ b/lib/msal-node/src/request/ManagedIdentityRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { CommonClientCredentialRequest } from "@azure/msal-common/node";
+import { CommonClientCredentialRequest } from "./CommonClientCredentialRequest.js";
 import { ManagedIdentityRequestParams } from "./ManagedIdentityRequestParams.js";
 
 /**

--- a/lib/msal-node/src/request/OnBehalfOfRequest.ts
+++ b/lib/msal-node/src/request/OnBehalfOfRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { CommonOnBehalfOfRequest } from "@azure/msal-common/node";
+import { CommonOnBehalfOfRequest } from "./CommonOnBehalfOfRequest.js";
 
 /**
  * - scopes                  - Array of scopes the application is requesting access to.

--- a/lib/msal-node/src/request/UsernamePasswordRequest.ts
+++ b/lib/msal-node/src/request/UsernamePasswordRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { CommonUsernamePasswordRequest } from "@azure/msal-common/node";
+import { CommonUsernamePasswordRequest } from "./CommonUsernamePasswordRequest.js";
 
 /**
  * UsernamePassword parameters passed by the user to retrieve credentials

--- a/lib/msal-node/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-node/test/client/ClientCredentialClient.spec.ts
@@ -12,7 +12,6 @@ import {
     BaseClient,
     CacheManager,
     ClientConfiguration,
-    CommonUsernamePasswordRequest,
     IAppTokenProvider,
     InteractionRequiredAuthError,
     TimeUtils,
@@ -44,6 +43,7 @@ import {
 } from "./ClientTestUtils.js";
 import { mockNetworkClient } from "../utils/MockNetworkClient.js";
 import { CommonClientCredentialRequest } from "../../src/request/CommonClientCredentialRequest.js";
+import { CommonUsernamePasswordRequest } from "../../src/request/CommonUsernamePasswordRequest.js";
 
 describe("ClientCredentialClient unit tests", () => {
     let createTokenRequestBodySpy: jest.SpyInstance;

--- a/lib/msal-node/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-node/test/client/ClientCredentialClient.spec.ts
@@ -12,7 +12,6 @@ import {
     BaseClient,
     CacheManager,
     ClientConfiguration,
-    CommonClientCredentialRequest,
     CommonUsernamePasswordRequest,
     IAppTokenProvider,
     InteractionRequiredAuthError,
@@ -44,6 +43,7 @@ import {
     mockCrypto,
 } from "./ClientTestUtils.js";
 import { mockNetworkClient } from "../utils/MockNetworkClient.js";
+import { CommonClientCredentialRequest } from "../../src/request/CommonClientCredentialRequest.js";
 
 describe("ClientCredentialClient unit tests", () => {
     let createTokenRequestBodySpy: jest.SpyInstance;

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -7,7 +7,6 @@ import {
     AuthorizationCodeClient,
     AuthenticationResult,
     OIDC_DEFAULT_SCOPES,
-    CommonClientCredentialRequest,
     createClientAuthError,
     ClientAuthErrorCodes,
     AccountEntity,
@@ -50,6 +49,7 @@ import { Constants, MSAL_FORCE_REGION } from "../../src/utils/Constants.js";
 import jwt from "jsonwebtoken";
 import { NodeAuthError } from "../../src/error/NodeAuthError.js";
 import { INetworkModule } from "../../../msal-common/lib/types/exports-common.js";
+import { CommonClientCredentialRequest } from "../../src/request/CommonClientCredentialRequest.js";
 
 jest.mock("jsonwebtoken");
 

--- a/lib/msal-node/test/client/DeviceCodeClient.spec.ts
+++ b/lib/msal-node/test/client/DeviceCodeClient.spec.ts
@@ -8,7 +8,6 @@ import {
     BaseClient,
     ClientAuthErrorCodes,
     ClientConfiguration,
-    CommonDeviceCodeRequest,
     Constants,
     GrantType,
     createAuthError,
@@ -31,6 +30,7 @@ import {
 } from "./ClientTestUtils.js";
 import { DeviceCodeClient } from "../../src/index.js";
 import { mockNetworkClient } from "../utils/MockNetworkClient.js";
+import { CommonDeviceCodeRequest } from "../../src/request/CommonDeviceCodeRequest.js";
 
 describe("DeviceCodeClient unit tests", () => {
     let createTokenRequestBodySpy: jest.SpyInstance;

--- a/lib/msal-node/test/client/OnBehalfOfClient.spec.ts
+++ b/lib/msal-node/test/client/OnBehalfOfClient.spec.ts
@@ -11,7 +11,6 @@ import {
     BaseClient,
     CacheManager,
     ClientConfiguration,
-    CommonOnBehalfOfRequest,
     AccountEntityUtils,
     CredentialType,
     IdTokenEntity,
@@ -33,6 +32,7 @@ import {
 } from "./ClientTestUtils.js";
 import { EncodingUtils } from "../../src/utils/EncodingUtils.js";
 import { mockNetworkClient } from "../utils/MockNetworkClient.js";
+import { CommonOnBehalfOfRequest } from "../../src/request/CommonOnBehalfOfRequest.js";
 
 describe("OnBehalfOf unit tests", () => {
     let createTokenRequestBodySpy: jest.SpyInstance;

--- a/lib/msal-node/test/client/UsernamePasswordClient.spec.ts
+++ b/lib/msal-node/test/client/UsernamePasswordClient.spec.ts
@@ -7,7 +7,6 @@ import {
     AuthenticationResult,
     BaseClient,
     ClientConfiguration,
-    CommonUsernamePasswordRequest,
     Constants,
     GrantType,
 } from "@azure/msal-common";
@@ -26,6 +25,7 @@ import {
     getClientAssertionCallback,
 } from "./ClientTestUtils.js";
 import { mockNetworkClient } from "../utils/MockNetworkClient.js";
+import { CommonUsernamePasswordRequest } from "../../src/request/CommonUsernamePasswordRequest.js";
 
 describe("Username Password unit tests", () => {
     let createTokenRequestBodySpy: jest.SpyInstance;


### PR DESCRIPTION
Some requests that live in MSAL Common are only used in MSAL Node. This PR preserves their usage in MSAL Node, but moves those requests out of Common into Node.

Requests that have moved include:
- CommonClientCredentialRequest
- CommonDeviceCodeRequest
- CommonOnBehalfOfRequest
- CommonUsernamePasswordRequest