### PR TITLE
Add JS platform telemetry params

### DIFF
--- a/change/@azure-msal-browser-412d93ef-1542-4310-8454-aa95628399fb.json
+++ b/change/@azure-msal-browser-412d93ef-1542-4310-8454-aa95628399fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Platform Telemetry (PR #7991)",
+  "packageName": "@azure/msal-browser",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-77d3efcd-bb11-4d43-8689-983edd5d9a54.json
+++ b/change/@azure-msal-common-77d3efcd-bb11-4d43-8689-983edd5d9a54.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Platform Telemetry (PR #7991)",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -571,7 +571,6 @@ export class StandardController implements IController {
                     }
                     rootMeasurement.end({
                         success: true,
-                        isNativeBroker: result.fromNativeBroker,
                         accountType: getAccountType(result.account),
                     });
                 } else {
@@ -728,17 +727,21 @@ export class StandardController implements IController {
                     this.nativeInternalStorage,
                     correlationId
                 );
+                atrMeasurement.add({
+                    isPlatformBrokerRequest: true,
+                });
                 result = nativeClient
                     .acquireTokenRedirect(request, atrMeasurement)
                     .catch((e: AuthError) => {
+                        atrMeasurement.add({
+                            brokerErrorName: e.name,
+                            brokerErrorCode: e.errorCode,
+                        });
                         if (
                             e instanceof NativeAuthError &&
                             isFatalNativeAuthError(e)
                         ) {
                             this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to
-                            atrMeasurement.add({
-                                brokerErrorName: e.name,
-                            });
                             const redirectClient =
                                 this.createRedirectClient(correlationId);
                             return redirectClient.acquireToken(request);
@@ -849,6 +852,9 @@ export class StandardController implements IController {
         const pkce = this.getPreGeneratedPkceCodes(correlationId);
 
         if (this.canUsePlatformBroker(request)) {
+            atPopupMeasurement.add({
+                isPlatformBrokerRequest: true,
+            });
             result = this.acquireTokenNative(
                 {
                     ...request,
@@ -859,20 +865,20 @@ export class StandardController implements IController {
                 .then((response) => {
                     atPopupMeasurement.end({
                         success: true,
-                        isNativeBroker: true,
                         accountType: getAccountType(response.account),
                     });
                     return response;
                 })
                 .catch((e: AuthError) => {
+                    atPopupMeasurement.add({
+                        brokerErrorName: e.name,
+                        brokerErrorCode: e.errorCode,
+                    });
                     if (
                         e instanceof NativeAuthError &&
                         isFatalNativeAuthError(e)
                     ) {
                         this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to
-                        atPopupMeasurement.add({
-                            brokerErrorName: e.name,
-                        });
                         const popupClient =
                             this.createPopupClient(correlationId);
                         return popupClient.acquireToken(request, pkce);
@@ -1025,19 +1031,23 @@ export class StandardController implements IController {
         let result: Promise<AuthenticationResult>;
 
         if (this.canUsePlatformBroker(validRequest)) {
+            this.ssoSilentMeasurement?.add({
+                isPlatformBrokerRequest: true,
+            });
             result = this.acquireTokenNative(
                 validRequest,
                 ApiId.ssoSilent
             ).catch((e: AuthError) => {
+                this.ssoSilentMeasurement?.add({
+                    brokerErrorName: e.name,
+                    brokerErrorCode: e.errorCode,
+                });
                 // If native token acquisition fails for availability reasons fallback to standard flow
                 if (e instanceof NativeAuthError && isFatalNativeAuthError(e)) {
                     this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to attempt
                     const silentIframeClient = this.createSilentIframeClient(
                         validRequest.correlationId
                     );
-                    this.ssoSilentMeasurement?.add({
-                        brokerErrorName: e.name,
-                    });
                     return silentIframeClient.acquireToken(validRequest);
                 }
                 throw e;
@@ -1058,7 +1068,6 @@ export class StandardController implements IController {
                 );
                 this.ssoSilentMeasurement?.end({
                     success: true,
-                    isNativeBroker: response.fromNativeBroker,
                     accessTokenSize: response.accessToken.length,
                     idTokenSize: response.idToken.length,
                     accountType: getAccountType(response.account),
@@ -1142,7 +1151,6 @@ export class StandardController implements IController {
                             this.hybridAuthCodeResponses.delete(hybridAuthCode);
                             atbcMeasurement.end({
                                 success: true,
-                                isNativeBroker: result.fromNativeBroker,
                                 accessTokenSize: result.accessToken.length,
                                 idTokenSize: result.idToken.length,
                                 accountType: getAccountType(result.account),
@@ -1178,6 +1186,9 @@ export class StandardController implements IController {
                 if (
                     this.canUsePlatformBroker(request, request.nativeAccountId)
                 ) {
+                    atbcMeasurement.add({
+                        isPlatformBrokerRequest: true,
+                    });
                     const result = await this.acquireTokenNative(
                         {
                             ...request,
@@ -1195,6 +1206,7 @@ export class StandardController implements IController {
                         }
                         atbcMeasurement.add({
                             brokerErrorName: e.name,
+                            brokerErrorCode: e.errorCode,
                         });
                         throw e;
                     });
@@ -1263,7 +1275,6 @@ export class StandardController implements IController {
                 this.acquireTokenByCodeAsyncMeasurement?.end({
                     success: true,
                     fromCache: response.fromCache,
-                    isNativeBroker: response.fromNativeBroker,
                 });
                 return response;
             })
@@ -1628,7 +1639,6 @@ export class StandardController implements IController {
                 BrowserAuthErrorCodes.nativeConnectionNotEstablished
             );
         }
-
         const nativeClient = new PlatformAuthInteractionClient(
             this.config,
             this.browserStorage,
@@ -2072,7 +2082,6 @@ export class StandardController implements IController {
                 atsMeasurement.end({
                     success: true,
                     fromCache: result.fromCache,
-                    isNativeBroker: result.fromNativeBroker,
                     accessTokenSize: result.accessToken.length,
                     idTokenSize: result.idToken.length,
                 });
@@ -2311,7 +2320,6 @@ export class StandardController implements IController {
                     this.performanceClient.addFields(
                         {
                             fromCache: response.fromCache,
-                            isNativeBroker: response.fromNativeBroker,
                         },
                         request.correlationId
                     );
@@ -2359,22 +2367,27 @@ export class StandardController implements IController {
             this.logger.verbose(
                 "acquireTokenSilent - attempting to acquire token from native platform"
             );
+            this.performanceClient.addFields(
+                { isPlatformBrokerRequest: true },
+                silentRequest.correlationId
+            );
             return this.acquireTokenNative(
                 silentRequest,
                 ApiId.acquireTokenSilent_silentFlow,
                 silentRequest.account.nativeAccountId,
                 cacheLookupPolicy
             ).catch(async (e: AuthError) => {
+                this.performanceClient.addFields(
+                    {
+                        brokerErrorName: e.name,
+                        brokerErrorCode: e.errorCode,
+                    },
+                    silentRequest.correlationId
+                );
                 // If native token acquisition fails for availability reasons fallback to web flow
                 if (e instanceof NativeAuthError && isFatalNativeAuthError(e)) {
                     this.logger.verbose(
                         "acquireTokenSilent - native platform unavailable, falling back to web flow"
-                    );
-                    this.performanceClient.addFields(
-                        {
-                            brokerErrorName: e.name,
-                        },
-                        silentRequest.correlationId
                     );
                     this.platformAuthProvider = undefined; // Prevent future requests from continuing to attempt
                     // Cache will not contain tokens, given that previous WAM requests succeeded. Skip cache and RT renewal and go straight to iframe renewal

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -742,7 +742,7 @@ export class StandardController implements IController {
                             e instanceof NativeAuthError &&
                             isFatalNativeAuthError(e)
                         ) {
-                            this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to
+                            this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to attempt platform broker calls
                             const redirectClient =
                                 this.createRedirectClient(correlationId);
                             return redirectClient.acquireToken(request);
@@ -879,7 +879,7 @@ export class StandardController implements IController {
                         e instanceof NativeAuthError &&
                         isFatalNativeAuthError(e)
                     ) {
-                        this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to
+                        this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to continuing to attempt platform broker calls
                         const popupClient =
                             this.createPopupClient(correlationId);
                         return popupClient.acquireToken(request, pkce);

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -571,6 +571,7 @@ export class StandardController implements IController {
                     }
                     rootMeasurement.end({
                         success: true,
+                        isNativeBroker: result.fromNativeBroker,
                         accountType: getAccountType(result.account),
                     });
                 } else {
@@ -734,7 +735,10 @@ export class StandardController implements IController {
                             e instanceof NativeAuthError &&
                             isFatalNativeAuthError(e)
                         ) {
-                            this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to attempt
+                            this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to
+                            atrMeasurement.add({
+                                brokerErrorName: e.name,
+                            });
                             const redirectClient =
                                 this.createRedirectClient(correlationId);
                             return redirectClient.acquireToken(request);
@@ -865,7 +869,10 @@ export class StandardController implements IController {
                         e instanceof NativeAuthError &&
                         isFatalNativeAuthError(e)
                     ) {
-                        this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to attempt
+                        this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to
+                        atPopupMeasurement.add({
+                            brokerErrorName: e.name,
+                        });
                         const popupClient =
                             this.createPopupClient(correlationId);
                         return popupClient.acquireToken(request, pkce);
@@ -1028,6 +1035,9 @@ export class StandardController implements IController {
                     const silentIframeClient = this.createSilentIframeClient(
                         validRequest.correlationId
                     );
+                    this.ssoSilentMeasurement?.add({
+                        brokerErrorName: e.name,
+                    });
                     return silentIframeClient.acquireToken(validRequest);
                 }
                 throw e;
@@ -1183,6 +1193,9 @@ export class StandardController implements IController {
                         ) {
                             this.platformAuthProvider = undefined; // If extension gets uninstalled during session prevent future requests from continuing to attempt
                         }
+                        atbcMeasurement.add({
+                            brokerErrorName: e.name,
+                        });
                         throw e;
                     });
                     atbcMeasurement.end({
@@ -2356,6 +2369,12 @@ export class StandardController implements IController {
                 if (e instanceof NativeAuthError && isFatalNativeAuthError(e)) {
                     this.logger.verbose(
                         "acquireTokenSilent - native platform unavailable, falling back to web flow"
+                    );
+                    this.performanceClient.addFields(
+                        {
+                            brokerErrorName: e.name,
+                        },
+                        silentRequest.correlationId
                     );
                     this.platformAuthProvider = undefined; // Prevent future requests from continuing to attempt
                     // Cache will not contain tokens, given that previous WAM requests succeeded. Skip cache and RT renewal and go straight to iframe renewal

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -730,9 +730,7 @@ export class StandardController implements IController {
                     this.nativeInternalStorage,
                     correlationId
                 );
-                atrMeasurement.add({
-                    isPlatformBrokerRequest: true,
-                });
+
                 result = nativeClient
                     .acquireTokenRedirect(request, atrMeasurement)
                     .catch((e: AuthError) => {

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -495,6 +495,9 @@ export class StandardController implements IController {
                 this.logger.trace(
                     "handleRedirectPromise - acquiring token from native platform"
                 );
+                rootMeasurement.add({
+                    isPlatformBrokerRequest: true,
+                });
                 const nativeClient = new PlatformAuthInteractionClient(
                     this.config,
                     this.browserStorage,

--- a/lib/msal-browser/src/error/NativeAuthError.ts
+++ b/lib/msal-browser/src/error/NativeAuthError.ts
@@ -52,8 +52,7 @@ export function isFatalNativeAuthError(error: NativeAuthError): boolean {
     if (
         error.ext &&
         error.ext.status &&
-        (error.ext.status === NativeStatusCodes.PERSISTENT_ERROR ||
-            error.ext.status === NativeStatusCodes.DISABLED)
+        error.ext.status === NativeStatusCodes.DISABLED
     ) {
         return true;
     }

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -164,6 +164,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             PerformanceEvents.NativeInteractionClientAcquireToken,
             request.correlationId
         );
+        nativeATMeasurement.add({
+            isPlatformBrokerRequest: true,
+        });
         const reqTimestamp = TimeUtils.nowSeconds();
 
         const serverTelemetryManager = this.initializeServerTelemetryManager(
@@ -191,6 +194,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                     this.logger.info(
                         "MSAL internal Cache does not contain tokens, return error as per cache policy"
                     );
+                    nativeATMeasurement.end({
+                        success: false,
+                        errorCode: "cache request failed",
+                    });
                     throw e;
                 }
                 // continue with a native call for any and all errors
@@ -245,7 +252,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): CommonSilentFlowRequest {
         return {
             authority: request.authority,
-            correlationId: this.correlationId,
+            correlationId: request.correlationId,
             scopes: ScopeSet.fromString(request.scope).asArray(),
             account: cachedAccount,
             forceRefresh: false,
@@ -273,7 +280,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             {
                 nativeAccountId,
             },
-            this.correlationId
+            request.correlationId
         );
 
         if (!account) {
@@ -324,6 +331,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         const nativeRequest = await this.initializeNativeRequest(
             remainingParameters
         );
+        rootMeasurement.add({
+            isPlatformBrokerRequest: true,
+        });
 
         try {
             await this.platformAuthProvider.sendMessage(nativeRequest);
@@ -423,6 +433,12 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             const serverTelemetryManager =
                 this.initializeServerTelemetryManager(this.apiId);
             serverTelemetryManager.clearNativeBrokerErrorCode();
+            if (performanceClient && correlationId) {
+                this.performanceClient.addFields(
+                    { isNativeBroker: true },
+                    correlationId
+                );
+            }
             return authResult;
         } catch (e) {
             throw e;
@@ -469,7 +485,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 {
                     nativeAccountId: request.accountId,
                 },
-                this.correlationId
+                request.correlationId
             )?.homeAccountId;
 
         // add exception for double brokering, please note this is temporary and will be fortified in future
@@ -498,7 +514,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             authority,
             homeAccountIdentifier,
             base64Decode,
-            this.correlationId,
+            request.correlationId,
             idTokenClaims,
             response.client_info,
             undefined, // environment
@@ -522,7 +538,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         );
 
         // cache accounts and tokens in the appropriate storage
-        await this.cacheAccount(baseAccount, this.correlationId);
+        await this.cacheAccount(baseAccount, request.correlationId);
         await this.cacheNativeTokens(
             response,
             request,
@@ -704,7 +720,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 reqTimestamp + response.expires_in
             ),
             tokenType: tokenType,
-            correlationId: this.correlationId,
+            correlationId: request.correlationId,
             state: response.state,
             fromNativeBroker: true,
         };
@@ -721,7 +737,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         correlationId: string
     ): Promise<void> {
         // Store the account info and hence `nativeAccountId` in browser cache
-        await this.browserStorage.setAccount(accountEntity, this.correlationId);
+        await this.browserStorage.setAccount(accountEntity, correlationId);
         // Remove any existing cached tokens for this account in browser storage
         this.browserStorage.removeAccountContext(
             accountEntity.getAccountInfo(),
@@ -794,7 +810,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
 
         return this.nativeStorageManager.saveCacheRecord(
             nativeCacheRecord,
-            this.correlationId,
+            request.correlationId,
             request.storeInCache
         );
     }
@@ -905,7 +921,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             scope: scopeSet.printScopes(),
             redirectUri: this.getRedirectUri(request.redirectUri),
             prompt: this.getPrompt(request.prompt),
-            correlationId: this.correlationId,
+            correlationId: request.correlationId || this.correlationId,
             tokenType: request.authenticationScheme,
             windowTitleSubstring: document.title,
             extraParameters: {

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -155,14 +155,14 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): Promise<AuthenticationResult> {
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.NativeInteractionClientAcquireToken,
-            request.correlationId
+            this.correlationId
         );
         this.logger.trace("NativeInteractionClient - acquireToken called.");
 
         // start the perf measurement
         const nativeATMeasurement = this.performanceClient.startMeasurement(
             PerformanceEvents.NativeInteractionClientAcquireToken,
-            request.correlationId
+            this.correlationId
         );
         const reqTimestamp = TimeUtils.nowSeconds();
 
@@ -960,7 +960,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                     PerformanceEvents.PopTokenGenerateCnf,
                     this.logger,
                     this.performanceClient,
-                    request.correlationId
+                    this.correlationId
                 )(shrParameters, this.logger);
                 reqCnfData = generatedReqCnfData.reqCnfString;
                 validatedRequest.keyId = generatedReqCnfData.kid;
@@ -1085,7 +1085,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 embeddedClientId: child_client_id,
                 embeddedRedirectUri: child_redirect_uri,
             },
-            request.correlationId
+            this.correlationId
         );
     }
 }

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -193,7 +193,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                     );
                     nativeATMeasurement.end({
                         success: false,
-                        errorCode: "cache request failed",
+                        brokerErrorCode: "cache_request_failed",
                     });
                     throw e;
                 }
@@ -234,9 +234,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             }
             nativeATMeasurement.end({
                 success: false,
-                errorCode:
-                    e instanceof AuthError ? e.errorCode : "unknown_error",
-                subErrorCode: e instanceof AuthError ? e.subError : undefined,
             });
             throw e;
         }

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -134,28 +134,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     }
 
     /**
-     * Ensures that this.correlationId is synchronized with request.correlationId
-     * @param request - Request object that may contain correlationId
-     * @private
-     */
-    private synchronizeCorrelationId(request: {
-        correlationId?: string;
-    }): void {
-        if (
-            request.correlationId &&
-            request.correlationId !== this.correlationId
-        ) {
-            this.correlationId = request.correlationId;
-            // Update logger with new correlationId for consistent logging
-            this.logger = this.logger.clone(
-                BrowserConstants.MSAL_SKU,
-                version,
-                this.correlationId
-            );
-        }
-    }
-
-    /**
      * Adds SKUs to request extra query parameters
      * @param request {PlatformAuthRequest}
      * @private
@@ -175,19 +153,16 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         request: PopupRequest | SilentRequest | SsoSilentRequest,
         cacheLookupPolicy?: CacheLookupPolicy
     ): Promise<AuthenticationResult> {
-        // Synchronize correlationId between instance and request
-        this.synchronizeCorrelationId(request);
-
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.NativeInteractionClientAcquireToken,
-            this.correlationId
+            request.correlationId
         );
         this.logger.trace("NativeInteractionClient - acquireToken called.");
 
         // start the perf measurement
         const nativeATMeasurement = this.performanceClient.startMeasurement(
             PerformanceEvents.NativeInteractionClientAcquireToken,
-            this.correlationId
+            request.correlationId
         );
         const reqTimestamp = TimeUtils.nowSeconds();
 
@@ -279,7 +254,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): CommonSilentFlowRequest {
         return {
             authority: request.authority,
-            correlationId: this.correlationId,
+            correlationId: request.correlationId,
             scopes: ScopeSet.fromString(request.scope).asArray(),
             account: cachedAccount,
             forceRefresh: false,
@@ -307,7 +282,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             {
                 nativeAccountId,
             },
-            this.correlationId
+            request.correlationId
         );
 
         if (!account) {
@@ -348,9 +323,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         request: RedirectRequest,
         rootMeasurement: InProgressPerformanceEvent
     ): Promise<void> {
-        // Synchronize correlationId between instance and request
-        this.synchronizeCorrelationId(request);
-
         this.logger.trace(
             "NativeInteractionClient - acquireTokenRedirect called."
         );
@@ -405,11 +377,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         performanceClient?: IPerformanceClient,
         correlationId?: string
     ): Promise<AuthenticationResult | null> {
-        // Synchronize correlationId if provided
-        if (correlationId && correlationId !== this.correlationId) {
-            this.synchronizeCorrelationId({ correlationId });
-        }
-
         this.logger.trace(
             "NativeInteractionClient - handleRedirectPromise called."
         );
@@ -426,10 +393,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             this.logger.verbose(
                 "NativeInteractionClient - handleRedirectPromise called but there is no cached request, returning null."
             );
-            if (performanceClient && this.correlationId) {
+            if (performanceClient && correlationId) {
                 performanceClient?.addFields(
                     { errorCode: "no_cached_request" },
-                    this.correlationId
+                    correlationId
                 );
             }
             return null;
@@ -465,10 +432,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             const serverTelemetryManager =
                 this.initializeServerTelemetryManager(this.apiId);
             serverTelemetryManager.clearNativeBrokerErrorCode();
-            if (performanceClient && this.correlationId) {
+            if (performanceClient && request.correlationId) {
                 this.performanceClient.addFields(
                     { isNativeBroker: true },
-                    this.correlationId
+                    request.correlationId
                 );
             }
             return authResult;
@@ -517,7 +484,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 {
                     nativeAccountId: request.accountId,
                 },
-                this.correlationId
+                request.correlationId
             )?.homeAccountId;
 
         // add exception for double brokering, please note this is temporary and will be fortified in future
@@ -546,7 +513,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             authority,
             homeAccountIdentifier,
             base64Decode,
-            this.correlationId,
+            request.correlationId,
             idTokenClaims,
             response.client_info,
             undefined, // environment
@@ -570,7 +537,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         );
 
         // cache accounts and tokens in the appropriate storage
-        await this.cacheAccount(baseAccount, this.correlationId);
+        await this.cacheAccount(baseAccount, request.correlationId);
         await this.cacheNativeTokens(
             response,
             request,
@@ -692,6 +659,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): Promise<AuthenticationResult> {
         // Add Native Broker fields to Telemetry
         const mats = this.addTelemetryFromNativeResponse(
+            request.correlationId,
             response.properties.MATS
         );
 
@@ -752,7 +720,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 reqTimestamp + response.expires_in
             ),
             tokenType: tokenType,
-            correlationId: this.correlationId,
+            correlationId: request.correlationId,
             state: response.state,
             fromNativeBroker: true,
         };
@@ -842,7 +810,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
 
         return this.nativeStorageManager.saveCacheRecord(
             nativeCacheRecord,
-            this.correlationId,
+            request.correlationId,
             request.storeInCache
         );
     }
@@ -859,6 +827,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     }
 
     protected addTelemetryFromNativeResponse(
+        correlationId: string,
         matsResponse?: string
     ): MATS | null {
         const mats = this.getMATSFromResponse(matsResponse);
@@ -886,7 +855,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 matsHttpStatus: mats.http_status,
                 matsHttpEventCount: mats.http_event_count,
             },
-            this.correlationId
+            correlationId
         );
 
         return mats;
@@ -934,9 +903,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected async initializeNativeRequest(
         request: PopupRequest | SsoSilentRequest
     ): Promise<PlatformAuthRequest> {
-        // Synchronize correlationId between instance and request
-        this.synchronizeCorrelationId(request);
-
         this.logger.trace(
             "NativeInteractionClient - initializeNativeRequest called"
         );
@@ -956,7 +922,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             scope: scopeSet.printScopes(),
             redirectUri: this.getRedirectUri(request.redirectUri),
             prompt: this.getPrompt(request.prompt),
-            correlationId: this.correlationId,
+            correlationId: request.correlationId
+                ? request.correlationId
+                : this.correlationId,
             tokenType: request.authenticationScheme,
             windowTitleSubstring: document.title,
             extraParameters: {
@@ -999,7 +967,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                     PerformanceEvents.PopTokenGenerateCnf,
                     this.logger,
                     this.performanceClient,
-                    this.correlationId
+                    request.correlationId
                 )(shrParameters, this.logger);
                 reqCnfData = generatedReqCnfData.reqCnfString;
                 validatedRequest.keyId = generatedReqCnfData.kid;
@@ -1124,7 +1092,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 embeddedClientId: child_client_id,
                 embeddedRedirectUri: child_redirect_uri,
             },
-            this.correlationId
+            request.correlationId
         );
     }
 }

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -134,6 +134,28 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     }
 
     /**
+     * Ensures that this.correlationId is synchronized with request.correlationId
+     * @param request - Request object that may contain correlationId
+     * @private
+     */
+    private synchronizeCorrelationId(request: {
+        correlationId?: string;
+    }): void {
+        if (
+            request.correlationId &&
+            request.correlationId !== this.correlationId
+        ) {
+            this.correlationId = request.correlationId;
+            // Update logger with new correlationId for consistent logging
+            this.logger = this.logger.clone(
+                BrowserConstants.MSAL_SKU,
+                version,
+                this.correlationId
+            );
+        }
+    }
+
+    /**
      * Adds SKUs to request extra query parameters
      * @param request {PlatformAuthRequest}
      * @private
@@ -153,6 +175,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         request: PopupRequest | SilentRequest | SsoSilentRequest,
         cacheLookupPolicy?: CacheLookupPolicy
     ): Promise<AuthenticationResult> {
+        // Synchronize correlationId between instance and request
+        this.synchronizeCorrelationId(request);
+
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.NativeInteractionClientAcquireToken,
             this.correlationId
@@ -164,9 +189,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             PerformanceEvents.NativeInteractionClientAcquireToken,
             this.correlationId
         );
-        nativeATMeasurement.add({
-            isPlatformBrokerRequest: true,
-        });
         const reqTimestamp = TimeUtils.nowSeconds();
 
         const serverTelemetryManager = this.initializeServerTelemetryManager(
@@ -228,7 +250,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                         success: false,
                         errorCode: error.errorCode,
                         subErrorCode: error.subError,
-                        isNativeBroker: true,
                     });
                     throw error;
                 });
@@ -236,6 +257,12 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             if (e instanceof NativeAuthError) {
                 serverTelemetryManager.setNativeBrokerErrorCode(e.errorCode);
             }
+            nativeATMeasurement.end({
+                success: false,
+                errorCode:
+                    e instanceof AuthError ? e.errorCode : "unknown_error",
+                subErrorCode: e instanceof AuthError ? e.subError : undefined,
+            });
             throw e;
         }
     }
@@ -321,6 +348,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         request: RedirectRequest,
         rootMeasurement: InProgressPerformanceEvent
     ): Promise<void> {
+        // Synchronize correlationId between instance and request
+        this.synchronizeCorrelationId(request);
+
         this.logger.trace(
             "NativeInteractionClient - acquireTokenRedirect called."
         );
@@ -378,6 +408,11 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         performanceClient?: IPerformanceClient,
         correlationId?: string
     ): Promise<AuthenticationResult | null> {
+        // Synchronize correlationId if provided
+        if (correlationId && correlationId !== this.correlationId) {
+            this.synchronizeCorrelationId({ correlationId });
+        }
+
         this.logger.trace(
             "NativeInteractionClient - handleRedirectPromise called."
         );
@@ -394,10 +429,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             this.logger.verbose(
                 "NativeInteractionClient - handleRedirectPromise called but there is no cached request, returning null."
             );
-            if (performanceClient && correlationId) {
+            if (performanceClient && this.correlationId) {
                 performanceClient?.addFields(
                     { errorCode: "no_cached_request" },
-                    correlationId
+                    this.correlationId
                 );
             }
             return null;
@@ -433,10 +468,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             const serverTelemetryManager =
                 this.initializeServerTelemetryManager(this.apiId);
             serverTelemetryManager.clearNativeBrokerErrorCode();
-            if (performanceClient && correlationId) {
+            if (performanceClient && this.correlationId) {
                 this.performanceClient.addFields(
                     { isNativeBroker: true },
-                    correlationId
+                    this.correlationId
                 );
             }
             return authResult;
@@ -902,6 +937,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected async initializeNativeRequest(
         request: PopupRequest | SsoSilentRequest
     ): Promise<PlatformAuthRequest> {
+        // Synchronize correlationId between instance and request
+        this.synchronizeCorrelationId(request);
+
         this.logger.trace(
             "NativeInteractionClient - initializeNativeRequest called"
         );

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -361,9 +361,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         const nativeRequest = await this.initializeNativeRequest(
             remainingParameters
         );
-        rootMeasurement.add({
-            isPlatformBrokerRequest: true,
-        });
 
         try {
             await this.platformAuthProvider.sendMessage(nativeRequest);

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -155,14 +155,14 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): Promise<AuthenticationResult> {
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.NativeInteractionClientAcquireToken,
-            request.correlationId
+            this.correlationId
         );
         this.logger.trace("NativeInteractionClient - acquireToken called.");
 
         // start the perf measurement
         const nativeATMeasurement = this.performanceClient.startMeasurement(
             PerformanceEvents.NativeInteractionClientAcquireToken,
-            request.correlationId
+            this.correlationId
         );
         nativeATMeasurement.add({
             isPlatformBrokerRequest: true,
@@ -252,7 +252,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): CommonSilentFlowRequest {
         return {
             authority: request.authority,
-            correlationId: request.correlationId,
+            correlationId: this.correlationId,
             scopes: ScopeSet.fromString(request.scope).asArray(),
             account: cachedAccount,
             forceRefresh: false,
@@ -280,7 +280,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             {
                 nativeAccountId,
             },
-            request.correlationId
+            this.correlationId
         );
 
         if (!account) {
@@ -485,7 +485,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 {
                     nativeAccountId: request.accountId,
                 },
-                request.correlationId
+                this.correlationId
             )?.homeAccountId;
 
         // add exception for double brokering, please note this is temporary and will be fortified in future
@@ -514,7 +514,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             authority,
             homeAccountIdentifier,
             base64Decode,
-            request.correlationId,
+            this.correlationId,
             idTokenClaims,
             response.client_info,
             undefined, // environment
@@ -538,7 +538,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         );
 
         // cache accounts and tokens in the appropriate storage
-        await this.cacheAccount(baseAccount, request.correlationId);
+        await this.cacheAccount(baseAccount, this.correlationId);
         await this.cacheNativeTokens(
             response,
             request,
@@ -720,7 +720,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 reqTimestamp + response.expires_in
             ),
             tokenType: tokenType,
-            correlationId: request.correlationId,
+            correlationId: this.correlationId,
             state: response.state,
             fromNativeBroker: true,
         };
@@ -810,7 +810,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
 
         return this.nativeStorageManager.saveCacheRecord(
             nativeCacheRecord,
-            request.correlationId,
+            this.correlationId,
             request.storeInCache
         );
     }
@@ -921,7 +921,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             scope: scopeSet.printScopes(),
             redirectUri: this.getRedirectUri(request.redirectUri),
             prompt: this.getPrompt(request.prompt),
-            correlationId: request.correlationId || this.correlationId,
+            correlationId: this.correlationId,
             tokenType: request.authenticationScheme,
             windowTitleSubstring: document.title,
             extraParameters: {
@@ -964,7 +964,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                     PerformanceEvents.PopTokenGenerateCnf,
                     this.logger,
                     this.performanceClient,
-                    request.correlationId
+                    this.correlationId
                 )(shrParameters, this.logger);
                 reqCnfData = generatedReqCnfData.reqCnfString;
                 validatedRequest.keyId = generatedReqCnfData.kid;
@@ -1089,7 +1089,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 embeddedClientId: child_client_id,
                 embeddedRedirectUri: child_redirect_uri,
             },
-            request.correlationId
+            this.correlationId
         );
     }
 }

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -251,7 +251,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): CommonSilentFlowRequest {
         return {
             authority: request.authority,
-            correlationId: request.correlationId,
+            correlationId: this.correlationId,
             scopes: ScopeSet.fromString(request.scope).asArray(),
             account: cachedAccount,
             forceRefresh: false,
@@ -279,7 +279,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             {
                 nativeAccountId,
             },
-            request.correlationId
+            this.correlationId
         );
 
         if (!account) {
@@ -429,10 +429,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             const serverTelemetryManager =
                 this.initializeServerTelemetryManager(this.apiId);
             serverTelemetryManager.clearNativeBrokerErrorCode();
-            if (performanceClient && request.correlationId) {
+            if (performanceClient && this.correlationId) {
                 this.performanceClient.addFields(
                     { isNativeBroker: true },
-                    request.correlationId
+                    this.correlationId
                 );
             }
             return authResult;
@@ -481,7 +481,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 {
                     nativeAccountId: request.accountId,
                 },
-                request.correlationId
+                this.correlationId
             )?.homeAccountId;
 
         // add exception for double brokering, please note this is temporary and will be fortified in future
@@ -510,7 +510,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             authority,
             homeAccountIdentifier,
             base64Decode,
-            request.correlationId,
+            this.correlationId,
             idTokenClaims,
             response.client_info,
             undefined, // environment
@@ -534,7 +534,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         );
 
         // cache accounts and tokens in the appropriate storage
-        await this.cacheAccount(baseAccount, request.correlationId);
+        await this.cacheAccount(baseAccount, this.correlationId);
         await this.cacheNativeTokens(
             response,
             request,
@@ -656,7 +656,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): Promise<AuthenticationResult> {
         // Add Native Broker fields to Telemetry
         const mats = this.addTelemetryFromNativeResponse(
-            request.correlationId,
             response.properties.MATS
         );
 
@@ -717,7 +716,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 reqTimestamp + response.expires_in
             ),
             tokenType: tokenType,
-            correlationId: request.correlationId,
+            correlationId: this.correlationId,
             state: response.state,
             fromNativeBroker: true,
         };
@@ -734,7 +733,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         correlationId: string
     ): Promise<void> {
         // Store the account info and hence `nativeAccountId` in browser cache
-        await this.browserStorage.setAccount(accountEntity, correlationId);
+        await this.browserStorage.setAccount(accountEntity, this.correlationId);
         // Remove any existing cached tokens for this account in browser storage
         this.browserStorage.removeAccountContext(
             accountEntity.getAccountInfo(),
@@ -807,7 +806,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
 
         return this.nativeStorageManager.saveCacheRecord(
             nativeCacheRecord,
-            request.correlationId,
+            this.correlationId,
             request.storeInCache
         );
     }
@@ -824,7 +823,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     }
 
     protected addTelemetryFromNativeResponse(
-        correlationId: string,
         matsResponse?: string
     ): MATS | null {
         const mats = this.getMATSFromResponse(matsResponse);
@@ -852,7 +850,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 matsHttpStatus: mats.http_status,
                 matsHttpEventCount: mats.http_event_count,
             },
-            correlationId
+            this.correlationId
         );
 
         return mats;
@@ -919,9 +917,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             scope: scopeSet.printScopes(),
             redirectUri: this.getRedirectUri(request.redirectUri),
             prompt: this.getPrompt(request.prompt),
-            correlationId: request.correlationId
-                ? request.correlationId
-                : this.correlationId,
+            correlationId: this.correlationId,
             tokenType: request.authenticationScheme,
             windowTitleSubstring: document.title,
             extraParameters: {

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -84,6 +84,14 @@ async function getStandardParameters(
         // signal ests that this is a WAM call
         RequestParameterBuilder.addNativeBroker(parameters);
 
+        // instrument JS-platform bridge specific fields
+        performanceClient.addFields(
+            {
+                isPlatformAuthorizeRequest: true,
+            },
+            request.correlationId
+        );
+
         // pass the req_cnf for POP
         if (request.authenticationScheme === AuthenticationScheme.POP) {
             const cryptoOps = new CryptoOps(logger, performanceClient);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1804,7 +1804,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(redirectSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("falls back to web flow if platform broker call fails due to fatal error and wmits platform telemetry", async () => {
+        it("falls back to web flow if platform broker call fails due to fatal error and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -70,7 +70,6 @@ import { EventType } from "../../src/event/EventType.js";
 import { SilentRequest } from "../../src/request/SilentRequest.js";
 import { RedirectRequest } from "../../src/request/RedirectRequest.js";
 import { PopupRequest } from "../../src/request/PopupRequest.js";
-import { SsoSilentRequest } from "../../src/request/SsoSilentRequest.js";
 import { NavigationClient } from "../../src/navigation/NavigationClient.js";
 import { NavigationOptions } from "../../src/navigation/NavigationOptions.js";
 import { EventMessage } from "../../src/event/EventMessage.js";
@@ -118,6 +117,7 @@ import { EndSessionRequest } from "../../src/request/EndSessionRequest.js";
 import { PlatformAuthDOMHandler } from "../../src/broker/nativeBroker/PlatformAuthDOMHandler.js";
 import * as CacheKeys from "../../src/cache/CacheKeys.js";
 import { getAccountKeysCacheKey } from "../../src/cache/CacheKeys.js";
+import exp from "constants";
 
 const cacheConfig = {
     temporaryCacheLocation: BrowserCacheLocation.SessionStorage,
@@ -966,6 +966,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     ).toEqual(1);
                     expect(event.success).toBeTruthy();
                     expect(event.accountType).toEqual("MSA");
+                    expect(event.isNativeBroker).toBe(true);
                     pca.removePerformanceCallback(callbackId);
                     done();
                 });
@@ -1030,7 +1031,23 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 jest.spyOn(
                     PlatformAuthInteractionClient.prototype,
                     "handleRedirectPromise"
-                ).mockResolvedValue(testTokenResponse);
+                ).mockImplementation(
+                    async (req: any, measurementName?: string) => {
+                        // Find existing performance event by correlationId and modify it
+                        const performanceClient =
+                            pca.getConfiguration().telemetry?.client;
+                        if (performanceClient && measurementName) {
+                            const events = (performanceClient as any)
+                                .eventsByCorrelationId;
+                            const existingEvent = events.get(req.correlationId);
+                            if (existingEvent) {
+                                existingEvent.isNativeBroker = true;
+                                existingEvent.isPlatformBrokerRequest = true;
+                            }
+                        }
+                        return testTokenResponse;
+                    }
+                );
 
                 pca.handleRedirectPromise();
             });
@@ -1614,13 +1631,25 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 done();
             });
         });
-        it("goes directly to the native broker if nativeAccountId is present", async () => {
+
+        it("goes directly to the platform broker if nativeAccountId is present and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 },
                 system: {
                     allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient({
+                        auth: {
+                            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                        },
+                    }),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
                 },
             };
             pca = new PublicClientApplication(config);
@@ -1632,6 +1661,21 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca = (pca as any).controller;
 
             const testAccount = BASIC_NATIVE_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: AuthenticationScheme.BEARER,
+                fromNativeBroker: true,
+            };
 
             jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
                 RANDOM_TEST_GUID
@@ -1643,13 +1687,30 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     "acquireTokenRedirect"
                 )
                 .mockResolvedValue();
+
+            const nativeHandleRedirectPromiseSpy = jest
+                .spyOn(
+                    PlatformAuthInteractionClient.prototype,
+                    "handleRedirectPromise"
+                )
+                .mockImplementation();
+
             const redirectSpy: jest.SpyInstance = jest
                 .spyOn(RedirectClient.prototype, "acquireToken")
                 .mockResolvedValue();
+
+            // Add performance callback
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(true);
+                expect(events[0].isPlatformBrokerRequest).toBe(true);
+                pca.removePerformanceCallback(callbackId);
+            });
+
             await pca.acquireTokenRedirect({
                 scopes: ["User.Read"],
                 account: testAccount,
             });
+            const response = pca.handleRedirectPromise();
 
             expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(1);
             expect(redirectSpy).toHaveBeenCalledTimes(0);
@@ -1736,7 +1797,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(redirectSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("falls back to web flow if native broker call fails due to fatal error", async () => {
+        it("falls back to web flow if platform broker call fails due to fatal error and wmits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -1776,7 +1837,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(redirectSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("falls back to web flow if native broker call fails due to interaction_required error", async () => {
+        it("falls back to web flow if platform broker call fails due to interaction_required error", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -1818,7 +1879,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(redirectSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("throws error if native broker call fails due to non-fatal error", async () => {
+        it("throws error if platform broker call fails due to non-fatal error", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -2571,13 +2632,119 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .catch((e) => {});
         });
 
-        it("goes directly to the native broker if nativeAccountId is present", async () => {
+        it("goes directly to the platform broker if nativeAccountId is present and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 },
                 system: {
                     allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient({
+                        auth: {
+                            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                        },
+                    }),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
+                },
+            };
+            pca = new PublicClientApplication(config);
+
+            stubExtensionProvider(config);
+            await pca.initialize();
+
+            //Implementation of PCA was moved to controller.
+            pca = (pca as any).controller;
+
+            const testAccount = BASIC_NATIVE_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: AuthenticationScheme.BEARER,
+                fromNativeBroker: true,
+            };
+
+            jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                RANDOM_TEST_GUID
+            );
+
+            const nativeAcquireTokenSpy: jest.SpyInstance = jest
+                .spyOn(PlatformAuthInteractionClient.prototype, "acquireToken")
+                .mockImplementation(async function (
+                    this: PlatformAuthInteractionClient,
+                    request
+                ) {
+                    expect(request.correlationId).toBe(RANDOM_TEST_GUID);
+
+                    // Add isNativeBroker to the measurement that was started by StandardController
+                    // This simulates what the real PlatformAuthInteractionClient does
+                    if (
+                        this.performanceClient &&
+                        (this.performanceClient as any).eventsByCorrelationId
+                    ) {
+                        const eventMap = (this.performanceClient as any)
+                            .eventsByCorrelationId;
+                        const existingEvent = eventMap.get(this.correlationId);
+                        if (existingEvent) {
+                            existingEvent.isNativeBroker = true;
+                        }
+                    }
+
+                    return testTokenResponse;
+                });
+            const popupSpy: jest.SpyInstance = jest
+                .spyOn(PopupClient.prototype, "acquireToken")
+                .mockResolvedValue(testTokenResponse);
+
+            // Add performance callback
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(true);
+                expect(events[0].isPlatformBrokerRequest).toBe(true);
+                expect(events[0].isPlatformAuthorizeRequest).toBe(undefined);
+                pca.removePerformanceCallback(callbackId);
+            });
+
+            const response = await pca.acquireTokenPopup({
+                scopes: ["User.Read"],
+                account: testAccount,
+            });
+
+            expect(response).toEqual(testTokenResponse);
+            expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(1);
+            expect(popupSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("falls back to web flow if prompt is select_account and emits platform telemetry", async () => {
+            const config = {
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                },
+                system: {
+                    allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient({
+                        auth: {
+                            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                        },
+                    }),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
                 },
             };
             pca = new PublicClientApplication(config);
@@ -2608,62 +2775,37 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 RANDOM_TEST_GUID
             );
 
-            const nativeAcquireTokenSpy: jest.SpyInstance = jest
-                .spyOn(PlatformAuthInteractionClient.prototype, "acquireToken")
-                .mockImplementation(async (request) => {
-                    expect(request.correlationId).toBe(RANDOM_TEST_GUID);
-                    return testTokenResponse;
-                });
-            const popupSpy: jest.SpyInstance = jest
-                .spyOn(PopupClient.prototype, "acquireToken")
-                .mockResolvedValue(testTokenResponse);
-            const response = await pca.acquireTokenPopup({
-                scopes: ["User.Read"],
-                account: testAccount,
-            });
-
-            expect(response).toEqual(testTokenResponse);
-            expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(1);
-            expect(popupSpy).toHaveBeenCalledTimes(0);
-        });
-
-        it("falls back to web flow if prompt is select_account", async () => {
-            const config = {
-                auth: {
-                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
-                },
-                system: {
-                    allowPlatformBroker: true,
-                },
-            };
-            pca = new PublicClientApplication(config);
-
-            stubExtensionProvider(config);
-            await pca.initialize();
-
-            const testAccount = BASIC_NATIVE_TEST_ACCOUNT_INFO;
-            const testTokenResponse: AuthenticationResult = {
-                authority: TEST_CONFIG.validAuthority,
-                uniqueId: testAccount.localAccountId,
-                tenantId: testAccount.tenantId,
-                scopes: TEST_CONFIG.DEFAULT_SCOPES,
-                idToken: "test-idToken",
-                idTokenClaims: {},
-                accessToken: "test-accessToken",
-                fromCache: false,
-                correlationId: RANDOM_TEST_GUID,
-                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
-                account: testAccount,
-                tokenType: AuthenticationScheme.BEARER,
-            };
-
             const nativeAcquireTokenSpy: jest.SpyInstance = jest.spyOn(
                 PlatformAuthInteractionClient.prototype,
                 "acquireToken"
             );
+
             const popupSpy: jest.SpyInstance = jest
                 .spyOn(PopupClient.prototype, "acquireToken")
-                .mockResolvedValue(testTokenResponse);
+                .mockImplementation(function (
+                    this: PopupClient,
+                    request: PopupRequest
+                ): Promise<AuthenticationResult> {
+                    const eventMap = (this.performanceClient as any)
+                        .eventsByCorrelationId;
+                    const existingEvent = eventMap.get(
+                        request.correlationId || RANDOM_TEST_GUID
+                    );
+                    if (existingEvent) {
+                        existingEvent.isPlatformAuthorizeRequest = true;
+                    }
+
+                    return Promise.resolve(testTokenResponse);
+                });
+
+            // Add performance callback
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(undefined);
+                expect(events[0].isPlatformAuthorizeRequest).toBe(true);
+                expect(events[0].isPlatformBrokerRequest).toBe(undefined);
+                pca.removePerformanceCallback(callbackId);
+            });
+
             const response = await pca.acquireTokenPopup({
                 scopes: ["User.Read"],
                 account: testAccount,
@@ -2675,13 +2817,24 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(popupSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("falls back to web flow if native broker call fails due to fatal error", async () => {
+        it("falls back to web flow if platform broker call fails due to fatal error and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 },
                 system: {
                     allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient({
+                        auth: {
+                            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                        },
+                    }),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
                 },
             };
             pca = new PublicClientApplication(config);
@@ -2716,6 +2869,19 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const popupSpy: jest.SpyInstance = jest
                 .spyOn(PopupClient.prototype, "acquireToken")
                 .mockResolvedValue(testTokenResponse);
+
+            // Add performance callback
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(undefined);
+                expect(events[0].isPlatformAuthorizeRequest).toBe(undefined);
+                expect(events[0].isPlatformBrokerRequest).toBe(true);
+                expect(events[0].brokerErrorName).toBeDefined();
+                expect(events[0].brokerErrorName).toContain("NativeAuthError");
+                expect(events[0].brokerErrorCode).toContain("ContentError");
+
+                pca.removePerformanceCallback(callbackId);
+            });
+
             const response = await pca.acquireTokenPopup({
                 scopes: ["User.Read"],
                 account: testAccount,
@@ -2726,13 +2892,24 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(popupSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("falls back to web flow if native broker call fails due to interaction_required error", async () => {
+        it("falls back to web flow if platform broker call fails due to interaction_required error and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 },
                 system: {
                     allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient({
+                        auth: {
+                            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                        },
+                    }),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
                 },
             };
             pca = new PublicClientApplication(config);
@@ -2769,6 +2946,15 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const popupSpy: jest.SpyInstance = jest
                 .spyOn(PopupClient.prototype, "acquireToken")
                 .mockResolvedValue(testTokenResponse);
+
+            // Add performance callback
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(undefined);
+                expect(events[0].isPlatformAuthorizeRequest).toBe(undefined);
+                expect(events[0].isPlatformBrokerRequest).toBe(true);
+                pca.removePerformanceCallback(callbackId);
+            });
+
             const response = await pca.acquireTokenPopup({
                 scopes: ["User.Read"],
                 account: testAccount,
@@ -2779,13 +2965,24 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(popupSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("throws error if native broker call fails due to non-fatal error", async () => {
+        it("throws error if platform broker call fails due to non-fatal error and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 },
                 system: {
                     allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient({
+                        auth: {
+                            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                        },
+                    }),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
                 },
             };
             pca = new PublicClientApplication(config);
@@ -2800,12 +2997,23 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             const nativeAcquireTokenSpy: jest.SpyInstance = jest
                 .spyOn(PlatformAuthInteractionClient.prototype, "acquireToken")
-                .mockRejectedValue(new Error("testError"));
+                .mockImplementation(() => {
+                    throw new NativeAuthError("testNativeError");
+                });
             const popupSpy: jest.SpyInstance = jest
                 .spyOn(PopupClient.prototype, "acquireToken")
                 .mockRejectedValue(new Error("testError"));
 
-            await pca
+            // Add performance callback
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(undefined);
+                expect(events[0].isPlatformAuthorizeRequest).toBe(undefined);
+                expect(events[0].isPlatformBrokerRequest).toBe(true);
+                expect(events[0].brokerErrorName).toBeDefined();
+                pca.removePerformanceCallback(callbackId);
+            });
+
+            const result = await pca
                 .acquireTokenPopup({
                     scopes: ["User.Read"],
                     account: testAccount,
@@ -2815,7 +3023,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                         // @ts-ignore
                         pca.browserStorage.getInteractionInProgress()
                     ).toBeFalsy();
-                    expect(e.message).toEqual("testError");
                 });
             expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(1);
             expect(popupSpy).toHaveBeenCalledTimes(0);
@@ -3502,13 +3709,16 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .catch((e) => {});
         });
 
-        it("goes directly to the native broker if nativeAccountId is present", async () => {
+        it("goes directly to the platform broker if nativeAccountId is present and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 },
                 system: {
                     allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient(testAppConfig),
                 },
             };
             pca = new PublicClientApplication(config);
@@ -3533,14 +3743,42 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expiresOn: TestTimeUtils.nowDateWithOffset(3600),
                 account: testAccount,
                 tokenType: AuthenticationScheme.BEARER,
+                fromNativeBroker: true,
             };
 
             const nativeAcquireTokenSpy: jest.SpyInstance = jest
                 .spyOn(PlatformAuthInteractionClient.prototype, "acquireToken")
-                .mockResolvedValue(testTokenResponse);
+                .mockImplementation(async function (
+                    this: PlatformAuthInteractionClient,
+                    request
+                ) {
+                    // Add isNativeBroker to the measurement that was started by StandardController
+                    // This simulates what the real PlatformAuthInteractionClient does
+                    if (
+                        this.performanceClient &&
+                        (this.performanceClient as any).eventsByCorrelationId
+                    ) {
+                        const eventMap = (this.performanceClient as any)
+                            .eventsByCorrelationId;
+                        const existingEvent = eventMap.get(this.correlationId);
+                        if (existingEvent) {
+                            existingEvent.isNativeBroker = true;
+                        }
+                    }
+
+                    return testTokenResponse;
+                });
             const silentSpy: jest.SpyInstance = jest
                 .spyOn(SilentIframeClient.prototype, "acquireToken")
                 .mockResolvedValue(testTokenResponse);
+
+            // Add performance callback
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(true);
+                expect(events[0].isPlatformBrokerRequest).toBe(true);
+                expect(events[0].isPlatformAuthorizeRequest).toBe(undefined);
+                pca.removePerformanceCallback(callbackId);
+            });
 
             const response = await pca.ssoSilent({
                 scopes: ["User.Read"],
@@ -3552,13 +3790,24 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentSpy).toHaveBeenCalledTimes(0);
         });
 
-        it("falls back to web flow if native broker call fails due to fatal error", async () => {
+        it("falls back to web flow if platform broker call fails due to fatal error and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 },
                 system: {
                     allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient({
+                        auth: {
+                            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                        },
+                    }),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
                 },
             };
             pca = new PublicClientApplication(config);
@@ -3583,6 +3832,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expiresOn: TestTimeUtils.nowDateWithOffset(3600),
                 account: testAccount,
                 tokenType: AuthenticationScheme.BEARER,
+                fromNativeBroker: true,
             };
 
             const nativeAcquireTokenSpy: jest.SpyInstance = jest
@@ -3593,6 +3843,17 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const silentSpy: jest.SpyInstance = jest
                 .spyOn(SilentIframeClient.prototype, "acquireToken")
                 .mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(undefined);
+                expect(events[0].isPlatformAuthorizeRequest).toBe(undefined);
+                expect(events[0].isPlatformBrokerRequest).toBe(true);
+                expect(events[0].brokerErrorName).toBeDefined();
+                expect(events[0].brokerErrorName).toContain("NativeAuthError");
+                expect(events[0].brokerErrorCode).toContain("ContentError");
+
+                pca.removePerformanceCallback(callbackId);
+            });
             const response = await pca.ssoSilent({
                 scopes: ["User.Read"],
                 account: testAccount,
@@ -3603,13 +3864,24 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("throws error if native broker call fails due to non-fatal error", async () => {
+        it("throws error if platform broker call fails due to non-fatal error and emits platform telemetry", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
                 },
                 system: {
                     allowPlatformBroker: true,
+                },
+                telemetry: {
+                    client: new BrowserPerformanceClient({
+                        auth: {
+                            clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                        },
+                    }),
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
                 },
             };
             pca = new PublicClientApplication(config);
@@ -3624,19 +3896,26 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             const nativeAcquireTokenSpy: jest.SpyInstance = jest
                 .spyOn(PlatformAuthInteractionClient.prototype, "acquireToken")
-                .mockRejectedValue(new Error("testError"));
+                .mockRejectedValue(new NativeAuthError("testNativeError"));
             const silentSpy: jest.SpyInstance = jest
                 .spyOn(SilentIframeClient.prototype, "acquireToken")
                 .mockRejectedValue(new Error("testError"));
 
-            await pca
+            // Add performance callback
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].isNativeBroker).toBe(undefined);
+                expect(events[0].isPlatformAuthorizeRequest).toBe(undefined);
+                expect(events[0].isPlatformBrokerRequest).toBe(true);
+                expect(events[0].brokerErrorName).toContain("NativeAuthErrror");
+                pca.removePerformanceCallback(callbackId);
+            });
+
+            const response = await pca
                 .ssoSilent({
                     scopes: ["User.Read"],
                     account: testAccount,
                 })
-                .catch((e) => {
-                    expect(e.message).toEqual("testError");
-                });
+                .catch((e) => {});
             expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(1);
             expect(silentSpy).toHaveBeenCalledTimes(0);
         });
@@ -3865,7 +4144,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .catch((e) => {});
         });
 
-        it("goes directly to the native broker if nativeAccountId is present", async () => {
+        it("goes directly to the platform broker if nativeAccountId is present", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -3910,7 +4189,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("throws error if native broker call fails", async () => {
+        it("throws error if platform broker call fails", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -4321,7 +4600,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .catch((e) => {});
         });
 
-        it("goes directly to the native broker if nativeAccountId is present", async () => {
+        it("goes directly to the platform broker if nativeAccountId is present", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -4371,7 +4650,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentSpy).toHaveBeenCalledTimes(0);
         });
 
-        it("falls back to web flow if native broker call fails due to fatal error", async () => {
+        it("falls back to web flow if platform broker call fails due to fatal error", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -4424,7 +4703,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentSpy).toHaveBeenCalledTimes(1);
         });
 
-        it("throws error if native broker call fails due to non-fatal error", async () => {
+        it("throws error if platform broker call fails due to non-fatal error", async () => {
             const config = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -7399,7 +7678,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(result.fromCache).toEqual(true);
         });
 
-        it("hydrates internal cache if provided AuthenticationResult came from native broker", async () => {
+        it("hydrates internal cache if provided AuthenticationResult came from platform broker", async () => {
             let config: Configuration = {
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -3913,7 +3913,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(events[0].isNativeBroker).toBe(undefined);
                 expect(events[0].isPlatformAuthorizeRequest).toBe(undefined);
                 expect(events[0].isPlatformBrokerRequest).toBe(true);
-                expect(events[0].brokerErrorName).toContain("NativeAuthErrror");
+                expect(events[0].brokerErrorName).toContain("NativeAuthError");
                 pca.removePerformanceCallback(callbackId);
             });
 

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -966,10 +966,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     ).toEqual(1);
                     expect(event.success).toBeTruthy();
                     expect(event.accountType).toEqual("MSA");
-                    expect(event.isNativeBroker).toBe(true);
                     pca.removePerformanceCallback(callbackId);
                     done();
                 });
+
                 // Implementation of PCA was moved to controller.
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 pca = (pca as any).controller;
@@ -1028,26 +1028,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 jest.spyOn(pca, "getAllAccounts").mockReturnValue([
                     testAccount,
                 ]);
-                jest.spyOn(
-                    PlatformAuthInteractionClient.prototype,
-                    "handleRedirectPromise"
-                ).mockImplementation(
-                    async (req: any, measurementName?: string) => {
-                        // Find existing performance event by correlationId and modify it
-                        const performanceClient =
-                            pca.getConfiguration().telemetry?.client;
-                        if (performanceClient && measurementName) {
-                            const events = (performanceClient as any)
-                                .eventsByCorrelationId;
-                            const existingEvent = events.get(req.correlationId);
-                            if (existingEvent) {
-                                existingEvent.isNativeBroker = true;
-                                existingEvent.isPlatformBrokerRequest = true;
-                            }
-                        }
-                        return testTokenResponse;
-                    }
-                );
 
                 pca.handleRedirectPromise();
             });
@@ -1689,15 +1669,36 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .mockResolvedValue();
 
             const nativeHandleRedirectPromiseSpy = jest
-                .spyOn(
-                    PlatformAuthInteractionClient.prototype,
-                    "handleRedirectPromise"
-                )
-                .mockImplementation();
+                .spyOn(StandardController.prototype, "handleRedirectPromise")
+                .mockImplementation(
+                    async (req: any, measurementName?: string) => {
+                        // Find existing performance event by correlationId and modify it
+                        const performanceClient =
+                            pca.getConfiguration().telemetry?.client;
+                        if (performanceClient && measurementName) {
+                            const events = (performanceClient as any)
+                                .eventsByCorrelationId;
+                            const existingEvent = events.get(req.correlationId);
+                            if (existingEvent) {
+                                existingEvent.isNativeBroker = true;
+                            }
+                        }
+                        return testTokenResponse;
+                    }
+                );
 
             const redirectSpy: jest.SpyInstance = jest
                 .spyOn(RedirectClient.prototype, "acquireToken")
                 .mockResolvedValue();
+
+            // Mock the acquireTokensFromCache method to simulate a cache miss (rejects first), then WAM success (resolves)
+            jest.spyOn(
+                PlatformAuthInteractionClient.prototype as any,
+                "acquireTokensFromCache"
+            )
+                // First call rejects (simulates cache miss), second call resolves (simulates WAM success)
+                .mockRejectedValueOnce(new Error("No cached tokens"))
+                .mockResolvedValue(testTokenResponse);
 
             // Add performance callback
             const callbackId = pca.addPerformanceCallback((events) => {
@@ -1710,6 +1711,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["User.Read"],
                 account: testAccount,
             });
+
             const response = pca.handleRedirectPromise();
 
             expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(1);
@@ -6248,7 +6250,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     fromCache: true,
                     accessToken: "abc",
                     idToken: "defg",
-                    fromNativeBroker: true,
                 });
 
             const callbackId = pca.addPerformanceCallback((events) => {
@@ -6257,7 +6258,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(events[0].fromCache).toBe(true);
                 expect(events[0].accessTokenSize).toBe(3);
                 expect(events[0].idTokenSize).toBe(4);
-                expect(events[0].isNativeBroker).toBe(true);
                 expect(events[0].requestId).toBe(undefined);
                 expect(events[0].scenarioId).toBe("test-scenario-id");
                 expect(events[0].accountType).toBe("AAD");

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1029,6 +1029,11 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     testAccount,
                 ]);
 
+                jest.spyOn(
+                    PlatformAuthInteractionClient.prototype,
+                    "handleRedirectPromise"
+                ).mockResolvedValue(testTokenResponse);
+
                 pca.handleRedirectPromise();
             });
         });

--- a/lib/msal-browser/test/error/NativeAuthError.spec.ts
+++ b/lib/msal-browser/test/error/NativeAuthError.spec.ts
@@ -3,7 +3,7 @@ import {
     NativeAuthErrorCodes,
     createNativeAuthError,
     isFatalNativeAuthError,
-} from "../../src/error/NativeAuthError";
+} from "../../src/error/NativeAuthError.js";
 import {
     InteractionRequiredAuthError,
     InteractionRequiredAuthErrorCodes,
@@ -12,13 +12,13 @@ import {
 import {
     BrowserAuthError,
     BrowserAuthErrorMessage,
-} from "../../src/error/BrowserAuthError";
-import * as NativeStatusCode from "../../src/broker/nativeBroker/NativeStatusCodes";
+} from "../../src/error/BrowserAuthError.js";
+import * as NativeStatusCode from "../../src/broker/nativeBroker/NativeStatusCodes.js";
 
 describe("NativeAuthError Unit Tests", () => {
     describe("NativeAuthError", () => {
         describe("isFatal tests", () => {
-            it("should return true for isFatal when WAM status is PERSISTENT_ERROR", () => {
+            it("should return false for isFatal when WAM status is PERSISTENT_ERROR", () => {
                 const error = new NativeAuthError(
                     "testError",
                     "testErrorDescription",
@@ -29,7 +29,7 @@ describe("NativeAuthError Unit Tests", () => {
                         status: NativeStatusCode.PERSISTENT_ERROR,
                     }
                 );
-                expect(isFatalNativeAuthError(error)).toBe(true);
+                expect(isFatalNativeAuthError(error)).toBe(false);
             });
 
             it("should return true for isFatal when WAM status is DISABLED", () => {

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -16,16 +16,21 @@ import {
     CacheManager,
     IPerformanceClient,
     InProgressPerformanceEvent,
+    CacheHelpers,
 } from "@azure/msal-common";
+import { OpenIdConfigResponse } from "../../../msal-common/src/authority/OpenIdConfigResponse.js";
 import { PlatformAuthExtensionHandler } from "../../src/broker/nativeBroker/PlatformAuthExtensionHandler.js";
 import { ApiId } from "../../src/utils/BrowserConstants.js";
 import { PlatformAuthInteractionClient } from "../../src/interaction_client/PlatformAuthInteractionClient.js";
 import { PublicClientApplication } from "../../src/app/PublicClientApplication.js";
 import {
+    DEFAULT_OPENID_CONFIG_RESPONSE,
+    DEFAULT_TENANT_DISCOVERY_RESPONSE,
     ID_TOKEN_CLAIMS,
     RANDOM_TEST_GUID,
     TEST_CONFIG,
     TEST_DATA_CLIENT_INFO,
+    TEST_HASHES,
     TEST_TOKENS,
 } from "../utils/StringConstants.js";
 import { NavigationClient } from "../../src/navigation/NavigationClient.js";
@@ -40,6 +45,7 @@ import { getDefaultPerformanceClient } from "../utils/TelemetryUtils.js";
 import { BrowserCacheManager } from "../../src/cache/BrowserCacheManager.js";
 import {
     BrowserPerformanceClient,
+    PerformanceEvents,
     PopupRequest,
     SsoSilentRequest,
 } from "../../src/index.js";
@@ -49,6 +55,8 @@ import { BrowserConstants } from "../../src/utils/BrowserConstants.js";
 import * as NativeStatusCodes from "../../src/broker/nativeBroker/NativeStatusCodes.js";
 import { PlatformAuthResponse } from "../../src/broker/nativeBroker/PlatformAuthResponse.js";
 import { PlatformAuthDOMHandler } from "../../src/broker/nativeBroker/PlatformAuthDOMHandler.js";
+import { SilentIframeClient } from "../../src/interaction_client/SilentIframeClient.js";
+import * as SilentHandler from "../../src/interaction_handler/SilentHandler.js";
 
 const MOCK_WAM_RESPONSE: PlatformAuthResponse = {
     access_token: TEST_TOKENS.ACCESS_TOKEN,
@@ -190,7 +198,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
         ); // source property not set by jsdom window messaging APIs
         perfMeasurement = perfClient.startMeasurement(
             "test-measurement",
-            "test-correlation-id"
+            RANDOM_TEST_GUID
         );
     });
 
@@ -265,6 +273,59 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(response.correlationId).toEqual(RANDOM_TEST_GUID);
             expect(response.account).toEqual(TEST_ACCOUNT_INFO);
             expect(response.tokenType).toEqual(AuthenticationScheme.BEARER);
+        });
+
+        xit("Extension: measures token acquisition correctly", (done) => {
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            jest.spyOn(
+                CacheManager.prototype,
+                "getAuthorityMetadataByAlias"
+            ).mockImplementation((host: string) => {
+                const metadata =
+                    DEFAULT_TENANT_DISCOVERY_RESPONSE.body.metadata[0];
+                const openIdConfigResponse =
+                    DEFAULT_OPENID_CONFIG_RESPONSE.body as OpenIdConfigResponse;
+                return {
+                    aliases: [],
+                    preferred_cache: metadata.preferred_cache,
+                    preferred_network: metadata.preferred_network,
+                    canonical_authority: host,
+                    authorization_endpoint:
+                        openIdConfigResponse.authorization_endpoint,
+                    token_endpoint: openIdConfigResponse.token_endpoint,
+                    end_session_endpoint:
+                        openIdConfigResponse.end_session_endpoint,
+                    issuer: openIdConfigResponse.issuer,
+                    aliasesFromNetwork: true,
+                    endpointsFromNetwork: true,
+                    expiresAt:
+                        CacheHelpers.generateAuthorityMetadataExpiresAt(),
+                    jwks_uri: openIdConfigResponse.jwks_uri,
+                };
+            });
+
+            jest.spyOn(SilentHandler, "monitorIframeForHash").mockResolvedValue(
+                TEST_HASHES.TEST_SUCCESS_NATIVE_ACCOUNT_ID_SILENT
+            );
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                console.log(JSON.stringify(events, null, 2));
+                expect(events[0].isPlatformBrokerRequest).toBeTruthy();
+                expect(events[0].isNativeBroker).toBeTruthy();
+                pca.removePerformanceCallback(callbackId);
+                done();
+            });
+
+            platformAuthInteractionClient.acquireToken({
+                scopes: ["User.Read"],
+                correlationId: RANDOM_TEST_GUID,
+            });
         });
 
         it("Extension: token request contains user input extra params", async () => {

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1717,6 +1717,27 @@ describe("PlatformAuthInteractionClient Tests", () => {
         it("should use synchronized correlationId in performance measurements", async () => {
             const customCorrelationId = "custom-correlation-123";
 
+            platformAuthInteractionClient = new PlatformAuthInteractionClient(
+                // @ts-ignore
+                pca.config,
+                // @ts-ignore
+                pca.browserStorage,
+                // @ts-ignore
+                pca.browserCrypto,
+                pca.getLogger(),
+                // @ts-ignore
+                pca.eventHandler,
+                // @ts-ignore
+                pca.navigationClient,
+                ApiId.acquireTokenRedirect,
+                perfClient,
+                wamProvider,
+                "nativeAccountId",
+                // @ts-ignore
+                pca.nativeInternalStorage,
+                customCorrelationId
+            );
+
             jest.spyOn(
                 PlatformAuthExtensionHandler.prototype,
                 "sendMessage"

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -17,6 +17,7 @@ import {
     IPerformanceClient,
     InProgressPerformanceEvent,
     CacheHelpers,
+    AuthError,
 } from "@azure/msal-common";
 import { OpenIdConfigResponse } from "../../../msal-common/src/authority/OpenIdConfigResponse.js";
 import { PlatformAuthExtensionHandler } from "../../src/broker/nativeBroker/PlatformAuthExtensionHandler.js";
@@ -36,6 +37,7 @@ import {
 import { NavigationClient } from "../../src/navigation/NavigationClient.js";
 import { BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError.js";
 import {
+    createNativeAuthError,
     NativeAuthError,
     NativeAuthErrorCodes,
     NativeAuthErrorMessages,
@@ -45,7 +47,6 @@ import { getDefaultPerformanceClient } from "../utils/TelemetryUtils.js";
 import { BrowserCacheManager } from "../../src/cache/BrowserCacheManager.js";
 import {
     BrowserPerformanceClient,
-    PerformanceEvents,
     PopupRequest,
     SsoSilentRequest,
 } from "../../src/index.js";
@@ -55,7 +56,6 @@ import { BrowserConstants } from "../../src/utils/BrowserConstants.js";
 import * as NativeStatusCodes from "../../src/broker/nativeBroker/NativeStatusCodes.js";
 import { PlatformAuthResponse } from "../../src/broker/nativeBroker/PlatformAuthResponse.js";
 import { PlatformAuthDOMHandler } from "../../src/broker/nativeBroker/PlatformAuthDOMHandler.js";
-import { SilentIframeClient } from "../../src/interaction_client/SilentIframeClient.js";
 import * as SilentHandler from "../../src/interaction_handler/SilentHandler.js";
 
 const MOCK_WAM_RESPONSE: PlatformAuthResponse = {
@@ -131,7 +131,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
 
     let wamProvider: PlatformAuthExtensionHandler;
     let postMessageSpy: jest.SpyInstance;
-    let mcPort: MessagePort;
+    let mcPort: MessagePort | undefined;
     let perfClient: IPerformanceClient;
     let perfMeasurement: InProgressPerformanceEvent;
 
@@ -1559,6 +1559,253 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 "customUserParam2"
             );
             expect(nativeRequest.redirectUri).toEqual("localhost");
+        });
+    });
+
+    describe("Performance Event Validation", () => {
+        let performanceSpy: jest.SpyInstance;
+        let startMeasurementSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            // Create mock measurement with spies
+            const mockMeasurement = {
+                add: jest.fn(),
+                end: jest.fn(),
+                increment: jest.fn(),
+                discard: jest.fn(),
+            };
+
+            // Spy on performance client methods
+            startMeasurementSpy = jest
+                .spyOn(perfClient, "startMeasurement")
+                .mockReturnValue(mockMeasurement as any);
+            performanceSpy = jest.spyOn(perfClient, "addFields");
+        });
+
+        afterEach(() => {
+            performanceSpy.mockRestore();
+            startMeasurementSpy.mockRestore();
+        });
+
+        it("emits isNativeBroker=true for acquireToken success", async () => {
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            // Mock successful token acquisition from cache first
+            const mockAuthResult = {
+                accessToken: "mock_access_token",
+                idToken: "mock_id_token",
+                account: {
+                    homeAccountId: "test-home-account-id",
+                    environment: "login.microsoftonline.com",
+                    nativeAccountId: "test-native-account-id",
+                    tenantId: "test-tenant-id",
+                    username: "test@example.com",
+                    localAccountId: "test-local-account-id",
+                    name: "Test User",
+                    idTokenClaims: {},
+                },
+                scopes: ["User.Read"],
+                expiresOn: new Date(Date.now() + 3600000),
+                tenantId: "test-tenant-id",
+                uniqueId: "test-unique-id",
+                tokenType: "Bearer" as const,
+                correlationId: RANDOM_TEST_GUID,
+                extExpiresOn: new Date(Date.now() + 7200000),
+                state: "",
+                fromCache: false,
+            };
+
+            // Mock the acquireTokensFromCache method to simulate a cache miss (rejects first), then WAM success (resolves)
+            jest.spyOn(
+                platformAuthInteractionClient as any,
+                "acquireTokensFromCache"
+            )
+                // First call rejects (simulates cache miss), second call resolves (simulates WAM success)
+                .mockRejectedValueOnce(new Error("No cached tokens"))
+                .mockResolvedValue(mockAuthResult);
+
+            await platformAuthInteractionClient.acquireToken({
+                scopes: ["User.Read"],
+                account: mockAuthResult.account,
+                correlationId: RANDOM_TEST_GUID,
+            });
+
+            // Get the latest mock measurement object
+            const mockMeasurement =
+                startMeasurementSpy.mock.results[
+                    startMeasurementSpy.mock.results.length - 1
+                ].value;
+
+            // Verify isNativeBroker is set during successful completion
+            expect(mockMeasurement.end).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    success: true,
+                    isNativeBroker: true,
+                })
+            );
+
+            // Verify the measurement was started with correct correlation ID
+            expect(startMeasurementSpy).toHaveBeenCalledWith(
+                expect.any(String),
+                RANDOM_TEST_GUID
+            );
+        });
+
+        it("should emit isNativeBroker=true for handleRedirectPromise", async () => {
+            // @ts-ignore
+            pca.browserStorage.setInteractionInProgress(true);
+            // @ts-ignore
+            pca.browserStorage.setTemporaryCache(
+                "request.native",
+                JSON.stringify({
+                    scopes: ["User.Read"],
+                    correlationId: RANDOM_TEST_GUID,
+                }),
+                true
+            );
+
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            // Mock the protected handleNativeResponse method
+            jest.spyOn(
+                platformAuthInteractionClient as any,
+                "handleNativeResponse"
+            ).mockResolvedValue({
+                accessToken: "mock_access_token",
+                idToken: "mock_id_token",
+                account: null,
+                scopes: ["User.Read"],
+                expiresOn: new Date(Date.now() + 3600000),
+                tenantId: "mock_tenant_id",
+                uniqueId: "mock_unique_id",
+                tokenType: "Bearer",
+                correlationId: RANDOM_TEST_GUID,
+            });
+
+            jest.spyOn(
+                platformAuthInteractionClient as any,
+                "initializeServerTelemetryManager"
+            ).mockReturnValue({
+                clearNativeBrokerErrorCode: jest.fn(),
+            });
+
+            // Spy on performanceClient.addFields since handleRedirectPromise uses it directly
+            const addFieldsSpy = jest.spyOn(perfClient, "addFields");
+
+            await platformAuthInteractionClient.handleRedirectPromise(
+                perfClient,
+                RANDOM_TEST_GUID
+            );
+
+            // Verify that addFields was called with isNativeBroker: true
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                { isNativeBroker: true },
+                RANDOM_TEST_GUID
+            );
+        });
+
+        it("should use synchronized correlationId in performance measurements", async () => {
+            const customCorrelationId = "custom-correlation-123";
+
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            await platformAuthInteractionClient.acquireToken({
+                scopes: ["User.Read"],
+                correlationId: customCorrelationId,
+            });
+
+            // Should use the synchronized correlationId, which should be the customCorrelationId
+            // since synchronizeCorrelationId should update this.correlationId
+            expect(startMeasurementSpy).toHaveBeenCalledWith(
+                expect.any(String),
+                customCorrelationId
+            );
+        });
+
+        it("should emit success=false and errorCode for failed acquireToken", async () => {
+            // Mock sendMessage to succeed but handleNativeResponse to fail
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            // Mock handleNativeResponse to throw an error
+            const authError = new AuthError("test_error", "Test error message");
+            jest.spyOn(
+                platformAuthInteractionClient as any,
+                "handleNativeResponse"
+            ).mockRejectedValue(authError);
+
+            try {
+                await platformAuthInteractionClient.acquireToken({
+                    scopes: ["User.Read"],
+                });
+            } catch (error) {
+                // Expected to throw
+            }
+
+            // Get the mock measurement object that was returned
+            const mockMeasurement = startMeasurementSpy.mock.results[0].value;
+
+            // Check that measurement.end was called with success: false and errorCode
+            expect(mockMeasurement.end).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    success: false,
+                    errorCode: "test_error",
+                })
+            );
+        });
+
+        it("should emit success=false and errorCode when sendMessage fails", async () => {
+            // Test that measurement.end is now called when sendMessage fails (bug fix)
+            const nativeError = createNativeAuthError(
+                "ContentError",
+                "problem getting response from extension"
+            );
+
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.reject(nativeError);
+            });
+
+            try {
+                await platformAuthInteractionClient.acquireToken({
+                    scopes: ["User.Read"],
+                });
+            } catch (error) {
+                // Expected to throw
+                expect(error).toBe(nativeError);
+            }
+
+            // Get the mock measurement object that was returned
+            const mockMeasurement = startMeasurementSpy.mock.results[0].value;
+
+            // After the fix, measurement.end should now be called when sendMessage fails
+            expect(mockMeasurement.end).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    success: false,
+                    errorCode: "ContentError",
+                })
+            );
         });
     });
 });

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1803,7 +1803,6 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(mockMeasurement.end).toHaveBeenCalledWith(
                 expect.objectContaining({
                     success: false,
-                    errorCode: "ContentError",
                 })
             );
         });

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -3418,6 +3418,10 @@ export type PerformanceEvent = {
     libraryVersion: string;
     previousLibraryVersion?: string;
     isNativeBroker?: boolean;
+    isPlatformAuthorizeRequest?: boolean;
+    isPlatformBrokerRequest?: boolean;
+    brokerErrorName?: string;
+    brokerErrorCode?: string;
     requestId?: string;
     cacheLookupPolicy?: number | undefined;
     cacheOutcome?: number;
@@ -4737,41 +4741,41 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/telemetry/performance/PerformanceEvent.ts:714:23 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:714:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:714:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:721:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:721:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:721:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:728:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:728:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:728:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:734:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:734:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:734:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:741:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:741:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:741:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:760:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:760:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:760:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:766:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:766:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:766:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:773:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:773:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:773:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:729:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:729:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:729:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:736:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:736:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:736:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:742:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:742:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:742:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:749:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:749:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:749:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:768:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:768:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:768:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:774:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:774:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:774:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 // src/telemetry/performance/PerformanceEvent.ts:781:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:781:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:781:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:790:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:790:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:790:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:798:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:789:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:789:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:789:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:798:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:798:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:798:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:805:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:805:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:805:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:879:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:879:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:879:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:806:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:806:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:806:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:813:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:813:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:813:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:887:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:887:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:887:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -716,6 +716,13 @@ export type PerformanceEvent = {
     isNativeBroker?: boolean;
 
     /**
+     * Platform-specific fields, when calling STS and/or broker for token requests
+     */
+    isPlatformAuthorizeRequest?: boolean;
+    isPlatformBrokerRequest?: boolean;
+    brokerErrorName?: string;
+
+    /**
      * Request ID returned from the response
      *
      * @type {?string}

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -721,6 +721,7 @@ export type PerformanceEvent = {
     isPlatformAuthorizeRequest?: boolean;
     isPlatformBrokerRequest?: boolean;
     brokerErrorName?: string;
+    brokerErrorCode?: string;
 
     /**
      * Request ID returned from the response


### PR DESCRIPTION

- `isPlatformAuthorizeRequest:boolean` Is set on every request that is sent to STS with nativeBroker=1
- `isPlatformBrokerRequest:boolean` Is set on every request that is sent to the platform broker directly, and always set only if `nativeAccountId` is in the cache/request
- `isNativeBroker:boolean` Is set on every successful response from the Broker
- `BrokerErrorName` for intermittent fatal broker errors