### PR TITLE
Add support for custom claims and password change required error

### DIFF
--- a/lib/msal-browser/src/custom_auth/CustomAuthActionInputs.ts
+++ b/lib/msal-browser/src/custom_auth/CustomAuthActionInputs.ts
@@ -15,6 +15,7 @@ export type SignInInputs = CustomAuthActionInputs & {
     username: string;
     password?: string;
     scopes?: Array<string>;
+    claimsRequest?: string;
 };
 
 export type SignUpInputs = CustomAuthActionInputs & {
@@ -30,8 +31,10 @@ export type ResetPasswordInputs = CustomAuthActionInputs & {
 export type AccessTokenRetrievalInputs = {
     forceRefresh: boolean;
     scopes?: Array<string>;
+    claimsRequest?: string;
 };
 
 export type SignInWithContinuationTokenInputs = {
     scopes?: Array<string>;
+    claimsRequest?: string;
 };

--- a/lib/msal-browser/src/custom_auth/CustomAuthActionInputs.ts
+++ b/lib/msal-browser/src/custom_auth/CustomAuthActionInputs.ts
@@ -15,7 +15,7 @@ export type SignInInputs = CustomAuthActionInputs & {
     username: string;
     password?: string;
     scopes?: Array<string>;
-    claimsRequest?: string;
+    claims?: string;
 };
 
 export type SignUpInputs = CustomAuthActionInputs & {
@@ -31,10 +31,10 @@ export type ResetPasswordInputs = CustomAuthActionInputs & {
 export type AccessTokenRetrievalInputs = {
     forceRefresh: boolean;
     scopes?: Array<string>;
-    claimsRequest?: string;
+    claims?: string;
 };
 
 export type SignInWithContinuationTokenInputs = {
     scopes?: Array<string>;
-    claimsRequest?: string;
+    claims?: string;
 };

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -231,6 +231,7 @@ export class CustomAuthStandardController
                         username: signInInputs.username,
                         codeLength: startResult.codeLength,
                         scopes: signInInputs.scopes ?? [],
+                        claimsRequest: signInInputs.claimsRequest,
                     })
                 );
             } else if (
@@ -258,6 +259,7 @@ export class CustomAuthStandardController
                             cacheClient: this.cacheClient,
                             username: signInInputs.username,
                             scopes: signInInputs.scopes ?? [],
+                            claimsRequest: signInInputs.claimsRequest,
                         })
                     );
                 }
@@ -277,6 +279,7 @@ export class CustomAuthStandardController
                     continuationToken: startResult.continuationToken,
                     password: signInInputs.password,
                     username: signInInputs.username,
+                    claimsRequest: signInInputs.claimsRequest,
                 };
 
                 const completedResult = await this.signInClient.submitPassword(

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -41,11 +41,7 @@ import { CustomAuthApiClient } from "../core/network_client/custom_auth_api/Cust
 import { FetchHttpClient } from "../core/network_client/http_client/FetchHttpClient.js";
 import { ResetPasswordClient } from "../reset_password/interaction_client/ResetPasswordClient.js";
 import { NoCachedAccountFoundError } from "../core/error/NoCachedAccountFoundError.js";
-import {
-    ensureArgumentIsJSONString,
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-} from "../core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../core/utils/ArgumentValidator.js";
 import { UserAlreadySignedInError } from "../core/error/UserAlreadySignedInError.js";
 import { CustomAuthSilentCacheClient } from "../get_account/interaction_client/CustomAuthSilentCacheClient.js";
 import { UnsupportedEnvironmentError } from "../core/error/UnsupportedEnvironmentError.js";
@@ -178,24 +174,26 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(signInInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "signInInputs",
                 signInInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "signInInputs.username",
                 signInInputs.username,
                 correlationId
             );
             this.ensureUserNotSignedIn(correlationId);
 
-            ensureArgumentIsJSONString(
-                "signInInputs.claims",
-                signInInputs.claims,
-                correlationId
-            );
+            if (signInInputs.claims) {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "signInInputs.claims",
+                    signInInputs.claims,
+                    correlationId
+                );
+            }
 
             // start the signin flow
             const signInStartParams: SignInStartParams = {
@@ -337,13 +335,13 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(signUpInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "signUpInputs",
                 signUpInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "signUpInputs.username",
                 signUpInputs.username,
                 correlationId
@@ -449,13 +447,13 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(resetPasswordInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "resetPasswordInputs",
                 resetPasswordInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "resetPasswordInputs.username",
                 resetPasswordInputs.username,
                 correlationId

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -231,7 +231,7 @@ export class CustomAuthStandardController
                         username: signInInputs.username,
                         codeLength: startResult.codeLength,
                         scopes: signInInputs.scopes ?? [],
-                        claimsRequest: signInInputs.claimsRequest,
+                        claims: signInInputs.claims,
                     })
                 );
             } else if (
@@ -259,7 +259,7 @@ export class CustomAuthStandardController
                             cacheClient: this.cacheClient,
                             username: signInInputs.username,
                             scopes: signInInputs.scopes ?? [],
-                            claimsRequest: signInInputs.claimsRequest,
+                            claims: signInInputs.claims,
                         })
                     );
                 }
@@ -279,7 +279,7 @@ export class CustomAuthStandardController
                     continuationToken: startResult.continuationToken,
                     password: signInInputs.password,
                     username: signInInputs.username,
-                    claimsRequest: signInInputs.claimsRequest,
+                    claims: signInInputs.claims,
                 };
 
                 const completedResult = await this.signInClient.submitPassword(

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -42,6 +42,7 @@ import { FetchHttpClient } from "../core/network_client/http_client/FetchHttpCli
 import { ResetPasswordClient } from "../reset_password/interaction_client/ResetPasswordClient.js";
 import { NoCachedAccountFoundError } from "../core/error/NoCachedAccountFoundError.js";
 import {
+    ensureArgumentIsJSONString,
     ensureArgumentIsNotEmptyString,
     ensureArgumentIsNotNullOrUndefined,
 } from "../core/utils/ArgumentValidator.js";
@@ -189,6 +190,12 @@ export class CustomAuthStandardController
                 correlationId
             );
             this.ensureUserNotSignedIn(correlationId);
+
+            ensureArgumentIsJSONString(
+                "signInInputs.claims",
+                signInInputs.claims,
+                correlationId
+            );
 
             // start the signin flow
             const signInStartParams: SignInStartParams = {

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
@@ -128,6 +128,10 @@ export abstract class AuthFlowErrorBase {
         );
     }
 
+    /**
+     * @todo During getAccesstoken, if user refresh access token by calling /token endpoint, and password change is required
+     * password change required will be ServerError and handled here
+     */
     protected isPasswordResetRequiredError(): boolean {
         return (
             this.errorData instanceof CustomAuthApiError &&

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
@@ -129,8 +129,8 @@ export abstract class AuthFlowErrorBase {
     }
 
     /**
-     * @todo During getAccesstoken, if user refresh access token by calling /token endpoint, and password change is required
-     * password change required will be ServerError and handled here
+     * @todo verify the password change required error can be detected once the MFA is in place.
+     * This error will be raised during signin and refresh tokens when calling /token endpoint.
      */
     protected isPasswordResetRequiredError(): boolean {
         return (

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
@@ -127,6 +127,14 @@ export abstract class AuthFlowErrorBase {
             this.errorData.error === CustomAuthApiErrorCode.EXPIRED_TOKEN
         );
     }
+
+    protected isPasswordResetRequiredError(): boolean {
+        return (
+            this.errorData instanceof CustomAuthApiError &&
+            this.errorData.error === CustomAuthApiErrorCode.INVALID_REQUEST &&
+            this.errorData.errorCodes?.includes(50142) === true
+        );
+    }
 }
 
 export abstract class AuthActionErrorBase extends AuthFlowErrorBase {

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowResultBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowResultBase.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthError, ServerError } from "@azure/msal-common/browser";
+import { AuthError } from "@azure/msal-common/browser";
 import { CustomAuthError } from "../error/CustomAuthError.js";
 import { MsalCustomAuthError } from "../error/MsalCustomAuthError.js";
 import { UnexpectedError } from "../error/UnexpectedError.js";
@@ -42,8 +42,10 @@ export abstract class AuthFlowResultBase<
         if (error instanceof CustomAuthError) {
             return error;
         } else if (error instanceof AuthError) {
-            // during getAccesstoken, if user refresh access token by calling /token endpoint, and password change is required
-            // password change required will be ServerError and handled here
+            /*
+             * During getAccesstoken, if user refresh access token by calling /token endpoint, and password change is required
+             * password change required will be ServerError and handled here
+             */
             return new MsalCustomAuthError(
                 error.errorCode,
                 error.errorMessage,

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowResultBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowResultBase.ts
@@ -42,10 +42,6 @@ export abstract class AuthFlowResultBase<
         if (error instanceof CustomAuthError) {
             return error;
         } else if (error instanceof AuthError) {
-            /*
-             * During getAccesstoken, if user refresh access token by calling /token endpoint, and password change is required
-             * password change required will be ServerError and handled here
-             */
             return new MsalCustomAuthError(
                 error.errorCode,
                 error.errorMessage,

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowResultBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowResultBase.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AuthError } from "@azure/msal-common/browser";
+import { AuthError, ServerError } from "@azure/msal-common/browser";
 import { CustomAuthError } from "../error/CustomAuthError.js";
 import { MsalCustomAuthError } from "../error/MsalCustomAuthError.js";
 import { UnexpectedError } from "../error/UnexpectedError.js";
@@ -42,6 +42,8 @@ export abstract class AuthFlowResultBase<
         if (error instanceof CustomAuthError) {
             return error;
         } else if (error instanceof AuthError) {
+            // during getAccesstoken, if user refresh access token by calling /token endpoint, and password change is required
+            // password change required will be ServerError and handled here
             return new MsalCustomAuthError(
                 error.errorCode,
                 error.errorMessage,

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
@@ -90,6 +90,7 @@ export class SignInApiClient extends BaseApiClient {
                 grant_type: GrantType.PASSWORD,
                 scope: params.scope,
                 password: params.password,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId
@@ -105,6 +106,7 @@ export class SignInApiClient extends BaseApiClient {
                 scope: params.scope,
                 oob: params.oob,
                 grant_type: GrantType.OOB,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId
@@ -121,6 +123,7 @@ export class SignInApiClient extends BaseApiClient {
                 scope: params.scope,
                 grant_type: GrantType.CONTINUATION_TOKEN,
                 client_info: true,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/types/ApiRequestTypes.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/types/ApiRequestTypes.ts
@@ -19,6 +19,7 @@ export interface SignInChallengeRequest extends ApiRequestBase {
 interface SignInTokenRequestBase extends ApiRequestBase {
     continuation_token: string;
     scope: string;
+    claims?: string;
 }
 
 export interface SignInPasswordTokenRequest extends SignInTokenRequestBase {

--- a/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
+++ b/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
@@ -27,14 +27,19 @@ export function ensureArgumentIsNotEmptyString(
 
 export function ensureArgumentIsJSONString(
     argName: string,
-    argValue: string | undefined,
+    argValue: string,
     correlationId?: string
 ): void {
-    if (argValue !== undefined) {
-        try {
-            JSON.parse(argValue);
-        } catch (e) {
+    try {
+        const parsed = JSON.parse(argValue);
+        if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            Array.isArray(parsed)
+        ) {
             throw new InvalidArgumentError(argName, correlationId);
         }
+    } catch (e) {
+        throw new InvalidArgumentError(argName, correlationId);
     }
 }

--- a/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
+++ b/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
@@ -24,3 +24,17 @@ export function ensureArgumentIsNotEmptyString(
         throw new InvalidArgumentError(argName, correlationId);
     }
 }
+
+export function ensureArgumentIsJSONString(
+    argName: string,
+    argValue: string | undefined,
+    correlationId?: string
+): void {
+    if (argValue !== undefined) {
+        try {
+            JSON.parse(argValue);
+        } catch (e) {
+            throw new InvalidArgumentError(argName, correlationId);
+        }
+    }
+}

--- a/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
@@ -19,6 +19,7 @@ import {
 } from "@azure/msal-common/browser";
 import { SilentRequest } from "../../../request/SilentRequest.js";
 import {
+    ensureArgumentIsJSONString,
     ensureArgumentIsNotEmptyString,
     ensureArgumentIsNotNullOrUndefined,
 } from "../../core/utils/ArgumentValidator.js";
@@ -110,6 +111,12 @@ export class CustomAuthAccountData {
             ensureArgumentIsNotNullOrUndefined(
                 "accessTokenRetrievalInputs",
                 accessTokenRetrievalInputs,
+                this.correlationId
+            );
+
+            ensureArgumentIsJSONString(
+                "accessTokenRetrievalInputs.claims",
+                accessTokenRetrievalInputs.claims,
                 this.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
@@ -133,7 +133,8 @@ export class CustomAuthAccountData {
             const commonSilentFlowRequest = this.createCommonSilentFlowRequest(
                 currentAccount,
                 accessTokenRetrievalInputs.forceRefresh,
-                newScopes
+                newScopes,
+                accessTokenRetrievalInputs.claimsRequest
             );
             const result = await this.cacheClient.acquireToken(
                 commonSilentFlowRequest
@@ -158,7 +159,8 @@ export class CustomAuthAccountData {
     private createCommonSilentFlowRequest(
         accountInfo: AccountInfo,
         forceRefresh: boolean = false,
-        requestScopes: Array<string>
+        requestScopes: Array<string>,
+        claimsRequest?: string
     ): CommonSilentFlowRequest {
         const silentRequest: SilentRequest = {
             authority: this.config.auth.authority,
@@ -171,6 +173,7 @@ export class CustomAuthAccountData {
                 accessToken: true,
                 refreshToken: true,
             },
+            ...(claimsRequest && { claims: claimsRequest }),
         };
 
         return {

--- a/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
@@ -18,11 +18,7 @@ import {
     TokenClaims,
 } from "@azure/msal-common/browser";
 import { SilentRequest } from "../../../request/SilentRequest.js";
-import {
-    ensureArgumentIsJSONString,
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-} from "../../core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../../core/utils/ArgumentValidator.js";
 
 /*
  * Account information.
@@ -35,8 +31,15 @@ export class CustomAuthAccountData {
         private readonly logger: Logger,
         private readonly correlationId: string
     ) {
-        ensureArgumentIsNotEmptyString("correlationId", correlationId);
-        ensureArgumentIsNotNullOrUndefined("account", account, correlationId);
+        ArgumentValidator.ensureArgumentIsNotEmptyString(
+            "correlationId",
+            correlationId
+        );
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+            "account",
+            account,
+            correlationId
+        );
     }
 
     /**
@@ -108,17 +111,19 @@ export class CustomAuthAccountData {
         accessTokenRetrievalInputs: AccessTokenRetrievalInputs
     ): Promise<GetAccessTokenResult> {
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "accessTokenRetrievalInputs",
                 accessTokenRetrievalInputs,
                 this.correlationId
             );
 
-            ensureArgumentIsJSONString(
-                "accessTokenRetrievalInputs.claims",
-                accessTokenRetrievalInputs.claims,
-                this.correlationId
-            );
+            if (accessTokenRetrievalInputs.claims) {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "accessTokenRetrievalInputs.claims",
+                    accessTokenRetrievalInputs.claims,
+                    this.correlationId
+                );
+            }
 
             this.logger.verbose("Getting current account.", this.correlationId);
 

--- a/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
@@ -134,7 +134,7 @@ export class CustomAuthAccountData {
                 currentAccount,
                 accessTokenRetrievalInputs.forceRefresh,
                 newScopes,
-                accessTokenRetrievalInputs.claimsRequest
+                accessTokenRetrievalInputs.claims
             );
             const result = await this.cacheClient.acquireToken(
                 commonSilentFlowRequest
@@ -160,7 +160,7 @@ export class CustomAuthAccountData {
         accountInfo: AccountInfo,
         forceRefresh: boolean = false,
         requestScopes: Array<string>,
-        claimsRequest?: string
+        claims?: string
     ): CommonSilentFlowRequest {
         const silentRequest: SilentRequest = {
             authority: this.config.auth.authority,
@@ -173,7 +173,7 @@ export class CustomAuthAccountData {
                 accessToken: true,
                 refreshToken: true,
             },
-            ...(claimsRequest && { claims: claimsRequest }),
+            ...(claims && { claims: claims }),
         };
 
         return {

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/error_type/SignInError.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/error_type/SignInError.ts
@@ -32,6 +32,14 @@ export class SignInError extends AuthActionErrorBase {
     }
 
     /**
+     * Checks if the error is due to password reset being required.
+     * @returns true if the error is due to password reset being required, false otherwise.
+     */
+    isPasswordResetRequired(): boolean {
+        return this.isPasswordResetRequiredError();
+    }
+
+    /**
      * Checks if the error is due to the provided challenge type is not supported.
      * @returns {boolean} True if the error is due to the provided challenge type is not supported, false otherwise.
      */

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
@@ -37,7 +37,7 @@ export class SignInCodeRequiredState extends SignInState<SignInCodeRequiredState
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 code: code,
                 username: this.stateParameters.username,
-                claimsRequest: this.stateParameters.claimsRequest,
+                claims: this.stateParameters.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
@@ -37,6 +37,7 @@ export class SignInCodeRequiredState extends SignInState<SignInCodeRequiredState
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 code: code,
                 username: this.stateParameters.username,
+                claimsRequest: this.stateParameters.claimsRequest,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
@@ -33,6 +33,7 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 username: this.stateParameters.username,
                 signInScenario: this.stateParameters.signInScenario,
+                claimsRequest: signInWithContinuationTokenInputs?.claimsRequest,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
@@ -10,7 +10,7 @@ import { SignInWithContinuationTokenInputs } from "../../../CustomAuthActionInpu
 import { SignInContinuationStateParameters } from "./SignInStateParameters.js";
 import { SignInState } from "./SignInState.js";
 import { SignInCompletedState } from "./SignInCompletedState.js";
-import { ensureArgumentIsJSONString } from "../../../core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../../../core/utils/ArgumentValidator.js";
 
 /*
  * Sign-in continuation state.
@@ -26,7 +26,7 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
     ): Promise<SignInResult> {
         try {
             if (signInWithContinuationTokenInputs?.claims) {
-                ensureArgumentIsJSONString(
+                ArgumentValidator.ensureArgumentIsJSONString(
                     "signInWithContinuationTokenInputs.claims",
                     signInWithContinuationTokenInputs.claims,
                     this.stateParameters.correlationId

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
@@ -33,7 +33,7 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 username: this.stateParameters.username,
                 signInScenario: this.stateParameters.signInScenario,
-                claimsRequest: signInWithContinuationTokenInputs?.claimsRequest,
+                claims: signInWithContinuationTokenInputs?.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
@@ -10,6 +10,7 @@ import { SignInWithContinuationTokenInputs } from "../../../CustomAuthActionInpu
 import { SignInContinuationStateParameters } from "./SignInStateParameters.js";
 import { SignInState } from "./SignInState.js";
 import { SignInCompletedState } from "./SignInCompletedState.js";
+import { ensureArgumentIsJSONString } from "../../../core/utils/ArgumentValidator.js";
 
 /*
  * Sign-in continuation state.
@@ -24,6 +25,14 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
         signInWithContinuationTokenInputs?: SignInWithContinuationTokenInputs
     ): Promise<SignInResult> {
         try {
+            if (signInWithContinuationTokenInputs?.claims) {
+                ensureArgumentIsJSONString(
+                    "signInWithContinuationTokenInputs.claims",
+                    signInWithContinuationTokenInputs.claims,
+                    this.stateParameters.correlationId
+                );
+            }
+
             const continuationTokenParams: SignInContinuationTokenParams = {
                 clientId: this.stateParameters.config.auth.clientId,
                 correlationId: this.stateParameters.correlationId,

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
@@ -34,7 +34,7 @@ export class SignInPasswordRequiredState extends SignInState<SignInPasswordRequi
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 password: password,
                 username: this.stateParameters.username,
-                claimsRequest: this.stateParameters.claimsRequest,
+                claims: this.stateParameters.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
@@ -34,6 +34,7 @@ export class SignInPasswordRequiredState extends SignInState<SignInPasswordRequi
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 password: password,
                 username: this.stateParameters.username,
+                claimsRequest: this.stateParameters.claimsRequest,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInStateParameters.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInStateParameters.ts
@@ -13,7 +13,7 @@ export interface SignInStateParameters
     username: string;
     signInClient: SignInClient;
     cacheClient: CustomAuthSilentCacheClient;
-    claimsRequest?: string;
+    claims?: string;
 }
 
 export interface SignInPasswordRequiredStateParameters

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInStateParameters.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInStateParameters.ts
@@ -13,6 +13,7 @@ export interface SignInStateParameters
     username: string;
     signInClient: SignInClient;
     cacheClient: CustomAuthSilentCacheClient;
+    claimsRequest?: string;
 }
 
 export interface SignInPasswordRequiredStateParameters

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
@@ -195,8 +195,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             scope: scopes.join(" "),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
-            ...(parameters.claimsRequest && {
-                claims: parameters.claimsRequest,
+            ...(parameters.claims && {
+                claims: parameters.claims,
             }),
         };
 
@@ -233,8 +233,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             scope: scopes.join(" "),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
-            ...(parameters.claimsRequest && {
-                claims: parameters.claimsRequest,
+            ...(parameters.claims && {
+                claims: parameters.claims,
             }),
         };
 
@@ -269,8 +269,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
             scope: scopes.join(" "),
-            ...(parameters.claimsRequest && {
-                claims: parameters.claimsRequest,
+            ...(parameters.claims && {
+                claims: parameters.claims,
             }),
         };
 

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
@@ -195,6 +195,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             scope: scopes.join(" "),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
+            ...(parameters.claimsRequest && {
+                claims: parameters.claimsRequest,
+            }),
         };
 
         return this.performTokenRequest(
@@ -230,6 +233,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             scope: scopes.join(" "),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
+            ...(parameters.claimsRequest && {
+                claims: parameters.claimsRequest,
+            }),
         };
 
         return this.performTokenRequest(
@@ -263,6 +269,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
             scope: scopes.join(" "),
+            ...(parameters.claimsRequest && {
+                claims: parameters.claimsRequest,
+            }),
         };
 
         // Call token endpoint.

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/parameter/SignInParams.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/parameter/SignInParams.ts
@@ -24,19 +24,19 @@ export interface SignInSubmitCodeParams extends SignInParamsBase {
     continuationToken: string;
     code: string;
     scopes: Array<string>;
-    claimsRequest?: string;
+    claims?: string;
 }
 
 export interface SignInSubmitPasswordParams extends SignInParamsBase {
     continuationToken: string;
     password: string;
     scopes: Array<string>;
-    claimsRequest?: string;
+    claims?: string;
 }
 
 export interface SignInContinuationTokenParams extends SignInParamsBase {
     continuationToken: string;
     signInScenario: SignInScenarioType;
     scopes: Array<string>;
-    claimsRequest?: string;
+    claims?: string;
 }

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/parameter/SignInParams.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/parameter/SignInParams.ts
@@ -24,16 +24,19 @@ export interface SignInSubmitCodeParams extends SignInParamsBase {
     continuationToken: string;
     code: string;
     scopes: Array<string>;
+    claimsRequest?: string;
 }
 
 export interface SignInSubmitPasswordParams extends SignInParamsBase {
     continuationToken: string;
     password: string;
     scopes: Array<string>;
+    claimsRequest?: string;
 }
 
 export interface SignInContinuationTokenParams extends SignInParamsBase {
     continuationToken: string;
     signInScenario: SignInScenarioType;
     scopes: Array<string>;
+    claimsRequest?: string;
 }

--- a/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
@@ -2,6 +2,7 @@ import { InvalidArgumentError } from "../../../../src/custom_auth/core/error/Inv
 import {
     ensureArgumentIsNotEmptyString,
     ensureArgumentIsNotNullOrUndefined,
+    ensureArgumentIsJSONString,
 } from "../../../../src/custom_auth/core/utils/ArgumentValidator.js";
 
 describe("ArgumentValidator", () => {
@@ -80,6 +81,149 @@ describe("ArgumentValidator", () => {
                     throw error;
                 }
             }
+        });
+    });
+
+    describe("ensureArgumentIsJSONString", () => {
+        it("should not throw an error when argValue is undefined", () => {
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", undefined);
+            }).not.toThrow();
+        });
+
+        it("should not throw an error when argValue is a valid JSON string", () => {
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", '{"key": "value"}');
+            }).not.toThrow();
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "[]");
+            }).not.toThrow();
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", '"string"');
+            }).not.toThrow();
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", '""'); // JSON string (empty string value)
+            }).not.toThrow();
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "123");
+            }).not.toThrow();
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "true");
+            }).not.toThrow();
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "null");
+            }).not.toThrow();
+        });
+
+        it("should not throw an error when argValue is a valid JSON string with whitespace", () => {
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", '  {"key": "value"}  ');
+            }).not.toThrow();
+        });
+
+        it("should throw InvalidArgumentError when argValue is an empty string", () => {
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "");
+            }).toThrow(InvalidArgumentError);
+        });
+
+        it("should throw InvalidArgumentError when argValue is only whitespace", () => {
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "   ");
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "\t\n ");
+            }).toThrow(InvalidArgumentError);
+        });
+
+        it("should throw InvalidArgumentError when argValue is not valid JSON", () => {
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "invalid json");
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", '{"key": value}'); // missing quotes around value
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", '{key: "value"}'); // missing quotes around key
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", '{"key": "value",}'); // trailing comma
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", "undefined");
+            }).toThrow(InvalidArgumentError);
+        });
+
+        it("should pass correlationId to the error when argValue is empty", () => {
+            const correlationId = "test-correlation-id";
+            try {
+                ensureArgumentIsJSONString("testArg", "", correlationId);
+            } catch (error) {
+                if (error instanceof InvalidArgumentError) {
+                    expect(error.correlationId).toBe(correlationId);
+                } else {
+                    throw error;
+                }
+            }
+        });
+
+        it("should pass correlationId to the error when argValue is invalid JSON", () => {
+            const correlationId = "test-correlation-id";
+            try {
+                ensureArgumentIsJSONString(
+                    "testArg",
+                    "invalid json",
+                    correlationId
+                );
+            } catch (error) {
+                if (error instanceof InvalidArgumentError) {
+                    expect(error.correlationId).toBe(correlationId);
+                } else {
+                    throw error;
+                }
+            }
+        });
+
+        it("should handle complex valid JSON structures", () => {
+            const complexJson = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+                id_token: {
+                    auth_time: {
+                        essential: true,
+                    },
+                },
+            });
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", complexJson);
+            }).not.toThrow();
+        });
+
+        it("should handle arrays as valid JSON", () => {
+            const arrayJson = JSON.stringify([
+                { name: "item1", value: 1 },
+                { name: "item2", value: 2 },
+            ]);
+
+            expect(() => {
+                ensureArgumentIsJSONString("testArg", arrayJson);
+            }).not.toThrow();
         });
     });
 });

--- a/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
@@ -1,34 +1,30 @@
 import { InvalidArgumentError } from "../../../../src/custom_auth/core/error/InvalidArgumentError.js";
-import {
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-    ensureArgumentIsJSONString,
-} from "../../../../src/custom_auth/core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../../../../src/custom_auth/core/utils/ArgumentValidator.js";
 
 describe("ArgumentValidator", () => {
     describe("ensureArgumentIsNotEmptyString", () => {
         it("should not throw an error if the string is non-empty", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "validString");
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "validString");
             }).not.toThrow();
         });
 
         it("should throw InvalidArgumentError if the string is empty", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "");
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "");
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError if the string is only whitespace", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "   ");
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "   ");
             }).toThrow(InvalidArgumentError);
         });
 
         it("should pass correlationId to the error when the string is invalid", () => {
             const correlationId = "12345";
             try {
-                ensureArgumentIsNotEmptyString("testArg", "", correlationId);
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "", correlationId);
             } catch (error) {
                 if (error instanceof InvalidArgumentError) {
                     expect(error.correlationId).toBe(correlationId);
@@ -42,34 +38,34 @@ describe("ArgumentValidator", () => {
     describe("ensureArgumentIsNotNullOrUndefined", () => {
         it("should not throw an error if the argument is not null or undefined", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", "validValue");
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", "validValue");
             }).not.toThrow();
 
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", 42);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", 42);
             }).not.toThrow();
 
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", {});
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", {});
             }).not.toThrow();
         });
 
         it("should throw InvalidArgumentError if the argument is null", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", null);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", null);
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError if the argument is undefined", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", undefined);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", undefined);
             }).toThrow(InvalidArgumentError);
         });
 
         it("should pass correlationId to the error when the argument is invalid", () => {
             const correlationId = "12345";
             try {
-                ensureArgumentIsNotNullOrUndefined(
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                     "testArg",
                     null,
                     correlationId
@@ -85,103 +81,86 @@ describe("ArgumentValidator", () => {
     });
 
     describe("ensureArgumentIsJSONString", () => {
-        it("should not throw an error when argValue is undefined", () => {
+        it("should not throw an error when argValue is a valid JSON object string", () => {
             expect(() => {
-                ensureArgumentIsJSONString("testArg", undefined);
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": "value"}');
+            }).not.toThrow();
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "{}"); // Empty object
             }).not.toThrow();
         });
 
-        it("should not throw an error when argValue is a valid JSON string", () => {
+        it("should not throw an error when argValue is a valid JSON object string with whitespace", () => {
             expect(() => {
-                ensureArgumentIsJSONString("testArg", '{"key": "value"}');
-            }).not.toThrow();
-
-            expect(() => {
-                ensureArgumentIsJSONString("testArg", "[]");
-            }).not.toThrow();
-
-            expect(() => {
-                ensureArgumentIsJSONString("testArg", '"string"');
-            }).not.toThrow();
-
-            expect(() => {
-                ensureArgumentIsJSONString("testArg", '""'); // JSON string (empty string value)
-            }).not.toThrow();
-
-            expect(() => {
-                ensureArgumentIsJSONString("testArg", "123");
-            }).not.toThrow();
-
-            expect(() => {
-                ensureArgumentIsJSONString("testArg", "true");
-            }).not.toThrow();
-
-            expect(() => {
-                ensureArgumentIsJSONString("testArg", "null");
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '  {"key": "value"}  ');
             }).not.toThrow();
         });
 
-        it("should not throw an error when argValue is a valid JSON string with whitespace", () => {
+        it("should throw InvalidArgumentError when argValue is not a JSON object", () => {
             expect(() => {
-                ensureArgumentIsJSONString("testArg", '  {"key": "value"}  ');
-            }).not.toThrow();
-        });
-
-        it("should throw InvalidArgumentError when argValue is an empty string", () => {
-            expect(() => {
-                ensureArgumentIsJSONString("testArg", "");
-            }).toThrow(InvalidArgumentError);
-        });
-
-        it("should throw InvalidArgumentError when argValue is only whitespace", () => {
-            expect(() => {
-                ensureArgumentIsJSONString("testArg", "   ");
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "[]"); // Array - not an object
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ensureArgumentIsJSONString("testArg", "\t\n ");
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '"string"'); // String - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '""'); // Empty string - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "123"); // Number - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "true"); // Boolean - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "null"); // Null - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", ""); // Empty string - not valid JSON
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "   "); // Whitespace only - not valid JSON
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "\t\n "); // Whitespace only - not valid JSON
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError when argValue is not valid JSON", () => {
             expect(() => {
-                ensureArgumentIsJSONString("testArg", "invalid json");
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "invalid json");
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ensureArgumentIsJSONString("testArg", '{"key": value}'); // missing quotes around value
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": value}'); // missing quotes around value
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ensureArgumentIsJSONString("testArg", '{key: "value"}'); // missing quotes around key
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{key: "value"}'); // missing quotes around key
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ensureArgumentIsJSONString("testArg", '{"key": "value",}'); // trailing comma
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": "value",}'); // trailing comma
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ensureArgumentIsJSONString("testArg", "undefined");
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "undefined");
             }).toThrow(InvalidArgumentError);
-        });
-
-        it("should pass correlationId to the error when argValue is empty", () => {
-            const correlationId = "test-correlation-id";
-            try {
-                ensureArgumentIsJSONString("testArg", "", correlationId);
-            } catch (error) {
-                if (error instanceof InvalidArgumentError) {
-                    expect(error.correlationId).toBe(correlationId);
-                } else {
-                    throw error;
-                }
-            }
         });
 
         it("should pass correlationId to the error when argValue is invalid JSON", () => {
             const correlationId = "test-correlation-id";
             try {
-                ensureArgumentIsJSONString(
+                ArgumentValidator.ensureArgumentIsJSONString(
                     "testArg",
                     "invalid json",
                     correlationId
@@ -211,19 +190,19 @@ describe("ArgumentValidator", () => {
             });
 
             expect(() => {
-                ensureArgumentIsJSONString("testArg", complexJson);
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", complexJson);
             }).not.toThrow();
         });
 
-        it("should handle arrays as valid JSON", () => {
+        it("should handle arrays as invalid (not JSON objects)", () => {
             const arrayJson = JSON.stringify([
                 { name: "item1", value: 1 },
                 { name: "item2", value: 2 },
             ]);
 
             expect(() => {
-                ensureArgumentIsJSONString("testArg", arrayJson);
-            }).not.toThrow();
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", arrayJson);
+            }).toThrow(InvalidArgumentError);
         });
     });
 });

--- a/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
@@ -14,6 +14,7 @@ import {
 import { AuthenticationResult } from "../../../../src/response/AuthenticationResult.js";
 import { ServerError } from "@azure/msal-common";
 import { INVALID_REQUEST } from "../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
+import { AccessTokenRetrievalInputs } from "../../../../src/custom_auth/CustomAuthActionInputs.js";
 
 describe("CustomAuthAccountData", () => {
     let mockAccount: AccountInfo;
@@ -189,23 +190,23 @@ describe("CustomAuthAccountData", () => {
     });
 
     describe("getAccessToken", () => {
-        it("should return succeed GetAccessTokenState.Completed with cached tokens", async () => {
+        let accountData: CustomAuthAccountData;
+        beforeEach(() => {
             (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
                 mockAccount
             );
-            jest.spyOn(
-                CustomAuthAccountData.prototype as any,
-                "createCommonSilentFlowRequest"
-            ).mockReturnValue({});
-            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
-                mockAuthenticationResult
-            );
-            const accountData = new CustomAuthAccountData(
+            accountData = new CustomAuthAccountData(
                 mockAccount,
                 mockConfig,
                 mockCacheClient,
                 mockLogger,
                 correlationId
+            );
+        });
+
+        it("should return succeed GetAccessTokenState.Completed with cached tokens", async () => {
+            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
+                mockAuthenticationResult
             );
 
             const response = await accountData.getAccessToken({
@@ -221,9 +222,6 @@ describe("CustomAuthAccountData", () => {
         });
 
         it("should return GetAccessTokenError if there is an error when aquire tokens", async () => {
-            (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
-                mockAccount
-            );
             const errorCode =
                 InteractionRequiredAuthErrorCodes.refreshTokenExpired;
             const errorMessage = "Refresh token has expired.";
@@ -237,14 +235,6 @@ describe("CustomAuthAccountData", () => {
                 );
             (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(
                 mockRefreshTokenExpiredError
-            );
-
-            const accountData = new CustomAuthAccountData(
-                mockAccount,
-                mockConfig,
-                mockCacheClient,
-                mockLogger,
-                correlationId
             );
 
             const response = await accountData.getAccessToken({
@@ -266,48 +256,84 @@ describe("CustomAuthAccountData", () => {
             expect(msalError.subError).toEqual(subError);
         });
 
-        describe("password reset required error handling", () => {
-            it("should wrap AADSTS50142 error with MsalCustomAuthError for password reset required", async () => {
-                (
-                    mockCacheClient.getCurrentAccount as jest.Mock
-                ).mockReturnValue(mockAccount);
+        it("should include claims in getAccessToken when provided", async () => {
+            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
+                mockAuthenticationResult
+            );
 
-                const errorCode = INVALID_REQUEST;
-                const errorMessage = "50142";
-                const mockMSALServerError = new ServerError(
-                    errorCode,
-                    errorMessage,
-                    "",
-                    "50142"
-                );
-                (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(
-                    mockMSALServerError
-                );
-
-                const accountData = new CustomAuthAccountData(
-                    mockAccount,
-                    mockConfig,
-                    mockCacheClient,
-                    mockLogger,
-                    correlationId
-                );
-
-                const response = await accountData.getAccessToken({
-                    forceRefresh: false,
-                });
-
-                expect(response).toBeDefined();
-                expect(response.isFailed()).toBe(true);
-                expect(response.error?.errorData).toEqual(mockMSALServerError);
-                expect(response.error?.errorData).toBeInstanceOf(
-                    MsalCustomAuthError
-                );
-
-                const msalError = response.error
-                    ?.errorData as MsalCustomAuthError;
-                expect(msalError.error).toEqual(errorCode);
-                expect(msalError.errorDescription).toEqual(errorMessage);
+            const claimsRequest = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
             });
+
+            const accessTokenRetrievalInputs: AccessTokenRetrievalInputs = {
+                forceRefresh: false,
+                scopes: ["test-scope"],
+                claimsRequest: claimsRequest,
+            };
+            const response = await accountData.getAccessToken(
+                accessTokenRetrievalInputs
+            );
+
+            expect(response).toBeDefined();
+            expect(response.isCompleted()).toBe(true);
+            expect(response.data?.account).toEqual(mockAccount);
+            expect(response.data?.idToken).toEqual(
+                mockAuthenticationResult.idToken
+            );
+
+            expect(mockCacheClient.acquireToken).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claimsRequest,
+                })
+            );
+        });
+    });
+
+    describe("password reset required error handling", () => {
+        it("should wrap AADSTS50142 error with MsalCustomAuthError for password reset required", async () => {
+            (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
+                mockAccount
+            );
+
+            const errorCode = INVALID_REQUEST;
+            const errorMessage = "50142";
+            const mockMSALServerError = new ServerError(
+                errorCode,
+                errorMessage,
+                "",
+                "50142"
+            );
+            (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(
+                mockMSALServerError
+            );
+
+            const accountData = new CustomAuthAccountData(
+                mockAccount,
+                mockConfig,
+                mockCacheClient,
+                mockLogger,
+                correlationId
+            );
+
+            const response = await accountData.getAccessToken({
+                forceRefresh: false,
+            });
+
+            expect(response).toBeDefined();
+            expect(response.isFailed()).toBe(true);
+            expect(response.error?.errorData).toEqual(mockMSALServerError);
+            expect(response.error?.errorData).toBeInstanceOf(
+                MsalCustomAuthError
+            );
+
+            const msalError = response.error?.errorData as MsalCustomAuthError;
+            expect(msalError.error).toEqual(errorCode);
+            expect(msalError.errorDescription).toEqual(errorMessage);
         });
     });
 });

--- a/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
@@ -261,7 +261,7 @@ describe("CustomAuthAccountData", () => {
                 mockAuthenticationResult
             );
 
-            const claimsRequest = JSON.stringify({
+            const claims = JSON.stringify({
                 access_token: {
                     acrs: {
                         essential: true,
@@ -273,7 +273,7 @@ describe("CustomAuthAccountData", () => {
             const accessTokenRetrievalInputs: AccessTokenRetrievalInputs = {
                 forceRefresh: false,
                 scopes: ["test-scope"],
-                claimsRequest: claimsRequest,
+                claims: claims,
             };
             const response = await accountData.getAccessToken(
                 accessTokenRetrievalInputs
@@ -288,7 +288,7 @@ describe("CustomAuthAccountData", () => {
 
             expect(mockCacheClient.acquireToken).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    claims: claimsRequest,
+                    claims: claims,
                 })
             );
         });

--- a/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
@@ -12,6 +12,8 @@ import {
     Logger,
 } from "@azure/msal-common/browser";
 import { AuthenticationResult } from "../../../../src/response/AuthenticationResult.js";
+import { ServerError } from "@azure/msal-common";
+import { INVALID_REQUEST } from "../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
 
 describe("CustomAuthAccountData", () => {
     let mockAccount: AccountInfo;
@@ -262,6 +264,50 @@ describe("CustomAuthAccountData", () => {
             expect(msalError.error).toEqual(errorCode);
             expect(msalError.errorDescription).toEqual(errorMessage);
             expect(msalError.subError).toEqual(subError);
+        });
+
+        describe("password reset required error handling", () => {
+            it("should wrap AADSTS50142 error with MsalCustomAuthError for password reset required", async () => {
+                (
+                    mockCacheClient.getCurrentAccount as jest.Mock
+                ).mockReturnValue(mockAccount);
+
+                const errorCode = INVALID_REQUEST;
+                const errorMessage = "50142";
+                const mockMSALServerError = new ServerError(
+                    errorCode,
+                    errorMessage,
+                    "",
+                    "50142"
+                );
+                (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(
+                    mockMSALServerError
+                );
+
+                const accountData = new CustomAuthAccountData(
+                    mockAccount,
+                    mockConfig,
+                    mockCacheClient,
+                    mockLogger,
+                    correlationId
+                );
+
+                const response = await accountData.getAccessToken({
+                    forceRefresh: false,
+                });
+
+                expect(response).toBeDefined();
+                expect(response.isFailed()).toBe(true);
+                expect(response.error?.errorData).toEqual(mockMSALServerError);
+                expect(response.error?.errorData).toBeInstanceOf(
+                    MsalCustomAuthError
+                );
+
+                const msalError = response.error
+                    ?.errorData as MsalCustomAuthError;
+                expect(msalError.error).toEqual(errorCode);
+                expect(msalError.errorDescription).toEqual(errorMessage);
+            });
         });
     });
 });

--- a/lib/msal-browser/test/custom_auth/integration_tests/GetAccount.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/GetAccount.spec.ts
@@ -27,6 +27,11 @@ describe("GetAccount", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;

--- a/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
@@ -178,6 +178,152 @@ describe("Reset password", () => {
         signInResult.data?.signOut();
     });
 
+    it("should sign in with custom claims after reset password successfully", async () => {
+        (fetch as jest.Mock)
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-1",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-2",
+                        challenge_type: "oob",
+                        binding_method: "prompt",
+                        challenge_channel: "email",
+                        challenge_target_label: "s****n@o*********m",
+                        code_length: 8,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-3",
+                        expires_in: 600,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-4",
+                        poll_interval: 1,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        status: "in_progress",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        status: "in_progress",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-5",
+                        status: "succeeded",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return TestServerTokenResponse;
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            });
+
+        const resetPasswordInputs = {
+            username: "test@test.com",
+            correlationId: correlationId,
+        };
+
+        const startResult = await app.resetPassword(resetPasswordInputs);
+
+        expect(startResult).toBeInstanceOf(ResetPasswordStartResult);
+        expect(startResult.error).toBeUndefined();
+        expect(startResult.isCodeRequired()).toBe(true);
+
+        const submitCodeResult = await (
+            startResult.state as ResetPasswordCodeRequiredState
+        ).submitCode("12345678");
+
+        expect(submitCodeResult).toBeInstanceOf(ResetPasswordSubmitCodeResult);
+        expect(submitCodeResult.error).toBeUndefined();
+        expect(submitCodeResult.isPasswordRequired()).toBe(true);
+
+        const submitPasswordResult = await (
+            submitCodeResult.state as ResetPasswordPasswordRequiredState
+        ).submitNewPassword("valid-password");
+
+        expect(submitPasswordResult).toBeInstanceOf(
+            ResetPasswordSubmitPasswordResult
+        );
+        expect(submitPasswordResult.error).toBeUndefined();
+        expect(submitPasswordResult.isCompleted()).toBe(true);
+
+        const claimsRequest = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInResult = await (
+            submitPasswordResult.state as ResetPasswordCompletedState
+        ).signIn({
+            claimsRequest: claimsRequest,
+        });
+
+        expect(signInResult).toBeInstanceOf(SignInResult);
+        expect(signInResult.error).toBeUndefined();
+        expect(signInResult.isCompleted()).toBe(true);
+        expect(signInResult.data).toBeDefined();
+        expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
+        expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
+            TestServerTokenResponse.id_token
+        );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
+    });
+
     it("should reset password failed if the redirect challenge returned", async () => {
         (fetch as jest.Mock)
             .mockResolvedValueOnce({

--- a/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
@@ -29,6 +29,11 @@ describe("Reset password", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;

--- a/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
@@ -296,7 +296,7 @@ describe("Reset password", () => {
         expect(submitPasswordResult.error).toBeUndefined();
         expect(submitPasswordResult.isCompleted()).toBe(true);
 
-        const claimsRequest = JSON.stringify({
+        const claims = JSON.stringify({
             access_token: {
                 acrs: {
                     essential: true,
@@ -308,7 +308,7 @@ describe("Reset password", () => {
         const signInResult = await (
             submitPasswordResult.state as ResetPasswordCompletedState
         ).signIn({
-            claimsRequest: claimsRequest,
+            claims: claims,
         });
 
         expect(signInResult).toBeInstanceOf(SignInResult);

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
@@ -392,4 +392,66 @@ describe("Sign in", () => {
         expect(submitCodeResult.error).toBeDefined();
         expect(submitCodeResult.error?.isInvalidCode()).toBe(true);
     });
+
+    it("should sign in successfully if giving custom claims with password as the challenge type", async () => {
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return {
+                    continuation_token: "test-continuation-token-1",
+                    challenge_type: "oob password redirect",
+                };
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return {
+                    continuation_token: "test-continuation-token-2",
+                    challenge_type: "password",
+                };
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return TestServerTokenResponse;
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        const claimsRequest = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInInputs = {
+            username: "test@test.com",
+            password: "password",
+            correlationId: correlationId,
+            claimsRequest: claimsRequest,
+        };
+
+        const result = await app.signIn(signInInputs);
+
+        expect(result).toBeInstanceOf(SignInResult);
+        expect(result.error).toBeUndefined();
+        expect(result.isCompleted()).toBe(true);
+        expect(result.data).toBeDefined();
+        expect(result.data).toBeInstanceOf(CustomAuthAccountData);
+
+        // Sign out the user for clean up the state for the other tests.
+        result.data?.signOut();
+    });
 });

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
@@ -27,6 +27,11 @@ describe("Sign in", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;
@@ -450,8 +455,5 @@ describe("Sign in", () => {
         expect(result.isCompleted()).toBe(true);
         expect(result.data).toBeDefined();
         expect(result.data).toBeInstanceOf(CustomAuthAccountData);
-
-        // Sign out the user for clean up the state for the other tests.
-        result.data?.signOut();
     });
 });

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
@@ -432,7 +432,7 @@ describe("Sign in", () => {
             ok: true,
         });
 
-        const claimsRequest = JSON.stringify({
+        const claims = JSON.stringify({
             access_token: {
                 acrs: {
                     essential: true,
@@ -445,7 +445,7 @@ describe("Sign in", () => {
             username: "test@test.com",
             password: "password",
             correlationId: correlationId,
-            claimsRequest: claimsRequest,
+            claims: claims,
         };
 
         const result = await app.signIn(signInInputs);

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
@@ -33,6 +33,11 @@ describe("Sign up", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
@@ -276,7 +276,7 @@ describe("Sign up", () => {
         expect(submitPasswordResult.error).toBeUndefined();
         expect(submitPasswordResult.isCompleted()).toBe(true);
 
-        const claimsRequest = JSON.stringify({
+        const claims = JSON.stringify({
             access_token: {
                 acrs: {
                     essential: true,
@@ -288,7 +288,7 @@ describe("Sign up", () => {
         const signInResult = await (
             submitPasswordResult.state as SignUpCompletedState
         ).signIn({
-            claimsRequest: claimsRequest,
+            claims: claims,
         });
 
         expect(signInResult).toBeInstanceOf(SignInResult);

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
@@ -170,6 +170,140 @@ describe("Sign up", () => {
         signInResult.data?.signOut();
     });
 
+    it("should sign in with custom claims after sign up successfully", async () => {
+        (fetch as jest.Mock)
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-1",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-2",
+                        challenge_type: "oob",
+                        binding_method: "prompt",
+                        challenge_channel: "email",
+                        challenge_target_label: "s****n@o*********m",
+                        code_length: 8,
+                        interval: 300,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 400,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-4",
+                        error: "credential_required",
+                        error_description: "Credential required.",
+                        error_codes: [55103],
+                        timestamp: "yy-mm-dd 02:37:33Z",
+                        trace_id: "test-trace-id",
+                        correlation_id: correlationId,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: false,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-5",
+                        challenge_type: "password",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-6",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return TestServerTokenResponse;
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            });
+
+        const attributes: UserAccountAttributes = {
+            city: "test-city",
+        };
+
+        const signUpInputs: SignUpInputs = {
+            username: "test@test.com",
+            correlationId: correlationId,
+            attributes: attributes,
+        };
+
+        const startResult = await app.signUp(signUpInputs);
+
+        expect(startResult).toBeInstanceOf(SignUpResult);
+        expect(startResult.error).toBeUndefined();
+        expect(startResult.isCodeRequired()).toBe(true);
+
+        const submitCodeResult = await (
+            startResult.state as SignUpCodeRequiredState
+        ).submitCode("12345678");
+
+        expect(submitCodeResult).toBeInstanceOf(SignUpSubmitCodeResult);
+        expect(submitCodeResult.error).toBeUndefined();
+        expect(submitCodeResult.isPasswordRequired()).toBe(true);
+
+        const submitPasswordResult = await (
+            submitCodeResult.state as SignUpPasswordRequiredState
+        ).submitPassword("valid-password");
+
+        expect(submitPasswordResult).toBeInstanceOf(SignUpSubmitPasswordResult);
+        expect(submitPasswordResult.error).toBeUndefined();
+        expect(submitPasswordResult.isCompleted()).toBe(true);
+
+        const claimsRequest = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInResult = await (
+            submitPasswordResult.state as SignUpCompletedState
+        ).signIn({
+            claimsRequest: claimsRequest,
+        });
+
+        expect(signInResult).toBeInstanceOf(SignInResult);
+        expect(signInResult.error).toBeUndefined();
+        expect(signInResult.isCompleted()).toBe(true);
+        expect(signInResult.data).toBeDefined();
+        expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
+        expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
+            TestServerTokenResponse.id_token
+        );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
+    });
+
     it("should sign up successfully if attributes are required after starting the password reset", async () => {
         (fetch as jest.Mock)
             .mockResolvedValueOnce({

--- a/lib/msal-browser/test/custom_auth/sign_in/auth_flow/error_type/SignInError.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/auth_flow/error_type/SignInError.spec.ts
@@ -3,6 +3,7 @@ import {
     RedirectError,
 } from "../../../../../src/custom_auth/core/error/CustomAuthApiError.js";
 import { InvalidArgumentError } from "../../../../../src/custom_auth/index.js";
+import { INVALID_REQUEST } from "../../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
 import {
     SignInError,
     SignInSubmitCodeError,
@@ -85,6 +86,26 @@ describe("SignInError", () => {
         );
         const signInError = new SignInError(errorData as any);
         expect(signInError.isTokenExpired()).toBe(true);
+    });
+
+    it("should return true for isPasswordResetRequired when error is PASSWORD_RESET_REQUIRED", () => {
+        const errorData = new CustomAuthApiError(
+            INVALID_REQUEST,
+            "error-message",
+            "correlation-id",
+            [50142]
+        );
+        const signInError = new SignInError(errorData);
+        expect(signInError.isPasswordResetRequired()).toBe(true);
+    });
+
+    it("should return false for isPasswordResetRequired when errorData is not CustomAuthApiError", () => {
+        const errorData = {
+            error: INVALID_REQUEST,
+            errorDescription: "error-message",
+        };
+        const signInError = new SignInError(errorData as any);
+        expect(signInError.isPasswordResetRequired()).toBe(false);
     });
 });
 

--- a/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
@@ -23,6 +23,11 @@ import {
     TestServerTokenResponse,
     TestTenantId,
 } from "../../test_resources/TestConstants.js";
+import {
+    SignInContinuationTokenParams,
+    SignInSubmitCodeParams,
+    SignInSubmitPasswordParams,
+} from "../../../../src/custom_auth/sign_in/interaction_client/parameter/SignInParams.js";
 
 jest.mock(
     "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js",
@@ -189,12 +194,14 @@ describe("SignInClient", () => {
     });
 
     describe("submitCode", () => {
-        it("should return SignInCompleteResult for valid code", async () => {
+        let signInSubmitCodeParams: SignInSubmitCodeParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokensWithOob.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.submitCode({
+            signInSubmitCodeParams = {
                 code: "123456",
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
@@ -206,7 +213,11 @@ describe("SignInClient", () => {
                 ],
                 correlationId: "corr123",
                 scopes: [],
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult for valid code", async () => {
+            const result = await client.submitCode(signInSubmitCodeParams);
 
             expect(result.type).toStrictEqual(SIGN_IN_COMPLETED_RESULT_TYPE);
             expect(result.correlationId).toBe(
@@ -232,15 +243,38 @@ describe("SignInClient", () => {
                 "abc@test.com"
             );
         });
+
+        it("should include claims in password token request", async () => {
+            const claimsRequest = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInSubmitCodeParams.claimsRequest = claimsRequest;
+            await client.submitCode(signInSubmitCodeParams);
+
+            // Verify that the API was called with claims
+            expect(signInApiClient.requestTokensWithOob).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claimsRequest,
+                })
+            );
+        });
     });
 
     describe("submitPassword", () => {
-        it("should return SignInCompleteResult for valid password", async () => {
+        let signInSubmitPasswordParams: SignInSubmitPasswordParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokensWithPassword.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.submitPassword({
+            signInSubmitPasswordParams = {
                 password: "123456",
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
@@ -252,7 +286,13 @@ describe("SignInClient", () => {
                 ],
                 correlationId: "corr123",
                 scopes: [],
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult for valid password", async () => {
+            const result = await client.submitPassword(
+                signInSubmitPasswordParams
+            );
 
             expect(result.type).toStrictEqual(SIGN_IN_COMPLETED_RESULT_TYPE);
             expect(result.correlationId).toBe(
@@ -276,6 +316,29 @@ describe("SignInClient", () => {
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
                 "abc@test.com"
+            );
+        });
+
+        it("should include claims in password token request", async () => {
+            const claimsRequest = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInSubmitPasswordParams.claimsRequest = claimsRequest;
+            await client.submitPassword(signInSubmitPasswordParams);
+
+            // Verify that the API was called with claims
+            expect(
+                signInApiClient.requestTokensWithPassword
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claimsRequest,
+                })
             );
         });
     });
@@ -312,12 +375,14 @@ describe("SignInClient", () => {
     });
 
     describe("signInWithContinuationToken", () => {
-        it("should return SignInCompleteResult", async () => {
+        let signInContinuationTokenParams: SignInContinuationTokenParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokenWithContinuationToken.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.signInWithContinuationToken({
+            signInContinuationTokenParams = {
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
                 clientId: customAuthConfig.auth.clientId,
@@ -329,7 +394,13 @@ describe("SignInClient", () => {
                 correlationId: "corr123",
                 scopes: [],
                 signInScenario: SignInScenario.SignInAfterSignUp,
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult", async () => {
+            const result = await client.signInWithContinuationToken(
+                signInContinuationTokenParams
+            );
 
             expect(result.correlationId).toBe(
                 TestServerTokenResponse.correlation_id
@@ -352,6 +423,31 @@ describe("SignInClient", () => {
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
                 "abc@test.com"
+            );
+        });
+
+        it("should include claims in password token request", async () => {
+            const claimsRequest = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInContinuationTokenParams.claimsRequest = claimsRequest;
+            await client.signInWithContinuationToken(
+                signInContinuationTokenParams
+            );
+
+            // Verify that the API was called with claims
+            expect(
+                signInApiClient.requestTokenWithContinuationToken
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claimsRequest,
+                })
             );
         });
     });

--- a/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
@@ -245,7 +245,7 @@ describe("SignInClient", () => {
         });
 
         it("should include claims in password token request", async () => {
-            const claimsRequest = JSON.stringify({
+            const claims = JSON.stringify({
                 access_token: {
                     acrs: {
                         essential: true,
@@ -254,13 +254,13 @@ describe("SignInClient", () => {
                 },
             });
 
-            signInSubmitCodeParams.claimsRequest = claimsRequest;
+            signInSubmitCodeParams.claims = claims;
             await client.submitCode(signInSubmitCodeParams);
 
             // Verify that the API was called with claims
             expect(signInApiClient.requestTokensWithOob).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    claims: claimsRequest,
+                    claims: claims,
                 })
             );
         });
@@ -320,7 +320,7 @@ describe("SignInClient", () => {
         });
 
         it("should include claims in password token request", async () => {
-            const claimsRequest = JSON.stringify({
+            const claims = JSON.stringify({
                 access_token: {
                     acrs: {
                         essential: true,
@@ -329,7 +329,7 @@ describe("SignInClient", () => {
                 },
             });
 
-            signInSubmitPasswordParams.claimsRequest = claimsRequest;
+            signInSubmitPasswordParams.claims = claims;
             await client.submitPassword(signInSubmitPasswordParams);
 
             // Verify that the API was called with claims
@@ -337,7 +337,7 @@ describe("SignInClient", () => {
                 signInApiClient.requestTokensWithPassword
             ).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    claims: claimsRequest,
+                    claims: claims,
                 })
             );
         });
@@ -427,7 +427,7 @@ describe("SignInClient", () => {
         });
 
         it("should include claims in password token request", async () => {
-            const claimsRequest = JSON.stringify({
+            const claims = JSON.stringify({
                 access_token: {
                     acrs: {
                         essential: true,
@@ -436,7 +436,7 @@ describe("SignInClient", () => {
                 },
             });
 
-            signInContinuationTokenParams.claimsRequest = claimsRequest;
+            signInContinuationTokenParams.claims = claims;
             await client.signInWithContinuationToken(
                 signInContinuationTokenParams
             );
@@ -446,7 +446,7 @@ describe("SignInClient", () => {
                 signInApiClient.requestTokenWithContinuationToken
             ).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    claims: claimsRequest,
+                    claims: claims,
                 })
             );
         });


### PR DESCRIPTION
This pull request introduces support for custom claims in various authentication flows within the `msal-browser` library. The most significant changes include adding a `claims` field to multiple input types, ensuring claims are valid JSON strings, and propagating the `claims` field through the authentication process.

### Support for custom claims:

* Added a `claims` field to several input types (`SignInInputs`, `ResetPasswordInputs`, `AccessTokenRetrievalInputs`, and others) to allow custom claims during authentication. 

### Validation enhancements:

* Introduced a new utility function, `ensureArgumentIsJSONString`, to validate that the `claims` field is a properly formatted JSON string. This function is used in multiple places to ensure input integrity.

### Integration into authentication flows:

* Updated the `CustomAuthStandardController` and related classes to handle the `claims` field during sign-in and token retrieval processes.
* Modified API request types and parameters to include the `claims` field, ensuring it is passed to the backend during token requests.
### Error handling improvements:

* Added methods to detect specific errors, such as password reset requirements, during authentication flows.

### Unit testing:

* Enhanced the `ArgumentValidator` unit tests to cover the new `ensureArgumentIsJSONString` function.