### PR TITLE
Export client capabilities helper

### DIFF
--- a/change/@azure-msal-browser-f8f33dfb-8db9-43df-b19f-e94a8b27593e.json
+++ b/change/@azure-msal-browser-f8f33dfb-8db9-43df-b19f-e94a8b27593e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export client capabilities helper",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -52,6 +52,7 @@ import { PerformanceEvent } from '@azure/msal-common/browser';
 import { PerformanceEvents } from '@azure/msal-common/browser';
 import { PromptValue } from '@azure/msal-common/browser';
 import { ProtocolMode } from '@azure/msal-common/browser';
+import { RequestParameterBuilder } from '@azure/msal-common/browser';
 import { ServerError } from '@azure/msal-common/browser';
 import { ServerResponseType } from '@azure/msal-common/browser';
 import { SignedHttpRequestParameters } from '@azure/msal-common/browser';
@@ -66,6 +67,11 @@ import { UrlString } from '@azure/msal-common/browser';
 export { AccountEntity }
 
 export { AccountInfo }
+
+// Warning: (ae-missing-release-tag) "addClientCapabilitiesToClaims" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const addClientCapabilitiesToClaims: typeof RequestParameterBuilder.addClientCapabilitiesToClaims;
 
 // Warning: (ae-missing-release-tag) "ApiId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "ApiId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -610,7 +616,8 @@ declare namespace BrowserUtils {
         preconnect,
         createGuid,
         invoke,
-        invokeAsync
+        invokeAsync,
+        addClientCapabilitiesToClaims
     }
 }
 export { BrowserUtils }

--- a/lib/msal-browser/src/utils/BrowserUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { UrlString, invoke, invokeAsync } from "@azure/msal-common/browser";
+import { UrlString, invoke, invokeAsync, RequestParameterBuilder } from "@azure/msal-common/browser";
 import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
@@ -211,3 +211,4 @@ export function createGuid(): string {
 
 export { invoke };
 export { invokeAsync };
+export const addClientCapabilitiesToClaims = RequestParameterBuilder.addClientCapabilitiesToClaims;

--- a/lib/msal-browser/src/utils/BrowserUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserUtils.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { UrlString, invoke, invokeAsync, RequestParameterBuilder } from "@azure/msal-common/browser";
+import {
+    UrlString,
+    invoke,
+    invokeAsync,
+    RequestParameterBuilder,
+} from "@azure/msal-common/browser";
 import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
@@ -211,4 +216,5 @@ export function createGuid(): string {
 
 export { invoke };
 export { invokeAsync };
-export const addClientCapabilitiesToClaims = RequestParameterBuilder.addClientCapabilitiesToClaims;
+export const addClientCapabilitiesToClaims =
+    RequestParameterBuilder.addClientCapabilitiesToClaims;


### PR DESCRIPTION
Exports client capabilities helper to be used by the pairwise broker when crafting embedded request