### PR TITLE
Add support for custom claims and password change required error

### DIFF
--- a/change/@azure-msal-browser-5d0005f5-6c0f-4282-92d2-975f3bad562a.json
+++ b/change/@azure-msal-browser-5d0005f5-6c0f-4282-92d2-975f3bad562a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for custom claims and password change required error",
+  "packageName": "@azure/msal-browser",
+  "email": "ydi.w127@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-5d0005f5-6c0f-4282-92d2-975f3bad562a.json
+++ b/change/@azure-msal-browser-5d0005f5-6c0f-4282-92d2-975f3bad562a.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
-  "comment": "Add support for custom claims and password change required error",
-  "packageName": "@azure/msal-browser",
-  "email": "ydi.w127@gmail.com",
-  "dependentChangeType": "patch"
+    "type": "minor",
+    "comment": "Add support for custom claims and password change required error, #7948",
+    "packageName": "@azure/msal-browser",
+    "email": "ydi.w127@gmail.com",
+    "dependentChangeType": "patch"
 }

--- a/lib/msal-browser/src/custom_auth/CustomAuthActionInputs.ts
+++ b/lib/msal-browser/src/custom_auth/CustomAuthActionInputs.ts
@@ -15,6 +15,7 @@ export type SignInInputs = CustomAuthActionInputs & {
     username: string;
     password?: string;
     scopes?: Array<string>;
+    claims?: string;
 };
 
 export type SignUpInputs = CustomAuthActionInputs & {
@@ -30,8 +31,10 @@ export type ResetPasswordInputs = CustomAuthActionInputs & {
 export type AccessTokenRetrievalInputs = {
     forceRefresh: boolean;
     scopes?: Array<string>;
+    claims?: string;
 };
 
 export type SignInWithContinuationTokenInputs = {
     scopes?: Array<string>;
+    claims?: string;
 };

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -41,10 +41,7 @@ import { CustomAuthApiClient } from "../core/network_client/custom_auth_api/Cust
 import { FetchHttpClient } from "../core/network_client/http_client/FetchHttpClient.js";
 import { ResetPasswordClient } from "../reset_password/interaction_client/ResetPasswordClient.js";
 import { NoCachedAccountFoundError } from "../core/error/NoCachedAccountFoundError.js";
-import {
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-} from "../core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../core/utils/ArgumentValidator.js";
 import { UserAlreadySignedInError } from "../core/error/UserAlreadySignedInError.js";
 import { CustomAuthSilentCacheClient } from "../get_account/interaction_client/CustomAuthSilentCacheClient.js";
 import { UnsupportedEnvironmentError } from "../core/error/UnsupportedEnvironmentError.js";
@@ -177,18 +174,26 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(signInInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "signInInputs",
                 signInInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "signInInputs.username",
                 signInInputs.username,
                 correlationId
             );
             this.ensureUserNotSignedIn(correlationId);
+
+            if (signInInputs.claims) {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "signInInputs.claims",
+                    signInInputs.claims,
+                    correlationId
+                );
+            }
 
             // start the signin flow
             const signInStartParams: SignInStartParams = {
@@ -231,6 +236,7 @@ export class CustomAuthStandardController
                         username: signInInputs.username,
                         codeLength: startResult.codeLength,
                         scopes: signInInputs.scopes ?? [],
+                        claims: signInInputs.claims,
                     })
                 );
             } else if (
@@ -258,6 +264,7 @@ export class CustomAuthStandardController
                             cacheClient: this.cacheClient,
                             username: signInInputs.username,
                             scopes: signInInputs.scopes ?? [],
+                            claims: signInInputs.claims,
                         })
                     );
                 }
@@ -277,6 +284,7 @@ export class CustomAuthStandardController
                     continuationToken: startResult.continuationToken,
                     password: signInInputs.password,
                     username: signInInputs.username,
+                    claims: signInInputs.claims,
                 };
 
                 const completedResult = await this.signInClient.submitPassword(
@@ -327,13 +335,13 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(signUpInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "signUpInputs",
                 signUpInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "signUpInputs.username",
                 signUpInputs.username,
                 correlationId
@@ -439,13 +447,13 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(resetPasswordInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "resetPasswordInputs",
                 resetPasswordInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "resetPasswordInputs.username",
                 resetPasswordInputs.username,
                 correlationId

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
@@ -127,6 +127,18 @@ export abstract class AuthFlowErrorBase {
             this.errorData.error === CustomAuthApiErrorCode.EXPIRED_TOKEN
         );
     }
+
+    /**
+     * @todo verify the password change required error can be detected once the MFA is in place.
+     * This error will be raised during signin and refresh tokens when calling /token endpoint.
+     */
+    protected isPasswordResetRequiredError(): boolean {
+        return (
+            this.errorData instanceof CustomAuthApiError &&
+            this.errorData.error === CustomAuthApiErrorCode.INVALID_REQUEST &&
+            this.errorData.errorCodes?.includes(50142) === true
+        );
+    }
 }
 
 export abstract class AuthActionErrorBase extends AuthFlowErrorBase {

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
@@ -90,6 +90,7 @@ export class SignInApiClient extends BaseApiClient {
                 grant_type: GrantType.PASSWORD,
                 scope: params.scope,
                 password: params.password,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId
@@ -105,6 +106,7 @@ export class SignInApiClient extends BaseApiClient {
                 scope: params.scope,
                 oob: params.oob,
                 grant_type: GrantType.OOB,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId
@@ -121,6 +123,7 @@ export class SignInApiClient extends BaseApiClient {
                 scope: params.scope,
                 grant_type: GrantType.CONTINUATION_TOKEN,
                 client_info: true,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/types/ApiRequestTypes.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/types/ApiRequestTypes.ts
@@ -19,6 +19,7 @@ export interface SignInChallengeRequest extends ApiRequestBase {
 interface SignInTokenRequestBase extends ApiRequestBase {
     continuation_token: string;
     scope: string;
+    claims?: string;
 }
 
 export interface SignInPasswordTokenRequest extends SignInTokenRequestBase {

--- a/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
+++ b/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
@@ -24,3 +24,22 @@ export function ensureArgumentIsNotEmptyString(
         throw new InvalidArgumentError(argName, correlationId);
     }
 }
+
+export function ensureArgumentIsJSONString(
+    argName: string,
+    argValue: string,
+    correlationId?: string
+): void {
+    try {
+        const parsed = JSON.parse(argValue);
+        if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            Array.isArray(parsed)
+        ) {
+            throw new InvalidArgumentError(argName, correlationId);
+        }
+    } catch (e) {
+        throw new InvalidArgumentError(argName, correlationId);
+    }
+}

--- a/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
+++ b/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
@@ -40,6 +40,9 @@ export function ensureArgumentIsJSONString(
             throw new InvalidArgumentError(argName, correlationId);
         }
     } catch (e) {
-        throw new InvalidArgumentError(argName, correlationId);
+        if (e instanceof SyntaxError) {
+            throw new InvalidArgumentError(argName, correlationId);
+        }
+        throw e; // Rethrow unexpected errors
     }
 }

--- a/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
@@ -18,10 +18,7 @@ import {
     TokenClaims,
 } from "@azure/msal-common/browser";
 import { SilentRequest } from "../../../request/SilentRequest.js";
-import {
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-} from "../../core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../../core/utils/ArgumentValidator.js";
 
 /*
  * Account information.
@@ -34,8 +31,15 @@ export class CustomAuthAccountData {
         private readonly logger: Logger,
         private readonly correlationId: string
     ) {
-        ensureArgumentIsNotEmptyString("correlationId", correlationId);
-        ensureArgumentIsNotNullOrUndefined("account", account, correlationId);
+        ArgumentValidator.ensureArgumentIsNotEmptyString(
+            "correlationId",
+            correlationId
+        );
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+            "account",
+            account,
+            correlationId
+        );
     }
 
     /**
@@ -107,11 +111,19 @@ export class CustomAuthAccountData {
         accessTokenRetrievalInputs: AccessTokenRetrievalInputs
     ): Promise<GetAccessTokenResult> {
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "accessTokenRetrievalInputs",
                 accessTokenRetrievalInputs,
                 this.correlationId
             );
+
+            if (accessTokenRetrievalInputs.claims) {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "accessTokenRetrievalInputs.claims",
+                    accessTokenRetrievalInputs.claims,
+                    this.correlationId
+                );
+            }
 
             this.logger.verbose("Getting current account.", this.correlationId);
 
@@ -133,7 +145,8 @@ export class CustomAuthAccountData {
             const commonSilentFlowRequest = this.createCommonSilentFlowRequest(
                 currentAccount,
                 accessTokenRetrievalInputs.forceRefresh,
-                newScopes
+                newScopes,
+                accessTokenRetrievalInputs.claims
             );
             const result = await this.cacheClient.acquireToken(
                 commonSilentFlowRequest
@@ -158,7 +171,8 @@ export class CustomAuthAccountData {
     private createCommonSilentFlowRequest(
         accountInfo: AccountInfo,
         forceRefresh: boolean = false,
-        requestScopes: Array<string>
+        requestScopes: Array<string>,
+        claims?: string
     ): CommonSilentFlowRequest {
         const silentRequest: SilentRequest = {
             authority: this.config.auth.authority,
@@ -171,6 +185,7 @@ export class CustomAuthAccountData {
                 accessToken: true,
                 refreshToken: true,
             },
+            ...(claims && { claims: claims }),
         };
 
         return {

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/error_type/SignInError.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/error_type/SignInError.ts
@@ -32,6 +32,14 @@ export class SignInError extends AuthActionErrorBase {
     }
 
     /**
+     * Checks if the error is due to password reset being required.
+     * @returns true if the error is due to password reset being required, false otherwise.
+     */
+    isPasswordResetRequired(): boolean {
+        return this.isPasswordResetRequiredError();
+    }
+
+    /**
      * Checks if the error is due to the provided challenge type is not supported.
      * @returns {boolean} True if the error is due to the provided challenge type is not supported, false otherwise.
      */

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
@@ -37,6 +37,7 @@ export class SignInCodeRequiredState extends SignInState<SignInCodeRequiredState
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 code: code,
                 username: this.stateParameters.username,
+                claims: this.stateParameters.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
@@ -10,6 +10,7 @@ import { SignInWithContinuationTokenInputs } from "../../../CustomAuthActionInpu
 import { SignInContinuationStateParameters } from "./SignInStateParameters.js";
 import { SignInState } from "./SignInState.js";
 import { SignInCompletedState } from "./SignInCompletedState.js";
+import * as ArgumentValidator from "../../../core/utils/ArgumentValidator.js";
 
 /*
  * Sign-in continuation state.
@@ -24,6 +25,14 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
         signInWithContinuationTokenInputs?: SignInWithContinuationTokenInputs
     ): Promise<SignInResult> {
         try {
+            if (signInWithContinuationTokenInputs?.claims) {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "signInWithContinuationTokenInputs.claims",
+                    signInWithContinuationTokenInputs.claims,
+                    this.stateParameters.correlationId
+                );
+            }
+
             const continuationTokenParams: SignInContinuationTokenParams = {
                 clientId: this.stateParameters.config.auth.clientId,
                 correlationId: this.stateParameters.correlationId,
@@ -33,6 +42,7 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 username: this.stateParameters.username,
                 signInScenario: this.stateParameters.signInScenario,
+                claims: signInWithContinuationTokenInputs?.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
@@ -34,6 +34,7 @@ export class SignInPasswordRequiredState extends SignInState<SignInPasswordRequi
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 password: password,
                 username: this.stateParameters.username,
+                claims: this.stateParameters.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInStateParameters.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInStateParameters.ts
@@ -13,6 +13,7 @@ export interface SignInStateParameters
     username: string;
     signInClient: SignInClient;
     cacheClient: CustomAuthSilentCacheClient;
+    claims?: string;
 }
 
 export interface SignInPasswordRequiredStateParameters

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
@@ -195,6 +195,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             scope: scopes.join(" "),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
+            ...(parameters.claims && {
+                claims: parameters.claims,
+            }),
         };
 
         return this.performTokenRequest(
@@ -230,6 +233,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             scope: scopes.join(" "),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
+            ...(parameters.claims && {
+                claims: parameters.claims,
+            }),
         };
 
         return this.performTokenRequest(
@@ -263,6 +269,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
             scope: scopes.join(" "),
+            ...(parameters.claims && {
+                claims: parameters.claims,
+            }),
         };
 
         // Call token endpoint.

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/parameter/SignInParams.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/parameter/SignInParams.ts
@@ -24,16 +24,19 @@ export interface SignInSubmitCodeParams extends SignInParamsBase {
     continuationToken: string;
     code: string;
     scopes: Array<string>;
+    claims?: string;
 }
 
 export interface SignInSubmitPasswordParams extends SignInParamsBase {
     continuationToken: string;
     password: string;
     scopes: Array<string>;
+    claims?: string;
 }
 
 export interface SignInContinuationTokenParams extends SignInParamsBase {
     continuationToken: string;
     signInScenario: SignInScenarioType;
     scopes: Array<string>;
+    claims?: string;
 }

--- a/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
@@ -1,33 +1,30 @@
 import { InvalidArgumentError } from "../../../../src/custom_auth/core/error/InvalidArgumentError.js";
-import {
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-} from "../../../../src/custom_auth/core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../../../../src/custom_auth/core/utils/ArgumentValidator.js";
 
 describe("ArgumentValidator", () => {
     describe("ensureArgumentIsNotEmptyString", () => {
         it("should not throw an error if the string is non-empty", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "validString");
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "validString");
             }).not.toThrow();
         });
 
         it("should throw InvalidArgumentError if the string is empty", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "");
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "");
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError if the string is only whitespace", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "   ");
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "   ");
             }).toThrow(InvalidArgumentError);
         });
 
         it("should pass correlationId to the error when the string is invalid", () => {
             const correlationId = "12345";
             try {
-                ensureArgumentIsNotEmptyString("testArg", "", correlationId);
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "", correlationId);
             } catch (error) {
                 if (error instanceof InvalidArgumentError) {
                     expect(error.correlationId).toBe(correlationId);
@@ -41,34 +38,34 @@ describe("ArgumentValidator", () => {
     describe("ensureArgumentIsNotNullOrUndefined", () => {
         it("should not throw an error if the argument is not null or undefined", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", "validValue");
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", "validValue");
             }).not.toThrow();
 
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", 42);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", 42);
             }).not.toThrow();
 
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", {});
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", {});
             }).not.toThrow();
         });
 
         it("should throw InvalidArgumentError if the argument is null", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", null);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", null);
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError if the argument is undefined", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", undefined);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", undefined);
             }).toThrow(InvalidArgumentError);
         });
 
         it("should pass correlationId to the error when the argument is invalid", () => {
             const correlationId = "12345";
             try {
-                ensureArgumentIsNotNullOrUndefined(
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                     "testArg",
                     null,
                     correlationId
@@ -80,6 +77,132 @@ describe("ArgumentValidator", () => {
                     throw error;
                 }
             }
+        });
+    });
+
+    describe("ensureArgumentIsJSONString", () => {
+        it("should not throw an error when argValue is a valid JSON object string", () => {
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": "value"}');
+            }).not.toThrow();
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "{}"); // Empty object
+            }).not.toThrow();
+        });
+
+        it("should not throw an error when argValue is a valid JSON object string with whitespace", () => {
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '  {"key": "value"}  ');
+            }).not.toThrow();
+        });
+
+        it("should throw InvalidArgumentError when argValue is not a JSON object", () => {
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "[]"); // Array - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '"string"'); // String - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '""'); // Empty string - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "123"); // Number - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "true"); // Boolean - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "null"); // Null - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", ""); // Empty string - not valid JSON
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "   "); // Whitespace only - not valid JSON
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "\t\n "); // Whitespace only - not valid JSON
+            }).toThrow(InvalidArgumentError);
+        });
+
+        it("should throw InvalidArgumentError when argValue is not valid JSON", () => {
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "invalid json");
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": value}'); // missing quotes around value
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{key: "value"}'); // missing quotes around key
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": "value",}'); // trailing comma
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "undefined");
+            }).toThrow(InvalidArgumentError);
+        });
+
+        it("should pass correlationId to the error when argValue is invalid JSON", () => {
+            const correlationId = "test-correlation-id";
+            try {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    "invalid json",
+                    correlationId
+                );
+            } catch (error) {
+                if (error instanceof InvalidArgumentError) {
+                    expect(error.correlationId).toBe(correlationId);
+                } else {
+                    throw error;
+                }
+            }
+        });
+
+        it("should handle complex valid JSON structures", () => {
+            const complexJson = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+                id_token: {
+                    auth_time: {
+                        essential: true,
+                    },
+                },
+            });
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", complexJson);
+            }).not.toThrow();
+        });
+
+        it("should handle arrays as invalid (not JSON objects)", () => {
+            const arrayJson = JSON.stringify([
+                { name: "item1", value: 1 },
+                { name: "item2", value: 2 },
+            ]);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", arrayJson);
+            }).toThrow(InvalidArgumentError);
         });
     });
 });

--- a/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
@@ -5,7 +5,10 @@ describe("ArgumentValidator", () => {
     describe("ensureArgumentIsNotEmptyString", () => {
         it("should not throw an error if the string is non-empty", () => {
             expect(() => {
-                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "validString");
+                ArgumentValidator.ensureArgumentIsNotEmptyString(
+                    "testArg",
+                    "validString"
+                );
             }).not.toThrow();
         });
 
@@ -17,14 +20,21 @@ describe("ArgumentValidator", () => {
 
         it("should throw InvalidArgumentError if the string is only whitespace", () => {
             expect(() => {
-                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "   ");
+                ArgumentValidator.ensureArgumentIsNotEmptyString(
+                    "testArg",
+                    "   "
+                );
             }).toThrow(InvalidArgumentError);
         });
 
         it("should pass correlationId to the error when the string is invalid", () => {
             const correlationId = "12345";
             try {
-                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "", correlationId);
+                ArgumentValidator.ensureArgumentIsNotEmptyString(
+                    "testArg",
+                    "",
+                    correlationId
+                );
             } catch (error) {
                 if (error instanceof InvalidArgumentError) {
                     expect(error.correlationId).toBe(correlationId);
@@ -38,27 +48,42 @@ describe("ArgumentValidator", () => {
     describe("ensureArgumentIsNotNullOrUndefined", () => {
         it("should not throw an error if the argument is not null or undefined", () => {
             expect(() => {
-                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", "validValue");
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    "validValue"
+                );
             }).not.toThrow();
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", 42);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    42
+                );
             }).not.toThrow();
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", {});
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    {}
+                );
             }).not.toThrow();
         });
 
         it("should throw InvalidArgumentError if the argument is null", () => {
             expect(() => {
-                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", null);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    null
+                );
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError if the argument is undefined", () => {
             expect(() => {
-                ArgumentValidator.ensureArgumentIsNotNullOrUndefined("testArg", undefined);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    undefined
+                );
             }).toThrow(InvalidArgumentError);
         });
 
@@ -83,7 +108,10 @@ describe("ArgumentValidator", () => {
     describe("ensureArgumentIsJSONString", () => {
         it("should not throw an error when argValue is a valid JSON object string", () => {
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": "value"}');
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '{"key": "value"}'
+                );
             }).not.toThrow();
 
             expect(() => {
@@ -93,7 +121,10 @@ describe("ArgumentValidator", () => {
 
         it("should not throw an error when argValue is a valid JSON object string with whitespace", () => {
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", '  {"key": "value"}  ');
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '  {"key": "value"}  '
+                );
             }).not.toThrow();
         });
 
@@ -103,7 +134,10 @@ describe("ArgumentValidator", () => {
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", '"string"'); // String - not an object
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '"string"'
+                ); // String - not an object
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
@@ -131,29 +165,47 @@ describe("ArgumentValidator", () => {
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", "\t\n "); // Whitespace only - not valid JSON
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    "\t\n "
+                ); // Whitespace only - not valid JSON
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError when argValue is not valid JSON", () => {
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", "invalid json");
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    "invalid json"
+                );
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": value}'); // missing quotes around value
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '{"key": value}'
+                ); // missing quotes around value
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{key: "value"}'); // missing quotes around key
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '{key: "value"}'
+                ); // missing quotes around key
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", '{"key": "value",}'); // trailing comma
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '{"key": "value",}'
+                ); // trailing comma
             }).toThrow(InvalidArgumentError);
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", "undefined");
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    "undefined"
+                );
             }).toThrow(InvalidArgumentError);
         });
 
@@ -190,7 +242,10 @@ describe("ArgumentValidator", () => {
             });
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", complexJson);
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    complexJson
+                );
             }).not.toThrow();
         });
 
@@ -201,7 +256,10 @@ describe("ArgumentValidator", () => {
             ]);
 
             expect(() => {
-                ArgumentValidator.ensureArgumentIsJSONString("testArg", arrayJson);
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    arrayJson
+                );
             }).toThrow(InvalidArgumentError);
         });
     });

--- a/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
@@ -12,6 +12,9 @@ import {
     Logger,
 } from "@azure/msal-common/browser";
 import { AuthenticationResult } from "../../../../src/response/AuthenticationResult.js";
+import { ServerError } from "@azure/msal-common";
+import { INVALID_REQUEST } from "../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
+import { AccessTokenRetrievalInputs } from "../../../../src/custom_auth/CustomAuthActionInputs.js";
 
 describe("CustomAuthAccountData", () => {
     let mockAccount: AccountInfo;
@@ -187,23 +190,23 @@ describe("CustomAuthAccountData", () => {
     });
 
     describe("getAccessToken", () => {
-        it("should return succeed GetAccessTokenState.Completed with cached tokens", async () => {
+        let accountData: CustomAuthAccountData;
+        beforeEach(() => {
             (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
                 mockAccount
             );
-            jest.spyOn(
-                CustomAuthAccountData.prototype as any,
-                "createCommonSilentFlowRequest"
-            ).mockReturnValue({});
-            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
-                mockAuthenticationResult
-            );
-            const accountData = new CustomAuthAccountData(
+            accountData = new CustomAuthAccountData(
                 mockAccount,
                 mockConfig,
                 mockCacheClient,
                 mockLogger,
                 correlationId
+            );
+        });
+
+        it("should return succeed GetAccessTokenState.Completed with cached tokens", async () => {
+            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
+                mockAuthenticationResult
             );
 
             const response = await accountData.getAccessToken({
@@ -219,9 +222,6 @@ describe("CustomAuthAccountData", () => {
         });
 
         it("should return GetAccessTokenError if there is an error when aquire tokens", async () => {
-            (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
-                mockAccount
-            );
             const errorCode =
                 InteractionRequiredAuthErrorCodes.refreshTokenExpired;
             const errorMessage = "Refresh token has expired.";
@@ -235,14 +235,6 @@ describe("CustomAuthAccountData", () => {
                 );
             (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(
                 mockRefreshTokenExpiredError
-            );
-
-            const accountData = new CustomAuthAccountData(
-                mockAccount,
-                mockConfig,
-                mockCacheClient,
-                mockLogger,
-                correlationId
             );
 
             const response = await accountData.getAccessToken({
@@ -262,6 +254,86 @@ describe("CustomAuthAccountData", () => {
             expect(msalError.error).toEqual(errorCode);
             expect(msalError.errorDescription).toEqual(errorMessage);
             expect(msalError.subError).toEqual(subError);
+        });
+
+        it("should include claims in getAccessToken when provided", async () => {
+            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
+                mockAuthenticationResult
+            );
+
+            const claims = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            const accessTokenRetrievalInputs: AccessTokenRetrievalInputs = {
+                forceRefresh: false,
+                scopes: ["test-scope"],
+                claims: claims,
+            };
+            const response = await accountData.getAccessToken(
+                accessTokenRetrievalInputs
+            );
+
+            expect(response).toBeDefined();
+            expect(response.isCompleted()).toBe(true);
+            expect(response.data?.account).toEqual(mockAccount);
+            expect(response.data?.idToken).toEqual(
+                mockAuthenticationResult.idToken
+            );
+
+            expect(mockCacheClient.acquireToken).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claims,
+                })
+            );
+        });
+    });
+
+    describe("password reset required error handling", () => {
+        it("should wrap AADSTS50142 error with MsalCustomAuthError for password reset required", async () => {
+            (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
+                mockAccount
+            );
+
+            const errorCode = INVALID_REQUEST;
+            const errorMessage = "50142";
+            const mockMSALServerError = new ServerError(
+                errorCode,
+                errorMessage,
+                "",
+                "50142"
+            );
+            (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(
+                mockMSALServerError
+            );
+
+            const accountData = new CustomAuthAccountData(
+                mockAccount,
+                mockConfig,
+                mockCacheClient,
+                mockLogger,
+                correlationId
+            );
+
+            const response = await accountData.getAccessToken({
+                forceRefresh: false,
+            });
+
+            expect(response).toBeDefined();
+            expect(response.isFailed()).toBe(true);
+            expect(response.error?.errorData).toEqual(mockMSALServerError);
+            expect(response.error?.errorData).toBeInstanceOf(
+                MsalCustomAuthError
+            );
+
+            const msalError = response.error?.errorData as MsalCustomAuthError;
+            expect(msalError.error).toEqual(errorCode);
+            expect(msalError.errorDescription).toEqual(errorMessage);
         });
     });
 });

--- a/lib/msal-browser/test/custom_auth/integration_tests/GetAccount.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/GetAccount.spec.ts
@@ -27,6 +27,11 @@ describe("GetAccount", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;

--- a/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
@@ -29,6 +29,11 @@ describe("Reset password", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;
@@ -164,6 +169,152 @@ describe("Reset password", () => {
         const signInResult = await (
             submitPasswordResult.state as ResetPasswordCompletedState
         ).signIn();
+
+        expect(signInResult).toBeInstanceOf(SignInResult);
+        expect(signInResult.error).toBeUndefined();
+        expect(signInResult.isCompleted()).toBe(true);
+        expect(signInResult.data).toBeDefined();
+        expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
+        expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
+            TestServerTokenResponse.id_token
+        );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
+    });
+
+    it("should sign in with custom claims after reset password successfully", async () => {
+        (fetch as jest.Mock)
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-1",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-2",
+                        challenge_type: "oob",
+                        binding_method: "prompt",
+                        challenge_channel: "email",
+                        challenge_target_label: "s****n@o*********m",
+                        code_length: 8,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-3",
+                        expires_in: 600,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-4",
+                        poll_interval: 1,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        status: "in_progress",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        status: "in_progress",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-5",
+                        status: "succeeded",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return TestServerTokenResponse;
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            });
+
+        const resetPasswordInputs = {
+            username: "test@test.com",
+            correlationId: correlationId,
+        };
+
+        const startResult = await app.resetPassword(resetPasswordInputs);
+
+        expect(startResult).toBeInstanceOf(ResetPasswordStartResult);
+        expect(startResult.error).toBeUndefined();
+        expect(startResult.isCodeRequired()).toBe(true);
+
+        const submitCodeResult = await (
+            startResult.state as ResetPasswordCodeRequiredState
+        ).submitCode("12345678");
+
+        expect(submitCodeResult).toBeInstanceOf(ResetPasswordSubmitCodeResult);
+        expect(submitCodeResult.error).toBeUndefined();
+        expect(submitCodeResult.isPasswordRequired()).toBe(true);
+
+        const submitPasswordResult = await (
+            submitCodeResult.state as ResetPasswordPasswordRequiredState
+        ).submitNewPassword("valid-password");
+
+        expect(submitPasswordResult).toBeInstanceOf(
+            ResetPasswordSubmitPasswordResult
+        );
+        expect(submitPasswordResult.error).toBeUndefined();
+        expect(submitPasswordResult.isCompleted()).toBe(true);
+
+        const claims = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInResult = await (
+            submitPasswordResult.state as ResetPasswordCompletedState
+        ).signIn({
+            claims: claims,
+        });
 
         expect(signInResult).toBeInstanceOf(SignInResult);
         expect(signInResult.error).toBeUndefined();

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
@@ -27,6 +27,11 @@ describe("Sign in", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;
@@ -391,5 +396,64 @@ describe("Sign in", () => {
         expect(submitCodeResult).toBeInstanceOf(SignInSubmitCodeResult);
         expect(submitCodeResult.error).toBeDefined();
         expect(submitCodeResult.error?.isInvalidCode()).toBe(true);
+    });
+
+    it("should sign in successfully if giving custom claims with password as the challenge type", async () => {
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return {
+                    continuation_token: "test-continuation-token-1",
+                    challenge_type: "oob password redirect",
+                };
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return {
+                    continuation_token: "test-continuation-token-2",
+                    challenge_type: "password",
+                };
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return TestServerTokenResponse;
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        const claims = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInInputs = {
+            username: "test@test.com",
+            password: "password",
+            correlationId: correlationId,
+            claims: claims,
+        };
+
+        const result = await app.signIn(signInInputs);
+
+        expect(result).toBeInstanceOf(SignInResult);
+        expect(result.error).toBeUndefined();
+        expect(result.isCompleted()).toBe(true);
+        expect(result.data).toBeDefined();
+        expect(result.data).toBeInstanceOf(CustomAuthAccountData);
     });
 });

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
@@ -33,6 +33,11 @@ describe("Sign up", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;
@@ -156,6 +161,140 @@ describe("Sign up", () => {
         const signInResult = await (
             submitPasswordResult.state as SignUpCompletedState
         ).signIn();
+
+        expect(signInResult).toBeInstanceOf(SignInResult);
+        expect(signInResult.error).toBeUndefined();
+        expect(signInResult.isCompleted()).toBe(true);
+        expect(signInResult.data).toBeDefined();
+        expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
+        expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
+            TestServerTokenResponse.id_token
+        );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
+    });
+
+    it("should sign in with custom claims after sign up successfully", async () => {
+        (fetch as jest.Mock)
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-1",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-2",
+                        challenge_type: "oob",
+                        binding_method: "prompt",
+                        challenge_channel: "email",
+                        challenge_target_label: "s****n@o*********m",
+                        code_length: 8,
+                        interval: 300,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 400,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-4",
+                        error: "credential_required",
+                        error_description: "Credential required.",
+                        error_codes: [55103],
+                        timestamp: "yy-mm-dd 02:37:33Z",
+                        trace_id: "test-trace-id",
+                        correlation_id: correlationId,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: false,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-5",
+                        challenge_type: "password",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-6",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return TestServerTokenResponse;
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            });
+
+        const attributes: UserAccountAttributes = {
+            city: "test-city",
+        };
+
+        const signUpInputs: SignUpInputs = {
+            username: "test@test.com",
+            correlationId: correlationId,
+            attributes: attributes,
+        };
+
+        const startResult = await app.signUp(signUpInputs);
+
+        expect(startResult).toBeInstanceOf(SignUpResult);
+        expect(startResult.error).toBeUndefined();
+        expect(startResult.isCodeRequired()).toBe(true);
+
+        const submitCodeResult = await (
+            startResult.state as SignUpCodeRequiredState
+        ).submitCode("12345678");
+
+        expect(submitCodeResult).toBeInstanceOf(SignUpSubmitCodeResult);
+        expect(submitCodeResult.error).toBeUndefined();
+        expect(submitCodeResult.isPasswordRequired()).toBe(true);
+
+        const submitPasswordResult = await (
+            submitCodeResult.state as SignUpPasswordRequiredState
+        ).submitPassword("valid-password");
+
+        expect(submitPasswordResult).toBeInstanceOf(SignUpSubmitPasswordResult);
+        expect(submitPasswordResult.error).toBeUndefined();
+        expect(submitPasswordResult.isCompleted()).toBe(true);
+
+        const claims = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInResult = await (
+            submitPasswordResult.state as SignUpCompletedState
+        ).signIn({
+            claims: claims,
+        });
 
         expect(signInResult).toBeInstanceOf(SignInResult);
         expect(signInResult.error).toBeUndefined();

--- a/lib/msal-browser/test/custom_auth/sign_in/auth_flow/error_type/SignInError.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/auth_flow/error_type/SignInError.spec.ts
@@ -3,6 +3,7 @@ import {
     RedirectError,
 } from "../../../../../src/custom_auth/core/error/CustomAuthApiError.js";
 import { InvalidArgumentError } from "../../../../../src/custom_auth/index.js";
+import { INVALID_REQUEST } from "../../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
 import {
     SignInError,
     SignInSubmitCodeError,
@@ -85,6 +86,26 @@ describe("SignInError", () => {
         );
         const signInError = new SignInError(errorData as any);
         expect(signInError.isTokenExpired()).toBe(true);
+    });
+
+    it("should return true for isPasswordResetRequired when error is PASSWORD_RESET_REQUIRED", () => {
+        const errorData = new CustomAuthApiError(
+            INVALID_REQUEST,
+            "error-message",
+            "correlation-id",
+            [50142]
+        );
+        const signInError = new SignInError(errorData);
+        expect(signInError.isPasswordResetRequired()).toBe(true);
+    });
+
+    it("should return false for isPasswordResetRequired when errorData is not CustomAuthApiError", () => {
+        const errorData = {
+            error: INVALID_REQUEST,
+            errorDescription: "error-message",
+        };
+        const signInError = new SignInError(errorData as any);
+        expect(signInError.isPasswordResetRequired()).toBe(false);
     });
 });
 

--- a/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
@@ -23,6 +23,11 @@ import {
     TestServerTokenResponse,
     TestTenantId,
 } from "../../test_resources/TestConstants.js";
+import {
+    SignInContinuationTokenParams,
+    SignInSubmitCodeParams,
+    SignInSubmitPasswordParams,
+} from "../../../../src/custom_auth/sign_in/interaction_client/parameter/SignInParams.js";
 
 jest.mock(
     "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js",
@@ -189,12 +194,14 @@ describe("SignInClient", () => {
     });
 
     describe("submitCode", () => {
-        it("should return SignInCompleteResult for valid code", async () => {
+        let signInSubmitCodeParams: SignInSubmitCodeParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokensWithOob.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.submitCode({
+            signInSubmitCodeParams = {
                 code: "123456",
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
@@ -206,7 +213,11 @@ describe("SignInClient", () => {
                 ],
                 correlationId: "corr123",
                 scopes: [],
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult for valid code", async () => {
+            const result = await client.submitCode(signInSubmitCodeParams);
 
             expect(result.type).toStrictEqual(SIGN_IN_COMPLETED_RESULT_TYPE);
             expect(result.correlationId).toBe(
@@ -232,15 +243,38 @@ describe("SignInClient", () => {
                 "abc@test.com"
             );
         });
+
+        it("should include claims in password token request", async () => {
+            const claims = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInSubmitCodeParams.claims = claims;
+            await client.submitCode(signInSubmitCodeParams);
+
+            // Verify that the API was called with claims
+            expect(signInApiClient.requestTokensWithOob).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claims,
+                })
+            );
+        });
     });
 
     describe("submitPassword", () => {
-        it("should return SignInCompleteResult for valid password", async () => {
+        let signInSubmitPasswordParams: SignInSubmitPasswordParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokensWithPassword.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.submitPassword({
+            signInSubmitPasswordParams = {
                 password: "123456",
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
@@ -252,7 +286,13 @@ describe("SignInClient", () => {
                 ],
                 correlationId: "corr123",
                 scopes: [],
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult for valid password", async () => {
+            const result = await client.submitPassword(
+                signInSubmitPasswordParams
+            );
 
             expect(result.type).toStrictEqual(SIGN_IN_COMPLETED_RESULT_TYPE);
             expect(result.correlationId).toBe(
@@ -276,6 +316,29 @@ describe("SignInClient", () => {
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
                 "abc@test.com"
+            );
+        });
+
+        it("should include claims in password token request", async () => {
+            const claims = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInSubmitPasswordParams.claims = claims;
+            await client.submitPassword(signInSubmitPasswordParams);
+
+            // Verify that the API was called with claims
+            expect(
+                signInApiClient.requestTokensWithPassword
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claims,
+                })
             );
         });
     });
@@ -312,12 +375,14 @@ describe("SignInClient", () => {
     });
 
     describe("signInWithContinuationToken", () => {
-        it("should return SignInCompleteResult", async () => {
+        let signInContinuationTokenParams: SignInContinuationTokenParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokenWithContinuationToken.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.signInWithContinuationToken({
+            signInContinuationTokenParams = {
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
                 clientId: customAuthConfig.auth.clientId,
@@ -329,7 +394,13 @@ describe("SignInClient", () => {
                 correlationId: "corr123",
                 scopes: [],
                 signInScenario: SignInScenario.SignInAfterSignUp,
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult", async () => {
+            const result = await client.signInWithContinuationToken(
+                signInContinuationTokenParams
+            );
 
             expect(result.correlationId).toBe(
                 TestServerTokenResponse.correlation_id
@@ -352,6 +423,31 @@ describe("SignInClient", () => {
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
                 "abc@test.com"
+            );
+        });
+
+        it("should include claims in password token request", async () => {
+            const claims = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInContinuationTokenParams.claims = claims;
+            await client.signInWithContinuationToken(
+                signInContinuationTokenParams
+            );
+
+            // Verify that the API was called with claims
+            expect(
+                signInApiClient.requestTokenWithContinuationToken
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claims,
+                })
             );
         });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,6 +260,7 @@
         "extensions/samples/msal-node-extensions": {
             "name": "msal-node-extensions-sample",
             "version": "1.0.0",
+            "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-node": "^3.6.0",
@@ -31279,10 +31280,6 @@
         },
         "node_modules/msal-node-device-code": {
             "resolved": "samples/msal-node-samples/device-code",
-            "link": true
-        },
-        "node_modules/msal-node-extensions-sample": {
-            "resolved": "extensions/samples/msal-node-extensions",
             "link": true
         },
         "node_modules/msal-node-obo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,7 +260,6 @@
         "extensions/samples/msal-node-extensions": {
             "name": "msal-node-extensions-sample",
             "version": "1.0.0",
-            "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-node": "^3.6.0",
@@ -31280,6 +31279,10 @@
         },
         "node_modules/msal-node-device-code": {
             "resolved": "samples/msal-node-samples/device-code",
+            "link": true
+        },
+        "node_modules/msal-node-extensions-sample": {
+            "resolved": "extensions/samples/msal-node-extensions",
             "link": true
         },
         "node_modules/msal-node-obo": {


### PR DESCRIPTION
This pull request introduces support for custom claims in various authentication flows within the `msal-browser` library. The most significant changes include adding a `claims` field to multiple input types, ensuring claims are valid JSON strings, and propagating the `claims` field through the authentication process.

### Support for custom claims:

* Added a `claims` field to several input types (`SignInInputs`, `ResetPasswordInputs`, `AccessTokenRetrievalInputs`, and others) to allow custom claims during authentication. 

### Validation enhancements:

* Introduced a new utility function, `ensureArgumentIsJSONString`, to validate that the `claims` field is a properly formatted JSON string. This function is used in multiple places to ensure input integrity.

### Integration into authentication flows:

* Updated the `CustomAuthStandardController` and related classes to handle the `claims` field during sign-in and token retrieval processes.
* Modified API request types and parameters to include the `claims` field, ensuring it is passed to the backend during token requests.
### Error handling improvements:

* Added methods to detect specific errors, such as password reset requirements, during authentication flows.

### Unit testing:

* Enhanced the `ArgumentValidator` unit tests to cover the new `ensureArgumentIsJSONString` function.