### PR TITLE
Add Node version support to migration guide

### DIFF
--- a/lib/msal-node/docs/v4-migration.md
+++ b/lib/msal-node/docs/v4-migration.md
@@ -1,7 +1,7 @@
 # Migrating from MSAL Node v3 to v4
 
 ## Dropped support for Node 16 and 18
-msal-node v4 no longer supports Node 16 or 18, you must use 20 or greater.
+MSAL Node v4 no longer supports Node.js 16 or 18; you must use Node.js 20 or greater.
 
 ## Configuration Changes
 

--- a/lib/msal-node/docs/v4-migration.md
+++ b/lib/msal-node/docs/v4-migration.md
@@ -1,5 +1,8 @@
 # Migrating from MSAL Node v3 to v4
 
+## Dropped support for Node 16 and 18
+msal-node v4 no longer supports Node 16 or 18, you must use 20 or greater.
+
 ## Configuration Changes
 
 The `protocolMode` parameter is no longer an auth config option and is instead a system config option.


### PR DESCRIPTION
Adds note to migration guide mentioning dropped support for Node 16 and 18