### PR TITLE
Add support for "pageException" error to fallback to web

### DIFF
--- a/change/@azure-msal-browser-dbf6e362-420c-44d0-b406-a1417a5f3741.json
+++ b/change/@azure-msal-browser-dbf6e362-420c-44d0-b406-a1417a5f3741.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "Add support for \"pageException\" error to fallback to web",
-  "packageName": "@azure/msal-browser",
-  "email": "sameera.gajjarapu@microsoft.com",
-  "dependentChangeType": "patch"
+    "type": "patch",
+    "comment": "Add support for \"pageException\" error to fallback to web (#8064)",
+    "packageName": "@azure/msal-browser",
+    "email": "sameera.gajjarapu@microsoft.com",
+    "dependentChangeType": "patch"
 }

--- a/change/@azure-msal-browser-dbf6e362-420c-44d0-b406-a1417a5f3741.json
+++ b/change/@azure-msal-browser-dbf6e362-420c-44d0-b406-a1417a5f3741.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for \"pageException\" error to fallback to web",
+  "packageName": "@azure/msal-browser",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/error/NativeAuthError.ts
+++ b/lib/msal-browser/src/error/NativeAuthError.ts
@@ -67,6 +67,7 @@ export function isFatalNativeAuthError(error: NativeAuthError): boolean {
 
     switch (error.errorCode) {
         case NativeAuthErrorCodes.contentError:
+        case NativeAuthErrorCodes.pageException:
             return true;
         default:
             return false;

--- a/lib/msal-browser/src/error/NativeAuthErrorCodes.ts
+++ b/lib/msal-browser/src/error/NativeAuthErrorCodes.ts
@@ -4,4 +4,5 @@
  */
 
 export const contentError = "ContentError";
+export const pageException = "PageException";
 export const userSwitch = "user_switch";

--- a/lib/msal-browser/test/error/NativeAuthError.spec.ts
+++ b/lib/msal-browser/test/error/NativeAuthError.spec.ts
@@ -63,6 +63,14 @@ describe("NativeAuthError Unit Tests", () => {
                 expect(isFatalNativeAuthError(error)).toBe(true);
             });
 
+            it("should return true for isFatal when extension throws an error", () => {
+                const error = new NativeAuthError(
+                    NativeAuthErrorCodes.pageException,
+                    "extension threw error"
+                );
+                expect(isFatalNativeAuthError(error)).toBe(true);
+            });
+
             it("should return false for isFatal", () => {
                 const error = new NativeAuthError(
                     "testError",


### PR DESCRIPTION
`PageException` is currently not being handled as a fatal error by MSAL JS, but the server falls back to web if it encounters the same. This PR addresses the gap.