### PR TITLE
Fix exception when using claims with Nested App Auth in JS Runtime environment

### DIFF
--- a/change/@azure-msal-browser-5ca5dd1f-922c-43cf-b6b5-cd03fb787ae1.json
+++ b/change/@azure-msal-browser-5ca5dd1f-922c-43cf-b6b5-cd03fb787ae1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix exception when using claims with Nested App Auth in JS Runtime environment (#7926)",
+  "packageName": "@azure/msal-browser",
+  "email": "dasau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -229,7 +229,10 @@ export class NestedAppAuthController implements IController {
             };
 
             // cache the tokens in the response
-            await this.hydrateCache(result, request);
+            try {
+                // cache hydration can fail in JS Runtime scenario that doesn't support full crypto API
+                await this.hydrateCache(result, request);
+            } catch {}
 
             // cache the account context in memory after successful token fetch
             this.currentAccountContext = {
@@ -332,7 +335,10 @@ export class NestedAppAuthController implements IController {
                 );
 
             // cache the tokens in the response
-            await this.hydrateCache(result, request);
+            try {
+                // cache hydration can fail in JS Runtime scenario that doesn't support full crypto API
+                await this.hydrateCache(result, request);
+            } catch {}
 
             // cache the account context in memory after successful token fetch
             this.currentAccountContext = {

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -232,7 +232,12 @@ export class NestedAppAuthController implements IController {
             try {
                 // cache hydration can fail in JS Runtime scenario that doesn't support full crypto API
                 await this.hydrateCache(result, request);
-            } catch {}
+            } catch (error) {
+                this.logger.warningPii(
+                    `Failed to hydrate cache. Error: ${error}`,
+                    validRequest.correlationId
+                );
+            }
 
             // cache the account context in memory after successful token fetch
             this.currentAccountContext = {
@@ -338,7 +343,12 @@ export class NestedAppAuthController implements IController {
             try {
                 // cache hydration can fail in JS Runtime scenario that doesn't support full crypto API
                 await this.hydrateCache(result, request);
-            } catch {}
+            } catch (error) {
+                this.logger.warningPii(
+                    `Failed to hydrate cache. Error: ${error}`,
+                    validRequest.correlationId
+                );
+            }
 
             // cache the account context in memory after successful token fetch
             this.currentAccountContext = {

--- a/lib/msal-browser/test/naa/JSRuntime.spec.ts
+++ b/lib/msal-browser/test/naa/JSRuntime.spec.ts
@@ -17,6 +17,7 @@ import {
     createNestablePublicClientApplication,
 } from "../../src/index.js";
 import { InteractionRequiredAuthError } from "@azure/msal-common";
+import { BridgeRequestEnvelope } from "../../src/naa/BridgeRequestEnvelope.js";
 
 /**
  * Tests Nested App Auth for JS Runtime environment
@@ -103,6 +104,22 @@ describe("JS Runtime Nested App Auth", () => {
             );
             expect(authResult.fromCache).toBe(true);
             expect(authResult.accessToken).toBe(TEST_TOKENS.ACCESS_TOKEN);
+        }
+
+        // Validate claims parameter
+        mockBridge.addAuthResultResponse("GetToken", SILENT_TOKEN_RESPONSE);
+        {
+            const claims = `{"access_token":{"nbf":{"essential":true,"value":"1752302923"}}}`;
+            const authResult = await pca.acquireTokenSilent({
+                scopes: ["User.Read"],
+                claims,
+            });
+            expect(authResult.fromCache).toBe(false);
+            expect(authResult.accessToken).toBe(TEST_TOKENS.ACCESS_TOKEN);
+            const bridgeRequest = JSON.parse(
+                mockBridge.getBridgeRequests().at(-1)!
+            ) as BridgeRequestEnvelope;
+            expect(bridgeRequest.tokenParams?.claims).toBe(claims);
         }
 
         // Validate error scenario

--- a/lib/msal-browser/test/naa/MockBridge.ts
+++ b/lib/msal-browser/test/naa/MockBridge.ts
@@ -12,6 +12,7 @@ import { BridgeResponseEnvelope } from "../../src/naa/BridgeResponseEnvelope.js"
 import { InitContext } from "../../src/naa/InitContext.js";
 
 export class MockBridge implements AuthBridge {
+    private bridgeRequests: string[] = [];
     private listeners: { [key: string]: ((response: string) => void)[] } = {};
     private responses: {
         [key: string]: Partial<BridgeResponseEnvelope>[];
@@ -28,6 +29,7 @@ export class MockBridge implements AuthBridge {
     }
 
     public postMessage(message: string): void {
+        this.bridgeRequests.push(message);
         const request = JSON.parse(message);
         if (isBridgeRequestEnvelope(request)) {
             const response = this.responses[request.method].pop();
@@ -93,6 +95,10 @@ export class MockBridge implements AuthBridge {
 
     public removeAllResponses(): void {
         this.responses = {};
+    }
+
+    public getBridgeRequests(): string[] {
+        return this.bridgeRequests;
     }
 }
 


### PR DESCRIPTION
JS Runtime does not support full crypto API, and is running into an exception in hydrateCache while trying to generate a sha-256 hash of the claims. The token response is received, but never returned to developer because writing to cache failed. For this scenario, there is already a cache in the host, so it is still able to avoid a network call if a previous request with the same claim was made. 