### PR TITLE
Format logging strings for future minification

### DIFF
--- a/change/@azure-msal-browser-7460dbe1-26fa-4278-934a-0f6f80022a1b.json
+++ b/change/@azure-msal-browser-7460dbe1-26fa-4278-934a-0f6f80022a1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Format logging strings for future minification #7999",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-06f8818a-3d44-4ef5-9300-0872714e09c0.json
+++ b/change/@azure-msal-common-06f8818a-3d44-4ef5-9300-0872714e09c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Format logging strings for future minification #7999",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-react-2663521d-da16-4d6a-a7b7-90ed718994e1.json
+++ b/change/@azure-msal-react-2663521d-da16-4d6a-a7b7-90ed718994e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Format logging strings for future minification #7999",
+  "packageName": "@azure/msal-react",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
@@ -95,7 +95,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         request: PlatformAuthRequest
     ): Promise<PlatformAuthResponse> {
         this.logger.trace(
-            this.platformAuthType + " - Sending request to browser DOM API"
+            `${this.platformAuthType} - Sending request to browser DOM API`
         );
 
         try {
@@ -109,7 +109,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
             return this.validatePlatformBrokerResponse(response);
         } catch (e) {
             this.logger.error(
-                this.platformAuthType + " - executeGetToken DOM API error"
+                `${this.platformAuthType} - executeGetToken DOM API error`
             );
             throw e;
         }
@@ -119,7 +119,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         request: PlatformAuthRequest
     ): PlatformDOMTokenRequest {
         this.logger.trace(
-            this.platformAuthType + " - initializeNativeDOMRequest called"
+            `${this.platformAuthType} - initializeNativeDOMRequest called`
         );
 
         const {
@@ -170,8 +170,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
                 response.hasOwnProperty("expiresIn")
             ) {
                 this.logger.trace(
-                    this.platformAuthType +
-                        " - platform broker returned successful and valid response"
+                    `${this.platformAuthType} - platform broker returned successful and valid response`
                 );
                 return this.convertToPlatformBrokerResponse(
                     response as PlatformDOMTokenResponse
@@ -184,8 +183,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
                     errorResponse.error.code
                 ) {
                     this.logger.trace(
-                        this.platformAuthType +
-                            " - platform broker returned error response"
+                        `${this.platformAuthType} - platform broker returned error response`
                     );
                     throw createNativeAuthError(
                         errorResponse.error.code,
@@ -210,7 +208,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         response: PlatformDOMTokenResponse
     ): PlatformAuthResponse {
         this.logger.trace(
-            this.platformAuthType + " - convertToNativeResponse called"
+            `${this.platformAuthType} - convertToNativeResponse called`
         );
         const nativeResponse: PlatformAuthResponse = {
             access_token: response.accessToken,

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
@@ -95,7 +95,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         request: PlatformAuthRequest
     ): Promise<PlatformAuthResponse> {
         this.logger.trace(
-            `${this.platformAuthType} - Sending request to browser DOM API`
+            `'${this.platformAuthType}' - Sending request to browser DOM API`
         );
 
         try {
@@ -109,7 +109,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
             return this.validatePlatformBrokerResponse(response);
         } catch (e) {
             this.logger.error(
-                `${this.platformAuthType} - executeGetToken DOM API error`
+                `'${this.platformAuthType}' - executeGetToken DOM API error`
             );
             throw e;
         }
@@ -119,7 +119,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         request: PlatformAuthRequest
     ): PlatformDOMTokenRequest {
         this.logger.trace(
-            `${this.platformAuthType} - initializeNativeDOMRequest called`
+            `'${this.platformAuthType}' - initializeNativeDOMRequest called`
         );
 
         const {
@@ -170,7 +170,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
                 response.hasOwnProperty("expiresIn")
             ) {
                 this.logger.trace(
-                    `${this.platformAuthType} - platform broker returned successful and valid response`
+                    `'${this.platformAuthType}' - platform broker returned successful and valid response`
                 );
                 return this.convertToPlatformBrokerResponse(
                     response as PlatformDOMTokenResponse
@@ -183,7 +183,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
                     errorResponse.error.code
                 ) {
                     this.logger.trace(
-                        `${this.platformAuthType} - platform broker returned error response`
+                        `'${this.platformAuthType}' - platform broker returned error response`
                     );
                     throw createNativeAuthError(
                         errorResponse.error.code,
@@ -208,7 +208,7 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         response: PlatformDOMTokenResponse
     ): PlatformAuthResponse {
         this.logger.trace(
-            `${this.platformAuthType} - convertToNativeResponse called`
+            `'${this.platformAuthType}' - convertToNativeResponse called`
         );
         const nativeResponse: PlatformAuthResponse = {
             access_token: response.accessToken,

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthExtensionHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthExtensionHandler.ts
@@ -79,7 +79,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
     async sendMessage(
         request: PlatformAuthRequest
     ): Promise<PlatformAuthResponse> {
-        this.logger.trace(this.platformAuthType + " - sendMessage called.");
+        this.logger.trace(`${this.platformAuthType} - sendMessage called.`);
 
         // fall back to native calls
         const messageBody: NativeExtensionRequestBody = {
@@ -95,13 +95,12 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
         };
 
         this.logger.trace(
-            this.platformAuthType + " - Sending request to browser extension"
+            `${this.platformAuthType} - Sending request to browser extension`
         );
         this.logger.tracePii(
-            this.platformAuthType +
-                ` - Sending request to browser extension: ${JSON.stringify(
-                    req
-                )}`
+            `${
+                this.platformAuthType
+            } - Sending request to browser extension: ${JSON.stringify(req)}`
         );
         this.messageChannel.port1.postMessage(req);
 
@@ -155,7 +154,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      */
     private async sendHandshakeRequest(): Promise<void> {
         this.logger.trace(
-            this.platformAuthType + " - sendHandshakeRequest called."
+            `${this.platformAuthType} - sendHandshakeRequest called.`
         );
         // Register this event listener before sending handshake
         window.addEventListener("message", this.windowListener, false); // false is important, because content script message processing should work first
@@ -212,7 +211,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      * @param event
      */
     private onWindowMessage(event: MessageEvent): void {
-        this.logger.trace(this.platformAuthType + " - onWindowMessage called");
+        this.logger.trace(`${this.platformAuthType} - onWindowMessage called`);
         // We only accept messages from ourselves
         if (event.source !== window) {
             return;
@@ -241,8 +240,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
              */
             if (!handshakeResolver) {
                 this.logger.trace(
-                    this.platformAuthType +
-                        `.onWindowMessage - resolver can't be found for request ${request.responseId}`
+                    `${this.platformAuthType}.onWindowMessage - resolver can't be found for request ${request.responseId}`
                 );
                 return;
             }
@@ -275,7 +273,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      */
     private onChannelMessage(event: MessageEvent): void {
         this.logger.trace(
-            this.platformAuthType + " - onChannelMessage called."
+            `${this.platformAuthType} - onChannelMessage called.`
         );
         const request = event.data;
 
@@ -293,14 +291,14 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
                 }
                 const response = request.body.response;
                 this.logger.trace(
-                    this.platformAuthType +
-                        " - Received response from browser extension"
+                    `${this.platformAuthType} - Received response from browser extension`
                 );
                 this.logger.tracePii(
-                    this.platformAuthType +
-                        ` - Received response from browser extension: ${JSON.stringify(
-                            response
-                        )}`
+                    `${
+                        this.platformAuthType
+                    } - Received response from browser extension: ${JSON.stringify(
+                        response
+                    )}`
                 );
                 if (response.status !== "Success") {
                     resolver.reject(
@@ -335,8 +333,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
             } else if (method === NativeExtensionMethod.HandshakeResponse) {
                 if (!handshakeResolver) {
                     this.logger.trace(
-                        this.platformAuthType +
-                            `.onChannelMessage - resolver can't be found for request ${request.responseId}`
+                        `${this.platformAuthType}.onChannelMessage - resolver can't be found for request ${request.responseId}`
                     );
                     return;
                 }
@@ -349,8 +346,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
                 this.extensionId = request.extensionId;
                 this.extensionVersion = request.body.version;
                 this.logger.verbose(
-                    this.platformAuthType +
-                        ` - Received HandshakeResponse from extension: ${this.extensionId}`
+                    `${this.platformAuthType} - Received HandshakeResponse from extension: ${this.extensionId}`
                 );
                 this.handshakeEvent.end({
                     extensionInstalled: true,

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthExtensionHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthExtensionHandler.ts
@@ -79,7 +79,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
     async sendMessage(
         request: PlatformAuthRequest
     ): Promise<PlatformAuthResponse> {
-        this.logger.trace(`${this.platformAuthType} - sendMessage called.`);
+        this.logger.trace(`'${this.platformAuthType}' - sendMessage called.`);
 
         // fall back to native calls
         const messageBody: NativeExtensionRequestBody = {
@@ -95,12 +95,12 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
         };
 
         this.logger.trace(
-            `${this.platformAuthType} - Sending request to browser extension`
+            `'${this.platformAuthType}' - Sending request to browser extension`
         );
         this.logger.tracePii(
-            `${
+            `'${
                 this.platformAuthType
-            } - Sending request to browser extension: ${JSON.stringify(req)}`
+            }' - Sending request to browser extension: '${JSON.stringify(req)}'`
         );
         this.messageChannel.port1.postMessage(req);
 
@@ -154,7 +154,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      */
     private async sendHandshakeRequest(): Promise<void> {
         this.logger.trace(
-            `${this.platformAuthType} - sendHandshakeRequest called.`
+            `'${this.platformAuthType}' - sendHandshakeRequest called.`
         );
         // Register this event listener before sending handshake
         window.addEventListener("message", this.windowListener, false); // false is important, because content script message processing should work first
@@ -211,7 +211,9 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      * @param event
      */
     private onWindowMessage(event: MessageEvent): void {
-        this.logger.trace(`${this.platformAuthType} - onWindowMessage called`);
+        this.logger.trace(
+            `'${this.platformAuthType}' - onWindowMessage called`
+        );
         // We only accept messages from ourselves
         if (event.source !== window) {
             return;
@@ -240,7 +242,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
              */
             if (!handshakeResolver) {
                 this.logger.trace(
-                    `${this.platformAuthType}.onWindowMessage - resolver can't be found for request ${request.responseId}`
+                    `'${this.platformAuthType}'.onWindowMessage - resolver can't be found for request '${request.responseId}'`
                 );
                 return;
             }
@@ -273,7 +275,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      */
     private onChannelMessage(event: MessageEvent): void {
         this.logger.trace(
-            `${this.platformAuthType} - onChannelMessage called.`
+            `'${this.platformAuthType}' - onChannelMessage called.`
         );
         const request = event.data;
 
@@ -291,14 +293,14 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
                 }
                 const response = request.body.response;
                 this.logger.trace(
-                    `${this.platformAuthType} - Received response from browser extension`
+                    `'${this.platformAuthType}' - Received response from browser extension`
                 );
                 this.logger.tracePii(
-                    `${
+                    `'${
                         this.platformAuthType
-                    } - Received response from browser extension: ${JSON.stringify(
+                    }' - Received response from browser extension: '${JSON.stringify(
                         response
-                    )}`
+                    )}'`
                 );
                 if (response.status !== "Success") {
                     resolver.reject(
@@ -333,7 +335,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
             } else if (method === NativeExtensionMethod.HandshakeResponse) {
                 if (!handshakeResolver) {
                     this.logger.trace(
-                        `${this.platformAuthType}.onChannelMessage - resolver can't be found for request ${request.responseId}`
+                        `'${this.platformAuthType}'.onChannelMessage - resolver can't be found for request '${request.responseId}'`
                     );
                     return;
                 }
@@ -346,7 +348,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
                 this.extensionId = request.extensionId;
                 this.extensionVersion = request.body.version;
                 this.logger.verbose(
-                    `${this.platformAuthType} - Received HandshakeResponse from extension: ${this.extensionId}`
+                    `'${this.platformAuthType}' - Received HandshakeResponse from extension: '${this.extensionId}'`
                 );
                 this.handshakeEvent.end({
                     extensionInstalled: true,
@@ -360,9 +362,9 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
         } catch (err) {
             this.logger.error("Error parsing response from WAM Extension");
             this.logger.errorPii(
-                `Error parsing response from WAM Extension: ${err as string}`
+                `Error parsing response from WAM Extension: '${err as string}'`
             );
-            this.logger.errorPii(`Unable to parse ${event}`);
+            this.logger.errorPii(`Unable to parse '${event}'`);
 
             if (resolver) {
                 resolver.reject(err as AuthError);

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
@@ -62,8 +62,7 @@ export async function getPlatformAuthProvider(
     const enablePlatformBrokerDOMSupport = isDomEnabledForPlatformAuth();
 
     logger.trace(
-        "Has client allowed platform auth via DOM API: " +
-            enablePlatformBrokerDOMSupport
+        `Has client allowed platform auth via DOM API: ${enablePlatformBrokerDOMSupport}`
     );
     let platformAuthProvider: IPlatformAuthHandler | undefined;
     try {

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
@@ -62,7 +62,7 @@ export async function getPlatformAuthProvider(
     const enablePlatformBrokerDOMSupport = isDomEnabledForPlatformAuth();
 
     logger.trace(
-        `Has client allowed platform auth via DOM API: ${enablePlatformBrokerDOMSupport}`
+        `Has client allowed platform auth via DOM API: '${enablePlatformBrokerDOMSupport}'`
     );
     let platformAuthProvider: IPlatformAuthHandler | undefined;
     try {

--- a/lib/msal-browser/src/cache/AccountManager.ts
+++ b/lib/msal-browser/src/cache/AccountManager.ts
@@ -88,7 +88,7 @@ export function getAccountByUsername(
             "getAccountByUsername: Account matching username found, returning"
         );
         logger.verbosePii(
-            `getAccountByUsername: Returning signed-in accounts matching username: ${username}`
+            `getAccountByUsername: Returning signed-in accounts matching username: '${username}'`
         );
         return account;
     } else {
@@ -129,7 +129,7 @@ export function getAccountByHomeId(
             "getAccountByHomeId: Account matching homeAccountId found, returning"
         );
         logger.verbosePii(
-            `getAccountByHomeId: Returning signed-in accounts matching homeAccountId: ${homeAccountId}`
+            `getAccountByHomeId: Returning signed-in accounts matching homeAccountId: '${homeAccountId}'`
         );
         return account;
     } else {
@@ -170,7 +170,7 @@ export function getAccountByLocalId(
             "getAccountByLocalId: Account matching localAccountId found, returning"
         );
         logger.verbosePii(
-            `getAccountByLocalId: Returning signed-in accounts matching localAccountId: ${localAccountId}`
+            `getAccountByLocalId: Returning signed-in accounts matching localAccountId: '${localAccountId}'`
         );
         return account;
     } else {

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -346,7 +346,7 @@ export class BrowserCacheManager extends CacheManager {
         );
         if (previousVersion) {
             this.logger.info(
-                `MSAL.js was last initialized by version: ${previousVersion}`
+                `MSAL.js was last initialized by version: '${previousVersion}'`
             );
             this.performanceClient.addFields(
                 { previousLibraryVersion: previousVersion },
@@ -615,7 +615,7 @@ export class BrowserCacheManager extends CacheManager {
     addAccountKeyToMap(key: string, correlationId: string): boolean {
         this.logger.trace("BrowserCacheManager.addAccountKeyToMap called");
         this.logger.tracePii(
-            `BrowserCacheManager.addAccountKeyToMap called with key: ${key}`
+            `BrowserCacheManager.addAccountKeyToMap called with key: '${key}'`
         );
         const accountKeys = this.getAccountKeys();
         if (accountKeys.indexOf(key) === -1) {
@@ -645,7 +645,7 @@ export class BrowserCacheManager extends CacheManager {
     removeAccountKeyFromMap(key: string, correlationId: string): void {
         this.logger.trace("BrowserCacheManager.removeAccountKeyFromMap called");
         this.logger.tracePii(
-            `BrowserCacheManager.removeAccountKeyFromMap called with key: ${key}`
+            `BrowserCacheManager.removeAccountKeyFromMap called with key: '${key}'`
         );
         const accountKeys = this.getAccountKeys();
         const removalIndex = accountKeys.indexOf(key);
@@ -767,7 +767,7 @@ export class BrowserCacheManager extends CacheManager {
 
         if (keysRemoved > 0) {
             this.logger.info(
-                `removed ${keysRemoved} accessToken keys from tokenKeys map`
+                `removed '${keysRemoved}' accessToken keys from tokenKeys map`
             );
             this.setTokenKeys(tokenKeys, correlationId, schemaVersion);
             return;
@@ -951,7 +951,7 @@ export class BrowserCacheManager extends CacheManager {
             tokenKeys.accessToken.splice(index, 1); // Remove existing key before pushing to the end
         }
         this.logger.trace(
-            `access token ${index === -1 ? "added to" : "updated in"} map`
+            `access token '${index === -1 ? "added to" : "updated in"}' map`
         );
         tokenKeys.accessToken.push(accessTokenKey);
         this.setTokenKeys(tokenKeys, correlationId);
@@ -1539,9 +1539,11 @@ export class BrowserCacheManager extends CacheManager {
                 verifier = base64Decode(encodedVerifier);
             }
         } catch (e) {
-            this.logger.errorPii(`Attempted to parse: ${encodedTokenRequest}`);
+            this.logger.errorPii(
+                `Attempted to parse: '${encodedTokenRequest}'`
+            );
             this.logger.error(
-                `Parsing cached token request threw with error: ${e}`
+                `Parsing cached token request threw with error: '${e}'`
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.unableToParseTokenRequestCacheError

--- a/lib/msal-browser/src/cache/LocalStorage.ts
+++ b/lib/msal-browser/src/cache/LocalStorage.ts
@@ -470,7 +470,7 @@ export class LocalStorage implements IWindowStorage<string> {
 
         if (context && context !== this.clientId) {
             this.logger.trace(
-                `Ignoring broadcast event from clientId: ${context}`
+                `Ignoring broadcast event from clientId: '${context}'`
             );
             perfMeasurement.end({
                 success: false,

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1593,7 +1593,7 @@ export class StandardController implements IController {
                     break;
                 default:
                     this.logger.trace(
-                        `canUsePlatformBroker: prompt = ${request.prompt} is not compatible with platform broker flow, returning false`
+                        `canUsePlatformBroker: prompt = '${request.prompt}' is not compatible with platform broker flow, returning false`
                     );
                     return false;
             }
@@ -2104,7 +2104,7 @@ export class StandardController implements IController {
                     const [activePromise, activeCorrelationId] =
                         this.activeIframeRequest;
                     this.logger.verbose(
-                        `Iframe request is already in progress, awaiting resolution for request with correlationId: ${activeCorrelationId}`,
+                        `Iframe request is already in progress, awaiting resolution for request with correlationId: '${activeCorrelationId}'`,
                         silentRequest.correlationId
                     );
                     const awaitConcurrentIframeMeasure =
@@ -2122,7 +2122,7 @@ export class StandardController implements IController {
                     });
                     if (activePromiseResult) {
                         this.logger.verbose(
-                            `Parallel iframe request with correlationId: ${activeCorrelationId} succeeded. Retrying cache and/or RT redemption`,
+                            `Parallel iframe request with correlationId: '${activeCorrelationId}' succeeded. Retrying cache and/or RT redemption`,
                             silentRequest.correlationId
                         );
                         // Retry cache lookup and/or RT exchange after iframe completes
@@ -2132,7 +2132,7 @@ export class StandardController implements IController {
                         );
                     } else {
                         this.logger.info(
-                            `Iframe request with correlationId: ${activeCorrelationId} failed. Interaction is required.`
+                            `Iframe request with correlationId: '${activeCorrelationId}' failed. Interaction is required.`
                         );
                         // If previous iframe request failed, it's unlikely to succeed this time. Throw original error.
                         throw refreshTokenError;
@@ -2302,7 +2302,7 @@ export class StandardController implements IController {
         const res = this.pkceCode ? { ...this.pkceCode } : undefined;
         this.pkceCode = undefined;
         this.logger.verbose(
-            `${res ? "Found" : "Did not find"} pre-generated PKCE codes`
+            `'${res ? "Found" : "Did not find"}' pre-generated PKCE codes`
         );
         this.performanceClient.addFields(
             { usePreGeneratedPkce: !!res },

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -197,7 +197,7 @@ export class CryptoOps implements ICrypto {
         } catch (e) {
             if (e instanceof Error) {
                 this.logger.error(
-                    `Clearing keystore failed with error: ${e.message}`
+                    `Clearing keystore failed with error: '${e.message}'`
                 );
             } else {
                 this.logger.error(

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -157,7 +157,7 @@ export class CustomAuthStandardController
             throw new NoCachedAccountFoundError(correlationId);
         } catch (error) {
             this.logger.errorPii(
-                `An error occurred during getting current account: ${error}`,
+                `An error occurred during getting current account: '${error}'`,
                 correlationId
             );
 
@@ -206,9 +206,9 @@ export class CustomAuthStandardController
             };
 
             this.logger.verbose(
-                `Starting sign-in flow ${
+                `Starting sign-in flow '${
                     !!signInInputs.password ? "with" : "without"
-                } password.`,
+                }' password.`,
                 correlationId
             );
 
@@ -318,7 +318,7 @@ export class CustomAuthStandardController
             );
         } catch (error) {
             this.logger.errorPii(
-                `An error occurred during starting sign-in: ${error}`,
+                `An error occurred during starting sign-in: '${error}'`,
                 correlationId
             );
 
@@ -349,7 +349,7 @@ export class CustomAuthStandardController
             this.ensureUserNotSignedIn(correlationId);
 
             this.logger.verbose(
-                `Starting sign-up flow${
+                `Starting sign-up flow'${
                     !!signUpInputs.password
                         ? ` with ${
                               !!signUpInputs.attributes
@@ -357,7 +357,7 @@ export class CustomAuthStandardController
                                   : "password"
                           }`
                         : ""
-                }.`,
+                }'.`,
                 correlationId
             );
 
@@ -428,7 +428,7 @@ export class CustomAuthStandardController
             );
         } catch (error) {
             this.logger.errorPii(
-                `An error occurred during starting sign-up: ${error}`,
+                `An error occurred during starting sign-up: '${error}'`,
                 correlationId
             );
 
@@ -487,7 +487,7 @@ export class CustomAuthStandardController
             );
         } catch (error) {
             this.logger.errorPii(
-                `An error occurred during starting reset-password: ${error}`,
+                `An error occurred during starting reset-password: '${error}'`,
                 correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/core/network_client/http_client/FetchHttpClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/http_client/FetchHttpClient.ts
@@ -26,23 +26,26 @@ export class FetchHttpClient implements IHttpClient {
             headers?.[AADServerParamKeys.CLIENT_REQUEST_ID] || undefined;
 
         try {
-            this.logger.verbosePii(`Sending request to ${url}`, correlationId);
+            this.logger.verbosePii(
+                `Sending request to '${url}'`,
+                correlationId
+            );
 
             const startTime = performance.now();
             const response = await fetch(url, options);
             const endTime = performance.now();
 
             this.logger.verbosePii(
-                `Request to '${url}' completed in ${
+                `Request to '${url}' completed in '${
                     endTime - startTime
-                }ms with status code ${response.status}`,
+                }'ms with status code '${response.status}'`,
                 correlationId
             );
 
             return response;
         } catch (e) {
             this.logger.errorPii(
-                `Failed to send request to ${url}: ${e}`,
+                `Failed to send request to '${url}': '${e}'`,
                 correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/auth_flow/CustomAuthAccountData.ts
@@ -70,7 +70,7 @@ export class CustomAuthAccountData {
             return new SignOutResult();
         } catch (error) {
             this.logger.errorPii(
-                `An error occurred during sign out: ${error}`,
+                `An error occurred during sign out: '${error}'`,
                 this.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/reset_password/auth_flow/state/ResetPasswordCodeRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/reset_password/auth_flow/state/ResetPasswordCodeRequiredState.ts
@@ -60,7 +60,7 @@ export class ResetPasswordCodeRequiredState extends ResetPasswordState<ResetPass
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to submit code for password reset. Error: ${error}.`,
+                `Failed to submit code for password reset. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 
@@ -112,7 +112,7 @@ export class ResetPasswordCodeRequiredState extends ResetPasswordState<ResetPass
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to resend code for password reset. Error: ${error}.`,
+                `Failed to resend code for password reset. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/reset_password/auth_flow/state/ResetPasswordPasswordRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/reset_password/auth_flow/state/ResetPasswordPasswordRequiredState.ts
@@ -63,7 +63,7 @@ export class ResetPasswordPasswordRequiredState extends ResetPasswordState<Reset
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to submit password for password reset. Error: ${error}.`,
+                `Failed to submit password for password reset. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/reset_password/interaction_client/ResetPasswordClient.ts
+++ b/lib/msal-browser/src/custom_auth/reset_password/interaction_client/ResetPasswordClient.ts
@@ -314,7 +314,7 @@ export class ResetPasswordClient extends CustomAuthInteractionClientBase {
             }
 
             this.logger.verbose(
-                `Poll completion endpoint for password reset is not started or in progress, waiting ${pollInterval} seconds for next check.`,
+                `Poll completion endpoint for password reset is not started or in progress, waiting '${pollInterval}' seconds for next check.`,
                 correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInCodeRequiredState.ts
@@ -69,7 +69,7 @@ export class SignInCodeRequiredState extends SignInState<SignInCodeRequiredState
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to submit code for sign-in. Error: ${error}.`,
+                `Failed to submit code for sign-in. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInContinuationState.ts
@@ -71,7 +71,7 @@ export class SignInContinuationState extends SignInState<SignInContinuationState
             return new SignInResult(new SignInCompletedState(), accountInfo);
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to sign in with continuation token. Error: ${error}.`,
+                `Failed to sign in with continuation token. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/state/SignInPasswordRequiredState.ts
@@ -66,7 +66,7 @@ export class SignInPasswordRequiredState extends SignInState<SignInPasswordRequi
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to sign in after submitting password. Error: ${error}.`,
+                `Failed to sign in after submitting password. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/sign_up/auth_flow/state/SignUpAttributesRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_up/auth_flow/state/SignUpAttributesRequiredState.ts
@@ -97,7 +97,7 @@ export class SignUpAttributesRequiredState extends SignUpState<SignUpAttributesR
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to submit attributes for sign up. Error: ${error}.`,
+                `Failed to submit attributes for sign up. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/sign_up/auth_flow/state/SignUpCodeRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_up/auth_flow/state/SignUpCodeRequiredState.ts
@@ -121,7 +121,7 @@ export class SignUpCodeRequiredState extends SignUpState<SignUpCodeRequiredState
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to submit code for sign up. Error: ${error}.`,
+                `Failed to submit code for sign up. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 
@@ -170,7 +170,7 @@ export class SignUpCodeRequiredState extends SignUpState<SignUpCodeRequiredState
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to resend code for sign up. Error: ${error}.`,
+                `Failed to resend code for sign up. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/sign_up/auth_flow/state/SignUpPasswordRequiredState.ts
+++ b/lib/msal-browser/src/custom_auth/sign_up/auth_flow/state/SignUpPasswordRequiredState.ts
@@ -102,7 +102,7 @@ export class SignUpPasswordRequiredState extends SignUpState<SignUpPasswordRequi
             );
         } catch (error) {
             this.stateParameters.logger.errorPii(
-                `Failed to submit password for sign up. Error: ${error}.`,
+                `Failed to submit password for sign up. Error: '${error}'.`,
                 this.stateParameters.correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/sign_up/interaction_client/SignUpClient.ts
+++ b/lib/msal-browser/src/custom_auth/sign_up/interaction_client/SignUpClient.ts
@@ -365,7 +365,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
         | SignUpAttributesRequiredResult
     > {
         this.logger.verbose(
-            `${callerName} is calling continue endpoint for sign up.`,
+            `'${callerName}' is calling continue endpoint for sign up.`,
             requestCorrelationId
         );
 
@@ -373,7 +373,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
             const response = await responseGetter();
 
             this.logger.verbose(
-                `Continue endpoint called by ${callerName} for sign up.`,
+                `Continue endpoint called by '${callerName}' for sign up.`,
                 requestCorrelationId
             );
 
@@ -391,7 +391,7 @@ export class SignUpClient extends CustomAuthInteractionClientBase {
                 );
             } else {
                 this.logger.errorPii(
-                    `${callerName} is failed to call continue endpoint for sign up. Error: ${error}`,
+                    `'${callerName}' is failed to call continue endpoint for sign up. Error: '${error}'`,
                     requestCorrelationId
                 );
 

--- a/lib/msal-browser/src/event/EventHandler.ts
+++ b/lib/msal-browser/src/event/EventHandler.ts
@@ -51,12 +51,12 @@ export class EventHandler {
             const id = callbackId || createGuid();
             if (this.eventCallbacks.has(id)) {
                 this.logger.error(
-                    `Event callback with id: ${id} is already registered. Please provide a unique id or remove the existing callback and try again.`
+                    `Event callback with id: '${id}' is already registered. Please provide a unique id or remove the existing callback and try again.`
                 );
                 return null;
             }
             this.eventCallbacks.set(id, [callback, eventTypes || []]);
-            this.logger.verbose(`Event callback registered with id: ${id}`);
+            this.logger.verbose(`Event callback registered with id: '${id}'`);
 
             return id;
         }
@@ -70,7 +70,7 @@ export class EventHandler {
      */
     removeEventCallback(callbackId: string): void {
         this.eventCallbacks.delete(callbackId);
-        this.logger.verbose(`Event callback ${callbackId} removed.`);
+        this.logger.verbose(`Event callback '${callbackId}' removed.`);
     }
 
     /**
@@ -126,7 +126,7 @@ export class EventHandler {
                     eventTypes.includes(message.eventType)
                 ) {
                     this.logger.verbose(
-                        `Emitting event to callback ${callbackId}: ${message.eventType}`
+                        `Emitting event to callback '${callbackId}': '${message.eventType}'`
                     );
                     callback.apply(null, [message]);
                 }

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -1050,7 +1050,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 return prompt;
             default:
                 this.logger.trace(
-                    `initializeNativeRequest: prompt = ${prompt} is not compatible with native flow`
+                    `initializeNativeRequest: prompt = '${prompt}' is not compatible with native flow`
                 );
                 throw createBrowserAuthError(
                     BrowserAuthErrorCodes.nativePromptNotSupported

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -738,7 +738,7 @@ export class PopupClient extends StandardInteractionClient {
             return popupWindow;
         } catch (e) {
             this.logger.error(
-                "error opening popup " + (e as AuthError).message
+                `error opening popup ${(e as AuthError).message}`
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.popupWindowError

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -634,7 +634,7 @@ export class PopupClient extends StandardInteractionClient {
                     "Redirecting main window to url specified in the request"
                 );
                 this.logger.verbosePii(
-                    `Redirecting main window to: ${absoluteUrl}`
+                    `Redirecting main window to: '${absoluteUrl}'`
                 );
                 await this.navigationClient.navigateInternal(
                     absoluteUrl,
@@ -677,7 +677,7 @@ export class PopupClient extends StandardInteractionClient {
     initiateAuthRequest(requestUrl: string, params: PopupParams): Window {
         // Check that request url is not empty.
         if (requestUrl) {
-            this.logger.infoPii(`Navigate to: ${requestUrl}`);
+            this.logger.infoPii(`Navigate to: '${requestUrl}'`);
             // Open the popup window to requestUrl.
             return this.openPopup(requestUrl, params);
         } else {
@@ -709,13 +709,13 @@ export class PopupClient extends StandardInteractionClient {
             if (popupParams.popup) {
                 popupWindow = popupParams.popup;
                 this.logger.verbosePii(
-                    `Navigating popup window to: ${urlNavigate}`
+                    `Navigating popup window to: '${urlNavigate}'`
                 );
                 popupWindow.location.assign(urlNavigate);
             } else if (typeof popupParams.popup === "undefined") {
                 // Popup will be undefined if it was not passed in
                 this.logger.verbosePii(
-                    `Opening popup window to: ${urlNavigate}`
+                    `Opening popup window to: '${urlNavigate}'`
                 );
                 popupWindow = this.openSizedPopup(urlNavigate, popupParams);
             }
@@ -738,7 +738,7 @@ export class PopupClient extends StandardInteractionClient {
             return popupWindow;
         } catch (e) {
             this.logger.error(
-                `error opening popup ${(e as AuthError).message}`
+                `error opening popup '${(e as AuthError).message}'`
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.popupWindowError

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -150,7 +150,7 @@ export class RedirectClient extends StandardInteractionClient {
         const redirectStartPage = this.getRedirectStartPage(
             request.redirectStartPage
         );
-        this.logger.verbosePii(`Redirect start page: ${redirectStartPage}`);
+        this.logger.verbosePii(`Redirect start page: '${redirectStartPage}'`);
         // Cache start page, returns to this page after redirectUri if navigateToLoginRequestUrl is true
         this.browserStorage.setTemporaryCache(
             TemporaryCacheKeys.ORIGIN_URI,
@@ -457,7 +457,7 @@ export class RedirectClient extends StandardInteractionClient {
                 } else {
                     // Navigate to page that initiated the redirect request
                     this.logger.verbose(
-                        `Navigating to loginRequestUrl: ${loginRequestUrl}`
+                        `Navigating to loginRequestUrl: '${loginRequestUrl}'`
                     );
                     processHashOnRedirect =
                         await this.navigationClient.navigateInternal(
@@ -520,7 +520,7 @@ export class RedirectClient extends StandardInteractionClient {
             } catch (e) {
                 if (e instanceof AuthError) {
                     this.logger.error(
-                        `Interaction type validation failed due to ${e.errorCode}: ${e.errorMessage}`
+                        `Interaction type validation failed due to '${e.errorCode}': '${e.errorMessage}'`
                     );
                 }
                 return [null, ""];
@@ -651,7 +651,7 @@ export class RedirectClient extends StandardInteractionClient {
         // Navigate if valid URL
         if (requestUrl) {
             this.logger.infoPii(
-                `RedirectHandler.initiateAuthRequest: Navigate to: ${requestUrl}`
+                `RedirectHandler.initiateAuthRequest: Navigate to: '${requestUrl}'`
             );
             const navigationOptions: NavigationOptions = {
                 apiId: ApiId.acquireTokenRedirect,

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -111,7 +111,7 @@ export class SilentIframeClient extends StandardInteractionClient {
                 inputRequest.prompt !== Constants.PromptValue.NO_SESSION
             ) {
                 this.logger.warning(
-                    `SilentIframeClient. Replacing invalid prompt ${inputRequest.prompt} with ${Constants.PromptValue.NONE}`
+                    `SilentIframeClient. Replacing invalid prompt '${inputRequest.prompt}' with '${Constants.PromptValue.NONE}'`
                 );
                 inputRequest.prompt = Constants.PromptValue.NONE;
             }

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -351,7 +351,7 @@ export async function initializeAuthorizationRequest(
     if (account) {
         logger.verbose("Setting validated request account", correlationId);
         logger.verbosePii(
-            `Setting validated request account: ${account.homeAccountId}`,
+            `Setting validated request account: '${account.homeAccountId}'`,
             correlationId
         );
         validatedRequest.account = account;

--- a/lib/msal-browser/src/operatingcontext/NestedAppOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/NestedAppOperatingContext.ts
@@ -78,11 +78,13 @@ export class NestedAppOperatingContext extends BaseOperatingContext {
             }
         } catch (ex) {
             this.logger.infoPii(
-                `Could not initialize Nested App Auth bridge (${ex})`
+                `Could not initialize Nested App Auth bridge ('${ex}')`
             );
         }
 
-        this.logger.info(`Nested App Auth Bridge available: ${this.available}`);
+        this.logger.info(
+            `Nested App Auth Bridge available: '${this.available}'`
+        );
         return this.available;
     }
 }

--- a/lib/msal-browser/src/request/RequestHelpers.ts
+++ b/lib/msal-browser/src/request/RequestHelpers.ts
@@ -63,7 +63,7 @@ export async function initializeBaseRequest(
             }
         }
         logger.verbose(
-            `Authentication Scheme set to "${validatedRequest.authenticationScheme}" as configured in Auth request`
+            `Authentication Scheme set to "'${validatedRequest.authenticationScheme}'" as configured in Auth request`
         );
     }
 

--- a/lib/msal-browser/src/response/ResponseHandler.ts
+++ b/lib/msal-browser/src/response/ResponseHandler.ts
@@ -27,15 +27,15 @@ export function deserializeResponse(
         if (!UrlUtils.stripLeadingHashOrQuery(responseString)) {
             // Hash or Query string is empty
             logger.error(
-                `The request has returned to the redirectUri but a ${responseLocation} is not present. It's likely that the ${responseLocation} has been removed or the page has been redirected by code running on the redirectUri page.`
+                `The request has returned to the redirectUri but a '${responseLocation}' is not present. It's likely that the '${responseLocation}' has been removed or the page has been redirected by code running on the redirectUri page.`
             );
             throw createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError);
         } else {
             logger.error(
-                `A ${responseLocation} is present in the iframe but it does not contain known properties. It's likely that the ${responseLocation} has been replaced by code running on the redirectUri page.`
+                `A '${responseLocation}' is present in the iframe but it does not contain known properties. It's likely that the '${responseLocation}' has been replaced by code running on the redirectUri page.`
             );
             logger.errorPii(
-                `The ${responseLocation} detected is: ${responseString}`
+                `The '${responseLocation}' detected is: '${responseString}'`
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.hashDoesNotContainKnownProperties

--- a/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/auth_flow/CustomAuthAccountData.spec.ts
@@ -122,7 +122,7 @@ describe("CustomAuthAccountData", () => {
             const result = await accountData.signOut();
 
             expect(mockLogger.errorPii).toHaveBeenCalledWith(
-                `An error occurred during sign out: ${error}`,
+                `An error occurred during sign out: '${error}'`,
                 "test-correlation-id"
             );
             expect(result).toBeInstanceOf(SignOutResult);

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2892,6 +2892,10 @@ export class Logger {
     error(message: string, correlationId?: string): void;
     errorPii(message: string, correlationId?: string): void;
     executeCallback(level: LogLevel, message: string, containsPii: boolean): void;
+    getCachedCorrelationIds(): string[];
+    // Warning: (ae-forgotten-export) The symbol "LoggedMessage" needs to be exported by the entry point index.d.ts
+    getCachedLogHashes(correlationId?: string): LoggedMessage[];
+    getCachedLogHashesAndFlush(correlationId?: string): LoggedMessage[];
     info(message: string, correlationId?: string): void;
     infoPii(message: string, correlationId?: string): void;
     isPiiLoggingEnabled(): boolean;
@@ -3238,31 +3242,31 @@ export abstract class PerformanceClient implements IPerformanceClient {
     addFields(fields: {
         [key: string]: {} | undefined;
     }, correlationId: string): void;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
     // (undocumented)
     protected applicationTelemetry: ApplicationTelemetry;
     // (undocumented)
     protected authority: string;
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-undefined-tag) The TSDoc tag "@private" is not defined in this configuration
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     protected cacheEventByCorrelationId(event: PerformanceEvent): void;
     // (undocumented)
     protected callbacks: Map<string, PerformanceCallbackFunction>;
     // (undocumented)
     protected clientId: string;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     discardMeasurements(correlationId: string): void;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-optional-name) The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     emitEvents(events: PerformanceEvent[], correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
@@ -3285,10 +3289,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     abstract generateId(): string;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     incrementFields(fields: {
         [key: string]: number | undefined;
     }, correlationId: string): void;
@@ -3300,10 +3304,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
     protected libraryVersion: string;
     // (undocumented)
     protected logger: Logger;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     removePerformanceCallback(callbackId: string): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
@@ -3407,6 +3411,7 @@ export type PerformanceEvent = {
     msalInstanceCount?: number;
     sameClientIdInstanceCount?: number;
     navigateCallbackResult?: boolean;
+    logs?: string[];
 };
 
 declare namespace PerformanceEvents {
@@ -4625,7 +4630,7 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/client/AuthorizationCodeClient.ts:147:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:148:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:205:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:440:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:439:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:178:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:264:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:265:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -4639,12 +4644,12 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/response/ResponseHandler.ts:326:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:327:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:328:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:669:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:669:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:681:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:681:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:682:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceClient.ts:682:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceClient.ts:668:5 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:670:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:680:5 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceClient.ts:680:5 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceClient.ts:680:5 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:682:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceEvent.ts:35:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:35:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:35:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2892,10 +2892,6 @@ export class Logger {
     error(message: string, correlationId?: string): void;
     errorPii(message: string, correlationId?: string): void;
     executeCallback(level: LogLevel, message: string, containsPii: boolean): void;
-    getCachedCorrelationIds(): string[];
-    // Warning: (ae-forgotten-export) The symbol "LoggedMessage" needs to be exported by the entry point index.d.ts
-    getCachedLogHashes(correlationId?: string): LoggedMessage[];
-    getCachedLogHashesAndFlush(correlationId?: string): LoggedMessage[];
     info(message: string, correlationId?: string): void;
     infoPii(message: string, correlationId?: string): void;
     isPiiLoggingEnabled(): boolean;
@@ -3242,31 +3238,31 @@ export abstract class PerformanceClient implements IPerformanceClient {
     addFields(fields: {
         [key: string]: {} | undefined;
     }, correlationId: string): void;
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     addPerformanceCallback(callback: PerformanceCallbackFunction): string;
     // (undocumented)
     protected applicationTelemetry: ApplicationTelemetry;
     // (undocumented)
     protected authority: string;
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-undefined-tag) The TSDoc tag "@private" is not defined in this configuration
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     protected cacheEventByCorrelationId(event: PerformanceEvent): void;
     // (undocumented)
     protected callbacks: Map<string, PerformanceCallbackFunction>;
     // (undocumented)
     protected clientId: string;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    discardMeasurements(correlationId: string): void;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    discardMeasurements(correlationId: string): void;
     // Warning: (tsdoc-param-tag-with-invalid-optional-name) The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     emitEvents(events: PerformanceEvent[], correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
@@ -3289,10 +3285,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     abstract generateId(): string;
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     incrementFields(fields: {
         [key: string]: number | undefined;
     }, correlationId: string): void;
@@ -3304,10 +3300,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
     protected libraryVersion: string;
     // (undocumented)
     protected logger: Logger;
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     removePerformanceCallback(callbackId: string): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
@@ -3411,7 +3407,6 @@ export type PerformanceEvent = {
     msalInstanceCount?: number;
     sameClientIdInstanceCount?: number;
     navigateCallbackResult?: boolean;
-    logs?: string[];
 };
 
 declare namespace PerformanceEvents {
@@ -4644,12 +4639,12 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/response/ResponseHandler.ts:326:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:327:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:328:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:668:5 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:670:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:680:5 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceClient.ts:680:5 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceClient.ts:680:5 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:682:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:669:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:669:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:681:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:681:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:682:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceClient.ts:682:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:35:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:35:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:35:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -349,7 +349,7 @@ export class Authority {
                  */
                 if (cachedPart !== tenantId) {
                     this.logger.verbose(
-                        `Replacing tenant domain name ${cachedPart} with id ${tenantId}`
+                        `Replacing tenant domain name '${cachedPart}' with id '${tenantId}'`
                     );
                     cachedPart = tenantId;
                 }
@@ -688,7 +688,7 @@ export class Authority {
         const openIdConfigurationEndpoint =
             this.defaultOpenIdConfigurationEndpoint;
         this.logger.verbose(
-            `Authority.getEndpointMetadataFromNetwork: attempting to retrieve OAuth endpoints from ${openIdConfigurationEndpoint}`
+            `Authority.getEndpointMetadataFromNetwork: attempting to retrieve OAuth endpoints from '${openIdConfigurationEndpoint}'`
         );
 
         try {
@@ -708,7 +708,7 @@ export class Authority {
             }
         } catch (e) {
             this.logger.verbose(
-                `Authority.getEndpointMetadataFromNetwork: ${e}`
+                `Authority.getEndpointMetadataFromNetwork: '${e}'`
             );
             return null;
         }
@@ -826,21 +826,21 @@ export class Authority {
             "Attempting to get cloud discovery metadata  from authority configuration"
         );
         this.logger.verbosePii(
-            `Known Authorities: ${
+            `Known Authorities: '${
                 this.authorityOptions.knownAuthorities ||
                 Constants.NOT_APPLICABLE
-            }`
+            }'`
         );
         this.logger.verbosePii(
-            `Authority Metadata: ${
+            `Authority Metadata: '${
                 this.authorityOptions.authorityMetadata ||
                 Constants.NOT_APPLICABLE
-            }`
+            }'`
         );
         this.logger.verbosePii(
-            `Canonical Authority: ${
+            `Canonical Authority: '${
                 metadataEntity.canonical_authority || Constants.NOT_APPLICABLE
-            }`
+            }'`
         );
         const metadata = this.getCloudDiscoveryMetadataFromConfig();
         if (metadata) {
@@ -990,11 +990,11 @@ export class Authority {
                 metadata = typedResponseBody.metadata;
 
                 this.logger.verbosePii(
-                    `tenant_discovery_endpoint is: ${typedResponseBody.tenant_discovery_endpoint}`
+                    `tenant_discovery_endpoint is: '${typedResponseBody.tenant_discovery_endpoint}'`
                 );
             } else if (isCloudInstanceDiscoveryErrorResponse(response.body)) {
                 this.logger.warning(
-                    `A CloudInstanceDiscoveryErrorResponse was returned. The cloud instance discovery network request's status code is: ${response.status}`
+                    `A CloudInstanceDiscoveryErrorResponse was returned. The cloud instance discovery network request's status code is: '${response.status}'`
                 );
 
                 typedResponseBody =
@@ -1007,10 +1007,10 @@ export class Authority {
                 }
 
                 this.logger.warning(
-                    `The CloudInstanceDiscoveryErrorResponse error is ${typedResponseBody.error}`
+                    `The CloudInstanceDiscoveryErrorResponse error is '${typedResponseBody.error}'`
                 );
                 this.logger.warning(
-                    `The CloudInstanceDiscoveryErrorResponse error description is ${typedResponseBody.error_description}`
+                    `The CloudInstanceDiscoveryErrorResponse error description is '${typedResponseBody.error_description}'`
                 );
 
                 this.logger.warning(
@@ -1034,12 +1034,12 @@ export class Authority {
         } catch (error) {
             if (error instanceof AuthError) {
                 this.logger.error(
-                    `There was a network error while attempting to get the cloud discovery instance metadata.\nError: ${error.errorCode}\nError Description: ${error.errorMessage}`
+                    `There was a network error while attempting to get the cloud discovery instance metadata.\nError: '${error.errorCode}'\nError Description: '${error.errorMessage}'`
                 );
             } else {
                 const typedError = error as Error;
                 this.logger.error(
-                    `A non-MSALJS error was thrown while attempting to get the cloud instance discovery metadata.\nError: ${typedError.name}\nError Description: ${typedError.message}`
+                    `A non-MSALJS error was thrown while attempting to get the cloud instance discovery metadata.\nError: '${typedError.name}'\nError Description: '${typedError.message}'`
                 );
             }
 

--- a/lib/msal-common/src/authority/AuthorityMetadata.ts
+++ b/lib/msal-common/src/authority/AuthorityMetadata.ts
@@ -156,7 +156,7 @@ export function getAliasesFromMetadata(
     source?: AuthorityMetadataSource,
     logger?: Logger
 ): string[] | null {
-    logger?.trace(`getAliasesFromMetadata called with source: ${source}`);
+    logger?.trace(`getAliasesFromMetadata called with source: '${source}'`);
     if (authorityHost && cloudDiscoveryMetadata) {
         const metadata = getCloudDiscoveryMetadataFromNetworkResponse(
             cloudDiscoveryMetadata,
@@ -165,12 +165,12 @@ export function getAliasesFromMetadata(
 
         if (metadata) {
             logger?.trace(
-                `getAliasesFromMetadata: found cloud discovery metadata in ${source}, returning aliases`
+                `getAliasesFromMetadata: found cloud discovery metadata in '${source}', returning aliases`
             );
             return metadata.aliases;
         } else {
             logger?.trace(
-                `getAliasesFromMetadata: did not find cloud discovery metadata in ${source}`
+                `getAliasesFromMetadata: did not find cloud discovery metadata in '${source}'`
             );
         }
     }

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -970,7 +970,7 @@ export abstract class CacheManager implements ICacheManager {
                         .removeTokenBindingKey(kid)
                         .catch(() => {
                             this.commonLogger.error(
-                                `Failed to remove token binding key ${kid}`,
+                                `Failed to remove token binding key '${kid}'`,
                                 correlationId
                             );
                             this.performanceClient?.incrementFields(

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -178,7 +178,7 @@ export class AuthorizationCodeClient extends BaseClient {
                 };
             } catch (e) {
                 this.logger.verbose(
-                    `Could not parse client info for CCS Header: ${e}`
+                    `Could not parse client info for CCS Header: '${e}'`
                 );
             }
         }
@@ -364,7 +364,7 @@ export class AuthorizationCodeClient extends BaseClient {
                 };
             } catch (e) {
                 this.logger.verbose(
-                    `Could not parse client info for CCS Header: ${e}`
+                    `Could not parse client info for CCS Header: '${e}'`
                 );
             }
         } else {
@@ -385,7 +385,7 @@ export class AuthorizationCodeClient extends BaseClient {
                         );
                     } catch (e) {
                         this.logger.verbose(
-                            `Could not parse home account ID for CCS Header: ${e}`
+                            `Could not parse home account ID for CCS Header: '${e}'`
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -178,7 +178,7 @@ export class AuthorizationCodeClient extends BaseClient {
                 };
             } catch (e) {
                 this.logger.verbose(
-                    "Could not parse client info for CCS Header: " + e
+                    `Could not parse client info for CCS Header: ${e}`
                 );
             }
         }
@@ -364,7 +364,7 @@ export class AuthorizationCodeClient extends BaseClient {
                 };
             } catch (e) {
                 this.logger.verbose(
-                    "Could not parse client info for CCS Header: " + e
+                    `Could not parse client info for CCS Header: ${e}`
                 );
             }
         } else {
@@ -385,8 +385,7 @@ export class AuthorizationCodeClient extends BaseClient {
                         );
                     } catch (e) {
                         this.logger.verbose(
-                            "Could not parse home account ID for CCS Header: " +
-                                e
+                            `Could not parse home account ID for CCS Header: ${e}`
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/BaseClient.ts
+++ b/lib/msal-common/src/client/BaseClient.ts
@@ -117,8 +117,7 @@ export abstract class BaseClient {
                         ] = `Oid:${clientInfo.uid}@${clientInfo.utid}`;
                     } catch (e) {
                         this.logger.verbose(
-                            "Could not parse home account ID for CCS Header: " +
-                                e
+                            `Could not parse home account ID for CCS Header: ${e}`
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/BaseClient.ts
+++ b/lib/msal-common/src/client/BaseClient.ts
@@ -117,7 +117,7 @@ export abstract class BaseClient {
                         ] = `Oid:${clientInfo.uid}@${clientInfo.utid}`;
                     } catch (e) {
                         this.logger.verbose(
-                            `Could not parse home account ID for CCS Header: ${e}`
+                            `Could not parse home account ID for CCS Header: '${e}'`
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -448,8 +448,7 @@ export class RefreshTokenClient extends BaseClient {
                         );
                     } catch (e) {
                         this.logger.verbose(
-                            "Could not parse home account ID for CCS Header: " +
-                                e
+                            `Could not parse home account ID for CCS Header: ${e}`
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -448,7 +448,7 @@ export class RefreshTokenClient extends BaseClient {
                         );
                     } catch (e) {
                         this.logger.verbose(
-                            `Could not parse home account ID for CCS Header: ${e}`
+                            `Could not parse home account ID for CCS Header: '${e}'`
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -154,7 +154,7 @@ export class SilentFlowClient extends BaseClient {
         );
         if (cacheOutcome !== CacheOutcome.NOT_APPLICABLE) {
             this.logger.info(
-                `Token refresh is required due to cache outcome: ${cacheOutcome}`
+                `Token refresh is required due to cache outcome: '${cacheOutcome}'`
             );
         }
     }

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -335,13 +335,13 @@ export abstract class PerformanceClient implements IPerformanceClient {
         const eventCorrelationId = correlationId || this.generateId();
         if (!correlationId) {
             this.logger.info(
-                `PerformanceClient: No correlation id provided for ${measureName}, generating`,
+                `PerformanceClient: No correlation id provided for '${measureName}', generating`,
                 eventCorrelationId
             );
         }
 
         this.logger.trace(
-            `PerformanceClient: Performance measurement started for ${measureName}`,
+            `PerformanceClient: Performance measurement started for '${measureName}'`,
             eventCorrelationId
         );
 
@@ -413,7 +413,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
             this.eventsByCorrelationId.get(event.correlationId);
         if (!rootEvent) {
             this.logger.trace(
-                `PerformanceClient: Measurement not found for ${event.eventId}`,
+                `PerformanceClient: Measurement not found for '${event.eventId}'`,
                 event.correlationId
             );
             return null;
@@ -440,7 +440,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
         }
 
         this.logger.trace(
-            `PerformanceClient: Performance measurement ended for ${event.name}: ${event.durationMs} ms`,
+            `PerformanceClient: Performance measurement ended for '${event.name}': '${event.durationMs}' ms`,
             event.correlationId
         );
 
@@ -460,7 +460,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
             (rootEvent.errorCode || rootEvent.subErrorCode)
         ) {
             this.logger.trace(
-                `PerformanceClient: Remove error and sub-error codes for root event ${event.name} as intermediate error was successfully handled`,
+                `PerformanceClient: Remove error and sub-error codes for root event '${event.name}' as intermediate error was successfully handled`,
                 event.correlationId
             );
             rootEvent.errorCode = undefined;
@@ -472,7 +472,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
         // Incomplete sub-measurements are discarded. They are likely an instrumentation bug that should be fixed.
         finalEvent.incompleteSubMeasurements?.forEach((subMeasurement) => {
             this.logger.trace(
-                `PerformanceClient: Incomplete submeasurement ${subMeasurement.name} found for ${event.name}`,
+                `PerformanceClient: Incomplete submeasurement '${subMeasurement.name}' found for '${event.name}'`,
                 finalEvent.correlationId
             );
             incompleteSubsCount++;
@@ -556,7 +556,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
         const rootEvent = this.eventsByCorrelationId.get(event.correlationId);
         if (rootEvent) {
             this.logger.trace(
-                `PerformanceClient: Performance measurement for ${event.name} added/updated`,
+                `PerformanceClient: Performance measurement for '${event.name}' added/updated`,
                 event.correlationId
             );
             rootEvent.incompleteSubMeasurements =
@@ -567,7 +567,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
             });
         } else {
             this.logger.trace(
-                `PerformanceClient: Performance measurement for ${event.name} started`,
+                `PerformanceClient: Performance measurement for '${event.name}' started`,
                 event.correlationId
             );
             this.eventsByCorrelationId.set(event.correlationId, { ...event });
@@ -613,7 +613,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
         const callbackId = this.generateId();
         this.callbacks.set(callbackId, callback);
         this.logger.verbose(
-            `PerformanceClient: Performance callback registered with id: ${callbackId}`
+            `PerformanceClient: Performance callback registered with id: '${callbackId}'`
         );
 
         return callbackId;
@@ -630,11 +630,11 @@ export abstract class PerformanceClient implements IPerformanceClient {
 
         if (result) {
             this.logger.verbose(
-                `PerformanceClient: Performance callback ${callbackId} removed.`
+                `PerformanceClient: Performance callback '${callbackId}' removed.`
             );
         } else {
             this.logger.verbose(
-                `PerformanceClient: Performance callback ${callbackId} not removed.`
+                `PerformanceClient: Performance callback '${callbackId}' not removed.`
             );
         }
 
@@ -656,7 +656,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
         this.callbacks.forEach(
             (callback: PerformanceCallbackFunction, callbackId: string) => {
                 this.logger.trace(
-                    `PerformanceClient: Emitting event to callback ${callbackId}`,
+                    `PerformanceClient: Emitting event to callback '${callbackId}'`,
                     correlationId
                 );
                 callback.apply(null, [events]);

--- a/lib/msal-common/src/utils/FunctionWrappers.ts
+++ b/lib/msal-common/src/utils/FunctionWrappers.ts
@@ -26,7 +26,7 @@ export const invoke = <T extends Array<any>, U>(
     correlationId?: string
 ) => {
     return (...args: T): U => {
-        logger.trace(`Executing function ${eventName}`);
+        logger.trace(`Executing function '${eventName}'`);
         const inProgressEvent = telemetryClient?.startMeasurement(
             eventName,
             correlationId
@@ -44,10 +44,10 @@ export const invoke = <T extends Array<any>, U>(
             inProgressEvent?.end({
                 success: true,
             });
-            logger.trace(`Returning result from ${eventName}`);
+            logger.trace(`Returning result from '${eventName}'`);
             return result;
         } catch (e) {
-            logger.trace(`Error occurred in ${eventName}`);
+            logger.trace(`Error occurred in '${eventName}'`);
             try {
                 logger.trace(JSON.stringify(e));
             } catch (e) {
@@ -85,7 +85,7 @@ export const invokeAsync = <T extends Array<any>, U>(
     correlationId?: string
 ) => {
     return (...args: T): Promise<U> => {
-        logger.trace(`Executing function ${eventName}`);
+        logger.trace(`Executing function '${eventName}'`);
         const inProgressEvent = telemetryClient?.startMeasurement(
             eventName,
             correlationId
@@ -100,14 +100,14 @@ export const invokeAsync = <T extends Array<any>, U>(
         }
         return callback(...args)
             .then((response) => {
-                logger.trace(`Returning result from ${eventName}`);
+                logger.trace(`Returning result from '${eventName}'`);
                 inProgressEvent?.end({
                     success: true,
                 });
                 return response;
             })
             .catch((e) => {
-                logger.trace(`Error occurred in ${eventName}`);
+                logger.trace(`Error occurred in '${eventName}'`);
                 try {
                     logger.trace(JSON.stringify(e));
                 } catch (e) {

--- a/lib/msal-react/apiReview/msal-react.api.md
+++ b/lib/msal-react/apiReview/msal-react.api.md
@@ -153,7 +153,7 @@ export function useMsalAuthentication(interactionType: InteractionType, authenti
 // Warning: (ae-missing-release-tag) "version" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const version = "3.0.12";
+export const version = "3.0.13";
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "withMsal" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/lib/msal-react/apiReview/msal-react.api.md
+++ b/lib/msal-react/apiReview/msal-react.api.md
@@ -153,7 +153,7 @@ export function useMsalAuthentication(interactionType: InteractionType, authenti
 // Warning: (ae-missing-release-tag) "version" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const version = "3.0.13";
+export const version = "3.0.12";
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "withMsal" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/lib/msal-react/src/MsalProvider.tsx
+++ b/lib/msal-react/src/MsalProvider.tsx
@@ -76,7 +76,7 @@ const reducer = (
             );
             if (status) {
                 payload.logger.info(
-                    `MsalProvider - ${message.eventType} results in setting inProgress from ${previousState.inProgress} to ${status}`
+                    `MsalProvider - '${message.eventType}' results in setting inProgress from '${previousState.inProgress}' to '${status}'`
                 );
                 newInProgress = status;
             }
@@ -158,7 +158,7 @@ export function MsalProvider({
             }
         );
         logger.verbose(
-            `MsalProvider - Registered event callback with id: ${callbackId}`
+            `MsalProvider - Registered event callback with id: '${callbackId}'`
         );
 
         instance
@@ -193,7 +193,7 @@ export function MsalProvider({
             // Remove callback when component unmounts or accounts change
             if (callbackId) {
                 logger.verbose(
-                    `MsalProvider - Removing event callback ${callbackId}`
+                    `MsalProvider - Removing event callback '${callbackId}'`
                 );
                 instance.removeEventCallback(callbackId);
             }

--- a/lib/msal-react/src/hooks/useMsalAuthentication.ts
+++ b/lib/msal-react/src/hooks/useMsalAuthentication.ts
@@ -235,13 +235,13 @@ export function useMsalAuthentication(
             }
         );
         logger.verbose(
-            `useMsalAuthentication - Registered event callback with id: ${callbackId}`
+            `useMsalAuthentication - Registered event callback with id: '${callbackId}'`
         );
 
         return () => {
             if (callbackId) {
                 logger.verbose(
-                    `useMsalAuthentication - Removing event callback ${callbackId}`
+                    `useMsalAuthentication - Removing event callback '${callbackId}'`
                 );
                 instance.removeEventCallback(callbackId);
             }

--- a/shared-configs/eslint-config-msal/index.js
+++ b/shared-configs/eslint-config-msal/index.js
@@ -74,6 +74,7 @@ module.exports = {
             }
         ],
         "custom-msal/no-string-concatenation-in-logging": 2,
+        "custom-msal/quote-logging-variables": 2,
         "eol-last": 2,
         "eqeqeq": 2,
         "header/header": [

--- a/shared-configs/eslint-config-msal/index.js
+++ b/shared-configs/eslint-config-msal/index.js
@@ -70,11 +70,21 @@ module.exports = {
             2,
             {
                 "errorDocPath": "../../docs/errors.md",
-                "ignoreModules": ["msal-node"]
+                "ignoreModules": ["msal-node", "msal-node-extensions"]
             }
         ],
-        "custom-msal/no-string-concatenation-in-logging": 2,
-        "custom-msal/quote-logging-variables": 2,
+        "custom-msal/no-string-concatenation-in-logging": [
+            2,
+            {
+                "ignoreModules": ["msal-node", "msal-node-extensions"]
+            }
+        ],
+        "custom-msal/quote-logging-variables": [
+            2,
+            {
+                "ignoreModules": ["msal-node", "msal-node-extensions"]
+            }
+        ],
         "eol-last": 2,
         "eqeqeq": 2,
         "header/header": [

--- a/shared-configs/eslint-config-msal/index.js
+++ b/shared-configs/eslint-config-msal/index.js
@@ -73,6 +73,7 @@ module.exports = {
                 "ignoreModules": ["msal-node"]
             }
         ],
+        "custom-msal/no-string-concatenation-in-logging": 2,
         "eol-last": 2,
         "eqeqeq": 2,
         "header/header": [

--- a/shared-configs/eslint-plugin-custom-msal/index.js
+++ b/shared-configs/eslint-plugin-custom-msal/index.js
@@ -1,12 +1,14 @@
 const noClassMethodsInConstructorRule = require("./rules/no-class-methods-in-constructor");
 const errorDescriptionIsDefined = require("./rules/error-description-is-defined");
 const noStringConcatenationInLogging = require("./rules/no-string-concatenation-in-logging");
+const quoteLoggingVariables = require("./rules/quote-logging-variables");
 
 const plugin = {
     rules: {
         "no-class-methods-in-constructor": noClassMethodsInConstructorRule,
         "error-description-is-defined": errorDescriptionIsDefined,
-        "no-string-concatenation-in-logging": noStringConcatenationInLogging
+        "no-string-concatenation-in-logging": noStringConcatenationInLogging,
+        "quote-logging-variables": quoteLoggingVariables
     }
 }
 

--- a/shared-configs/eslint-plugin-custom-msal/index.js
+++ b/shared-configs/eslint-plugin-custom-msal/index.js
@@ -1,10 +1,12 @@
 const noClassMethodsInConstructorRule = require("./rules/no-class-methods-in-constructor");
 const errorDescriptionIsDefined = require("./rules/error-description-is-defined");
+const noStringConcatenationInLogging = require("./rules/no-string-concatenation-in-logging");
 
 const plugin = {
     rules: {
         "no-class-methods-in-constructor": noClassMethodsInConstructorRule,
-        "error-description-is-defined": errorDescriptionIsDefined
+        "error-description-is-defined": errorDescriptionIsDefined,
+        "no-string-concatenation-in-logging": noStringConcatenationInLogging
     }
 }
 

--- a/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
@@ -36,8 +36,6 @@ module.exports = {
         const ignoreModules = options.ignoreModules;
         const fileName = context.getFilename();
         
-        for (const ignoreModule of ignoreModules) {
-            if (fileName.includes(ignoreModule)) {
         if (ignoreModules) {
             for (const ignoreModule of ignoreModules) {
                 if (fileName.includes(ignoreModule)) {

--- a/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
@@ -6,6 +6,7 @@ module.exports = {
             category: "Best Practices",
             recommended: true,
         },
+        hasSuggestions: true,
         fixable: "code",
         schema: [
             {
@@ -15,6 +16,10 @@ module.exports = {
                         type: "array",
                         items: { type: "string" },
                         default: ["trace", "tracePii", "error", "errorPii", "verbose", "verbosePii", "warn", "warnPii", "info", "infoPii"]
+                    },
+                    ignoreModules: {
+                        type: "array",
+                        items: { type: "string" },
                     },
                 },
                 additionalProperties: false,
@@ -28,6 +33,15 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] || {};
+        const ignoreModules = options.ignoreModules;
+        const fileName = context.getFilename();
+        
+        for (const ignoreModule of ignoreModules) {
+            if (fileName.includes(ignoreModule)) {
+                return {};
+            }
+        }
+
         const loggerMethods = options.loggerMethods || ["trace", "tracePii", "error", "errorPii", "verbose", "verbosePii", "warn", "warnPii", "info", "infoPii"];
         const sourceCode = context.getSourceCode();
 

--- a/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
@@ -59,14 +59,13 @@ module.exports = {
                 return false;
             }
 
-            // Check for this.logger.method() or logger.method()
             if (node.callee.type === "MemberExpression") {
                 const methodName = node.callee.property.name;
                 const objectName = node.callee.object.name;
-                const isLoggerObject = objectName === "logger" ||
+                const loggerObjectNames = ["logger", "commonLogger", "log"];
+                const isLoggerObject = loggerObjectNames.includes(objectName) ||
                     (node.callee.object.type === "MemberExpression" &&
-                     node.callee.object.property.name === "logger");
-
+                     loggerObjectNames.includes(node.callee.object.property.name));
                 return loggerMethods.includes(methodName) && isLoggerObject;
             }
 

--- a/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
@@ -38,7 +38,11 @@ module.exports = {
         
         for (const ignoreModule of ignoreModules) {
             if (fileName.includes(ignoreModule)) {
-                return {};
+        if (ignoreModules) {
+            for (const ignoreModule of ignoreModules) {
+                if (fileName.includes(ignoreModule)) {
+                    return {};
+                }
             }
         }
 

--- a/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/no-string-concatenation-in-logging.js
@@ -1,0 +1,159 @@
+module.exports = {
+    meta: {
+        type: "suggestion",
+        docs: {
+            description: "Prohibit string concatenation in logging calls and suggest template literals instead",
+            category: "Best Practices",
+            recommended: true,
+        },
+        fixable: "code",
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    loggerMethods: {
+                        type: "array",
+                        items: { type: "string" },
+                        default: ["trace", "tracePii", "error", "errorPii", "verbose", "verbosePii", "warn", "warnPii", "info", "infoPii"]
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        messages: {
+            noConcatenation: "Avoid string concatenation in logging calls. Use template literals instead.",
+            suggestion: "Replace with template literal: `{{suggestion}}`"
+        }
+    },
+
+    create(context) {
+        const options = context.options[0] || {};
+        const loggerMethods = options.loggerMethods || ["trace", "tracePii", "error", "errorPii", "verbose", "verbosePii", "warn", "warnPii", "info", "infoPii"];
+        const sourceCode = context.getSourceCode();
+
+        /**
+         * Checks if a node is a logging method call
+         * @param {Object} node - The CallExpression node
+         * @returns {boolean} - True if it's a logging method call
+         */
+        function isLoggingMethodCall(node) {
+            if (node.type !== "CallExpression") {
+                return false;
+            }
+
+            // Check for this.logger.method() or logger.method()
+            if (node.callee.type === "MemberExpression") {
+                const methodName = node.callee.property.name;
+                const objectName = node.callee.object.name;
+                const isLoggerObject = objectName === "logger" ||
+                    (node.callee.object.type === "MemberExpression" &&
+                     node.callee.object.property.name === "logger");
+
+                return loggerMethods.includes(methodName) && isLoggerObject;
+            }
+
+            return false;
+        }
+
+        /**
+         * Checks if an expression contains string concatenation
+         * @param {Object} node - The expression node
+         * @returns {boolean} - True if contains concatenation
+         */
+        function hasConcatenation(node) {
+            if (node.type === "BinaryExpression" && node.operator === "+") {
+                // Check if at least one side is a string literal
+                const leftIsString = node.left.type === "Literal" && typeof node.left.value === "string";
+                const rightIsString = node.right.type === "Literal" && typeof node.right.value === "string";
+
+                // Don't flag if it's just numeric addition
+                if (!leftIsString && !rightIsString) {
+                    const leftIsNumber = node.left.type === "Literal" && typeof node.left.value === "number";
+                    const rightIsNumber = node.right.type === "Literal" && typeof node.right.value === "number";
+                    if (leftIsNumber || rightIsNumber) {
+                        return false;
+                    }
+                }
+
+                // If we have string concatenation, check further
+                if (leftIsString || rightIsString ||
+                    node.left.type === "Identifier" ||
+                    node.left.type === "MemberExpression" ||
+                    node.right.type === "Identifier" ||
+                    node.right.type === "MemberExpression") {
+                    return true;
+                }
+
+                // Recursively check nested expressions
+                return hasConcatenation(node.left) || hasConcatenation(node.right);
+            }
+
+            return false;
+        }
+
+        /**
+         * Converts a concatenation expression to template literal
+         * @param {Object} node - The expression node
+         * @returns {string} - Template literal equivalent
+         */
+        function convertToTemplateLiteral(node) {
+            if (node.type === "Literal" && typeof node.value === "string") {
+                // Escape any backticks and ${ in the string literal
+                return node.value.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+            }
+
+            if (node.type === "Identifier") {
+                return "${" + node.name + "}";
+            }
+
+            if (node.type === "MemberExpression") {
+                return "${" + sourceCode.getText(node) + "}";
+            }
+
+            if (node.type === "BinaryExpression" && node.operator === "+") {
+                const left = convertToTemplateLiteral(node.left);
+                const right = convertToTemplateLiteral(node.right);
+                return left + right;
+            }
+
+            if (node.type === "CallExpression" || node.type === "ConditionalExpression") {
+                return "${" + sourceCode.getText(node) + "}";
+            }
+
+            // For other expressions, use the original text
+            return "${" + sourceCode.getText(node) + "}";
+        }
+
+        return {
+            CallExpression(node) {
+                if (!isLoggingMethodCall(node)) {
+                    return;
+                }
+
+                // Check each argument for concatenation
+                for (const arg of node.arguments) {
+                    if (hasConcatenation(arg)) {
+                        const suggestion = convertToTemplateLiteral(arg);
+
+                        context.report({
+                            node: arg,
+                            messageId: "noConcatenation",
+                            fix(fixer) {
+                                return fixer.replaceText(arg, "`" + suggestion + "`");
+                            },
+                            suggest: [
+                                {
+                                    messageId: "suggestion",
+                                    data: { suggestion: "`" + suggestion + "`" },
+                                    fix(fixer) {
+                                        return fixer.replaceText(arg, "`" + suggestion + "`");
+                                    }
+                                }
+                            ]
+                        });
+                    }
+                }
+            }
+        };
+    },
+};

--- a/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
@@ -1,0 +1,161 @@
+module.exports = {
+    meta: {
+        type: "suggestion",
+        docs: {
+            description: "Enforce that all variables and expressions in logging template literals are wrapped with single quotes",
+            category: "Best Practices",
+            recommended: true,
+        },
+        fixable: "code",
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    loggerMethods: {
+                        type: "array",
+                        items: { type: "string" },
+                        default: ["trace", "tracePii", "error", "errorPii", "verbose", "verbosePii", "warn", "warnPii", "info", "infoPii"]
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        messages: {
+            unquotedVariable: "Variables and expressions in logging template literals should be wrapped with single quotes for hash consistency.",
+            suggestion: "Wrap variable with single quotes: '${{{variable}}}'"
+        }
+    },
+
+    create(context) {
+        const options = context.options[0] || {};
+        const loggerMethods = options.loggerMethods || ["trace", "tracePii", "error", "errorPii", "verbose", "verbosePii", "warn", "warnPii", "info", "infoPii"];
+        const sourceCode = context.getSourceCode();
+
+        /**
+         * Checks if a node is a logging method call
+         * @param {Object} node - The CallExpression node
+         * @returns {boolean} - True if it's a logging method call
+         */
+        function isLoggingMethodCall(node) {
+            if (node.type !== "CallExpression") {
+                return false;
+            }
+
+            // Check for this.logger.method() or logger.method()
+            if (node.callee.type === "MemberExpression") {
+                const methodName = node.callee.property.name;
+                const objectName = node.callee.object.name;
+                const isLoggerObject = objectName === "logger" ||
+                    (node.callee.object.type === "MemberExpression" &&
+                     node.callee.object.property.name === "logger");
+
+                return loggerMethods.includes(methodName) && isLoggerObject;
+            }
+
+            return false;
+        }
+
+        /**
+         * Checks if an expression in a template literal needs quotes
+         * @param {Object} templateLiteral - The TemplateLiteral node
+         * @param {number} expressionIndex - Index of the expression
+         * @returns {boolean} - True if expression needs quotes
+         */
+        function needsQuotes(templateLiteral, expressionIndex) {
+            const beforeQuasi = templateLiteral.quasis[expressionIndex];
+            const afterQuasi = templateLiteral.quasis[expressionIndex + 1];
+            
+            if (!beforeQuasi || !afterQuasi) {
+                return false;
+            }
+            
+            const beforeText = beforeQuasi.value.raw;
+            const afterText = afterQuasi.value.raw;
+            
+            // Check if already properly quoted
+            return !(beforeText.endsWith("'") && afterText.startsWith("'"));
+        }
+
+        /**
+         * Creates a fixer function to add quotes around an expression
+         * @param {Object} templateLiteral - The TemplateLiteral node
+         * @param {number} expressionIndex - Index of the expression to quote
+         * @returns {Function} - Fixer function
+         */
+        function createFixer(templateLiteral, expressionIndex) {
+            return function(fixer) {
+                // Reconstruct the entire template literal with proper quotes
+                let newTemplate = "`";
+                
+                for (let i = 0; i < templateLiteral.quasis.length; i++) {
+                    const quasi = templateLiteral.quasis[i];
+                    let quasiText = quasi.value.raw;
+                    
+                    // Add the quasi text
+                    newTemplate += quasiText;
+                    
+                    // Add expression if not the last quasi
+                    if (i < templateLiteral.expressions.length) {
+                        const expr = templateLiteral.expressions[i];
+                        const exprText = sourceCode.getText(expr);
+                        
+                        if (i === expressionIndex) {
+                            // This is the expression we're fixing - add quotes
+                            const beforeQuasi = templateLiteral.quasis[i];
+                            const afterQuasi = templateLiteral.quasis[i + 1];
+                            const needsBefore = !beforeQuasi.value.raw.endsWith("'");
+                            const needsAfter = !afterQuasi.value.raw.startsWith("'");
+                            
+                            if (needsBefore) {
+                                newTemplate += "'";
+                            }
+                            newTemplate += "${" + exprText + "}";
+                            if (needsAfter) {
+                                newTemplate += "'";
+                            }
+                        } else {
+                            newTemplate += "${" + exprText + "}";
+                        }
+                    }
+                }
+                newTemplate += "`";
+                
+                return fixer.replaceText(templateLiteral, newTemplate);
+            };
+        }
+
+        return {
+            CallExpression(node) {
+                if (!isLoggingMethodCall(node)) {
+                    return;
+                }
+
+                // Check each argument for template literals
+                for (const arg of node.arguments) {
+                    if (arg.type === "TemplateLiteral") {
+                        // Check each expression in the template literal
+                        for (let i = 0; i < arg.expressions.length; i++) {
+                            if (needsQuotes(arg, i)) {
+                                const expression = arg.expressions[i];
+                                const variableText = sourceCode.getText(expression);
+                                
+                                context.report({
+                                    node: expression,
+                                    messageId: "unquotedVariable",
+                                    fix: createFixer(arg, i),
+                                    suggest: [
+                                        {
+                                            messageId: "suggestion",
+                                            data: { variable: variableText },
+                                            fix: createFixer(arg, i)
+                                        }
+                                    ]
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    },
+};

--- a/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
@@ -36,8 +36,6 @@ module.exports = {
         const ignoreModules = options.ignoreModules;
         const fileName = context.getFilename();
 
-        for (const ignoreModule of ignoreModules) {
-            if (fileName.includes(ignoreModule)) {
         if (ignoreModules) {
             for (const ignoreModule of ignoreModules) {
                 if (fileName.includes(ignoreModule)) {

--- a/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
@@ -59,14 +59,13 @@ module.exports = {
                 return false;
             }
 
-            // Check for this.logger.method() or logger.method()
             if (node.callee.type === "MemberExpression") {
                 const methodName = node.callee.property.name;
                 const objectName = node.callee.object.name;
-                const isLoggerObject = objectName === "logger" ||
+                const loggerObjectNames = ["logger", "commonLogger", "log"];
+                const isLoggerObject = loggerObjectNames.includes(objectName) ||
                     (node.callee.object.type === "MemberExpression" &&
-                     node.callee.object.property.name === "logger");
-
+                     loggerObjectNames.includes(node.callee.object.property.name));
                 return loggerMethods.includes(methodName) && isLoggerObject;
             }
 

--- a/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
@@ -6,6 +6,7 @@ module.exports = {
             category: "Best Practices",
             recommended: true,
         },
+        hasSuggestions: true,
         fixable: "code",
         schema: [
             {
@@ -15,6 +16,10 @@ module.exports = {
                         type: "array",
                         items: { type: "string" },
                         default: ["trace", "tracePii", "error", "errorPii", "verbose", "verbosePii", "warn", "warnPii", "info", "infoPii"]
+                    },
+                    ignoreModules: {
+                        type: "array",
+                        items: { type: "string" },
                     },
                 },
                 additionalProperties: false,
@@ -28,6 +33,15 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] || {};
+        const ignoreModules = options.ignoreModules;
+        const fileName = context.getFilename();
+
+        for (const ignoreModule of ignoreModules) {
+            if (fileName.includes(ignoreModule)) {
+                return {};
+            }
+        }
+
         const loggerMethods = options.loggerMethods || ["trace", "tracePii", "error", "errorPii", "verbose", "verbosePii", "warn", "warnPii", "info", "infoPii"];
         const sourceCode = context.getSourceCode();
 

--- a/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/quote-logging-variables.js
@@ -38,7 +38,11 @@ module.exports = {
 
         for (const ignoreModule of ignoreModules) {
             if (fileName.includes(ignoreModule)) {
-                return {};
+        if (ignoreModules) {
+            for (const ignoreModule of ignoreModules) {
+                if (fileName.includes(ignoreModule)) {
+                    return {};
+                }
             }
         }
 

--- a/shared-configs/eslint-plugin-custom-msal/test/no-string-concatenation-in-logging.test.js
+++ b/shared-configs/eslint-plugin-custom-msal/test/no-string-concatenation-in-logging.test.js
@@ -1,0 +1,149 @@
+const { RuleTester } = require('eslint');
+const noStringConcatenationInLogging = require("../rules/no-string-concatenation-in-logging");
+
+const ruleTester = new RuleTester({
+    parserOptions: { 
+        ecmaVersion: 2020,
+        sourceType: 'module'
+    }
+});
+
+ruleTester.run(
+    "no-string-concatenation-in-logging",
+    noStringConcatenationInLogging,
+    {
+        valid: [
+            // Template literals are allowed
+            {
+                code: `this.logger.trace(\`Message with \${variable}\`);`
+            },
+            {
+                code: `logger.error(\`Error: \${error.message}\`);`
+            },
+            {
+                code: `this.logger.verbose(\`\${this.platformAuthType} - Sending request\`);`
+            },
+            // Single string literals are allowed
+            {
+                code: `this.logger.trace("Simple message");`
+            },
+            {
+                code: `logger.error("Static error message");`
+            },
+            // Non-logging method calls with concatenation are allowed
+            {
+                code: `console.log("Message " + variable);`
+            },
+            {
+                code: `someOtherMethod("String " + variable);`
+            },
+            // Multiple arguments without concatenation
+            {
+                code: `this.logger.trace("Message", variable, "more text");`
+            },
+            // Concatenation in non-logging contexts
+            {
+                code: `const message = "Hello " + name; this.logger.trace(message);`
+            }
+        ],
+        invalid: [
+            // Basic string concatenation
+            {
+                code: `this.logger.trace("Message " + variable);`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.trace(\`Message \${variable}\`);`
+            },
+            // Error logging with concatenation
+            {
+                code: `this.logger.error("Error occurred: " + error);`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.error(\`Error occurred: \${error}\`);`
+            },
+            // Verbose logging with concatenation
+            {
+                code: `this.logger.verbose("Could not parse: " + e);`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.verbose(\`Could not parse: \${e}\`);`
+            },
+            // Complex concatenation with member expression
+            {
+                code: `this.logger.trace(this.platformAuthType + " - Sending request");`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.trace(\`\${this.platformAuthType} - Sending request\`);`
+            },
+            // Multiple concatenations
+            {
+                code: `this.logger.error("Error: " + error.message + " in " + context);`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.error(\`Error: \${error.message} in \${context}\`);`
+            },
+            // TracePii logging
+            {
+                code: `this.logger.tracePii("User info: " + userInfo);`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.tracePii(\`User info: \${userInfo}\`);`
+            },
+            // Warn logging
+            {
+                code: `this.logger.warn("Warning: " + message);`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.warn(\`Warning: \${message}\`);`
+            },
+            // Logger without 'this'
+            {
+                code: `logger.info("Info: " + details);`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `logger.info(\`Info: \${details}\`);`
+            },
+            // Multi-line concatenation
+            {
+                code: `this.logger.verbose(
+                    "Could not parse home account ID for CCS Header: " +
+                        e
+                );`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.verbose(
+                    \`Could not parse home account ID for CCS Header: \${e}\`
+                );`
+            },
+            // Variable + string concatenation
+            {
+                code: `this.logger.trace(prefix + ": Processing request");`,
+                errors: [{
+                    messageId: "noConcatenation",
+                    type: "BinaryExpression"
+                }],
+                output: `this.logger.trace(\`\${prefix}: Processing request\`);`
+            }
+        ]
+    }
+);
+
+console.log("All tests for no-string-concatenation-in-logging rule passed!");

--- a/shared-configs/eslint-plugin-custom-msal/test/quote-logging-variables.test.js
+++ b/shared-configs/eslint-plugin-custom-msal/test/quote-logging-variables.test.js
@@ -1,0 +1,230 @@
+const { RuleTester } = require('eslint');
+const quoteLoggingVariables = require("../rules/quote-logging-variables");
+
+const ruleTester = new RuleTester({
+    parserOptions: { 
+        ecmaVersion: 2020,
+        sourceType: 'module'
+    }
+});
+
+ruleTester.run(
+    "quote-logging-variables",
+    quoteLoggingVariables,
+    {
+        valid: [
+            // Variables already properly quoted with single quotes
+            {
+                code: `this.logger.trace(\`Message with '\${variable}'\`);`
+            },
+            {
+                code: `logger.error(\`Error: '\${error.message}'\`);`
+            },
+            {
+                code: `this.logger.verbose(\`'\${this.platformAuthType}' - Sending request\`);`
+            },
+            // Multiple quoted variables
+            {
+                code: `this.logger.error(\`Error with '\${errorCode}' and '\${userId}'\`);`
+            },
+            // Complex expressions properly quoted
+            {
+                code: `this.logger.trace(\`Navigate to: '\${requestUrl}'\`);`
+            },
+            {
+                code: `this.logger.info(\`Token refresh required due to cache outcome: '\${cacheOutcome}'\`);`
+            },
+            // Static strings without variables
+            {
+                code: `this.logger.trace("Simple message without variables");`
+            },
+            {
+                code: `this.logger.error("Static error message");`
+            },
+            // Template literals without variables
+            {
+                code: `this.logger.verbose(\`Static message\`);`
+            },
+            // Non-logging method calls (should be ignored)
+            {
+                code: `console.log(\`Message with \${variable}\`);`
+            },
+            {
+                code: `someOtherMethod(\`String \${variable}\`);`
+            },
+            // Conditional expressions properly quoted
+            {
+                code: `this.logger.trace(\`access token '\${index === -1 ? "added to" : "updated in"}' map\`);`
+            },
+            // JSON.stringify properly quoted
+            {
+                code: `this.logger.tracePii(\`Received response: '\${JSON.stringify(response)}'\`);`
+            },
+            // String concatenation (handled by other rule)
+            {
+                code: `this.logger.trace("Message " + variable);`
+            }
+        ],
+        invalid: [
+            // Basic unquoted variable
+            {
+                code: `this.logger.trace(\`Message with \${variable}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.trace(\`Message with '\${variable}'\`);`
+            },
+            // Error logging with unquoted variable
+            {
+                code: `this.logger.error(\`Error occurred: \${error}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.error(\`Error occurred: '\${error}'\`);`
+            },
+            // Member expression unquoted
+            {
+                code: `this.logger.verbose(\`Could not parse: \${e.message}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "MemberExpression"
+                }],
+                output: `this.logger.verbose(\`Could not parse: '\${e.message}'\`);`
+            },
+            // Complex member expression
+            {
+                code: `this.logger.trace(\`\${this.platformAuthType} - Sending request\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "MemberExpression"
+                }],
+                output: `this.logger.trace(\`'\${this.platformAuthType}' - Sending request\`);`
+            },
+            // Multiple unquoted variables - first fix only
+            {
+                code: `this.logger.error(\`Error: \${error.errorCode} with message: \${error.errorMessage}\`);`,
+                errors: [
+                    {
+                        messageId: "unquotedVariable",
+                        type: "MemberExpression"
+                    },
+                    {
+                        messageId: "unquotedVariable", 
+                        type: "MemberExpression"
+                    }
+                ],
+                output: `this.logger.error(\`Error: '\${error.errorCode}' with message: \${error.errorMessage}\`);`
+            },
+
+            // After first fix, second variable can be fixed
+            {
+                code: `this.logger.error(\`Error: '\${error.errorCode}' with message: \${error.errorMessage}\`);`,
+                errors: [
+                    {
+                        messageId: "unquotedVariable", 
+                        type: "MemberExpression"
+                    }
+                ],
+                output: `this.logger.error(\`Error: '\${error.errorCode}' with message: '\${error.errorMessage}'\`);`
+            },
+            // TracePii logging
+            {
+                code: `this.logger.tracePii(\`User info: \${userInfo}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.tracePii(\`User info: '\${userInfo}'\`);`
+            },
+            // Warn logging
+            {
+                code: `this.logger.warn(\`Warning: \${message}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.warn(\`Warning: '\${message}'\`);`
+            },
+            // Logger without 'this'
+            {
+                code: `logger.info(\`Info: \${details}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `logger.info(\`Info: '\${details}'\`);`
+            },
+            // Complex conditional expression
+            {
+                code: `this.logger.trace(\`access token \${index === -1 ? "added to" : "updated in"} map\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "ConditionalExpression"
+                }],
+                output: `this.logger.trace(\`access token '\${index === -1 ? "added to" : "updated in"}' map\`);`
+            },
+            // Function call expression
+            {
+                code: `this.logger.tracePii(\`Response: \${JSON.stringify(response)}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "CallExpression"
+                }],
+                output: `this.logger.tracePii(\`Response: '\${JSON.stringify(response)}'\`);`
+            },
+            // Multi-line template literal
+            {
+                code: `this.logger.verbose(
+                    \`Could not parse home account ID for CCS Header: \${e}\`
+                );`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.verbose(
+                    \`Could not parse home account ID for CCS Header: '\${e}'\`
+                );`
+            },
+            // Mixed quoted and unquoted (partially quoted)
+            {
+                code: `this.logger.error(\`Error with '\${errorCode}' and \${userId}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.error(\`Error with '\${errorCode}' and '\${userId}'\`);`
+            },
+            // VerbosePii logging
+            {
+                code: `this.logger.verbosePii(\`Redirect start page: \${redirectStartPage}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.verbosePii(\`Redirect start page: '\${redirectStartPage}'\`);`
+            },
+            // InfoPii logging
+            {
+                code: `this.logger.infoPii(\`Navigate to: \${requestUrl}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.infoPii(\`Navigate to: '\${requestUrl}'\`);`
+            },
+            // ErrorPii logging
+            {
+                code: `this.logger.errorPii(\`Attempted to parse: \${encodedTokenRequest}\`);`,
+                errors: [{
+                    messageId: "unquotedVariable",
+                    type: "Identifier"
+                }],
+                output: `this.logger.errorPii(\`Attempted to parse: '\${encodedTokenRequest}'\`);`
+            }
+        ]
+    }
+);
+
+console.log("All tests for quote-logging-variables rule passed!");


### PR DESCRIPTION
- Replace concatenated logging strings with quoted literals.
- Wrap all variables and expressions in logging strings with single quotes.
- Add corresponding eslint rules.