### PR TITLE
Improve custom auth unit tests, remove preview from readme, add support to custom claims and password change required error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ The [`lib`](https://github.com/AzureAD/microsoft-authentication-library-for-js/t
 
 -   [Native Authentication Support for JavaScript](lib/msal-browser/src/custom_auth/): MSAL also provides native authentication APIs that allow applications to implement a native experience with end-to-end customizable flows in their applications. With native authentication, users are guided through a rich, native, sign-up and sign-in journey without leaving the app. The native authentication feature is available for SPAs on [External ID for customers](https://learn.microsoft.com/en-us/entra/identity-platform/concept-native-authentication). It is recommended to always use the most up-to-date version of the SDK.
 
-    > **Note:** The native authentication feature is currently in preview and is not considered production-stable. Features and APIs may change before general availability.
-    >
     > **Terminology:** In the codebase, the term "Custom Auth" is used instead of "Native Auth". You will find classes, interfaces, and configuration options prefixed with `CustomAuth` (e.g., `CustomAuthPublicClientApplication`, `CustomAuthConfiguration`). Please refer to these when implementing or exploring the native authentication feature in the code.
 
 -   [Microsoft Authentication Library for React](lib/msal-react/): A wrapper of the msal-browser library for apps using React.

--- a/change/@azure-msal-browser-5d0005f5-6c0f-4282-92d2-975f3bad562a.json
+++ b/change/@azure-msal-browser-5d0005f5-6c0f-4282-92d2-975f3bad562a.json
@@ -1,7 +1,7 @@
 {
     "type": "minor",
-    "comment": "Add support for custom claims and password change required error, #7948",
+    "comment": "Add support for custom claims and password change required error, #7955",
     "packageName": "@azure/msal-browser",
-    "email": "ydi.w127@gmail.com",
+    "email": "yongdiwang@microsoft.com",
     "dependentChangeType": "patch"
 }

--- a/change/@azure-msal-browser-5d0005f5-6c0f-4282-92d2-975f3bad562a.json
+++ b/change/@azure-msal-browser-5d0005f5-6c0f-4282-92d2-975f3bad562a.json
@@ -1,0 +1,7 @@
+{
+    "type": "minor",
+    "comment": "Add support for custom claims and password change required error, #7948",
+    "packageName": "@azure/msal-browser",
+    "email": "ydi.w127@gmail.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-ba911169-a843-495e-a0ec-be0947de6cac.json
+++ b/change/@azure-msal-browser-ba911169-a843-495e-a0ec-be0947de6cac.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Improve the custom auth unit tests",
+  "packageName": "@azure/msal-browser",
+  "email": "shen.jian@live.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-browser-ba911169-a843-495e-a0ec-be0947de6cac.json
+++ b/change/@azure-msal-browser-ba911169-a843-495e-a0ec-be0947de6cac.json
@@ -1,7 +1,7 @@
 {
-  "type": "none",
-  "comment": "Improve the custom auth unit tests",
-  "packageName": "@azure/msal-browser",
-  "email": "shen.jian@live.com",
-  "dependentChangeType": "none"
+    "type": "none",
+    "comment": "Improve the custom auth unit tests #7955",
+    "packageName": "@azure/msal-browser",
+    "email": "jiashen@microsoft.com",
+    "dependentChangeType": "none"
 }

--- a/lib/msal-browser/src/custom_auth/CustomAuthActionInputs.ts
+++ b/lib/msal-browser/src/custom_auth/CustomAuthActionInputs.ts
@@ -15,6 +15,7 @@ export type SignInInputs = CustomAuthActionInputs & {
     username: string;
     password?: string;
     scopes?: Array<string>;
+    claims?: string;
 };
 
 export type SignUpInputs = CustomAuthActionInputs & {
@@ -30,8 +31,10 @@ export type ResetPasswordInputs = CustomAuthActionInputs & {
 export type AccessTokenRetrievalInputs = {
     forceRefresh: boolean;
     scopes?: Array<string>;
+    claims?: string;
 };
 
 export type SignInWithContinuationTokenInputs = {
     scopes?: Array<string>;
+    claims?: string;
 };

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -41,10 +41,7 @@ import { CustomAuthApiClient } from "../core/network_client/custom_auth_api/Cust
 import { FetchHttpClient } from "../core/network_client/http_client/FetchHttpClient.js";
 import { ResetPasswordClient } from "../reset_password/interaction_client/ResetPasswordClient.js";
 import { NoCachedAccountFoundError } from "../core/error/NoCachedAccountFoundError.js";
-import {
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-} from "../core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../core/utils/ArgumentValidator.js";
 import { UserAlreadySignedInError } from "../core/error/UserAlreadySignedInError.js";
 import { CustomAuthSilentCacheClient } from "../get_account/interaction_client/CustomAuthSilentCacheClient.js";
 import { UnsupportedEnvironmentError } from "../core/error/UnsupportedEnvironmentError.js";
@@ -177,18 +174,26 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(signInInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "signInInputs",
                 signInInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "signInInputs.username",
                 signInInputs.username,
                 correlationId
             );
             this.ensureUserNotSignedIn(correlationId);
+
+            if (signInInputs.claims) {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "signInInputs.claims",
+                    signInInputs.claims,
+                    correlationId
+                );
+            }
 
             // start the signin flow
             const signInStartParams: SignInStartParams = {
@@ -231,6 +236,7 @@ export class CustomAuthStandardController
                         username: signInInputs.username,
                         codeLength: startResult.codeLength,
                         scopes: signInInputs.scopes ?? [],
+                        claims: signInInputs.claims,
                     })
                 );
             } else if (
@@ -258,6 +264,7 @@ export class CustomAuthStandardController
                             cacheClient: this.cacheClient,
                             username: signInInputs.username,
                             scopes: signInInputs.scopes ?? [],
+                            claims: signInInputs.claims,
                         })
                     );
                 }
@@ -277,6 +284,7 @@ export class CustomAuthStandardController
                     continuationToken: startResult.continuationToken,
                     password: signInInputs.password,
                     username: signInInputs.username,
+                    claims: signInInputs.claims,
                 };
 
                 const completedResult = await this.signInClient.submitPassword(
@@ -327,13 +335,13 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(signUpInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "signUpInputs",
                 signUpInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "signUpInputs.username",
                 signUpInputs.username,
                 correlationId
@@ -439,13 +447,13 @@ export class CustomAuthStandardController
         const correlationId = this.getCorrelationId(resetPasswordInputs);
 
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "resetPasswordInputs",
                 resetPasswordInputs,
                 correlationId
             );
 
-            ensureArgumentIsNotEmptyString(
+            ArgumentValidator.ensureArgumentIsNotEmptyString(
                 "resetPasswordInputs.username",
                 resetPasswordInputs.username,
                 correlationId

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/AuthFlowErrorBase.ts
@@ -127,6 +127,18 @@ export abstract class AuthFlowErrorBase {
             this.errorData.error === CustomAuthApiErrorCode.EXPIRED_TOKEN
         );
     }
+
+    /**
+     * @todo verify the password change required error can be detected once the MFA is in place.
+     * This error will be raised during signin and refresh tokens when calling /token endpoint.
+     */
+    protected isPasswordResetRequiredError(): boolean {
+        return (
+            this.errorData instanceof CustomAuthApiError &&
+            this.errorData.error === CustomAuthApiErrorCode.INVALID_REQUEST &&
+            this.errorData.errorCodes?.includes(50142) === true
+        );
+    }
 }
 
 export abstract class AuthActionErrorBase extends AuthFlowErrorBase {

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
@@ -90,6 +90,7 @@ export class SignInApiClient extends BaseApiClient {
                 grant_type: GrantType.PASSWORD,
                 scope: params.scope,
                 password: params.password,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId
@@ -105,6 +106,7 @@ export class SignInApiClient extends BaseApiClient {
                 scope: params.scope,
                 oob: params.oob,
                 grant_type: GrantType.OOB,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId
@@ -121,6 +123,7 @@ export class SignInApiClient extends BaseApiClient {
                 scope: params.scope,
                 grant_type: GrantType.CONTINUATION_TOKEN,
                 client_info: true,
+                ...(params.claims && { claims: params.claims }),
             },
             params.telemetryManager,
             params.correlationId

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/types/ApiRequestTypes.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/types/ApiRequestTypes.ts
@@ -19,6 +19,7 @@ export interface SignInChallengeRequest extends ApiRequestBase {
 interface SignInTokenRequestBase extends ApiRequestBase {
     continuation_token: string;
     scope: string;
+    claims?: string;
 }
 
 export interface SignInPasswordTokenRequest extends SignInTokenRequestBase {

--- a/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
+++ b/lib/msal-browser/src/custom_auth/core/utils/ArgumentValidator.ts
@@ -24,3 +24,25 @@ export function ensureArgumentIsNotEmptyString(
         throw new InvalidArgumentError(argName, correlationId);
     }
 }
+
+export function ensureArgumentIsJSONString(
+    argName: string,
+    argValue: string,
+    correlationId?: string
+): void {
+    try {
+        const parsed = JSON.parse(argValue);
+        if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            Array.isArray(parsed)
+        ) {
+            throw new InvalidArgumentError(argName, correlationId);
+        }
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            throw new InvalidArgumentError(argName, correlationId);
+        }
+        throw e; // Rethrow unexpected errors
+    }
+}

--- a/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
@@ -18,10 +18,7 @@ import {
     TokenClaims,
 } from "@azure/msal-common/browser";
 import { SilentRequest } from "../../../request/SilentRequest.js";
-import {
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-} from "../../core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../../core/utils/ArgumentValidator.js";
 
 /*
  * Account information.
@@ -34,8 +31,15 @@ export class CustomAuthAccountData {
         private readonly logger: Logger,
         private readonly correlationId: string
     ) {
-        ensureArgumentIsNotEmptyString("correlationId", correlationId);
-        ensureArgumentIsNotNullOrUndefined("account", account, correlationId);
+        ArgumentValidator.ensureArgumentIsNotEmptyString(
+            "correlationId",
+            correlationId
+        );
+        ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+            "account",
+            account,
+            correlationId
+        );
     }
 
     /**
@@ -107,11 +111,19 @@ export class CustomAuthAccountData {
         accessTokenRetrievalInputs: AccessTokenRetrievalInputs
     ): Promise<GetAccessTokenResult> {
         try {
-            ensureArgumentIsNotNullOrUndefined(
+            ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                 "accessTokenRetrievalInputs",
                 accessTokenRetrievalInputs,
                 this.correlationId
             );
+
+            if (accessTokenRetrievalInputs.claims) {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "accessTokenRetrievalInputs.claims",
+                    accessTokenRetrievalInputs.claims,
+                    this.correlationId
+                );
+            }
 
             this.logger.verbose("Getting current account.", this.correlationId);
 
@@ -133,7 +145,8 @@ export class CustomAuthAccountData {
             const commonSilentFlowRequest = this.createCommonSilentFlowRequest(
                 currentAccount,
                 accessTokenRetrievalInputs.forceRefresh,
-                newScopes
+                newScopes,
+                accessTokenRetrievalInputs.claims
             );
             const result = await this.cacheClient.acquireToken(
                 commonSilentFlowRequest
@@ -158,7 +171,8 @@ export class CustomAuthAccountData {
     private createCommonSilentFlowRequest(
         accountInfo: AccountInfo,
         forceRefresh: boolean = false,
-        requestScopes: Array<string>
+        requestScopes: Array<string>,
+        claims?: string
     ): CommonSilentFlowRequest {
         const silentRequest: SilentRequest = {
             authority: this.config.auth.authority,
@@ -171,6 +185,7 @@ export class CustomAuthAccountData {
                 accessToken: true,
                 refreshToken: true,
             },
+            ...(claims && { claims: claims }),
         };
 
         return {

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/error_type/SignInError.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/error_type/SignInError.ts
@@ -32,6 +32,14 @@ export class SignInError extends AuthActionErrorBase {
     }
 
     /**
+     * Checks if the error is due to password reset being required.
+     * @returns true if the error is due to password reset being required, false otherwise.
+     */
+    isPasswordResetRequired(): boolean {
+        return this.isPasswordResetRequiredError();
+    }
+
+    /**
      * Checks if the error is due to the provided challenge type is not supported.
      * @returns {boolean} True if the error is due to the provided challenge type is not supported, false otherwise.
      */

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
@@ -37,6 +37,7 @@ export class SignInCodeRequiredState extends SignInState<SignInCodeRequiredState
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 code: code,
                 username: this.stateParameters.username,
+                claims: this.stateParameters.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
@@ -10,6 +10,7 @@ import { SignInWithContinuationTokenInputs } from "../../../CustomAuthActionInpu
 import { SignInContinuationStateParameters } from "./SignInStateParameters.js";
 import { SignInState } from "./SignInState.js";
 import { SignInCompletedState } from "./SignInCompletedState.js";
+import * as ArgumentValidator from "../../../core/utils/ArgumentValidator.js";
 
 /*
  * Sign-in continuation state.
@@ -24,6 +25,14 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
         signInWithContinuationTokenInputs?: SignInWithContinuationTokenInputs
     ): Promise<SignInResult> {
         try {
+            if (signInWithContinuationTokenInputs?.claims) {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "signInWithContinuationTokenInputs.claims",
+                    signInWithContinuationTokenInputs.claims,
+                    this.stateParameters.correlationId
+                );
+            }
+
             const continuationTokenParams: SignInContinuationTokenParams = {
                 clientId: this.stateParameters.config.auth.clientId,
                 correlationId: this.stateParameters.correlationId,
@@ -33,6 +42,7 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 username: this.stateParameters.username,
                 signInScenario: this.stateParameters.signInScenario,
+                claims: signInWithContinuationTokenInputs?.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
@@ -34,6 +34,7 @@ export class SignInPasswordRequiredState extends SignInState<SignInPasswordRequi
                 continuationToken: this.stateParameters.continuationToken ?? "",
                 password: password,
                 username: this.stateParameters.username,
+                claims: this.stateParameters.claims,
             };
 
             this.stateParameters.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInStateParameters.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInStateParameters.ts
@@ -13,6 +13,7 @@ export interface SignInStateParameters
     username: string;
     signInClient: SignInClient;
     cacheClient: CustomAuthSilentCacheClient;
+    claims?: string;
 }
 
 export interface SignInPasswordRequiredStateParameters

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
@@ -195,6 +195,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             scope: scopes.join(" "),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
+            ...(parameters.claims && {
+                claims: parameters.claims,
+            }),
         };
 
         return this.performTokenRequest(
@@ -230,6 +233,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             scope: scopes.join(" "),
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
+            ...(parameters.claims && {
+                claims: parameters.claims,
+            }),
         };
 
         return this.performTokenRequest(
@@ -263,6 +269,9 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             correlationId: parameters.correlationId,
             telemetryManager: telemetryManager,
             scope: scopes.join(" "),
+            ...(parameters.claims && {
+                claims: parameters.claims,
+            }),
         };
 
         // Call token endpoint.

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/parameter/SignInParams.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/parameter/SignInParams.ts
@@ -24,16 +24,19 @@ export interface SignInSubmitCodeParams extends SignInParamsBase {
     continuationToken: string;
     code: string;
     scopes: Array<string>;
+    claims?: string;
 }
 
 export interface SignInSubmitPasswordParams extends SignInParamsBase {
     continuationToken: string;
     password: string;
     scopes: Array<string>;
+    claims?: string;
 }
 
 export interface SignInContinuationTokenParams extends SignInParamsBase {
     continuationToken: string;
     signInScenario: SignInScenarioType;
     scopes: Array<string>;
+    claims?: string;
 }

--- a/lib/msal-browser/test/custom_auth/controller/CustomAuthStandardController.spec.ts
+++ b/lib/msal-browser/test/custom_auth/controller/CustomAuthStandardController.spec.ts
@@ -21,6 +21,7 @@ import * as CustomAuthApiSuberror from "../../../src/custom_auth/core/network_cl
 import { ResetPasswordError } from "../../../src/custom_auth/reset_password/auth_flow/error_type/ResetPasswordError.js";
 import { ResetPasswordCodeRequiredState } from "../../../src/custom_auth/reset_password/auth_flow/state/ResetPasswordCodeRequiredState.js";
 import { ResetPasswordStartResult } from "../../../src/custom_auth/reset_password/auth_flow/result/ResetPasswordStartResult.js";
+import { TestServerTokenResponse } from "../test_resources/TestConstants.js";
 
 jest.mock(
     "../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js",
@@ -62,32 +63,6 @@ jest.mock(
     }
 );
 
-jest.mock("@azure/msal-common/browser", () => {
-    const actualModule = jest.requireActual("@azure/msal-common/browser");
-    return {
-        ...actualModule,
-        ResponseHandler: jest.fn().mockImplementation(() => ({
-            handleServerTokenResponse: jest.fn().mockResolvedValue({
-                uniqueId: "test-unique-id",
-                tenantId: "test-tenant-id",
-                scopes: ["test-scope"],
-                account: {
-                    homeAccountId: "test-home-account-id",
-                    environment: "test-environment",
-                    tenantId: "test-tenant-id",
-                    username: "test-username",
-                },
-                idToken: "test-id-token",
-                idTokenClaims: {},
-                accessToken: "test-access-token",
-                refreshToken: "test-refresh-token",
-                expiresOn: new Date(),
-                extExpiresOn: new Date(),
-            }),
-        })),
-    };
-});
-
 describe("CustomAuthStandardController", () => {
     let controller: CustomAuthStandardController;
     const { signInApiClient, signUpApiClient, resetPasswordApiClient } =
@@ -112,10 +87,6 @@ describe("CustomAuthStandardController", () => {
         ) {
             controller["eventHandler"]["broadcastChannel"].close();
         }
-    });
-
-    test("Check if BroadcastChannel exists in JSDOM", () => {
-        expect(typeof BroadcastChannel).toBe("function");
     });
 
     describe("signIn", () => {
@@ -189,14 +160,9 @@ describe("CustomAuthStandardController", () => {
                 correlation_id: "corr123",
                 continuation_token: "continuation_token_2",
             });
-            signInApiClient.requestTokensWithPassword.mockResolvedValue({
-                correlation_id: "test-correlation-id",
-                access_token: "test-access-token",
-                refresh_token: "test-refresh-token",
-                id_token: "test-id-token",
-                expires_in: 3600,
-                token_type: "Bearer",
-            });
+            signInApiClient.requestTokensWithPassword.mockResolvedValue(
+                TestServerTokenResponse
+            );
 
             const signInInputs: SignInInputs = {
                 correlationId: "correlation-id",
@@ -211,6 +177,9 @@ describe("CustomAuthStandardController", () => {
             expect(result.isCompleted()).toBe(true);
             expect(result.data).toBeDefined();
             expect(result.data).toBeInstanceOf(CustomAuthAccountData);
+
+            // Sign out for the other tests.
+            await result.data?.signOut();
         });
 
         it("should return failed result if the challenge type is redirect", async () => {

--- a/lib/msal-browser/test/custom_auth/core/CustomAuthAuthority.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/CustomAuthAuthority.spec.ts
@@ -1,48 +1,41 @@
-import { INetworkModule, Logger } from "@azure/msal-common/browser";
-import { BrowserCacheManager } from "../../../src/cache/BrowserCacheManager.js";
-import { BrowserConfiguration } from "../../../src/config/Configuration.js";
+import { StubbedNetworkModule } from "@azure/msal-common/browser";
+import { buildConfiguration } from "../../../src/config/Configuration.js";
 import { CustomAuthAuthority } from "../../../src/custom_auth/core/CustomAuthAuthority.js";
 import { customAuthConfig } from "../test_resources/CustomAuthConfig.js";
+import {
+    getDefaultBrowserCacheManager,
+    getDefaultLogger,
+} from "../test_resources/TestModules.js";
 
 describe("CustomAuthAuthority", () => {
     const authorityUrl = customAuthConfig.auth.authority;
     const customAuthProxyDomain = customAuthConfig.customAuth.authApiProxyUrl;
-    const mockMemoryStorage = new Map<string, object>();
     const authorityHostname =
         authorityUrl && authorityUrl.startsWith("https")
             ? authorityUrl.split("/")[2]
             : authorityUrl;
-    const authorityMetadataEntityKey = `authority-metadata-${customAuthConfig.auth.clientId}-${authorityHostname}`;
-    const mockCacheManager = {
-        generateAuthorityMetadataCacheKey: jest.fn().mockImplementation(() => {
-            return authorityMetadataEntityKey;
-        }),
-        setAuthorityMetadata: jest.fn().mockImplementation((key, metadata) => {
-            mockMemoryStorage.set(key, metadata);
-        }),
-    } as unknown as BrowserCacheManager;
-    const mockNetworkModule = {} as unknown as jest.Mocked<INetworkModule>;
-    const mockLogger = {} as unknown as jest.Mocked<Logger>;
-    const mockConfig = {
-        auth: {
-            OIDCOptions: {},
-            knownAuthorities: [],
-            cloudDiscoveryMetadata: "",
-            authorityMetadata: "",
-        },
-        system: {
-            protocolMode: "",
-        },
-    } as unknown as jest.Mocked<BrowserConfiguration>;
+    const clientId = customAuthConfig.auth.clientId;
+    const authorityMetadataEntityKey = `authority-metadata-${clientId}-${authorityHostname}`;
+
+    const config = buildConfiguration({ auth: { clientId: clientId } }, true);
+    const logger = getDefaultLogger();
+    const browserStorage = getDefaultBrowserCacheManager(
+        clientId,
+        logger,
+        undefined,
+        undefined,
+        undefined,
+        config.cache
+    );
 
     describe("constructor", () => {
         it("should correctly parse and store the authority URL", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 authorityUrl ?? "",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger
             );
             expect(customAuthAuthority.canonicalAuthority).toBe(
                 "https://spasamples.ciamlogin.com/spasamples.onmicrosoft.com/"
@@ -52,10 +45,10 @@ describe("CustomAuthAuthority", () => {
         it("should correctly store the customAuthProxyDomain when provided", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 authorityUrl ?? "",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger,
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger,
                 customAuthProxyDomain
             );
             expect(customAuthAuthority["customAuthProxyDomain"]).toBe(
@@ -66,10 +59,10 @@ describe("CustomAuthAuthority", () => {
         it("should correctly store the customAuthProxyDomain when provided", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 "https://login.microsoftonline.com/",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger,
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger,
                 customAuthProxyDomain
             );
             expect(customAuthAuthority["customAuthProxyDomain"]).toBe(
@@ -80,10 +73,10 @@ describe("CustomAuthAuthority", () => {
         it("should save authority metadata entity into cache", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 authorityUrl ?? "",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger
             );
             expect(customAuthAuthority.canonicalAuthority).toBe(
                 "https://spasamples.ciamlogin.com/spasamples.onmicrosoft.com/"
@@ -92,14 +85,15 @@ describe("CustomAuthAuthority", () => {
             const authorityHostname =
                 customAuthAuthority.canonicalAuthorityUrlComponents
                     .HostNameAndPort;
-            const authorityMetadataCacheKey =
-                "authority-metadata-d5e97fb9-24bb-418d-8e7a-4e1918303c92-spasamples.ciamlogin.com";
-            const metadataEntity = mockMemoryStorage.get(
-                authorityMetadataCacheKey
-            );
 
-            expect(mockMemoryStorage.has(authorityMetadataCacheKey)).toBe(true);
-            expect(metadataEntity).toMatchObject({
+            expect(
+                browserStorage
+                    .getAuthorityMetadataKeys()
+                    .includes(authorityMetadataEntityKey)
+            ).toBe(true);
+            expect(
+                browserStorage.getAuthorityMetadata(authorityMetadataEntityKey)
+            ).toMatchObject({
                 aliases: [authorityHostname],
                 preferred_cache: authorityHostname,
             });
@@ -110,10 +104,10 @@ describe("CustomAuthAuthority", () => {
         it("should extract the tenant from the authority URL hostname", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 authorityUrl ?? "",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger
             );
             expect(customAuthAuthority.tenant).toBe(
                 "spasamples.onmicrosoft.com"
@@ -125,10 +119,10 @@ describe("CustomAuthAuthority", () => {
         it("should return the customAuthProxyDomain when provided", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 authorityUrl ?? "",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger,
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger,
                 customAuthProxyDomain
             );
             expect(customAuthAuthority.getCustomAuthApiDomain()).toBe(
@@ -139,10 +133,10 @@ describe("CustomAuthAuthority", () => {
         it("should generate the auth API domain based on the authority URL when customAuthProxyDomain is not provided", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 authorityUrl ?? "",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger
             );
             expect(customAuthAuthority.getCustomAuthApiDomain()).toBe(
                 "https://spasamples.ciamlogin.com/spasamples.onmicrosoft.com/"
@@ -154,10 +148,10 @@ describe("CustomAuthAuthority", () => {
         it("should return the host of authority as preferred cache", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 authorityUrl ?? "",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger,
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger,
                 customAuthProxyDomain
             );
             expect(customAuthAuthority.getPreferredCache()).toBe(
@@ -170,10 +164,10 @@ describe("CustomAuthAuthority", () => {
         it("should return the correct token endpoint", () => {
             const customAuthAuthority = new CustomAuthAuthority(
                 authorityUrl ?? "",
-                mockConfig,
-                mockNetworkModule,
-                mockCacheManager,
-                mockLogger,
+                config,
+                StubbedNetworkModule,
+                browserStorage,
+                logger,
                 customAuthProxyDomain
             );
             expect(customAuthAuthority.tokenEndpoint).toBe(

--- a/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.spec.ts
@@ -1,22 +1,16 @@
-import { Logger } from "@azure/msal-browser";
 import { CustomAuthApiClient } from "../../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js";
 import { FetchHttpClient } from "../../../../../src/custom_auth/core/network_client/http_client/FetchHttpClient.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("CustomAuthApiClient", () => {
     let customAuthApiClient: CustomAuthApiClient;
 
     beforeEach(() => {
-        const mockLogger = {
-            clone: jest.fn(),
-            verbose: jest.fn(),
-            info: jest.fn(),
-            error: jest.fn(),
-            errorPii: jest.fn(),
-        } as unknown as jest.Mocked<Logger>;
+        const logger = getDefaultLogger();
         customAuthApiClient = new CustomAuthApiClient(
             "https://test.com",
             "client_id",
-            new FetchHttpClient(mockLogger)
+            new FetchHttpClient(logger)
         );
     });
 

--- a/lib/msal-browser/test/custom_auth/core/network_client/http_client/FetchClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/network_client/http_client/FetchClient.spec.ts
@@ -1,5 +1,5 @@
-import { Logger } from "@azure/msal-browser";
 import { FetchHttpClient } from "../../../../../src/custom_auth/core/network_client/http_client/FetchHttpClient.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 class MockResponse {
     public readonly status: number;
@@ -20,23 +20,13 @@ class MockResponse {
 describe("FetchHttpClient", () => {
     let httpClient: FetchHttpClient;
     let mockFetch: jest.Mock;
-    const mockLogger = {
-        clone: jest.fn(),
-        info: jest.fn(),
-        infoPii: jest.fn(),
-        verbose: jest.fn(),
-        verbosePii: jest.fn(),
-        error: jest.fn(),
-        trace: jest.fn(),
-        errorPii: jest.fn(),
-        tracePii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
+    const logger = getDefaultLogger();
 
     beforeEach(() => {
         // Create a mock for the global fetch
         mockFetch = jest.fn();
         global.fetch = mockFetch;
-        httpClient = new FetchHttpClient(mockLogger);
+        httpClient = new FetchHttpClient(logger);
     });
 
     afterEach(() => {

--- a/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/utils/ArgumentValidator.spec.ts
@@ -1,33 +1,40 @@
 import { InvalidArgumentError } from "../../../../src/custom_auth/core/error/InvalidArgumentError.js";
-import {
-    ensureArgumentIsNotEmptyString,
-    ensureArgumentIsNotNullOrUndefined,
-} from "../../../../src/custom_auth/core/utils/ArgumentValidator.js";
+import * as ArgumentValidator from "../../../../src/custom_auth/core/utils/ArgumentValidator.js";
 
 describe("ArgumentValidator", () => {
     describe("ensureArgumentIsNotEmptyString", () => {
         it("should not throw an error if the string is non-empty", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "validString");
+                ArgumentValidator.ensureArgumentIsNotEmptyString(
+                    "testArg",
+                    "validString"
+                );
             }).not.toThrow();
         });
 
         it("should throw InvalidArgumentError if the string is empty", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "");
+                ArgumentValidator.ensureArgumentIsNotEmptyString("testArg", "");
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError if the string is only whitespace", () => {
             expect(() => {
-                ensureArgumentIsNotEmptyString("testArg", "   ");
+                ArgumentValidator.ensureArgumentIsNotEmptyString(
+                    "testArg",
+                    "   "
+                );
             }).toThrow(InvalidArgumentError);
         });
 
         it("should pass correlationId to the error when the string is invalid", () => {
             const correlationId = "12345";
             try {
-                ensureArgumentIsNotEmptyString("testArg", "", correlationId);
+                ArgumentValidator.ensureArgumentIsNotEmptyString(
+                    "testArg",
+                    "",
+                    correlationId
+                );
             } catch (error) {
                 if (error instanceof InvalidArgumentError) {
                     expect(error.correlationId).toBe(correlationId);
@@ -41,34 +48,49 @@ describe("ArgumentValidator", () => {
     describe("ensureArgumentIsNotNullOrUndefined", () => {
         it("should not throw an error if the argument is not null or undefined", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", "validValue");
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    "validValue"
+                );
             }).not.toThrow();
 
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", 42);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    42
+                );
             }).not.toThrow();
 
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", {});
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    {}
+                );
             }).not.toThrow();
         });
 
         it("should throw InvalidArgumentError if the argument is null", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", null);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    null
+                );
             }).toThrow(InvalidArgumentError);
         });
 
         it("should throw InvalidArgumentError if the argument is undefined", () => {
             expect(() => {
-                ensureArgumentIsNotNullOrUndefined("testArg", undefined);
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
+                    "testArg",
+                    undefined
+                );
             }).toThrow(InvalidArgumentError);
         });
 
         it("should pass correlationId to the error when the argument is invalid", () => {
             const correlationId = "12345";
             try {
-                ensureArgumentIsNotNullOrUndefined(
+                ArgumentValidator.ensureArgumentIsNotNullOrUndefined(
                     "testArg",
                     null,
                     correlationId
@@ -80,6 +102,165 @@ describe("ArgumentValidator", () => {
                     throw error;
                 }
             }
+        });
+    });
+
+    describe("ensureArgumentIsJSONString", () => {
+        it("should not throw an error when argValue is a valid JSON object string", () => {
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '{"key": "value"}'
+                );
+            }).not.toThrow();
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "{}"); // Empty object
+            }).not.toThrow();
+        });
+
+        it("should not throw an error when argValue is a valid JSON object string with whitespace", () => {
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '  {"key": "value"}  '
+                );
+            }).not.toThrow();
+        });
+
+        it("should throw InvalidArgumentError when argValue is not a JSON object", () => {
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "[]"); // Array - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '"string"'
+                ); // String - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", '""'); // Empty string - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "123"); // Number - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "true"); // Boolean - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "null"); // Null - not an object
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", ""); // Empty string - not valid JSON
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString("testArg", "   "); // Whitespace only - not valid JSON
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    "\t\n "
+                ); // Whitespace only - not valid JSON
+            }).toThrow(InvalidArgumentError);
+        });
+
+        it("should throw InvalidArgumentError when argValue is not valid JSON", () => {
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    "invalid json"
+                );
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '{"key": value}'
+                ); // missing quotes around value
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '{key: "value"}'
+                ); // missing quotes around key
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    '{"key": "value",}'
+                ); // trailing comma
+            }).toThrow(InvalidArgumentError);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    "undefined"
+                );
+            }).toThrow(InvalidArgumentError);
+        });
+
+        it("should pass correlationId to the error when argValue is invalid JSON", () => {
+            const correlationId = "test-correlation-id";
+            try {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    "invalid json",
+                    correlationId
+                );
+            } catch (error) {
+                if (error instanceof InvalidArgumentError) {
+                    expect(error.correlationId).toBe(correlationId);
+                } else {
+                    throw error;
+                }
+            }
+        });
+
+        it("should handle complex valid JSON structures", () => {
+            const complexJson = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+                id_token: {
+                    auth_time: {
+                        essential: true,
+                    },
+                },
+            });
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    complexJson
+                );
+            }).not.toThrow();
+        });
+
+        it("should handle arrays as invalid (not JSON objects)", () => {
+            const arrayJson = JSON.stringify([
+                { name: "item1", value: 1 },
+                { name: "item2", value: 2 },
+            ]);
+
+            expect(() => {
+                ArgumentValidator.ensureArgumentIsJSONString(
+                    "testArg",
+                    arrayJson
+                );
+            }).toThrow(InvalidArgumentError);
         });
     });
 });

--- a/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
@@ -12,6 +12,9 @@ import {
     Logger,
 } from "@azure/msal-common/browser";
 import { AuthenticationResult } from "../../../../src/response/AuthenticationResult.js";
+import { ServerError } from "@azure/msal-common";
+import { INVALID_REQUEST } from "../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
+import { AccessTokenRetrievalInputs } from "../../../../src/custom_auth/CustomAuthActionInputs.js";
 
 describe("CustomAuthAccountData", () => {
     let mockAccount: AccountInfo;
@@ -187,23 +190,23 @@ describe("CustomAuthAccountData", () => {
     });
 
     describe("getAccessToken", () => {
-        it("should return succeed GetAccessTokenState.Completed with cached tokens", async () => {
+        let accountData: CustomAuthAccountData;
+        beforeEach(() => {
             (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
                 mockAccount
             );
-            jest.spyOn(
-                CustomAuthAccountData.prototype as any,
-                "createCommonSilentFlowRequest"
-            ).mockReturnValue({});
-            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
-                mockAuthenticationResult
-            );
-            const accountData = new CustomAuthAccountData(
+            accountData = new CustomAuthAccountData(
                 mockAccount,
                 mockConfig,
                 mockCacheClient,
                 mockLogger,
                 correlationId
+            );
+        });
+
+        it("should return succeed GetAccessTokenState.Completed with cached tokens", async () => {
+            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
+                mockAuthenticationResult
             );
 
             const response = await accountData.getAccessToken({
@@ -219,9 +222,6 @@ describe("CustomAuthAccountData", () => {
         });
 
         it("should return GetAccessTokenError if there is an error when aquire tokens", async () => {
-            (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
-                mockAccount
-            );
             const errorCode =
                 InteractionRequiredAuthErrorCodes.refreshTokenExpired;
             const errorMessage = "Refresh token has expired.";
@@ -235,14 +235,6 @@ describe("CustomAuthAccountData", () => {
                 );
             (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(
                 mockRefreshTokenExpiredError
-            );
-
-            const accountData = new CustomAuthAccountData(
-                mockAccount,
-                mockConfig,
-                mockCacheClient,
-                mockLogger,
-                correlationId
             );
 
             const response = await accountData.getAccessToken({
@@ -262,6 +254,86 @@ describe("CustomAuthAccountData", () => {
             expect(msalError.error).toEqual(errorCode);
             expect(msalError.errorDescription).toEqual(errorMessage);
             expect(msalError.subError).toEqual(subError);
+        });
+
+        it("should include claims in getAccessToken when provided", async () => {
+            (mockCacheClient.acquireToken as jest.Mock).mockResolvedValue(
+                mockAuthenticationResult
+            );
+
+            const claims = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            const accessTokenRetrievalInputs: AccessTokenRetrievalInputs = {
+                forceRefresh: false,
+                scopes: ["test-scope"],
+                claims: claims,
+            };
+            const response = await accountData.getAccessToken(
+                accessTokenRetrievalInputs
+            );
+
+            expect(response).toBeDefined();
+            expect(response.isCompleted()).toBe(true);
+            expect(response.data?.account).toEqual(mockAccount);
+            expect(response.data?.idToken).toEqual(
+                mockAuthenticationResult.idToken
+            );
+
+            expect(mockCacheClient.acquireToken).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claims,
+                })
+            );
+        });
+    });
+
+    describe("password reset required error handling", () => {
+        it("should wrap AADSTS50142 error with MsalCustomAuthError for password reset required", async () => {
+            (mockCacheClient.getCurrentAccount as jest.Mock).mockReturnValue(
+                mockAccount
+            );
+
+            const errorCode = INVALID_REQUEST;
+            const errorMessage = "50142";
+            const mockMSALServerError = new ServerError(
+                errorCode,
+                errorMessage,
+                "",
+                "50142"
+            );
+            (mockCacheClient.acquireToken as jest.Mock).mockRejectedValue(
+                mockMSALServerError
+            );
+
+            const accountData = new CustomAuthAccountData(
+                mockAccount,
+                mockConfig,
+                mockCacheClient,
+                mockLogger,
+                correlationId
+            );
+
+            const response = await accountData.getAccessToken({
+                forceRefresh: false,
+            });
+
+            expect(response).toBeDefined();
+            expect(response.isFailed()).toBe(true);
+            expect(response.error?.errorData).toEqual(mockMSALServerError);
+            expect(response.error?.errorData).toBeInstanceOf(
+                MsalCustomAuthError
+            );
+
+            const msalError = response.error?.errorData as MsalCustomAuthError;
+            expect(msalError.error).toEqual(errorCode);
+            expect(msalError.errorDescription).toEqual(errorMessage);
         });
     });
 });

--- a/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
@@ -4,16 +4,15 @@ import { CustomAuthAuthority } from "../../../../src/custom_auth/core/CustomAuth
 import {
     AccessTokenEntity,
     AccountEntity,
+    AccountEntityUtils,
     CacheHelpers,
     CommonSilentFlowRequest,
-    Constants,
     createInteractionRequiredAuthError,
     ICrypto,
     INetworkModule,
     InteractionRequiredAuthErrorCodes,
     Logger,
     RefreshTokenEntity,
-    StubPerformanceClient,
     TimeUtils,
 } from "@azure/msal-common/browser";
 import {
@@ -22,23 +21,19 @@ import {
     TestServerTokenResponse,
     TestHomeAccountId,
     TestTenantId,
-    TestIdTokenClaims,
     RenewedTokens,
 } from "../../test_resources/TestConstants.js";
 import { DefaultScopes } from "../../../../src/custom_auth/CustomAuthConstants.js";
 import { BrowserCacheManager } from "../../../../src/cache/BrowserCacheManager.js";
 import { BrowserConfiguration } from "../../../../src/config/Configuration.js";
 import { INavigationClient } from "../../../../src/navigation/INavigationClient.js";
-import { EventHandler } from "../../../../src/event/EventHandler.js";
-import { CryptoOps } from "../../../../src/crypto/CryptoOps.js";
-
-jest.mock("@azure/msal-browser", () => {
-    const actualModule = jest.requireActual("@azure/msal-browser");
-    return {
-        ...actualModule,
-        ServerTelemetryManager: jest.fn(),
-    };
-});
+import { RANDOM_TEST_GUID } from "../../../utils/StringConstants.js";
+import {
+    getDefaultCrypto,
+    getDefaultEventHandler,
+    getDefaultPerformanceClient,
+} from "../../test_resources/TestModules.js";
+import { AuthenticationScheme } from "../../../../../msal-common/lib/types/utils/Constants.js";
 
 describe("CustomAuthSilentCacheClient", () => {
     let client: CustomAuthSilentCacheClient;
@@ -93,10 +88,6 @@ describe("CustomAuthSilentCacheClient", () => {
             telemetry: {},
         } as unknown as jest.Mocked<BrowserConfiguration>;
 
-        const mockEventHandler = {} as unknown as jest.Mocked<EventHandler>;
-        const mockPerformanceClient = new StubPerformanceClient();
-        const mockedApiClient = {} as unknown as jest.Mocked<any>;
-
         const mockLogger = {
             clone: jest.fn(),
             info: jest.fn(),
@@ -111,7 +102,15 @@ describe("CustomAuthSilentCacheClient", () => {
         } as unknown as jest.Mocked<Logger>;
 
         mockLogger.clone.mockReturnValue(mockLogger);
-        mockCrypto = new CryptoOps(mockLogger);
+
+        const mockEventHandler = getDefaultEventHandler();
+        const mockPerformanceClient = getDefaultPerformanceClient();
+        const mockedApiClient = {} as unknown as jest.Mocked<any>;
+        mockCrypto = getDefaultCrypto(
+            customAuthConfig.auth.clientId,
+            mockLogger,
+            mockPerformanceClient
+        );
 
         mockCacheManager = new BrowserCacheManager(
             customAuthConfig.auth.clientId,
@@ -168,7 +167,10 @@ describe("CustomAuthSilentCacheClient", () => {
         } as CommonSilentFlowRequest;
 
         beforeEach(() => {
-            accountEntityToCache = createAccountEntityFromAccountInfo();
+            accountEntityToCache =
+                AccountEntityUtils.createAccountEntityFromAccountInfo(
+                    TestAccountDetails
+                );
             accessTokenEntityToCache = createAccessTokenEntity(mockCrypto);
             refreshTokenEntityToCache = createRefreshTokenEntity();
         });
@@ -219,7 +221,7 @@ describe("CustomAuthSilentCacheClient", () => {
                 )[0];
             const refreshToken = mockCacheManager.getRefreshTokenCredential(
                 refreshTokenKey,
-                "test-correlation-id"
+                RANDOM_TEST_GUID
             );
             expect(refreshToken?.secret).toEqual("renewed-refresh-token");
         });
@@ -249,7 +251,7 @@ describe("CustomAuthSilentCacheClient", () => {
                 )[0];
             const refreshToken = mockCacheManager.getRefreshTokenCredential(
                 refreshTokenKey,
-                "test-correlation-id"
+                RANDOM_TEST_GUID
             );
             expect(refreshToken?.secret).toEqual("renewed-refresh-token");
         });
@@ -277,7 +279,7 @@ describe("CustomAuthSilentCacheClient", () => {
                 )[0];
             const refreshToken = mockCacheManager.getRefreshTokenCredential(
                 refreshTokenKey,
-                "test-correlation-id"
+                RANDOM_TEST_GUID
             );
             expect(refreshToken?.secret).toEqual("renewed-refresh-token");
         });
@@ -431,7 +433,7 @@ function createAccessTokenEntity(browserCrypto: ICrypto): AccessTokenEntity {
         expiresOn + 0,
         browserCrypto.base64Decode,
         undefined,
-        TestServerTokenResponse.token_type as Constants.AuthenticationScheme
+        TestServerTokenResponse.token_type as AuthenticationScheme
     );
 }
 
@@ -442,20 +444,4 @@ function createRefreshTokenEntity(): RefreshTokenEntity {
         TestServerTokenResponse.refresh_token,
         customAuthConfig.auth.clientId
     );
-}
-
-function createAccountEntityFromAccountInfo(): AccountEntity {
-    console.log(
-        "🎯 DEBUG: Local createAccountEntityFromAccountInfo called in test!"
-    );
-
-    return {
-        authorityType: Constants.CACHE_ACCOUNT_TYPE_GENERIC,
-        homeAccountId: TestAccountDetails.homeAccountId,
-        localAccountId: TestAccountDetails.localAccountId,
-        realm: TestAccountDetails.tenantId,
-        environment: TestAccountDetails.environment,
-        username: TestAccountDetails.username,
-        name: TestAccountDetails.name,
-    } as AccountEntity;
 }

--- a/lib/msal-browser/test/custom_auth/integration_tests/GetAccount.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/GetAccount.spec.ts
@@ -27,6 +27,11 @@ describe("GetAccount", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;

--- a/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
@@ -14,33 +14,7 @@ import { CustomAuthStandardController } from "../../../src/custom_auth/controlle
 import { ResetPasswordCodeRequiredState } from "../../../src/custom_auth/reset_password/auth_flow/state/ResetPasswordCodeRequiredState.js";
 import { ResetPasswordPasswordRequiredState } from "../../../src/custom_auth/reset_password/auth_flow/state/ResetPasswordPasswordRequiredState.js";
 import { ResetPasswordCompletedState } from "../../../src/custom_auth/reset_password/auth_flow/state/ResetPasswordCompletedState.js";
-
-jest.mock("@azure/msal-common/browser", () => {
-    const actualModule = jest.requireActual("@azure/msal-common/browser");
-    return {
-        ...actualModule,
-        ResponseHandler: jest.fn().mockImplementation(() => ({
-            handleServerTokenResponse: jest.fn().mockResolvedValue({
-                uniqueId: "test-unique-id",
-                tenantId: "test-tenant-id",
-                scopes: ["test-scope"],
-                account: {
-                    homeAccountId: "test-home-account-id",
-                    environment: "test-environment",
-                    tenantId: "test-tenant-id",
-                    username: "test-username",
-                    idToken: "test-id-token",
-                },
-                idToken: "test-id-token",
-                idTokenClaims: {},
-                accessToken: "test-access-token",
-                refreshToken: "test-refresh-token",
-                expiresOn: new Date(),
-                extExpiresOn: new Date(),
-            }),
-        })),
-    };
-});
+import { TestServerTokenResponse } from "../test_resources/TestConstants.js";
 
 describe("Reset password", () => {
     let app: CustomAuthPublicClientApplication;
@@ -152,16 +126,7 @@ describe("Reset password", () => {
             .mockResolvedValueOnce({
                 status: 200,
                 json: async () => {
-                    return {
-                        correlation_id: correlationId,
-                        token_type: "Bearer",
-                        scopes: "test-scope",
-                        expires_in: 3600,
-                        id_token: "test-id-token",
-                        access_token: "test-access-token",
-                        refresh_token: "test-refresh-token",
-                        client_info: "test-client-info",
-                    };
+                    return TestServerTokenResponse;
                 },
                 headers: new Headers({ "content-type": "application/json" }),
                 ok: true,
@@ -206,8 +171,11 @@ describe("Reset password", () => {
         expect(signInResult.data).toBeDefined();
         expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
         expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
-            "test-id-token"
+            TestServerTokenResponse.id_token
         );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
     });
 
     it("should reset password failed if the redirect challenge returned", async () => {

--- a/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/ResetPassword.spec.ts
@@ -29,6 +29,11 @@ describe("Reset password", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;
@@ -164,6 +169,152 @@ describe("Reset password", () => {
         const signInResult = await (
             submitPasswordResult.state as ResetPasswordCompletedState
         ).signIn();
+
+        expect(signInResult).toBeInstanceOf(SignInResult);
+        expect(signInResult.error).toBeUndefined();
+        expect(signInResult.isCompleted()).toBe(true);
+        expect(signInResult.data).toBeDefined();
+        expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
+        expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
+            TestServerTokenResponse.id_token
+        );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
+    });
+
+    it("should sign in with custom claims after reset password successfully", async () => {
+        (fetch as jest.Mock)
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-1",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-2",
+                        challenge_type: "oob",
+                        binding_method: "prompt",
+                        challenge_channel: "email",
+                        challenge_target_label: "s****n@o*********m",
+                        code_length: 8,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-3",
+                        expires_in: 600,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-4",
+                        poll_interval: 1,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        status: "in_progress",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        status: "in_progress",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-5",
+                        status: "succeeded",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return TestServerTokenResponse;
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            });
+
+        const resetPasswordInputs = {
+            username: "test@test.com",
+            correlationId: correlationId,
+        };
+
+        const startResult = await app.resetPassword(resetPasswordInputs);
+
+        expect(startResult).toBeInstanceOf(ResetPasswordStartResult);
+        expect(startResult.error).toBeUndefined();
+        expect(startResult.isCodeRequired()).toBe(true);
+
+        const submitCodeResult = await (
+            startResult.state as ResetPasswordCodeRequiredState
+        ).submitCode("12345678");
+
+        expect(submitCodeResult).toBeInstanceOf(ResetPasswordSubmitCodeResult);
+        expect(submitCodeResult.error).toBeUndefined();
+        expect(submitCodeResult.isPasswordRequired()).toBe(true);
+
+        const submitPasswordResult = await (
+            submitCodeResult.state as ResetPasswordPasswordRequiredState
+        ).submitNewPassword("valid-password");
+
+        expect(submitPasswordResult).toBeInstanceOf(
+            ResetPasswordSubmitPasswordResult
+        );
+        expect(submitPasswordResult.error).toBeUndefined();
+        expect(submitPasswordResult.isCompleted()).toBe(true);
+
+        const claims = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInResult = await (
+            submitPasswordResult.state as ResetPasswordCompletedState
+        ).signIn({
+            claims: claims,
+        });
 
         expect(signInResult).toBeInstanceOf(SignInResult);
         expect(signInResult.error).toBeUndefined();

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
@@ -27,6 +27,11 @@ describe("Sign in", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;
@@ -391,5 +396,64 @@ describe("Sign in", () => {
         expect(submitCodeResult).toBeInstanceOf(SignInSubmitCodeResult);
         expect(submitCodeResult.error).toBeDefined();
         expect(submitCodeResult.error?.isInvalidCode()).toBe(true);
+    });
+
+    it("should sign in successfully if giving custom claims with password as the challenge type", async () => {
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return {
+                    continuation_token: "test-continuation-token-1",
+                    challenge_type: "oob password redirect",
+                };
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return {
+                    continuation_token: "test-continuation-token-2",
+                    challenge_type: "password",
+                };
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            status: 200,
+            json: async () => {
+                return TestServerTokenResponse;
+            },
+            headers: new Headers({ "content-type": "application/json" }),
+            ok: true,
+        });
+
+        const claims = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInInputs = {
+            username: "test@test.com",
+            password: "password",
+            correlationId: correlationId,
+            claims: claims,
+        };
+
+        const result = await app.signIn(signInInputs);
+
+        expect(result).toBeInstanceOf(SignInResult);
+        expect(result.error).toBeUndefined();
+        expect(result.isCompleted()).toBe(true);
+        expect(result.data).toBeDefined();
+        expect(result.data).toBeInstanceOf(CustomAuthAccountData);
     });
 });

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignIn.spec.ts
@@ -12,32 +12,7 @@ import { CustomAuthAccountData } from "../../../src/custom_auth/get_account/auth
 import { CustomAuthStandardController } from "../../../src/custom_auth/controller/CustomAuthStandardController.js";
 import { SignInCodeRequiredState } from "../../../src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.js";
 import { SignInPasswordRequiredState } from "../../../src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.js";
-
-jest.mock("@azure/msal-common/browser", () => {
-    const actualModule = jest.requireActual("@azure/msal-common/browser");
-    return {
-        ...actualModule,
-        ResponseHandler: jest.fn().mockImplementation(() => ({
-            handleServerTokenResponse: jest.fn().mockResolvedValue({
-                uniqueId: "test-unique-id",
-                tenantId: "test-tenant-id",
-                scopes: ["test-scope"],
-                account: {
-                    homeAccountId: "test-home-account-id",
-                    environment: "test-environment",
-                    tenantId: "test-tenant-id",
-                    username: "test-username",
-                },
-                idToken: "test-id-token",
-                idTokenClaims: {},
-                accessToken: "test-access-token",
-                refreshToken: "test-refresh-token",
-                expiresOn: new Date(),
-                extExpiresOn: new Date(),
-            }),
-        })),
-    };
-});
+import { TestServerTokenResponse } from "../test_resources/TestConstants.js";
 
 describe("Sign in", () => {
     let app: CustomAuthPublicClientApplication;
@@ -94,16 +69,7 @@ describe("Sign in", () => {
         (fetch as jest.Mock).mockResolvedValueOnce({
             status: 200,
             json: async () => {
-                return {
-                    correlation_id: correlationId,
-                    token_type: "Bearer",
-                    scopes: "test-scope",
-                    expires_in: 3600,
-                    id_token: "test-id-token",
-                    access_token: "test-access-token",
-                    refresh_token: "test-refresh-token",
-                    client_info: "test-client-info",
-                };
+                return TestServerTokenResponse;
             },
             headers: new Headers({ "content-type": "application/json" }),
             ok: true,
@@ -122,6 +88,9 @@ describe("Sign in", () => {
         expect(result.isCompleted()).toBe(true);
         expect(result.data).toBeDefined();
         expect(result.data).toBeInstanceOf(CustomAuthAccountData);
+
+        // Sign out the user for clean up the state for the other tests.
+        result.data?.signOut();
     });
 
     it("should sign in successfully if the challenge type is oob", async () => {
@@ -155,16 +124,7 @@ describe("Sign in", () => {
         (fetch as jest.Mock).mockResolvedValueOnce({
             status: 200,
             json: async () => {
-                return {
-                    correlation_id: correlationId,
-                    token_type: "Bearer",
-                    scopes: "test-scope",
-                    expires_in: 3600,
-                    id_token: "test-id-token",
-                    access_token: "test-access-token",
-                    refresh_token: "test-refresh-token",
-                    client_info: "test-client-info",
-                };
+                return TestServerTokenResponse;
             },
             headers: new Headers({ "content-type": "application/json" }),
             ok: true,
@@ -187,6 +147,9 @@ describe("Sign in", () => {
         expect(submitCodeResult).toBeDefined();
         expect(submitCodeResult).toBeInstanceOf(SignInSubmitCodeResult);
         expect(submitCodeResult.data).toBeInstanceOf(CustomAuthAccountData);
+
+        // Sign out the user for clean up the state for the other tests.
+        submitCodeResult.data?.signOut();
     });
 
     it("should sign in successfully if the challenge type is password", async () => {
@@ -219,16 +182,7 @@ describe("Sign in", () => {
         (fetch as jest.Mock).mockResolvedValueOnce({
             status: 200,
             json: async () => {
-                return {
-                    correlation_id: correlationId,
-                    token_type: "Bearer",
-                    scopes: "test-scope",
-                    expires_in: 3600,
-                    id_token: "test-id-token",
-                    access_token: "test-access-token",
-                    refresh_token: "test-refresh-token",
-                    client_info: "test-client-info",
-                };
+                return TestServerTokenResponse;
             },
             headers: new Headers({ "content-type": "application/json" }),
             ok: true,
@@ -252,6 +206,9 @@ describe("Sign in", () => {
         expect(submitCodeResult).toBeDefined();
         expect(submitCodeResult).toBeInstanceOf(SignInSubmitPasswordResult);
         expect(submitCodeResult.data).toBeInstanceOf(CustomAuthAccountData);
+
+        // Sign out the user for clean up the state for the other tests.
+        submitCodeResult.data?.signOut();
     });
 
     it("should sign in failed with error if the challenge type is redirect", async () => {

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
@@ -33,6 +33,11 @@ describe("Sign up", () => {
     });
 
     afterEach(() => {
+        const activeUser = app.getAllAccounts();
+        if (activeUser.length > 0) {
+            app.clearCache();
+        }
+
         const controller = app[
             "customAuthController"
         ] as CustomAuthStandardController;
@@ -156,6 +161,140 @@ describe("Sign up", () => {
         const signInResult = await (
             submitPasswordResult.state as SignUpCompletedState
         ).signIn();
+
+        expect(signInResult).toBeInstanceOf(SignInResult);
+        expect(signInResult.error).toBeUndefined();
+        expect(signInResult.isCompleted()).toBe(true);
+        expect(signInResult.data).toBeDefined();
+        expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
+        expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
+            TestServerTokenResponse.id_token
+        );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
+    });
+
+    it("should sign in with custom claims after sign up successfully", async () => {
+        (fetch as jest.Mock)
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-1",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-2",
+                        challenge_type: "oob",
+                        binding_method: "prompt",
+                        challenge_channel: "email",
+                        challenge_target_label: "s****n@o*********m",
+                        code_length: 8,
+                        interval: 300,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 400,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-4",
+                        error: "credential_required",
+                        error_description: "Credential required.",
+                        error_codes: [55103],
+                        timestamp: "yy-mm-dd 02:37:33Z",
+                        trace_id: "test-trace-id",
+                        correlation_id: correlationId,
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: false,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-5",
+                        challenge_type: "password",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return {
+                        continuation_token: "test-continuation-token-6",
+                    };
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                json: async () => {
+                    return TestServerTokenResponse;
+                },
+                headers: new Headers({ "content-type": "application/json" }),
+                ok: true,
+            });
+
+        const attributes: UserAccountAttributes = {
+            city: "test-city",
+        };
+
+        const signUpInputs: SignUpInputs = {
+            username: "test@test.com",
+            correlationId: correlationId,
+            attributes: attributes,
+        };
+
+        const startResult = await app.signUp(signUpInputs);
+
+        expect(startResult).toBeInstanceOf(SignUpResult);
+        expect(startResult.error).toBeUndefined();
+        expect(startResult.isCodeRequired()).toBe(true);
+
+        const submitCodeResult = await (
+            startResult.state as SignUpCodeRequiredState
+        ).submitCode("12345678");
+
+        expect(submitCodeResult).toBeInstanceOf(SignUpSubmitCodeResult);
+        expect(submitCodeResult.error).toBeUndefined();
+        expect(submitCodeResult.isPasswordRequired()).toBe(true);
+
+        const submitPasswordResult = await (
+            submitCodeResult.state as SignUpPasswordRequiredState
+        ).submitPassword("valid-password");
+
+        expect(submitPasswordResult).toBeInstanceOf(SignUpSubmitPasswordResult);
+        expect(submitPasswordResult.error).toBeUndefined();
+        expect(submitPasswordResult.isCompleted()).toBe(true);
+
+        const claims = JSON.stringify({
+            access_token: {
+                acrs: {
+                    essential: true,
+                    value: "c1",
+                },
+            },
+        });
+
+        const signInResult = await (
+            submitPasswordResult.state as SignUpCompletedState
+        ).signIn({
+            claims: claims,
+        });
 
         expect(signInResult).toBeInstanceOf(SignInResult);
         expect(signInResult.error).toBeUndefined();

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignUp.spec.ts
@@ -18,33 +18,7 @@ import { SignUpCodeRequiredState } from "../../../src/custom_auth/sign_up/auth_f
 import { SignUpCompletedState } from "../../../src/custom_auth/sign_up/auth_flow/state/SignUpCompletedState.js";
 import { SignUpPasswordRequiredState } from "../../../src/custom_auth/sign_up/auth_flow/state/SignUpPasswordRequiredState.js";
 import { SignUpAttributesRequiredState } from "../../../src/custom_auth/sign_up/auth_flow/state/SignUpAttributesRequiredState.js";
-
-jest.mock("@azure/msal-common/browser", () => {
-    const actualModule = jest.requireActual("@azure/msal-common/browser");
-    return {
-        ...actualModule,
-        ResponseHandler: jest.fn().mockImplementation(() => ({
-            handleServerTokenResponse: jest.fn().mockResolvedValue({
-                uniqueId: "test-unique-id",
-                tenantId: "test-tenant-id",
-                scopes: ["test-scope"],
-                account: {
-                    homeAccountId: "test-home-account-id",
-                    environment: "test-environment",
-                    tenantId: "test-tenant-id",
-                    username: "test-username",
-                    idToken: "test-id-token",
-                },
-                idToken: "test-id-token",
-                idTokenClaims: {},
-                accessToken: "test-access-token",
-                refreshToken: "test-refresh-token",
-                expiresOn: new Date(),
-                extExpiresOn: new Date(),
-            }),
-        })),
-    };
-});
+import { TestServerTokenResponse } from "../test_resources/TestConstants.js";
 
 describe("Sign up", () => {
     let app: CustomAuthPublicClientApplication;
@@ -141,16 +115,7 @@ describe("Sign up", () => {
             .mockResolvedValueOnce({
                 status: 200,
                 json: async () => {
-                    return {
-                        correlation_id: correlationId,
-                        token_type: "Bearer",
-                        scopes: "test-scope",
-                        expires_in: 3600,
-                        id_token: "test-id-token",
-                        access_token: "test-access-token",
-                        refresh_token: "test-refresh-token",
-                        client_info: "test-client-info",
-                    };
+                    return TestServerTokenResponse;
                 },
                 headers: new Headers({ "content-type": "application/json" }),
                 ok: true,
@@ -198,8 +163,11 @@ describe("Sign up", () => {
         expect(signInResult.data).toBeDefined();
         expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
         expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
-            "test-id-token"
+            TestServerTokenResponse.id_token
         );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
     });
 
     it("should sign up successfully if attributes are required after starting the password reset", async () => {
@@ -282,16 +250,7 @@ describe("Sign up", () => {
             .mockResolvedValueOnce({
                 status: 200,
                 json: async () => {
-                    return {
-                        correlation_id: correlationId,
-                        token_type: "Bearer",
-                        scopes: "test-scope",
-                        expires_in: 3600,
-                        id_token: "test-id-token",
-                        access_token: "test-access-token",
-                        refresh_token: "test-refresh-token",
-                        client_info: "test-client-info",
-                    };
+                    return TestServerTokenResponse;
                 },
                 headers: new Headers({ "content-type": "application/json" }),
                 ok: true,
@@ -349,8 +308,11 @@ describe("Sign up", () => {
         expect(signInResult.data).toBeDefined();
         expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
         expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
-            "test-id-token"
+            TestServerTokenResponse.id_token
         );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
     });
 
     it("should sign up successfully if password and attributes are required after starting the password reset", async () => {
@@ -460,16 +422,7 @@ describe("Sign up", () => {
             .mockResolvedValueOnce({
                 status: 200,
                 json: async () => {
-                    return {
-                        correlation_id: correlationId,
-                        token_type: "Bearer",
-                        scopes: "test-scope",
-                        expires_in: 3600,
-                        id_token: "test-id-token",
-                        access_token: "test-access-token",
-                        refresh_token: "test-refresh-token",
-                        client_info: "test-client-info",
-                    };
+                    return TestServerTokenResponse;
                 },
                 headers: new Headers({ "content-type": "application/json" }),
                 ok: true,
@@ -530,8 +483,11 @@ describe("Sign up", () => {
         expect(signInResult.data).toBeDefined();
         expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
         expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
-            "test-id-token"
+            TestServerTokenResponse.id_token
         );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
     });
 
     it("should sign up successfully if the password and attributes are provided when starting the password reset", async () => {
@@ -575,16 +531,7 @@ describe("Sign up", () => {
             .mockResolvedValueOnce({
                 status: 200,
                 json: async () => {
-                    return {
-                        correlation_id: correlationId,
-                        token_type: "Bearer",
-                        scopes: "test-scope",
-                        expires_in: 3600,
-                        id_token: "test-id-token",
-                        access_token: "test-access-token",
-                        refresh_token: "test-refresh-token",
-                        client_info: "test-client-info",
-                    };
+                    return TestServerTokenResponse;
                 },
                 headers: new Headers({ "content-type": "application/json" }),
                 ok: true,
@@ -625,8 +572,11 @@ describe("Sign up", () => {
         expect(signInResult.data).toBeDefined();
         expect(signInResult.data).toBeInstanceOf(CustomAuthAccountData);
         expect(signInResult.data?.getAccount()?.idToken).toStrictEqual(
-            "test-id-token"
+            TestServerTokenResponse.id_token
         );
+
+        // Sign out the user for clean up the state for the other tests.
+        signInResult.data?.signOut();
     });
 
     it("should sign up failed if the redirect challenge returned", async () => {

--- a/lib/msal-browser/test/custom_auth/reset_password/auth_flow/state/ResetPasswordCodeRequiredState.spec.ts
+++ b/lib/msal-browser/test/custom_auth/reset_password/auth_flow/state/ResetPasswordCodeRequiredState.spec.ts
@@ -5,13 +5,14 @@ import { ResetPasswordResendCodeResult } from "../../../../../src/custom_auth/re
 import { ResetPasswordSubmitCodeResult } from "../../../../../src/custom_auth/reset_password/auth_flow/result/ResetPasswordSubmitCodeResult.js";
 import { ResetPasswordCodeRequiredState } from "../../../../../src/custom_auth/reset_password/auth_flow/state/ResetPasswordCodeRequiredState.js";
 import { ResetPasswordClient } from "../../../../../src/custom_auth/reset_password/interaction_client/ResetPasswordClient.js";
-import { Logger } from "@azure/msal-browser";
 import { SignInClient } from "../../../../../src/custom_auth/sign_in/interaction_client/SignInClient.js";
 import { CustomAuthSilentCacheClient } from "../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("ResetPasswordCodeRequiredState", () => {
+    const clientId = "test-client-id";
     const mockConfig = {
-        auth: { clientId: "test-client-id" },
+        auth: { clientId: clientId },
         customAuth: { challengeTypes: ["code"] },
     } as unknown as jest.Mocked<CustomAuthBrowserConfiguration>;
 
@@ -22,13 +23,6 @@ describe("ResetPasswordCodeRequiredState", () => {
 
     const mockSignInClient = {} as unknown as jest.Mocked<SignInClient>;
 
-    const mockLogger = {
-        info: jest.fn(),
-        verbose: jest.fn(),
-        error: jest.fn(),
-        errorPii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
-
     const username = "testuser";
     const correlationId = "test-correlation-id";
     const continuationToken = "test-continuation-token";
@@ -38,7 +32,7 @@ describe("ResetPasswordCodeRequiredState", () => {
     beforeEach(() => {
         state = new ResetPasswordCodeRequiredState({
             correlationId: correlationId,
-            logger: mockLogger,
+            logger: getDefaultLogger(),
             continuationToken: continuationToken,
             config: mockConfig,
             resetPasswordClient: mockResetPasswordClient,
@@ -79,7 +73,7 @@ describe("ResetPasswordCodeRequiredState", () => {
             expect(result).toBeInstanceOf(ResetPasswordSubmitCodeResult);
             expect(result.isPasswordRequired()).toBe(true);
             expect(mockResetPasswordClient.submitCode).toHaveBeenCalledWith({
-                clientId: "test-client-id",
+                clientId: clientId,
                 correlationId: correlationId,
                 challengeType: ["code"],
                 continuationToken: continuationToken,
@@ -100,7 +94,7 @@ describe("ResetPasswordCodeRequiredState", () => {
             expect(result).toBeInstanceOf(ResetPasswordSubmitCodeResult);
             expect(result.isPasswordRequired()).toBe(true);
             expect(mockResetPasswordClient.submitCode).toHaveBeenCalledWith({
-                clientId: "test-client-id",
+                clientId: clientId,
                 correlationId: correlationId,
                 challengeType: ["code"],
                 continuationToken: continuationToken,

--- a/lib/msal-browser/test/custom_auth/reset_password/auth_flow/state/ResetPasswordPasswordRequiredState.spec.ts
+++ b/lib/msal-browser/test/custom_auth/reset_password/auth_flow/state/ResetPasswordPasswordRequiredState.spec.ts
@@ -3,15 +3,16 @@ import { InvalidArgumentError } from "../../../../../src/custom_auth/core/error/
 import { ResetPasswordSubmitPasswordError } from "../../../../../src/custom_auth/reset_password/auth_flow/error_type/ResetPasswordError.js";
 import { ResetPasswordSubmitPasswordResult } from "../../../../../src/custom_auth/reset_password/auth_flow/result/ResetPasswordSubmitPasswordResult.js";
 import { ResetPasswordClient } from "../../../../../src/custom_auth/reset_password/interaction_client/ResetPasswordClient.js";
-import { Logger } from "@azure/msal-browser";
 import { SignInClient } from "../../../../../src/custom_auth/sign_in/interaction_client/SignInClient.js";
 import { CustomAuthSilentCacheClient } from "../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
 import { ResetPasswordPasswordRequiredState } from "../../../../../src/custom_auth/reset_password/auth_flow/state/ResetPasswordPasswordRequiredState.js";
 import { CustomAuthApiError } from "../../../../../src/custom_auth/core/error/CustomAuthApiError.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("ResetPasswordPasswordRequiredState", () => {
+    const clientId = "test-client-id";
     const mockConfig = {
-        auth: { clientId: "test-client-id" },
+        auth: { clientId: clientId },
         customAuth: { challengeTypes: ["password"] },
     } as unknown as jest.Mocked<CustomAuthBrowserConfiguration>;
 
@@ -20,13 +21,6 @@ describe("ResetPasswordPasswordRequiredState", () => {
     } as unknown as jest.Mocked<ResetPasswordClient>;
 
     const mockSignInClient = {} as unknown as jest.Mocked<SignInClient>;
-
-    const mockLogger = {
-        info: jest.fn(),
-        verbose: jest.fn(),
-        error: jest.fn(),
-        errorPii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";
     const correlationId = "test-correlation-id";
@@ -37,7 +31,7 @@ describe("ResetPasswordPasswordRequiredState", () => {
     beforeEach(() => {
         state = new ResetPasswordPasswordRequiredState({
             correlationId: correlationId,
-            logger: mockLogger,
+            logger: getDefaultLogger(),
             continuationToken: continuationToken,
             config: mockConfig,
             resetPasswordClient: mockResetPasswordClient,
@@ -83,7 +77,7 @@ describe("ResetPasswordPasswordRequiredState", () => {
             expect(
                 mockResetPasswordClient.submitNewPassword
             ).toHaveBeenCalledWith({
-                clientId: "test-client-id",
+                clientId: clientId,
                 correlationId: correlationId,
                 challengeType: ["password"],
                 continuationToken: continuationToken,
@@ -115,7 +109,7 @@ describe("ResetPasswordPasswordRequiredState", () => {
             expect(
                 mockResetPasswordClient.submitNewPassword
             ).toHaveBeenCalledWith({
-                clientId: "test-client-id",
+                clientId: clientId,
                 correlationId: correlationId,
                 challengeType: ["password"],
                 continuationToken: continuationToken,

--- a/lib/msal-browser/test/custom_auth/reset_password/interaction_client/ResetPasswordClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/reset_password/interaction_client/ResetPasswordClient.spec.ts
@@ -18,16 +18,16 @@ import { customAuthConfig } from "../../test_resources/CustomAuthConfig.js";
 import { CustomAuthAuthority } from "../../../../src/custom_auth/core/CustomAuthAuthority.js";
 import { ChallengeType } from "../../../../src/custom_auth/CustomAuthConstants.js";
 import * as CustomAuthApiErrorCode from "../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
-import { BrowserConfiguration } from "../../../../src/config/Configuration.js";
+import { buildConfiguration } from "../../../../src/config/Configuration.js";
+import { StubbedNetworkModule } from "@azure/msal-common/browser";
 import {
-    ICrypto,
-    INetworkModule,
-    IPerformanceClient,
-    Logger,
-} from "@azure/msal-common/browser";
-import { BrowserCacheManager } from "../../../../src/cache/BrowserCacheManager.js";
-import { EventHandler } from "../../../../src/event/EventHandler.js";
-import { INavigationClient } from "../../../../src/navigation/INavigationClient.js";
+    getDefaultBrowserCacheManager,
+    getDefaultCrypto,
+    getDefaultEventHandler,
+    getDefaultLogger,
+    getDefaultNavigationClient,
+    getDefaultPerformanceClient,
+} from "../../test_resources/TestModules.js";
 
 jest.mock(
     "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js",
@@ -73,74 +73,37 @@ jest.mock(
 describe("ResetPasswordClient", () => {
     let client: ResetPasswordClient;
     let authority: CustomAuthAuthority;
-    const {
-        mockedApiClient,
-        signInApiClient,
-        signUpApiClient,
-        resetPasswordApiClient,
-    } = jest.requireMock(
+    const { mockedApiClient, resetPasswordApiClient } = jest.requireMock(
         "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js"
     );
-    const mockConfig = {
-        auth: {
-            OIDCOptions: {},
-            knownAuthorities: [],
-            cloudDiscoveryMetadata: "",
-            authorityMetadata: "",
-        },
-        system: {
-            protocolMode: "",
-        },
-    } as unknown as jest.Mocked<BrowserConfiguration>;
 
     beforeEach(() => {
-        jest.resetAllMocks();
-        const mockBrowserConfiguration = {
-            system: {
-                networkClient: {
-                    sendGetRequestAsync: jest.fn(),
-                    sendPostRequestAsync: jest.fn(),
-                } as unknown as jest.Mocked<INetworkModule>,
-            },
-            auth: {
-                clientId: customAuthConfig.auth.clientId,
-            },
-        } as unknown as jest.Mocked<BrowserConfiguration>;
-
-        const mockCacheManager = {
-            getWrapperMetadata: jest.fn(),
-            getServerTelemetry: jest.fn(),
-            generateAuthorityMetadataCacheKey: jest.fn(),
-            setAuthorityMetadata: jest.fn(),
-        } as unknown as jest.Mocked<BrowserCacheManager>;
-        mockCacheManager.getWrapperMetadata.mockReturnValue(["", ""]);
-        mockCacheManager.getServerTelemetry.mockReturnValue(null);
-
-        const mockCrypto = {
-            createNewGuid: jest.fn(),
-        } as unknown as jest.Mocked<ICrypto>;
-
-        const mockEventHandler = {} as unknown as jest.Mocked<EventHandler>;
-        const mockNavigationClient =
-            {} as unknown as jest.Mocked<INavigationClient>;
-        const mockPerformanceClient =
-            {} as unknown as jest.Mocked<IPerformanceClient>;
-        const mockNetworkModule = {} as unknown as jest.Mocked<INetworkModule>;
-
-        const mockLogger = {
-            clone: jest.fn(),
-            verbose: jest.fn(),
-            info: jest.fn(),
-            infoPii: jest.fn(),
-            error: jest.fn(),
-            errorPii: jest.fn(),
-        } as unknown as jest.Mocked<Logger>;
-        mockLogger.clone.mockReturnValue(mockLogger);
+        const clientId = customAuthConfig.auth.clientId;
+        const mockBrowserConfiguration = buildConfiguration(
+            { auth: { clientId: clientId } },
+            false
+        );
+        const mockLogger = getDefaultLogger();
+        const mockPerformanceClient = getDefaultPerformanceClient(clientId);
+        const mockEventHandler = getDefaultEventHandler();
+        const mockCrypto = getDefaultCrypto(
+            clientId,
+            mockLogger,
+            mockPerformanceClient
+        );
+        const mockCacheManager = getDefaultBrowserCacheManager(
+            clientId,
+            mockLogger,
+            mockPerformanceClient,
+            mockEventHandler,
+            undefined,
+            mockBrowserConfiguration.cache
+        );
 
         authority = new CustomAuthAuthority(
             customAuthConfig.auth.authority ?? "",
-            mockConfig,
-            mockNetworkModule,
+            mockBrowserConfiguration,
+            StubbedNetworkModule,
             mockCacheManager,
             mockLogger,
             customAuthConfig.customAuth.authApiProxyUrl
@@ -152,7 +115,7 @@ describe("ResetPasswordClient", () => {
             mockCrypto,
             mockLogger,
             mockEventHandler,
-            mockNavigationClient,
+            getDefaultNavigationClient(),
             mockPerformanceClient,
             mockedApiClient,
             authority

--- a/lib/msal-browser/test/custom_auth/sign_in/auth_flow/error_type/SignInError.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/auth_flow/error_type/SignInError.spec.ts
@@ -3,6 +3,7 @@ import {
     RedirectError,
 } from "../../../../../src/custom_auth/core/error/CustomAuthApiError.js";
 import { InvalidArgumentError } from "../../../../../src/custom_auth/index.js";
+import { INVALID_REQUEST } from "../../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
 import {
     SignInError,
     SignInSubmitCodeError,
@@ -85,6 +86,26 @@ describe("SignInError", () => {
         );
         const signInError = new SignInError(errorData as any);
         expect(signInError.isTokenExpired()).toBe(true);
+    });
+
+    it("should return true for isPasswordResetRequired when error is PASSWORD_RESET_REQUIRED", () => {
+        const errorData = new CustomAuthApiError(
+            INVALID_REQUEST,
+            "error-message",
+            "correlation-id",
+            [50142]
+        );
+        const signInError = new SignInError(errorData);
+        expect(signInError.isPasswordResetRequired()).toBe(true);
+    });
+
+    it("should return false for isPasswordResetRequired when errorData is not CustomAuthApiError", () => {
+        const errorData = {
+            error: INVALID_REQUEST,
+            errorDescription: "error-message",
+        };
+        const signInError = new SignInError(errorData as any);
+        expect(signInError.isPasswordResetRequired()).toBe(false);
     });
 });
 

--- a/lib/msal-browser/test/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.spec.ts
@@ -12,10 +12,10 @@ import {
     createSignInCompleteResult,
 } from "../../../../../src/custom_auth/sign_in/interaction_client/result/SignInActionResult.js";
 import { SignInClient } from "../../../../../src/custom_auth/sign_in/interaction_client/SignInClient.js";
-import { Logger } from "@azure/msal-browser";
 import { CustomAuthSilentCacheClient } from "../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
 import { SignInCodeRequiredState } from "../../../../../src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.js";
 import { DefaultCustomAuthApiCodeLength } from "../../../../../src/custom_auth/CustomAuthConstants.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("SignInCodeRequiredState", () => {
     const mockConfig = {
@@ -31,13 +31,6 @@ describe("SignInCodeRequiredState", () => {
     const mockCacheClient =
         {} as unknown as jest.Mocked<CustomAuthSilentCacheClient>;
 
-    const mockLogger = {
-        info: jest.fn(),
-        verbose: jest.fn(),
-        error: jest.fn(),
-        errorPii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
-
     const username = "testuser";
     const correlationId = "test-correlation-id";
     const continuationToken = "test-continuation-token";
@@ -50,7 +43,7 @@ describe("SignInCodeRequiredState", () => {
             signInClient: mockSignInClient,
             cacheClient: mockCacheClient,
             correlationId: correlationId,
-            logger: mockLogger,
+            logger: getDefaultLogger(),
             continuationToken: continuationToken,
             config: mockConfig,
             codeLength: 8,

--- a/lib/msal-browser/test/custom_auth/sign_in/auth_flow/state/SignInContinuationState.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/auth_flow/state/SignInContinuationState.spec.ts
@@ -1,4 +1,3 @@
-import { Logger } from "@azure/msal-browser";
 import { CustomAuthAccountData } from "../../../../../src/custom_auth/get_account/auth_flow/CustomAuthAccountData.js";
 import { CustomAuthBrowserConfiguration } from "../../../../../src/custom_auth/configuration/CustomAuthConfiguration.js";
 import { SignInError } from "../../../../../src/custom_auth/sign_in/auth_flow/error_type/SignInError.js";
@@ -8,6 +7,7 @@ import { createSignInCompleteResult } from "../../../../../src/custom_auth/sign_
 import { SignInClient } from "../../../../../src/custom_auth/sign_in/interaction_client/SignInClient.js";
 import { SignInScenario } from "../../../../../src/custom_auth/sign_in/auth_flow/SignInScenario.js";
 import { CustomAuthSilentCacheClient } from "../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("SignInContinuationState", () => {
     const mockConfig = {
@@ -18,13 +18,6 @@ describe("SignInContinuationState", () => {
     const mockSignInClient = {
         signInWithContinuationToken: jest.fn(),
     } as unknown as jest.Mocked<SignInClient>;
-
-    const mockLogger = {
-        info: jest.fn(),
-        verbose: jest.fn(),
-        error: jest.fn(),
-        errorPii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
 
     const mockCacheClient =
         {} as unknown as jest.Mocked<CustomAuthSilentCacheClient>;
@@ -41,7 +34,7 @@ describe("SignInContinuationState", () => {
             signInClient: mockSignInClient,
             cacheClient: mockCacheClient,
             correlationId: correlationId,
-            logger: mockLogger,
+            logger: getDefaultLogger(),
             continuationToken: continuationToken,
             config: mockConfig,
             signInScenario: SignInScenario.SignInAfterSignUp,

--- a/lib/msal-browser/test/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.spec.ts
@@ -1,4 +1,3 @@
-import { Logger } from "@azure/msal-browser";
 import { CustomAuthAccountData } from "../../../../../src/custom_auth/get_account/auth_flow/CustomAuthAccountData.js";
 import { CustomAuthBrowserConfiguration } from "../../../../../src/custom_auth/configuration/CustomAuthConfiguration.js";
 import { InvalidArgumentError } from "../../../../../src/custom_auth/core/error/InvalidArgumentError.js";
@@ -8,6 +7,7 @@ import { SignInPasswordRequiredState } from "../../../../../src/custom_auth/sign
 import { createSignInCompleteResult } from "../../../../../src/custom_auth/sign_in/interaction_client/result/SignInActionResult.js";
 import { SignInClient } from "../../../../../src/custom_auth/sign_in/interaction_client/SignInClient.js";
 import { CustomAuthSilentCacheClient } from "../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("SignInPasswordRequiredState", () => {
     const mockConfig = {
@@ -18,13 +18,6 @@ describe("SignInPasswordRequiredState", () => {
     const mockSignInClient = {
         submitPassword: jest.fn(),
     } as unknown as jest.Mocked<SignInClient>;
-
-    const mockLogger = {
-        info: jest.fn(),
-        verbose: jest.fn(),
-        error: jest.fn(),
-        errorPii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
 
     const mockCacheClient =
         {} as unknown as jest.Mocked<CustomAuthSilentCacheClient>;
@@ -41,7 +34,7 @@ describe("SignInPasswordRequiredState", () => {
             signInClient: mockSignInClient,
             cacheClient: mockCacheClient,
             correlationId: correlationId,
-            logger: mockLogger,
+            logger: getDefaultLogger(),
             continuationToken: continuationToken,
             config: mockConfig,
             scopes: ["scope1", "scope2"],

--- a/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
@@ -9,16 +9,20 @@ import {
     SignInCodeSendResult,
 } from "../../../../src/custom_auth/sign_in/interaction_client/result/SignInActionResult.js";
 import { SignInScenario } from "../../../../src/custom_auth/sign_in/auth_flow/SignInScenario.js";
+import { StubbedNetworkModule } from "@azure/msal-common/browser";
+import { buildConfiguration } from "../../../../src/config/Configuration.js";
 import {
-    ICrypto,
-    INetworkModule,
-    IPerformanceClient,
-    Logger,
-} from "@azure/msal-common/browser";
-import { BrowserConfiguration } from "../../../../src/config/Configuration.js";
-import { BrowserCacheManager } from "../../../../src/cache/BrowserCacheManager.js";
-import { EventHandler } from "../../../../src/event/EventHandler.js";
-import { INavigationClient } from "../../../../src/navigation/INavigationClient.js";
+    getDefaultBrowserCacheManager,
+    getDefaultCrypto,
+    getDefaultEventHandler,
+    getDefaultLogger,
+    getDefaultNavigationClient,
+    getDefaultPerformanceClient,
+} from "../../test_resources/TestModules.js";
+import {
+    TestServerTokenResponse,
+    TestTenantId,
+} from "../../test_resources/TestConstants.js";
 
 jest.mock(
     "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js",
@@ -65,73 +69,37 @@ jest.mock(
 describe("SignInClient", () => {
     let client: SignInClient;
     let authority: CustomAuthAuthority;
-    const {
-        mockedApiClient,
-        signInApiClient,
-        signUpApiClient,
-        resetPasswordApiClient,
-    } = jest.requireMock(
+    const { mockedApiClient, signInApiClient } = jest.requireMock(
         "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js"
     );
 
     beforeEach(() => {
-        jest.resetAllMocks();
-        const mockBrowserConfiguration = {
-            system: {
-                networkClient: {
-                    sendGetRequestAsync: jest.fn(),
-                    sendPostRequestAsync: jest.fn(),
-                } as unknown as jest.Mocked<INetworkModule>,
-            },
-            auth: {
-                clientId: customAuthConfig.auth.clientId,
-            },
-        } as unknown as jest.Mocked<BrowserConfiguration>;
-
-        const mockCacheManager = {
-            getWrapperMetadata: jest.fn(),
-            getServerTelemetry: jest.fn(),
-            generateAuthorityMetadataCacheKey: jest.fn(),
-            setAuthorityMetadata: jest.fn(),
-        } as unknown as jest.Mocked<BrowserCacheManager>;
-        mockCacheManager.getWrapperMetadata.mockReturnValue(["", ""]);
-        mockCacheManager.getServerTelemetry.mockReturnValue(null);
-        const mockNetworkModule = {} as unknown as jest.Mocked<INetworkModule>;
-
-        const mockCrypto = {
-            createNewGuid: jest.fn(),
-        } as unknown as jest.Mocked<ICrypto>;
-
-        const mockEventHandler = {} as unknown as jest.Mocked<EventHandler>;
-        const mockNavigationClient =
-            {} as unknown as jest.Mocked<INavigationClient>;
-        const mockPerformanceClient =
-            {} as unknown as jest.Mocked<IPerformanceClient>;
-
-        const mockLogger = {
-            clone: jest.fn(),
-            verbose: jest.fn(),
-            info: jest.fn(),
-            errorPii: jest.fn(),
-        } as unknown as jest.Mocked<Logger>;
-        mockLogger.clone.mockReturnValue(mockLogger);
-
-        const mockConfig = {
-            auth: {
-                OIDCOptions: {},
-                knownAuthorities: [],
-                cloudDiscoveryMetadata: "",
-                authorityMetadata: "",
-            },
-            system: {
-                protocolMode: "",
-            },
-        } as unknown as jest.Mocked<BrowserConfiguration>;
+        const clientId = customAuthConfig.auth.clientId;
+        const mockBrowserConfiguration = buildConfiguration(
+            { auth: { clientId: clientId } },
+            false
+        );
+        const mockLogger = getDefaultLogger();
+        const mockPerformanceClient = getDefaultPerformanceClient(clientId);
+        const mockEventHandler = getDefaultEventHandler();
+        const mockCrypto = getDefaultCrypto(
+            clientId,
+            mockLogger,
+            mockPerformanceClient
+        );
+        const mockCacheManager = getDefaultBrowserCacheManager(
+            clientId,
+            mockLogger,
+            mockPerformanceClient,
+            mockEventHandler,
+            undefined,
+            mockBrowserConfiguration.cache
+        );
 
         authority = new CustomAuthAuthority(
             customAuthConfig.auth.authority ?? "",
-            mockConfig,
-            mockNetworkModule,
+            mockBrowserConfiguration,
+            StubbedNetworkModule,
             mockCacheManager,
             mockLogger,
             customAuthConfig.customAuth.authApiProxyUrl
@@ -143,34 +111,11 @@ describe("SignInClient", () => {
             mockCrypto,
             mockLogger,
             mockEventHandler,
-            mockNavigationClient,
+            getDefaultNavigationClient(),
             mockPerformanceClient,
             mockedApiClient,
             authority
         );
-
-        (client as any).tokenResponseHandler = {
-            handleServerTokenResponse: jest.fn().mockResolvedValue({
-                uniqueId: "test-unique-id",
-                tenantId: "test-tenant-id",
-                scopes: ["test-scope"],
-                account: {
-                    homeAccountId: "test-home-account-id",
-                    environment: "test-environment",
-                    tenantId: "test-tenant-id",
-                    username: "abc@abc.com",
-                },
-                idToken: "test-id-token",
-                idTokenClaims: {},
-                accessToken: "test-access-token",
-                refreshToken: "test-refresh-token",
-                expiresOn: new Date(),
-                extExpiresOn: new Date(),
-                tokenType: "Bearer",
-                authority:
-                    "https://spasamples.ciamlogin.com/spasamples.onmicrosoft.com/",
-            }),
-        } as any;
     });
 
     afterEach(() => {
@@ -245,19 +190,14 @@ describe("SignInClient", () => {
 
     describe("submitCode", () => {
         it("should return SignInCompleteResult for valid code", async () => {
-            signInApiClient.requestTokensWithOob.mockResolvedValue({
-                correlation_id: "test-correlation-id",
-                access_token: "test-access-token",
-                refresh_token: "test-refresh-token",
-                id_token: "test-id-token",
-                expires_in: 3600,
-                token_type: "Bearer",
-            });
+            signInApiClient.requestTokensWithOob.mockResolvedValue(
+                TestServerTokenResponse
+            );
 
             const result = await client.submitCode({
                 code: "123456",
                 continuationToken: "continuation_token_1",
-                username: "abc@abc.com",
+                username: "abc@test.com",
                 clientId: customAuthConfig.auth.clientId,
                 challengeType: [
                     ChallengeType.OOB,
@@ -269,40 +209,41 @@ describe("SignInClient", () => {
             });
 
             expect(result.type).toStrictEqual(SIGN_IN_COMPLETED_RESULT_TYPE);
-            expect(result.correlationId).toBe("test-correlation-id");
+            expect(result.correlationId).toBe(
+                TestServerTokenResponse.correlation_id
+            );
             expect(result.authenticationResult).toBeDefined();
             expect(result.authenticationResult.accessToken).toBe(
-                "test-access-token"
+                TestServerTokenResponse.access_token
             );
-            expect(result.authenticationResult.idToken).toBe("test-id-token");
+            expect(result.authenticationResult.idToken).toBe(
+                TestServerTokenResponse.id_token
+            );
             expect(result.authenticationResult.expiresOn).toBeDefined();
-            expect(result.authenticationResult.tokenType).toBe("Bearer");
+            expect(result.authenticationResult.tokenType).toBe(
+                TestServerTokenResponse.token_type
+            );
             expect(result.authenticationResult.authority).toBe(
                 authority.canonicalAuthority
             );
-            expect(result.authenticationResult.tenantId).toBe("test-tenant-id");
+            expect(result.authenticationResult.tenantId).toBe(TestTenantId);
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
-                "abc@abc.com"
+                "abc@test.com"
             );
         });
     });
 
     describe("submitPassword", () => {
         it("should return SignInCompleteResult for valid password", async () => {
-            signInApiClient.requestTokensWithPassword.mockResolvedValue({
-                correlation_id: "test-correlation-id",
-                access_token: "test-access-token",
-                refresh_token: "test-refresh-token",
-                id_token: "test-id-token",
-                expires_in: 3600,
-                token_type: "Bearer",
-            });
+            signInApiClient.requestTokensWithPassword.mockResolvedValue(
+                TestServerTokenResponse
+            );
 
             const result = await client.submitPassword({
                 password: "123456",
                 continuationToken: "continuation_token_1",
-                username: "abc@abc.com",
+                username: "abc@test.com",
                 clientId: customAuthConfig.auth.clientId,
                 challengeType: [
                     ChallengeType.OOB,
@@ -314,21 +255,27 @@ describe("SignInClient", () => {
             });
 
             expect(result.type).toStrictEqual(SIGN_IN_COMPLETED_RESULT_TYPE);
-            expect(result.correlationId).toBe("test-correlation-id");
+            expect(result.correlationId).toBe(
+                TestServerTokenResponse.correlation_id
+            );
             expect(result.authenticationResult).toBeDefined();
             expect(result.authenticationResult.accessToken).toBe(
-                "test-access-token"
+                TestServerTokenResponse.access_token
             );
-            expect(result.authenticationResult.idToken).toBe("test-id-token");
+            expect(result.authenticationResult.idToken).toBe(
+                TestServerTokenResponse.id_token
+            );
             expect(result.authenticationResult.expiresOn).toBeDefined();
-            expect(result.authenticationResult.tokenType).toBe("Bearer");
+            expect(result.authenticationResult.tokenType).toBe(
+                TestServerTokenResponse.token_type
+            );
             expect(result.authenticationResult.authority).toBe(
                 authority.canonicalAuthority
             );
-            expect(result.authenticationResult.tenantId).toBe("test-tenant-id");
+            expect(result.authenticationResult.tenantId).toBe(TestTenantId);
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
-                "abc@abc.com"
+                "abc@test.com"
             );
         });
     });
@@ -367,19 +314,12 @@ describe("SignInClient", () => {
     describe("signInWithContinuationToken", () => {
         it("should return SignInCompleteResult", async () => {
             signInApiClient.requestTokenWithContinuationToken.mockResolvedValue(
-                {
-                    correlation_id: "test-correlation-id",
-                    access_token: "test-access-token",
-                    refresh_token: "test-refresh-token",
-                    id_token: "test-id-token",
-                    expires_in: 3600,
-                    token_type: "Bearer",
-                }
+                TestServerTokenResponse
             );
 
             const result = await client.signInWithContinuationToken({
                 continuationToken: "continuation_token_1",
-                username: "abc@abc.com",
+                username: "abc@test.com",
                 clientId: customAuthConfig.auth.clientId,
                 challengeType: [
                     ChallengeType.OOB,
@@ -391,21 +331,27 @@ describe("SignInClient", () => {
                 signInScenario: SignInScenario.SignInAfterSignUp,
             });
 
-            expect(result.correlationId).toBe("test-correlation-id");
+            expect(result.correlationId).toBe(
+                TestServerTokenResponse.correlation_id
+            );
             expect(result.authenticationResult).toBeDefined();
             expect(result.authenticationResult.accessToken).toBe(
-                "test-access-token"
+                TestServerTokenResponse.access_token
             );
-            expect(result.authenticationResult.idToken).toBe("test-id-token");
+            expect(result.authenticationResult.idToken).toBe(
+                TestServerTokenResponse.id_token
+            );
             expect(result.authenticationResult.expiresOn).toBeDefined();
-            expect(result.authenticationResult.tokenType).toBe("Bearer");
+            expect(result.authenticationResult.tokenType).toBe(
+                TestServerTokenResponse.token_type
+            );
             expect(result.authenticationResult.authority).toBe(
                 authority.canonicalAuthority
             );
-            expect(result.authenticationResult.tenantId).toBe("test-tenant-id");
+            expect(result.authenticationResult.tenantId).toBe(TestTenantId);
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
-                "abc@abc.com"
+                "abc@test.com"
             );
         });
     });

--- a/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_in/interation_client/SignInClient.spec.ts
@@ -23,6 +23,11 @@ import {
     TestServerTokenResponse,
     TestTenantId,
 } from "../../test_resources/TestConstants.js";
+import {
+    SignInContinuationTokenParams,
+    SignInSubmitCodeParams,
+    SignInSubmitPasswordParams,
+} from "../../../../src/custom_auth/sign_in/interaction_client/parameter/SignInParams.js";
 
 jest.mock(
     "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js",
@@ -189,12 +194,14 @@ describe("SignInClient", () => {
     });
 
     describe("submitCode", () => {
-        it("should return SignInCompleteResult for valid code", async () => {
+        let signInSubmitCodeParams: SignInSubmitCodeParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokensWithOob.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.submitCode({
+            signInSubmitCodeParams = {
                 code: "123456",
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
@@ -206,7 +213,11 @@ describe("SignInClient", () => {
                 ],
                 correlationId: "corr123",
                 scopes: [],
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult for valid code", async () => {
+            const result = await client.submitCode(signInSubmitCodeParams);
 
             expect(result.type).toStrictEqual(SIGN_IN_COMPLETED_RESULT_TYPE);
             expect(result.correlationId).toBe(
@@ -232,15 +243,38 @@ describe("SignInClient", () => {
                 "abc@test.com"
             );
         });
+
+        it("should include claims in password token request", async () => {
+            const claims = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInSubmitCodeParams.claims = claims;
+            await client.submitCode(signInSubmitCodeParams);
+
+            // Verify that the API was called with claims
+            expect(signInApiClient.requestTokensWithOob).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claims,
+                })
+            );
+        });
     });
 
     describe("submitPassword", () => {
-        it("should return SignInCompleteResult for valid password", async () => {
+        let signInSubmitPasswordParams: SignInSubmitPasswordParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokensWithPassword.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.submitPassword({
+            signInSubmitPasswordParams = {
                 password: "123456",
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
@@ -252,7 +286,13 @@ describe("SignInClient", () => {
                 ],
                 correlationId: "corr123",
                 scopes: [],
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult for valid password", async () => {
+            const result = await client.submitPassword(
+                signInSubmitPasswordParams
+            );
 
             expect(result.type).toStrictEqual(SIGN_IN_COMPLETED_RESULT_TYPE);
             expect(result.correlationId).toBe(
@@ -276,6 +316,29 @@ describe("SignInClient", () => {
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
                 "abc@test.com"
+            );
+        });
+
+        it("should include claims in password token request", async () => {
+            const claims = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInSubmitPasswordParams.claims = claims;
+            await client.submitPassword(signInSubmitPasswordParams);
+
+            // Verify that the API was called with claims
+            expect(
+                signInApiClient.requestTokensWithPassword
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claims,
+                })
             );
         });
     });
@@ -312,12 +375,14 @@ describe("SignInClient", () => {
     });
 
     describe("signInWithContinuationToken", () => {
-        it("should return SignInCompleteResult", async () => {
+        let signInContinuationTokenParams: SignInContinuationTokenParams;
+
+        beforeEach(() => {
             signInApiClient.requestTokenWithContinuationToken.mockResolvedValue(
                 TestServerTokenResponse
             );
 
-            const result = await client.signInWithContinuationToken({
+            signInContinuationTokenParams = {
                 continuationToken: "continuation_token_1",
                 username: "abc@test.com",
                 clientId: customAuthConfig.auth.clientId,
@@ -329,7 +394,13 @@ describe("SignInClient", () => {
                 correlationId: "corr123",
                 scopes: [],
                 signInScenario: SignInScenario.SignInAfterSignUp,
-            });
+            };
+        });
+
+        it("should return SignInCompleteResult", async () => {
+            const result = await client.signInWithContinuationToken(
+                signInContinuationTokenParams
+            );
 
             expect(result.correlationId).toBe(
                 TestServerTokenResponse.correlation_id
@@ -352,6 +423,31 @@ describe("SignInClient", () => {
             expect(result.authenticationResult.account).toBeDefined();
             expect(result.authenticationResult.account.username).toBe(
                 "abc@test.com"
+            );
+        });
+
+        it("should include claims in password token request", async () => {
+            const claims = JSON.stringify({
+                access_token: {
+                    acrs: {
+                        essential: true,
+                        value: "c1",
+                    },
+                },
+            });
+
+            signInContinuationTokenParams.claims = claims;
+            await client.signInWithContinuationToken(
+                signInContinuationTokenParams
+            );
+
+            // Verify that the API was called with claims
+            expect(
+                signInApiClient.requestTokenWithContinuationToken
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    claims: claims,
+                })
             );
         });
     });

--- a/lib/msal-browser/test/custom_auth/sign_up/auth_flow/state/SignUpAttributesRequiredState.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_up/auth_flow/state/SignUpAttributesRequiredState.spec.ts
@@ -4,10 +4,10 @@ import { SignUpSubmitAttributesResult } from "../../../../../src/custom_auth/sig
 import { SignUpAttributesRequiredState } from "../../../../../src/custom_auth/sign_up/auth_flow/state/SignUpAttributesRequiredState.js";
 import { createSignUpCompletedResult } from "../../../../../src/custom_auth/sign_up/interaction_client/result/SignUpActionResult.js";
 import { SignUpClient } from "../../../../../src/custom_auth/sign_up/interaction_client/SignUpClient.js";
-import { Logger } from "@azure/msal-browser";
 import { SignInClient } from "../../../../../src/custom_auth/sign_in/interaction_client/SignInClient.js";
 import { UserAccountAttributes } from "../../../../../src/custom_auth/UserAccountAttributes.js";
 import { CustomAuthSilentCacheClient } from "../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("SignUpAttributesRequiredState", () => {
     const mockConfig = {
@@ -20,13 +20,6 @@ describe("SignUpAttributesRequiredState", () => {
     } as unknown as jest.Mocked<SignUpClient>;
 
     const mockSignInClient = {} as unknown as jest.Mocked<SignInClient>;
-
-    const mockLogger = {
-        info: jest.fn(),
-        verbose: jest.fn(),
-        error: jest.fn(),
-        errorPii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";
     const correlationId = "test-correlation-id";
@@ -45,7 +38,7 @@ describe("SignUpAttributesRequiredState", () => {
             cacheClient:
                 {} as unknown as jest.Mocked<CustomAuthSilentCacheClient>,
             correlationId: correlationId,
-            logger: mockLogger,
+            logger: getDefaultLogger(),
             continuationToken: continuationToken,
             config: mockConfig,
             requiredAttributes: [

--- a/lib/msal-browser/test/custom_auth/sign_up/auth_flow/state/SignUpCodeRequiredState.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_up/auth_flow/state/SignUpCodeRequiredState.spec.ts
@@ -11,9 +11,9 @@ import {
     createSignUpPasswordRequiredResult,
 } from "../../../../../src/custom_auth/sign_up/interaction_client/result/SignUpActionResult.js";
 import { SignUpClient } from "../../../../../src/custom_auth/sign_up/interaction_client/SignUpClient.js";
-import { Logger } from "@azure/msal-browser";
 import { SignInClient } from "../../../../../src/custom_auth/sign_in/interaction_client/SignInClient.js";
 import { CustomAuthSilentCacheClient } from "../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("SignUpCodeRequiredState", () => {
     const mockConfig = {
@@ -27,13 +27,6 @@ describe("SignUpCodeRequiredState", () => {
     } as unknown as jest.Mocked<SignUpClient>;
 
     const mockSignInClient = {} as unknown as jest.Mocked<SignInClient>;
-
-    const mockLogger = {
-        info: jest.fn(),
-        verbose: jest.fn(),
-        error: jest.fn(),
-        errorPii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";
     const correlationId = "test-correlation-id";
@@ -49,7 +42,7 @@ describe("SignUpCodeRequiredState", () => {
             cacheClient:
                 {} as unknown as jest.Mocked<CustomAuthSilentCacheClient>,
             correlationId: correlationId,
-            logger: mockLogger,
+            logger: getDefaultLogger(),
             continuationToken: continuationToken,
             config: mockConfig,
             codeLength: 8,

--- a/lib/msal-browser/test/custom_auth/sign_up/auth_flow/state/SignUpPasswordRequiredState.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_up/auth_flow/state/SignUpPasswordRequiredState.spec.ts
@@ -8,9 +8,9 @@ import {
     createSignUpCompletedResult,
 } from "../../../../../src/custom_auth/sign_up/interaction_client/result/SignUpActionResult.js";
 import { SignUpClient } from "../../../../../src/custom_auth/sign_up/interaction_client/SignUpClient.js";
-import { Logger } from "@azure/msal-browser";
 import { SignInClient } from "../../../../../src/custom_auth/sign_in/interaction_client/SignInClient.js";
 import { CustomAuthSilentCacheClient } from "../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
 
 describe("SignUpPasswordRequiredState", () => {
     const mockConfig = {
@@ -23,13 +23,6 @@ describe("SignUpPasswordRequiredState", () => {
     } as unknown as jest.Mocked<SignUpClient>;
 
     const mockSignInClient = {} as unknown as jest.Mocked<SignInClient>;
-
-    const mockLogger = {
-        info: jest.fn(),
-        verbose: jest.fn(),
-        error: jest.fn(),
-        errorPii: jest.fn(),
-    } as unknown as jest.Mocked<Logger>;
 
     const username = "testuser";
     const correlationId = "test-correlation-id";
@@ -45,7 +38,7 @@ describe("SignUpPasswordRequiredState", () => {
             cacheClient:
                 {} as unknown as jest.Mocked<CustomAuthSilentCacheClient>,
             correlationId: correlationId,
-            logger: mockLogger,
+            logger: getDefaultLogger(),
             continuationToken: continuationToken,
             config: mockConfig,
         });

--- a/lib/msal-browser/test/custom_auth/sign_up/interaction_client/SignUpClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_up/interaction_client/SignUpClient.spec.ts
@@ -11,16 +11,16 @@ import {
 } from "../../../../src/custom_auth/sign_up/interaction_client/result/SignUpActionResult.js";
 import { CustomAuthApiError } from "../../../../src/custom_auth/index.js";
 import * as CustomAuthApiErrorCode from "../../../../src/custom_auth/core/network_client/custom_auth_api/types/ApiErrorCodes.js";
+import { StubbedNetworkModule } from "@azure/msal-common/browser";
+import { buildConfiguration } from "../../../../src/config/Configuration.js";
 import {
-    ICrypto,
-    INetworkModule,
-    IPerformanceClient,
-    Logger,
-} from "@azure/msal-common/browser";
-import { BrowserConfiguration } from "../../../../src/config/Configuration.js";
-import { BrowserCacheManager } from "../../../../src/cache/BrowserCacheManager.js";
-import { EventHandler } from "../../../../src/event/EventHandler.js";
-import { INavigationClient } from "../../../../src/navigation/INavigationClient.js";
+    getDefaultBrowserCacheManager,
+    getDefaultCrypto,
+    getDefaultEventHandler,
+    getDefaultLogger,
+    getDefaultNavigationClient,
+    getDefaultPerformanceClient,
+} from "../../test_resources/TestModules.js";
 
 jest.mock(
     "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js",
@@ -66,73 +66,36 @@ jest.mock(
 describe("SignUpClient", () => {
     let client: SignUpClient;
     let authority: CustomAuthAuthority;
-    const {
-        mockedApiClient,
-        signInApiClient,
-        signUpApiClient,
-        resetPasswordApiClient,
-    } = jest.requireMock(
+    const { mockedApiClient, signUpApiClient } = jest.requireMock(
         "../../../../src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.js"
     );
     beforeEach(() => {
-        jest.resetAllMocks();
-        const mockBrowserConfiguration = {
-            system: {
-                networkClient: {
-                    sendGetRequestAsync: jest.fn(),
-                    sendPostRequestAsync: jest.fn(),
-                } as unknown as jest.Mocked<INetworkModule>,
-            },
-            auth: {
-                clientId: customAuthConfig.auth.clientId,
-            },
-        } as unknown as jest.Mocked<BrowserConfiguration>;
-
-        const mockCacheManager = {
-            getWrapperMetadata: jest.fn(),
-            getServerTelemetry: jest.fn(),
-            generateAuthorityMetadataCacheKey: jest.fn(),
-            setAuthorityMetadata: jest.fn(),
-        } as unknown as jest.Mocked<BrowserCacheManager>;
-        mockCacheManager.getWrapperMetadata.mockReturnValue(["", ""]);
-        mockCacheManager.getServerTelemetry.mockReturnValue(null);
-
-        const mockCrypto = {
-            createNewGuid: jest.fn(),
-        } as unknown as jest.Mocked<ICrypto>;
-
-        const mockEventHandler = {} as unknown as jest.Mocked<EventHandler>;
-        const mockNavigationClient =
-            {} as unknown as jest.Mocked<INavigationClient>;
-        const mockPerformanceClient =
-            {} as unknown as jest.Mocked<IPerformanceClient>;
-        const mockNetworkModule = {} as unknown as jest.Mocked<INetworkModule>;
-
-        const mockLogger = {
-            clone: jest.fn(),
-            verbose: jest.fn(),
-            info: jest.fn(),
-            error: jest.fn(),
-            errorPii: jest.fn(),
-        } as unknown as jest.Mocked<Logger>;
-        mockLogger.clone.mockReturnValue(mockLogger);
-
-        const mockConfig = {
-            auth: {
-                OIDCOptions: {},
-                knownAuthorities: [],
-                cloudDiscoveryMetadata: "",
-                authorityMetadata: "",
-            },
-            system: {
-                protocolMode: "",
-            },
-        } as unknown as jest.Mocked<BrowserConfiguration>;
+        const clientId = customAuthConfig.auth.clientId;
+        const mockBrowserConfiguration = buildConfiguration(
+            { auth: { clientId: clientId } },
+            false
+        );
+        const mockLogger = getDefaultLogger();
+        const mockPerformanceClient = getDefaultPerformanceClient(clientId);
+        const mockEventHandler = getDefaultEventHandler();
+        const mockCrypto = getDefaultCrypto(
+            clientId,
+            mockLogger,
+            mockPerformanceClient
+        );
+        const mockCacheManager = getDefaultBrowserCacheManager(
+            clientId,
+            mockLogger,
+            mockPerformanceClient,
+            mockEventHandler,
+            undefined,
+            mockBrowserConfiguration.cache
+        );
 
         authority = new CustomAuthAuthority(
             customAuthConfig.auth.authority ?? "",
-            mockConfig,
-            mockNetworkModule,
+            mockBrowserConfiguration,
+            StubbedNetworkModule,
             mockCacheManager,
             mockLogger,
             customAuthConfig.customAuth.authApiProxyUrl
@@ -144,7 +107,7 @@ describe("SignUpClient", () => {
             mockCrypto,
             mockLogger,
             mockEventHandler,
-            mockNavigationClient,
+            getDefaultNavigationClient(),
             mockPerformanceClient,
             mockedApiClient,
             authority

--- a/lib/msal-browser/test/custom_auth/test_resources/TestModules.ts
+++ b/lib/msal-browser/test/custom_auth/test_resources/TestModules.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ICrypto, IPerformanceClient, Logger } from "@azure/msal-common";
+import { EventHandler } from "../../../src/event/EventHandler.js";
+import { CryptoOps } from "../../../src/crypto/CryptoOps.js";
+import { BrowserCacheManager } from "../../../src/cache/BrowserCacheManager.js";
+import {
+    buildConfiguration,
+    CacheOptions,
+} from "../../../src/config/Configuration.js";
+import { BrowserPerformanceClient } from "../../../src/telemetry/BrowserPerformanceClient.js";
+import { NavigationClient } from "../../../src/navigation/NavigationClient.js";
+import { INavigationClient } from "../../../src/navigation/INavigationClient.js";
+
+export function getDefaultLogger(): Logger {
+    return new Logger({}, "test", "1.0.0");
+}
+
+export function getDefaultPerformanceClient(
+    clientId: string = "client-id"
+): IPerformanceClient {
+    return new BrowserPerformanceClient({
+        auth: {
+            clientId: clientId,
+        },
+    });
+}
+
+export function getDefaultEventHandler(): EventHandler {
+    return new EventHandler();
+}
+
+export function getDefaultCrypto(
+    clientId: string = "client-id",
+    logger: Logger = getDefaultLogger(),
+    performanceClient: IPerformanceClient = getDefaultPerformanceClient(
+        clientId
+    )
+): ICrypto {
+    return new CryptoOps(logger, performanceClient);
+}
+
+export function getDefaultNavigationClient(): INavigationClient {
+    return new NavigationClient();
+}
+
+export function getDefaultBrowserCacheManager(
+    clientId: string = "client-id",
+    logger: Logger = getDefaultLogger(),
+    performanceClient: IPerformanceClient = getDefaultPerformanceClient(
+        clientId
+    ),
+    eventHandler: EventHandler = getDefaultEventHandler(),
+    crypto: ICrypto = getDefaultCrypto(clientId, logger, performanceClient),
+    cacheOption?: Required<CacheOptions>
+): BrowserCacheManager {
+    if (!cacheOption) {
+        const config = buildConfiguration(
+            { auth: { clientId: clientId } },
+            true
+        );
+        cacheOption = config.cache;
+    }
+
+    return new BrowserCacheManager(
+        clientId,
+        cacheOption,
+        crypto,
+        logger,
+        performanceClient,
+        eventHandler
+    );
+}


### PR DESCRIPTION
Improve the custom auth unit tests (https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/7871)
Remove preview from readme (https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/7947)
Add support for custom claims and password change required error (https://github.com/AzureAD/microsoft-authentication-library-for-js/commit/2ffb0a2d38a153a952e9a1522f4aa4d1e503de2a)
