### PR TITLE
[v5] Adding removed functions and parameters to MSAL Browser migration guide

### DIFF
--- a/lib/msal-browser/docs/v4-migration.md
+++ b/lib/msal-browser/docs/v4-migration.md
@@ -123,7 +123,7 @@ The following functions in `PublicClientApplication` have been removed:
         });
 
         // AFTER
-        const pca = createNestablePublicClientApplication({
+        const pca = await createNestablePublicClientApplication({
             auth: {
                 clientId: "your-client-id",
                 authority: "https://login.microsoftonline.com/common"

--- a/lib/msal-browser/docs/v4-migration.md
+++ b/lib/msal-browser/docs/v4-migration.md
@@ -75,6 +75,17 @@ pca.handleRedirectPromise({
 })
 ```
 
+### Removal of some functions in `PublicClientApplication` 
+
+The following functions in `PublicClientApplication` have been removed:
+1. `enableAccountStorageEvents()` and `disableAccountStorageEvents()`: account storage events are now always enabled.
+1. `getAccountByHomeId()`, `getAccountByLocalId()`, and `getAccountByUsername()`: use `getAccount()` instead.
+1. `logout()`: use `logoutRedirect()` or `logoutPopup` instead.
+
+## Removal of `startPerformanceMeasurement()`
+
+`startPerformanceMeasurement()` has been removed. Please use `startMeasurement()` instead.
+
 ## Configuration changes
 
 ### BrowserAuthOptions changes
@@ -87,6 +98,9 @@ pca.handleRedirectPromise({
     ```typescript
       pca.handleRedirectPromise({ navigateToLoginRequestUrl: false })
     ```
+1. The `encodeExtraQueryParams` parameter has been removed. All extra query params will be encoded.
+1. The `supportsNestedAppAuth` parameter has been removed. Use `createNestablePublicClientApplication()` instead.
+1. The `OIDCOptions` parameter now takes in a `ResponseMode` instead of a `ServerResponseType`. Please use `ResponseMode.QUERY` in place of `ServerResponseType.QUERY` and `ResponseMode.FRAGMENT` instead of `ServerResponseType.FRAGMENT`.
 
 ### CacheOptions changes
 
@@ -101,6 +115,7 @@ The following parameters were deprecated in MSAL Browser v4 and have been remove
 ### SystemOptions
 
 1. The `protocolMode` parameter has been moved to `SystemOptions` from `BrowserAuthOptions` in Configuration. There are no changes to its options or functionality.
+1. The `navigateFrameWait` parameter has been removed. This was previously needed by older browsers which are no longer supported by MSAL.js.
 
 #### `asyncPopups`
 
@@ -112,7 +127,9 @@ See the [Configuration doc](./configuration.md#system-config-options) for more d
 
 ## Changes on request
 
-[TBD]
+### Removal of `onRedirectNavigate` parameter
+
+The `onRedirectNavigate` parameter has been removed from the `RedirectRequest` object. It has *not* been removed from the `Configuration` object and can continue to be set there.
 
 ## Behavioral Breaking Changes
 

--- a/lib/msal-browser/docs/v4-migration.md
+++ b/lib/msal-browser/docs/v4-migration.md
@@ -78,8 +78,20 @@ pca.handleRedirectPromise({
 ### Removal of some functions in `PublicClientApplication` 
 
 The following functions in `PublicClientApplication` have been removed:
-1. `enableAccountStorageEvents()` and `disableAccountStorageEvents()`: account storage events are now always enabled.
+1. `enableAccountStorageEvents()` and `disableAccountStorageEvents()`: account storage events are now always enabled. These function calls are no longer necessary.
 1. `getAccountByHomeId()`, `getAccountByLocalId()`, and `getAccountByUsername()`: use `getAccount()` instead.
+
+    ```typescript
+    // BEFORE
+    const account1 = accountManager.getAccountByHomeId(yourHomeAccountId);
+    const account2 = accountManager.getAccountByLocalId(yourLocalAccountId);
+    const account3 = accountManager.getAccountByUsername(yourUsername);
+
+    // AFTER
+    const account1 = accountManager.getAccount({ homeAccountId: yourHomeAccountId });
+    const account2 = accountManager.getAccount({ localAccountId: yourLocalAccountId });
+    const account3 = accountManager.getAccount({ username: yourUsername });
+    ```
 1. `logout()`: use `logoutRedirect()` or `logoutPopup()` instead.
 
 ### Removal of `startPerformanceMeasurement()`
@@ -100,6 +112,24 @@ The following functions in `PublicClientApplication` have been removed:
     ```
 1. The `encodeExtraQueryParams` parameter has been removed. All extra query params will be encoded.
 1. The `supportsNestedAppAuth` parameter has been removed. Use `createNestablePublicClientApplication()` instead.
+    ```typescript
+        // BEFORE
+        const pca = new PublicClientApplication({
+            auth: {
+                clientId: "your-client-id",
+                authority: "https://login.microsoftonline.com/common"
+                supportsNestedAppAuth: true
+            },
+        });
+
+        // AFTER
+        const pca = createNestablePublicClientApplication({
+            auth: {
+                clientId: "your-client-id",
+                authority: "https://login.microsoftonline.com/common"
+            }
+        });
+    ```
 1. The `OIDCOptions` parameter now takes in a `ResponseMode` instead of a `ServerResponseType`. Please use `ResponseMode.QUERY` in place of `ServerResponseType.QUERY` and `ResponseMode.FRAGMENT` instead of `ServerResponseType.FRAGMENT`.
 
 ### CacheOptions changes

--- a/lib/msal-browser/docs/v4-migration.md
+++ b/lib/msal-browser/docs/v4-migration.md
@@ -82,7 +82,7 @@ The following functions in `PublicClientApplication` have been removed:
 1. `getAccountByHomeId()`, `getAccountByLocalId()`, and `getAccountByUsername()`: use `getAccount()` instead.
 1. `logout()`: use `logoutRedirect()` or `logoutPopup()` instead.
 
-## Removal of `startPerformanceMeasurement()`
+### Removal of `startPerformanceMeasurement()`
 
 `startPerformanceMeasurement()` has been removed. Please use `startMeasurement()` instead.
 

--- a/lib/msal-browser/docs/v4-migration.md
+++ b/lib/msal-browser/docs/v4-migration.md
@@ -80,7 +80,7 @@ pca.handleRedirectPromise({
 The following functions in `PublicClientApplication` have been removed:
 1. `enableAccountStorageEvents()` and `disableAccountStorageEvents()`: account storage events are now always enabled.
 1. `getAccountByHomeId()`, `getAccountByLocalId()`, and `getAccountByUsername()`: use `getAccount()` instead.
-1. `logout()`: use `logoutRedirect()` or `logoutPopup` instead.
+1. `logout()`: use `logoutRedirect()` or `logoutPopup()` instead.
 
 ## Removal of `startPerformanceMeasurement()`
 


### PR DESCRIPTION
Added the following removals to the migration guide: 
1. Functions and parameters from `PublicClientApplication`
2. `startPerformanceMeasurement()`
3. Parameters from `Configuration`
4. `onRedirectNavigate` from `RedirectRequest`

These functions and parameters are derived from the "Remove deprecated functions and parameters" PR #7669