### PR TITLE
Update http and https imports, as they flag build errors with TS.

### DIFF
--- a/lib/msal-node/src/config/Configuration.ts
+++ b/lib/msal-node/src/config/Configuration.ts
@@ -17,8 +17,8 @@ import {
     ClientAssertionCallback,
 } from "@azure/msal-common/node";
 import { HttpClient } from "../network/HttpClient.js";
-import http from "http";
-import https from "https";
+import * as http from "http";
+import * as https from "https";
 import { ManagedIdentityId } from "./ManagedIdentityId.js";
 import { NodeAuthError } from "../error/NodeAuthError.js";
 


### PR DESCRIPTION
Running a tsc over modules that are dependent on this run into a "No default export" error. Doing this locally fixes the issue.