### PR TITLE
[v4] Remove access tokens synchronously

### DIFF
--- a/change/@azure-msal-browser-f0b6da2e-a220-4654-b1aa-6b4a0f4a921b.json
+++ b/change/@azure-msal-browser-f0b6da2e-a220-4654-b1aa-6b4a0f4a921b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove access tokens synchronously",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-042c27fe-92dc-4b48-b5e0-3d114168f8d4.json
+++ b/change/@azure-msal-common-042c27fe-92dc-4b48-b5e0-3d114168f8d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove access tokens synchronously",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-74ee63c8-51fb-422d-bbac-294ec6e9b0e5.json
+++ b/change/@azure-msal-node-74ee63c8-51fb-422d-bbac-294ec6e9b0e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove access tokens synchronously",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -86,8 +86,6 @@ export class BrowserCacheManager extends CacheManager {
     protected cookieStorage: CookieStorage;
     // Logger instance
     protected logger: Logger;
-    // Telemetry perf client
-    protected performanceClient: IPerformanceClient;
     // Event Handler
     private eventHandler: EventHandler;
 
@@ -100,7 +98,13 @@ export class BrowserCacheManager extends CacheManager {
         eventHandler: EventHandler,
         staticAuthorityOptions?: StaticAuthorityOptions
     ) {
-        super(clientId, cryptoImpl, logger, staticAuthorityOptions);
+        super(
+            clientId,
+            cryptoImpl,
+            logger,
+            performanceClient,
+            staticAuthorityOptions
+        );
         this.cacheConfig = cacheConfig;
         this.logger = logger;
         this.internalStorage = new MemoryStorage();
@@ -118,7 +122,6 @@ export class BrowserCacheManager extends CacheManager {
         );
         this.cookieStorage = new CookieStorage();
 
-        this.performanceClient = performanceClient;
         this.eventHandler = eventHandler;
     }
 
@@ -298,8 +301,8 @@ export class BrowserCacheManager extends CacheManager {
      * Extends inherited removeAccount function to include removal of the account key from the map
      * @param key
      */
-    async removeAccount(key: string): Promise<void> {
-        void super.removeAccount(key);
+    removeAccount(key: string, correlationId: string): void {
+        super.removeAccount(key, correlationId);
         this.removeAccountKeyFromMap(key);
     }
 
@@ -307,8 +310,8 @@ export class BrowserCacheManager extends CacheManager {
      * Removes credentials associated with the provided account
      * @param account
      */
-    async removeAccountContext(account: AccountEntity): Promise<void> {
-        await super.removeAccountContext(account);
+    removeAccountContext(account: AccountEntity, correlationId: string): void {
+        super.removeAccountContext(account, correlationId);
 
         /**
          * @deprecated - Remove this in next major version in favor of more consistent LOGOUT event
@@ -337,8 +340,8 @@ export class BrowserCacheManager extends CacheManager {
      * Removes given accessToken from the cache and from the key map
      * @param key
      */
-    async removeAccessToken(key: string): Promise<void> {
-        void super.removeAccessToken(key);
+    removeAccessToken(key: string, correlationId: string): void {
+        super.removeAccessToken(key, correlationId);
         this.removeTokenKey(key, CredentialType.ACCESS_TOKEN);
     }
 
@@ -1012,9 +1015,9 @@ export class BrowserCacheManager extends CacheManager {
     /**
      * Clears all cache entries created by MSAL.
      */
-    async clear(): Promise<void> {
+    clear(correlationId: string): void {
         // Removes all accounts and their credentials
-        await this.removeAllAccounts();
+        this.removeAllAccounts(correlationId);
         this.removeAppMetadata();
 
         // Remove temp storage first to make sure any cookies are cleared
@@ -1046,18 +1049,14 @@ export class BrowserCacheManager extends CacheManager {
      * @param correlationId {string} correlation id
      * @returns
      */
-    async clearTokensAndKeysWithClaims(
-        performanceClient: IPerformanceClient,
-        correlationId: string
-    ): Promise<void> {
-        performanceClient.addQueueMeasurement(
+    clearTokensAndKeysWithClaims(correlationId: string): void {
+        this.performanceClient.addQueueMeasurement(
             PerformanceEvents.ClearTokensAndKeysWithClaims,
             correlationId
         );
 
         const tokenKeys = this.getTokenKeys();
-
-        const removedAccessTokens: Array<Promise<void>> = [];
+        let removedAccessTokens = 0;
         tokenKeys.accessToken.forEach((key: string) => {
             // if the access token has claims in its key, remove the token key and the token
             const credential = this.getAccessTokenCredential(key);
@@ -1065,15 +1064,15 @@ export class BrowserCacheManager extends CacheManager {
                 credential?.requestedClaimsHash &&
                 key.includes(credential.requestedClaimsHash.toLowerCase())
             ) {
-                removedAccessTokens.push(this.removeAccessToken(key));
+                this.removeAccessToken(key, correlationId);
+                removedAccessTokens++;
             }
         });
-        await Promise.all(removedAccessTokens);
 
         // warn if any access tokens are removed
-        if (removedAccessTokens.length > 0) {
+        if (removedAccessTokens > 0) {
             this.logger.warning(
-                `${removedAccessTokens.length} access tokens with claims in the cache keys have been removed from the cache.`
+                `${removedAccessTokens} access tokens with claims in the cache keys have been removed from the cache.`
             );
         }
     }

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -506,8 +506,7 @@ export class NestedAppAuthController implements IController {
             authRequest,
             tokenKeys,
             currentAccount.tenantId,
-            this.performanceClient,
-            authRequest.correlationId
+            this.performanceClient
         );
 
         // If there is no access token, log it and return null

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -505,8 +505,7 @@ export class NestedAppAuthController implements IController {
             currentAccount,
             authRequest,
             tokenKeys,
-            currentAccount.tenantId,
-            this.performanceClient
+            currentAccount.tenantId
         );
 
         // If there is no access token, log it and return null

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -23,6 +23,7 @@ import {
     getRequestThumbprint,
     AccountEntity,
     invokeAsync,
+    invoke,
     createClientAuthError,
     ClientAuthErrorCodes,
     AccountFilter,
@@ -380,7 +381,7 @@ export class StandardController implements IController {
                 "Claims-based caching is disabled. Clearing the previous cache with claims"
             );
 
-            await invokeAsync(
+            invoke(
                 this.browserStorage.clearTokensAndKeysWithClaims.bind(
                     this.browserStorage
                 ),
@@ -388,7 +389,7 @@ export class StandardController implements IController {
                 this.logger,
                 this.performanceClient,
                 initCorrelationId
-            )(this.performanceClient, initCorrelationId);
+            )(initCorrelationId);
         }
 
         this.config.system.asyncPopups &&

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -4,6 +4,8 @@
  */
 
 import {
+    ClientAuthErrorCodes,
+    createClientAuthError,
     ICrypto,
     IPerformanceClient,
     JoseHeader,
@@ -168,10 +170,14 @@ export class CryptoOps implements ICrypto {
      * Removes cryptographic keypair from key store matching the keyId passed in
      * @param kid
      */
-    async removeTokenBindingKey(kid: string): Promise<boolean> {
+    async removeTokenBindingKey(kid: string): Promise<void> {
         await this.cache.removeItem(kid);
         const keyFound = await this.cache.containsKey(kid);
-        return !keyFound;
+        if (keyFound) {
+            throw createClientAuthError(
+                ClientAuthErrorCodes.bindingKeyNotRemoved
+            );
+        }
     }
 
     /**

--- a/lib/msal-browser/src/crypto/SignedHttpRequest.ts
+++ b/lib/msal-browser/src/crypto/SignedHttpRequest.ts
@@ -5,6 +5,8 @@
 
 import { CryptoOps } from "./CryptoOps.js";
 import {
+    ClientAuthError,
+    ClientAuthErrorCodes,
     Logger,
     LoggerOptions,
     PopTokenGenerator,
@@ -71,6 +73,22 @@ export class SignedHttpRequest {
      * @returns If keys are properly deleted
      */
     async removeKeys(publicKeyThumbprint: string): Promise<boolean> {
-        return this.cryptoOps.removeTokenBindingKey(publicKeyThumbprint);
+        return this.cryptoOps
+            .removeTokenBindingKey(publicKeyThumbprint)
+            .then(() => true)
+            .catch((error) => {
+                /*
+                 * @deprecated - To maintain public API signature, we return false if the error is due to the key still being present in indexedDB.
+                 */
+                if (
+                    error instanceof ClientAuthError &&
+                    error.errorCode ===
+                        ClientAuthErrorCodes.bindingKeyNotRemoved
+                ) {
+                    return false;
+                }
+
+                throw error;
+            });
     }
 }

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -102,8 +102,9 @@ export abstract class BaseInteractionClient {
             }
             // Clear given account.
             try {
-                await this.browserStorage.removeAccount(
-                    AccountEntity.generateAccountCacheKey(account)
+                this.browserStorage.removeAccount(
+                    AccountEntity.generateAccountCacheKey(account),
+                    this.correlationId
                 );
                 this.logger.verbose(
                     "Cleared cache items belonging to the account provided in the logout request."
@@ -120,7 +121,7 @@ export abstract class BaseInteractionClient {
                     this.correlationId
                 );
                 // Clear all accounts and tokens
-                await this.browserStorage.clear();
+                this.browserStorage.clear(this.correlationId);
                 // Clear any stray keys from IndexedDB
                 await this.browserCrypto.clearKeystore();
             } catch (e) {

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -714,11 +714,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         await this.browserStorage.setAccount(accountEntity, this.correlationId);
 
         // Remove any existing cached tokens for this account in browser storage
-        this.browserStorage.removeAccountContext(accountEntity).catch((e) => {
-            this.logger.error(
-                `Error occurred while removing account context from browser storage. ${e}`
-            );
-        });
+        this.browserStorage.removeAccountContext(
+            accountEntity,
+            this.correlationId
+        );
     }
 
     /**

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -503,8 +503,9 @@ export class PopupClient extends StandardInteractionClient {
                     validRequest.postLogoutRedirectUri &&
                     authClient.authority.protocolMode === ProtocolMode.OIDC
                 ) {
-                    void this.browserStorage.removeAccount(
-                        validRequest.account?.homeAccountId
+                    this.browserStorage.removeAccount(
+                        validRequest.account?.homeAccountId,
+                        this.correlationId
                     );
 
                     this.eventHandler.emitEvent(

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -704,8 +704,9 @@ export class RedirectClient extends StandardInteractionClient {
                     authClient.authority.endSessionEndpoint;
                 } catch {
                     if (validLogoutRequest.account?.homeAccountId) {
-                        void this.browserStorage.removeAccount(
-                            validLogoutRequest.account?.homeAccountId
+                        this.browserStorage.removeAccount(
+                            validLogoutRequest.account?.homeAccountId,
+                            this.correlationId
                         );
 
                         this.eventHandler.emitEvent(

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -7779,7 +7779,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     // Ensure account is present in the cache before removing it
                     const cacheKey =
                         AccountEntity.generateAccountCacheKey(accountInfo);
-                    secondBrowserStorageInstance.removeAccount(cacheKey);
+                    secondBrowserStorageInstance.removeAccount(
+                        cacheKey,
+                        RANDOM_TEST_GUID
+                    );
                 });
         });
 

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -269,8 +269,8 @@ describe("BrowserCacheManager tests", () => {
         });
 
         afterEach(async () => {
-            await browserSessionStorage.clear();
-            await browserLocalStorage.clear();
+            browserSessionStorage.clear(RANDOM_TEST_GUID);
+            browserLocalStorage.clear(RANDOM_TEST_GUID);
         });
 
         it("setTemporaryCache", () => {
@@ -334,11 +334,11 @@ describe("BrowserCacheManager tests", () => {
             ]);
         });
 
-        it("clear()", async () => {
+        it("clear()", () => {
             browserSessionStorage.setTemporaryCache("cacheKey", cacheVal, true);
             browserLocalStorage.setTemporaryCache("cacheKey", cacheVal, true);
-            await browserSessionStorage.clear();
-            await browserLocalStorage.clear();
+            browserSessionStorage.clear(RANDOM_TEST_GUID);
+            browserLocalStorage.clear(RANDOM_TEST_GUID);
             expect(browserSessionStorage.getKeys()).toHaveLength(0);
             expect(browserLocalStorage.getKeys()).toHaveLength(0);
         });
@@ -979,11 +979,9 @@ describe("BrowserCacheManager tests", () => {
                     ).toEqual(testAT4);
 
                     browserSessionStorage.clearTokensAndKeysWithClaims(
-                        getDefaultPerformanceClient(),
                         "test-correlation-id"
                     );
                     browserLocalStorage.clearTokensAndKeysWithClaims(
-                        getDefaultPerformanceClient(),
                         "test-correlation-id"
                     );
 
@@ -1366,8 +1364,8 @@ describe("BrowserCacheManager tests", () => {
                         browserSessionStorage.getAuthorityMetadataKeys()
                     ).toEqual(expect.arrayContaining([key]));
 
-                    await browserSessionStorage.clear();
-                    await browserLocalStorage.clear();
+                    browserSessionStorage.clear(RANDOM_TEST_GUID);
+                    browserLocalStorage.clear(RANDOM_TEST_GUID);
                     expect(
                         browserSessionStorage.getAuthorityMetadata(key)
                     ).toBeNull();
@@ -1686,8 +1684,8 @@ describe("BrowserCacheManager tests", () => {
         });
 
         afterEach(async () => {
-            await browserSessionStorage.clear();
-            await browserLocalStorage.clear();
+            browserSessionStorage.clear(RANDOM_TEST_GUID);
+            browserLocalStorage.clear(RANDOM_TEST_GUID);
         });
 
         it("setTemporaryCache", () => {
@@ -1732,11 +1730,11 @@ describe("BrowserCacheManager tests", () => {
             ).toBeNull();
         });
 
-        it("clear()", async () => {
+        it("clear()", () => {
             browserSessionStorage.setTemporaryCache("cacheKey", cacheVal, true);
             browserLocalStorage.setTemporaryCache("cacheKey", cacheVal, true);
-            await browserSessionStorage.clear();
-            await browserLocalStorage.clear();
+            browserSessionStorage.clear(RANDOM_TEST_GUID);
+            browserLocalStorage.clear(RANDOM_TEST_GUID);
             expect(browserSessionStorage.getKeys()).toHaveLength(0);
             expect(browserLocalStorage.getKeys()).toHaveLength(0);
         });
@@ -2443,7 +2441,7 @@ describe("BrowserCacheManager tests", () => {
                     ).toEqual(expect.arrayContaining([key]));
                 });
 
-                it("clear() removes AuthorityMetadataEntity from in-memory storage", async () => {
+                it("clear() removes AuthorityMetadataEntity from in-memory storage", () => {
                     browserSessionStorage.setAuthorityMetadata(key, testObj);
                     browserLocalStorage.setAuthorityMetadata(key, testObj);
 
@@ -2460,8 +2458,8 @@ describe("BrowserCacheManager tests", () => {
                         browserSessionStorage.getAuthorityMetadataKeys()
                     ).toEqual(expect.arrayContaining([key]));
 
-                    await browserSessionStorage.clear();
-                    await browserLocalStorage.clear();
+                    browserSessionStorage.clear(RANDOM_TEST_GUID);
+                    browserLocalStorage.clear(RANDOM_TEST_GUID);
                     expect(
                         browserSessionStorage.getAuthorityMetadata(key)
                     ).toBeNull();
@@ -2592,9 +2590,9 @@ describe("BrowserCacheManager tests", () => {
             msalCacheKey = browserSessionStorage.generateCacheKey("cacheKey");
         });
 
-        afterEach(async () => {
-            await browserSessionStorage.clear();
-            await browserLocalStorage.clear();
+        afterEach(() => {
+            browserSessionStorage.clear(RANDOM_TEST_GUID);
+            browserLocalStorage.clear(RANDOM_TEST_GUID);
         });
 
         it("setTempCache()", () => {
@@ -2703,11 +2701,11 @@ describe("BrowserCacheManager tests", () => {
             expect(clearCookieSpy).toHaveBeenCalledTimes(3);
         });
 
-        it("clear()", async () => {
+        it("clear()", () => {
             // sessionStorage
             browserSessionStorage.setTemporaryCache(msalCacheKey, cacheVal);
             expect(document.cookie).toContain(`${msalCacheKey}=${cacheVal}`);
-            await browserSessionStorage.clear();
+            browserSessionStorage.clear(RANDOM_TEST_GUID);
             expect(browserSessionStorage.getKeys()).toHaveLength(0);
             expect(document.cookie).not.toContain(
                 `${msalCacheKey}=${cacheVal}`
@@ -2715,7 +2713,7 @@ describe("BrowserCacheManager tests", () => {
             // localStorage
             browserLocalStorage.setTemporaryCache(msalCacheKey, cacheVal);
             expect(document.cookie).toContain(`${msalCacheKey}=${cacheVal}`);
-            await browserLocalStorage.clear();
+            browserLocalStorage.clear(RANDOM_TEST_GUID);
             expect(browserLocalStorage.getKeys()).toHaveLength(0);
             expect(document.cookie).not.toContain(
                 `${msalCacheKey}=${cacheVal}`
@@ -2723,7 +2721,7 @@ describe("BrowserCacheManager tests", () => {
             // browser memory
             browserMemoryStorage.setTemporaryCache(msalCacheKey, cacheVal);
             expect(document.cookie).toContain(`${msalCacheKey}=${cacheVal}`);
-            await browserMemoryStorage.clear();
+            browserMemoryStorage.clear(RANDOM_TEST_GUID);
             expect(browserMemoryStorage.getKeys()).toHaveLength(0);
             expect(document.cookie).not.toContain(
                 `${msalCacheKey}=${cacheVal}`
@@ -2825,12 +2823,12 @@ describe("BrowserCacheManager tests", () => {
             expect(clearCookieSpy).toHaveBeenCalledTimes(3);
         });
 
-        it("clear() with item that contains ==", async () => {
+        it("clear() with item that contains ==", () => {
             msalCacheKey = `${Constants.CACHE_PREFIX}.${TEST_STATE_VALUES.ENCODED_LIB_STATE}`;
             // sessionStorage
             browserSessionStorage.setTemporaryCache(msalCacheKey, cacheVal);
             expect(document.cookie).toContain(`${msalCacheKey}=${cacheVal}`);
-            await browserSessionStorage.clear();
+            browserSessionStorage.clear(RANDOM_TEST_GUID);
             expect(browserSessionStorage.getKeys()).toHaveLength(0);
             expect(document.cookie).not.toContain(
                 `${msalCacheKey}=${cacheVal}`
@@ -2838,7 +2836,7 @@ describe("BrowserCacheManager tests", () => {
             // localStorage
             browserLocalStorage.setTemporaryCache(msalCacheKey, cacheVal);
             expect(document.cookie).toContain(`${msalCacheKey}=${cacheVal}`);
-            await browserLocalStorage.clear();
+            browserLocalStorage.clear(RANDOM_TEST_GUID);
             expect(browserLocalStorage.getKeys()).toHaveLength(0);
             expect(document.cookie).not.toContain(
                 `${msalCacheKey}=${cacheVal}`
@@ -2846,7 +2844,7 @@ describe("BrowserCacheManager tests", () => {
             // browser memory
             browserMemoryStorage.setTemporaryCache(msalCacheKey, cacheVal);
             expect(document.cookie).toContain(`${msalCacheKey}=${cacheVal}`);
-            await browserMemoryStorage.clear();
+            browserMemoryStorage.clear(RANDOM_TEST_GUID);
             expect(browserMemoryStorage.getKeys()).toHaveLength(0);
             expect(document.cookie).not.toContain(
                 `${msalCacheKey}=${cacheVal}`

--- a/lib/msal-browser/test/cache/TestStorageManager.ts
+++ b/lib/msal-browser/test/cache/TestStorageManager.ts
@@ -13,10 +13,10 @@ import {
     ServerTelemetryEntity,
     ThrottlingEntity,
     AuthorityMetadataEntity,
-    ValidCredentialType,
     TokenKeys,
     CacheHelpers,
 } from "@azure/msal-common";
+import { RANDOM_TEST_GUID } from "../utils/StringConstants.js";
 
 const ACCOUNT_KEYS = "ACCOUNT_KEYS";
 const TOKEN_KEYS = "TOKEN_KEYS";
@@ -53,8 +53,8 @@ export class TestStorageManager extends CacheManager {
         }
     }
 
-    async removeAccount(key: string): Promise<void> {
-        await super.removeAccount(key);
+    removeAccount(key: string): void {
+        super.removeAccount(key, RANDOM_TEST_GUID);
         this.removeAccountKeyFromMap(key);
     }
 

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -29,6 +29,7 @@ import {
 import { BrowserCacheLocation } from "../../src/utils/BrowserConstants.js";
 import {
     ID_TOKEN_CLAIMS,
+    RANDOM_TEST_GUID,
     TEST_CONFIG,
     TEST_DATA_CLIENT_INFO,
     TEST_TOKENS,
@@ -175,7 +176,7 @@ describe("TokenCache tests", () => {
         });
 
         afterEach(() => {
-            browserStorage.clear();
+            browserStorage.clear(RANDOM_TEST_GUID);
         });
 
         it("loads id token with a request account", async () => {

--- a/lib/msal-browser/test/crypto/CryptoOps.spec.ts
+++ b/lib/msal-browser/test/crypto/CryptoOps.spec.ts
@@ -301,10 +301,9 @@ describe("CryptoOps.ts Unit Tests", () => {
             resourceRequestUri: TEST_URIS.TEST_AUTH_ENDPT_WITH_PARAMS,
         } as BaseAuthRequest);
         const key = mockDatabase["TestDB.keys"][pkThumbprint];
-        const keyDeleted = await cryptoObj.removeTokenBindingKey(pkThumbprint);
+        await cryptoObj.removeTokenBindingKey(pkThumbprint);
         expect(key).not.toBe(undefined);
         expect(mockDatabase["TestDB.keys"][pkThumbprint]).toBe(undefined);
-        expect(keyDeleted).toBe(true);
     }, 30000);
 
     it("signJwt() throws signingKeyNotFoundInStorage error if signing keypair is not found in storage", async () => {

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -139,8 +139,8 @@ const cryptoInterface = {
     signJwt: async (): Promise<string> => {
         return "signedJwt";
     },
-    removeTokenBindingKey: async (): Promise<boolean> => {
-        return Promise.resolve(true);
+    removeTokenBindingKey: async (): Promise<void> => {
+        return Promise.resolve();
     },
     clearKeystore: async (): Promise<boolean> => {
         return Promise.resolve(true);
@@ -222,7 +222,8 @@ describe("InteractionHandler.ts Unit Tests", () => {
             storageInterface: new TestStorageManager(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 cryptoInterface,
-                logger
+                logger,
+                new StubPerformanceClient()
             ),
             networkInterface: {
                 sendGetRequestAsync: async (

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1045,7 +1045,7 @@ export { CacheHelpers }
 //
 // @internal
 export abstract class CacheManager implements ICacheManager {
-    constructor(clientId: string, cryptoImpl: ICrypto, logger: Logger, staticAuthorityOptions?: StaticAuthorityOptions);
+    constructor(clientId: string, cryptoImpl: ICrypto, logger: Logger, performanceClient: IPerformanceClient, staticAuthorityOptions?: StaticAuthorityOptions);
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1066,9 +1066,7 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    getAccessToken(account: AccountInfo, request: BaseAuthRequest, tokenKeys?: TokenKeys, targetRealm?: string, performanceClient?: IPerformanceClient, correlationId?: string): AccessTokenEntity | null;
+    getAccessToken(account: AccountInfo, request: BaseAuthRequest, tokenKeys?: TokenKeys, targetRealm?: string): AccessTokenEntity | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract getAccessTokenCredential(accessTokenKey: string): AccessTokenEntity | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1140,6 +1138,8 @@ export abstract class CacheManager implements ICacheManager {
     protected isAuthorityMetadata(key: string): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     isCredentialKey(key: string): boolean;
+    // (undocumented)
+    protected performanceClient: IPerformanceClient;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     readAccountFromCache(account: AccountInfo): AccountEntity | null;
     readAppMetadataFromCache(environment: string): AppMetadataEntity | null;
@@ -1147,12 +1147,12 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     refreshTokenKeyMatchesFilter(inputKey: string, filter: CredentialFilter): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    removeAccessToken(key: string): Promise<void>;
+    removeAccessToken(key: string, correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    removeAccount(accountKey: string): Promise<void>;
+    removeAccount(accountKey: string, correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    removeAccountContext(account: AccountEntity): Promise<void>;
-    removeAllAccounts(): Promise<void>;
+    removeAccountContext(account: AccountEntity, correlationId: string): void;
+    removeAllAccounts(correlationId: string): void;
     removeAppMetadata(): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     removeIdToken(key: string): void;
@@ -2476,7 +2476,7 @@ export interface ICrypto {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     hashString(plainText: string): Promise<string>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    removeTokenBindingKey(kid: string): Promise<boolean>;
+    removeTokenBindingKey(kid: string): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     signJwt(payload: SignedHttpRequest, kid: string, shrOptions?: ShrOptions, correlationId?: string): Promise<string>;
 }
@@ -4579,42 +4579,42 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/authority/Authority.ts:818:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/Authority.ts:1009:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/AuthorityOptions.ts:26:5 - (ae-forgotten-export) The symbol "CloudInstanceDiscoveryResponse" needs to be exported by the entry point index.d.ts
-// src/cache/CacheManager.ts:289:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:290:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:572:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1559:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1560:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1574:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1575:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1595:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1596:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1605:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1606:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1622:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1623:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1637:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1638:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1671:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1672:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1686:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1687:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1698:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1699:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1710:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1711:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1722:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1723:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1740:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1741:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1765:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1766:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1785:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1786:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1805:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1806:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1817:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1818:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1826:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:292:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:293:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:575:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1564:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1565:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1579:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1580:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1600:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1601:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1610:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1611:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1627:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1628:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1642:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1643:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1676:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1677:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1691:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1692:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1703:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1704:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1715:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1716:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1727:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1728:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1745:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1746:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1770:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1771:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1790:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1791:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1810:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1811:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1822:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1823:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1831:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/utils/CacheTypes.ts:94:53 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
 // src/cache/utils/CacheTypes.ts:94:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
 // src/client/AuthorizationCodeClient.ts:158:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -4625,9 +4625,9 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/client/RefreshTokenClient.ts:287:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:288:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:339:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/SilentFlowClient.ts:172:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/config/ClientConfiguration.ts:50:5 - (ae-forgotten-export) The symbol "ClientCredentials" needs to be exported by the entry point index.d.ts
-// src/config/ClientConfiguration.ts:52:5 - (ae-forgotten-export) The symbol "TelemetryOptions" needs to be exported by the entry point index.d.ts
+// src/client/SilentFlowClient.ts:170:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/config/ClientConfiguration.ts:51:5 - (ae-forgotten-export) The symbol "ClientCredentials" needs to be exported by the entry point index.d.ts
+// src/config/ClientConfiguration.ts:53:5 - (ae-forgotten-export) The symbol "TelemetryOptions" needs to be exported by the entry point index.d.ts
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/request/AuthenticationHeaderParser.ts:74:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -1033,13 +1033,13 @@ export abstract class CacheManager implements ICacheManager {
                 if (kid) {
                     void this.cryptoImpl
                         .removeTokenBindingKey(kid)
-                        .catch((e) => {
+                        .catch(() => {
                             this.commonLogger.error(
                                 `Failed to remove token binding key ${kid}`,
                                 correlationId
                             );
                             this.performanceClient?.incrementFields(
-                                { removeTokenBindingKeyError: 1 },
+                                { removeTokenBindingKeyFailure: 1 },
                                 correlationId
                             );
                         });

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -64,17 +64,20 @@ export abstract class CacheManager implements ICacheManager {
     // Instance of logger for functions defined in the msal-common layer
     private commonLogger: Logger;
     private staticAuthorityOptions?: StaticAuthorityOptions;
+    protected performanceClient: IPerformanceClient;
 
     constructor(
         clientId: string,
         cryptoImpl: ICrypto,
         logger: Logger,
-        staticAuthorityOptions?: StaticAuthorityOptions
+        performanceClient: IPerformanceClient,
+        staticAuthorityOptions?: StaticAuthorityOptions,
     ) {
         this.clientId = clientId;
         this.cryptoImpl = cryptoImpl;
         this.commonLogger = logger.clone(name, version);
         this.staticAuthorityOptions = staticAuthorityOptions;
+        this.performanceClient = performanceClient;
     }
 
     /**
@@ -588,7 +591,6 @@ export abstract class CacheManager implements ICacheManager {
         const tokenKeys = this.getTokenKeys();
         const currentScopes = ScopeSet.fromString(credential.target);
 
-        const removedAccessTokens: Array<Promise<void>> = [];
         tokenKeys.accessToken.forEach((key) => {
             if (
                 !this.accessTokenKeyMatchesFilter(key, accessTokenFilter, false)
@@ -604,11 +606,10 @@ export abstract class CacheManager implements ICacheManager {
             ) {
                 const tokenScopeSet = ScopeSet.fromString(tokenEntity.target);
                 if (tokenScopeSet.intersectingScopeSets(currentScopes)) {
-                    removedAccessTokens.push(this.removeAccessToken(key));
+                    this.removeAccessToken(key, correlationId);
                 }
             }
         });
-        await Promise.all(removedAccessTokens);
         await this.setAccessTokenCredential(credential, correlationId);
     }
 
@@ -959,27 +960,24 @@ export abstract class CacheManager implements ICacheManager {
     /**
      * Removes all accounts and related tokens from cache.
      */
-    async removeAllAccounts(): Promise<void> {
+    removeAllAccounts(correlationId: string): void {
         const allAccountKeys = this.getAccountKeys();
-        const removedAccounts: Array<Promise<void>> = [];
 
         allAccountKeys.forEach((cacheKey) => {
-            removedAccounts.push(this.removeAccount(cacheKey));
+            this.removeAccount(cacheKey, correlationId);
         });
-
-        await Promise.all(removedAccounts);
     }
 
     /**
      * Removes the account and related tokens for a given account key
      * @param account
      */
-    async removeAccount(accountKey: string): Promise<void> {
+    removeAccount(accountKey: string, correlationId: string): void {
         const account = this.getAccount(accountKey, this.commonLogger);
         if (!account) {
             return;
         }
-        await this.removeAccountContext(account);
+        this.removeAccountContext(account, correlationId);
         this.removeItem(accountKey);
     }
 
@@ -987,10 +985,9 @@ export abstract class CacheManager implements ICacheManager {
      * Removes credentials associated with the provided account
      * @param account
      */
-    async removeAccountContext(account: AccountEntity): Promise<void> {
+    removeAccountContext(account: AccountEntity, correlationId: string): void {
         const allTokenKeys = this.getTokenKeys();
         const accountId = account.generateAccountId();
-        const removedCredentials: Array<Promise<void>> = [];
 
         allTokenKeys.idToken.forEach((key) => {
             if (key.indexOf(accountId) === 0) {
@@ -1000,7 +997,7 @@ export abstract class CacheManager implements ICacheManager {
 
         allTokenKeys.accessToken.forEach((key) => {
             if (key.indexOf(accountId) === 0) {
-                removedCredentials.push(this.removeAccessToken(key));
+                this.removeAccessToken(key, correlationId);
             }
         });
 
@@ -1009,19 +1006,19 @@ export abstract class CacheManager implements ICacheManager {
                 this.removeRefreshToken(key);
             }
         });
-
-        await Promise.all(removedCredentials);
     }
 
     /**
      * returns a boolean if the given credential is removed
      * @param credential
      */
-    async removeAccessToken(key: string): Promise<void> {
+    removeAccessToken(key: string, correlationId: string): void {
         const credential = this.getAccessTokenCredential(key);
         if (!credential) {
             return;
         }
+
+        this.removeItem(key);
 
         // Remove Token Binding Key from key store for PoP Tokens Credentials
         if (
@@ -1034,18 +1031,19 @@ export abstract class CacheManager implements ICacheManager {
                 const kid = accessTokenWithAuthSchemeEntity.keyId;
 
                 if (kid) {
-                    try {
-                        await this.cryptoImpl.removeTokenBindingKey(kid);
-                    } catch (error) {
-                        throw createClientAuthError(
-                            ClientAuthErrorCodes.bindingKeyNotRemoved
+                    void this.cryptoImpl.removeTokenBindingKey(kid).catch((e) => {
+                        this.commonLogger.error(
+                            `Failed to remove token binding key ${kid}`,
+                            correlationId
                         );
-                    }
+                        this.performanceClient?.incrementFields(
+                            { removeTokenBindingKeyError: 1 },
+                            correlationId
+                        );
+                    });
                 }
             }
         }
-
-        return this.removeItem(key);
     }
 
     /**
@@ -1239,7 +1237,6 @@ export abstract class CacheManager implements ICacheManager {
      * @param request {BaseAuthRequest}
      * @param tokenKeys {?TokenKeys}
      * @param performanceClient {?IPerformanceClient}
-     * @param correlationId {?string}
      */
     getAccessToken(
         account: AccountInfo,
@@ -1247,9 +1244,9 @@ export abstract class CacheManager implements ICacheManager {
         tokenKeys?: TokenKeys,
         targetRealm?: string,
         performanceClient?: IPerformanceClient,
-        correlationId?: string
     ): AccessTokenEntity | null {
-        this.commonLogger.trace("CacheManager - getAccessToken called");
+        const correlationId = request.correlationId;
+        this.commonLogger.trace("CacheManager - getAccessToken called", correlationId);
         const scopes = ScopeSet.createSearchScopes(request.scopes);
         const authScheme =
             request.authenticationScheme || AuthenticationScheme.BEARER;
@@ -1301,15 +1298,17 @@ export abstract class CacheManager implements ICacheManager {
         const numAccessTokens = accessTokens.length;
         if (numAccessTokens < 1) {
             this.commonLogger.info(
-                "CacheManager:getAccessToken - No token found"
+                "CacheManager:getAccessToken - No token found",
+                correlationId
             );
             return null;
         } else if (numAccessTokens > 1) {
             this.commonLogger.info(
-                "CacheManager:getAccessToken - Multiple access tokens found, clearing them"
+                "CacheManager:getAccessToken - Multiple access tokens found, clearing them",
+                correlationId
             );
             accessTokens.forEach((accessToken) => {
-                void this.removeAccessToken(generateCredentialKey(accessToken));
+                this.removeAccessToken(generateCredentialKey(accessToken), correlationId);
             });
             if (performanceClient && correlationId) {
                 performanceClient.addFields(
@@ -1321,7 +1320,8 @@ export abstract class CacheManager implements ICacheManager {
         }
 
         this.commonLogger.info(
-            "CacheManager:getAccessToken - Returning access token"
+            "CacheManager:getAccessToken - Returning access token",
+            correlationId
         );
         return accessTokens[0];
     }

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -71,7 +71,7 @@ export abstract class CacheManager implements ICacheManager {
         cryptoImpl: ICrypto,
         logger: Logger,
         performanceClient: IPerformanceClient,
-        staticAuthorityOptions?: StaticAuthorityOptions,
+        staticAuthorityOptions?: StaticAuthorityOptions
     ) {
         this.clientId = clientId;
         this.cryptoImpl = cryptoImpl;
@@ -1031,16 +1031,18 @@ export abstract class CacheManager implements ICacheManager {
                 const kid = accessTokenWithAuthSchemeEntity.keyId;
 
                 if (kid) {
-                    void this.cryptoImpl.removeTokenBindingKey(kid).catch((e) => {
-                        this.commonLogger.error(
-                            `Failed to remove token binding key ${kid}`,
-                            correlationId
-                        );
-                        this.performanceClient?.incrementFields(
-                            { removeTokenBindingKeyError: 1 },
-                            correlationId
-                        );
-                    });
+                    void this.cryptoImpl
+                        .removeTokenBindingKey(kid)
+                        .catch((e) => {
+                            this.commonLogger.error(
+                                `Failed to remove token binding key ${kid}`,
+                                correlationId
+                            );
+                            this.performanceClient?.incrementFields(
+                                { removeTokenBindingKeyError: 1 },
+                                correlationId
+                            );
+                        });
                 }
             }
         }
@@ -1242,11 +1244,13 @@ export abstract class CacheManager implements ICacheManager {
         account: AccountInfo,
         request: BaseAuthRequest,
         tokenKeys?: TokenKeys,
-        targetRealm?: string,
-        performanceClient?: IPerformanceClient,
+        targetRealm?: string
     ): AccessTokenEntity | null {
         const correlationId = request.correlationId;
-        this.commonLogger.trace("CacheManager - getAccessToken called", correlationId);
+        this.commonLogger.trace(
+            "CacheManager - getAccessToken called",
+            correlationId
+        );
         const scopes = ScopeSet.createSearchScopes(request.scopes);
         const authScheme =
             request.authenticationScheme || AuthenticationScheme.BEARER;
@@ -1308,14 +1312,15 @@ export abstract class CacheManager implements ICacheManager {
                 correlationId
             );
             accessTokens.forEach((accessToken) => {
-                this.removeAccessToken(generateCredentialKey(accessToken), correlationId);
-            });
-            if (performanceClient && correlationId) {
-                performanceClient.addFields(
-                    { multiMatchedAT: accessTokens.length },
+                this.removeAccessToken(
+                    generateCredentialKey(accessToken),
                     correlationId
                 );
-            }
+            });
+            this.performanceClient.addFields(
+                { multiMatchedAT: accessTokens.length },
+                correlationId
+            );
             return null;
         }
 

--- a/lib/msal-common/src/cache/interface/ICacheManager.ts
+++ b/lib/msal-common/src/cache/interface/ICacheManager.ts
@@ -197,19 +197,19 @@ export interface ICacheManager {
     /**
      * Removes all accounts and related tokens from cache.
      */
-    removeAllAccounts(): Promise<void>;
+    removeAllAccounts(correlationId: string): void;
 
     /**
      * returns a boolean if the given account is removed
      * @param account
      */
-    removeAccount(accountKey: string): Promise<void>;
+    removeAccount(accountKey: string, correlationId: string): void;
 
     /**
      * returns a boolean if the given account is removed
      * @param account
      */
-    removeAccountContext(account: AccountEntity): Promise<void>;
+    removeAccountContext(account: AccountEntity, correlationId: string): void;
 
     /**
      * @param key
@@ -219,7 +219,7 @@ export interface ICacheManager {
     /**
      * @param key
      */
-    removeAccessToken(key: string): Promise<void>;
+    removeAccessToken(key: string, correlationId: string): void;
 
     /**
      * @param key

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -76,8 +76,7 @@ export class SilentFlowClient extends BaseClient {
             request,
             tokenKeys,
             requestTenantId,
-            this.performanceClient,
-            request.correlationId
+            this.performanceClient
         );
 
         if (!cachedAccessToken) {

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -75,8 +75,7 @@ export class SilentFlowClient extends BaseClient {
             request.account,
             request,
             tokenKeys,
-            requestTenantId,
-            this.performanceClient
+            requestTenantId
         );
 
         if (!cachedAccessToken) {

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -23,6 +23,7 @@ import {
     ClientAuthErrorCodes,
     createClientAuthError,
 } from "../error/ClientAuthError.js";
+import { StubPerformanceClient } from "../telemetry/performance/StubPerformanceClient.js";
 
 /**
  * Use the configuration object to configure MSAL Modules and initialize the base interfaces for MSAL.
@@ -260,7 +261,8 @@ export function buildClientConfiguration({
             new DefaultStorageClass(
                 userAuthOptions.clientId,
                 DEFAULT_CRYPTO_IMPLEMENTATION,
-                new Logger(loggerOptions)
+                new Logger(loggerOptions),
+                new StubPerformanceClient()
             ),
         networkInterface:
             networkImplementation || DEFAULT_NETWORK_IMPLEMENTATION,

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -70,7 +70,7 @@ export interface ICrypto {
      * Removes cryptographic keypair from key store matching the keyId passed in
      * @param kid
      */
-    removeTokenBindingKey(kid: string): Promise<boolean>;
+    removeTokenBindingKey(kid: string): Promise<void>;
     /**
      * Removes all cryptographic keys from IndexedDB storage
      */
@@ -111,7 +111,7 @@ export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
     async getPublicKeyThumbprint(): Promise<string> {
         throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented);
     },
-    async removeTokenBindingKey(): Promise<boolean> {
+    async removeTokenBindingKey(): Promise<void> {
         throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented);
     },
     async clearKeystore(): Promise<boolean> {

--- a/lib/msal-common/test/account/AuthToken.spec.ts
+++ b/lib/msal-common/test/account/AuthToken.spec.ts
@@ -1,84 +1,17 @@
 import * as AuthToken from "../../src/account/AuthToken";
-import {
-    TEST_DATA_CLIENT_INFO,
-    RANDOM_TEST_GUID,
-    TEST_POP_VALUES,
-    TEST_CRYPTO_VALUES,
-    TEST_TOKENS,
-    ID_TOKEN_CLAIMS,
-} from "../test_kit/StringConstants";
+import { TEST_TOKENS, ID_TOKEN_CLAIMS } from "../test_kit/StringConstants";
 import { ICrypto } from "../../src/crypto/ICrypto";
 import {
     ClientAuthErrorMessage,
     ClientAuthError,
 } from "../../src/error/ClientAuthError";
 import { AuthError } from "../../src/error/AuthError";
-
-const TEST_ID_TOKEN_PAYLOAD = TEST_TOKENS.IDTOKEN_V2.split(".")[1];
+import { mockCrypto } from "../client/ClientTestUtils.js";
 
 describe("AuthToken.ts Class Unit Tests", () => {
     let cryptoInterface: ICrypto;
     beforeEach(() => {
-        cryptoInterface = {
-            createNewGuid(): string {
-                return RANDOM_TEST_GUID;
-            },
-            base64Decode(input: string): string {
-                switch (input) {
-                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
-                        return TEST_POP_VALUES.DECODED_REQ_CNF;
-                    case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
-                        return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
-                    case TEST_ID_TOKEN_PAYLOAD:
-                        return JSON.stringify(ID_TOKEN_CLAIMS);
-                    default:
-                        return input;
-                }
-            },
-            base64Encode(input: string): string {
-                switch (input) {
-                    case "123-test-uid":
-                        return "MTIzLXRlc3QtdWlk";
-                    case "456-test-uid":
-                        return "NDU2LXRlc3QtdWlk";
-                    case TEST_POP_VALUES.DECODED_REQ_CNF:
-                        return TEST_POP_VALUES.ENCODED_REQ_CNF;
-                    default:
-                        return input;
-                }
-            },
-            base64UrlEncode(input: string): string {
-                switch (input) {
-                    case '{"kid": "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc"}':
-                        return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                    default:
-                        return input;
-                }
-            },
-            encodeKid(input: string): string {
-                switch (input) {
-                    case "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc":
-                        return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                    default:
-                        return input;
-                }
-            },
-            async getPublicKeyThumbprint(): Promise<string> {
-                return TEST_POP_VALUES.KID;
-            },
-            async signJwt(): Promise<string> {
-                return "";
-            },
-            async removeTokenBindingKey(): Promise<boolean> {
-                return Promise.resolve(true);
-            },
-            async clearKeystore(): Promise<boolean> {
-                return Promise.resolve(true);
-            },
-            async hashString(): Promise<string> {
-                return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
-            },
-        };
+        cryptoInterface = mockCrypto;
     });
 
     afterEach(() => {

--- a/lib/msal-common/test/account/ClientInfo.spec.ts
+++ b/lib/msal-common/test/account/ClientInfo.spec.ts
@@ -3,12 +3,7 @@ import {
     buildClientInfoFromHomeAccountId,
     ClientInfo,
 } from "../../src/account/ClientInfo";
-import {
-    TEST_DATA_CLIENT_INFO,
-    RANDOM_TEST_GUID,
-    TEST_POP_VALUES,
-    TEST_CRYPTO_VALUES,
-} from "../test_kit/StringConstants";
+import { TEST_DATA_CLIENT_INFO } from "../test_kit/StringConstants";
 import { ICrypto } from "../../src/crypto/ICrypto";
 import {
     ClientAuthError,
@@ -17,69 +12,13 @@ import {
     createClientAuthError,
 } from "../../src/error/ClientAuthError";
 import { Constants } from "../../src";
+import { mockCrypto } from "../client/ClientTestUtils.js";
 
 describe("ClientInfo.ts Class Unit Tests", () => {
     describe("buildClientInfo()", () => {
         let cryptoInterface: ICrypto;
         beforeEach(() => {
-            cryptoInterface = {
-                createNewGuid(): string {
-                    return RANDOM_TEST_GUID;
-                },
-                base64Decode(input: string): string {
-                    switch (input) {
-                        case TEST_POP_VALUES.ENCODED_REQ_CNF:
-                            return TEST_POP_VALUES.DECODED_REQ_CNF;
-                        case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
-                            return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
-                        default:
-                            return input;
-                    }
-                },
-                base64Encode(input: string): string {
-                    switch (input) {
-                        case "123-test-uid":
-                            return "MTIzLXRlc3QtdWlk";
-                        case "456-test-uid":
-                            return "NDU2LXRlc3QtdWlk";
-                        case TEST_POP_VALUES.DECODED_REQ_CNF:
-                            return TEST_POP_VALUES.ENCODED_REQ_CNF;
-                        default:
-                            return input;
-                    }
-                },
-                base64UrlEncode(input: string): string {
-                    switch (input) {
-                        case '{"kid": "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc"}':
-                            return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                        default:
-                            return input;
-                    }
-                },
-                encodeKid(input: string): string {
-                    switch (input) {
-                        case "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc":
-                            return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                        default:
-                            return input;
-                    }
-                },
-                async getPublicKeyThumbprint(): Promise<string> {
-                    return TEST_POP_VALUES.KID;
-                },
-                async signJwt(): Promise<string> {
-                    return "";
-                },
-                async removeTokenBindingKey(): Promise<boolean> {
-                    return Promise.resolve(true);
-                },
-                async clearKeystore(): Promise<boolean> {
-                    return Promise.resolve(true);
-                },
-                async hashString(): Promise<string> {
-                    return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
-                },
-            };
+            cryptoInterface = mockCrypto;
         });
 
         afterEach(() => {

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -46,6 +46,7 @@ import {
 import { RegionDiscovery } from "../../src/authority/RegionDiscovery";
 import { InstanceDiscoveryMetadata } from "../../src/authority/AuthorityMetadata";
 import * as authorityMetadata from "../../src/authority/AuthorityMetadata";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 
 let mockStorage: MockStorageClass;
 
@@ -87,7 +88,8 @@ describe("Authority.ts Class Unit Tests", () => {
         mockStorage = new MockStorageClass(
             TEST_CONFIG.MSAL_CLIENT_ID,
             mockCrypto,
-            logger
+            logger,
+            new StubPerformanceClient()
         );
     });
     afterEach(() => {

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -23,11 +23,8 @@ import {
     TEST_TOKEN_LIFETIMES,
     ID_TOKEN_ALT_CLAIMS,
     GUEST_ID_TOKEN_CLAIMS,
+    RANDOM_TEST_GUID,
 } from "../test_kit/StringConstants.js";
-import {
-    ClientAuthErrorCodes,
-    createClientAuthError,
-} from "../../src/error/ClientAuthError.js";
 import { AccountInfo } from "../../src/account/AccountInfo.js";
 import { MockCache } from "./MockCache.js";
 import { buildAccountFromIdTokenClaims, buildIdToken } from "msal-test-utils";
@@ -1561,22 +1558,22 @@ describe("CacheManager.ts test cases", () => {
         ).toBeUndefined();
     });
 
-    it("removeAllAccounts", async () => {
+    it("removeAllAccounts", () => {
         const accountsBeforeRemove = mockCache.cacheManager.getAllAccounts();
-        await mockCache.cacheManager.removeAllAccounts();
+        mockCache.cacheManager.removeAllAccounts(RANDOM_TEST_GUID);
         const accountsAfterRemove = mockCache.cacheManager.getAllAccounts();
 
         expect(accountsBeforeRemove).toHaveLength(3);
         expect(accountsAfterRemove).toHaveLength(0);
     });
 
-    it("removeAccount", async () => {
+    it("removeAccount", () => {
         const accountToRemove = buildAccountFromIdTokenClaims(ID_TOKEN_CLAIMS);
         const accountToRemoveKey = accountToRemove.generateAccountKey();
         expect(
             mockCache.cacheManager.getAccount(accountToRemoveKey)
         ).not.toBeNull();
-        await mockCache.cacheManager.removeAccount(accountToRemoveKey);
+        mockCache.cacheManager.removeAccount(accountToRemoveKey);
         expect(
             mockCache.cacheManager.getAccount(accountToRemoveKey)
         ).toBeNull();
@@ -1596,8 +1593,9 @@ describe("CacheManager.ts test cases", () => {
             extendedExpiresOn: "4600",
         };
 
-        await mockCache.cacheManager.removeAccessToken(
-            CacheHelpers.generateCredentialKey(at)
+        mockCache.cacheManager.removeAccessToken(
+            CacheHelpers.generateCredentialKey(at),
+            RANDOM_TEST_GUID
         );
         const atKey = CacheHelpers.generateCredentialKey(at);
         expect(mockCache.cacheManager.getAccount(atKey)).toBeNull();
@@ -1624,8 +1622,9 @@ describe("CacheManager.ts test cases", () => {
             "removeTokenBindingKey"
         );
 
-        await mockCache.cacheManager.removeAccessToken(
-            CacheHelpers.generateCredentialKey(atWithAuthScheme)
+        mockCache.cacheManager.removeAccessToken(
+            CacheHelpers.generateCredentialKey(atWithAuthScheme),
+            RANDOM_TEST_GUID
         );
         const atKey = CacheHelpers.generateCredentialKey(atWithAuthScheme);
         expect(mockCache.cacheManager.getAccount(atKey)).toBeNull();
@@ -1655,43 +1654,13 @@ describe("CacheManager.ts test cases", () => {
             "removeTokenBindingKey"
         );
 
-        await mockCache.cacheManager.removeAccessToken(
-            CacheHelpers.generateCredentialKey(atWithAuthScheme)
+        mockCache.cacheManager.removeAccessToken(
+            CacheHelpers.generateCredentialKey(atWithAuthScheme),
+            RANDOM_TEST_GUID
         );
         const atKey = CacheHelpers.generateCredentialKey(atWithAuthScheme);
         expect(mockCache.cacheManager.getAccount(atKey)).toBeNull();
         expect(removeTokenBindingKeySpy).toHaveBeenCalledTimes(0);
-    });
-
-    it("throws bindingKeyNotRemoved error when key is not deleted from storage", async () => {
-        const atWithAuthScheme = {
-            environment: "login.microsoftonline.com",
-            credentialType: CredentialType.ACCESS_TOKEN_WITH_AUTH_SCHEME,
-            secret: "an access token",
-            realm: "microsoft",
-            target: "scope1 scope2 scope3",
-            clientId: "mock_client_id",
-            cachedAt: "1000",
-            homeAccountId: "uid.utid",
-            extendedExpiresOn: "4600",
-            expiresOn: "4600",
-            keyId: "V6N_HMPagNpYS_wxM14X73q3eWzbTr9Z31RyHkIcN0Y",
-            tokenType: AuthenticationScheme.POP,
-        };
-
-        jest.spyOn(mockCrypto, "removeTokenBindingKey").mockImplementation(
-            (keyId: string): Promise<boolean> => {
-                return Promise.reject();
-            }
-        );
-
-        return await expect(
-            mockCache.cacheManager.removeAccessToken(
-                CacheHelpers.generateCredentialKey(atWithAuthScheme)
-            )
-        ).rejects.toThrow(
-            createClientAuthError(ClientAuthErrorCodes.bindingKeyNotRemoved)
-        );
     });
 
     it("getAccessToken matches multiple tokens, removes them and returns null", (done) => {
@@ -1770,35 +1739,18 @@ describe("CacheManager.ts test cases", () => {
                 forceRefresh: false,
             };
 
-            const mockPerfClient = new MockPerformanceClient();
-            const correlationId = "test-correlation-id";
-
-            mockPerfClient.addPerformanceCallback((events) => {
-                expect(events.length).toBe(1);
-                expect(events[0].multiMatchedAT).toEqual(2);
-                done();
-            });
-
-            const measurement = mockPerfClient.startMeasurement(
-                PerformanceEvents.AcquireTokenSilent,
-                correlationId
-            );
-
             expect(
                 mockCache.cacheManager.getAccessToken(
                     mockedAccountInfo,
                     silentFlowRequest,
                     undefined,
-                    undefined,
-                    mockPerfClient,
-                    correlationId
+                    undefined
                 )
             ).toBeNull();
             expect(
                 mockCache.cacheManager.getTokenKeys().accessToken.length
             ).toEqual(0);
-
-            measurement.end();
+            done();
         });
     });
 

--- a/lib/msal-common/test/cache/MockCache.ts
+++ b/lib/msal-common/test/cache/MockCache.ts
@@ -7,6 +7,7 @@ import { StaticAuthorityOptions } from "../../src/authority/AuthorityOptions.js"
 import { RefreshTokenEntity } from "../../src/cache/entities/RefreshTokenEntity.js";
 import { ICrypto } from "../../src/crypto/ICrypto.js";
 import { Logger } from "../../src/logger/Logger.js";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 import {
     AuthenticationScheme,
     CredentialType,
@@ -33,6 +34,7 @@ export class MockCache {
             clientId,
             cryptoImpl,
             new Logger({}),
+            new StubPerformanceClient(),
             staticAuthorityOptions
         );
     }

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -8,13 +8,10 @@ import {
 } from "../../../src/network/INetworkModule.js";
 import { ICrypto } from "../../../src/crypto/ICrypto.js";
 import {
-    RANDOM_TEST_GUID,
     TEST_DATA_CLIENT_INFO,
     TEST_TOKENS,
     TEST_URIS,
-    TEST_POP_VALUES,
     PREFERRED_CACHE_ALIAS,
-    TEST_CRYPTO_VALUES,
     ID_TOKEN_CLAIMS,
     GUEST_ID_TOKEN_CLAIMS,
     TEST_CONFIG,
@@ -31,67 +28,9 @@ import { Authority } from "../../../src/authority/Authority.js";
 import { AuthorityType } from "../../../src/authority/AuthorityType.js";
 import { TokenClaims } from "../../../src/index.js";
 import { buildAccountFromIdTokenClaims } from "msal-test-utils";
+import { StubPerformanceClient } from "../../../src/telemetry/performance/StubPerformanceClient.js";
 
-const cryptoInterface: ICrypto = {
-    createNewGuid(): string {
-        return RANDOM_TEST_GUID;
-    },
-    base64Decode(input: string): string {
-        switch (input) {
-            case TEST_POP_VALUES.ENCODED_REQ_CNF:
-                return TEST_POP_VALUES.DECODED_REQ_CNF;
-            case TEST_DATA_CLIENT_INFO.TEST_CACHE_RAW_CLIENT_INFO:
-                return TEST_DATA_CLIENT_INFO.TEST_CACHE_DECODED_CLIENT_INFO;
-            case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS:
-                return TEST_DATA_CLIENT_INFO.TEST_CACHE_DECODED_CLIENT_INFO_GUIDS;
-            default:
-                return input;
-        }
-    },
-    base64Encode(input: string): string {
-        switch (input) {
-            case TEST_POP_VALUES.DECODED_REQ_CNF:
-                return TEST_POP_VALUES.ENCODED_REQ_CNF;
-            case "uid":
-                return "dWlk";
-            case "utid":
-                return "dXRpZA==";
-            default:
-                return input;
-        }
-    },
-    base64UrlEncode(input: string): string {
-        switch (input) {
-            case '{"kid": "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc"}':
-                return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-            default:
-                return input;
-        }
-    },
-    encodeKid(input: string): string {
-        switch (input) {
-            case "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc":
-                return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-            default:
-                return input;
-        }
-    },
-    async getPublicKeyThumbprint(): Promise<string> {
-        return TEST_POP_VALUES.KID;
-    },
-    async signJwt(): Promise<string> {
-        return "";
-    },
-    async removeTokenBindingKey(): Promise<boolean> {
-        return Promise.resolve(true);
-    },
-    async clearKeystore(): Promise<boolean> {
-        return Promise.resolve(true);
-    },
-    async hashString(): Promise<string> {
-        return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
-    },
-};
+const cryptoInterface: ICrypto = mockCrypto;
 
 const networkInterface: INetworkModule = {
     sendGetRequestAsync<T>(url: string, options?: NetworkRequestOptions): T {
@@ -121,11 +60,12 @@ const loggerOptions = {
     logLevel: LogLevel.Verbose,
 };
 const logger = new Logger(loggerOptions);
+const performanceClient = new StubPerformanceClient();
 
 const authority = new Authority(
     Constants.DEFAULT_AUTHORITY,
     networkInterface,
-    new MockStorageClass("client-id", mockCrypto, logger),
+    new MockStorageClass("client-id", mockCrypto, logger, performanceClient),
     authorityOptions,
     logger,
     TEST_CONFIG.CORRELATION_ID
@@ -276,7 +216,12 @@ describe("AccountEntity.ts Unit Tests", () => {
         const authority = new Authority(
             Constants.DEFAULT_AUTHORITY,
             networkInterface,
-            new MockStorageClass("client-id", mockCrypto, logger),
+            new MockStorageClass(
+                "client-id",
+                mockCrypto,
+                logger,
+                performanceClient
+            ),
             authorityOptions,
             logger,
             TEST_CONFIG.CORRELATION_ID
@@ -324,7 +269,12 @@ describe("AccountEntity.ts Unit Tests", () => {
         const authority = new Authority(
             Constants.DEFAULT_AUTHORITY,
             networkInterface,
-            new MockStorageClass("client-id", mockCrypto, logger),
+            new MockStorageClass(
+                "client-id",
+                mockCrypto,
+                logger,
+                performanceClient
+            ),
             {
                 protocolMode: ProtocolMode.OIDC,
                 knownAuthorities: [Constants.DEFAULT_AUTHORITY],
@@ -657,7 +607,12 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         const authority = new Authority(
             "https://myadfs.com/adfs",
             networkInterface,
-            new MockStorageClass("client-id", mockCrypto, logger),
+            new MockStorageClass(
+                "client-id",
+                mockCrypto,
+                logger,
+                performanceClient
+            ),
             authorityOptions,
             logger,
             TEST_CONFIG.CORRELATION_ID
@@ -713,7 +668,12 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         const authority = new Authority(
             "https://myadfs.com/adfs",
             networkInterface,
-            new MockStorageClass("client-id", mockCrypto, logger),
+            new MockStorageClass(
+                "client-id",
+                mockCrypto,
+                logger,
+                performanceClient
+            ),
             authorityOptions,
             logger,
             TEST_CONFIG.CORRELATION_ID

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -8,6 +8,7 @@ import {
     TEST_CONFIG,
     TEST_CRYPTO_VALUES,
     TEST_POP_VALUES,
+    TEST_TOKENS,
 } from "../test_kit/StringConstants.js";
 
 import { CacheManager } from "../../src/cache/CacheManager.js";
@@ -32,6 +33,7 @@ import { ServerTelemetryManager } from "../../src/telemetry/server/ServerTelemet
 import { Constants, EncodingTypes } from "../../src/utils/Constants.js";
 import { AuthorityOptions } from "../../src/authority/AuthorityOptions.js";
 import { TokenKeys } from "../../src/cache/utils/CacheTypes.js";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 
 const ACCOUNT_KEYS = "ACCOUNT_KEYS";
 const TOKEN_KEYS = "TOKEN_KEYS";
@@ -59,8 +61,8 @@ export class MockStorageClass extends CacheManager {
         }
     }
 
-    async removeAccount(key: string): Promise<void> {
-        await super.removeAccount(key);
+    removeAccount(key: string): void {
+        super.removeAccount(key, RANDOM_TEST_GUID);
         const currentAccounts = this.getAccountKeys();
         const removalIndex = currentAccounts.indexOf(key);
         if (removalIndex > -1) {
@@ -70,17 +72,17 @@ export class MockStorageClass extends CacheManager {
     }
 
     getAccountKeys(): string[] {
-        return this.store[ACCOUNT_KEYS] || [];
+        return [...(this.store[ACCOUNT_KEYS] || [])];
     }
 
     getTokenKeys(): TokenKeys {
-        return (
-            this.store[TOKEN_KEYS] || {
+        return {
+            ...(this.store[TOKEN_KEYS] || {
                 idToken: [],
                 accessToken: [],
                 refreshToken: [],
-            }
-        );
+            }),
+        } as TokenKeys;
     }
 
     // Credentials (idtokens)
@@ -215,11 +217,11 @@ export const mockCrypto = {
     async getPublicKeyThumbprint(): Promise<string> {
         return TEST_POP_VALUES.KID;
     },
-    async removeTokenBindingKey(keyId: string): Promise<boolean> {
-        return Promise.resolve(true);
+    async removeTokenBindingKey(keyId: string): Promise<void> {
+        return Promise.resolve();
     },
     async signJwt(): Promise<string> {
-        return "";
+        return TEST_TOKENS.POP_TOKEN;
     },
     async clearKeystore(): Promise<boolean> {
         return Promise.resolve(true);
@@ -238,6 +240,7 @@ export class ClientTestUtils {
             TEST_CONFIG.MSAL_CLIENT_ID,
             mockCrypto,
             new Logger({}),
+            new StubPerformanceClient(),
             {
                 canonicalAuthority: TEST_CONFIG.validAuthority,
             }
@@ -316,6 +319,7 @@ export async function getDiscoveredAuthority(
         TEST_CONFIG.MSAL_CLIENT_ID,
         mockCrypto,
         new Logger({}),
+        new StubPerformanceClient(),
         {
             canonicalAuthority: TEST_CONFIG.validAuthority,
         }

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -783,7 +783,8 @@ describe("SilentFlowClient unit tests", () => {
                 new MockStorageClass(
                     TEST_CONFIG.MSAL_CLIENT_ID,
                     mockCrypto,
-                    logger
+                    logger,
+                    new StubPerformanceClient()
                 )
             );
             client = new SilentFlowClient(config, stubPerformanceClient);

--- a/lib/msal-common/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-common/test/config/ClientConfiguration.spec.ts
@@ -6,16 +6,13 @@ import { AuthError } from "../../src/error/AuthError.js";
 import { NetworkRequestOptions } from "../../src/network/INetworkModule.js";
 import { Logger, LogLevel } from "../../src/logger/Logger.js";
 import { version } from "../../src/packageMetadata.js";
-import {
-    TEST_CONFIG,
-    TEST_CRYPTO_VALUES,
-    TEST_POP_VALUES,
-} from "../test_kit/StringConstants.js";
+import { TEST_CONFIG } from "../test_kit/StringConstants.js";
 import { MockStorageClass, mockCrypto } from "../client/ClientTestUtils.js";
 import { MockCache } from "../cache/entities/cacheConstants.js";
 import { Constants } from "../../src/utils/Constants.js";
 import * as ClientAuthErrorCodes from "../../src/error/ClientAuthErrorCodes.js";
 import { createClientAuthError } from "../../src/error/ClientAuthError.js";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 
 describe("ClientConfiguration.ts Class Unit Tests", () => {
     it("buildConfiguration assigns default functions", async () => {
@@ -124,7 +121,8 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
     const cacheStorageMock = new MockStorageClass(
         TEST_CONFIG.MSAL_CLIENT_ID,
         mockCrypto,
-        new Logger({})
+        new Logger({}),
+        new StubPerformanceClient()
     );
 
     const testNetworkResult = {
@@ -137,48 +135,7 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
             authOptions: {
                 clientId: TEST_CONFIG.MSAL_CLIENT_ID,
             },
-            cryptoInterface: {
-                createNewGuid: (): string => {
-                    return "newGuid";
-                },
-                base64Decode: (input: string): string => {
-                    return "testDecodedString";
-                },
-                base64Encode: (input: string): string => {
-                    return "testEncodedString";
-                },
-                base64UrlEncode(input: string): string {
-                    switch (input) {
-                        case '{"kid": "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc"}':
-                            return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                        default:
-                            return input;
-                    }
-                },
-                encodeKid(input: string): string {
-                    switch (input) {
-                        case "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc":
-                            return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                        default:
-                            return input;
-                    }
-                },
-                async getPublicKeyThumbprint(): Promise<string> {
-                    return TEST_POP_VALUES.KID;
-                },
-                async signJwt(): Promise<string> {
-                    return "signedJwt";
-                },
-                async removeTokenBindingKey(): Promise<boolean> {
-                    return Promise.resolve(true);
-                },
-                async clearKeystore(): Promise<boolean> {
-                    return Promise.resolve(true);
-                },
-                async hashString(): Promise<string> {
-                    return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
-                },
-            },
+            cryptoInterface: mockCrypto,
             storageInterface: cacheStorageMock,
             networkInterface: {
                 sendGetRequestAsync: async (
@@ -219,62 +176,11 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
             },
         });
         await cacheStorageMock.setAccount(MockCache.acc);
-        // Crypto interface tests
         expect(newConfig.cryptoInterface).not.toBeNull();
-        expect(newConfig.cryptoInterface.base64Decode).not.toBeNull();
-        expect(newConfig.cryptoInterface.base64Decode("testString")).toBe(
-            "testDecodedString"
-        );
-        expect(newConfig.cryptoInterface.base64Encode).not.toBeNull();
-        expect(newConfig.cryptoInterface.base64Encode("testString")).toBe(
-            "testEncodedString"
-        );
-        expect(newConfig.cryptoInterface.removeTokenBindingKey).not.toBeNull();
-        expect(
-            newConfig.cryptoInterface.removeTokenBindingKey("testString")
-        ).resolves.toBe(true);
-        // Storage interface tests
         expect(newConfig.storageInterface).not.toBeNull();
-        expect(newConfig.storageInterface.getAccount).not.toBeNull();
-        expect(
-            newConfig.storageInterface.getAccount(
-                MockCache.acc.generateAccountKey()
-            )
-        ).toBe(MockCache.acc);
-        expect(newConfig.storageInterface.getKeys).not.toBeNull();
-        expect(newConfig.storageInterface.getKeys()).toEqual([
-            MockCache.acc.generateAccountKey(),
-            "ACCOUNT_KEYS",
-        ]);
-        expect(newConfig.storageInterface.removeItem).not.toBeNull();
-        expect(newConfig.storageInterface.removeItem).toBe(
-            cacheStorageMock.removeItem
-        );
-        expect(newConfig.storageInterface.setAccount).not.toBeNull();
-        expect(newConfig.storageInterface.setAccount).toBe(
-            cacheStorageMock.setAccount
-        );
-        // Network interface tests
         expect(newConfig.networkInterface).not.toBeNull();
-        expect(newConfig.networkInterface.sendGetRequestAsync).not.toBeNull();
-
-        expect(
-            //@ts-ignore
-            newConfig.networkInterface.sendGetRequestAsync("", null)
-        ).resolves.toBe(testNetworkResult);
-        expect(newConfig.networkInterface.sendPostRequestAsync).not.toBeNull();
-
-        expect(
-            //@ts-ignore
-            newConfig.networkInterface.sendPostRequestAsync("", null)
-        ).resolves.toBe(testNetworkResult);
-        // Logger option tests
         expect(newConfig.loggerOptions).not.toBeNull();
-        expect(newConfig.loggerOptions.loggerCallback).not.toBeNull();
-        expect(newConfig.loggerOptions.piiLoggingEnabled).toBe(true);
-        // Cache options tests
         expect(newConfig.cacheOptions).not.toBeNull();
-        expect(newConfig.cacheOptions.claimsBasedCachingEnabled).toBe(true);
         // Client info tests
         expect(newConfig.libraryInfo.sku).toBe(TEST_CONFIG.TEST_SKU);
         expect(newConfig.libraryInfo.version).toBe(TEST_CONFIG.TEST_VERSION);

--- a/lib/msal-common/test/crypto/PopTokenGenerator.spec.ts
+++ b/lib/msal-common/test/crypto/PopTokenGenerator.spec.ts
@@ -1,10 +1,8 @@
 import {
     RANDOM_TEST_GUID,
     TEST_POP_VALUES,
-    TEST_DATA_CLIENT_INFO,
     TEST_CONFIG,
     TEST_URIS,
-    TEST_CRYPTO_VALUES,
 } from "../test_kit/StringConstants.js";
 import { PopTokenGenerator } from "../../src/crypto/PopTokenGenerator.js";
 import { ICrypto } from "../../src/crypto/ICrypto.js";
@@ -14,78 +12,14 @@ import { UrlString } from "../../src/url/UrlString.js";
 import { AuthenticationScheme } from "../../src/utils/Constants.js";
 import { SignedHttpRequest } from "../../src/crypto/SignedHttpRequest.js";
 import { Logger } from "../../src/logger/Logger.js";
+import { mockCrypto } from "../client/ClientTestUtils.js";
 
 describe("PopTokenGenerator Unit Tests", () => {
     afterEach(() => {
         jest.restoreAllMocks();
     });
 
-    const cryptoInterface: ICrypto = {
-        createNewGuid(): string {
-            return RANDOM_TEST_GUID;
-        },
-        base64Decode(input: string): string {
-            switch (input) {
-                case TEST_POP_VALUES.ENCODED_REQ_CNF:
-                    return TEST_POP_VALUES.DECODED_REQ_CNF;
-                case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
-                    return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
-                case TEST_POP_VALUES.SAMPLE_POP_AT_PAYLOAD_ENCODED:
-                    return TEST_POP_VALUES.SAMPLE_POP_AT_PAYLOAD_DECODED;
-                default:
-                    return input;
-            }
-        },
-        base64Encode(input: string): string {
-            switch (input) {
-                case "123-test-uid":
-                    return "MTIzLXRlc3QtdWlk";
-                case "456-test-uid":
-                    return "NDU2LXRlc3QtdWlk";
-                case TEST_POP_VALUES.DECODED_REQ_CNF:
-                    return TEST_POP_VALUES.ENCODED_REQ_CNF;
-                case TEST_POP_VALUES.SAMPLE_POP_AT_PAYLOAD_DECODED:
-                    return TEST_POP_VALUES.SAMPLE_POP_AT_PAYLOAD_ENCODED;
-                default:
-                    return input;
-            }
-        },
-        base64UrlEncode(input: string): string {
-            switch (input) {
-                case '{"kid": "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc"}':
-                    return "e2tpZDogIlhuc3VBdnR0VFBwMG5uMUtfWU1MZVBMRGJwN3N5Q0toTkh0N0hqWUhKWWMifQ";
-                case '{"kid":"NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs","xms_ksl":"sw"}':
-                    return "eyJraWQiOiJOemJMc1hoOHVEQ2NkLTZNTndYRjRXXzdub1dYRlpBZkhreFpzUkdDOVhzIiwieG1zX2tzbCI6InN3In0";
-                default:
-                    return input;
-            }
-        },
-        encodeKid(input: string): string {
-            switch (input) {
-                case "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc":
-                    return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                case "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs":
-                    return "eyJraWQiOiJOemJMc1hoOHVEQ2NkLTZNTndYRjRXXzdub1dYRlpBZkhreFpzUkdDOVhzIiwieG1zX2tzbCI6InN3In0";
-                default:
-                    return input;
-            }
-        },
-        async getPublicKeyThumbprint(): Promise<string> {
-            return TEST_POP_VALUES.KID;
-        },
-        async signJwt(): Promise<string> {
-            return "";
-        },
-        async removeTokenBindingKey(): Promise<boolean> {
-            return Promise.resolve(true);
-        },
-        async clearKeystore(): Promise<boolean> {
-            return Promise.resolve(true);
-        },
-        async hashString(): Promise<string> {
-            return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
-        },
-    };
+    const cryptoInterface: ICrypto = mockCrypto;
 
     describe("generateCnf", () => {
         const testRequest = {

--- a/lib/msal-common/test/network/ThrottlingUtils.spec.ts
+++ b/lib/msal-common/test/network/ThrottlingUtils.spec.ts
@@ -16,6 +16,9 @@ import {
 } from "../test_kit/StringConstants.js";
 import { ServerError } from "../../src/error/ServerError.js";
 import { BaseAuthRequest, Logger } from "../../src/index.js";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
+
+const performanceClient = new StubPerformanceClient();
 
 describe("ThrottlingUtils", () => {
     afterAll(() => {
@@ -40,7 +43,8 @@ describe("ThrottlingUtils", () => {
             const cache = new MockStorageClass(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 mockCrypto,
-                new Logger({})
+                new Logger({}),
+                performanceClient
             );
             const removeItemStub = jest
                 .spyOn(cache, "removeItem")
@@ -66,7 +70,8 @@ describe("ThrottlingUtils", () => {
             const cache = new MockStorageClass(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 mockCrypto,
-                new Logger({})
+                new Logger({}),
+                performanceClient
             );
             const removeItemStub = jest
                 .spyOn(cache, "removeItem")
@@ -89,7 +94,8 @@ describe("ThrottlingUtils", () => {
             const cache = new MockStorageClass(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 mockCrypto,
-                new Logger({})
+                new Logger({}),
+                performanceClient
             );
             const removeItemStub = jest
                 .spyOn(cache, "removeItem")
@@ -116,7 +122,8 @@ describe("ThrottlingUtils", () => {
             const cache = new MockStorageClass(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 mockCrypto,
-                new Logger({})
+                new Logger({}),
+                performanceClient
             );
             const setItemStub = jest
                 .spyOn(cache, "setThrottlingCache")
@@ -136,7 +143,8 @@ describe("ThrottlingUtils", () => {
             const cache = new MockStorageClass(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 mockCrypto,
-                new Logger({})
+                new Logger({}),
+                performanceClient
             );
             const setItemStub = jest
                 .spyOn(cache, "setThrottlingCache")
@@ -269,7 +277,8 @@ describe("ThrottlingUtils", () => {
             const cache = new MockStorageClass(
                 TEST_CONFIG.MSAL_CLIENT_ID,
                 mockCrypto,
-                new Logger({})
+                new Logger({}),
+                performanceClient
             );
             const clientId = TEST_CONFIG.MSAL_CLIENT_ID;
             const removeItemStub = jest.spyOn(cache, "removeItem");

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -4,9 +4,7 @@ import {
     AUTHENTICATION_RESULT,
     ID_TOKEN_CLAIMS,
     POP_AUTHENTICATION_RESULT,
-    RANDOM_TEST_GUID,
     TEST_CONFIG,
-    TEST_CRYPTO_VALUES,
     TEST_DATA_CLIENT_INFO,
     TEST_POP_VALUES,
     TEST_TOKEN_LIFETIMES,
@@ -19,7 +17,7 @@ import {
     NetworkRequestOptions,
 } from "../../src/network/INetworkModule.js";
 import { ICrypto } from "../../src/crypto/ICrypto.js";
-import { MockStorageClass } from "../client/ClientTestUtils.js";
+import { mockCrypto, MockStorageClass } from "../client/ClientTestUtils.js";
 import { TokenClaims } from "../../src/account/TokenClaims.js";
 import { AccountInfo } from "../../src/account/AccountInfo.js";
 import { AuthenticationResult } from "../../src/response/AuthenticationResult.js";
@@ -46,6 +44,7 @@ import {
 import { CacheManager } from "../../src/cache/CacheManager.js";
 import { cacheQuotaExceededErrorCode } from "../../src/error/CacheErrorCodes.js";
 import { TestTimeUtils } from "msal-test-utils";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 
 const networkInterface: INetworkModule = {
     sendGetRequestAsync<T>(url: string, options?: NetworkRequestOptions): T {
@@ -55,68 +54,8 @@ const networkInterface: INetworkModule = {
         return {} as T;
     },
 };
-const signedJwt =
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJjbmYiOnsia2lkIjoiTnpiTHNYaDh1RENjZC02TU53WEY0V183bm9XWEZaQWZIa3hac1JHQzlYcyJ9fQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
-const cryptoInterface: ICrypto = {
-    createNewGuid(): string {
-        return RANDOM_TEST_GUID;
-    },
-    base64Decode(input: string): string {
-        switch (input) {
-            case TEST_POP_VALUES.ENCODED_REQ_CNF:
-                return TEST_POP_VALUES.DECODED_REQ_CNF;
-            case TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO:
-                return TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO;
-            case TEST_POP_VALUES.SAMPLE_POP_AT_PAYLOAD_ENCODED:
-                return TEST_POP_VALUES.SAMPLE_POP_AT_PAYLOAD_DECODED;
-            default:
-                return input;
-        }
-    },
-    base64Encode(input: string): string {
-        switch (input) {
-            case TEST_POP_VALUES.DECODED_REQ_CNF:
-                return TEST_POP_VALUES.ENCODED_REQ_CNF;
-            case TEST_DATA_CLIENT_INFO.TEST_DECODED_CLIENT_INFO:
-                return TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO;
-            case TEST_POP_VALUES.SAMPLE_POP_AT_PAYLOAD_DECODED:
-                return TEST_POP_VALUES.SAMPLE_POP_AT_PAYLOAD_ENCODED;
-            default:
-                return input;
-        }
-    },
-    base64UrlEncode(input: string): string {
-        switch (input) {
-            case '{"kid": "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc"}':
-                return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-            default:
-                return input;
-        }
-    },
-    encodeKid(input: string): string {
-        switch (input) {
-            case "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc":
-                return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-            default:
-                return input;
-        }
-    },
-    async getPublicKeyThumbprint(): Promise<string> {
-        return TEST_POP_VALUES.KID;
-    },
-    async signJwt(): Promise<string> {
-        return signedJwt;
-    },
-    async removeTokenBindingKey(): Promise<boolean> {
-        return Promise.resolve(true);
-    },
-    async clearKeystore(): Promise<boolean> {
-        return Promise.resolve(true);
-    },
-    async hashString(): Promise<string> {
-        return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
-    },
-};
+
+const cryptoInterface: ICrypto = mockCrypto;
 
 const testServerTokenResponse = {
     headers: null,
@@ -174,7 +113,8 @@ const logger = new Logger(loggerOptions);
 const testCacheManager = new MockStorageClass(
     TEST_CONFIG.MSAL_CLIENT_ID,
     cryptoInterface,
-    logger
+    logger,
+    new StubPerformanceClient()
 );
 
 const testAuthority = new Authority(
@@ -642,7 +582,7 @@ describe("ResponseHandler.ts", () => {
             );
 
             expect(result.tokenType).toBe(AuthenticationScheme.POP);
-            expect(result.accessToken).toBe(signedJwt);
+            expect(result.accessToken).toBe(TEST_TOKENS.POP_TOKEN);
         });
 
         it("Does not sign access token when PoP kid is set and PoP scheme enabled", async () => {

--- a/lib/msal-common/test/telemetry/ServerTelemetryManager.spec.ts
+++ b/lib/msal-common/test/telemetry/ServerTelemetryManager.spec.ts
@@ -11,11 +11,13 @@ import { AuthError } from "../../src/error/AuthError.js";
 import { ServerTelemetryEntity } from "../../src/cache/entities/ServerTelemetryEntity.js";
 import { CacheOutcome } from "../../src/utils/Constants.js";
 import { Logger } from "../../src/logger/Logger.js";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 
 const testCacheManager = new MockStorageClass(
     TEST_CONFIG.MSAL_CLIENT_ID,
     mockCrypto,
-    new Logger({})
+    new Logger({}),
+    new StubPerformanceClient()
 );
 const testApiCode = 9999999;
 const testError = "interaction_required";

--- a/lib/msal-common/test/utils/ProtocolUtils.spec.ts
+++ b/lib/msal-common/test/utils/ProtocolUtils.spec.ts
@@ -1,15 +1,12 @@
 import { ProtocolUtils } from "../../src/utils/ProtocolUtils.js";
-import {
-    RANDOM_TEST_GUID,
-    TEST_CRYPTO_VALUES,
-    TEST_POP_VALUES,
-} from "../test_kit/StringConstants.js";
+import { RANDOM_TEST_GUID } from "../test_kit/StringConstants.js";
 import { ICrypto } from "../../src/crypto/ICrypto.js";
 import { Constants } from "../../src/utils/Constants.js";
 import {
     ClientAuthError,
     ClientAuthErrorMessage,
 } from "../../src/error/ClientAuthError.js";
+import { mockCrypto } from "../client/ClientTestUtils.js";
 
 describe("ProtocolUtils.ts Class Unit Tests", () => {
     const userState = "userState";
@@ -19,62 +16,7 @@ describe("ProtocolUtils.ts Class Unit Tests", () => {
 
     let cryptoInterface: ICrypto;
     beforeEach(() => {
-        cryptoInterface = {
-            createNewGuid(): string {
-                return RANDOM_TEST_GUID;
-            },
-            base64Decode(input: string): string {
-                switch (input) {
-                    case TEST_POP_VALUES.ENCODED_REQ_CNF:
-                        return TEST_POP_VALUES.DECODED_REQ_CNF;
-                    case encodedLibState:
-                        return decodedLibState;
-                    default:
-                        return input;
-                }
-            },
-            base64Encode(input: string): string {
-                switch (input) {
-                    case TEST_POP_VALUES.DECODED_REQ_CNF:
-                        return TEST_POP_VALUES.ENCODED_REQ_CNF;
-                    case `${decodedLibState}`:
-                        return encodedLibState;
-                    default:
-                        return input;
-                }
-            },
-            base64UrlEncode(input: string): string {
-                switch (input) {
-                    case '{"kid": "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc"}':
-                        return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                    default:
-                        return input;
-                }
-            },
-            encodeKid(input: string): string {
-                switch (input) {
-                    case "XnsuAvttTPp0nn1K_YMLePLDbp7syCKhNHt7HjYHJYc":
-                        return "eyJraWQiOiAiWG5zdUF2dHRUUHAwbm4xS19ZTUxlUExEYnA3c3lDS2hOSHQ3SGpZSEpZYyJ9";
-                    default:
-                        return input;
-                }
-            },
-            async getPublicKeyThumbprint(): Promise<string> {
-                return TEST_POP_VALUES.KID;
-            },
-            async signJwt(): Promise<string> {
-                return "";
-            },
-            async removeTokenBindingKey(): Promise<boolean> {
-                return Promise.resolve(true);
-            },
-            async clearKeystore(): Promise<boolean> {
-                return Promise.resolve(true);
-            },
-            async hashString(): Promise<string> {
-                return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
-            },
-        };
+        cryptoInterface = mockCrypto;
     });
 
     afterEach(() => {
@@ -127,7 +69,7 @@ describe("ProtocolUtils.ts Class Unit Tests", () => {
     it("parseRequestState() returns empty userRequestState if no resource delimiter found in state string", () => {
         const requestState = ProtocolUtils.parseRequestState(
             cryptoInterface,
-            decodedLibState
+            cryptoInterface.base64Encode(decodedLibState)
         );
         expect(requestState.userRequestState).toHaveLength(0);
     });

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -230,7 +230,7 @@ export class CryptoProvider implements ICrypto {
     generatePkceCodes(): Promise<PkceCodes>;
     getPublicKeyThumbprint(): Promise<string>;
     hashString(plainText: string): Promise<string>;
-    removeTokenBindingKey(): Promise<boolean>;
+    removeTokenBindingKey(): Promise<void>;
     signJwt(): Promise<string>;
 }
 
@@ -607,7 +607,7 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
     overwriteCache(): Promise<void>;
     // (undocumented)
     readonly persistence: ICachePlugin;
-    removeAccount(account: AccountInfo): Promise<void>;
+    removeAccount(account: AccountInfo, correlationId?: string): Promise<void>;
     serialize(): string;
 }
 

--- a/lib/msal-node/src/cache/NodeStorage.ts
+++ b/lib/msal-node/src/cache/NodeStorage.ts
@@ -29,6 +29,7 @@ import {
     JsonCache,
     CacheKVStore,
 } from "./serializer/SerializerTypes.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * This class implements Storage for node, reading cache from user specified storage location or an  extension library
@@ -46,7 +47,13 @@ export class NodeStorage extends CacheManager {
         cryptoImpl: ICrypto,
         staticAuthorityOptions?: StaticAuthorityOptions
     ) {
-        super(clientId, cryptoImpl, logger, staticAuthorityOptions);
+        super(
+            clientId,
+            cryptoImpl,
+            logger,
+            new StubPerformanceClient(),
+            staticAuthorityOptions
+        );
         this.logger = logger;
     }
 

--- a/lib/msal-node/src/cache/TokenCache.ts
+++ b/lib/msal-node/src/cache/TokenCache.ts
@@ -25,6 +25,7 @@ import {
 import { Deserializer } from "./serializer/Deserializer.js";
 import { Serializer } from "./serializer/Serializer.js";
 import { ITokenCache } from "./ITokenCache.js";
+import { GuidGenerator } from "../crypto/GuidGenerator.js";
 
 const defaultSerializedCache: JsonCache = {
     Account: {},
@@ -191,7 +192,10 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
      * API to remove a specific account and the relevant data from cache
      * @param account - AccountInfo passed by the user
      */
-    async removeAccount(account: AccountInfo): Promise<void> {
+    async removeAccount(
+        account: AccountInfo,
+        correlationId?: string
+    ): Promise<void> {
         this.logger.trace("removeAccount called");
         let cacheContext;
         try {
@@ -199,8 +203,9 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
                 cacheContext = new TokenCacheContext(this, true);
                 await this.persistence.beforeCacheAccess(cacheContext);
             }
-            await this.storage.removeAccount(
-                AccountEntity.generateAccountCacheKey(account)
+            this.storage.removeAccount(
+                AccountEntity.generateAccountCacheKey(account),
+                correlationId || new GuidGenerator().generateGuid()
             );
         } finally {
             if (this.persistence && cacheContext) {

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -291,7 +291,10 @@ export class PublicClientApplication
             await this.nativeBrokerPlugin.signOut(signoutRequest);
         }
 
-        await this.getTokenCache().removeAccount(request.account);
+        await this.getTokenCache().removeAccount(
+            request.account,
+            request.correlationId
+        );
     }
 
     /**

--- a/lib/msal-node/src/crypto/CryptoProvider.ts
+++ b/lib/msal-node/src/crypto/CryptoProvider.ts
@@ -83,7 +83,7 @@ export class CryptoProvider implements ICrypto {
      * Removes cryptographic keypair from key store matching the keyId passed in
      * @param kid - public key id
      */
-    removeTokenBindingKey(): Promise<boolean> {
+    removeTokenBindingKey(): Promise<void> {
         throw new Error("Method not implemented.");
     }
 

--- a/lib/msal-node/test/client/ClientTestUtils.ts
+++ b/lib/msal-node/test/client/ClientTestUtils.ts
@@ -32,6 +32,7 @@ import {
     ClientAssertionConfig,
     PasswordGrantConstants,
     OAuthResponseType,
+    StubPerformanceClient,
 } from "@azure/msal-common";
 import {
     AUTHENTICATION_RESULT,
@@ -77,8 +78,8 @@ export class MockStorageClass extends CacheManager {
         }
     }
 
-    async removeAccount(key: string): Promise<void> {
-        await super.removeAccount(key);
+    removeAccount(key: string): void {
+        super.removeAccount(key, RANDOM_TEST_GUID);
         const currentAccounts = this.getAccountKeys();
         const removalIndex = currentAccounts.indexOf(key);
         if (removalIndex > -1) {
@@ -250,8 +251,8 @@ export const mockCrypto = {
     async getPublicKeyThumbprint(): Promise<string> {
         return TEST_POP_VALUES.KID;
     },
-    async removeTokenBindingKey(): Promise<boolean> {
-        return Promise.resolve(true);
+    async removeTokenBindingKey(): Promise<void> {
+        return Promise.resolve();
     },
     async signJwt(): Promise<string> {
         return "";
@@ -272,7 +273,8 @@ export class ClientTestUtils {
         const mockStorage = new MockStorageClass(
             TEST_CONFIG.MSAL_CLIENT_ID,
             mockCrypto,
-            new Logger({})
+            new Logger({}),
+            new StubPerformanceClient()
         );
 
         const testLoggerCallback = (): void => {

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -81,6 +81,7 @@ import { NodeStorage } from "../../src/cache/NodeStorage.js";
 import { TokenCache } from "../../src/index.js";
 import { buildAccountFromIdTokenClaims } from "msal-test-utils";
 import * as AuthorizeProtocol from "../../src/protocol/Authorize.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 const msalCommon: MSALCommonModule = jest.requireActual(
     "@azure/msal-common/node"
@@ -1051,7 +1052,8 @@ describe("PublicClientApplication", () => {
                     new MockStorageClass(
                         TEST_CONFIG.MSAL_CLIENT_ID,
                         cryptoProvider,
-                        new Logger({})
+                        new Logger({}),
+                        new StubPerformanceClient()
                     ),
                     {
                         protocolMode: ProtocolMode.AAD,

--- a/lib/msal-node/test/utils/TestConstants.ts
+++ b/lib/msal-node/test/utils/TestConstants.ts
@@ -111,7 +111,7 @@ export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
     async getPublicKeyThumbprint(): Promise<string> {
         throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented);
     },
-    async removeTokenBindingKey(): Promise<boolean> {
+    async removeTokenBindingKey(): Promise<void> {
         throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented);
     },
     async clearKeystore(): Promise<boolean> {


### PR DESCRIPTION
Updates the remove access token cache logic to perform its steps synchronously. This is a pre-requisite for additional work to handle cache quota errors in the near future. This requires pushing the POP key removal (which is asynchronous) to the background, we will track failures around this in telemetry instead of throwing an error developers can't resolve anyway.