### PR TITLE
Update CODEOWNERS with MSAL.js Team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,31 +1,11 @@
-* @tnorling @sameerag @jo-arroyo @hectormmg @lalimasharda @peterzenz @bgavrilMS @robbie-microsoft @konstantin-msft @shylasummers
-
-# MSAL Angular
-/lib/msal-angular/ @jo-arroyo @tnorling @peterzenz @shylasummers @sameerag @konstantin-msft
-/samples/msal-angular-samples/ @jo-arroyo @tnorling @peterzenz @shylasummers @sameerag @konstantin-msft
+* @AzureAD/msal-js-public-client
 
 # MSAL Browser
-/lib/msal-browser/ @sameerag @tnorling @hectormmg @jo-arroyo @peterzenz @konstantin-msft @lalimasharda @shylasummers
 /lib/msal-browser/custom-auth @shenj @yongdiw
-/samples/msal-browser-samples/ @sameerag @tnorling @hectormmg @jo-arroyo @peterzenz @konstantin-msft @lalimasharda @shylasummers
-
-# MSAL Common
-/lib/msal-common/ @sameerag @tnorling @hectormmg @jo-arroyo @peterzenz @robbie-microsoft @konstantin-msft @lalimasharda @shylasummers
 
 # MSAL Node
-/lib/msal-node/ @sameerag @tnorling @hectormmg @peterzenz @AzureAD/id4s-msal-team
-/samples/msal-node-samples/ @sameerag @tnorling @hectormmg @peterzenz @AzureAD/id4s-msal-team
-/extensions/msal-node-extensions/ @sameerag @tnorling @hectormmg @peterzenz
-
-# MSAL React
-/lib/msal-react/ @tnorling @jo-arroyo @peterzenz @sameerag @konstantin-msft
-/samples/msal-react-samples/ @tnorling @jo-arroyo @peterzenz @sameerag @konstantin-msft
-
-# Build
-/build/ @sameerag @tnorling @hectormmg @peterzenz
-/release-scripts/ @sameerag @tnorling @hectormmg @peterzenz @shylasummers
-/.github/ @sameerag @tnorling @hectormmg @peterzenz
-/.pipelines/ @hectormmg @tnorling @peterzenz @sameerag @konstantin-msft @shylasummers
+/lib/msal-node/ @AzureAD/msal-js-public-client @AzureAD/id4s-msal-team
+/samples/msal-node-samples/ @AzureAD/msal-js-public-client @AzureAD/id4s-msal-team
 
 # MSAL Node Confidential Client Regression Tests
 .github/workflows/client-credential-benchmark.yml @AzureAD/id4s-msal-team


### PR DESCRIPTION
This pull request updates the `CODEOWNERS` file to consolidate and simplify code ownership assignments. The main change is replacing individual maintainer usernames with the `@AzureAD/msal-js-public-client` team for most areas, and updating node-related paths to include both `@AzureAD/msal-js-public-client` and `@AzureAD/id4s-msal-team`. This streamlines code review responsibilities and reflects current team structures.

Ownership assignment updates:

* Replaced individual user assignments with the `@AzureAD/msal-js-public-client` team for general ownership and for several library and sample directories.
* Updated ownership for `/lib/msal-node/` and `/samples/msal-node-samples/` to include both `@AzureAD/msal-js-public-client` and `@AzureAD/id4s-msal-team`, ensuring both teams are responsible for these areas.

Cleanup and simplification:

* Removed redundant or outdated individual user assignments from various directories, consolidating ownership under relevant teams.