### PR TITLE
Enable passing of redirect uri for Nativebroker

### DIFF
--- a/change/@azure-msal-node-118ac835-7803-4e30-81cd-91c4afe6bf9d.json
+++ b/change/@azure-msal-node-118ac835-7803-4e30-81cd-91c4afe6bf9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "enable passing of redirect uri",
+  "packageName": "@azure/msal-node",
+  "email": "akaliugonna@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-extensions-bce3798f-5840-4955-a647-70f9009359fc.json
+++ b/change/@azure-msal-node-extensions-bce3798f-5840-4955-a647-70f9009359fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "enable passing of redirect uri",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "akaliugonna@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
+++ b/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
@@ -197,7 +197,8 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
             platformRequest.redirectUri =
                 this.chooseRedirectUriByPlatform(platformRequest);
             this.logger.info(
-                "NativeBrokerPlugin - No Redirect URI provided, using default", platformRequest.redirectUri
+                "NativeBrokerPlugin - No Redirect URI provided, using default",
+                platformRequest.redirectUri
             );
         }
         const authParams = this.generateRequestParameters(platformRequest);
@@ -260,7 +261,8 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
             platformRequest.redirectUri =
                 this.chooseRedirectUriByPlatform(platformRequest);
             this.logger.info(
-                "NativeBrokerPlugin - No Redirect URI provided, using default", platformRequest.redirectUri
+                "NativeBrokerPlugin - No Redirect URI provided, using default",
+                platformRequest.redirectUri
             );
         }
         const authParams = this.generateRequestParameters(platformRequest);
@@ -476,9 +478,7 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
                 request.authority
             );
 
-            authParams.SetRedirectUri(
-                request.redirectUri
-            );
+            authParams.SetRedirectUri(request.redirectUri);
             authParams.SetRequestedScopes(request.scopes.join(" "));
 
             if (request.claims) {

--- a/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
+++ b/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
@@ -193,10 +193,15 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
             request.correlationId
         );
         const platformRequest = request;
+        if (!platformRequest.redirectUri) {
+            platformRequest.redirectUri =
+                this.chooseRedirectUriByPlatform(platformRequest);
+            this.logger.info(
+                "NativeBrokerPlugin - No Redirect URI provided, using default", platformRequest.redirectUri
+            );
+        }
         const authParams = this.generateRequestParameters(platformRequest);
         const account = await this.getAccount(platformRequest);
-        platformRequest.redirectUri =
-            this.chooseRedirectUriByPlatform(platformRequest);
 
         return new Promise(
             (resolve: (value: AuthenticationResult) => void, reject) => {
@@ -251,9 +256,14 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
             request.correlationId
         );
         const platformRequest = request;
+        if (!platformRequest.redirectUri) {
+            platformRequest.redirectUri =
+                this.chooseRedirectUriByPlatform(platformRequest);
+            this.logger.info(
+                "NativeBrokerPlugin - No Redirect URI provided, using default", platformRequest.redirectUri
+            );
+        }
         const authParams = this.generateRequestParameters(platformRequest);
-        platformRequest.redirectUri =
-            this.chooseRedirectUriByPlatform(platformRequest);
         const account = await this.getAccount(platformRequest);
         const windowHandle = providedWindowHandle || Buffer.from([0]);
 
@@ -467,7 +477,7 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
             );
 
             authParams.SetRedirectUri(
-                this.chooseRedirectUriByPlatform(request)
+                request.redirectUri
             );
             authParams.SetRequestedScopes(request.scopes.join(" "));
 

--- a/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
+++ b/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
@@ -38,6 +38,7 @@ import {
     LogLevel as MsalRuntimeLogLevel,
 } from "@azure/msal-node-runtime";
 import { ErrorCodes } from "../utils/Constants.js";
+import { StringUtils } from "../utils/StringUtils.js";
 import { NativeAuthError } from "../error/NativeAuthError.js";
 import { version, name } from "../packageMetadata.js";
 
@@ -655,9 +656,10 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
         ) {
             const { errorCode, errorStatus, errorContext, errorTag } =
                 error as MsalRuntimeError;
+            const tagString = StringUtils.tagToString(errorTag);
             const enhancedErrorContext = errorContext
-                ? `${errorContext} (Error Code: ${errorCode}, Tag: ${errorTag})`
-                : `(Error Code: ${errorCode}, Tag: ${errorTag})`;
+                ? `${errorContext} (Error Code: ${errorCode}, Tag: ${tagString})`
+                : `(Error Code: ${errorCode}, Tag: ${tagString})`;
             switch (errorStatus) {
                 case ErrorStatus.InteractionRequired:
                 case ErrorStatus.AccountUnusable:

--- a/extensions/msal-node-extensions/src/error/NativeAuthError.ts
+++ b/extensions/msal-node-extensions/src/error/NativeAuthError.ts
@@ -19,7 +19,7 @@ export class NativeAuthError extends AuthError {
         super(errorStatus, errorContext);
         this.name = "NativeAuthError";
         this.statusCode = errorCode;
-        this.tag =StringUtils.tagToString(errorTag);
+        this.tag = StringUtils.tagToString(errorTag);
         Object.setPrototypeOf(this, NativeAuthError.prototype);
     }
 }

--- a/extensions/msal-node-extensions/src/error/NativeAuthError.ts
+++ b/extensions/msal-node-extensions/src/error/NativeAuthError.ts
@@ -4,10 +4,11 @@
  */
 
 import { AuthError } from "@azure/msal-common/node";
+import { StringUtils } from "../utils/StringUtils.js";
 
 export class NativeAuthError extends AuthError {
     public statusCode: number;
-    public tag: number;
+    public tag: string;
 
     constructor(
         errorStatus: string,
@@ -18,7 +19,7 @@ export class NativeAuthError extends AuthError {
         super(errorStatus, errorContext);
         this.name = "NativeAuthError";
         this.statusCode = errorCode;
-        this.tag = errorTag;
+        this.tag =StringUtils.tagToString(errorTag);
         Object.setPrototypeOf(this, NativeAuthError.prototype);
     }
 }

--- a/extensions/msal-node-extensions/src/index.ts
+++ b/extensions/msal-node-extensions/src/index.ts
@@ -14,4 +14,5 @@ export { CrossPlatformLockOptions } from "./lock/CrossPlatformLockOptions.js";
 export { PersistenceCreator } from "./persistence/PersistenceCreator.js";
 export { IPersistenceConfiguration } from "./persistence/IPersistenceConfiguration.js";
 export { Environment } from "./utils/Environment.js";
+export { StringUtils } from "./utils/StringUtils.js";
 export { NativeBrokerPlugin } from "./broker/NativeBrokerPlugin.js";

--- a/extensions/msal-node-extensions/src/utils/StringUtils.ts
+++ b/extensions/msal-node-extensions/src/utils/StringUtils.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export class StringUtils {
+    /**
+     * Converts a numeric tag to a string representation
+     * @param tag - The numeric tag to convert
+     * @returns The string representation of the tag
+     */
+    static tagToString(tag: number): string {
+        if (tag === 0) {
+            return "UNTAG";
+        }
+
+        const tagSymbolSpace =
+            "abcdefghijklmnopqrstuvwxyz0123456789****************************";
+        let tagBuffer = "*****";
+
+        const chars = [
+            tagSymbolSpace[(tag >> 24) & 0x3f],
+            tagSymbolSpace[(tag >> 18) & 0x3f],
+            tagSymbolSpace[(tag >> 12) & 0x3f],
+            tagSymbolSpace[(tag >> 6) & 0x3f],
+            tagSymbolSpace[(tag >> 0) & 0x3f],
+        ];
+
+        tagBuffer = chars.join("");
+
+        return tagBuffer;
+    }
+}

--- a/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
+++ b/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
@@ -55,6 +55,7 @@ import {
 } from "@azure/msal-common";
 import { randomUUID } from "crypto";
 import { NativeAuthError } from "../../src/error/NativeAuthError";
+import { StringUtils } from "../../src/utils/StringUtils.js";
 import {
     testMsalRuntimeAccount,
     testAccountInfo,
@@ -87,8 +88,16 @@ function createMockAuthResult(
 if (process.platform === "win32") {
     describe("NativeBrokerPlugin", () => {
         const enhancedErrorContext = msalRuntimeExampleError.errorContext
-            ? `${msalRuntimeExampleError.errorContext} (Error Code: ${msalRuntimeExampleError.errorCode}, Tag: ${msalRuntimeExampleError.errorTag})`
-            : `(Error Code: ${msalRuntimeExampleError.errorCode}, Tag: ${msalRuntimeExampleError.errorTag})`;
+            ? `${msalRuntimeExampleError.errorContext} (Error Code: ${
+                  msalRuntimeExampleError.errorCode
+              }, Tag: ${StringUtils.tagToString(
+                  msalRuntimeExampleError.errorTag
+              )})`
+            : `(Error Code: ${
+                  msalRuntimeExampleError.errorCode
+              }, Tag: ${StringUtils.tagToString(
+                  msalRuntimeExampleError.errorTag
+              )})`;
         const testNativeAuthError = new NativeAuthError(
             ErrorStatus[msalRuntimeExampleError.errorStatus],
             enhancedErrorContext,

--- a/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
+++ b/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
@@ -672,7 +672,7 @@ if (process.platform === "win32") {
                     scopes: testAuthenticationResult.scopes,
                     correlationId: testCorrelationId,
                     authority: testAuthenticationResult.authority,
-                    redirectUri: TEST_REDIRECTURI,
+                    redirectUri: "",
                 };
 
                 const chooseRedirectUriMock = jest.spyOn(
@@ -1509,7 +1509,7 @@ if (process.platform === "win32") {
                     scopes: testAuthenticationResult.scopes,
                     correlationId: testCorrelationId,
                     authority: testAuthenticationResult.authority,
-                    redirectUri: TEST_REDIRECTURI,
+                    redirectUri: "",
                 };
 
                 const chooseRedirectUriMock = jest.spyOn(

--- a/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
+++ b/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
@@ -2434,7 +2434,7 @@ if (process.platform === "win32") {
                 scopes: testAuthenticationResult.scopes,
                 correlationId: testCorrelationId,
                 authority: testAuthenticationResult.authority,
-                redirectUri: TEST_REDIRECTURI,
+                redirectUri: "",
             };
 
             const chooseRedirectUriMock = jest.spyOn(
@@ -2479,7 +2479,7 @@ if (process.platform === "win32") {
                 scopes: testAuthenticationResult.scopes,
                 correlationId: testCorrelationId,
                 authority: testAuthenticationResult.authority,
-                redirectUri: TEST_REDIRECTURI,
+                redirectUri: "",
             };
 
             const chooseRedirectUriMock = jest.spyOn(

--- a/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
+++ b/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
@@ -1,29 +1,69 @@
 jest.mock("@azure/msal-node-runtime", () => {
-    const actual = jest.requireActual("@azure/msal-node-runtime");
-    return {
-        ...actual,
-        msalNodeRuntime: {
-            ...actual.msalNodeRuntime,
-            SignInSilentlyAsync: jest.fn(),
-            SignInAsync: jest.fn(),
-            AcquireTokenSilentlyAsync: jest.fn(),
-            AcquireTokenInteractivelyAsync: jest.fn(),
-            SignInInteractivelyAsync: jest.fn(),
-            ReadAccountByIdAsync: jest.fn(),
-            DiscoverAccountsAsync: jest.fn(),
-            SignOutSilentlyAsync: jest.fn(),
-            RegisterLogger: jest.fn(),
-            StartupError: undefined,
-            AuthParameters: jest.fn().mockImplementation(() => ({
-                CreateAuthParameters: jest.fn(),
-                SetRedirectUri: jest.fn(),
-                SetRequestedScopes: jest.fn(),
-                SetDecodedClaims: jest.fn(),
-                SetPopParams: jest.fn(),
-                SetAdditionalParameter: jest.fn(),
-            })),
-        },
-    };
+    if (process.platform === "win32") {
+        const actual = jest.requireActual("@azure/msal-node-runtime");
+        return {
+            ...actual,
+            msalNodeRuntime: {
+                ...actual.msalNodeRuntime,
+                SignInSilentlyAsync: jest.fn(),
+                SignInAsync: jest.fn(),
+                AcquireTokenSilentlyAsync: jest.fn(),
+                AcquireTokenInteractivelyAsync: jest.fn(),
+                SignInInteractivelyAsync: jest.fn(),
+                ReadAccountByIdAsync: jest.fn(),
+                DiscoverAccountsAsync: jest.fn(),
+                SignOutSilentlyAsync: jest.fn(),
+                RegisterLogger: jest.fn(),
+                StartupError: undefined,
+                AuthParameters: jest.fn().mockImplementation(() => ({
+                    CreateAuthParameters: jest.fn(),
+                    SetRedirectUri: jest.fn(),
+                    SetRequestedScopes: jest.fn(),
+                    SetDecodedClaims: jest.fn(),
+                    SetPopParams: jest.fn(),
+                    SetAdditionalParameter: jest.fn(),
+                })),
+            },
+        };
+    } else {
+        // Mock for non-Windows platforms where msal-node-runtime is not available
+        return {
+            msalNodeRuntime: {
+                SignInSilentlyAsync: jest.fn(),
+                SignInAsync: jest.fn(),
+                AcquireTokenSilentlyAsync: jest.fn(),
+                AcquireTokenInteractivelyAsync: jest.fn(),
+                SignInInteractivelyAsync: jest.fn(),
+                ReadAccountByIdAsync: jest.fn(),
+                DiscoverAccountsAsync: jest.fn(),
+                SignOutSilentlyAsync: jest.fn(),
+                RegisterLogger: jest.fn(),
+                StartupError: undefined,
+                AuthParameters: jest.fn().mockImplementation(() => ({
+                    CreateAuthParameters: jest.fn(),
+                    SetRedirectUri: jest.fn(),
+                    SetRequestedScopes: jest.fn(),
+                    SetDecodedClaims: jest.fn(),
+                    SetPopParams: jest.fn(),
+                    SetAdditionalParameter: jest.fn(),
+                })),
+            },
+            ErrorStatus: {
+                Unexpected: 0,
+                UserCanceled: 1,
+                NetworkError: 2,
+                InvalidRequest: 3,
+                AuthError: 4,
+                InteractionRequired: 5,
+                AccountUnusable: 6,
+                NoNetwork: 7,
+                NetworkTemporarilyUnavailable: 8,
+                ServerTemporarilyUnavailable: 9,
+                AuthorityUntrusted: 10,
+                UserSwitched: 11,
+            },
+        };
+    }
 });
 import { NativeBrokerPlugin } from "../../src/broker/NativeBrokerPlugin";
 import {

--- a/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
+++ b/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
@@ -1,69 +1,29 @@
 jest.mock("@azure/msal-node-runtime", () => {
-    if (process.platform === "win32") {
-        const actual = jest.requireActual("@azure/msal-node-runtime");
-        return {
-            ...actual,
-            msalNodeRuntime: {
-                ...actual.msalNodeRuntime,
-                SignInSilentlyAsync: jest.fn(),
-                SignInAsync: jest.fn(),
-                AcquireTokenSilentlyAsync: jest.fn(),
-                AcquireTokenInteractivelyAsync: jest.fn(),
-                SignInInteractivelyAsync: jest.fn(),
-                ReadAccountByIdAsync: jest.fn(),
-                DiscoverAccountsAsync: jest.fn(),
-                SignOutSilentlyAsync: jest.fn(),
-                RegisterLogger: jest.fn(),
-                StartupError: undefined,
-                AuthParameters: jest.fn().mockImplementation(() => ({
-                    CreateAuthParameters: jest.fn(),
-                    SetRedirectUri: jest.fn(),
-                    SetRequestedScopes: jest.fn(),
-                    SetDecodedClaims: jest.fn(),
-                    SetPopParams: jest.fn(),
-                    SetAdditionalParameter: jest.fn(),
-                })),
-            },
-        };
-    } else {
-        // Mock for non-Windows platforms where msal-node-runtime is not available
-        return {
-            msalNodeRuntime: {
-                SignInSilentlyAsync: jest.fn(),
-                SignInAsync: jest.fn(),
-                AcquireTokenSilentlyAsync: jest.fn(),
-                AcquireTokenInteractivelyAsync: jest.fn(),
-                SignInInteractivelyAsync: jest.fn(),
-                ReadAccountByIdAsync: jest.fn(),
-                DiscoverAccountsAsync: jest.fn(),
-                SignOutSilentlyAsync: jest.fn(),
-                RegisterLogger: jest.fn(),
-                StartupError: undefined,
-                AuthParameters: jest.fn().mockImplementation(() => ({
-                    CreateAuthParameters: jest.fn(),
-                    SetRedirectUri: jest.fn(),
-                    SetRequestedScopes: jest.fn(),
-                    SetDecodedClaims: jest.fn(),
-                    SetPopParams: jest.fn(),
-                    SetAdditionalParameter: jest.fn(),
-                })),
-            },
-            ErrorStatus: {
-                Unexpected: 0,
-                UserCanceled: 1,
-                NetworkError: 2,
-                InvalidRequest: 3,
-                AuthError: 4,
-                InteractionRequired: 5,
-                AccountUnusable: 6,
-                NoNetwork: 7,
-                NetworkTemporarilyUnavailable: 8,
-                ServerTemporarilyUnavailable: 9,
-                AuthorityUntrusted: 10,
-                UserSwitched: 11,
-            },
-        };
-    }
+    const actual = jest.requireActual("@azure/msal-node-runtime");
+    return {
+        ...actual,
+        msalNodeRuntime: {
+            ...actual.msalNodeRuntime,
+            SignInSilentlyAsync: jest.fn(),
+            SignInAsync: jest.fn(),
+            AcquireTokenSilentlyAsync: jest.fn(),
+            AcquireTokenInteractivelyAsync: jest.fn(),
+            SignInInteractivelyAsync: jest.fn(),
+            ReadAccountByIdAsync: jest.fn(),
+            DiscoverAccountsAsync: jest.fn(),
+            SignOutSilentlyAsync: jest.fn(),
+            RegisterLogger: jest.fn(),
+            StartupError: undefined,
+            AuthParameters: jest.fn().mockImplementation(() => ({
+                CreateAuthParameters: jest.fn(),
+                SetRedirectUri: jest.fn(),
+                SetRequestedScopes: jest.fn(),
+                SetDecodedClaims: jest.fn(),
+                SetPopParams: jest.fn(),
+                SetAdditionalParameter: jest.fn(),
+            })),
+        },
+    };
 });
 import { NativeBrokerPlugin } from "../../src/broker/NativeBrokerPlugin";
 import {

--- a/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
+++ b/extensions/msal-node-extensions/test/broker/NativeBrokerPlugin.spec.ts
@@ -2287,7 +2287,7 @@ if (process.platform === "win32") {
                 scopes: testAuthenticationResult.scopes,
                 correlationId: testCorrelationId,
                 authority: testAuthenticationResult.authority,
-                redirectUri: TEST_REDIRECTURI,
+                redirectUri: "",
             };
 
             const chooseRedirectUriMock = jest.spyOn(
@@ -2332,7 +2332,7 @@ if (process.platform === "win32") {
                 scopes: testAuthenticationResult.scopes,
                 correlationId: testCorrelationId,
                 authority: testAuthenticationResult.authority,
-                redirectUri: TEST_REDIRECTURI,
+                redirectUri: "",
             };
 
             const chooseRedirectUriMock = jest.spyOn(

--- a/extensions/msal-node-extensions/test/utils/StringUtils.test.ts
+++ b/extensions/msal-node-extensions/test/utils/StringUtils.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { StringUtils } from "../../src/utils/StringUtils.js";
+
+describe("StringUtils", () => {
+    describe("tagToString tests", () => {
+        it("Returns 'UNTAG' for tag value 0", () => {
+            expect(StringUtils.tagToString(0)).toBe("UNTAG");
+        });
+
+        it("Converts numeric tag to 5-character string", () => {
+            const tag = 0x01234567;
+            const result = StringUtils.tagToString(tag);
+
+            expect(result).toHaveLength(5);
+            expect(typeof result).toBe("string");
+        });
+
+        it("Produce same results for same input", () => {
+            const tag = 0x12345678;
+            const result1 = StringUtils.tagToString(tag);
+            const result2 = StringUtils.tagToString(tag);
+
+            expect(result1).toBe(result2);
+        });
+    });
+});

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -325,7 +325,7 @@ export { InteractionRequiredAuthErrorCodes }
 export { InteractionRequiredAuthErrorMessage }
 
 // @public
-export type InteractiveRequest = Partial<Omit<CommonAuthorizationUrlRequest, "scopes" | "redirectUri" | "requestedClaimsHash" | "storeInCache">> & {
+export type InteractiveRequest = Partial<Omit<CommonAuthorizationUrlRequest, "scopes" | "requestedClaimsHash" | "storeInCache">> & {
     openBrowser: (url: string) => Promise<void>;
     scopes?: Array<string>;
     successTemplate?: string;

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -163,7 +163,7 @@ export class PublicClientApplication
                 ...remainingProperties,
                 clientId: this.config.auth.clientId,
                 scopes: request.scopes || OIDC_DEFAULT_SCOPES,
-                redirectUri: `${Constants.HTTP_PROTOCOL}${Constants.LOCALHOST}`,
+                redirectUri: request.redirectUri || "",
                 authority: request.authority || this.config.auth.authority,
                 correlationId: correlationId,
                 extraParameters: {
@@ -200,6 +200,10 @@ export class PublicClientApplication
 
             // Wait for server to be listening
             const redirectUri = await this.waitForRedirectUri(loopbackClient);
+
+            if (request.redirectUri) {
+                this.logger.warning("RedirectUri provided in an unsupported scenario. Falling back to default", redirectUri);
+            }
 
             const validRequest: AuthorizationUrlRequest = {
                 ...remainingProperties,
@@ -258,7 +262,7 @@ export class PublicClientApplication
                 ...request,
                 clientId: this.config.auth.clientId,
                 scopes: request.scopes || OIDC_DEFAULT_SCOPES,
-                redirectUri: `${Constants.HTTP_PROTOCOL}${Constants.LOCALHOST}`,
+                redirectUri: request.redirectUri || "",
                 authority: request.authority || this.config.auth.authority,
                 correlationId: correlationId,
                 extraParameters: {
@@ -270,6 +274,11 @@ export class PublicClientApplication
             };
             return this.nativeBrokerPlugin.acquireTokenSilent(brokerRequest);
         }
+
+        if (request.redirectUri) {
+                this.logger.warning("RedirectUri provided in an unsupported scenario. Falling back to default");
+                request.redirectUri = `${Constants.HTTP_PROTOCOL}${Constants.LOCALHOST}`;
+            }
 
         return super.acquireTokenSilent(request);
     }

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -202,7 +202,10 @@ export class PublicClientApplication
             const redirectUri = await this.waitForRedirectUri(loopbackClient);
 
             if (request.redirectUri) {
-                this.logger.warning("RedirectUri provided in an unsupported scenario. Falling back to default", redirectUri);
+                this.logger.warning(
+                    "RedirectUri provided in an unsupported scenario. Falling back to default",
+                    redirectUri
+                );
             }
 
             const validRequest: AuthorizationUrlRequest = {
@@ -276,9 +279,11 @@ export class PublicClientApplication
         }
 
         if (request.redirectUri) {
-                this.logger.warning("RedirectUri provided in an unsupported scenario. Falling back to default");
-                request.redirectUri = `${Constants.HTTP_PROTOCOL}${Constants.LOCALHOST}`;
-            }
+            this.logger.warning(
+                "RedirectUri provided in an unsupported scenario. Falling back to default"
+            );
+            request.redirectUri = `${Constants.HTTP_PROTOCOL}${Constants.LOCALHOST}`;
+        }
 
         return super.acquireTokenSilent(request);
     }

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -179,6 +179,9 @@ export class PublicClientApplication
             );
         }
 
+        if (request.redirectUri) {
+            throw NodeAuthError.createRedirectUriNotSupportedError();
+        }
         const { verifier, challenge } =
             await this.cryptoProvider.generatePkceCodes();
 
@@ -200,13 +203,6 @@ export class PublicClientApplication
 
             // Wait for server to be listening
             const redirectUri = await this.waitForRedirectUri(loopbackClient);
-
-            if (request.redirectUri) {
-                this.logger.warning(
-                    "RedirectUri provided in an unsupported scenario. Falling back to default",
-                    redirectUri
-                );
-            }
 
             const validRequest: AuthorizationUrlRequest = {
                 ...remainingProperties,
@@ -279,10 +275,7 @@ export class PublicClientApplication
         }
 
         if (request.redirectUri) {
-            this.logger.warning(
-                "RedirectUri provided in an unsupported scenario. Falling back to default"
-            );
-            request.redirectUri = `${Constants.HTTP_PROTOCOL}${Constants.LOCALHOST}`;
+            throw NodeAuthError.createRedirectUriNotSupportedError();
         }
 
         return super.acquireTokenSilent(request);

--- a/lib/msal-node/src/error/NodeAuthError.ts
+++ b/lib/msal-node/src/error/NodeAuthError.ts
@@ -41,6 +41,10 @@ export const NodeAuthErrorMessage = {
         code: "thumbprint_missing_from_client_certificate",
         desc: "Client certificate does not contain a SHA-1 or SHA-256 thumbprint.",
     },
+    redirectUriNotSupported: {
+        code: "redirect_uri_not_supported",
+        desc: "RedirectUri is not supported in this scenario. Please remove redirectUri from the request.",
+    },
 };
 
 export class NodeAuthError extends AuthError {
@@ -126,6 +130,16 @@ export class NodeAuthError extends AuthError {
         return new NodeAuthError(
             NodeAuthErrorMessage.thumbprintMissing.code,
             NodeAuthErrorMessage.thumbprintMissing.desc
+        );
+    }
+
+    /**
+     * Creates an error thrown when redirectUri is provided in an unsupported scenario
+     */
+    static createRedirectUriNotSupportedError(): NodeAuthError {
+        return new NodeAuthError(
+            NodeAuthErrorMessage.redirectUriNotSupported.code,
+            NodeAuthErrorMessage.redirectUriNotSupported.desc
         );
     }
 }

--- a/lib/msal-node/src/request/InteractiveRequest.ts
+++ b/lib/msal-node/src/request/InteractiveRequest.ts
@@ -20,7 +20,7 @@ import { ILoopbackClient } from "../network/ILoopbackClient.js";
 export type InteractiveRequest = Partial<
     Omit<
         CommonAuthorizationUrlRequest,
-        "scopes"  | "requestedClaimsHash" | "storeInCache"
+        "scopes" | "requestedClaimsHash" | "storeInCache"
     >
 > & {
     openBrowser: (url: string) => Promise<void>;

--- a/lib/msal-node/src/request/InteractiveRequest.ts
+++ b/lib/msal-node/src/request/InteractiveRequest.ts
@@ -20,7 +20,7 @@ import { ILoopbackClient } from "../network/ILoopbackClient.js";
 export type InteractiveRequest = Partial<
     Omit<
         CommonAuthorizationUrlRequest,
-        "scopes" | "redirectUri" | "requestedClaimsHash" | "storeInCache"
+        "scopes"  | "requestedClaimsHash" | "storeInCache"
     >
 > & {
     openBrowser: (url: string) => Promise<void>;

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -616,6 +616,19 @@ describe("PublicClientApplication", () => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
+
+        test("acquireTokenSilent throws error when redirectUri is provided", async () => {
+            const authApp = new PublicClientApplication(appConfig);
+            const request: SilentFlowRequest = {
+                scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
+                account: testAccount,
+                redirectUri: "http://localhost:3000/redirect",
+            };
+
+            await expect(authApp.acquireTokenSilent(request)).rejects.toThrow(
+                "RedirectUri is not supported in this scenario"
+            );
+        });
     });
 
     describe("acquireTokenInteractive tests", () => {
@@ -1023,6 +1036,19 @@ describe("PublicClientApplication", () => {
                 expect(mockCloseServer).toHaveBeenCalled();
                 done();
             });
+        });
+
+        test("acquireTokenInteractive throws error when redirectUri is provided", async () => {
+            const authApp = new PublicClientApplication(appConfig);
+            const request: InteractiveRequest = {
+                scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
+                redirectUri: "http://localhost:3000/redirect",
+                openBrowser: jest.fn(),
+            };
+
+            await expect(
+                authApp.acquireTokenInteractive(request)
+            ).rejects.toThrow("RedirectUri is not supported in this scenario");
         });
     });
 


### PR DESCRIPTION
Current PCA requests don't allow the customer to pass in their own redirecturi. This is an issue for signed MacOS apps because the customer is forced to use the unsigned redirect URI which will hit a redirecturi validation error in the Apple Broker
```
  errorMessage: 'Description: Error Domain=MSALErrorDomain Code=-50000 "(null)" UserInfo={MSALErrorDescriptionKey=MSAL redirectUri validation error: redirect uri has incorrect scheme - it must be in the form of msauth.<app_bundle_id>://auth\n' +
    'ADAL redirectUri validation error: Source application does not match redirect uri host. Invalid source app., MSALInternalErrorCodeKey=-42000, MSALBrokerVersionKey=5.2508.0}, Domain: MSALErrorDomain.Error was thrown in sourceArea: Broker (Error Code: -42000, Tag: 508638916)',

```
Solution:
Make providing a redirecturi optional. If the customer doesn't provide one, we fallback to the default for each platform in broker scenarios
For non-broker scenarios, if redirecturi is provided, we warn them it won't be used and use the default

Also added a function to convert error tags to their string version to make error lookup quicker.
