### PR TITLE
Pass forceRefresh param to NAA bridge

### DIFF
--- a/change/@azure-msal-browser-72dc9028-4332-49a7-970c-e7e2c1d6d385.json
+++ b/change/@azure-msal-browser-72dc9028-4332-49a7-970c-e7e2c1d6d385.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pass forceRefresh param to NAA bridge #8042",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -329,6 +329,7 @@ export class NestedAppAuthController implements IController {
         try {
             const naaRequest =
                 this.nestedAppAuthAdapter.toNaaTokenRequest(validRequest);
+            naaRequest.forceRefresh = validRequest.forceRefresh;
             const reqTimestamp = TimeUtils.nowSeconds();
             const response = await this.bridgeProxy.getTokenSilent(naaRequest);
 

--- a/lib/msal-browser/src/naa/TokenRequest.ts
+++ b/lib/msal-browser/src/naa/TokenRequest.ts
@@ -20,4 +20,5 @@ export type TokenRequest = {
     resourceRequestUri?: string;
     extendedExpiryToken?: boolean;
     extraParameters?: Map<string, string>;
+    forceRefresh?: boolean;
 };

--- a/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
+++ b/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
@@ -383,6 +383,42 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
             );
         });
 
+        it("acquireTokenSilent forwards forceRefresh flag to bridge token params", async () => {
+            mockBridge.addAuthResultResponse("GetToken", SILENT_TOKEN_RESPONSE);
+
+            const testRequest = {
+                scopes: [NAA_SCOPE],
+                account: testAccount,
+                forceRefresh: true,
+                correlationId: NAA_CORRELATION_ID,
+            };
+
+            await pca.acquireTokenSilent(testRequest);
+
+            const bridgeRequest = JSON.parse(
+                mockBridge.getBridgeRequests().at(-1)!
+            ) as any;
+            expect(bridgeRequest.tokenParams?.forceRefresh).toBe(true);
+        });
+
+        it("acquireTokenSilent does not set forceRefresh on bridge token params when not provided", async () => {
+            mockBridge.addAuthResultResponse("GetToken", SILENT_TOKEN_RESPONSE);
+
+            const testRequest = {
+                scopes: [NAA_SCOPE],
+                account: testAccount,
+                correlationId: NAA_CORRELATION_ID,
+                cacheLookupPolicy: CacheLookupPolicy.Skip,
+            };
+
+            await pca.acquireTokenSilent(testRequest);
+
+            const bridgeRequest = JSON.parse(
+                mockBridge.getBridgeRequests().at(-1)!
+            ) as any;
+            expect(bridgeRequest.tokenParams?.forceRefresh).toBeUndefined();
+        });
+
         afterEach(() => {
             jest.restoreAllMocks();
         });


### PR DESCRIPTION
- Child frame does not pass "forceRefresh" param to NAA host that breaks preventive token acquisition. This PR adds new param to NAA Token payload and propagetes it for silent API.