### PR TITLE
Make correlation id mandatory for Logger calls

### DIFF
--- a/change/@azure-msal-angular-57e278bd-8f59-442f-8c90-cf7b59fedfbe.json
+++ b/change/@azure-msal-angular-57e278bd-8f59-442f-8c90-cf7b59fedfbe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make correlation id mandatory for Logger calls #8071",
+  "packageName": "@azure/msal-angular",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-0aefe1bc-dece-47e6-8195-d8a1c4ea4ab0.json
+++ b/change/@azure-msal-browser-0aefe1bc-dece-47e6-8195-d8a1c4ea4ab0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make correlation id mandatory for Logger calls #8071",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-d021ba37-0c23-4618-9aea-bc279fa69ed0.json
+++ b/change/@azure-msal-common-d021ba37-0c23-4618-9aea-bc279fa69ed0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make correlation id mandatory for Logger calls #8071",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-6509546b-7ffc-44f9-9a81-0cd5011c0ffe.json
+++ b/change/@azure-msal-node-6509546b-7ffc-44f9-9a81-0cd5011c0ffe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make correlation id mandatory for Logger calls #8071",
+  "packageName": "@azure/msal-node",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-extensions-67808d8e-bf98-4de5-9531-10c7035bac32.json
+++ b/change/@azure-msal-node-extensions-67808d8e-bf98-4de5-9531-10c7035bac32.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make correlation id mandatory for Logger calls #8071",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-react-52340411-9a33-4b41-91db-0b6c81628d41.json
+++ b/change/@azure-msal-react-52340411-9a33-4b41-91db-0b6c81628d41.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make correlation id mandatory for Logger calls #8071",
+  "packageName": "@azure/msal-react",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
+++ b/extensions/msal-node-extensions/src/broker/NativeBrokerPlugin.ts
@@ -59,56 +59,57 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
         const logCallback = (
             message: string,
             logLevel: MsalRuntimeLogLevel,
-            containsPii: boolean
+            containsPii: boolean,
+            correlationId: string = ""
         ) => {
             switch (logLevel) {
                 case MsalRuntimeLogLevel.Trace:
                     if (containsPii) {
-                        this.logger.tracePii(message);
+                        this.logger.tracePii(message, correlationId);
                     } else {
-                        this.logger.trace(message);
+                        this.logger.trace(message, correlationId);
                     }
                     break;
                 case MsalRuntimeLogLevel.Debug:
                     if (containsPii) {
-                        this.logger.tracePii(message);
+                        this.logger.tracePii(message, correlationId);
                     } else {
-                        this.logger.trace(message);
+                        this.logger.trace(message, correlationId);
                     }
                     break;
                 case MsalRuntimeLogLevel.Info:
                     if (containsPii) {
-                        this.logger.infoPii(message);
+                        this.logger.infoPii(message, correlationId);
                     } else {
-                        this.logger.info(message);
+                        this.logger.info(message, correlationId);
                     }
                     break;
                 case MsalRuntimeLogLevel.Warning:
                     if (containsPii) {
-                        this.logger.warningPii(message);
+                        this.logger.warningPii(message, correlationId);
                     } else {
-                        this.logger.warning(message);
+                        this.logger.warning(message, correlationId);
                     }
                     break;
                 case MsalRuntimeLogLevel.Error:
                     if (containsPii) {
-                        this.logger.errorPii(message);
+                        this.logger.errorPii(message, correlationId);
                     } else {
-                        this.logger.error(message);
+                        this.logger.error(message, correlationId);
                     }
                     break;
                 case MsalRuntimeLogLevel.Fatal:
                     if (containsPii) {
-                        this.logger.errorPii(message);
+                        this.logger.errorPii(message, correlationId);
                     } else {
-                        this.logger.error(message);
+                        this.logger.error(message, correlationId);
                     }
                     break;
                 default:
                     if (containsPii) {
-                        this.logger.infoPii(message);
+                        this.logger.infoPii(message, correlationId);
                     } else {
-                        this.logger.info(message);
+                        this.logger.info(message, correlationId);
                     }
                     break;
             }
@@ -611,7 +612,10 @@ export class NativeBrokerPlugin implements INativeBrokerPlugin {
         account: Account,
         idTokenClaims?: IdTokenClaims
     ): AccountInfo {
-        this.logger.trace("NativeBrokerPlugin - generateAccountInfo called");
+        this.logger.trace(
+            "NativeBrokerPlugin - generateAccountInfo called",
+            ""
+        );
 
         const accountInfo: AccountInfo = {
             homeAccountId: account.homeAccountId,

--- a/extensions/msal-node-extensions/src/lock/CrossPlatformLock.ts
+++ b/extensions/msal-node-extensions/src/lock/CrossPlatformLock.ts
@@ -41,10 +41,10 @@ export class CrossPlatformLock {
     public async lock(): Promise<void> {
         for (let tryCount = 0; tryCount < this.retryNumber; tryCount++) {
             try {
-                this.logger.info(`Pid ${pid} trying to acquire lock`);
+                this.logger.info(`Pid ${pid} trying to acquire lock`, "");
                 this.lockFileHandle = await fs.open(this.lockFilePath, "wx+");
 
-                this.logger.info(`Pid ${pid} acquired lock`);
+                this.logger.info(`Pid ${pid} acquired lock`, "");
                 await this.lockFileHandle.write(pid.toString());
                 return;
             } catch (err) {
@@ -53,11 +53,12 @@ export class CrossPlatformLock {
                         err.code === Constants.EEXIST_ERROR ||
                         err.code === Constants.EPERM_ERROR
                     ) {
-                        this.logger.info(err.message);
+                        this.logger.info(err.message, "");
                         await this.sleep(this.retryDelay);
                     } else {
                         this.logger.error(
-                            `${pid} was not able to acquire lock. Ran into error: ${err.message}`
+                            `${pid} was not able to acquire lock. Ran into error: ${err.message}`,
+                            ""
                         );
                         throw PersistenceError.createCrossPlatformLockError(
                             err.message
@@ -69,7 +70,8 @@ export class CrossPlatformLock {
             }
         }
         this.logger.error(
-            `${pid} was not able to acquire lock. Exceeded amount of retries set in the options`
+            `${pid} was not able to acquire lock. Exceeded amount of retries set in the options`,
+            ""
         );
         throw PersistenceError.createCrossPlatformLockError(
             "Not able to acquire lock. Exceeded amount of retries set in options"
@@ -85,21 +87,24 @@ export class CrossPlatformLock {
                 // if we have a file handle to the .lockfile, delete lock file
                 await fs.unlink(this.lockFilePath);
                 await this.lockFileHandle.close();
-                this.logger.info("lockfile deleted");
+                this.logger.info("lockfile deleted", "");
             } else {
                 this.logger.warning(
-                    "lockfile handle does not exist, so lockfile could not be deleted"
+                    "lockfile handle does not exist, so lockfile could not be deleted",
+                    ""
                 );
             }
         } catch (err) {
             if (isNodeError(err)) {
                 if (err.code === Constants.ENOENT_ERROR) {
                     this.logger.info(
-                        "Tried to unlock but lockfile does not exist"
+                        "Tried to unlock but lockfile does not exist",
+                        ""
                     );
                 } else {
                     this.logger.error(
-                        `${pid} was not able to release lock. Ran into error: ${err.message}`
+                        `${pid} was not able to release lock. Ran into error: ${err.message}`,
+                        ""
                     );
                     throw PersistenceError.createCrossPlatformLockError(
                         err.message

--- a/extensions/msal-node-extensions/src/persistence/FilePersistence.ts
+++ b/extensions/msal-node-extensions/src/persistence/FilePersistence.ts
@@ -112,7 +112,8 @@ export class FilePersistence extends BasePersistence implements IPersistence {
                 if (err.code === Constants.ENOENT_ERROR) {
                     // file does not exist, so it was not deleted
                     this.logger.warning(
-                        "Cache file does not exist, so it could not be deleted"
+                        "Cache file does not exist, so it could not be deleted",
+                        ""
                     );
                     return false;
                 }
@@ -161,7 +162,7 @@ export class FilePersistence extends BasePersistence implements IPersistence {
             if (isNodeError(err)) {
                 if (err.code === Constants.ENOENT_ERROR) {
                     // file does not exist, so it's never been modified
-                    this.logger.verbose("Cache file does not exist");
+                    this.logger.verbose("Cache file does not exist", "");
                     return 0;
                 }
                 throw PersistenceError.createFileSystemError(
@@ -179,7 +180,7 @@ export class FilePersistence extends BasePersistence implements IPersistence {
         // File is created only if it does not exist
         const fileHandle = await fs.open(this.filePath, "a");
         await fileHandle.close();
-        this.logger.info(`File created at ${this.filePath}`);
+        this.logger.info(`File created at ${this.filePath}`, "");
     }
 
     private async createFileDirectory(): Promise<void> {
@@ -189,7 +190,8 @@ export class FilePersistence extends BasePersistence implements IPersistence {
             if (isNodeError(err)) {
                 if (err.code === Constants.EEXIST_ERROR) {
                     this.logger.info(
-                        `Directory ${dirname(this.filePath)}  already exists`
+                        `Directory ${dirname(this.filePath)}  already exists`,
+                        ""
                     );
                 } else {
                     throw PersistenceError.createFileSystemError(

--- a/extensions/msal-node-extensions/src/persistence/FilePersistenceWithDataProtection.ts
+++ b/extensions/msal-node-extensions/src/persistence/FilePersistenceWithDataProtection.ts
@@ -88,7 +88,8 @@ export class FilePersistenceWithDataProtection
                 this.filePersistence
                     .getLogger()
                     .info(
-                        "Encrypted contents loaded from file were null or empty"
+                        "Encrypted contents loaded from file were null or empty",
+                        ""
                     );
                 return null;
             }

--- a/extensions/msal-node-extensions/src/persistence/PersistenceCachePlugin.ts
+++ b/extensions/msal-node-extensions/src/persistence/PersistenceCachePlugin.ts
@@ -69,20 +69,21 @@ export class PersistenceCachePlugin implements ICachePlugin {
     public async beforeCacheAccess(
         cacheContext: TokenCacheContext
     ): Promise<void> {
-        this.logger.info("Executing before cache access");
+        this.logger.info("Executing before cache access", "");
         const reloadNecessary = await this.persistence.reloadNecessary(
             this.lastSync
         );
         if (!reloadNecessary && this.currentCache !== null) {
             if (cacheContext.cacheHasChanged) {
-                this.logger.verbose("Cache context has changed");
+                this.logger.verbose("Cache context has changed", "");
                 await this.crossPlatformLock.lock();
             }
             return;
         }
         try {
             this.logger.info(
-                `Reload necessary. Last sync time: ${this.lastSync}`
+                `Reload necessary. Last sync time: ${this.lastSync}`,
+                ""
             );
             await this.crossPlatformLock.lock();
 
@@ -91,17 +92,18 @@ export class PersistenceCachePlugin implements ICachePlugin {
             if (this.currentCache) {
                 cacheContext.tokenCache.deserialize(this.currentCache);
             } else {
-                this.logger.info("Cache empty.");
+                this.logger.info("Cache empty.", "");
             }
 
-            this.logger.info(`Last sync time updated to: ${this.lastSync}`);
+            this.logger.info(`Last sync time updated to: ${this.lastSync}`, "");
         } finally {
             if (!cacheContext.cacheHasChanged) {
                 await this.crossPlatformLock.unlock();
-                this.logger.info(`Pid ${pid} released lock`);
+                this.logger.info(`Pid ${pid} released lock`, "");
             } else {
                 this.logger.info(
-                    `Pid ${pid} beforeCacheAccess did not release lock`
+                    `Pid ${pid} beforeCacheAccess did not release lock`,
+                    ""
                 );
             }
         }
@@ -113,22 +115,24 @@ export class PersistenceCachePlugin implements ICachePlugin {
     public async afterCacheAccess(
         cacheContext: TokenCacheContext
     ): Promise<void> {
-        this.logger.info("Executing after cache access");
+        this.logger.info("Executing after cache access", "");
         try {
             if (cacheContext.cacheHasChanged) {
                 this.logger.info(
-                    "Msal in-memory cache has changed. Writing changes to persistence"
+                    "Msal in-memory cache has changed. Writing changes to persistence",
+                    ""
                 );
                 this.currentCache = cacheContext.tokenCache.serialize();
                 await this.persistence.save(this.currentCache);
             } else {
                 this.logger.info(
-                    "Msal in-memory cache has not changed. Did not write to persistence"
+                    "Msal in-memory cache has not changed. Did not write to persistence",
+                    ""
                 );
             }
         } finally {
             await this.crossPlatformLock.unlock();
-            this.logger.info(`Pid ${pid} afterCacheAccess released lock`);
+            this.logger.info(`Pid ${pid} afterCacheAccess released lock`, "");
         }
     }
 }

--- a/lib/msal-angular/src/msal.broadcast.service.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.ts
@@ -37,7 +37,8 @@ export class MsalBroadcastService {
         .getLogger()
         .clone(name, version)
         .verbose(
-          `BroadcastService - eventsToReplay set on BroadcastConfig, replaying the last ${this.msalBroadcastConfig.eventsToReplay} events`
+          `BroadcastService - eventsToReplay set on BroadcastConfig, replaying the last ${this.msalBroadcastConfig.eventsToReplay} events`,
+          ""
         );
       this._msalSubject = new ReplaySubject<EventMessage>(
         this.msalBroadcastConfig.eventsToReplay
@@ -66,7 +67,8 @@ export class MsalBroadcastService {
           .getLogger()
           .clone(name, version)
           .verbose(
-            `BroadcastService - ${message.eventType} results in setting inProgress from ${this._inProgress.value} to ${status}`
+            `BroadcastService - ${message.eventType} results in setting inProgress from ${this._inProgress.value} to ${status}`,
+            ""
           );
         this._inProgress.next(status);
       }

--- a/lib/msal-angular/src/msal.guard.ts
+++ b/lib/msal-angular/src/msal.guard.ts
@@ -55,7 +55,7 @@ export class MsalGuard {
    * @returns Full destination url
    */
   getDestinationUrl(path: string): string {
-    this.authService.getLogger().verbose("Guard - getting destination url");
+    this.authService.getLogger().verbose("Guard - getting destination url", "");
     // Absolute base url for the application (default to origin if base element not present)
     const baseElements = document.getElementsByTagName("base");
     const baseUrl = this.location.normalize(
@@ -69,7 +69,7 @@ export class MsalGuard {
     if (pathUrl.startsWith("#")) {
       this.authService
         .getLogger()
-        .verbose("Guard - destination by hash routing");
+        .verbose("Guard - destination by hash routing", "");
       return `${baseUrl}/${pathUrl}`;
     }
 
@@ -90,13 +90,16 @@ export class MsalGuard {
         ? this.msalGuardConfig.authRequest(this.authService, state)
         : { ...this.msalGuardConfig.authRequest };
     if (this.msalGuardConfig.interactionType === InteractionType.Popup) {
-      this.authService.getLogger().verbose("Guard - logging in by popup");
+      this.authService
+        .getLogger()
+        .verbose("Guard - logging in by popup", authRequest.correlationId);
       return this.authService.loginPopup(authRequest as PopupRequest).pipe(
         map((response: AuthenticationResult) => {
           this.authService
             .getLogger()
             .verbose(
-              "Guard - login by popup successful, can activate, setting active account"
+              "Guard - login by popup successful, can activate, setting active account",
+              authRequest.correlationId
             );
           this.authService.instance.setActiveAccount(response.account);
           return true;
@@ -104,7 +107,9 @@ export class MsalGuard {
       );
     }
 
-    this.authService.getLogger().verbose("Guard - logging in by redirect");
+    this.authService
+      .getLogger()
+      .verbose("Guard - logging in by redirect", authRequest.correlationId);
     const redirectStartPage = this.getDestinationUrl(state.url);
     return this.authService
       .loginRedirect({
@@ -130,7 +135,7 @@ export class MsalGuard {
         "Invalid interaction type provided to MSAL Guard. InteractionType.Popup or InteractionType.Redirect must be provided in the MsalGuardConfiguration"
       );
     }
-    this.authService.getLogger().verbose("MSAL Guard activated");
+    this.authService.getLogger().verbose("MSAL Guard activated", "");
 
     /*
      * If a page with MSAL Guard is set as the redirect for acquireTokenSilent,
@@ -140,7 +145,8 @@ export class MsalGuard {
       this.authService
         .getLogger()
         .info(
-          "Guard - window is undefined, MSAL does not support server-side token acquisition"
+          "Guard - window is undefined, MSAL does not support server-side token acquisition",
+          ""
         );
       return of(true);
     } else {
@@ -154,7 +160,8 @@ export class MsalGuard {
           this.authService
             .getLogger()
             .warning(
-              "Guard - redirectUri set to page with MSAL Guard. It is recommended to not set redirectUri to a page that requires authentication."
+              "Guard - redirectUri set to page with MSAL Guard. It is recommended to not set redirectUri to a page that requires authentication.",
+              ""
             );
           return of(false);
         }
@@ -183,19 +190,26 @@ export class MsalGuard {
             this.authService
               .getLogger()
               .verbose(
-                "Guard - no accounts retrieved, log in required to activate"
+                "Guard - no accounts retrieved, log in required to activate",
+                ""
               );
             return this.loginInteractively(state);
           }
           this.authService
             .getLogger()
-            .verbose("Guard - no accounts retrieved, no state, cannot load");
+            .verbose(
+              "Guard - no accounts retrieved, no state, cannot load",
+              ""
+            );
           return of(false);
         }
 
         this.authService
           .getLogger()
-          .verbose("Guard - at least 1 account exists, can activate or load");
+          .verbose(
+            "Guard - at least 1 account exists, can activate or load",
+            ""
+          );
 
         // Prevent navigating the app to /#code= or /code=
         if (state) {
@@ -223,7 +237,8 @@ export class MsalGuard {
             this.authService
               .getLogger()
               .info(
-                "Guard - Hash contains known code response, stopping navigation."
+                "Guard - Hash contains known code response, stopping navigation.",
+                ""
               );
 
             // Path routing (navigate to current path without hash)
@@ -241,17 +256,17 @@ export class MsalGuard {
       catchError((error: Error) => {
         this.authService
           .getLogger()
-          .error("Guard - error while logging in, unable to activate");
+          .error("Guard - error while logging in, unable to activate", "");
         this.authService
           .getLogger()
-          .errorPii(`Guard - error: ${error.message}`);
+          .errorPii(`Guard - error: ${error.message}`, "");
         /**
          * If a loginFailedRoute is set, checks to see if state is passed before returning route
          */
         if (this.loginFailedRoute && state) {
           this.authService
             .getLogger()
-            .verbose("Guard - loginFailedRoute set, redirecting");
+            .verbose("Guard - loginFailedRoute set, redirecting", "");
           return of(this.loginFailedRoute);
         }
         return of(false);
@@ -272,7 +287,7 @@ export class MsalGuard {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> {
-    this.authService.getLogger().verbose("Guard - canActivate");
+    this.authService.getLogger().verbose("Guard - canActivate", "");
     return this.activateHelper(state);
   }
 
@@ -280,12 +295,12 @@ export class MsalGuard {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> {
-    this.authService.getLogger().verbose("Guard - canActivateChild");
+    this.authService.getLogger().verbose("Guard - canActivateChild", "");
     return this.activateHelper(state);
   }
 
   canMatch(): Observable<boolean | UrlTree> {
-    this.authService.getLogger().verbose("Guard - canLoad");
+    this.authService.getLogger().verbose("Guard - canLoad", "");
     return this.activateHelper();
   }
 }

--- a/lib/msal-angular/src/msal.interceptor.ts
+++ b/lib/msal-angular/src/msal.interceptor.ts
@@ -61,14 +61,14 @@ export class MsalInterceptor implements HttpInterceptor {
       );
     }
 
-    this.authService.getLogger().verbose("MSAL Interceptor activated");
+    this.authService.getLogger().verbose("MSAL Interceptor activated", "");
     const scopes = this.getScopesForEndpoint(req.url, req.method);
 
     // If no scopes for endpoint, does not acquire token
     if (!scopes || scopes.length === 0) {
       this.authService
         .getLogger()
-        .verbose("Interceptor - no scopes for endpoint");
+        .verbose("Interceptor - no scopes for endpoint", "");
       return next.handle(req);
     }
 
@@ -77,12 +77,15 @@ export class MsalInterceptor implements HttpInterceptor {
     if (!!this.authService.instance.getActiveAccount()) {
       this.authService
         .getLogger()
-        .verbose("Interceptor - active account selected");
+        .verbose("Interceptor - active account selected", "");
       account = this.authService.instance.getActiveAccount();
     } else {
       this.authService
         .getLogger()
-        .verbose("Interceptor - no active account, fallback to first account");
+        .verbose(
+          "Interceptor - no active account, fallback to first account",
+          ""
+        );
       account = this.authService.instance.getAllAccounts()[0];
     }
 
@@ -95,16 +98,16 @@ export class MsalInterceptor implements HttpInterceptor {
 
     this.authService
       .getLogger()
-      .info(`Interceptor - ${scopes.length} scopes found for endpoint`);
+      .info(`Interceptor - ${scopes.length} scopes found for endpoint`, "");
     this.authService
       .getLogger()
-      .infoPii(`Interceptor - [${scopes}] scopes found for ${req.url}`);
+      .infoPii(`Interceptor - [${scopes}] scopes found for ${req.url}`, "");
 
     return this.acquireToken(authRequest, scopes, account).pipe(
       switchMap((result: AuthenticationResult) => {
         this.authService
           .getLogger()
-          .verbose("Interceptor - setting authorization headers");
+          .verbose("Interceptor - setting authorization headers", "");
         const headers = req.headers.set(
           "Authorization",
           `Bearer ${result.accessToken}`
@@ -136,7 +139,8 @@ export class MsalInterceptor implements HttpInterceptor {
           this.authService
             .getLogger()
             .error(
-              "Interceptor - acquireTokenSilent rejected with error. Invoking interaction to resolve."
+              "Interceptor - acquireTokenSilent rejected with error. Invoking interaction to resolve.",
+              authRequest.correlationId
             );
           return this.msalBroadcastService.inProgress$.pipe(
             take(1),
@@ -161,7 +165,8 @@ export class MsalInterceptor implements HttpInterceptor {
             this.authService
               .getLogger()
               .error(
-                "Interceptor - acquireTokenSilent resolved with null access token. Known issue with B2C tenants, invoking interaction to resolve."
+                "Interceptor - acquireTokenSilent resolved with null access token. Known issue with B2C tenants, invoking interaction to resolve.",
+                authRequest.correlationId
               );
             return this.msalBroadcastService.inProgress$.pipe(
               filter(
@@ -192,14 +197,16 @@ export class MsalInterceptor implements HttpInterceptor {
       this.authService
         .getLogger()
         .verbose(
-          "Interceptor - error acquiring token silently, acquiring by popup"
+          "Interceptor - error acquiring token silently, acquiring by popup",
+          authRequest.correlationId
         );
       return this.authService.acquireTokenPopup({ ...authRequest, scopes });
     }
     this.authService
       .getLogger()
       .verbose(
-        "Interceptor - error acquiring token silently, acquiring by redirect"
+        "Interceptor - error acquiring token silently, acquiring by redirect",
+        authRequest.correlationId
       );
     const redirectStartPage = window.location.href;
     this.authService.acquireTokenRedirect({
@@ -223,7 +230,7 @@ export class MsalInterceptor implements HttpInterceptor {
   ): Array<string> | null {
     this.authService
       .getLogger()
-      .verbose("Interceptor - getting scopes for endpoint");
+      .verbose("Interceptor - getting scopes for endpoint", "");
 
     // Ensures endpoints and protected resources compared are normalized
     const normalizedEndpoint = this.location.normalize(endpoint);
@@ -376,7 +383,8 @@ export class MsalInterceptor implements HttpInterceptor {
         this.authService
           .getLogger()
           .warning(
-            "Interceptor - More than 1 matching scopes for endpoint found."
+            "Interceptor - More than 1 matching scopes for endpoint found.",
+            ""
           );
       }
       // Returns scopes for first matching endpoint

--- a/lib/msal-angular/src/msal.navigation.client.ts
+++ b/lib/msal-angular/src/msal.navigation.client.ts
@@ -32,14 +32,14 @@ export class MsalCustomNavigationClient extends NavigationClient {
     url: string,
     options: NavigationOptions
   ): Promise<boolean> {
-    this.authService.getLogger().trace("MsalCustomNavigationClient called");
+    this.authService.getLogger().trace("MsalCustomNavigationClient called", "");
 
     this.authService
       .getLogger()
-      .verbose("MsalCustomNavigationClient - navigating");
+      .verbose("MsalCustomNavigationClient - navigating", "");
     this.authService
       .getLogger()
-      .verbosePii(`MsalCustomNavigationClient - navigating to url: ${url}`);
+      .verbosePii(`MsalCustomNavigationClient - navigating to url: ${url}`, "");
 
     // Prevent hash clearing from causing an issue with Client-side navigation after redirect is handled
     if (options.noHistory) {

--- a/lib/msal-angular/src/msal.redirect.component.ts
+++ b/lib/msal-angular/src/msal.redirect.component.ts
@@ -21,7 +21,7 @@ export class MsalRedirectComponent implements OnInit {
   constructor(private authService: MsalService) {}
 
   ngOnInit(): void {
-    this.authService.getLogger().verbose("MsalRedirectComponent activated");
+    this.authService.getLogger().verbose("MsalRedirectComponent activated", "");
     this.authService.handleRedirectObservable().subscribe();
   }
 }

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1459,7 +1459,7 @@ export class SessionStorage implements IWindowStorage<string> {
 //
 // @public (undocumented)
 export class SignedHttpRequest {
-    constructor(shrParameters: SignedHttpRequestParameters, performanceClient: IPerformanceClient, shrOptions?: SignedHttpRequestOptions);
+    constructor(shrParameters: SignedHttpRequestParameters, shrOptions?: SignedHttpRequestOptions);
     generatePublicKeyThumbprint(): Promise<string>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     removeKeys(publicKeyThumbprint: string): Promise<void>;

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -943,10 +943,11 @@ function isInPopup(): boolean;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "isPlatformBrokerAvailable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function isPlatformBrokerAvailable(loggerOptions: LoggerOptions | undefined, perfClient: IPerformanceClient, correlationId: string): Promise<boolean>;
+export function isPlatformBrokerAvailable(loggerOptions?: LoggerOptions, perfClient?: IPerformanceClient, correlationId?: string): Promise<boolean>;
 
 // Warning: (ae-missing-release-tag) "IWindowStorage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1463,7 +1463,8 @@ export class SignedHttpRequest {
     constructor(shrParameters: SignedHttpRequestParameters, shrOptions?: SignedHttpRequestOptions);
     generatePublicKeyThumbprint(): Promise<string>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    removeKeys(publicKeyThumbprint: string): Promise<void>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    removeKeys(publicKeyThumbprint: string, correlationId: string): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -946,7 +946,7 @@ function isInPopup(): boolean;
 // Warning: (ae-missing-release-tag) "isPlatformBrokerAvailable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function isPlatformBrokerAvailable(loggerOptions?: LoggerOptions, perfClient?: IPerformanceClient, correlationId?: string): Promise<boolean>;
+export function isPlatformBrokerAvailable(loggerOptions: LoggerOptions | undefined, perfClient: IPerformanceClient, correlationId: string): Promise<boolean>;
 
 // Warning: (ae-missing-release-tag) "IWindowStorage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1459,7 +1459,7 @@ export class SessionStorage implements IWindowStorage<string> {
 //
 // @public (undocumented)
 export class SignedHttpRequest {
-    constructor(shrParameters: SignedHttpRequestParameters, shrOptions?: SignedHttpRequestOptions);
+    constructor(shrParameters: SignedHttpRequestParameters, performanceClient: IPerformanceClient, shrOptions?: SignedHttpRequestOptions);
     generatePublicKeyThumbprint(): Promise<string>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     removeKeys(publicKeyThumbprint: string): Promise<void>;
@@ -1599,12 +1599,12 @@ export type WrapperSKU = (typeof WrapperSKU)[keyof typeof WrapperSKU];
 // src/app/PublicClientNext.ts:87:79 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/app/PublicClientNext.ts:90:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/app/PublicClientNext.ts:91:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/LocalStorage.ts:356:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/LocalStorage.ts:414:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/LocalStorage.ts:445:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/LocalStorage.ts:358:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/LocalStorage.ts:416:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/LocalStorage.ts:447:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/Configuration.ts:211:5 - (ae-forgotten-export) The symbol "InternalAuthOptions" needs to be exported by the entry point index.d.ts
-// src/event/EventHandler.ts:113:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/event/EventHandler.ts:139:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/event/EventHandler.ts:117:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/event/EventHandler.ts:144:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/navigation/NavigationClient.ts:40:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -37,6 +37,7 @@ import { NestedAppAuthController } from "../controllers/NestedAppAuthController.
 import { NestedAppOperatingContext } from "../operatingcontext/NestedAppOperatingContext.js";
 import { InitializeApplicationRequest } from "../request/InitializeApplicationRequest.js";
 import { EventType } from "../event/EventType.js";
+import { createNewGuid } from "../crypto/BrowserCrypto.js";
 
 /**
  * The PublicClientApplication class is the object exposed by the library to perform authentication and authorization functions in Single Page Applications
@@ -378,8 +379,9 @@ export class PublicClientApplication implements IPublicClientApplication {
 export async function createNestablePublicClientApplication(
     configuration: Configuration
 ): Promise<IPublicClientApplication> {
+    const correlationId = createNewGuid();
     const nestedAppAuth = new NestedAppOperatingContext(configuration);
-    await nestedAppAuth.initialize();
+    await nestedAppAuth.initialize(correlationId);
 
     if (nestedAppAuth.isAvailable()) {
         const controller = new NestedAppAuthController(nestedAppAuth);
@@ -387,7 +389,7 @@ export async function createNestablePublicClientApplication(
             configuration,
             controller
         );
-        await nestablePCA.initialize();
+        await nestablePCA.initialize({ correlationId });
         return nestablePCA;
     }
 

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
@@ -45,7 +45,10 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         performanceClient: IPerformanceClient,
         correlationId: string
     ): Promise<PlatformAuthDOMHandler | undefined> {
-        logger.trace("PlatformAuthDOMHandler: createProvider called");
+        logger.trace(
+            "PlatformAuthDOMHandler: createProvider called",
+            correlationId
+        );
 
         // @ts-ignore
         if (window.navigator?.platformAuthentication) {
@@ -59,7 +62,10 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
                     PlatformAuthConstants.PLATFORM_DOM_APIS
                 )
             ) {
-                logger.trace("Platform auth api available in DOM");
+                logger.trace(
+                    "Platform auth api available in DOM",
+                    correlationId
+                );
                 return new PlatformAuthDOMHandler(
                     logger,
                     performanceClient,
@@ -95,7 +101,8 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         request: PlatformAuthRequest
     ): Promise<PlatformAuthResponse> {
         this.logger.trace(
-            `'${this.platformAuthType}' - Sending request to browser DOM API`
+            `'${this.platformAuthType}' - Sending request to browser DOM API`,
+            request.correlationId
         );
 
         try {
@@ -106,10 +113,14 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
                 await window.navigator.platformAuthentication.executeGetToken(
                     platformDOMRequest
                 );
-            return this.validatePlatformBrokerResponse(response);
+            return this.validatePlatformBrokerResponse(
+                response,
+                request.correlationId
+            );
         } catch (e) {
             this.logger.error(
-                `'${this.platformAuthType}' - executeGetToken DOM API error`
+                `'${this.platformAuthType}' - executeGetToken DOM API error`,
+                request.correlationId
             );
             throw e;
         }
@@ -119,7 +130,8 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
         request: PlatformAuthRequest
     ): PlatformDOMTokenRequest {
         this.logger.trace(
-            `'${this.platformAuthType}' - initializeNativeDOMRequest called`
+            `'${this.platformAuthType}' - initializeNativeDOMRequest called`,
+            request.correlationId
         );
 
         const {
@@ -158,7 +170,8 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
     }
 
     private validatePlatformBrokerResponse(
-        response: object
+        response: object,
+        correlationId: string
     ): PlatformAuthResponse {
         if (response.hasOwnProperty("isSuccess")) {
             if (
@@ -170,10 +183,12 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
                 response.hasOwnProperty("expiresIn")
             ) {
                 this.logger.trace(
-                    `'${this.platformAuthType}' - platform broker returned successful and valid response`
+                    `'${this.platformAuthType}' - platform broker returned successful and valid response`,
+                    correlationId
                 );
                 return this.convertToPlatformBrokerResponse(
-                    response as PlatformDOMTokenResponse
+                    response as PlatformDOMTokenResponse,
+                    correlationId
                 );
             } else if (response.hasOwnProperty("error")) {
                 const errorResponse = response as PlatformDOMTokenResponse;
@@ -183,7 +198,8 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
                     errorResponse.error.code
                 ) {
                     this.logger.trace(
-                        `'${this.platformAuthType}' - platform broker returned error response`
+                        `'${this.platformAuthType}' - platform broker returned error response`,
+                        correlationId
                     );
                     throw createNativeAuthError(
                         errorResponse.error.code,
@@ -205,10 +221,12 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
     }
 
     private convertToPlatformBrokerResponse(
-        response: PlatformDOMTokenResponse
+        response: PlatformDOMTokenResponse,
+        correlationId: string
     ): PlatformAuthResponse {
         this.logger.trace(
-            `'${this.platformAuthType}' - convertToNativeResponse called`
+            `'${this.platformAuthType}' - convertToNativeResponse called`,
+            correlationId
         );
         const nativeResponse: PlatformAuthResponse = {
             access_token: response.accessToken,

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthExtensionHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthExtensionHandler.ts
@@ -29,6 +29,7 @@ import {
 import { createNewGuid } from "../../crypto/BrowserCrypto.js";
 import { PlatformAuthResponse } from "./PlatformAuthResponse.js";
 import { IPlatformAuthHandler } from "./IPlatformAuthHandler.js";
+import { createGuid } from "../../utils/BrowserUtils.js";
 
 type ResponseResolvers<T> = {
     resolve: (value: T | PromiseLike<T>) => void;
@@ -79,7 +80,10 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
     async sendMessage(
         request: PlatformAuthRequest
     ): Promise<PlatformAuthResponse> {
-        this.logger.trace(`'${this.platformAuthType}' - sendMessage called.`);
+        this.logger.trace(
+            `'${this.platformAuthType}' - sendMessage called.`,
+            request.correlationId
+        );
 
         // fall back to native calls
         const messageBody: NativeExtensionRequestBody = {
@@ -95,12 +99,16 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
         };
 
         this.logger.trace(
-            `'${this.platformAuthType}' - Sending request to browser extension`
+            `'${this.platformAuthType}' - Sending request to browser extension`,
+            request.correlationId
         );
         this.logger.tracePii(
             `'${
                 this.platformAuthType
-            }' - Sending request to browser extension: '${JSON.stringify(req)}'`
+            }' - Sending request to browser extension: '${JSON.stringify(
+                req
+            )}'`,
+            request.correlationId
         );
         this.messageChannel.port1.postMessage(req);
 
@@ -124,9 +132,13 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
     static async createProvider(
         logger: Logger,
         handshakeTimeoutMs: number,
-        performanceClient: IPerformanceClient
+        performanceClient: IPerformanceClient,
+        correlationId: string
     ): Promise<PlatformAuthExtensionHandler> {
-        logger.trace("PlatformAuthExtensionHandler - createProvider called.");
+        logger.trace(
+            "PlatformAuthExtensionHandler - createProvider called.",
+            correlationId
+        );
 
         try {
             const preferredProvider = new PlatformAuthExtensionHandler(
@@ -135,7 +147,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
                 performanceClient,
                 PlatformAuthConstants.PREFERRED_EXTENSION_ID
             );
-            await preferredProvider.sendHandshakeRequest();
+            await preferredProvider.sendHandshakeRequest(correlationId);
             return preferredProvider;
         } catch (e) {
             // If preferred extension fails for whatever reason, fallback to using any installed extension
@@ -144,7 +156,7 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
                 handshakeTimeoutMs,
                 performanceClient
             );
-            await backupProvider.sendHandshakeRequest();
+            await backupProvider.sendHandshakeRequest(correlationId);
             return backupProvider;
         }
     }
@@ -152,9 +164,10 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
     /**
      * Send handshake request helper.
      */
-    private async sendHandshakeRequest(): Promise<void> {
+    private async sendHandshakeRequest(correlationId: string): Promise<void> {
         this.logger.trace(
-            `'${this.platformAuthType}' - sendHandshakeRequest called.`
+            `'${this.platformAuthType}' - sendHandshakeRequest called.`,
+            correlationId
         );
         // Register this event listener before sending handshake
         window.addEventListener("message", this.windowListener, false); // false is important, because content script message processing should work first
@@ -211,8 +224,10 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      * @param event
      */
     private onWindowMessage(event: MessageEvent): void {
+        const correlationId = createGuid();
         this.logger.trace(
-            `'${this.platformAuthType}' - onWindowMessage called`
+            `'${this.platformAuthType}' - onWindowMessage called`,
+            correlationId
         );
         // We only accept messages from ourselves
         if (event.source !== window) {
@@ -242,7 +257,8 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
              */
             if (!handshakeResolver) {
                 this.logger.trace(
-                    `'${this.platformAuthType}'.onWindowMessage - resolver can't be found for request '${request.responseId}'`
+                    `'${this.platformAuthType}'.onWindowMessage - resolver can't be found for request '${request.responseId}'`,
+                    correlationId
                 );
                 return;
             }
@@ -251,7 +267,8 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
             this.logger.verbose(
                 request.extensionId
                     ? `Extension with id: ${request.extensionId} not installed`
-                    : "No extension installed"
+                    : "No extension installed",
+                correlationId
             );
             clearTimeout(this.timeoutId);
             this.messageChannel.port1.close();
@@ -274,8 +291,10 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
      * @param event
      */
     private onChannelMessage(event: MessageEvent): void {
+        const correlationId = createGuid();
         this.logger.trace(
-            `'${this.platformAuthType}' - onChannelMessage called.`
+            `'${this.platformAuthType}' - onChannelMessage called.`,
+            correlationId
         );
         const request = event.data;
 
@@ -293,14 +312,16 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
                 }
                 const response = request.body.response;
                 this.logger.trace(
-                    `'${this.platformAuthType}' - Received response from browser extension`
+                    `'${this.platformAuthType}' - Received response from browser extension`,
+                    correlationId
                 );
                 this.logger.tracePii(
                     `'${
                         this.platformAuthType
                     }' - Received response from browser extension: '${JSON.stringify(
                         response
-                    )}'`
+                    )}'`,
+                    correlationId
                 );
                 if (response.status !== "Success") {
                     resolver.reject(
@@ -335,7 +356,8 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
             } else if (method === NativeExtensionMethod.HandshakeResponse) {
                 if (!handshakeResolver) {
                     this.logger.trace(
-                        `'${this.platformAuthType}'.onChannelMessage - resolver can't be found for request '${request.responseId}'`
+                        `'${this.platformAuthType}'.onChannelMessage - resolver can't be found for request '${request.responseId}'`,
+                        correlationId
                     );
                     return;
                 }
@@ -348,7 +370,8 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
                 this.extensionId = request.extensionId;
                 this.extensionVersion = request.body.version;
                 this.logger.verbose(
-                    `'${this.platformAuthType}' - Received HandshakeResponse from extension: '${this.extensionId}'`
+                    `'${this.platformAuthType}' - Received HandshakeResponse from extension: '${this.extensionId}'`,
+                    correlationId
                 );
                 this.handshakeEvent.end({
                     extensionInstalled: true,
@@ -360,11 +383,15 @@ export class PlatformAuthExtensionHandler implements IPlatformAuthHandler {
             }
             // Do nothing if method is not Response or HandshakeResponse
         } catch (err) {
-            this.logger.error("Error parsing response from WAM Extension");
-            this.logger.errorPii(
-                `Error parsing response from WAM Extension: '${err as string}'`
+            this.logger.error(
+                "Error parsing response from WAM Extension",
+                correlationId
             );
-            this.logger.errorPii(`Unable to parse '${event}'`);
+            this.logger.errorPii(
+                `Error parsing response from WAM Extension: '${err as string}'`,
+                correlationId
+            );
+            this.logger.errorPii(`Unable to parse '${event}'`, correlationId);
 
             if (resolver) {
                 resolver.reject(err as AuthError);

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
@@ -8,6 +8,7 @@ import {
     IPerformanceClient,
     Logger,
     Constants,
+    StubPerformanceClient,
 } from "@azure/msal-common/browser";
 import { name, version } from "../../packageMetadata.js";
 import {
@@ -25,30 +26,27 @@ import { PLATFORM_AUTH_DOM_SUPPORT } from "../../cache/CacheKeys.js";
  * Checks if the platform broker is available in the current environment.
  * @param loggerOptions
  * @param perfClient
+ * @param correlationId
  * @returns
  */
 export async function isPlatformBrokerAvailable(
-    loggerOptions: LoggerOptions = {},
-    perfClient: IPerformanceClient,
-    correlationId: string
+    loggerOptions?: LoggerOptions,
+    perfClient?: IPerformanceClient,
+    correlationId?: string
 ): Promise<boolean> {
-    const logger = new Logger(loggerOptions, name, version);
+    const logger = new Logger(loggerOptions || {}, name, version);
+    const cid = correlationId || "";
 
-    logger.trace("isPlatformBrokerAvailable called", correlationId);
+    logger.trace("isPlatformBrokerAvailable called", cid);
+
+    const performanceClient = perfClient || new StubPerformanceClient();
 
     if (typeof window === "undefined") {
-        logger.trace(
-            "Non-browser environment detected, returning false",
-            correlationId
-        );
+        logger.trace("Non-browser environment detected, returning false", cid);
         return false;
     }
 
-    return !!(await getPlatformAuthProvider(
-        logger,
-        perfClient,
-        correlationId || createNewGuid()
-    ));
+    return !!(await getPlatformAuthProvider(logger, performanceClient, cid));
 }
 
 export async function getPlatformAuthProvider(

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
@@ -8,7 +8,6 @@ import {
     IPerformanceClient,
     Logger,
     Constants,
-    StubPerformanceClient,
 } from "@azure/msal-common/browser";
 import { name, version } from "../../packageMetadata.js";
 import {
@@ -29,24 +28,25 @@ import { PLATFORM_AUTH_DOM_SUPPORT } from "../../cache/CacheKeys.js";
  * @returns
  */
 export async function isPlatformBrokerAvailable(
-    loggerOptions?: LoggerOptions,
-    perfClient?: IPerformanceClient,
-    correlationId?: string
+    loggerOptions: LoggerOptions = {},
+    perfClient: IPerformanceClient,
+    correlationId: string
 ): Promise<boolean> {
-    const logger = new Logger(loggerOptions || {}, name, version);
+    const logger = new Logger(loggerOptions, name, version);
 
-    logger.trace("isPlatformBrokerAvailable called");
-
-    const performanceClient = perfClient || new StubPerformanceClient();
+    logger.trace("isPlatformBrokerAvailable called", correlationId);
 
     if (typeof window === "undefined") {
-        logger.trace("Non-browser environment detected, returning false");
+        logger.trace(
+            "Non-browser environment detected, returning false",
+            correlationId
+        );
         return false;
     }
 
     return !!(await getPlatformAuthProvider(
         logger,
-        performanceClient,
+        perfClient,
         correlationId || createNewGuid()
     ));
 }
@@ -62,7 +62,8 @@ export async function getPlatformAuthProvider(
     const enablePlatformBrokerDOMSupport = isDomEnabledForPlatformAuth();
 
     logger.trace(
-        `Has client allowed platform auth via DOM API: '${enablePlatformBrokerDOMSupport}'`
+        `Has client allowed platform auth via DOM API: '${enablePlatformBrokerDOMSupport}'`,
+        correlationId
     );
     let platformAuthProvider: IPlatformAuthHandler | undefined;
     try {
@@ -76,7 +77,8 @@ export async function getPlatformAuthProvider(
         }
         if (!platformAuthProvider) {
             logger.trace(
-                "Platform auth via DOM API not available, checking for extension"
+                "Platform auth via DOM API not available, checking for extension",
+                correlationId
             );
             /*
              * If DOM APIs are not available, check if browser extension is available.
@@ -87,7 +89,8 @@ export async function getPlatformAuthProvider(
                     logger,
                     nativeBrokerHandshakeTimeout ||
                         DEFAULT_NATIVE_BROKER_HANDSHAKE_TIMEOUT_MS,
-                    performanceClient
+                    performanceClient,
+                    correlationId
                 );
         }
     } catch (e) {
@@ -116,19 +119,22 @@ export function isDomEnabledForPlatformAuth(): boolean {
  * Returns boolean indicating whether or not the request should attempt to use native broker
  * @param logger
  * @param config
+ * @param correlationId
  * @param platformAuthProvider
  * @param authenticationScheme
  */
 export function isPlatformAuthAllowed(
     config: BrowserConfiguration,
     logger: Logger,
+    correlationId: string,
     platformAuthProvider?: IPlatformAuthHandler,
     authenticationScheme?: Constants.AuthenticationScheme
 ): boolean {
-    logger.trace("isPlatformAuthAllowed called");
+    logger.trace("isPlatformAuthAllowed called", correlationId);
     if (!config.system.allowPlatformBroker) {
         logger.trace(
-            "isPlatformAuthAllowed: allowPlatformBroker is not enabled, returning false"
+            "isPlatformAuthAllowed: allowPlatformBroker is not enabled, returning false",
+            correlationId
         );
         // Developer disabled WAM
         return false;
@@ -136,7 +142,8 @@ export function isPlatformAuthAllowed(
 
     if (!platformAuthProvider) {
         logger.trace(
-            "isPlatformAuthAllowed: Platform auth provider is not initialized, returning false"
+            "isPlatformAuthAllowed: Platform auth provider is not initialized, returning false",
+            correlationId
         );
         // Platform broker auth providers are not available
         return false;
@@ -147,12 +154,14 @@ export function isPlatformAuthAllowed(
             case Constants.AuthenticationScheme.BEARER:
             case Constants.AuthenticationScheme.POP:
                 logger.trace(
-                    "isPlatformAuthAllowed: authenticationScheme is supported, returning true"
+                    "isPlatformAuthAllowed: authenticationScheme is supported, returning true",
+                    correlationId
                 );
                 return true;
             default:
                 logger.trace(
-                    "isPlatformAuthAllowed: authenticationScheme is not supported, returning false"
+                    "isPlatformAuthAllowed: authenticationScheme is not supported, returning false",
+                    correlationId
                 );
                 return false;
         }

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
@@ -18,7 +18,6 @@ import {
 import { PlatformAuthExtensionHandler } from "./PlatformAuthExtensionHandler.js";
 import { IPlatformAuthHandler } from "./IPlatformAuthHandler.js";
 import { PlatformAuthDOMHandler } from "./PlatformAuthDOMHandler.js";
-import { createNewGuid } from "../../crypto/BrowserCrypto.js";
 import { BrowserCacheLocation } from "../../utils/BrowserConstants.js";
 import { PLATFORM_AUTH_DOM_SUPPORT } from "../../cache/CacheKeys.js";
 

--- a/lib/msal-browser/src/cache/AccountManager.ts
+++ b/lib/msal-browser/src/cache/AccountManager.ts
@@ -18,7 +18,7 @@ export function getAllAccounts(
     correlationId: string,
     accountFilter?: AccountFilter
 ): AccountInfo[] {
-    logger.verbose("getAllAccounts called");
+    logger.verbose("getAllAccounts called", correlationId);
     return isInBrowser
         ? browserStorage.getAllAccounts(accountFilter, correlationId)
         : [];
@@ -35,9 +35,9 @@ export function getAccount(
     browserStorage: BrowserCacheManager,
     correlationId: string
 ): AccountInfo | null {
-    logger.trace("getAccount called");
+    logger.trace("getAccount called", correlationId);
     if (Object.keys(accountFilter).length === 0) {
-        logger.warning("getAccount: No accountFilter provided");
+        logger.warning("getAccount: No accountFilter provided", correlationId);
         return null;
     }
 
@@ -48,11 +48,15 @@ export function getAccount(
 
     if (account) {
         logger.verbose(
-            "getAccount: Account matching provided filter found, returning"
+            "getAccount: Account matching provided filter found, returning",
+            correlationId
         );
         return account;
     } else {
-        logger.verbose("getAccount: No matching account found, returning null");
+        logger.verbose(
+            "getAccount: No matching account found, returning null",
+            correlationId
+        );
         return null;
     }
 }
@@ -71,9 +75,12 @@ export function getAccountByUsername(
     browserStorage: BrowserCacheManager,
     correlationId: string
 ): AccountInfo | null {
-    logger.trace("getAccountByUsername called");
+    logger.trace("getAccountByUsername called", correlationId);
     if (!username) {
-        logger.warning("getAccountByUsername: No username provided");
+        logger.warning(
+            "getAccountByUsername: No username provided",
+            correlationId
+        );
         return null;
     }
 
@@ -85,15 +92,18 @@ export function getAccountByUsername(
     );
     if (account) {
         logger.verbose(
-            "getAccountByUsername: Account matching username found, returning"
+            "getAccountByUsername: Account matching username found, returning",
+            correlationId
         );
         logger.verbosePii(
-            `getAccountByUsername: Returning signed-in accounts matching username: '${username}'`
+            `getAccountByUsername: Returning signed-in accounts matching username: '${username}'`,
+            correlationId
         );
         return account;
     } else {
         logger.verbose(
-            "getAccountByUsername: No matching account found, returning null"
+            "getAccountByUsername: No matching account found, returning null",
+            correlationId
         );
         return null;
     }
@@ -112,9 +122,12 @@ export function getAccountByHomeId(
     browserStorage: BrowserCacheManager,
     correlationId: string
 ): AccountInfo | null {
-    logger.trace("getAccountByHomeId called");
+    logger.trace("getAccountByHomeId called", correlationId);
     if (!homeAccountId) {
-        logger.warning("getAccountByHomeId: No homeAccountId provided");
+        logger.warning(
+            "getAccountByHomeId: No homeAccountId provided",
+            correlationId
+        );
         return null;
     }
 
@@ -126,15 +139,18 @@ export function getAccountByHomeId(
     );
     if (account) {
         logger.verbose(
-            "getAccountByHomeId: Account matching homeAccountId found, returning"
+            "getAccountByHomeId: Account matching homeAccountId found, returning",
+            correlationId
         );
         logger.verbosePii(
-            `getAccountByHomeId: Returning signed-in accounts matching homeAccountId: '${homeAccountId}'`
+            `getAccountByHomeId: Returning signed-in accounts matching homeAccountId: '${homeAccountId}'`,
+            correlationId
         );
         return account;
     } else {
         logger.verbose(
-            "getAccountByHomeId: No matching account found, returning null"
+            "getAccountByHomeId: No matching account found, returning null",
+            correlationId
         );
         return null;
     }
@@ -153,9 +169,12 @@ export function getAccountByLocalId(
     browserStorage: BrowserCacheManager,
     correlationId: string
 ): AccountInfo | null {
-    logger.trace("getAccountByLocalId called");
+    logger.trace("getAccountByLocalId called", correlationId);
     if (!localAccountId) {
-        logger.warning("getAccountByLocalId: No localAccountId provided");
+        logger.warning(
+            "getAccountByLocalId: No localAccountId provided",
+            correlationId
+        );
         return null;
     }
 
@@ -167,15 +186,18 @@ export function getAccountByLocalId(
     );
     if (account) {
         logger.verbose(
-            "getAccountByLocalId: Account matching localAccountId found, returning"
+            "getAccountByLocalId: Account matching localAccountId found, returning",
+            correlationId
         );
         logger.verbosePii(
-            `getAccountByLocalId: Returning signed-in accounts matching localAccountId: '${localAccountId}'`
+            `getAccountByLocalId: Returning signed-in accounts matching localAccountId: '${localAccountId}'`,
+            correlationId
         );
         return account;
     } else {
         logger.verbose(
-            "getAccountByLocalId: No matching account found, returning null"
+            "getAccountByLocalId: No matching account found, returning null",
+            correlationId
         );
         return null;
     }

--- a/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
+++ b/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
@@ -33,7 +33,8 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
             error.errorCode === BrowserAuthErrorCodes.databaseUnavailable
         ) {
             this.logger.error(
-                "Could not access persistent storage. This may be caused by browser privacy features which block persistent storage in third-party contexts."
+                "Could not access persistent storage. This may be caused by browser privacy features which block persistent storage in third-party contexts.",
+                ""
             );
         } else {
             throw error;
@@ -49,7 +50,8 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
         if (!item) {
             try {
                 this.logger.verbose(
-                    "Queried item not found in in-memory cache, now querying persistent storage."
+                    "Queried item not found in in-memory cache, now querying persistent storage.",
+                    ""
                 );
                 return await this.indexedDBCache.getItem(key);
             } catch (e) {
@@ -96,7 +98,8 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
         if (cacheKeys.length === 0) {
             try {
                 this.logger.verbose(
-                    "In-memory cache is empty, now querying persistent storage."
+                    "In-memory cache is empty, now querying persistent storage.",
+                    ""
                 );
                 return await this.indexedDBCache.getKeys();
             } catch (e) {
@@ -115,7 +118,8 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
         if (!containsKey) {
             try {
                 this.logger.verbose(
-                    "Key not found in in-memory cache, now querying persistent storage."
+                    "Key not found in in-memory cache, now querying persistent storage.",
+                    ""
                 );
                 return await this.indexedDBCache.containsKey(key);
             } catch (e) {
@@ -130,9 +134,9 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
      */
     clearInMemory(): void {
         // InMemory cache is a Map instance, clear is straightforward
-        this.logger.verbose(`Deleting in-memory keystore`);
+        this.logger.verbose(`Deleting in-memory keystore`, "");
         this.inMemoryCache.clear();
-        this.logger.verbose(`In-memory keystore deleted`);
+        this.logger.verbose(`In-memory keystore deleted`, "");
     }
 
     /**
@@ -141,10 +145,10 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
      */
     async clearPersistent(): Promise<boolean> {
         try {
-            this.logger.verbose("Deleting persistent keystore");
+            this.logger.verbose("Deleting persistent keystore", "");
             const dbDeleted = await this.indexedDBCache.deleteDatabase();
             if (dbDeleted) {
-                this.logger.verbose("Persistent keystore deleted");
+                this.logger.verbose("Persistent keystore deleted", "");
             }
 
             return dbDeleted;

--- a/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
+++ b/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
@@ -27,14 +27,17 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
         this.logger = logger;
     }
 
-    private handleDatabaseAccessError(error: unknown): void {
+    private handleDatabaseAccessError(
+        error: unknown,
+        correlationId: string
+    ): void {
         if (
             error instanceof BrowserAuthError &&
             error.errorCode === BrowserAuthErrorCodes.databaseUnavailable
         ) {
             this.logger.error(
                 "Could not access persistent storage. This may be caused by browser privacy features which block persistent storage in third-party contexts.",
-                ""
+                correlationId
             );
         } else {
             throw error;
@@ -44,18 +47,19 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
      * Get the item matching the given key. Tries in-memory cache first, then in the asynchronous
      * storage object if item isn't found in-memory.
      * @param key
+     * @param correlationId
      */
-    async getItem(key: string): Promise<T | null> {
+    async getItem(key: string, correlationId: string): Promise<T | null> {
         const item = this.inMemoryCache.getItem(key);
         if (!item) {
             try {
                 this.logger.verbose(
                     "Queried item not found in in-memory cache, now querying persistent storage.",
-                    ""
+                    correlationId
                 );
                 return await this.indexedDBCache.getItem(key);
             } catch (e) {
-                this.handleDatabaseAccessError(e);
+                this.handleDatabaseAccessError(e, correlationId);
             }
         }
         return item;
@@ -66,44 +70,47 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
      * storage object with the given key.
      * @param key
      * @param value
+     * @param correlationId
      */
-    async setItem(key: string, value: T): Promise<void> {
+    async setItem(key: string, value: T, correlationId: string): Promise<void> {
         this.inMemoryCache.setItem(key, value);
         try {
             await this.indexedDBCache.setItem(key, value);
         } catch (e) {
-            this.handleDatabaseAccessError(e);
+            this.handleDatabaseAccessError(e, correlationId);
         }
     }
 
     /**
      * Removes the item matching the key from the in-memory cache, then tries to remove it from the asynchronous storage object.
      * @param key
+     * @param correlationId
      */
-    async removeItem(key: string): Promise<void> {
+    async removeItem(key: string, correlationId: string): Promise<void> {
         this.inMemoryCache.removeItem(key);
         try {
             await this.indexedDBCache.removeItem(key);
         } catch (e) {
-            this.handleDatabaseAccessError(e);
+            this.handleDatabaseAccessError(e, correlationId);
         }
     }
 
     /**
      * Get all the keys from the in-memory cache as an iterable array of strings. If no keys are found, query the keys in the
      * asynchronous storage object.
+     * @param correlationId
      */
-    async getKeys(): Promise<string[]> {
+    async getKeys(correlationId: string): Promise<string[]> {
         const cacheKeys = this.inMemoryCache.getKeys();
         if (cacheKeys.length === 0) {
             try {
                 this.logger.verbose(
                     "In-memory cache is empty, now querying persistent storage.",
-                    ""
+                    correlationId
                 );
                 return await this.indexedDBCache.getKeys();
             } catch (e) {
-                this.handleDatabaseAccessError(e);
+                this.handleDatabaseAccessError(e, correlationId);
             }
         }
         return cacheKeys;
@@ -112,18 +119,19 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
     /**
      * Returns true or false if the given key is present in the cache.
      * @param key
+     * @param correlationId
      */
-    async containsKey(key: string): Promise<boolean> {
+    async containsKey(key: string, correlationId: string): Promise<boolean> {
         const containsKey = this.inMemoryCache.containsKey(key);
         if (!containsKey) {
             try {
                 this.logger.verbose(
                     "Key not found in in-memory cache, now querying persistent storage.",
-                    ""
+                    correlationId
                 );
                 return await this.indexedDBCache.containsKey(key);
             } catch (e) {
-                this.handleDatabaseAccessError(e);
+                this.handleDatabaseAccessError(e, correlationId);
             }
         }
         return containsKey;
@@ -131,29 +139,34 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
 
     /**
      * Clears in-memory Map
+     * @param correlationId
      */
-    clearInMemory(): void {
+    clearInMemory(correlationId: string): void {
         // InMemory cache is a Map instance, clear is straightforward
-        this.logger.verbose(`Deleting in-memory keystore`, "");
+        this.logger.verbose(`Deleting in-memory keystore`, correlationId);
         this.inMemoryCache.clear();
-        this.logger.verbose(`In-memory keystore deleted`, "");
+        this.logger.verbose(`In-memory keystore deleted`, correlationId);
     }
 
     /**
      * Tries to delete the IndexedDB database
+     * @param correlationId
      * @returns
      */
-    async clearPersistent(): Promise<boolean> {
+    async clearPersistent(correlationId: string): Promise<boolean> {
         try {
-            this.logger.verbose("Deleting persistent keystore", "");
+            this.logger.verbose("Deleting persistent keystore", correlationId);
             const dbDeleted = await this.indexedDBCache.deleteDatabase();
             if (dbDeleted) {
-                this.logger.verbose("Persistent keystore deleted", "");
+                this.logger.verbose(
+                    "Persistent keystore deleted",
+                    correlationId
+                );
             }
 
             return dbDeleted;
         } catch (e) {
-            this.handleDatabaseAccessError(e);
+            this.handleDatabaseAccessError(e, correlationId);
             return false;
         }
     }

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1403,9 +1403,14 @@ export class BrowserCacheManager extends CacheManager {
     /**
      * Gets cache item with given key.
      * @param cacheKey
+     * @param correlationId
      * @param generateKey
      */
-    getTemporaryCache(cacheKey: string, generateKey?: boolean): string | null {
+    getTemporaryCache(
+        cacheKey: string,
+        correlationId: string,
+        generateKey?: boolean
+    ): string | null {
         const key = generateKey ? this.generateCacheKey(cacheKey) : cacheKey;
         const value = this.temporaryCacheStorage.getItem(key);
         if (!value) {
@@ -1418,14 +1423,14 @@ export class BrowserCacheManager extends CacheManager {
                 if (item) {
                     this.logger.trace(
                         "BrowserCacheManager.getTemporaryCache: Temporary cache item found in local storage",
-                        ""
+                        correlationId
                     );
                     return item;
                 }
             }
             this.logger.trace(
                 "BrowserCacheManager.getTemporaryCache: No cache item found in local storage",
-                ""
+                correlationId
             );
             return null;
         }
@@ -1565,9 +1570,13 @@ export class BrowserCacheManager extends CacheManager {
 
     /**
      * Reset all temporary cache items
+     * @param correlationId
      */
-    resetRequestCache(): void {
-        this.logger.trace("BrowserCacheManager.resetRequestCache called", "");
+    resetRequestCache(correlationId: string): void {
+        this.logger.trace(
+            "BrowserCacheManager.resetRequestCache called",
+            correlationId
+        );
 
         this.removeTemporaryItem(
             this.generateCacheKey(TemporaryCacheKeys.REQUEST_PARAMS)
@@ -1618,11 +1627,17 @@ export class BrowserCacheManager extends CacheManager {
      * Gets the token exchange parameters from the cache. Throws an error if nothing is found.
      * @param correlationId
      */
-    getCachedRequest(): [CommonAuthorizationUrlRequest, string] {
-        this.logger.trace("BrowserCacheManager.getCachedRequest called", "");
+    getCachedRequest(
+        correlationId: string
+    ): [CommonAuthorizationUrlRequest, string] {
+        this.logger.trace(
+            "BrowserCacheManager.getCachedRequest called",
+            correlationId
+        );
         // Get token request from cache and parse as TokenExchangeParameters.
         const encodedTokenRequest = this.getTemporaryCache(
             TemporaryCacheKeys.REQUEST_PARAMS,
+            correlationId,
             true
         );
         if (!encodedTokenRequest) {
@@ -1632,6 +1647,7 @@ export class BrowserCacheManager extends CacheManager {
         }
         const encodedVerifier = this.getTemporaryCache(
             TemporaryCacheKeys.VERIFIER,
+            correlationId,
             true
         );
 
@@ -1645,11 +1661,11 @@ export class BrowserCacheManager extends CacheManager {
         } catch (e) {
             this.logger.errorPii(
                 `Attempted to parse: '${encodedTokenRequest}'`,
-                ""
+                correlationId
             );
             this.logger.error(
                 `Parsing cached token request threw with error: '${e}'`,
-                ""
+                correlationId
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.unableToParseTokenRequestCacheError
@@ -1670,6 +1686,7 @@ export class BrowserCacheManager extends CacheManager {
         );
         const cachedRequest = this.getTemporaryCache(
             TemporaryCacheKeys.NATIVE_REQUEST,
+            "",
             true
         );
         if (!cachedRequest) {
@@ -1709,7 +1726,7 @@ export class BrowserCacheManager extends CacheManager {
         type: INTERACTION_TYPE;
     } | null {
         const key = `${CacheKeys.PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`;
-        const value = this.getTemporaryCache(key, false);
+        const value = this.getTemporaryCache(key, "", false);
         try {
             return value ? JSON.parse(value) : null;
         } catch (e) {
@@ -1719,7 +1736,7 @@ export class BrowserCacheManager extends CacheManager {
                 ""
             );
             this.removeTemporaryItem(key);
-            this.resetRequestCache();
+            this.resetRequestCache("");
             clearHash(window);
             return null;
         }

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -95,6 +95,7 @@ export class BrowserCacheManager extends CacheManager {
         logger: Logger,
         performanceClient: IPerformanceClient,
         eventHandler: EventHandler,
+        correlationId: string,
         staticAuthorityOptions?: StaticAuthorityOptions
     ) {
         super(
@@ -111,13 +112,15 @@ export class BrowserCacheManager extends CacheManager {
             clientId,
             cacheConfig.cacheLocation,
             logger,
-            performanceClient
+            performanceClient,
+            correlationId
         );
         this.temporaryCacheStorage = getStorageImplementation(
             clientId,
             BrowserCacheLocation.SessionStorage,
             logger,
-            performanceClient
+            performanceClient,
+            correlationId
         );
         this.cookieStorage = new CookieStorage();
 
@@ -346,7 +349,8 @@ export class BrowserCacheManager extends CacheManager {
         );
         if (previousVersion) {
             this.logger.info(
-                `MSAL.js was last initialized by version: '${previousVersion}'`
+                `MSAL.js was last initialized by version: '${previousVersion}'`,
+                correlationId
             );
             this.performanceClient.addFields(
                 { previousLibraryVersion: previousVersion },
@@ -477,7 +481,8 @@ export class BrowserCacheManager extends CacheManager {
                     this.browserStorage.setUserData.bind(this.browserStorage),
                     PerformanceEvents.SetUserData,
                     this.logger,
-                    this.performanceClient
+                    this.performanceClient,
+                    correlationId
                 )(key, value, correlationId, timestamp);
                 if (i > 0) {
                     // Finally update the token keys array with the tokens removed
@@ -541,7 +546,10 @@ export class BrowserCacheManager extends CacheManager {
         accountKey: string,
         correlationId: string
     ): AccountEntity | null {
-        this.logger.trace("BrowserCacheManager.getAccount called");
+        this.logger.trace(
+            "BrowserCacheManager.getAccount called",
+            correlationId
+        );
         const serializedAccount = this.browserStorage.getUserData(accountKey);
         if (!serializedAccount) {
             this.removeAccountKeyFromMap(accountKey, correlationId);
@@ -570,7 +578,10 @@ export class BrowserCacheManager extends CacheManager {
         account: AccountEntity,
         correlationId: string
     ): Promise<void> {
-        this.logger.trace("BrowserCacheManager.setAccount called");
+        this.logger.trace(
+            "BrowserCacheManager.setAccount called",
+            correlationId
+        );
         const key = this.generateAccountKey(
             AccountEntityUtils.getAccountInfo(account)
         );
@@ -613,9 +624,13 @@ export class BrowserCacheManager extends CacheManager {
      * @param key
      */
     addAccountKeyToMap(key: string, correlationId: string): boolean {
-        this.logger.trace("BrowserCacheManager.addAccountKeyToMap called");
+        this.logger.trace(
+            "BrowserCacheManager.addAccountKeyToMap called",
+            correlationId
+        );
         this.logger.tracePii(
-            `BrowserCacheManager.addAccountKeyToMap called with key: '${key}'`
+            `BrowserCacheManager.addAccountKeyToMap called with key: '${key}'`,
+            correlationId
         );
         const accountKeys = this.getAccountKeys();
         if (accountKeys.indexOf(key) === -1) {
@@ -627,12 +642,14 @@ export class BrowserCacheManager extends CacheManager {
                 correlationId
             );
             this.logger.verbose(
-                "BrowserCacheManager.addAccountKeyToMap account key added"
+                "BrowserCacheManager.addAccountKeyToMap account key added",
+                correlationId
             );
             return true;
         } else {
             this.logger.verbose(
-                "BrowserCacheManager.addAccountKeyToMap account key already exists in map"
+                "BrowserCacheManager.addAccountKeyToMap account key already exists in map",
+                correlationId
             );
             return false;
         }
@@ -643,9 +660,13 @@ export class BrowserCacheManager extends CacheManager {
      * @param key
      */
     removeAccountKeyFromMap(key: string, correlationId: string): void {
-        this.logger.trace("BrowserCacheManager.removeAccountKeyFromMap called");
+        this.logger.trace(
+            "BrowserCacheManager.removeAccountKeyFromMap called",
+            correlationId
+        );
         this.logger.tracePii(
-            `BrowserCacheManager.removeAccountKeyFromMap called with key: '${key}'`
+            `BrowserCacheManager.removeAccountKeyFromMap called with key: '${key}'`,
+            correlationId
         );
         const accountKeys = this.getAccountKeys();
         const removalIndex = accountKeys.indexOf(key);
@@ -663,11 +684,13 @@ export class BrowserCacheManager extends CacheManager {
                 );
             }
             this.logger.trace(
-                "BrowserCacheManager.removeAccountKeyFromMap account key removed"
+                "BrowserCacheManager.removeAccountKeyFromMap account key removed",
+                correlationId
             );
         } else {
             this.logger.trace(
-                "BrowserCacheManager.removeAccountKeyFromMap key not found in existing map"
+                "BrowserCacheManager.removeAccountKeyFromMap key not found in existing map",
+                correlationId
             );
         }
     }
@@ -724,7 +747,10 @@ export class BrowserCacheManager extends CacheManager {
         const tokenKeys = this.getTokenKeys();
         const idRemoval = tokenKeys.idToken.indexOf(key);
         if (idRemoval > -1) {
-            this.logger.info("idToken removed from tokenKeys map");
+            this.logger.info(
+                "idToken removed from tokenKeys map",
+                correlationId
+            );
             tokenKeys.idToken.splice(idRemoval, 1);
             this.setTokenKeys(tokenKeys, correlationId);
         }
@@ -754,7 +780,7 @@ export class BrowserCacheManager extends CacheManager {
         correlationId: string,
         schemaVersion: number = CacheKeys.CREDENTIAL_SCHEMA_VERSION
     ): void {
-        this.logger.trace("removeAccessTokenKey called");
+        this.logger.trace("removeAccessTokenKey called", correlationId);
         const tokenKeys = this.getTokenKeys(schemaVersion);
         let keysRemoved = 0;
         keys.forEach((key) => {
@@ -767,7 +793,8 @@ export class BrowserCacheManager extends CacheManager {
 
         if (keysRemoved > 0) {
             this.logger.info(
-                `removed '${keysRemoved}' accessToken keys from tokenKeys map`
+                `removed '${keysRemoved}' accessToken keys from tokenKeys map`,
+                correlationId
             );
             this.setTokenKeys(tokenKeys, correlationId, schemaVersion);
             return;
@@ -783,7 +810,10 @@ export class BrowserCacheManager extends CacheManager {
         const tokenKeys = this.getTokenKeys();
         const refreshRemoval = tokenKeys.refreshToken.indexOf(key);
         if (refreshRemoval > -1) {
-            this.logger.info("refreshToken removed from tokenKeys map");
+            this.logger.info(
+                "refreshToken removed from tokenKeys map",
+                correlationId
+            );
             tokenKeys.refreshToken.splice(refreshRemoval, 1);
             this.setTokenKeys(tokenKeys, correlationId);
         }
@@ -840,7 +870,8 @@ export class BrowserCacheManager extends CacheManager {
         const value = this.browserStorage.getUserData(idTokenKey);
         if (!value) {
             this.logger.trace(
-                "BrowserCacheManager.getIdTokenCredential: called, no cache hit"
+                "BrowserCacheManager.getIdTokenCredential: called, no cache hit",
+                correlationId
             );
             this.removeIdToken(idTokenKey, correlationId);
             return null;
@@ -849,13 +880,15 @@ export class BrowserCacheManager extends CacheManager {
         const parsedIdToken = this.validateAndParseJson(value);
         if (!parsedIdToken || !CacheHelpers.isIdTokenEntity(parsedIdToken)) {
             this.logger.trace(
-                "BrowserCacheManager.getIdTokenCredential: called, no cache hit"
+                "BrowserCacheManager.getIdTokenCredential: called, no cache hit",
+                correlationId
             );
             return null;
         }
 
         this.logger.trace(
-            "BrowserCacheManager.getIdTokenCredential: cache hit"
+            "BrowserCacheManager.getIdTokenCredential: cache hit",
+            correlationId
         );
         return parsedIdToken as IdTokenEntity;
     }
@@ -868,7 +901,10 @@ export class BrowserCacheManager extends CacheManager {
         idToken: IdTokenEntity,
         correlationId: string
     ): Promise<void> {
-        this.logger.trace("BrowserCacheManager.setIdTokenCredential called");
+        this.logger.trace(
+            "BrowserCacheManager.setIdTokenCredential called",
+            correlationId
+        );
         const idTokenKey = this.generateCredentialKey(idToken);
         const timestamp = Date.now().toString();
         idToken.lastUpdatedAt = timestamp;
@@ -883,7 +919,8 @@ export class BrowserCacheManager extends CacheManager {
         const tokenKeys = this.getTokenKeys();
         if (tokenKeys.idToken.indexOf(idTokenKey) === -1) {
             this.logger.info(
-                "BrowserCacheManager: addTokenKey - idToken added to map"
+                "BrowserCacheManager: addTokenKey - idToken added to map",
+                correlationId
             );
             tokenKeys.idToken.push(idTokenKey);
             this.setTokenKeys(tokenKeys, correlationId);
@@ -901,7 +938,8 @@ export class BrowserCacheManager extends CacheManager {
         const value = this.browserStorage.getUserData(accessTokenKey);
         if (!value) {
             this.logger.trace(
-                "BrowserCacheManager.getAccessTokenCredential: called, no cache hit"
+                "BrowserCacheManager.getAccessTokenCredential: called, no cache hit",
+                correlationId
             );
             this.removeAccessTokenKeys([accessTokenKey], correlationId);
             return null;
@@ -912,13 +950,15 @@ export class BrowserCacheManager extends CacheManager {
             !CacheHelpers.isAccessTokenEntity(parsedAccessToken)
         ) {
             this.logger.trace(
-                "BrowserCacheManager.getAccessTokenCredential: called, no cache hit"
+                "BrowserCacheManager.getAccessTokenCredential: called, no cache hit",
+                correlationId
             );
             return null;
         }
 
         this.logger.trace(
-            "BrowserCacheManager.getAccessTokenCredential: cache hit"
+            "BrowserCacheManager.getAccessTokenCredential: cache hit",
+            correlationId
         );
         return parsedAccessToken as AccessTokenEntity;
     }
@@ -932,7 +972,8 @@ export class BrowserCacheManager extends CacheManager {
         correlationId: string
     ): Promise<void> {
         this.logger.trace(
-            "BrowserCacheManager.setAccessTokenCredential called"
+            "BrowserCacheManager.setAccessTokenCredential called",
+            correlationId
         );
         const accessTokenKey = this.generateCredentialKey(accessToken);
         const timestamp = Date.now().toString();
@@ -951,7 +992,8 @@ export class BrowserCacheManager extends CacheManager {
             tokenKeys.accessToken.splice(index, 1); // Remove existing key before pushing to the end
         }
         this.logger.trace(
-            `access token '${index === -1 ? "added to" : "updated in"}' map`
+            `access token '${index === -1 ? "added to" : "updated in"}' map`,
+            correlationId
         );
         tokenKeys.accessToken.push(accessTokenKey);
         this.setTokenKeys(tokenKeys, correlationId);
@@ -968,7 +1010,8 @@ export class BrowserCacheManager extends CacheManager {
         const value = this.browserStorage.getUserData(refreshTokenKey);
         if (!value) {
             this.logger.trace(
-                "BrowserCacheManager.getRefreshTokenCredential: called, no cache hit"
+                "BrowserCacheManager.getRefreshTokenCredential: called, no cache hit",
+                correlationId
             );
             this.removeRefreshToken(refreshTokenKey, correlationId);
             return null;
@@ -979,13 +1022,15 @@ export class BrowserCacheManager extends CacheManager {
             !CacheHelpers.isRefreshTokenEntity(parsedRefreshToken)
         ) {
             this.logger.trace(
-                "BrowserCacheManager.getRefreshTokenCredential: called, no cache hit"
+                "BrowserCacheManager.getRefreshTokenCredential: called, no cache hit",
+                correlationId
             );
             return null;
         }
 
         this.logger.trace(
-            "BrowserCacheManager.getRefreshTokenCredential: cache hit"
+            "BrowserCacheManager.getRefreshTokenCredential: cache hit",
+            correlationId
         );
         return parsedRefreshToken as RefreshTokenEntity;
     }
@@ -999,7 +1044,8 @@ export class BrowserCacheManager extends CacheManager {
         correlationId: string
     ): Promise<void> {
         this.logger.trace(
-            "BrowserCacheManager.setRefreshTokenCredential called"
+            "BrowserCacheManager.setRefreshTokenCredential called",
+            correlationId
         );
         const refreshTokenKey = this.generateCredentialKey(refreshToken);
         const timestamp = Date.now().toString();
@@ -1015,7 +1061,8 @@ export class BrowserCacheManager extends CacheManager {
         const tokenKeys = this.getTokenKeys();
         if (tokenKeys.refreshToken.indexOf(refreshTokenKey) === -1) {
             this.logger.info(
-                "BrowserCacheManager: addTokenKey - refreshToken added to map"
+                "BrowserCacheManager: addTokenKey - refreshToken added to map",
+                correlationId
             );
             tokenKeys.refreshToken.push(refreshTokenKey);
             this.setTokenKeys(tokenKeys, correlationId);
@@ -1025,12 +1072,17 @@ export class BrowserCacheManager extends CacheManager {
     /**
      * fetch appMetadata entity from the platform cache
      * @param appMetadataKey
+     * @param correlationId
      */
-    getAppMetadata(appMetadataKey: string): AppMetadataEntity | null {
+    getAppMetadata(
+        appMetadataKey: string,
+        correlationId: string
+    ): AppMetadataEntity | null {
         const value = this.browserStorage.getItem(appMetadataKey);
         if (!value) {
             this.logger.trace(
-                "BrowserCacheManager.getAppMetadata: called, no cache hit"
+                "BrowserCacheManager.getAppMetadata: called, no cache hit",
+                correlationId
             );
             return null;
         }
@@ -1041,24 +1093,32 @@ export class BrowserCacheManager extends CacheManager {
             !CacheHelpers.isAppMetadataEntity(appMetadataKey, parsedMetadata)
         ) {
             this.logger.trace(
-                "BrowserCacheManager.getAppMetadata: called, no cache hit"
+                "BrowserCacheManager.getAppMetadata: called, no cache hit",
+                correlationId
             );
             return null;
         }
 
-        this.logger.trace("BrowserCacheManager.getAppMetadata: cache hit");
+        this.logger.trace(
+            "BrowserCacheManager.getAppMetadata: cache hit",
+            correlationId
+        );
         return parsedMetadata as AppMetadataEntity;
     }
 
     /**
      * set appMetadata entity to the platform cache
      * @param appMetadata
+     * @param correlationId
      */
     setAppMetadata(
         appMetadata: AppMetadataEntity,
         correlationId: string
     ): void {
-        this.logger.trace("BrowserCacheManager.setAppMetadata called");
+        this.logger.trace(
+            "BrowserCacheManager.setAppMetadata called",
+            correlationId
+        );
         const appMetadataKey = CacheHelpers.generateAppMetadataKey(appMetadata);
         this.setItem(
             appMetadataKey,
@@ -1070,14 +1130,17 @@ export class BrowserCacheManager extends CacheManager {
     /**
      * fetch server telemetry entity from the platform cache
      * @param serverTelemetryKey
+     * @param correlationId
      */
     getServerTelemetry(
-        serverTelemetryKey: string
+        serverTelemetryKey: string,
+        correlationId: string
     ): ServerTelemetryEntity | null {
         const value = this.browserStorage.getItem(serverTelemetryKey);
         if (!value) {
             this.logger.trace(
-                "BrowserCacheManager.getServerTelemetry: called, no cache hit"
+                "BrowserCacheManager.getServerTelemetry: called, no cache hit",
+                correlationId
             );
             return null;
         }
@@ -1090,12 +1153,16 @@ export class BrowserCacheManager extends CacheManager {
             )
         ) {
             this.logger.trace(
-                "BrowserCacheManager.getServerTelemetry: called, no cache hit"
+                "BrowserCacheManager.getServerTelemetry: called, no cache hit",
+                correlationId
             );
             return null;
         }
 
-        this.logger.trace("BrowserCacheManager.getServerTelemetry: cache hit");
+        this.logger.trace(
+            "BrowserCacheManager.getServerTelemetry: cache hit",
+            correlationId
+        );
         return parsedEntity as ServerTelemetryEntity;
     }
 
@@ -1109,7 +1176,10 @@ export class BrowserCacheManager extends CacheManager {
         serverTelemetry: ServerTelemetryEntity,
         correlationId: string
     ): void {
-        this.logger.trace("BrowserCacheManager.setServerTelemetry called");
+        this.logger.trace(
+            "BrowserCacheManager.setServerTelemetry called",
+            correlationId
+        );
         this.setItem(
             serverTelemetryKey,
             JSON.stringify(serverTelemetry),
@@ -1120,11 +1190,15 @@ export class BrowserCacheManager extends CacheManager {
     /**
      *
      */
-    getAuthorityMetadata(key: string): AuthorityMetadataEntity | null {
+    getAuthorityMetadata(
+        key: string,
+        correlationId: string
+    ): AuthorityMetadataEntity | null {
         const value = this.internalStorage.getItem(key);
         if (!value) {
             this.logger.trace(
-                "BrowserCacheManager.getAuthorityMetadata: called, no cache hit"
+                "BrowserCacheManager.getAuthorityMetadata: called, no cache hit",
+                correlationId
             );
             return null;
         }
@@ -1134,7 +1208,8 @@ export class BrowserCacheManager extends CacheManager {
             CacheHelpers.isAuthorityMetadataEntity(key, parsedMetadata)
         ) {
             this.logger.trace(
-                "BrowserCacheManager.getAuthorityMetadata: cache hit"
+                "BrowserCacheManager.getAuthorityMetadata: cache hit",
+                correlationId
             );
             return parsedMetadata as AuthorityMetadataEntity;
         }
@@ -1177,10 +1252,19 @@ export class BrowserCacheManager extends CacheManager {
 
     /**
      *
+     * @param key
      * @param entity
+     * @param correlationId
      */
-    setAuthorityMetadata(key: string, entity: AuthorityMetadataEntity): void {
-        this.logger.trace("BrowserCacheManager.setAuthorityMetadata called");
+    setAuthorityMetadata(
+        key: string,
+        entity: AuthorityMetadataEntity,
+        correlationId: string
+    ): void {
+        this.logger.trace(
+            "BrowserCacheManager.setAuthorityMetadata called",
+            correlationId
+        );
         this.internalStorage.setItem(key, JSON.stringify(entity));
     }
 
@@ -1196,7 +1280,8 @@ export class BrowserCacheManager extends CacheManager {
         );
         if (!activeAccountValueFilters) {
             this.logger.trace(
-                "BrowserCacheManager.getActiveAccount: No active account filters found"
+                "BrowserCacheManager.getActiveAccount: No active account filters found",
+                correlationId
             );
             return null;
         }
@@ -1205,7 +1290,8 @@ export class BrowserCacheManager extends CacheManager {
         ) as AccountInfo;
         if (activeAccountValueObj) {
             this.logger.trace(
-                "BrowserCacheManager.getActiveAccount: Active account filters schema found"
+                "BrowserCacheManager.getActiveAccount: Active account filters schema found",
+                correlationId
             );
             return this.getAccountInfoFilteredBy(
                 {
@@ -1217,7 +1303,8 @@ export class BrowserCacheManager extends CacheManager {
             );
         }
         this.logger.trace(
-            "BrowserCacheManager.getActiveAccount: No active account found"
+            "BrowserCacheManager.getActiveAccount: No active account found",
+            correlationId
         );
         return null;
     }
@@ -1231,7 +1318,10 @@ export class BrowserCacheManager extends CacheManager {
             Constants.PersistentCacheKeys.ACTIVE_ACCOUNT_FILTERS
         );
         if (account) {
-            this.logger.verbose("setActiveAccount: Active account set");
+            this.logger.verbose(
+                "setActiveAccount: Active account set",
+                correlationId
+            );
             const activeAccountValue: ActiveAccountFilters = {
                 homeAccountId: account.homeAccountId,
                 localAccountId: account.localAccountId,
@@ -1244,7 +1334,8 @@ export class BrowserCacheManager extends CacheManager {
             );
         } else {
             this.logger.verbose(
-                "setActiveAccount: No account passed, active account not set"
+                "setActiveAccount: No account passed, active account not set",
+                correlationId
             );
             this.browserStorage.removeItem(activeAccountKey);
         }
@@ -1254,12 +1345,17 @@ export class BrowserCacheManager extends CacheManager {
     /**
      * fetch throttling entity from the platform cache
      * @param throttlingCacheKey
+     * @param correlationId
      */
-    getThrottlingCache(throttlingCacheKey: string): ThrottlingEntity | null {
+    getThrottlingCache(
+        throttlingCacheKey: string,
+        correlationId: string
+    ): ThrottlingEntity | null {
         const value = this.browserStorage.getItem(throttlingCacheKey);
         if (!value) {
             this.logger.trace(
-                "BrowserCacheManager.getThrottlingCache: called, no cache hit"
+                "BrowserCacheManager.getThrottlingCache: called, no cache hit",
+                correlationId
             );
             return null;
         }
@@ -1273,12 +1369,16 @@ export class BrowserCacheManager extends CacheManager {
             )
         ) {
             this.logger.trace(
-                "BrowserCacheManager.getThrottlingCache: called, no cache hit"
+                "BrowserCacheManager.getThrottlingCache: called, no cache hit",
+                correlationId
             );
             return null;
         }
 
-        this.logger.trace("BrowserCacheManager.getThrottlingCache: cache hit");
+        this.logger.trace(
+            "BrowserCacheManager.getThrottlingCache: cache hit",
+            correlationId
+        );
         return parsedThrottlingCache as ThrottlingEntity;
     }
 
@@ -1292,7 +1392,10 @@ export class BrowserCacheManager extends CacheManager {
         throttlingCache: ThrottlingEntity,
         correlationId: string
     ): void {
-        this.logger.trace("BrowserCacheManager.setThrottlingCache called");
+        this.logger.trace(
+            "BrowserCacheManager.setThrottlingCache called",
+            correlationId
+        );
         this.setItem(
             throttlingCacheKey,
             JSON.stringify(throttlingCache),
@@ -1302,7 +1405,8 @@ export class BrowserCacheManager extends CacheManager {
 
     /**
      * Gets cache item with given key.
-     * @param key
+     * @param cacheKey
+     * @param generateKey
      */
     getTemporaryCache(cacheKey: string, generateKey?: boolean): string | null {
         const key = generateKey ? this.generateCacheKey(cacheKey) : cacheKey;
@@ -1316,19 +1420,18 @@ export class BrowserCacheManager extends CacheManager {
                 const item = this.browserStorage.getItem(key);
                 if (item) {
                     this.logger.trace(
-                        "BrowserCacheManager.getTemporaryCache: Temporary cache item found in local storage"
+                        "BrowserCacheManager.getTemporaryCache: Temporary cache item found in local storage",
+                        ""
                     );
                     return item;
                 }
             }
             this.logger.trace(
-                "BrowserCacheManager.getTemporaryCache: No cache item found in local storage"
+                "BrowserCacheManager.getTemporaryCache: No cache item found in local storage",
+                ""
             );
             return null;
         }
-        this.logger.trace(
-            "BrowserCacheManager.getTemporaryCache: Temporary cache item returned"
-        );
         return value;
     }
 
@@ -1465,10 +1568,9 @@ export class BrowserCacheManager extends CacheManager {
 
     /**
      * Reset all temporary cache items
-     * @param state
      */
     resetRequestCache(): void {
-        this.logger.trace("BrowserCacheManager.resetRequestCache called");
+        this.logger.trace("BrowserCacheManager.resetRequestCache called", "");
 
         this.removeTemporaryItem(
             this.generateCacheKey(TemporaryCacheKeys.REQUEST_PARAMS)
@@ -1485,14 +1587,18 @@ export class BrowserCacheManager extends CacheManager {
         this.removeTemporaryItem(
             this.generateCacheKey(TemporaryCacheKeys.NATIVE_REQUEST)
         );
-        this.setInteractionInProgress(false);
+        this.setInteractionInProgress(false, undefined);
     }
 
     cacheAuthorizeRequest(
         authCodeRequest: CommonAuthorizationUrlRequest,
+        correlationId: string,
         codeVerifier?: string
     ): void {
-        this.logger.trace("BrowserCacheManager.cacheAuthorizeRequest called");
+        this.logger.trace(
+            "BrowserCacheManager.cacheAuthorizeRequest called",
+            correlationId
+        );
 
         const encodedValue = base64Encode(JSON.stringify(authCodeRequest));
         this.setTemporaryCache(
@@ -1513,9 +1619,10 @@ export class BrowserCacheManager extends CacheManager {
 
     /**
      * Gets the token exchange parameters from the cache. Throws an error if nothing is found.
+     * @param correlationId
      */
     getCachedRequest(): [CommonAuthorizationUrlRequest, string] {
-        this.logger.trace("BrowserCacheManager.getCachedRequest called");
+        this.logger.trace("BrowserCacheManager.getCachedRequest called", "");
         // Get token request from cache and parse as TokenExchangeParameters.
         const encodedTokenRequest = this.getTemporaryCache(
             TemporaryCacheKeys.REQUEST_PARAMS,
@@ -1540,10 +1647,12 @@ export class BrowserCacheManager extends CacheManager {
             }
         } catch (e) {
             this.logger.errorPii(
-                `Attempted to parse: '${encodedTokenRequest}'`
+                `Attempted to parse: '${encodedTokenRequest}'`,
+                ""
             );
             this.logger.error(
-                `Parsing cached token request threw with error: '${e}'`
+                `Parsing cached token request threw with error: '${e}'`,
+                ""
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.unableToParseTokenRequestCacheError
@@ -1555,16 +1664,21 @@ export class BrowserCacheManager extends CacheManager {
 
     /**
      * Gets cached native request for redirect flows
+     * @param correlationId
      */
     getCachedNativeRequest(): PlatformAuthRequest | null {
-        this.logger.trace("BrowserCacheManager.getCachedNativeRequest called");
+        this.logger.trace(
+            "BrowserCacheManager.getCachedNativeRequest called",
+            ""
+        );
         const cachedRequest = this.getTemporaryCache(
             TemporaryCacheKeys.NATIVE_REQUEST,
             true
         );
         if (!cachedRequest) {
             this.logger.trace(
-                "BrowserCacheManager.getCachedNativeRequest: No cached native request found"
+                "BrowserCacheManager.getCachedNativeRequest: No cached native request found",
+                ""
             );
             return null;
         }
@@ -1574,7 +1688,8 @@ export class BrowserCacheManager extends CacheManager {
         ) as PlatformAuthRequest;
         if (!parsedRequest) {
             this.logger.error(
-                "BrowserCacheManager.getCachedNativeRequest: Unable to parse native request"
+                "BrowserCacheManager.getCachedNativeRequest: Unable to parse native request",
+                ""
             );
             return null;
         }
@@ -1603,7 +1718,8 @@ export class BrowserCacheManager extends CacheManager {
         } catch (e) {
             // Remove interaction and other temp keys if interaction status can't be parsed
             this.logger.error(
-                `Cannot parse interaction status. Removing temporary cache items and clearing url hash. Retrying interaction should fix the error`
+                `Cannot parse interaction status. Removing temporary cache items and clearing url hash. Retrying interaction should fix the error`,
+                ""
             );
             this.removeTemporaryItem(key);
             this.resetRequestCache();
@@ -1746,7 +1862,8 @@ function getStorageImplementation(
     clientId: string,
     cacheLocation: BrowserCacheLocation | string,
     logger: Logger,
-    performanceClient: IPerformanceClient
+    performanceClient: IPerformanceClient,
+    correlationId: string
 ): IWindowStorage<string> {
     try {
         switch (cacheLocation) {
@@ -1759,7 +1876,7 @@ function getStorageImplementation(
                 break;
         }
     } catch (e) {
-        logger.error(e as string);
+        logger.error(e as string, correlationId);
     }
 
     return new MemoryStorage();
@@ -1769,7 +1886,8 @@ export const DEFAULT_BROWSER_CACHE_MANAGER = (
     clientId: string,
     logger: Logger,
     performanceClient: IPerformanceClient,
-    eventHandler: EventHandler
+    eventHandler: EventHandler,
+    correlationId: string
 ): BrowserCacheManager => {
     const cacheOptions: Required<CacheOptions> = {
         cacheLocation: BrowserCacheLocation.MemoryStorage,
@@ -1781,6 +1899,7 @@ export const DEFAULT_BROWSER_CACHE_MANAGER = (
         DEFAULT_CRYPTO_IMPLEMENTATION,
         logger,
         performanceClient,
-        eventHandler
+        eventHandler,
+        correlationId
     );
 };

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -95,7 +95,6 @@ export class BrowserCacheManager extends CacheManager {
         logger: Logger,
         performanceClient: IPerformanceClient,
         eventHandler: EventHandler,
-        correlationId: string,
         staticAuthorityOptions?: StaticAuthorityOptions
     ) {
         super(
@@ -112,15 +111,13 @@ export class BrowserCacheManager extends CacheManager {
             clientId,
             cacheConfig.cacheLocation,
             logger,
-            performanceClient,
-            correlationId
+            performanceClient
         );
         this.temporaryCacheStorage = getStorageImplementation(
             clientId,
             BrowserCacheLocation.SessionStorage,
             logger,
-            performanceClient,
-            correlationId
+            performanceClient
         );
         this.cookieStorage = new CookieStorage();
 
@@ -1862,8 +1859,7 @@ function getStorageImplementation(
     clientId: string,
     cacheLocation: BrowserCacheLocation | string,
     logger: Logger,
-    performanceClient: IPerformanceClient,
-    correlationId: string
+    performanceClient: IPerformanceClient
 ): IWindowStorage<string> {
     try {
         switch (cacheLocation) {
@@ -1876,7 +1872,7 @@ function getStorageImplementation(
                 break;
         }
     } catch (e) {
-        logger.error(e as string, correlationId);
+        logger.error(e as string, "");
     }
 
     return new MemoryStorage();
@@ -1886,8 +1882,7 @@ export const DEFAULT_BROWSER_CACHE_MANAGER = (
     clientId: string,
     logger: Logger,
     performanceClient: IPerformanceClient,
-    eventHandler: EventHandler,
-    correlationId: string
+    eventHandler: EventHandler
 ): BrowserCacheManager => {
     const cacheOptions: Required<CacheOptions> = {
         cacheLocation: BrowserCacheLocation.MemoryStorage,
@@ -1899,7 +1894,6 @@ export const DEFAULT_BROWSER_CACHE_MANAGER = (
         DEFAULT_CRYPTO_IMPLEMENTATION,
         logger,
         performanceClient,
-        eventHandler,
-        correlationId
+        eventHandler
     );
 };

--- a/lib/msal-browser/src/cache/IAsyncStorage.ts
+++ b/lib/msal-browser/src/cache/IAsyncStorage.ts
@@ -7,30 +7,35 @@ export interface IAsyncStorage<T> {
     /**
      * Get the item from the asynchronous storage object matching the given key.
      * @param key
+     * @param correlationId
      */
-    getItem(key: string): Promise<T | null>;
+    getItem(key: string, correlationId: string): Promise<T | null>;
 
     /**
      * Sets the item in the asynchronous storage object with the given key.
      * @param key
      * @param value
+     * @param correlationId
      */
-    setItem(key: string, value: T): Promise<void>;
+    setItem(key: string, value: T, correlationId: string): Promise<void>;
 
     /**
      * Removes the item in the asynchronous storage object matching the given key.
      * @param key
+     * @param correlationId
      */
-    removeItem(key: string): Promise<void>;
+    removeItem(key: string, correlationId: string): Promise<void>;
 
     /**
      * Get all the keys from the asynchronous storage object as an iterable array of strings.
+     * @param correlationId
      */
-    getKeys(): Promise<string[]>;
+    getKeys(correlationId: string): Promise<string[]>;
 
     /**
      * Returns true or false if the given key is present in the cache.
      * @param key
+     * @param correlationId
      */
-    containsKey(key: string): Promise<boolean>;
+    containsKey(key: string, correlationId: string): Promise<boolean>;
 }

--- a/lib/msal-browser/src/cache/LocalStorage.ts
+++ b/lib/msal-browser/src/cache/LocalStorage.ts
@@ -150,7 +150,9 @@ export class LocalStorage implements IWindowStorage<string> {
         )(correlationId);
 
         // Register listener for cache updates in other tabs
-        this.broadcast.addEventListener("message", this.updateCache.bind(this));
+        this.broadcast.addEventListener("message", (event: MessageEvent) => {
+            this.updateCache(event, correlationId);
+        });
 
         this.initialized = true;
     }
@@ -454,8 +456,11 @@ export class LocalStorage implements IWindowStorage<string> {
         return context;
     }
 
-    private updateCache(event: MessageEvent): void {
-        this.logger.trace("Updating internal cache from broadcast event");
+    private updateCache(event: MessageEvent, correlationId: string): void {
+        this.logger.trace(
+            "Updating internal cache from broadcast event",
+            correlationId
+        );
         const perfMeasurement = this.performanceClient.startMeasurement(
             BrowserRootPerformanceEvents.LocalStorageUpdated
         );
@@ -463,14 +468,15 @@ export class LocalStorage implements IWindowStorage<string> {
 
         const { key, value, context } = event.data;
         if (!key) {
-            this.logger.error("Broadcast event missing key");
+            this.logger.error("Broadcast event missing key", correlationId);
             perfMeasurement.end({ success: false, errorCode: "noKey" });
             return;
         }
 
         if (context && context !== this.clientId) {
             this.logger.trace(
-                `Ignoring broadcast event from clientId: '${context}'`
+                `Ignoring broadcast event from clientId: '${context}'`,
+                correlationId
             );
             perfMeasurement.end({
                 success: false,
@@ -481,10 +487,16 @@ export class LocalStorage implements IWindowStorage<string> {
 
         if (!value) {
             this.memoryStorage.removeItem(key);
-            this.logger.verbose("Removed item from internal cache");
+            this.logger.verbose(
+                "Removed item from internal cache",
+                correlationId
+            );
         } else {
             this.memoryStorage.setItem(key, value);
-            this.logger.verbose("Updated item in internal cache");
+            this.logger.verbose(
+                "Updated item in internal cache",
+                correlationId
+            );
         }
         perfMeasurement.end({ success: true });
     }

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -83,6 +83,7 @@ export async function loadExternalTokens(
         logger,
         browserConfig.telemetry.client,
         new EventHandler(logger),
+        correlationId,
         buildStaticAuthorityOptions(browserConfig.auth)
     );
 
@@ -96,7 +97,8 @@ export async function loadExternalTokens(
               storage,
               authorityOptions,
               logger,
-              request.correlationId || BrowserCrypto.createNewGuid()
+              request.correlationId || BrowserCrypto.createNewGuid(),
+              browserConfig.telemetry.client
           )
         : undefined;
 
@@ -177,7 +179,7 @@ async function loadAccount(
     idTokenClaims?: TokenClaims,
     authority?: Authority
 ): Promise<AccountEntity> {
-    logger.verbose("TokenCache - loading account");
+    logger.verbose("TokenCache - loading account", correlationId);
 
     if (request.account) {
         const accountEntity =
@@ -188,7 +190,8 @@ async function loadAccount(
         return accountEntity;
     } else if (!authority || (!clientInfo && !idTokenClaims)) {
         logger.error(
-            "TokenCache - if an account is not provided on the request, authority and either clientInfo or idToken must be provided instead."
+            "TokenCache - if an account is not provided on the request, authority and either clientInfo or idToken must be provided instead.",
+            correlationId
         );
         throw createBrowserAuthError(BrowserAuthErrorCodes.unableToLoadToken);
     }
@@ -198,6 +201,7 @@ async function loadAccount(
         authority.authorityType,
         logger,
         cryptoObj,
+        correlationId,
         idTokenClaims
     );
 
@@ -241,11 +245,14 @@ async function loadIdToken(
     clientId: string
 ): Promise<IdTokenEntity | null> {
     if (!response.id_token) {
-        logger.verbose("TokenCache - no id token found in response");
+        logger.verbose(
+            "TokenCache - no id token found in response",
+            correlationId
+        );
         return null;
     }
 
-    logger.verbose("TokenCache - loading id token");
+    logger.verbose("TokenCache - loading id token", correlationId);
     const idTokenEntity = CacheHelpers.createIdTokenEntity(
         homeAccountId,
         environment,
@@ -280,21 +287,26 @@ async function loadAccessToken(
     clientId: string
 ): Promise<AccessTokenEntity | null> {
     if (!response.access_token) {
-        logger.verbose("TokenCache - no access token found in response");
+        logger.verbose(
+            "TokenCache - no access token found in response",
+            correlationId
+        );
         return null;
     } else if (!response.expires_in) {
         logger.error(
-            "TokenCache - no expiration set on the access token. Cannot add it to the cache."
+            "TokenCache - no expiration set on the access token. Cannot add it to the cache.",
+            correlationId
         );
         return null;
     } else if (!response.scope && (!request.scopes || !request.scopes.length)) {
         logger.error(
-            "TokenCache - scopes not specified in the request or response. Cannot add token to the cache."
+            "TokenCache - scopes not specified in the request or response. Cannot add token to the cache.",
+            correlationId
         );
         return null;
     }
 
-    logger.verbose("TokenCache - loading access token");
+    logger.verbose("TokenCache - loading access token", correlationId);
 
     const scopes = response.scope
         ? ScopeSet.fromString(response.scope)
@@ -341,11 +353,14 @@ async function loadRefreshToken(
     clientId: string
 ): Promise<RefreshTokenEntity | null> {
     if (!response.refresh_token) {
-        logger.verbose("TokenCache - no refresh token found in response");
+        logger.verbose(
+            "TokenCache - no refresh token found in response",
+            correlationId
+        );
         return null;
     }
 
-    logger.verbose("TokenCache - loading refresh token");
+    logger.verbose("TokenCache - loading refresh token", correlationId);
     const refreshTokenEntity = CacheHelpers.createRefreshTokenEntity(
         homeAccountId,
         environment,

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -83,7 +83,6 @@ export async function loadExternalTokens(
         logger,
         browserConfig.telemetry.client,
         new EventHandler(logger),
-        correlationId,
         buildStaticAuthorityOptions(browserConfig.auth)
     );
 

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -324,7 +324,8 @@ export function buildConfiguration(
                 createClientConfigurationError(
                     ClientConfigurationErrorCodes.cannotSetOIDCOptions
                 )
-            )
+            ),
+            ""
         );
     }
 

--- a/lib/msal-browser/src/controllers/ControllerFactory.ts
+++ b/lib/msal-browser/src/controllers/ControllerFactory.ts
@@ -10,31 +10,38 @@ import { Configuration } from "../config/Configuration.js";
 import { StandardController } from "./StandardController.js";
 import { NestedAppAuthController } from "./NestedAppAuthController.js";
 import { InitializeApplicationRequest } from "../request/InitializeApplicationRequest.js";
+import { createNewGuid } from "../crypto/BrowserCrypto.js";
 
 export async function createV3Controller(
     config: Configuration,
     request?: InitializeApplicationRequest
 ): Promise<IController> {
+    const correlationId = request?.correlationId || createNewGuid();
     const standard = new StandardOperatingContext(config);
 
-    await standard.initialize();
-    return StandardController.createController(standard, request);
+    await standard.initialize(correlationId);
+    return StandardController.createController(standard, { correlationId });
 }
 
 export async function createController(
-    config: Configuration
+    config: Configuration,
+    request?: InitializeApplicationRequest
 ): Promise<IController | null> {
+    const correlationId = request?.correlationId || createNewGuid();
     const standard = new StandardOperatingContext(config);
     const nestedApp = new NestedAppOperatingContext(config);
 
-    const operatingContexts = [standard.initialize(), nestedApp.initialize()];
+    const operatingContexts = [
+        standard.initialize(correlationId),
+        nestedApp.initialize(correlationId),
+    ];
 
     await Promise.all(operatingContexts);
 
     if (nestedApp.isAvailable()) {
         return NestedAppAuthController.createController(nestedApp);
     } else if (standard.isAvailable()) {
-        return StandardController.createController(standard);
+        return StandardController.createController(standard, { correlationId });
     } else {
         // Since neither of the actual operating contexts are available keep the UnknownOperatingContextController
         return null;

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -88,7 +88,6 @@ export class NestedAppAuthController implements IController {
     protected currentAccountContext: AccountContext | null;
 
     constructor(operatingContext: NestedAppOperatingContext) {
-        const correlationId = "";
         this.operatingContext = operatingContext;
         const proxy = this.operatingContext.getBridgeProxy();
         if (proxy !== undefined) {
@@ -121,15 +120,13 @@ export class NestedAppAuthController implements IController {
                   this.logger,
                   this.performanceClient,
                   this.eventHandler,
-                  correlationId,
                   buildStaticAuthorityOptions(this.config.auth)
               )
             : DEFAULT_BROWSER_CACHE_MANAGER(
                   this.config.auth.clientId,
                   this.logger,
                   this.performanceClient,
-                  this.eventHandler,
-                  correlationId
+                  this.eventHandler
               );
 
         this.nestedAppAuthAdapter = new NestedAppAuthAdapter(

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -88,6 +88,7 @@ export class NestedAppAuthController implements IController {
     protected currentAccountContext: AccountContext | null;
 
     constructor(operatingContext: NestedAppOperatingContext) {
+        const correlationId = "";
         this.operatingContext = operatingContext;
         const proxy = this.operatingContext.getBridgeProxy();
         if (proxy !== undefined) {
@@ -120,13 +121,15 @@ export class NestedAppAuthController implements IController {
                   this.logger,
                   this.performanceClient,
                   this.eventHandler,
+                  correlationId,
                   buildStaticAuthorityOptions(this.config.auth)
               )
             : DEFAULT_BROWSER_CACHE_MANAGER(
                   this.config.auth.clientId,
                   this.logger,
                   this.performanceClient,
-                  this.eventHandler
+                  this.eventHandler,
+                  correlationId
               );
 
         this.nestedAppAuthAdapter = new NestedAppAuthAdapter(
@@ -197,6 +200,7 @@ export class NestedAppAuthController implements IController {
         request: PopupRequest | RedirectRequest
     ): Promise<AuthenticationResult> {
         const validRequest = this.ensureValidRequest(request);
+        const correlationId = validRequest.correlationId || createNewGuid();
 
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
@@ -206,7 +210,7 @@ export class NestedAppAuthController implements IController {
 
         const atPopupMeasurement = this.performanceClient.startMeasurement(
             RootPerformanceEvents.AcquireTokenPopup,
-            validRequest.correlationId
+            correlationId
         );
 
         atPopupMeasurement?.add({ nestedAppAuthRequest: true });
@@ -233,7 +237,7 @@ export class NestedAppAuthController implements IController {
             } catch (error) {
                 this.logger.warningPii(
                     `Failed to hydrate cache. Error: ${error}`,
-                    validRequest.correlationId
+                    correlationId
                 );
             }
 
@@ -293,6 +297,7 @@ export class NestedAppAuthController implements IController {
         request: SilentRequest
     ): Promise<AuthenticationResult> {
         const validRequest = this.ensureValidRequest(request);
+        const correlationId = validRequest.correlationId || createNewGuid();
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
             InteractionType.Silent,
@@ -313,7 +318,7 @@ export class NestedAppAuthController implements IController {
         // proceed with acquiring tokens via the host
         const ssoSilentMeasurement = this.performanceClient.startMeasurement(
             RootPerformanceEvents.SsoSilent,
-            validRequest.correlationId
+            correlationId
         );
 
         ssoSilentMeasurement?.increment({
@@ -345,7 +350,7 @@ export class NestedAppAuthController implements IController {
             } catch (error) {
                 this.logger.warningPii(
                     `Failed to hydrate cache. Error: ${error}`,
-                    validRequest.correlationId
+                    correlationId
                 );
             }
 
@@ -399,9 +404,10 @@ export class NestedAppAuthController implements IController {
     private async acquireTokenFromCache(
         request: SilentRequest
     ): Promise<AuthenticationResult | null> {
+        const correlationId = request.correlationId || createNewGuid();
         const atsMeasurement = this.performanceClient.startMeasurement(
             RootPerformanceEvents.AcquireTokenSilent,
-            request.correlationId
+            correlationId
         );
 
         atsMeasurement?.add({
@@ -411,7 +417,8 @@ export class NestedAppAuthController implements IController {
         // if the request has claims, we cannot look up in the cache
         if (request.claims) {
             this.logger.verbose(
-                "Claims are present in the request, skipping cache lookup"
+                "Claims are present in the request, skipping cache lookup",
+                correlationId
             );
             return null;
         }
@@ -419,7 +426,8 @@ export class NestedAppAuthController implements IController {
         // if the request has forceRefresh, we cannot look up in the cache
         if (request.forceRefresh) {
             this.logger.verbose(
-                "forceRefresh is set to true, skipping cache lookup"
+                "forceRefresh is set to true, skipping cache lookup",
+                correlationId
             );
             return null;
         }
@@ -457,7 +465,8 @@ export class NestedAppAuthController implements IController {
         }
 
         this.logger.warning(
-            "Cached tokens are not found for the account, proceeding with silent token request."
+            "Cached tokens are not found for the account, proceeding with silent token request.",
+            correlationId
         );
 
         this.eventHandler.emitEvent(
@@ -497,13 +506,15 @@ export class NestedAppAuthController implements IController {
         // fall back to brokering if no cached account is found
         if (!currentAccount) {
             this.logger.verbose(
-                "No active account found, falling back to the host"
+                "No active account found, falling back to the host",
+                correlationId
             );
             return Promise.resolve(null);
         }
 
         this.logger.verbose(
-            "active account found, attempting to acquire token silently"
+            "active account found, attempting to acquire token silently",
+            correlationId
         );
 
         const authRequest: BaseAuthRequest = {
@@ -526,7 +537,7 @@ export class NestedAppAuthController implements IController {
 
         // If there is no access token, log it and return null
         if (!cachedAccessToken) {
-            this.logger.verbose("No cached access token found");
+            this.logger.verbose("No cached access token found", correlationId);
             return Promise.resolve(null);
         } else if (
             TimeUtils.wasClockTurnedBack(cachedAccessToken.cachedAt) ||
@@ -535,7 +546,10 @@ export class NestedAppAuthController implements IController {
                 this.config.system.tokenRenewalOffsetSeconds
             )
         ) {
-            this.logger.verbose("Cached access token has expired");
+            this.logger.verbose(
+                "Cached access token has expired",
+                correlationId
+            );
             return Promise.resolve(null);
         }
 
@@ -547,7 +561,7 @@ export class NestedAppAuthController implements IController {
         );
 
         if (!cachedIdToken) {
-            this.logger.verbose("No cached id token found");
+            this.logger.verbose("No cached id token found", correlationId);
             return Promise.resolve(null);
         }
 
@@ -845,7 +859,8 @@ export class NestedAppAuthController implements IController {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setNavigationClient(navigationClient: INavigationClient): void {
         this.logger.warning(
-            "setNavigationClient is not supported in nested app auth"
+            "setNavigationClient is not supported in nested app auth",
+            ""
         );
     }
 
@@ -882,7 +897,7 @@ export class NestedAppAuthController implements IController {
             | RedirectRequest
             | PopupRequest
     ): Promise<void> {
-        this.logger.verbose("hydrateCache called");
+        this.logger.verbose("hydrateCache called", result.correlationId);
 
         const accountEntity =
             AccountEntityUtils.createAccountEntityFromAccountInfo(

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -244,15 +244,13 @@ export class StandardController implements IController {
                   this.logger,
                   this.performanceClient,
                   this.eventHandler,
-                  "",
                   buildStaticAuthorityOptions(this.config.auth)
               )
             : DEFAULT_BROWSER_CACHE_MANAGER(
                   this.config.auth.clientId,
                   this.logger,
                   this.performanceClient,
-                  this.eventHandler,
-                  ""
+                  this.eventHandler
               );
 
         // initialize in memory storage for native flows
@@ -266,8 +264,7 @@ export class StandardController implements IController {
             this.browserCrypto,
             this.logger,
             this.performanceClient,
-            this.eventHandler,
-            ""
+            this.eventHandler
         );
 
         this.activeSilentTokenRequests = new Map();

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -472,13 +472,15 @@ export class StandardController implements IController {
         let redirectResponse: Promise<AuthenticationResult | null>;
         try {
             if (useNative && this.platformAuthProvider) {
+                const correlationId =
+                    platformBrokerRequest?.correlationId || "";
                 rootMeasurement = this.performanceClient.startMeasurement(
                     BrowserRootPerformanceEvents.AcquireTokenRedirect,
-                    platformBrokerRequest?.correlationId || ""
+                    correlationId
                 );
                 this.logger.trace(
                     "handleRedirectPromise - acquiring token from native platform",
-                    ""
+                    correlationId
                 );
                 const nativeClient = new PlatformAuthInteractionClient(
                     this.config,
@@ -504,7 +506,7 @@ export class StandardController implements IController {
                 )(this.performanceClient, rootMeasurement.event.correlationId);
             } else {
                 const [standardRequest, codeVerifier] =
-                    this.browserStorage.getCachedRequest();
+                    this.browserStorage.getCachedRequest("");
                 const correlationId = standardRequest.correlationId;
                 // Reset rootMeasurement now that we have correlationId
                 rootMeasurement = this.performanceClient.startMeasurement(
@@ -525,14 +527,14 @@ export class StandardController implements IController {
                 )(standardRequest, codeVerifier, rootMeasurement, options);
             }
         } catch (e) {
-            this.browserStorage.resetRequestCache();
+            this.browserStorage.resetRequestCache("");
             throw e;
         }
 
         return redirectResponse
             .then((result: AuthenticationResult | null) => {
                 if (result) {
-                    this.browserStorage.resetRequestCache();
+                    this.browserStorage.resetRequestCache(result.correlationId);
                     // Emit login event if number of accounts change
                     const isLoggingIn =
                         loggedInAccounts.length < this.getAllAccounts().length;
@@ -581,7 +583,9 @@ export class StandardController implements IController {
                 return result;
             })
             .catch((e) => {
-                this.browserStorage.resetRequestCache();
+                this.browserStorage.resetRequestCache(
+                    rootMeasurement.event.correlationId
+                );
                 const eventError = e as EventError;
                 // Emit login event if there is an account
                 if (loggedInAccounts.length > 0) {
@@ -724,7 +728,7 @@ export class StandardController implements IController {
 
             return await result;
         } catch (e) {
-            this.browserStorage.resetRequestCache();
+            this.browserStorage.resetRequestCache(correlationId);
             /*
              * Pre-redirect event completes before navigation occurs.
              * Timed out navigation needs to be instrumented separately as a post-redirect event.

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -244,13 +244,15 @@ export class StandardController implements IController {
                   this.logger,
                   this.performanceClient,
                   this.eventHandler,
+                  "",
                   buildStaticAuthorityOptions(this.config.auth)
               )
             : DEFAULT_BROWSER_CACHE_MANAGER(
                   this.config.auth.clientId,
                   this.logger,
                   this.performanceClient,
-                  this.eventHandler
+                  this.eventHandler,
+                  ""
               );
 
         // initialize in memory storage for native flows
@@ -264,7 +266,8 @@ export class StandardController implements IController {
             this.browserCrypto,
             this.logger,
             this.performanceClient,
-            this.eventHandler
+            this.eventHandler,
+            ""
         );
 
         this.activeSilentTokenRequests = new Map();
@@ -290,7 +293,7 @@ export class StandardController implements IController {
         if (!correlationId) {
             return;
         }
-        this.logger.info("Perf: Visibility change detected");
+        this.logger.info("Perf: Visibility change detected", correlationId);
         this.performanceClient.incrementFields(
             { visibilityChangeCount: 1 },
             correlationId
@@ -305,16 +308,21 @@ export class StandardController implements IController {
         request?: InitializeApplicationRequest,
         isBroker?: boolean
     ): Promise<void> {
-        this.logger.trace("initialize called");
+        const correlationId = this.getRequestCorrelationId(request);
+        this.logger.trace("initialize called", correlationId);
         if (this.initialized) {
             this.logger.info(
-                "initialize has already been called, exiting early."
+                "initialize has already been called, exiting early.",
+                correlationId
             );
             return;
         }
 
         if (!this.isBrowserEnvironment) {
-            this.logger.info("in non-browser environment, exiting early.");
+            this.logger.info(
+                "in non-browser environment, exiting early.",
+                correlationId
+            );
             this.initialized = true;
             this.eventHandler.emitEvent(EventType.INITIALIZE_END);
             return;
@@ -332,7 +340,7 @@ export class StandardController implements IController {
         // Broker applications are initialized twice, so we avoid double-counting it
         if (!isBroker) {
             try {
-                this.logMultipleInstances(initMeasurement);
+                this.logMultipleInstances(initMeasurement, initCorrelationId);
             } catch {}
         }
 
@@ -354,7 +362,7 @@ export class StandardController implements IController {
                     this.config.system.nativeBrokerHandshakeTimeout
                 );
             } catch (e) {
-                this.logger.verbose(e as string);
+                this.logger.verbose(e as string, initCorrelationId);
             }
         }
 
@@ -388,7 +396,7 @@ export class StandardController implements IController {
     async handleRedirectPromise(
         options?: HandleRedirectPromiseOptions
     ): Promise<AuthenticationResult | null> {
-        this.logger.verbose("handleRedirectPromise called");
+        this.logger.verbose("handleRedirectPromise called", "");
         // Block token acquisition before initialize has been called
         BrowserUtils.blockAPICallsBeforeInitialize(this.initialized);
         if (this.isBrowserEnvironment) {
@@ -403,18 +411,21 @@ export class StandardController implements IController {
                 response = this.handleRedirectPromiseInternal(options);
                 this.redirectResponse.set(redirectResponseKey, response);
                 this.logger.verbose(
-                    "handleRedirectPromise has been called for the first time, storing the promise"
+                    "handleRedirectPromise has been called for the first time, storing the promise",
+                    ""
                 );
             } else {
                 this.logger.verbose(
-                    "handleRedirectPromise has been called previously, returning the result from the first call"
+                    "handleRedirectPromise has been called previously, returning the result from the first call",
+                    ""
                 );
             }
 
             return response;
         }
         this.logger.verbose(
-            "handleRedirectPromise returns null, not browser environment"
+            "handleRedirectPromise returns null, not browser environment",
+            ""
         );
         return null;
     }
@@ -429,7 +440,8 @@ export class StandardController implements IController {
     ): Promise<AuthenticationResult | null> {
         if (!this.browserStorage.isInteractionInProgress(true)) {
             this.logger.info(
-                "handleRedirectPromise called but there is no interaction in progress, returning null."
+                "handleRedirectPromise called but there is no interaction in progress, returning null.",
+                ""
             );
             return null;
         }
@@ -438,7 +450,8 @@ export class StandardController implements IController {
             this.browserStorage.getInteractionInProgress()?.type;
         if (interactionType === INTERACTION_TYPE.SIGNOUT) {
             this.logger.verbose(
-                "handleRedirectPromise removing interaction_in_progress flag and returning null after sign-out"
+                "handleRedirectPromise removing interaction_in_progress flag and returning null after sign-out",
+                ""
             );
             this.browserStorage.setInteractionInProgress(false);
             return Promise.resolve(null);
@@ -467,7 +480,8 @@ export class StandardController implements IController {
                     platformBrokerRequest?.correlationId || ""
                 );
                 this.logger.trace(
-                    "handleRedirectPromise - acquiring token from native platform"
+                    "handleRedirectPromise - acquiring token from native platform",
+                    ""
                 );
                 const nativeClient = new PlatformAuthInteractionClient(
                     this.config,
@@ -501,7 +515,8 @@ export class StandardController implements IController {
                     correlationId
                 );
                 this.logger.trace(
-                    "handleRedirectPromise - acquiring token from web flow"
+                    "handleRedirectPromise - acquiring token from web flow",
+                    correlationId
                 );
                 const redirectClient = this.createRedirectClient(correlationId);
                 redirectResponse = invokeAsync(
@@ -531,7 +546,8 @@ export class StandardController implements IController {
                             result
                         );
                         this.logger.verbose(
-                            "handleRedirectResponse returned result, login success"
+                            "handleRedirectResponse returned result, login success",
+                            result.correlationId
                         );
                     } else {
                         this.eventHandler.emitEvent(
@@ -540,7 +556,8 @@ export class StandardController implements IController {
                             result
                         );
                         this.logger.verbose(
-                            "handleRedirectResponse returned result, acquire token success"
+                            "handleRedirectResponse returned result, acquire token success",
+                            result.correlationId
                         );
                     }
                     rootMeasurement.end({
@@ -694,7 +711,8 @@ export class StandardController implements IController {
                             return redirectClient.acquireToken(request);
                         } else if (e instanceof InteractionRequiredAuthError) {
                             this.logger.verbose(
-                                "acquireTokenRedirect - Resolving interaction required error thrown by native broker by falling back to web flow"
+                                "acquireTokenRedirect - Resolving interaction required error thrown by native broker by falling back to web flow",
+                                correlationId
                             );
                             const redirectClient =
                                 this.createRedirectClient(correlationId);
@@ -825,7 +843,8 @@ export class StandardController implements IController {
                         return popupClient.acquireToken(request, pkce);
                     } else if (e instanceof InteractionRequiredAuthError) {
                         this.logger.verbose(
-                            "acquireTokenPopup - Resolving interaction required error thrown by native broker by falling back to web flow"
+                            "acquireTokenPopup - Resolving interaction required error thrown by native broker by falling back to web flow",
+                            correlationId
                         );
                         const popupClient =
                             this.createPopupClient(correlationId);
@@ -910,10 +929,6 @@ export class StandardController implements IController {
             return;
         }
 
-        this.logger.info(
-            "Perf: Visibility change detected in ",
-            measurement.event.name
-        );
         measurement.increment({
             visibilityChangeCount: 1,
         });
@@ -1179,14 +1194,12 @@ export class StandardController implements IController {
     private async acquireTokenByCodeAsync(
         request: AuthorizationCodeRequest
     ): Promise<AuthenticationResult> {
-        this.logger.trace(
-            "acquireTokenByCodeAsync called",
-            request.correlationId
-        );
+        const correlationId = this.getRequestCorrelationId(request);
+        this.logger.trace("acquireTokenByCodeAsync called", correlationId);
         this.acquireTokenByCodeAsyncMeasurement =
             this.performanceClient.startMeasurement(
                 BrowserPerformanceEvents.AcquireTokenByCodeAsync,
-                request.correlationId
+                correlationId
             );
         this.acquireTokenByCodeAsyncMeasurement?.increment({
             visibilityChangeCount: 0,
@@ -1195,9 +1208,8 @@ export class StandardController implements IController {
             "visibilitychange",
             this.trackPageVisibilityWithMeasurement
         );
-        const silentAuthCodeClient = this.createSilentAuthCodeClient(
-            request.correlationId
-        );
+        const silentAuthCodeClient =
+            this.createSilentAuthCodeClient(correlationId);
         const silentTokenResult = await silentAuthCodeClient
             .acquireToken(request)
             .then((response) => {
@@ -1362,7 +1374,6 @@ export class StandardController implements IController {
      */
     async clearCache(logoutRequest?: ClearCacheRequest): Promise<void> {
         if (!this.isBrowserEnvironment) {
-            this.logger.info("in non-browser environment, returning early.");
             return;
         }
         const correlationId = this.getRequestCorrelationId(logoutRequest);
@@ -1490,7 +1501,7 @@ export class StandardController implements IController {
             | RedirectRequest
             | PopupRequest
     ): Promise<void> {
-        this.logger.verbose("hydrateCache called");
+        this.logger.verbose("hydrateCache called", result.correlationId);
 
         // Account gets saved to browser storage regardless of native or not
         const accountEntity =
@@ -1506,7 +1517,8 @@ export class StandardController implements IController {
 
         if (result.fromPlatformBroker) {
             this.logger.verbose(
-                "Response was from native broker, storing in-memory"
+                "Response was from native broker, storing in-memory",
+                result.correlationId
             );
             // Tokens from native broker are stored in-memory
             return this.nativeInternalStorage.hydrateCache(result, request);
@@ -1527,7 +1539,8 @@ export class StandardController implements IController {
         accountId?: string,
         cacheLookupPolicy?: CacheLookupPolicy
     ): Promise<AuthenticationResult> {
-        this.logger.trace("acquireTokenNative called");
+        const correlationId = this.getRequestCorrelationId(request);
+        this.logger.trace("acquireTokenNative called", correlationId);
         if (!this.platformAuthProvider) {
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.nativeConnectionNotEstablished
@@ -1546,7 +1559,7 @@ export class StandardController implements IController {
             this.platformAuthProvider,
             accountId || this.getNativeAccountId(request),
             this.nativeInternalStorage,
-            request.correlationId
+            correlationId
         );
 
         return nativeClient.acquireToken(request, cacheLookupPolicy);
@@ -1560,10 +1573,12 @@ export class StandardController implements IController {
         request: RedirectRequest | PopupRequest | SsoSilentRequest,
         accountId?: string
     ): boolean {
-        this.logger.trace("canUsePlatformBroker called");
+        const correlationId = this.getRequestCorrelationId(request);
+        this.logger.trace("canUsePlatformBroker called", correlationId);
         if (!this.platformAuthProvider) {
             this.logger.trace(
-                "canUsePlatformBroker: platform broker unavilable, returning false"
+                "canUsePlatformBroker: platform broker unavilable, returning false",
+                correlationId
             );
             return false;
         }
@@ -1572,12 +1587,14 @@ export class StandardController implements IController {
             !isPlatformAuthAllowed(
                 this.config,
                 this.logger,
+                correlationId,
                 this.platformAuthProvider,
                 request.authenticationScheme
             )
         ) {
             this.logger.trace(
-                "canUsePlatformBroker: isBrokerAvailable returned false, returning false"
+                "canUsePlatformBroker: isBrokerAvailable returned false, returning false",
+                correlationId
             );
             return false;
         }
@@ -1588,12 +1605,14 @@ export class StandardController implements IController {
                 case Constants.PromptValue.CONSENT:
                 case Constants.PromptValue.LOGIN:
                     this.logger.trace(
-                        "canUsePlatformBroker: prompt is compatible with platform broker flow"
+                        "canUsePlatformBroker: prompt is compatible with platform broker flow",
+                        correlationId
                     );
                     break;
                 default:
                     this.logger.trace(
-                        `canUsePlatformBroker: prompt = '${request.prompt}' is not compatible with platform broker flow, returning false`
+                        `canUsePlatformBroker: prompt = '${request.prompt}' is not compatible with platform broker flow, returning false`,
+                        correlationId
                     );
                     return false;
             }
@@ -1601,7 +1620,8 @@ export class StandardController implements IController {
 
         if (!accountId && !this.getNativeAccountId(request)) {
             this.logger.trace(
-                "canUsePlatformBroker: nativeAccountId is not available, returning false"
+                "canUsePlatformBroker: nativeAccountId is not available, returning false",
+                correlationId
             );
             return false;
         }
@@ -1632,7 +1652,7 @@ export class StandardController implements IController {
      * Returns new instance of the Popup Interaction Client
      * @param correlationId
      */
-    public createPopupClient(correlationId?: string): PopupClient {
+    public createPopupClient(correlationId: string): PopupClient {
         return new PopupClient(
             this.config,
             this.browserStorage,
@@ -1642,8 +1662,8 @@ export class StandardController implements IController {
             this.navigationClient,
             this.performanceClient,
             this.nativeInternalStorage,
-            this.platformAuthProvider,
-            correlationId
+            correlationId,
+            this.platformAuthProvider
         );
     }
 
@@ -1651,7 +1671,7 @@ export class StandardController implements IController {
      * Returns new instance of the Redirect Interaction Client
      * @param correlationId
      */
-    protected createRedirectClient(correlationId?: string): RedirectClient {
+    protected createRedirectClient(correlationId: string): RedirectClient {
         return new RedirectClient(
             this.config,
             this.browserStorage,
@@ -1661,8 +1681,8 @@ export class StandardController implements IController {
             this.navigationClient,
             this.performanceClient,
             this.nativeInternalStorage,
-            this.platformAuthProvider,
-            correlationId
+            correlationId,
+            this.platformAuthProvider
         );
     }
 
@@ -1670,9 +1690,7 @@ export class StandardController implements IController {
      * Returns new instance of the Silent Iframe Interaction Client
      * @param correlationId
      */
-    public createSilentIframeClient(
-        correlationId?: string
-    ): SilentIframeClient {
+    public createSilentIframeClient(correlationId: string): SilentIframeClient {
         return new SilentIframeClient(
             this.config,
             this.browserStorage,
@@ -1683,8 +1701,8 @@ export class StandardController implements IController {
             ApiId.ssoSilent,
             this.performanceClient,
             this.nativeInternalStorage,
-            this.platformAuthProvider,
-            correlationId
+            correlationId,
+            this.platformAuthProvider
         );
     }
 
@@ -1692,7 +1710,7 @@ export class StandardController implements IController {
      * Returns new instance of the Silent Cache Interaction Client
      */
     protected createSilentCacheClient(
-        correlationId?: string
+        correlationId: string
     ): SilentCacheClient {
         return new SilentCacheClient(
             this.config,
@@ -1702,8 +1720,8 @@ export class StandardController implements IController {
             this.eventHandler,
             this.navigationClient,
             this.performanceClient,
-            this.platformAuthProvider,
-            correlationId
+            correlationId,
+            this.platformAuthProvider
         );
     }
 
@@ -1711,7 +1729,7 @@ export class StandardController implements IController {
      * Returns new instance of the Silent Refresh Interaction Client
      */
     protected createSilentRefreshClient(
-        correlationId?: string
+        correlationId: string
     ): SilentRefreshClient {
         return new SilentRefreshClient(
             this.config,
@@ -1721,8 +1739,8 @@ export class StandardController implements IController {
             this.eventHandler,
             this.navigationClient,
             this.performanceClient,
-            this.platformAuthProvider,
-            correlationId
+            correlationId,
+            this.platformAuthProvider
         );
     }
 
@@ -1730,7 +1748,7 @@ export class StandardController implements IController {
      * Returns new instance of the Silent AuthCode Interaction Client
      */
     protected createSilentAuthCodeClient(
-        correlationId?: string
+        correlationId: string
     ): SilentAuthCodeClient {
         return new SilentAuthCodeClient(
             this.config,
@@ -1741,8 +1759,8 @@ export class StandardController implements IController {
             this.navigationClient,
             ApiId.acquireTokenByCode,
             this.performanceClient,
-            this.platformAuthProvider,
-            correlationId
+            correlationId,
+            this.platformAuthProvider
         );
     }
 
@@ -2132,7 +2150,8 @@ export class StandardController implements IController {
                         );
                     } else {
                         this.logger.info(
-                            `Iframe request with correlationId: '${activeCorrelationId}' failed. Interaction is required.`
+                            `Iframe request with correlationId: '${activeCorrelationId}' failed. Interaction is required.`,
+                            silentRequest.correlationId
                         );
                         // If previous iframe request failed, it's unlikely to succeed this time. Throw original error.
                         throw refreshTokenError;
@@ -2208,13 +2227,15 @@ export class StandardController implements IController {
             isPlatformAuthAllowed(
                 this.config,
                 this.logger,
+                silentRequest.correlationId,
                 this.platformAuthProvider,
                 silentRequest.authenticationScheme
             ) &&
             silentRequest.account.nativeAccountId
         ) {
             this.logger.verbose(
-                "acquireTokenSilent - attempting to acquire token from native platform"
+                "acquireTokenSilent - attempting to acquire token from native platform",
+                silentRequest.correlationId
             );
             return this.acquireTokenNative(
                 silentRequest,
@@ -2225,7 +2246,8 @@ export class StandardController implements IController {
                 // If native token acquisition fails for availability reasons fallback to web flow
                 if (e instanceof NativeAuthError && isFatalNativeAuthError(e)) {
                     this.logger.verbose(
-                        "acquireTokenSilent - native platform unavailable, falling back to web flow"
+                        "acquireTokenSilent - native platform unavailable, falling back to web flow",
+                        silentRequest.correlationId
                     );
                     this.platformAuthProvider = undefined; // Prevent future requests from continuing to attempt
                     // Cache will not contain tokens, given that previous WAM requests succeeded. Skip cache and RT renewal and go straight to iframe renewal
@@ -2237,12 +2259,14 @@ export class StandardController implements IController {
             });
         } else {
             this.logger.verbose(
-                "acquireTokenSilent - attempting to acquire token from web flow"
+                "acquireTokenSilent - attempting to acquire token from web flow",
+                silentRequest.correlationId
             );
             // add logs to identify embedded cache retrieval
             if (cacheLookupPolicy === CacheLookupPolicy.AccessToken) {
                 this.logger.verbose(
-                    "acquireTokenSilent - cache lookup policy set to AccessToken, attempting to acquire token from local cache"
+                    "acquireTokenSilent - cache lookup policy set to AccessToken, attempting to acquire token from local cache",
+                    silentRequest.correlationId
                 );
             }
             return invokeAsync(
@@ -2280,7 +2304,7 @@ export class StandardController implements IController {
      * @param correlationId
      */
     private async preGeneratePkceCodes(correlationId: string): Promise<void> {
-        this.logger.verbose("Generating new PKCE codes");
+        this.logger.verbose("Generating new PKCE codes", correlationId);
         this.pkceCode = await invokeAsync(
             generatePkceCodes,
             BrowserPerformanceEvents.GeneratePkceCodes,
@@ -2298,11 +2322,15 @@ export class StandardController implements IController {
     private getPreGeneratedPkceCodes(
         correlationId: string
     ): PkceCodes | undefined {
-        this.logger.verbose("Attempting to pick up pre-generated PKCE codes");
+        this.logger.verbose(
+            "Attempting to pick up pre-generated PKCE codes",
+            correlationId
+        );
         const res = this.pkceCode ? { ...this.pkceCode } : undefined;
         this.pkceCode = undefined;
         this.logger.verbose(
-            `'${res ? "Found" : "Did not find"}' pre-generated PKCE codes`
+            `'${res ? "Found" : "Did not find"}' pre-generated PKCE codes`,
+            correlationId
         );
         this.performanceClient.addFields(
             { usePreGeneratedPkce: !!res },
@@ -2312,7 +2340,8 @@ export class StandardController implements IController {
     }
 
     private logMultipleInstances(
-        performanceEvent: InProgressPerformanceEvent
+        performanceEvent: InProgressPerformanceEvent,
+        correlationId: string
     ): void {
         const clientId = this.config.auth.clientId;
 
@@ -2327,12 +2356,18 @@ export class StandardController implements IController {
 
         if (clientIds.length > 0) {
             this.logger.verbose(
-                "There is already an instance of MSAL.js in the window."
+                "There is already an instance of MSAL.js in the window.",
+                correlationId
             );
         }
         // @ts-ignore
         window.msal.clientIds.push(clientId);
-        collectInstanceStats(clientId, performanceEvent, this.logger);
+        collectInstanceStats(
+            clientId,
+            performanceEvent,
+            this.logger,
+            correlationId
+        );
     }
 }
 

--- a/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
+++ b/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
@@ -84,6 +84,7 @@ export class UnknownOperatingContextController implements IController {
     protected initialized: boolean = false;
 
     constructor(operatingContext: UnknownOperatingContext) {
+        const correlationId = "";
         this.operatingContext = operatingContext;
 
         this.isBrowserEnvironment =
@@ -112,13 +113,14 @@ export class UnknownOperatingContextController implements IController {
                   this.logger,
                   this.performanceClient,
                   this.eventHandler,
-                  undefined
+                  correlationId
               )
             : DEFAULT_BROWSER_CACHE_MANAGER(
                   this.config.auth.clientId,
                   this.logger,
                   this.performanceClient,
-                  this.eventHandler
+                  this.eventHandler,
+                  correlationId
               );
     }
     getBrowserStorage(): BrowserCacheManager {

--- a/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
+++ b/lib/msal-browser/src/controllers/UnknownOperatingContextController.ts
@@ -84,7 +84,6 @@ export class UnknownOperatingContextController implements IController {
     protected initialized: boolean = false;
 
     constructor(operatingContext: UnknownOperatingContext) {
-        const correlationId = "";
         this.operatingContext = operatingContext;
 
         this.isBrowserEnvironment =
@@ -112,15 +111,13 @@ export class UnknownOperatingContextController implements IController {
                   this.browserCrypto,
                   this.logger,
                   this.performanceClient,
-                  this.eventHandler,
-                  correlationId
+                  this.eventHandler
               )
             : DEFAULT_BROWSER_CACHE_MANAGER(
                   this.config.auth.clientId,
                   this.logger,
                   this.performanceClient,
-                  this.eventHandler,
-                  correlationId
+                  this.eventHandler
               );
     }
     getBrowserStorage(): BrowserCacheManager {

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -150,12 +150,16 @@ export class CryptoOps implements ICrypto {
             await BrowserCrypto.importJwk(privateKeyJwk, false, ["sign"]);
 
         // Store Keypair data in keystore
-        await this.cache.setItem(publicJwkHash, {
-            privateKey: unextractablePrivateKey,
-            publicKey: keyPair.publicKey,
-            requestMethod: request.resourceRequestMethod,
-            requestUri: request.resourceRequestUri,
-        });
+        await this.cache.setItem(
+            publicJwkHash,
+            {
+                privateKey: unextractablePrivateKey,
+                publicKey: keyPair.publicKey,
+                requestMethod: request.resourceRequestMethod,
+                requestUri: request.resourceRequestUri,
+            },
+            request.correlationId
+        );
 
         if (publicKeyThumbMeasurement) {
             publicKeyThumbMeasurement.end({
@@ -169,10 +173,14 @@ export class CryptoOps implements ICrypto {
     /**
      * Removes cryptographic keypair from key store matching the keyId passed in
      * @param kid
+     * @param correlationId
      */
-    async removeTokenBindingKey(kid: string): Promise<void> {
-        await this.cache.removeItem(kid);
-        const keyFound = await this.cache.containsKey(kid);
+    async removeTokenBindingKey(
+        kid: string,
+        correlationId: string
+    ): Promise<void> {
+        await this.cache.removeItem(kid, correlationId);
+        const keyFound = await this.cache.containsKey(kid, correlationId);
         if (keyFound) {
             throw createClientAuthError(
                 ClientAuthErrorCodes.bindingKeyNotRemoved
@@ -182,28 +190,29 @@ export class CryptoOps implements ICrypto {
 
     /**
      * Removes all cryptographic keys from IndexedDB storage
+     * @param correlationId
      */
-    async clearKeystore(): Promise<boolean> {
+    async clearKeystore(correlationId: string): Promise<boolean> {
         // Delete in-memory keystores
-        this.cache.clearInMemory();
+        this.cache.clearInMemory(correlationId);
 
         /**
          * There is only one database, so calling clearPersistent on asymmetric keystore takes care of
          * every persistent keystore
          */
         try {
-            await this.cache.clearPersistent();
+            await this.cache.clearPersistent(correlationId);
             return true;
         } catch (e) {
             if (e instanceof Error) {
                 this.logger.error(
                     `Clearing keystore failed with error: '${e.message}'`,
-                    ""
+                    correlationId
                 );
             } else {
                 this.logger.error(
                     "Clearing keystore failed with unknown error",
-                    ""
+                    correlationId
                 );
             }
 
@@ -226,7 +235,10 @@ export class CryptoOps implements ICrypto {
             BrowserPerformanceEvents.CryptoOptsSignJwt,
             correlationId
         );
-        const cachedKeyPair = await this.cache.getItem(kid);
+        const cachedKeyPair = await this.cache.getItem(
+            kid,
+            correlationId || ""
+        );
 
         if (!cachedKeyPair) {
             throw createBrowserAuthError(

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -197,11 +197,13 @@ export class CryptoOps implements ICrypto {
         } catch (e) {
             if (e instanceof Error) {
                 this.logger.error(
-                    `Clearing keystore failed with error: '${e.message}'`
+                    `Clearing keystore failed with error: '${e.message}'`,
+                    ""
                 );
             } else {
                 this.logger.error(
-                    "Clearing keystore failed with unknown error"
+                    "Clearing keystore failed with unknown error",
+                    ""
                 );
             }
 

--- a/lib/msal-browser/src/crypto/SignedHttpRequest.ts
+++ b/lib/msal-browser/src/crypto/SignedHttpRequest.ts
@@ -5,11 +5,11 @@
 
 import { CryptoOps } from "./CryptoOps.js";
 import {
-    IPerformanceClient,
     Logger,
     LoggerOptions,
     PopTokenGenerator,
     SignedHttpRequestParameters,
+    StubPerformanceClient,
 } from "@azure/msal-common/browser";
 import { version, name } from "../packageMetadata.js";
 
@@ -25,7 +25,6 @@ export class SignedHttpRequest {
 
     constructor(
         shrParameters: SignedHttpRequestParameters,
-        performanceClient: IPerformanceClient,
         shrOptions?: SignedHttpRequestOptions
     ) {
         const loggerOptions = (shrOptions && shrOptions.loggerOptions) || {};
@@ -33,7 +32,7 @@ export class SignedHttpRequest {
         this.cryptoOps = new CryptoOps(this.logger);
         this.popTokenGenerator = new PopTokenGenerator(
             this.cryptoOps,
-            performanceClient
+            new StubPerformanceClient()
         );
         this.shrParameters = shrParameters;
     }

--- a/lib/msal-browser/src/crypto/SignedHttpRequest.ts
+++ b/lib/msal-browser/src/crypto/SignedHttpRequest.ts
@@ -72,9 +72,16 @@ export class SignedHttpRequest {
     /**
      * Removes cached keys from browser for given public key thumbprint
      * @param publicKeyThumbprint Public key digest (from generatePublicKeyThumbprint API)
+     * @param correlationId
      * @returns If keys are properly deleted
      */
-    async removeKeys(publicKeyThumbprint: string): Promise<void> {
-        return this.cryptoOps.removeTokenBindingKey(publicKeyThumbprint);
+    async removeKeys(
+        publicKeyThumbprint: string,
+        correlationId: string
+    ): Promise<void> {
+        return this.cryptoOps.removeTokenBindingKey(
+            publicKeyThumbprint,
+            correlationId
+        );
     }
 }

--- a/lib/msal-browser/src/crypto/SignedHttpRequest.ts
+++ b/lib/msal-browser/src/crypto/SignedHttpRequest.ts
@@ -5,6 +5,7 @@
 
 import { CryptoOps } from "./CryptoOps.js";
 import {
+    IPerformanceClient,
     Logger,
     LoggerOptions,
     PopTokenGenerator,
@@ -24,12 +25,16 @@ export class SignedHttpRequest {
 
     constructor(
         shrParameters: SignedHttpRequestParameters,
+        performanceClient: IPerformanceClient,
         shrOptions?: SignedHttpRequestOptions
     ) {
         const loggerOptions = (shrOptions && shrOptions.loggerOptions) || {};
         this.logger = new Logger(loggerOptions, name, version);
         this.cryptoOps = new CryptoOps(this.logger);
-        this.popTokenGenerator = new PopTokenGenerator(this.cryptoOps);
+        this.popTokenGenerator = new PopTokenGenerator(
+            this.cryptoOps,
+            performanceClient
+        );
         this.shrParameters = shrParameters;
     }
 

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -85,7 +85,8 @@ export class CustomAuthStandardController
 
         if (!this.isBrowserEnvironment) {
             this.logger.verbose(
-                "The SDK can only be used in a browser environment."
+                "The SDK can only be used in a browser environment.",
+                ""
             );
             throw new UnsupportedEnvironmentError();
         }

--- a/lib/msal-browser/src/custom_auth/core/CustomAuthAuthority.ts
+++ b/lib/msal-browser/src/custom_auth/core/CustomAuthAuthority.ts
@@ -8,6 +8,7 @@ import {
     AuthorityOptions,
     INetworkModule,
     Logger,
+    StubPerformanceClient,
 } from "@azure/msal-common/browser";
 import * as CustomAuthApiEndpoint from "./network_client/custom_auth_api/CustomAuthApiEndpoint.js";
 import { buildUrl } from "./utils/UrlUtils.js";
@@ -52,7 +53,8 @@ export class CustomAuthAuthority extends Authority {
             cacheManager,
             authorityOptions,
             logger,
-            ""
+            "",
+            new StubPerformanceClient()
         );
 
         // Set the metadata for the authority
@@ -75,9 +77,14 @@ export class CustomAuthAuthority extends Authority {
             jwks_uri: "",
         };
         const cacheKey = this.cacheManager.generateAuthorityMetadataCacheKey(
-            metadataEntity.preferred_cache
+            metadataEntity.preferred_cache,
+            this.correlationId
         );
-        cacheManager.setAuthorityMetadata(cacheKey, metadataEntity);
+        cacheManager.setAuthorityMetadata(
+            cacheKey,
+            metadataEntity,
+            this.correlationId
+        );
     }
 
     /**

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts
@@ -48,7 +48,8 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
             logger,
             eventHandler,
             navigationClient,
-            performanceClient
+            performanceClient,
+            ""
         );
 
         this.tokenResponseHandler = new ResponseHandler(
@@ -56,6 +57,7 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
             this.browserStorage,
             this.browserCrypto,
             this.logger,
+            this.performanceClient,
             null,
             null
         );

--- a/lib/msal-browser/src/custom_auth/core/network_client/http_client/FetchHttpClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/http_client/FetchHttpClient.ts
@@ -23,7 +23,7 @@ export class FetchHttpClient implements IHttpClient {
     ): Promise<Response> {
         const headers = options.headers as Record<string, string>;
         const correlationId =
-            headers?.[AADServerParamKeys.CLIENT_REQUEST_ID] || undefined;
+            headers?.[AADServerParamKeys.CLIENT_REQUEST_ID] || "";
 
         try {
             this.logger.verbosePii(

--- a/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
@@ -113,20 +113,19 @@ export class CustomAuthSilentCacheClient extends CustomAuthInteractionClientBase
 
     override async logout(logoutRequest?: ClearCacheRequest): Promise<void> {
         const validLogoutRequest = this.initializeLogoutRequest(logoutRequest);
+        const correlationId =
+            logoutRequest?.correlationId || this.correlationId;
 
         // Clear the cache
-        this.logger.verbose(
-            "Start to clear the cache",
-            logoutRequest?.correlationId
-        );
+        this.logger.verbose("Start to clear the cache", correlationId);
         await clearCacheOnLogout(
             this.browserStorage,
             this.browserCrypto,
             this.logger,
-            this.correlationId,
+            correlationId,
             validLogoutRequest?.account
         );
-        this.logger.verbose("Cache cleared", logoutRequest?.correlationId);
+        this.logger.verbose("Cache cleared", correlationId);
 
         const postLogoutRedirectUri = this.config.auth.postLogoutRedirectUri;
 
@@ -138,7 +137,7 @@ export class CustomAuthSilentCacheClient extends CustomAuthInteractionClientBase
 
             this.logger.verbose(
                 "Post logout redirect uri is set, redirecting to uri",
-                logoutRequest?.correlationId
+                correlationId
             );
 
             // Redirect to post logout redirect uri

--- a/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
@@ -113,19 +113,17 @@ export class CustomAuthSilentCacheClient extends CustomAuthInteractionClientBase
 
     override async logout(logoutRequest?: ClearCacheRequest): Promise<void> {
         const validLogoutRequest = this.initializeLogoutRequest(logoutRequest);
-        const correlationId =
-            logoutRequest?.correlationId || this.correlationId;
 
         // Clear the cache
-        this.logger.verbose("Start to clear the cache", correlationId);
+        this.logger.verbose("Start to clear the cache", this.correlationId);
         await clearCacheOnLogout(
             this.browserStorage,
             this.browserCrypto,
             this.logger,
-            correlationId,
+            this.correlationId,
             validLogoutRequest?.account
         );
-        this.logger.verbose("Cache cleared", correlationId);
+        this.logger.verbose("Cache cleared", this.correlationId);
 
         const postLogoutRedirectUri = this.config.auth.postLogoutRedirectUri;
 
@@ -137,7 +135,7 @@ export class CustomAuthSilentCacheClient extends CustomAuthInteractionClientBase
 
             this.logger.verbose(
                 "Post logout redirect uri is set, redirecting to uri",
-                correlationId
+                this.correlationId
             );
 
             // Redirect to post logout redirect uri

--- a/lib/msal-browser/src/event/EventHandler.ts
+++ b/lib/msal-browser/src/event/EventHandler.ts
@@ -51,12 +51,16 @@ export class EventHandler {
             const id = callbackId || createGuid();
             if (this.eventCallbacks.has(id)) {
                 this.logger.error(
-                    `Event callback with id: '${id}' is already registered. Please provide a unique id or remove the existing callback and try again.`
+                    `Event callback with id: '${id}' is already registered. Please provide a unique id or remove the existing callback and try again.`,
+                    ""
                 );
                 return null;
             }
             this.eventCallbacks.set(id, [callback, eventTypes || []]);
-            this.logger.verbose(`Event callback registered with id: '${id}'`);
+            this.logger.verbose(
+                `Event callback registered with id: '${id}'`,
+                ""
+            );
 
             return id;
         }
@@ -70,7 +74,7 @@ export class EventHandler {
      */
     removeEventCallback(callbackId: string): void {
         this.eventCallbacks.delete(callbackId);
-        this.logger.verbose(`Event callback '${callbackId}' removed.`);
+        this.logger.verbose(`Event callback '${callbackId}' removed.`, "");
     }
 
     /**
@@ -126,7 +130,8 @@ export class EventHandler {
                     eventTypes.includes(message.eventType)
                 ) {
                     this.logger.verbose(
-                        `Emitting event to callback '${callbackId}': '${message.eventType}'`
+                        `Emitting event to callback '${callbackId}': '${message.eventType}'`,
+                        ""
                     );
                     callback.apply(null, [message]);
                 }

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -35,7 +35,6 @@ import * as BrowserUtils from "../utils/BrowserUtils.js";
 import { INavigationClient } from "../navigation/INavigationClient.js";
 import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import { ClearCacheRequest } from "../request/ClearCacheRequest.js";
-import { createNewGuid } from "../crypto/BrowserCrypto.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 
 export abstract class BaseInteractionClient {
@@ -58,8 +57,8 @@ export abstract class BaseInteractionClient {
         eventHandler: EventHandler,
         navigationClient: INavigationClient,
         performanceClient: IPerformanceClient,
-        platformAuthProvider?: IPlatformAuthHandler,
-        correlationId?: string
+        correlationId: string,
+        platformAuthProvider?: IPlatformAuthHandler
     ) {
         this.config = config;
         this.browserStorage = storageImpl;
@@ -68,12 +67,8 @@ export abstract class BaseInteractionClient {
         this.eventHandler = eventHandler;
         this.navigationClient = navigationClient;
         this.platformAuthProvider = platformAuthProvider;
-        this.correlationId = correlationId || createNewGuid();
-        this.logger = logger.clone(
-            BrowserConstants.MSAL_SKU,
-            version,
-            this.correlationId
-        );
+        this.correlationId = correlationId;
+        this.logger = logger.clone(BrowserConstants.MSAL_SKU, version);
         this.performanceClient = performanceClient;
     }
 
@@ -91,14 +86,16 @@ export abstract class BaseInteractionClient {
  * @param requestRedirectUri - Redirect URI from the request or undefined if not configured
  * @param clientConfigRedirectUri - Redirect URI from the client configuration or undefined if not configured
  * @param logger - Logger instance from the calling client
+ * @param correlationId
  * @returns Absolute redirect URL constructed from the provided URI, config, or current page
  */
 export function getRedirectUri(
     requestRedirectUri: string | undefined,
     clientConfigRedirectUri: string | undefined,
-    logger: Logger
+    logger: Logger,
+    correlationId: string
 ): string {
-    logger.verbose("getRedirectUri called");
+    logger.verbose("getRedirectUri called", correlationId);
     const redirectUri = requestRedirectUri || clientConfigRedirectUri || "";
     return UrlString.getAbsoluteUrl(redirectUri, BrowserUtils.getCurrentUri());
 }
@@ -121,7 +118,7 @@ export function initializeServerTelemetryManager(
     logger: Logger,
     forceRefresh?: boolean
 ): ServerTelemetryManager {
-    logger.verbose("initializeServerTelemetryManager called");
+    logger.verbose("initializeServerTelemetryManager called", correlationId);
     const telemetryPayload: ServerTelemetryRequest = {
         clientId: clientId,
         correlationId: correlationId,
@@ -242,11 +239,13 @@ export async function clearCacheOnLogout(
         try {
             browserStorage.removeAccount(account, correlationId);
             logger.verbose(
-                "Cleared cache items belonging to the account provided in the logout request."
+                "Cleared cache items belonging to the account provided in the logout request.",
+                correlationId
             );
         } catch (error) {
             logger.error(
-                "Account provided in logout request was not found. Local cache unchanged."
+                "Account provided in logout request was not found. Local cache unchanged.",
+                correlationId
             );
         }
     } else {
@@ -261,7 +260,8 @@ export async function clearCacheOnLogout(
             await browserCrypto.clearKeystore();
         } catch (e) {
             logger.error(
-                "Attempted to clear all MSAL cache items and failed. Local cache unchanged."
+                "Attempted to clear all MSAL cache items and failed. Local cache unchanged.",
+                correlationId
             );
         }
     }

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -257,7 +257,7 @@ export async function clearCacheOnLogout(
             // Clear all accounts and tokens
             browserStorage.clear(correlationId);
             // Clear any stray keys from IndexedDB
-            await browserCrypto.clearKeystore();
+            await browserCrypto.clearKeystore(correlationId);
         } catch (e) {
             logger.error(
                 "Attempted to clear all MSAL cache items and failed. Local cache unchanged.",

--- a/lib/msal-browser/src/interaction_client/HybridSpaAuthorizationCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/HybridSpaAuthorizationCodeClient.ts
@@ -6,11 +6,15 @@
 import {
     AuthorizationCodeClient,
     ClientConfiguration,
+    IPerformanceClient,
 } from "@azure/msal-common/browser";
 
 export class HybridSpaAuthorizationCodeClient extends AuthorizationCodeClient {
-    constructor(config: ClientConfiguration) {
-        super(config);
+    constructor(
+        config: ClientConfiguration,
+        performanceClient: IPerformanceClient
+    ) {
+        super(config, performanceClient);
         this.includeRedirectUri = false;
     }
 }

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -99,7 +99,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         provider: IPlatformAuthHandler,
         accountId: string,
         nativeStorageImpl: BrowserCacheManager,
-        correlationId?: string
+        correlationId: string
     ) {
         super(
             config,
@@ -109,8 +109,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             eventHandler,
             navigationClient,
             performanceClient,
-            provider,
-            correlationId
+            correlationId,
+            provider
         );
         this.apiId = apiId;
         this.accountId = accountId;
@@ -124,8 +124,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             eventHandler,
             navigationClient,
             performanceClient,
-            provider,
-            correlationId
+            correlationId,
+            provider
         );
 
         const extensionName = this.platformAuthProvider.getExtensionName();
@@ -158,7 +158,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         request: PopupRequest | SilentRequest | SsoSilentRequest,
         cacheLookupPolicy?: CacheLookupPolicy
     ): Promise<AuthenticationResult> {
-        this.logger.trace("NativeInteractionClient - acquireToken called.");
+        this.logger.trace(
+            "NativeInteractionClient - acquireToken called.",
+            this.correlationId
+        );
 
         // start the perf measurement
         const nativeATMeasurement = this.performanceClient.startMeasurement(
@@ -194,13 +197,15 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             } catch (e) {
                 if (cacheLookupPolicy === CacheLookupPolicy.AccessToken) {
                     this.logger.info(
-                        "MSAL internal Cache does not contain tokens, return error as per cache policy"
+                        "MSAL internal Cache does not contain tokens, return error as per cache policy",
+                        this.correlationId
                     );
                     throw e;
                 }
                 // continue with a native call for any and all errors
                 this.logger.info(
-                    "MSAL internal Cache does not contain tokens, proceed to make a native call"
+                    "MSAL internal Cache does not contain tokens, proceed to make a native call",
+                    this.correlationId
                 );
             }
 
@@ -269,7 +274,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     ): Promise<AuthenticationResult> {
         if (!nativeAccountId) {
             this.logger.warning(
-                "NativeInteractionClient:acquireTokensFromCache - No nativeAccountId provided"
+                "NativeInteractionClient:acquireTokensFromCache - No nativeAccountId provided",
+                this.correlationId
             );
             throw createClientAuthError(ClientAuthErrorCodes.noAccountFound);
         }
@@ -322,7 +328,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         options?: HandleRedirectPromiseOptions
     ): Promise<void> {
         this.logger.trace(
-            "NativeInteractionClient - acquireTokenRedirect called."
+            "NativeInteractionClient - acquireTokenRedirect called.",
+            this.correlationId
         );
 
         const nativeRequest = await this.initializeNativeRequest(request);
@@ -363,7 +370,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             : getRedirectUri(
                   request.redirectUri,
                   this.config.auth.redirectUri,
-                  this.logger
+                  this.logger,
+                  this.correlationId
               );
         rootMeasurement.end({ success: true });
         await this.navigationClient.navigateExternal(
@@ -382,11 +390,13 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         correlationId?: string
     ): Promise<AuthenticationResult | null> {
         this.logger.trace(
-            "NativeInteractionClient - handleRedirectPromise called."
+            "NativeInteractionClient - handleRedirectPromise called.",
+            this.correlationId
         );
         if (!this.browserStorage.isInteractionInProgress(true)) {
             this.logger.info(
-                "handleRedirectPromise called but there is no interaction in progress, returning null."
+                "handleRedirectPromise called but there is no interaction in progress, returning null.",
+                this.correlationId
             );
             return null;
         }
@@ -395,7 +405,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         const cachedRequest = this.browserStorage.getCachedNativeRequest();
         if (!cachedRequest) {
             this.logger.verbose(
-                "NativeInteractionClient - handleRedirectPromise called but there is no cached request, returning null."
+                "NativeInteractionClient - handleRedirectPromise called but there is no cached request, returning null.",
+                this.correlationId
             );
             if (performanceClient && correlationId) {
                 performanceClient?.addFields(
@@ -409,7 +420,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         const { prompt, ...request } = cachedRequest;
         if (prompt) {
             this.logger.verbose(
-                "NativeInteractionClient - handleRedirectPromise called and prompt was included in the original request, removing prompt from cached request to prevent second interaction with native broker window."
+                "NativeInteractionClient - handleRedirectPromise called and prompt was included in the original request, removing prompt from cached request to prevent second interaction with native broker window.",
+                this.correlationId
             );
         }
 
@@ -423,7 +435,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
 
         try {
             this.logger.verbose(
-                "NativeInteractionClient - handleRedirectPromise sending message to native broker."
+                "NativeInteractionClient - handleRedirectPromise sending message to native broker.",
+                this.correlationId
             );
             const response: PlatformAuthResponse =
                 await this.platformAuthProvider.sendMessage(request);
@@ -452,7 +465,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      * @param request
      */
     logout(): Promise<void> {
-        this.logger.trace("NativeInteractionClient - logout called.");
+        this.logger.trace(
+            "NativeInteractionClient - logout called.",
+            this.correlationId
+        );
         return Promise.reject("Logout not implemented yet");
     }
 
@@ -468,7 +484,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         reqTimestamp: number
     ): Promise<AuthenticationResult> {
         this.logger.trace(
-            "NativeInteractionClient - handleNativeResponse called."
+            "NativeInteractionClient - handleNativeResponse called.",
+            this.correlationId
         );
 
         // generate identifiers
@@ -496,7 +513,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             response.account.id !== request.accountId
         ) {
             this.logger.info(
-                "handleNativeServerResponse: Double broker flow detected, ignoring accountId mismatch"
+                "handleNativeServerResponse: Double broker flow detected, ignoring accountId mismatch",
+                this.correlationId
             );
         } else if (
             homeAccountIdentifier !== cachedhomeAccountId &&
@@ -574,6 +592,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             AuthorityType.Default,
             this.logger,
             this.browserCrypto,
+            this.correlationId,
             idTokenClaims
         );
 
@@ -613,20 +632,23 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             // Check if native layer returned an SHR token
             if (response.shr) {
                 this.logger.trace(
-                    "handleNativeServerResponse: SHR is enabled in native layer"
+                    "handleNativeServerResponse: SHR is enabled in native layer",
+                    this.correlationId
                 );
                 return response.shr;
             }
 
             // Generate SHR in msal js if WAM does not compute it when POP is enabled
             const popTokenGenerator: PopTokenGenerator = new PopTokenGenerator(
-                this.browserCrypto
+                this.browserCrypto,
+                this.performanceClient
             );
             const shrParameters: SignedHttpRequestParameters = {
                 resourceRequestMethod: request.resourceRequestMethod,
                 resourceRequestUri: request.resourceRequestUri,
                 shrClaims: request.shrClaims,
                 shrNonce: request.shrNonce,
+                correlationId: this.correlationId,
             };
 
             /**
@@ -871,7 +893,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 return JSON.parse(matsResponse);
             } catch (e) {
                 this.logger.error(
-                    "NativeInteractionClient - Error parsing MATS telemetry, returning null instead"
+                    "NativeInteractionClient - Error parsing MATS telemetry, returning null instead",
+                    this.correlationId
                 );
             }
         }
@@ -887,7 +910,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected isResponseFromCache(mats: MATS): boolean {
         if (typeof mats.is_cached === "undefined") {
             this.logger.verbose(
-                "NativeInteractionClient - MATS telemetry does not contain field indicating if response was served from cache. Returning false."
+                "NativeInteractionClient - MATS telemetry does not contain field indicating if response was served from cache. Returning false.",
+                this.correlationId
             );
             return false;
         }
@@ -903,7 +927,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         request: PopupRequest | SsoSilentRequest
     ): Promise<PlatformAuthRequest> {
         this.logger.trace(
-            "NativeInteractionClient - initializeNativeRequest called"
+            "NativeInteractionClient - initializeNativeRequest called",
+            this.correlationId
         );
 
         const canonicalAuthority = await this.getCanonicalAuthority(request);
@@ -922,7 +947,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             redirectUri: getRedirectUri(
                 request.redirectUri,
                 this.config.auth.redirectUri,
-                this.logger
+                this.logger,
+                this.correlationId
             ),
             prompt: this.getPrompt(request.prompt),
             correlationId: this.correlationId,
@@ -958,9 +984,13 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 resourceRequestMethod: request.resourceRequestMethod,
                 shrClaims: request.shrClaims,
                 shrNonce: request.shrNonce,
+                correlationId: this.correlationId,
             };
 
-            const popTokenGenerator = new PopTokenGenerator(this.browserCrypto);
+            const popTokenGenerator = new PopTokenGenerator(
+                this.browserCrypto,
+                this.performanceClient
+            );
 
             // generate reqCnf if not provided in the request
             let reqCnfData;
@@ -970,7 +1000,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                     PerformanceEvents.PopTokenGenerateCnf,
                     this.logger,
                     this.performanceClient,
-                    request.correlationId
+                    this.correlationId
                 )(shrParameters, this.logger);
                 reqCnfData = generatedReqCnfData.reqCnfString;
                 validatedRequest.keyId = generatedReqCnfData.kid;
@@ -1024,7 +1054,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             case ApiId.ssoSilent:
             case ApiId.acquireTokenSilent_silentFlow:
                 this.logger.trace(
-                    "initializeNativeRequest: silent request sets prompt to none"
+                    "initializeNativeRequest: silent request sets prompt to none",
+                    this.correlationId
                 );
                 return Constants.PromptValue.NONE;
             default:
@@ -1034,7 +1065,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         // Prompt not provided, request may proceed and native broker decides if it needs to prompt
         if (!prompt) {
             this.logger.trace(
-                "initializeNativeRequest: prompt was not provided"
+                "initializeNativeRequest: prompt was not provided",
+                this.correlationId
             );
             return undefined;
         }
@@ -1045,12 +1077,14 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             case Constants.PromptValue.CONSENT:
             case Constants.PromptValue.LOGIN:
                 this.logger.trace(
-                    "initializeNativeRequest: prompt is compatible with native flow"
+                    "initializeNativeRequest: prompt is compatible with native flow",
+                    this.correlationId
                 );
                 return prompt;
             default:
                 this.logger.trace(
-                    `initializeNativeRequest: prompt = '${prompt}' is not compatible with native flow`
+                    `initializeNativeRequest: prompt = '${prompt}' is not compatible with native flow`,
+                    this.correlationId
                 );
                 throw createBrowserAuthError(
                     BrowserAuthErrorCodes.nativePromptNotSupported

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -78,8 +78,8 @@ export class PopupClient extends StandardInteractionClient {
         navigationClient: INavigationClient,
         performanceClient: IPerformanceClient,
         nativeStorageImpl: BrowserCacheManager,
-        platformAuthHandler?: IPlatformAuthHandler,
-        correlationId?: string
+        correlationId: string,
+        platformAuthHandler?: IPlatformAuthHandler
     ) {
         super(
             config,
@@ -89,8 +89,8 @@ export class PopupClient extends StandardInteractionClient {
             eventHandler,
             navigationClient,
             performanceClient,
-            platformAuthHandler,
-            correlationId
+            correlationId,
+            platformAuthHandler
         );
         // Properly sets this reference for the unload event.
         this.unloadWindow = this.unloadWindow.bind(this);
@@ -126,7 +126,8 @@ export class PopupClient extends StandardInteractionClient {
             // navigatePopups flag is false. Acquires token without first opening popup. Popup will be opened later asynchronously.
             if (!this.config.system.navigatePopups) {
                 this.logger.verbose(
-                    "navigatePopups set to false, acquiring token"
+                    "navigatePopups set to false, acquiring token",
+                    this.correlationId
                 );
                 // Passes on popup position and dimensions if in request
                 return this.acquireTokenPopupAsync(
@@ -137,7 +138,8 @@ export class PopupClient extends StandardInteractionClient {
             } else {
                 // navigatePopups flag is set to true. Opens popup before acquiring token.
                 this.logger.verbose(
-                    "navigatePopups set to true, opening popup before acquiring token"
+                    "navigatePopups set to true, opening popup before acquiring token",
+                    this.correlationId
                 );
                 popupParams.popup = this.openSizedPopup(
                     "about:blank",
@@ -160,7 +162,7 @@ export class PopupClient extends StandardInteractionClient {
      */
     logout(logoutRequest?: EndSessionPopupRequest): Promise<void> {
         try {
-            this.logger.verbose("logoutPopup called");
+            this.logger.verbose("logoutPopup called", this.correlationId);
             const validLogoutRequest =
                 this.initializeLogoutRequest(logoutRequest);
             const popupParams: PopupParams = {
@@ -175,7 +177,10 @@ export class PopupClient extends StandardInteractionClient {
 
             // navigatePopups flag set to false. Acquires token without first opening popup. Popup will be opened later asynchronously.
             if (!this.config.system.navigatePopups) {
-                this.logger.verbose("navigatePopups set to false");
+                this.logger.verbose(
+                    "navigatePopups set to false",
+                    this.correlationId
+                );
                 // Passes on popup position and dimensions if in request
                 return this.logoutPopupAsync(
                     validLogoutRequest,
@@ -186,7 +191,8 @@ export class PopupClient extends StandardInteractionClient {
             } else {
                 // navigatePopups flag is set to true. Opens popup before logging out.
                 this.logger.verbose(
-                    "navigatePopups set to true, opening popup"
+                    "navigatePopups set to true, opening popup",
+                    this.correlationId
                 );
                 popupParams.popup = this.openSizedPopup(
                     "about:blank",
@@ -218,7 +224,10 @@ export class PopupClient extends StandardInteractionClient {
         popupParams: PopupParams,
         pkceCodes?: PkceCodes
     ): Promise<AuthenticationResult> {
-        this.logger.verbose("acquireTokenPopupAsync called");
+        this.logger.verbose(
+            "acquireTokenPopupAsync called",
+            this.correlationId
+        );
 
         const validRequest = await invokeAsync(
             initializeAuthorizationRequest,
@@ -248,6 +257,7 @@ export class PopupClient extends StandardInteractionClient {
         const isPlatformBroker = isPlatformAuthAllowed(
             this.config,
             this.logger,
+            this.correlationId,
             this.platformAuthProvider,
             request.authenticationScheme
         );
@@ -346,7 +356,8 @@ export class PopupClient extends StandardInteractionClient {
                 this.config.auth.OIDCOptions.responseMode,
                 this.config.system.pollIntervalMilliseconds,
                 this.logger,
-                this.unloadWindow
+                this.unloadWindow,
+                this.correlationId
             );
 
             const serverParams = invoke(
@@ -358,7 +369,8 @@ export class PopupClient extends StandardInteractionClient {
             )(
                 responseString,
                 this.config.auth.OIDCOptions.responseMode,
-                this.logger
+                this.logger,
+                this.correlationId
             );
 
             return await invokeAsync(
@@ -464,7 +476,8 @@ export class PopupClient extends StandardInteractionClient {
             this.config.auth.OIDCOptions.responseMode,
             this.config.system.pollIntervalMilliseconds,
             this.logger,
-            this.unloadWindow
+            this.unloadWindow,
+            correlationId
         );
 
         const serverParams = invoke(
@@ -476,7 +489,8 @@ export class PopupClient extends StandardInteractionClient {
         )(
             responseString,
             this.config.auth.OIDCOptions.responseMode,
-            this.logger
+            this.logger,
+            this.correlationId
         );
 
         return invokeAsync(
@@ -515,7 +529,7 @@ export class PopupClient extends StandardInteractionClient {
         requestAuthority?: string,
         mainWindowRedirectUri?: string
     ): Promise<void> {
-        this.logger.verbose("logoutPopupAsync called");
+        this.logger.verbose("logoutPopupAsync called", this.correlationId);
         this.eventHandler.emitEvent(
             EventType.LOGOUT_START,
             InteractionType.Popup,
@@ -614,7 +628,8 @@ export class PopupClient extends StandardInteractionClient {
                 this.config.auth.OIDCOptions.responseMode,
                 this.config.system.pollIntervalMilliseconds,
                 this.logger,
-                this.unloadWindow
+                this.unloadWindow,
+                this.correlationId
             ).catch(() => {
                 // Swallow any errors related to monitoring the window. Server logout is best effort
             });
@@ -631,17 +646,22 @@ export class PopupClient extends StandardInteractionClient {
                 );
 
                 this.logger.verbose(
-                    "Redirecting main window to url specified in the request"
+                    "Redirecting main window to url specified in the request",
+                    this.correlationId
                 );
                 this.logger.verbosePii(
-                    `Redirecting main window to: '${absoluteUrl}'`
+                    `Redirecting main window to: '${absoluteUrl}'`,
+                    this.correlationId
                 );
                 await this.navigationClient.navigateInternal(
                     absoluteUrl,
                     navigationOptions
                 );
             } else {
-                this.logger.verbose("No main window navigation requested");
+                this.logger.verbose(
+                    "No main window navigation requested",
+                    this.correlationId
+                );
             }
         } catch (e) {
             // Close the synchronous popup if an error is thrown before the window unload event is registered
@@ -677,12 +697,15 @@ export class PopupClient extends StandardInteractionClient {
     initiateAuthRequest(requestUrl: string, params: PopupParams): Window {
         // Check that request url is not empty.
         if (requestUrl) {
-            this.logger.infoPii(`Navigate to: '${requestUrl}'`);
+            this.logger.infoPii(
+                `Navigate to: '${requestUrl}'`,
+                this.correlationId
+            );
             // Open the popup window to requestUrl.
             return this.openPopup(requestUrl, params);
         } else {
             // Throw error if request URL is empty.
-            this.logger.error("Navigate url is empty");
+            this.logger.error("Navigate url is empty", this.correlationId);
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.emptyNavigateUri
             );
@@ -709,13 +732,15 @@ export class PopupClient extends StandardInteractionClient {
             if (popupParams.popup) {
                 popupWindow = popupParams.popup;
                 this.logger.verbosePii(
-                    `Navigating popup window to: '${urlNavigate}'`
+                    `Navigating popup window to: '${urlNavigate}'`,
+                    this.correlationId
                 );
                 popupWindow.location.assign(urlNavigate);
             } else if (typeof popupParams.popup === "undefined") {
                 // Popup will be undefined if it was not passed in
                 this.logger.verbosePii(
-                    `Opening popup window to: '${urlNavigate}'`
+                    `Opening popup window to: '${urlNavigate}'`,
+                    this.correlationId
                 );
                 popupWindow = this.openSizedPopup(urlNavigate, popupParams);
             }
@@ -738,7 +763,8 @@ export class PopupClient extends StandardInteractionClient {
             return popupWindow;
         } catch (e) {
             this.logger.error(
-                `error opening popup '${(e as AuthError).message}'`
+                `error opening popup '${(e as AuthError).message}'`,
+                this.correlationId
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.popupWindowError
@@ -787,21 +813,24 @@ export class PopupClient extends StandardInteractionClient {
 
         if (!width || width < 0 || width > winWidth) {
             this.logger.verbose(
-                "Default popup window width used. Window width not configured or invalid."
+                "Default popup window width used. Window width not configured or invalid.",
+                this.correlationId
             );
             width = BrowserConstants.POPUP_WIDTH;
         }
 
         if (!height || height < 0 || height > winHeight) {
             this.logger.verbose(
-                "Default popup window height used. Window height not configured or invalid."
+                "Default popup window height used. Window height not configured or invalid.",
+                this.correlationId
             );
             height = BrowserConstants.POPUP_HEIGHT;
         }
 
         if (!top || top < 0 || top > winHeight) {
             this.logger.verbose(
-                "Default popup window top position used. Window top not configured or invalid."
+                "Default popup window top position used. Window top not configured or invalid.",
+                this.correlationId
             );
             top = Math.max(
                 0,
@@ -811,7 +840,8 @@ export class PopupClient extends StandardInteractionClient {
 
         if (!left || left < 0 || left > winWidth) {
             this.logger.verbose(
-                "Default popup window left position used. Window left not configured or invalid."
+                "Default popup window left position used. Window left not configured or invalid.",
+                this.correlationId
             );
             left = Math.max(
                 0,

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -141,7 +141,7 @@ export class RedirectClient extends StandardInteractionClient {
                     "Page was restored from back/forward cache. Clearing temporary cache.",
                     this.correlationId
                 );
-                this.browserStorage.resetRequestCache();
+                this.browserStorage.resetRequestCache(this.correlationId);
                 this.eventHandler.emitEvent(
                     EventType.RESTORE_FROM_BFCACHE,
                     InteractionType.Redirect
@@ -366,7 +366,7 @@ export class RedirectClient extends StandardInteractionClient {
                     "handleRedirectPromise did not detect a response as a result of a redirect. Cleaning temporary cache.",
                     this.correlationId
                 );
-                this.browserStorage.resetRequestCache();
+                this.browserStorage.resetRequestCache(this.correlationId);
 
                 // Do not instrument "no_server_response" if user clicked back button
                 if (getNavigationType() !== "back_forward") {
@@ -384,6 +384,7 @@ export class RedirectClient extends StandardInteractionClient {
             const loginRequestUrl =
                 this.browserStorage.getTemporaryCache(
                     TemporaryCacheKeys.ORIGIN_URI,
+                    this.correlationId,
                     true
                 ) || "";
             const loginRequestUrlNormalized =
@@ -555,6 +556,7 @@ export class RedirectClient extends StandardInteractionClient {
 
         const cachedHash = this.browserStorage.getTemporaryCache(
             TemporaryCacheKeys.URL_HASH,
+            this.correlationId,
             true
         );
         this.browserStorage.removeItem(

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -87,8 +87,8 @@ export class RedirectClient extends StandardInteractionClient {
         navigationClient: INavigationClient,
         performanceClient: IPerformanceClient,
         nativeStorageImpl: BrowserCacheManager,
-        platformAuthHandler?: IPlatformAuthHandler,
-        correlationId?: string
+        correlationId: string,
+        platformAuthHandler?: IPlatformAuthHandler
     ) {
         super(
             config,
@@ -98,8 +98,8 @@ export class RedirectClient extends StandardInteractionClient {
             eventHandler,
             navigationClient,
             performanceClient,
-            platformAuthHandler,
-            correlationId
+            correlationId,
+            platformAuthHandler
         );
         this.nativeStorage = nativeStorageImpl;
     }
@@ -129,6 +129,7 @@ export class RedirectClient extends StandardInteractionClient {
         validRequest.platformBroker = isPlatformAuthAllowed(
             this.config,
             this.logger,
+            this.correlationId,
             this.platformAuthProvider,
             request.authenticationScheme
         );
@@ -137,7 +138,8 @@ export class RedirectClient extends StandardInteractionClient {
             // Clear temporary cache if the back button is clicked during the redirect flow.
             if (event.persisted) {
                 this.logger.verbose(
-                    "Page was restored from back/forward cache. Clearing temporary cache."
+                    "Page was restored from back/forward cache. Clearing temporary cache.",
+                    this.correlationId
                 );
                 this.browserStorage.resetRequestCache();
                 this.eventHandler.emitEvent(
@@ -150,7 +152,10 @@ export class RedirectClient extends StandardInteractionClient {
         const redirectStartPage = this.getRedirectStartPage(
             request.redirectStartPage
         );
-        this.logger.verbosePii(`Redirect start page: '${redirectStartPage}'`);
+        this.logger.verbosePii(
+            `Redirect start page: '${redirectStartPage}'`,
+            this.correlationId
+        );
         // Cache start page, returns to this page after redirectUri if navigateToLoginRequestUrl is true
         this.browserStorage.setTemporaryCache(
             TemporaryCacheKeys.ORIGIN_URI,
@@ -208,6 +213,7 @@ export class RedirectClient extends StandardInteractionClient {
 
         this.browserStorage.cacheAuthorizeRequest(
             redirectRequest,
+            this.correlationId,
             pkceCodes.verifier
         );
 
@@ -297,7 +303,10 @@ export class RedirectClient extends StandardInteractionClient {
             ...request,
             earJwk: earJwk,
         };
-        this.browserStorage.cacheAuthorizeRequest(redirectRequest);
+        this.browserStorage.cacheAuthorizeRequest(
+            redirectRequest,
+            this.correlationId
+        );
 
         const form = await Authorize.getEARForm(
             document,
@@ -354,7 +363,8 @@ export class RedirectClient extends StandardInteractionClient {
             if (!serverParams) {
                 // Not a recognized server response hash or hash not associated with a redirect request
                 this.logger.info(
-                    "handleRedirectPromise did not detect a response as a result of a redirect. Cleaning temporary cache."
+                    "handleRedirectPromise did not detect a response as a result of a redirect. Cleaning temporary cache.",
+                    this.correlationId
                 );
                 this.browserStorage.resetRequestCache();
 
@@ -363,7 +373,8 @@ export class RedirectClient extends StandardInteractionClient {
                     parentMeasurement.event.errorCode = "no_server_response";
                 } else {
                     this.logger.verbose(
-                        "Back navigation event detected. Muting no_server_response error"
+                        "Back navigation event detected. Muting no_server_response error",
+                        this.correlationId
                     );
                 }
                 return null;
@@ -387,7 +398,8 @@ export class RedirectClient extends StandardInteractionClient {
             ) {
                 // We are on the page we need to navigate to - handle hash
                 this.logger.verbose(
-                    "Current page is loginRequestUrl, handling response"
+                    "Current page is loginRequestUrl, handling response",
+                    this.correlationId
                 );
 
                 if (loginRequestUrl.indexOf("#") > -1) {
@@ -405,7 +417,8 @@ export class RedirectClient extends StandardInteractionClient {
                 return handleHashResult;
             } else if (!navigateToLoginRequestUrl) {
                 this.logger.verbose(
-                    "NavigateToLoginRequestUrl set to false, handling response"
+                    "NavigateToLoginRequestUrl set to false, handling response",
+                    this.correlationId
                 );
                 return await this.handleResponse(
                     serverParams,
@@ -447,7 +460,8 @@ export class RedirectClient extends StandardInteractionClient {
                         true
                     );
                     this.logger.warning(
-                        "Unable to get valid login request url from cache, redirecting to home page"
+                        "Unable to get valid login request url from cache, redirecting to home page",
+                        this.correlationId
                     );
                     processHashOnRedirect =
                         await this.navigationClient.navigateInternal(
@@ -457,7 +471,8 @@ export class RedirectClient extends StandardInteractionClient {
                 } else {
                     // Navigate to page that initiated the redirect request
                     this.logger.verbose(
-                        `Navigating to loginRequestUrl: '${loginRequestUrl}'`
+                        `Navigating to loginRequestUrl: '${loginRequestUrl}'`,
+                        this.correlationId
                     );
                     processHashOnRedirect =
                         await this.navigationClient.navigateInternal(
@@ -495,7 +510,10 @@ export class RedirectClient extends StandardInteractionClient {
     protected getRedirectResponse(
         userProvidedResponse: string
     ): [AuthorizeResponse | null, string] {
-        this.logger.verbose("getRedirectResponseHash called");
+        this.logger.verbose(
+            "getRedirectResponseHash called",
+            this.correlationId
+        );
         // Get current location hash from window or cache.
         let responseString = userProvidedResponse;
         if (!responseString) {
@@ -520,7 +538,8 @@ export class RedirectClient extends StandardInteractionClient {
             } catch (e) {
                 if (e instanceof AuthError) {
                     this.logger.error(
-                        `Interaction type validation failed due to '${e.errorCode}': '${e.errorMessage}'`
+                        `Interaction type validation failed due to '${e.errorCode}': '${e.errorMessage}'`,
+                        this.correlationId
                     );
                 }
                 return [null, ""];
@@ -528,7 +547,8 @@ export class RedirectClient extends StandardInteractionClient {
 
             BrowserUtils.clearHash(window);
             this.logger.verbose(
-                "Hash contains known properties, returning response hash"
+                "Hash contains known properties, returning response hash",
+                this.correlationId
             );
             return [response, responseString];
         }
@@ -545,7 +565,8 @@ export class RedirectClient extends StandardInteractionClient {
             response = UrlUtils.getDeserializedResponse(cachedHash);
             if (response) {
                 this.logger.verbose(
-                    "Hash does not contain known properties, returning cached hash"
+                    "Hash does not contain known properties, returning cached hash",
+                    this.correlationId
                 );
                 return [response, cachedHash];
             }
@@ -647,11 +668,15 @@ export class RedirectClient extends StandardInteractionClient {
      * @param onRedirectNavigateRequest - onRedirectNavigate callback provided on the request
      */
     async initiateAuthRequest(requestUrl: string): Promise<void> {
-        this.logger.verbose("RedirectHandler.initiateAuthRequest called");
+        this.logger.verbose(
+            "RedirectHandler.initiateAuthRequest called",
+            this.correlationId
+        );
         // Navigate if valid URL
         if (requestUrl) {
             this.logger.infoPii(
-                `RedirectHandler.initiateAuthRequest: Navigate to: '${requestUrl}'`
+                `RedirectHandler.initiateAuthRequest: Navigate to: '${requestUrl}'`,
+                this.correlationId
             );
             const navigationOptions: NavigationOptions = {
                 apiId: ApiId.acquireTokenRedirect,
@@ -664,14 +689,16 @@ export class RedirectClient extends StandardInteractionClient {
             // If onRedirectNavigate is implemented, invoke it and provide requestUrl
             if (typeof onRedirectNavigate === "function") {
                 this.logger.verbose(
-                    "RedirectHandler.initiateAuthRequest: Invoking onRedirectNavigate callback"
+                    "RedirectHandler.initiateAuthRequest: Invoking onRedirectNavigate callback",
+                    this.correlationId
                 );
                 const navigate = onRedirectNavigate(requestUrl);
 
                 // Returning false from onRedirectNavigate will stop navigation
                 if (navigate !== false) {
                     this.logger.verbose(
-                        "RedirectHandler.initiateAuthRequest: onRedirectNavigate did not return false, navigating"
+                        "RedirectHandler.initiateAuthRequest: onRedirectNavigate did not return false, navigating",
+                        this.correlationId
                     );
                     await this.navigationClient.navigateExternal(
                         requestUrl,
@@ -680,14 +707,16 @@ export class RedirectClient extends StandardInteractionClient {
                     return;
                 } else {
                     this.logger.verbose(
-                        "RedirectHandler.initiateAuthRequest: onRedirectNavigate returned false, stopping navigation"
+                        "RedirectHandler.initiateAuthRequest: onRedirectNavigate returned false, stopping navigation",
+                        this.correlationId
                     );
                     return;
                 }
             } else {
                 // Navigate window to request URL
                 this.logger.verbose(
-                    "RedirectHandler.initiateAuthRequest: Navigating window to navigate url"
+                    "RedirectHandler.initiateAuthRequest: Navigating window to navigate url",
+                    this.correlationId
                 );
                 await this.navigationClient.navigateExternal(
                     requestUrl,
@@ -698,7 +727,8 @@ export class RedirectClient extends StandardInteractionClient {
         } else {
             // Throw error if request URL is empty.
             this.logger.info(
-                "RedirectHandler.initiateAuthRequest: Navigate url is empty"
+                "RedirectHandler.initiateAuthRequest: Navigate url is empty",
+                this.correlationId
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.emptyNavigateUri
@@ -712,7 +742,7 @@ export class RedirectClient extends StandardInteractionClient {
      * @param logoutRequest
      */
     async logout(logoutRequest?: EndSessionRequest): Promise<void> {
-        this.logger.verbose("logoutRedirect called");
+        this.logger.verbose("logoutRedirect called", this.correlationId);
         const validLogoutRequest = this.initializeLogoutRequest(logoutRequest);
         const serverTelemetryManager = initializeServerTelemetryManager(
             ApiId.logout,
@@ -792,7 +822,8 @@ export class RedirectClient extends StandardInteractionClient {
 
                 if (navigate !== false) {
                     this.logger.verbose(
-                        "Logout onRedirectNavigate did not return false, navigating"
+                        "Logout onRedirectNavigate did not return false, navigating",
+                        this.correlationId
                     );
                     // Ensure interaction is in progress
                     if (!this.browserStorage.getInteractionInProgress()) {
@@ -810,7 +841,8 @@ export class RedirectClient extends StandardInteractionClient {
                     // Ensure interaction is not in progress
                     this.browserStorage.setInteractionInProgress(false);
                     this.logger.verbose(
-                        "Logout onRedirectNavigate returned false, stopping navigation"
+                        "Logout onRedirectNavigate returned false, stopping navigation",
+                        this.correlationId
                     );
                 }
             } else {

--- a/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
@@ -46,8 +46,8 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
         navigationClient: INavigationClient,
         apiId: ApiId,
         performanceClient: IPerformanceClient,
-        platformAuthProvider?: IPlatformAuthHandler,
-        correlationId?: string
+        correlationId: string,
+        platformAuthProvider?: IPlatformAuthHandler
     ) {
         super(
             config,
@@ -57,8 +57,8 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
             eventHandler,
             navigationClient,
             performanceClient,
-            platformAuthProvider,
-            correlationId
+            correlationId,
+            platformAuthProvider
         );
         this.apiId = apiId;
     }
@@ -83,7 +83,7 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
             BrowserPerformanceEvents.StandardInteractionClientInitializeAuthorizationRequest,
             this.logger,
             this.performanceClient,
-            request.correlationId
+            this.correlationId
         )(
             request,
             InteractionType.Silent,
@@ -116,7 +116,7 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
                 BrowserPerformanceEvents.StandardInteractionClientGetClientConfiguration,
                 this.logger,
                 this.performanceClient,
-                request.correlationId
+                this.correlationId
             )({
                 serverTelemetryManager,
                 requestAuthority: silentRequest.authority,
@@ -125,8 +125,11 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
                 account: silentRequest.account,
             });
             const authClient: HybridSpaAuthorizationCodeClient =
-                new HybridSpaAuthorizationCodeClient(clientConfig);
-            this.logger.verbose("Auth code client created");
+                new HybridSpaAuthorizationCodeClient(
+                    clientConfig,
+                    this.performanceClient
+                );
+            this.logger.verbose("Auth code client created", this.correlationId);
 
             // Create silent handler
             const interactionHandler = new InteractionHandler(
@@ -145,7 +148,7 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
                 PerformanceEvents.HandleCodeResponseFromServer,
                 this.logger,
                 this.performanceClient,
-                request.correlationId
+                this.correlationId
             )(
                 {
                     code: request.code,

--- a/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
@@ -92,6 +92,10 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
             this.browserStorage,
             this.logger,
             this.performanceClient,
+            /*
+             * correlationId is optional in request payload, while this.correlationId is always instantiated as request.correlationId || createGuid().
+             * Each auth request creates a new instance of *Client so we can safely use this.correlationId.
+             */
             this.correlationId
         );
 

--- a/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentCacheClient.ts
@@ -55,7 +55,7 @@ export class SilentCacheClient extends StandardInteractionClient {
             clientConfig,
             this.performanceClient
         );
-        this.logger.verbose("Silent auth client created");
+        this.logger.verbose("Silent auth client created", this.correlationId);
 
         try {
             const response = await invokeAsync(
@@ -80,7 +80,8 @@ export class SilentCacheClient extends StandardInteractionClient {
                 error.errorCode === BrowserAuthErrorCodes.cryptoKeyNotFound
             ) {
                 this.logger.verbose(
-                    "Signing keypair for bound access token not found. Refreshing bound access token and generating a new crypto keypair."
+                    "Signing keypair for bound access token not found. Refreshing bound access token and generating a new crypto keypair.",
+                    this.correlationId
                 );
             }
             throw error;
@@ -92,7 +93,7 @@ export class SilentCacheClient extends StandardInteractionClient {
      * @param logoutRequest
      */
     logout(logoutRequest?: ClearCacheRequest): Promise<void> {
-        this.logger.verbose("logoutRedirect called");
+        this.logger.verbose("logoutRedirect called", this.correlationId);
         const validLogoutRequest = this.initializeLogoutRequest(logoutRequest);
         return clearCacheOnLogout(
             this.browserStorage,

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -67,8 +67,8 @@ export class SilentIframeClient extends StandardInteractionClient {
         apiId: ApiId,
         performanceClient: IPerformanceClient,
         nativeStorageImpl: BrowserCacheManager,
-        platformAuthProvider?: IPlatformAuthHandler,
-        correlationId?: string
+        correlationId: string,
+        platformAuthProvider?: IPlatformAuthHandler
     ) {
         super(
             config,
@@ -78,8 +78,8 @@ export class SilentIframeClient extends StandardInteractionClient {
             eventHandler,
             navigationClient,
             performanceClient,
-            platformAuthProvider,
-            correlationId
+            correlationId,
+            platformAuthProvider
         );
         this.apiId = apiId;
         this.nativeStorage = nativeStorageImpl;
@@ -99,7 +99,8 @@ export class SilentIframeClient extends StandardInteractionClient {
             (!request.account || !request.account.username)
         ) {
             this.logger.warning(
-                "No user hint provided. The authorization server may need more information to complete this request."
+                "No user hint provided. The authorization server may need more information to complete this request.",
+                this.correlationId
             );
         }
 
@@ -111,7 +112,8 @@ export class SilentIframeClient extends StandardInteractionClient {
                 inputRequest.prompt !== Constants.PromptValue.NO_SESSION
             ) {
                 this.logger.warning(
-                    `SilentIframeClient. Replacing invalid prompt '${inputRequest.prompt}' with '${Constants.PromptValue.NONE}'`
+                    `SilentIframeClient. Replacing invalid prompt '${inputRequest.prompt}' with '${Constants.PromptValue.NONE}'`,
+                    this.correlationId
                 );
                 inputRequest.prompt = Constants.PromptValue.NONE;
             }
@@ -125,7 +127,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             BrowserPerformanceEvents.StandardInteractionClientInitializeAuthorizationRequest,
             this.logger,
             this.performanceClient,
-            request.correlationId
+            this.correlationId
         )(
             inputRequest,
             InteractionType.Silent,
@@ -139,6 +141,7 @@ export class SilentIframeClient extends StandardInteractionClient {
         silentRequest.platformBroker = isPlatformAuthAllowed(
             this.config,
             this.logger,
+            this.correlationId,
             this.platformAuthProvider,
             silentRequest.authenticationScheme
         );
@@ -303,7 +306,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             this.logger,
             this.performanceClient,
             correlationId
-        )(responseString, responseType, this.logger);
+        )(responseString, responseType, this.logger, this.correlationId);
 
         return invokeAsync(
             Authorize.handleResponseEAR,
@@ -408,7 +411,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             this.logger,
             this.performanceClient,
             correlationId
-        )(responseString, responseType, this.logger);
+        )(responseString, responseType, this.logger, this.correlationId);
 
         return invokeAsync(
             Authorize.handleResponseCode,

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -41,7 +41,13 @@ export class SilentRefreshClient extends StandardInteractionClient {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(request, this.config, this.performanceClient, this.logger);
+        )(
+            request,
+            this.config,
+            this.performanceClient,
+            this.logger,
+            this.correlationId
+        );
         const silentRequest: CommonSilentFlowRequest = {
             ...request,
             ...baseRequest,
@@ -52,7 +58,8 @@ export class SilentRefreshClient extends StandardInteractionClient {
             silentRequest.redirectUri = getRedirectUri(
                 request.redirectUri,
                 this.config.auth.redirectUri,
-                this.logger
+                this.logger,
+                this.correlationId
             );
         }
 

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -56,11 +56,11 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
     ): CommonEndSessionRequest {
         this.logger.verbose(
             "initializeLogoutRequest called",
-            logoutRequest?.correlationId
+            this.correlationId
         );
 
         const validLogoutRequest: CommonEndSessionRequest = {
-            correlationId: this.correlationId || createNewGuid(),
+            correlationId: this.correlationId,
             ...logoutRequest,
         };
 
@@ -77,23 +77,27 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
                     );
                     if (logoutHint) {
                         this.logger.verbose(
-                            "Setting logoutHint to login_hint ID Token Claim value for the account provided"
+                            "Setting logoutHint to login_hint ID Token Claim value for the account provided",
+                            this.correlationId
                         );
                         validLogoutRequest.logoutHint = logoutHint;
                     }
                 } else {
                     this.logger.verbose(
-                        "logoutHint was not set and account was not passed into logout request, logoutHint will not be set"
+                        "logoutHint was not set and account was not passed into logout request, logoutHint will not be set",
+                        this.correlationId
                     );
                 }
             } else {
                 this.logger.verbose(
-                    "logoutHint has already been set in logoutRequest"
+                    "logoutHint has already been set in logoutRequest",
+                    this.correlationId
                 );
             }
         } else {
             this.logger.verbose(
-                "logoutHint will not be set since no logout request was configured"
+                "logoutHint will not be set since no logout request was configured",
+                this.correlationId
             );
         }
 
@@ -162,12 +166,14 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
                 return idTokenClaims.login_hint;
             } else {
                 this.logger.verbose(
-                    "The ID Token Claims tied to the provided account do not contain a login_hint claim, logoutHint will not be added to logout request"
+                    "The ID Token Claims tied to the provided account do not contain a login_hint claim, logoutHint will not be added to logout request",
+                    this.correlationId
                 );
             }
         } else {
             this.logger.verbose(
-                "The provided account does not contain ID Token Claims, logoutHint will not be added to logout request"
+                "The provided account does not contain ID Token Claims, logoutHint will not be added to logout request",
+                this.correlationId
             );
         }
 
@@ -309,7 +315,8 @@ export async function initializeAuthorizationRequest(
     const redirectUri = getRedirectUri(
         request.redirectUri,
         config.auth.redirectUri,
-        logger
+        logger,
+        correlationId
     );
     const browserState: BrowserStateObject = {
         interactionType: interactionType,
@@ -330,7 +337,8 @@ export async function initializeAuthorizationRequest(
         { ...request, correlationId: correlationId },
         config,
         performanceClient,
-        logger
+        logger,
+        correlationId
     );
 
     const validatedRequest: CommonAuthorizationUrlRequest = {

--- a/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
@@ -90,9 +90,8 @@ export class InteractionHandler {
     /**
      * Process auth code response from AAD
      * @param authCodeResponse
-     * @param state
-     * @param authority
-     * @param networkModule
+     * @param request
+     * @param validateNonce
      * @returns
      */
     async handleCodeResponseFromServer(
@@ -101,7 +100,8 @@ export class InteractionHandler {
         validateNonce: boolean = true
     ): Promise<AuthenticationResult> {
         this.logger.trace(
-            "InteractionHandler.handleCodeResponseFromServer called"
+            "InteractionHandler.handleCodeResponseFromServer called",
+            request.correlationId
         );
 
         // Assign code to request

--- a/lib/msal-browser/src/interaction_handler/SilentHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/SilentHandler.ts
@@ -35,7 +35,7 @@ export async function initiateCodeRequest(
 ): Promise<HTMLIFrameElement> {
     if (!requestUrl) {
         // Throw error if request URL is empty.
-        logger.info("Navigate url is empty");
+        logger.info("Navigate url is empty", correlationId);
         throw createBrowserAuthError(BrowserAuthErrorCodes.emptyNavigateUri);
     }
 
@@ -88,7 +88,8 @@ export async function monitorIframeForHash(
     return new Promise<string>((resolve, reject) => {
         if (timeout < DEFAULT_IFRAME_TIMEOUT_MS) {
             logger.warning(
-                `system.loadFrameTimeout or system.iframeHashTimeout set to lower (${timeout}ms) than the default (${DEFAULT_IFRAME_TIMEOUT_MS}ms). This may result in timeouts.`
+                `system.loadFrameTimeout or system.iframeHashTimeout set to lower (${timeout}ms) than the default (${DEFAULT_IFRAME_TIMEOUT_MS}ms). This may result in timeouts.`,
+                correlationId
             );
         }
 

--- a/lib/msal-browser/src/operatingcontext/BaseOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/BaseOperatingContext.ts
@@ -108,7 +108,7 @@ export abstract class BaseOperatingContext {
     /**
      * returns a boolean indicating whether this operating context is present
      */
-    abstract initialize(): Promise<boolean>;
+    abstract initialize(correlationId: string): Promise<boolean>;
 
     /**
      * Return the MSAL config

--- a/lib/msal-browser/src/operatingcontext/BaseOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/BaseOperatingContext.ts
@@ -107,6 +107,7 @@ export abstract class BaseOperatingContext {
 
     /**
      * returns a boolean indicating whether this operating context is present
+     * @param correlationId
      */
     abstract initialize(correlationId: string): Promise<boolean>;
 

--- a/lib/msal-browser/src/operatingcontext/NestedAppOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/NestedAppOperatingContext.ts
@@ -57,9 +57,10 @@ export class NestedAppOperatingContext extends BaseOperatingContext {
     /**
      * Checks whether the operating context is available.
      * Confirms that the code is running a browser rather.  This is required.
+     * @param correlationId
      * @returns Promise<boolean> indicating whether this operating context is currently available.
      */
-    async initialize(): Promise<boolean> {
+    async initialize(correlationId: string): Promise<boolean> {
         try {
             if (typeof window !== "undefined") {
                 if (typeof window.__initializeNestedAppAuth === "function") {
@@ -78,12 +79,14 @@ export class NestedAppOperatingContext extends BaseOperatingContext {
             }
         } catch (ex) {
             this.logger.infoPii(
-                `Could not initialize Nested App Auth bridge ('${ex}')`
+                `Could not initialize Nested App Auth bridge ('${ex}')`,
+                correlationId
             );
         }
 
         this.logger.info(
-            `Nested App Auth Bridge available: '${this.available}'`
+            `Nested App Auth Bridge available: '${this.available}'`,
+            correlationId
         );
         return this.available;
     }

--- a/lib/msal-browser/src/operatingcontext/StandardOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/StandardOperatingContext.ts
@@ -39,7 +39,7 @@ export class StandardOperatingContext extends BaseOperatingContext {
      * Confirms that the code is running a browser rather.  This is required.
      * @returns Promise<boolean> indicating whether this operating context is currently available.
      */
-    async initialize(): Promise<boolean> {
+    async initialize(correlationId: string): Promise<boolean> {
         this.available = typeof window !== "undefined";
         return this.available;
         /*

--- a/lib/msal-browser/src/operatingcontext/StandardOperatingContext.ts
+++ b/lib/msal-browser/src/operatingcontext/StandardOperatingContext.ts
@@ -39,6 +39,7 @@ export class StandardOperatingContext extends BaseOperatingContext {
      * Confirms that the code is running a browser rather.  This is required.
      * @returns Promise<boolean> indicating whether this operating context is currently available.
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async initialize(correlationId: string): Promise<boolean> {
         this.available = typeof window !== "undefined";
         return this.available;

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -88,7 +88,10 @@ async function getStandardParameters(
             request.authenticationScheme === Constants.AuthenticationScheme.POP
         ) {
             const cryptoOps = new CryptoOps(logger, performanceClient);
-            const popTokenGenerator = new PopTokenGenerator(cryptoOps);
+            const popTokenGenerator = new PopTokenGenerator(
+                cryptoOps,
+                performanceClient
+            );
 
             // req_cnf is always sent as a string for SPAs
             let reqCnfData;
@@ -259,7 +262,10 @@ export async function handleResponsePlatformBroker(
     performanceClient: IPerformanceClient,
     platformAuthProvider?: IPlatformAuthHandler
 ): Promise<AuthenticationResult> {
-    logger.verbose("Account id found, calling WAM for token");
+    logger.verbose(
+        "Account id found, calling WAM for token",
+        request.correlationId
+    );
 
     if (!platformAuthProvider) {
         throw createBrowserAuthError(
@@ -456,12 +462,13 @@ export async function handleResponseEAR(
         browserStorage,
         new CryptoOps(logger, performanceClient),
         logger,
+        performanceClient,
         null,
         null
     );
 
     // Validate response. This function throws a server error if an error is returned by the server.
-    responseHandler.validateTokenResponse(decryptedData);
+    responseHandler.validateTokenResponse(decryptedData, request.correlationId);
 
     // Temporary until response handler is refactored to be more flow agnostic.
     const additionalData: AuthorizationCodePayload = {

--- a/lib/msal-browser/src/request/RequestHelpers.ts
+++ b/lib/msal-browser/src/request/RequestHelpers.ts
@@ -21,12 +21,17 @@ import { SilentRequest } from "./SilentRequest.js";
 /**
  * Initializer function for all request APIs
  * @param request
+ * @param config
+ * @param performanceClient
+ * @param logger
+ * @param correlationId
  */
 export async function initializeBaseRequest(
     request: Partial<BaseAuthRequest> & { correlationId: string },
     config: BrowserConfiguration,
     performanceClient: IPerformanceClient,
-    logger: Logger
+    logger: Logger,
+    correlationId: string
 ): Promise<BaseAuthRequest> {
     const authority = request.authority || config.auth.authority;
 
@@ -44,7 +49,8 @@ export async function initializeBaseRequest(
         validatedRequest.authenticationScheme =
             Constants.AuthenticationScheme.BEARER;
         logger.verbose(
-            'Authentication Scheme wasn\'t explicitly set in request, defaulting to "Bearer" request'
+            'Authentication Scheme was not explicitly set in request, defaulting to "Bearer" request',
+            correlationId
         );
     } else {
         if (
@@ -63,7 +69,8 @@ export async function initializeBaseRequest(
             }
         }
         logger.verbose(
-            `Authentication Scheme set to "'${validatedRequest.authenticationScheme}'" as configured in Auth request`
+            `Authentication Scheme set to "'${validatedRequest.authenticationScheme}'" as configured in Auth request`,
+            correlationId
         );
     }
 
@@ -83,7 +90,7 @@ export async function initializeSilentRequest(
         logger,
         performanceClient,
         request.correlationId
-    )(request, config, performanceClient, logger);
+    )(request, config, performanceClient, logger, request.correlationId);
     return {
         ...request,
         ...baseRequest,

--- a/lib/msal-browser/src/response/ResponseHandler.ts
+++ b/lib/msal-browser/src/response/ResponseHandler.ts
@@ -19,7 +19,8 @@ import { InteractionType } from "../utils/BrowserConstants.js";
 export function deserializeResponse(
     responseString: string,
     responseLocation: string,
-    logger: Logger
+    logger: Logger,
+    correlationId: string
 ): AuthorizeResponse {
     // Deserialize hash fragment response parameters.
     const serverParams = UrlUtils.getDeserializedResponse(responseString);
@@ -27,15 +28,18 @@ export function deserializeResponse(
         if (!UrlUtils.stripLeadingHashOrQuery(responseString)) {
             // Hash or Query string is empty
             logger.error(
-                `The request has returned to the redirectUri but a '${responseLocation}' is not present. It's likely that the '${responseLocation}' has been removed or the page has been redirected by code running on the redirectUri page.`
+                `The request has returned to the redirectUri but a '${responseLocation}' is not present. It's likely that the '${responseLocation}' has been removed or the page has been redirected by code running on the redirectUri page.`,
+                correlationId
             );
             throw createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError);
         } else {
             logger.error(
-                `A '${responseLocation}' is present in the iframe but it does not contain known properties. It's likely that the '${responseLocation}' has been replaced by code running on the redirectUri page.`
+                `A '${responseLocation}' is present in the iframe but it does not contain known properties. It's likely that the '${responseLocation}' has been replaced by code running on the redirectUri page.`,
+                correlationId
             );
             logger.errorPii(
-                `The '${responseLocation}' detected is: '${responseString}'`
+                `The '${responseLocation}' detected is: '${responseString}'`,
+                correlationId
             );
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.hashDoesNotContainKnownProperties

--- a/lib/msal-browser/src/utils/MsalFrameStatsUtils.ts
+++ b/lib/msal-browser/src/utils/MsalFrameStatsUtils.ts
@@ -8,7 +8,8 @@ import { InProgressPerformanceEvent, Logger } from "@azure/msal-common/browser";
 export function collectInstanceStats(
     currentClientId: string,
     performanceEvent: InProgressPerformanceEvent,
-    logger: Logger
+    logger: Logger,
+    correlationId: string
 ): void {
     const frameInstances: string[] =
         // @ts-ignore
@@ -22,7 +23,8 @@ export function collectInstanceStats(
 
     if (sameClientIdInstanceCount > 1) {
         logger.warning(
-            "There is already an instance of MSAL.js in the window with the same client id."
+            "There is already an instance of MSAL.js in the window with the same client id.",
+            correlationId
         );
     }
     performanceEvent.add({

--- a/lib/msal-browser/src/utils/PopupUtils.ts
+++ b/lib/msal-browser/src/utils/PopupUtils.ts
@@ -22,6 +22,7 @@ import {
  * @param pollIntervalMilliseconds - The interval, in milliseconds, at which to poll the popup window.
  * @param logger - Logger instance for logging monitoring events.
  * @param unloadWindow - Event handler to remove from the parent window on cleanup.
+ * @param correlationId
  * @returns Promise<string> - Resolves with the response string (query or hash) from the popup window,
  * or rejects if the popup is closed before a response is received.
  *
@@ -35,16 +36,21 @@ export async function monitorPopupForHash(
     responseMode: Constants.ResponseMode,
     pollIntervalMilliseconds: number,
     logger: Logger,
-    unloadWindow: (e: Event) => void
+    unloadWindow: (e: Event) => void,
+    correlationId: string
 ): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-        logger.verbose("PopupHandler.monitorPopupForHash - polling started");
+        logger.verbose(
+            "PopupHandler.monitorPopupForHash - polling started",
+            correlationId
+        );
 
         const intervalId = setInterval(() => {
             // Window is closed
             if (popupWindow.closed) {
                 logger.error(
-                    "PopupHandler.monitorPopupForHash - window closed"
+                    "PopupHandler.monitorPopupForHash - window closed",
+                    correlationId
                 );
                 clearInterval(intervalId);
                 reject(
@@ -79,7 +85,8 @@ export async function monitorPopupForHash(
             }
 
             logger.verbose(
-                "PopupHandler.monitorPopupForHash - popup window is on same origin as caller"
+                "PopupHandler.monitorPopupForHash - popup window is on same origin as caller",
+                correlationId
             );
 
             resolve(responseString);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1872,8 +1872,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             browserStorage.setInteractionInProgress(true);
             await expect(
@@ -1894,8 +1893,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             const secondInstanceStorage = new BrowserCacheManager(
                 "different-client-id",
@@ -1903,8 +1901,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             secondInstanceStorage.setInteractionInProgress(true);
 
@@ -2882,8 +2879,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             browserStorage.setInteractionInProgress(true);
 
@@ -5992,8 +5988,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             browserStorage.setInteractionInProgress(true);
 
@@ -6971,8 +6966,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 new CryptoOps(new Logger({})),
                 new Logger({}),
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             await secondBrowserStorageInstance.initialize(
                 TEST_CONFIG.CORRELATION_ID

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1872,7 +1872,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             browserStorage.setInteractionInProgress(true);
             await expect(
@@ -1893,7 +1894,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             const secondInstanceStorage = new BrowserCacheManager(
                 "different-client-id",
@@ -1901,7 +1903,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             secondInstanceStorage.setInteractionInProgress(true);
 
@@ -2879,7 +2882,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             browserStorage.setInteractionInProgress(true);
 
@@ -5988,7 +5992,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             browserStorage.setInteractionInProgress(true);
 
@@ -6551,14 +6556,18 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
 
             expect(pca.getLogger()).toEqual(logger);
 
-            pca.getLogger().info("Message");
+            pca.getLogger().info("Message", TEST_CONFIG.CORRELATION_ID);
         });
 
         test("logger undefined", async () => {
             const authApp = new PublicClientApplication(testAppConfig);
 
             expect(authApp.getLogger()).toBeDefined();
-            expect(authApp.getLogger().info("Test logger")).toEqual(undefined);
+            expect(
+                authApp
+                    .getLogger()
+                    .info("Test logger", TEST_CONFIG.CORRELATION_ID)
+            ).toEqual(undefined);
         });
     });
 
@@ -6716,9 +6725,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .spyOn(logger, "executeCallback")
                 .mockImplementation();
 
-            logger.info("test info");
-            logger.verbose("test verbose");
-            logger.verbosePii("test pii verbose");
+            logger.info("test info", TEST_CONFIG.CORRELATION_ID);
+            logger.verbose("test verbose", TEST_CONFIG.CORRELATION_ID);
+            logger.verbosePii("test pii verbose", TEST_CONFIG.CORRELATION_ID);
 
             expect(loggerCallbackStub).toHaveBeenCalledTimes(2);
             expect(loggerCallbackStub).toHaveBeenCalledWith(
@@ -6762,9 +6771,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .spyOn(logger, "executeCallback")
                 .mockImplementation();
 
-            logger.info("test info");
-            logger.verbose("test verbose");
-            logger.verbosePii("test pii verbose");
+            logger.info("test info", TEST_CONFIG.CORRELATION_ID);
+            logger.verbose("test verbose", TEST_CONFIG.CORRELATION_ID);
+            logger.verbosePii("test pii verbose", TEST_CONFIG.CORRELATION_ID);
 
             expect(loggerCallbackStub).toHaveBeenCalledTimes(1);
             expect(loggerCallbackStub).toHaveBeenCalledWith(
@@ -6805,9 +6814,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .spyOn(logger, "executeCallback")
                 .mockImplementation();
 
-            logger.info("test info");
-            logger.verbose("test verbose");
-            logger.verbosePii("test pii verbose");
+            logger.info("test info", TEST_CONFIG.CORRELATION_ID);
+            logger.verbose("test verbose", TEST_CONFIG.CORRELATION_ID);
+            logger.verbosePii("test pii verbose", TEST_CONFIG.CORRELATION_ID);
 
             expect(loggerCallbackStub).toHaveBeenCalledTimes(3);
             expect(loggerCallbackStub).toHaveBeenCalledWith(
@@ -6859,9 +6868,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .spyOn(logger, "executeCallback")
                 .mockImplementation();
 
-            logger.info("test info");
-            logger.verbose("test verbose");
-            logger.verbosePii("test pii verbose");
+            logger.info("test info", TEST_CONFIG.CORRELATION_ID);
+            logger.verbose("test verbose", TEST_CONFIG.CORRELATION_ID);
+            logger.verbosePii("test pii verbose", TEST_CONFIG.CORRELATION_ID);
 
             expect(loggerCallbackStub).toHaveBeenCalledTimes(2);
             expect(loggerCallbackStub).toHaveBeenCalledWith(
@@ -6911,9 +6920,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .spyOn(logger, "executeCallback")
                 .mockImplementation();
 
-            logger.info("test info");
-            logger.verbose("test verbose");
-            logger.verbosePii("test pii verbose");
+            logger.info("test info", TEST_CONFIG.CORRELATION_ID);
+            logger.verbose("test verbose", TEST_CONFIG.CORRELATION_ID);
+            logger.verbosePii("test pii verbose", TEST_CONFIG.CORRELATION_ID);
 
             expect(loggerCallbackStub).toHaveBeenCalledTimes(3);
             expect(loggerCallbackStub).toHaveBeenCalledWith(
@@ -6962,7 +6971,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 new CryptoOps(new Logger({})),
                 new Logger({}),
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             await secondBrowserStorageInstance.initialize(
                 TEST_CONFIG.CORRELATION_ID

--- a/lib/msal-browser/test/broker/PlatformAuthExtensionHandler.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthExtensionHandler.spec.ts
@@ -81,7 +81,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
                 await PlatformAuthExtensionHandler.createProvider(
                     new Logger({}),
                     2000,
-                    performanceClient
+                    performanceClient,
+                    TEST_CONFIG.CORRELATION_ID
                 );
             expect(wamMessageHandler).toBeInstanceOf(
                 PlatformAuthExtensionHandler
@@ -132,7 +133,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
             PlatformAuthExtensionHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             ).then(() => {
                 window.removeEventListener("message", eventHandler, true);
             });
@@ -170,7 +172,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
                 await PlatformAuthExtensionHandler.createProvider(
                     new Logger({}),
                     2000,
-                    performanceClient
+                    performanceClient,
+                    TEST_CONFIG.CORRELATION_ID
                 );
             expect(wamMessageHandler).toBeInstanceOf(
                 PlatformAuthExtensionHandler
@@ -183,7 +186,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
             PlatformAuthExtensionHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             ).catch((e) => {
                 expect(e).toBeInstanceOf(BrowserAuthError);
                 expect(e.errorCode).toBe(
@@ -208,7 +212,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
             PlatformAuthExtensionHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             )
                 .catch((e) => {
                     expect(e).toBeInstanceOf(BrowserAuthError);
@@ -248,7 +253,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
             PlatformAuthExtensionHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             ).catch(() => {
                 if (callbackDone) {
                     done();
@@ -315,7 +321,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
                 await PlatformAuthExtensionHandler.createProvider(
                     new Logger({}),
                     2000,
-                    performanceClient
+                    performanceClient,
+                    TEST_CONFIG.CORRELATION_ID
                 );
             expect(wamMessageHandler).toBeInstanceOf(
                 PlatformAuthExtensionHandler
@@ -372,7 +379,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
             PlatformAuthExtensionHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             )
                 .then((wamMessageHandler) => {
                     wamMessageHandler.sendMessage(TEST_REQUEST).catch((e) => {
@@ -436,7 +444,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
             PlatformAuthExtensionHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             )
                 .then((wamMessageHandler) => {
                     wamMessageHandler.sendMessage(TEST_REQUEST).catch((e) => {
@@ -496,7 +505,8 @@ describe("PlatformAuthExtensionHandler Tests", () => {
             PlatformAuthExtensionHandler.createProvider(
                 new Logger({}),
                 2000,
-                performanceClient
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             )
                 .then((wamMessageHandler) => {
                     wamMessageHandler.sendMessage(TEST_REQUEST).catch((e) => {

--- a/lib/msal-browser/test/broker/PlatformAuthProvider.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthProvider.spec.ts
@@ -15,6 +15,7 @@ import { PlatformAuthExtensionHandler } from "../../src/broker/nativeBroker/Plat
 import exp from "constants";
 import { log } from "console";
 import { BrowserAuthError } from "../../src/index.js";
+import { TEST_CONFIG } from "../utils/StringConstants.js";
 
 describe("PlatformAuthProvider tests", () => {
     function stubExtensionProvider() {
@@ -79,8 +80,11 @@ describe("PlatformAuthProvider tests", () => {
 
             const domProviderSpy = stubDOMProvider();
 
-            const result =
-                await PlatformAuthProvider.isPlatformBrokerAvailable();
+            const result = await PlatformAuthProvider.isPlatformBrokerAvailable(
+                {},
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
+            );
             expect(result).toBe(true);
             expect(getItemSpy).toHaveBeenCalled();
             expect(domProviderSpy).toHaveBeenCalled();
@@ -89,8 +93,11 @@ describe("PlatformAuthProvider tests", () => {
         it("should return true if its a browser app and extension handler is available", async () => {
             const extensionProviderSpy = stubExtensionProvider();
 
-            const result =
-                await PlatformAuthProvider.isPlatformBrokerAvailable();
+            const result = await PlatformAuthProvider.isPlatformBrokerAvailable(
+                {},
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
+            );
             expect(result).toBe(true);
             expect(extensionProviderSpy).toHaveBeenCalled();
         });
@@ -110,8 +117,11 @@ describe("PlatformAuthProvider tests", () => {
                 throw new Error("No handler available");
             });
 
-            const result =
-                await PlatformAuthProvider.isPlatformBrokerAvailable();
+            const result = await PlatformAuthProvider.isPlatformBrokerAvailable(
+                {},
+                performanceClient,
+                TEST_CONFIG.CORRELATION_ID
+            );
             expect(result).toBe(false);
         });
     });
@@ -227,6 +237,7 @@ describe("PlatformAuthProvider tests", () => {
             const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,
+                TEST_CONFIG.CORRELATION_ID,
                 new PlatformAuthDOMHandler(
                     logger,
                     performanceClient,
@@ -241,6 +252,7 @@ describe("PlatformAuthProvider tests", () => {
             const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,
+                TEST_CONFIG.CORRELATION_ID,
                 undefined,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -250,6 +262,7 @@ describe("PlatformAuthProvider tests", () => {
             const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,
+                TEST_CONFIG.CORRELATION_ID,
                 new PlatformAuthDOMHandler(
                     logger,
                     performanceClient,
@@ -264,6 +277,7 @@ describe("PlatformAuthProvider tests", () => {
             const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,
+                TEST_CONFIG.CORRELATION_ID,
                 new PlatformAuthDOMHandler(
                     logger,
                     performanceClient,

--- a/lib/msal-browser/test/cache/AsyncMemoryStorage.spec.ts
+++ b/lib/msal-browser/test/cache/AsyncMemoryStorage.spec.ts
@@ -2,8 +2,9 @@ import { Logger, LogLevel } from "@azure/msal-common";
 import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
-} from "../../src/error/BrowserAuthError";
-import { AsyncMemoryStorage } from "../../src/cache/AsyncMemoryStorage";
+} from "../../src/error/BrowserAuthError.js";
+import { AsyncMemoryStorage } from "../../src/cache/AsyncMemoryStorage.js";
+import { TEST_CONFIG } from "../utils/StringConstants.js";
 
 let mockDatabase = {};
 
@@ -168,7 +169,8 @@ describe("AsyncMemoryStorage Unit Tests", () => {
                     TEST_CACHE_ITEMS.TestItem.key
                 ] = TEST_CACHE_ITEMS.TestItem.value;
                 const item = await asyncMemoryStorage.getItem(
-                    TEST_CACHE_ITEMS.TestItem.key
+                    TEST_CACHE_ITEMS.TestItem.key,
+                    TEST_CONFIG.CORRELATION_ID
                 );
                 expect(callCounter.getItem).toBe(1);
                 expect(callCounter.getItemPersistent).toBe(0);
@@ -180,7 +182,8 @@ describe("AsyncMemoryStorage Unit Tests", () => {
                     TEST_CACHE_ITEMS.TestItem.key
                 ] = TEST_CACHE_ITEMS.TestItem.value;
                 const item = await asyncMemoryStorage.getItem(
-                    TEST_CACHE_ITEMS.TestItem.key
+                    TEST_CACHE_ITEMS.TestItem.key,
+                    TEST_CONFIG.CORRELATION_ID
                 );
                 expect(callCounter.getItem).toBe(1);
                 expect(callCounter.getItemPersistent).toBe(1);
@@ -205,7 +208,8 @@ describe("AsyncMemoryStorage Unit Tests", () => {
             it("should set item in in-memory cache and persistent storage", async () => {
                 await asyncMemoryStorage.setItem(
                     TEST_CACHE_ITEMS.TestItem.key,
-                    TEST_CACHE_ITEMS.TestItem.value
+                    TEST_CACHE_ITEMS.TestItem.value,
+                    TEST_CONFIG.CORRELATION_ID
                 );
                 const memoryItem =
                     mockInMemoryCache[TEST_DB_TABLE_NAME][
@@ -238,7 +242,8 @@ describe("AsyncMemoryStorage Unit Tests", () => {
                     TEST_CACHE_ITEMS.TestItem.key
                 ] = TEST_CACHE_ITEMS.TestItem.value;
                 await asyncMemoryStorage.removeItem(
-                    TEST_CACHE_ITEMS.TestItem.key
+                    TEST_CACHE_ITEMS.TestItem.key,
+                    TEST_CONFIG.CORRELATION_ID
                 );
                 expect(callCounter.removeItem).toBe(1);
                 expect(callCounter.removeItemPersistent).toBe(1);
@@ -271,7 +276,7 @@ describe("AsyncMemoryStorage Unit Tests", () => {
             });
 
             it("should clear in-memory storage by deleting all elements inside", async () => {
-                asyncMemoryStorage.clearInMemory();
+                asyncMemoryStorage.clearInMemory(TEST_CONFIG.CORRELATION_ID);
                 expect(callCounter.clearInMemory).toBe(1);
                 expect(
                     Object.keys(mockInMemoryCache[TEST_DB_TABLE_NAME]).length
@@ -279,7 +284,9 @@ describe("AsyncMemoryStorage Unit Tests", () => {
             });
 
             it("should clear persistent storage by deleting the IndexedDB database", async () => {
-                const deleted = await asyncMemoryStorage.clearPersistent();
+                const deleted = await asyncMemoryStorage.clearPersistent(
+                    TEST_CONFIG.CORRELATION_ID
+                );
                 expect(deleted).toBe(true);
                 expect(callCounter.clearPersistent).toBe(1);
                 expect(mockDatabase[TEST_DB_TABLE_NAME]).toBe(undefined);
@@ -290,7 +297,7 @@ describe("AsyncMemoryStorage Unit Tests", () => {
 
                 return new Promise((resolve, reject) => {
                     asyncMemoryStorage
-                        .clearPersistent()
+                        .clearPersistent(TEST_CONFIG.CORRELATION_ID)
                         .then(() => {
                             reject("This code path should not be reached");
                         })
@@ -327,7 +334,8 @@ describe("AsyncMemoryStorage Unit Tests", () => {
                     TEST_CACHE_ITEMS.TestItem.key
                 ] = DB_UNAVAILABLE;
                 const item = await asyncMemoryStorage.getItem(
-                    TEST_CACHE_ITEMS.TestItem.key
+                    TEST_CACHE_ITEMS.TestItem.key,
+                    TEST_CONFIG.CORRELATION_ID
                 );
                 const lastLog = logMessages[logMessages.length - 1];
                 expect(callCounter.getItem).toBe(1);
@@ -353,7 +361,8 @@ describe("AsyncMemoryStorage Unit Tests", () => {
             it("should log an error if persistent storage is unavailable or inaccessible", async () => {
                 const item = await asyncMemoryStorage.setItem(
                     TEST_CACHE_ITEMS.TestItem.key,
-                    DB_UNAVAILABLE
+                    DB_UNAVAILABLE,
+                    TEST_CONFIG.CORRELATION_ID
                 );
                 const lastLog = logMessages[logMessages.length - 1];
                 expect(callCounter.setItem).toBe(1);
@@ -381,7 +390,8 @@ describe("AsyncMemoryStorage Unit Tests", () => {
                     TEST_CACHE_ITEMS.TestItem.key
                 ] = DB_UNAVAILABLE;
                 await asyncMemoryStorage.removeItem(
-                    TEST_CACHE_ITEMS.TestItem.key
+                    TEST_CACHE_ITEMS.TestItem.key,
+                    TEST_CONFIG.CORRELATION_ID
                 );
                 const lastLog = logMessages[logMessages.length - 1];
                 expect(callCounter.removeItem).toBe(1);

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -85,8 +85,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             // @ts-ignore
             cacheManager.browserStorage.setItem("key", "value");
@@ -106,8 +105,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             // @ts-ignore
             sessionCache.browserStorage.setItem("key", "value");
@@ -126,8 +124,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             // @ts-ignore
             localCache.browserStorage.setItem("key", "value");
@@ -147,8 +144,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             await browserCacheManager.initialize(TEST_CONFIG.CORRELATION_ID);
             expect(
@@ -167,8 +163,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             await browserCacheManager.initialize(TEST_CONFIG.CORRELATION_ID);
             expect(
@@ -187,8 +182,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             await browserCacheManager1.initialize(TEST_CONFIG.CORRELATION_ID);
             expect(
@@ -205,8 +199,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             await browserCacheManager2.initialize(TEST_CONFIG.CORRELATION_ID);
             expect(
@@ -234,8 +227,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 performanceClient,
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
         });
 
@@ -594,8 +586,7 @@ describe("BrowserCacheManager tests", () => {
                     browserCrypto,
                     logger,
                     performanceClient,
-                    new EventHandler(),
-                    TEST_CONFIG.CORRELATION_ID
+                    new EventHandler()
                 );
 
                 // Create mock localStorage implementation
@@ -979,8 +970,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             await browserSessionStorage.initialize(TEST_CONFIG.CORRELATION_ID);
             authority = new Authority(
@@ -1010,8 +1000,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             await browserLocalStorage.initialize(TEST_CONFIG.CORRELATION_ID);
             cacheVal = "cacheVal";
@@ -1044,8 +1033,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             expect(browserLocalStorage.getTemporaryCache(testTempItemKey)).toBe(
                 testTempItemValue
@@ -1066,8 +1054,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             // Create a real AccessTokenEntity to be removed
             const accessToken1 = CacheHelpers.createAccessTokenEntity(
@@ -1164,8 +1151,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             // Create a real AccessTokenEntity to be removed
             const accessToken1 = CacheHelpers.createAccessTokenEntity(
@@ -1280,8 +1266,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
 
             const atKeys = [];
@@ -1358,8 +1343,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             // Create a real AccessTokenEntity to be removed
             const accessToken1 = CacheHelpers.createAccessTokenEntity(
@@ -1457,8 +1441,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             const atKeys = [];
             for (let i = 0; i < 25; i++) {
@@ -1534,8 +1517,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             // Create a real AccessTokenEntity to be removed
             const accessToken1 = CacheHelpers.createAccessTokenEntity(
@@ -1652,8 +1634,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
 
             // Create v0 access tokens
@@ -1836,8 +1817,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
 
             // Create one v0 token and multiple v1 tokens
@@ -1965,8 +1945,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
 
             // Create v0 and v1 access tokens
@@ -2075,8 +2054,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
 
             // Create mixed v0 and v1 tokens
@@ -3435,8 +3413,7 @@ describe("BrowserCacheManager tests", () => {
                         browserCrypto,
                         logger,
                         perfClient,
-                        new EventHandler(),
-                        TEST_CONFIG.CORRELATION_ID
+                        new EventHandler()
                     );
 
                     jest.spyOn(
@@ -3511,8 +3488,7 @@ describe("BrowserCacheManager tests", () => {
                         browserCrypto,
                         logger,
                         perfClient,
-                        new EventHandler(),
-                        TEST_CONFIG.CORRELATION_ID
+                        new EventHandler()
                     );
 
                     cacheManager.setInteractionInProgress(true);
@@ -3536,8 +3512,7 @@ describe("BrowserCacheManager tests", () => {
                         browserCrypto,
                         logger,
                         perfClient,
-                        new EventHandler(),
-                        TEST_CONFIG.CORRELATION_ID
+                        new EventHandler()
                     );
 
                     cacheManager.setTemporaryCache(
@@ -3559,8 +3534,7 @@ describe("BrowserCacheManager tests", () => {
                         browserCrypto,
                         logger,
                         perfClient,
-                        new EventHandler(),
-                        TEST_CONFIG.CORRELATION_ID
+                        new EventHandler()
                     );
 
                     cacheManager.setTemporaryCache(
@@ -3595,8 +3569,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             const requestParamsKey = `${CacheKeys.PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.REQUEST_PARAMS}`;
             window.sessionStorage.setItem(
@@ -3629,8 +3602,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             const tokenRequest: CommonAuthorizationUrlRequest = {
                 redirectUri: `${TEST_URIS.DEFAULT_INSTANCE}`,
@@ -3662,8 +3634,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
 
             expect(() => browserStorage.getCachedRequest()).toThrow(
@@ -3686,8 +3657,7 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             const tokenRequest: AuthorizationCodeRequest = {
                 redirectUri: `${TEST_URIS.DEFAULT_INSTANCE}`,

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -85,7 +85,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             // @ts-ignore
             cacheManager.browserStorage.setItem("key", "value");
@@ -105,7 +106,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             // @ts-ignore
             sessionCache.browserStorage.setItem("key", "value");
@@ -124,7 +126,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             // @ts-ignore
             localCache.browserStorage.setItem("key", "value");
@@ -144,7 +147,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             await browserCacheManager.initialize(TEST_CONFIG.CORRELATION_ID);
             expect(
@@ -163,7 +167,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             await browserCacheManager.initialize(TEST_CONFIG.CORRELATION_ID);
             expect(
@@ -182,7 +187,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             await browserCacheManager1.initialize(TEST_CONFIG.CORRELATION_ID);
             expect(
@@ -199,7 +205,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             await browserCacheManager2.initialize(TEST_CONFIG.CORRELATION_ID);
             expect(
@@ -227,7 +234,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 performanceClient,
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
         });
 
@@ -586,7 +594,8 @@ describe("BrowserCacheManager tests", () => {
                     browserCrypto,
                     logger,
                     performanceClient,
-                    new EventHandler()
+                    new EventHandler(),
+                    TEST_CONFIG.CORRELATION_ID
                 );
 
                 // Create mock localStorage implementation
@@ -970,7 +979,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             await browserSessionStorage.initialize(TEST_CONFIG.CORRELATION_ID);
             authority = new Authority(
@@ -984,7 +994,8 @@ describe("BrowserCacheManager tests", () => {
                     knownAuthorities: [],
                 },
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             jest.spyOn(
                 Authority.prototype,
@@ -999,7 +1010,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             await browserLocalStorage.initialize(TEST_CONFIG.CORRELATION_ID);
             cacheVal = "cacheVal";
@@ -1032,7 +1044,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             expect(browserLocalStorage.getTemporaryCache(testTempItemKey)).toBe(
                 testTempItemValue
@@ -1053,7 +1066,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             // Create a real AccessTokenEntity to be removed
             const accessToken1 = CacheHelpers.createAccessTokenEntity(
@@ -1150,7 +1164,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             // Create a real AccessTokenEntity to be removed
             const accessToken1 = CacheHelpers.createAccessTokenEntity(
@@ -1265,7 +1280,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
 
             const atKeys = [];
@@ -1342,7 +1358,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             // Create a real AccessTokenEntity to be removed
             const accessToken1 = CacheHelpers.createAccessTokenEntity(
@@ -1440,7 +1457,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             const atKeys = [];
             for (let i = 0; i < 25; i++) {
@@ -1516,7 +1534,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             // Create a real AccessTokenEntity to be removed
             const accessToken1 = CacheHelpers.createAccessTokenEntity(
@@ -1633,7 +1652,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
 
             // Create v0 access tokens
@@ -1816,7 +1836,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
 
             // Create one v0 token and multiple v1 tokens
@@ -1944,7 +1965,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
 
             // Create v0 and v1 access tokens
@@ -2053,7 +2075,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
 
             // Create mixed v0 and v1 tokens
@@ -2915,9 +2938,17 @@ describe("BrowserCacheManager tests", () => {
                 it("getAppMetadata returns null if key not in cache", () => {
                     const key = "not-in-cache";
                     expect(
-                        browserSessionStorage.getAppMetadata(key)
+                        browserSessionStorage.getAppMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
-                    expect(browserLocalStorage.getAppMetadata(key)).toBeNull();
+                    expect(
+                        browserLocalStorage.getAppMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
+                    ).toBeNull();
                 });
 
                 it("getAppMetadata returns null if value is not JSON", () => {
@@ -2926,9 +2957,17 @@ describe("BrowserCacheManager tests", () => {
                     window.sessionStorage.setItem(key, "this is not json");
 
                     expect(
-                        browserSessionStorage.getAppMetadata(key)
+                        browserSessionStorage.getAppMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
-                    expect(browserLocalStorage.getAppMetadata(key)).toBeNull();
+                    expect(
+                        browserLocalStorage.getAppMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
+                    ).toBeNull();
                 });
 
                 it("getAppMetadata returns null if value is not appMetadata entity", () => {
@@ -2947,9 +2986,17 @@ describe("BrowserCacheManager tests", () => {
                     );
 
                     expect(
-                        browserSessionStorage.getAppMetadata(key)
+                        browserSessionStorage.getAppMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
-                    expect(browserLocalStorage.getAppMetadata(key)).toBeNull();
+                    expect(
+                        browserLocalStorage.getAppMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
+                    ).toBeNull();
                 });
 
                 it("getAppMetadata returns AppMetadataEntity", () => {
@@ -2970,12 +3017,18 @@ describe("BrowserCacheManager tests", () => {
 
                     expect(
                         browserSessionStorage.getAppMetadata(
-                            CacheHelpers.generateAppMetadataKey(testAppMetadata)
+                            CacheHelpers.generateAppMetadataKey(
+                                testAppMetadata
+                            ),
+                            TEST_CONFIG.CORRELATION_ID
                         )
                     ).toEqual(testAppMetadata);
                     expect(
                         browserLocalStorage.getAppMetadata(
-                            CacheHelpers.generateAppMetadataKey(testAppMetadata)
+                            CacheHelpers.generateAppMetadataKey(
+                                testAppMetadata
+                            ),
+                            TEST_CONFIG.CORRELATION_ID
                         )
                     ).toEqual(testAppMetadata);
                 });
@@ -2985,10 +3038,16 @@ describe("BrowserCacheManager tests", () => {
                 it("getServerTelemetry returns null if key not in cache", () => {
                     const key = "not-in-cache";
                     expect(
-                        browserSessionStorage.getServerTelemetry(key)
+                        browserSessionStorage.getServerTelemetry(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getServerTelemetry(key)
+                        browserLocalStorage.getServerTelemetry(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                 });
 
@@ -2998,10 +3057,16 @@ describe("BrowserCacheManager tests", () => {
                     window.sessionStorage.setItem(key, "this is not json");
 
                     expect(
-                        browserSessionStorage.getServerTelemetry(key)
+                        browserSessionStorage.getServerTelemetry(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getServerTelemetry(key)
+                        browserLocalStorage.getServerTelemetry(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                 });
 
@@ -3021,10 +3086,16 @@ describe("BrowserCacheManager tests", () => {
                     );
 
                     expect(
-                        browserSessionStorage.getServerTelemetry(key)
+                        browserSessionStorage.getServerTelemetry(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getServerTelemetry(key)
+                        browserLocalStorage.getServerTelemetry(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                 });
 
@@ -3048,10 +3119,16 @@ describe("BrowserCacheManager tests", () => {
                     );
 
                     expect(
-                        browserSessionStorage.getServerTelemetry(testKey)
+                        browserSessionStorage.getServerTelemetry(
+                            testKey,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toEqual(testVal);
                     expect(
-                        browserLocalStorage.getServerTelemetry(testKey)
+                        browserLocalStorage.getServerTelemetry(
+                            testKey,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toEqual(testVal);
                 });
             });
@@ -3088,27 +3165,47 @@ describe("BrowserCacheManager tests", () => {
 
                 it("getAuthorityMetadata() returns null if key is not in cache", () => {
                     expect(
-                        browserSessionStorage.getAuthorityMetadata(key)
+                        browserSessionStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getAuthorityMetadata(key)
+                        browserLocalStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                 });
 
                 it("getAuthorityMetadata() returns null if isAuthorityMetadataEntity returns false", () => {
-                    browserSessionStorage.setAuthorityMetadata(key, {
-                        // @ts-ignore
-                        invalidKey: "invalidValue",
-                    });
-                    browserLocalStorage.setAuthorityMetadata(key, {
-                        // @ts-ignore
-                        invalidKey: "invalidValue",
-                    });
+                    browserSessionStorage.setAuthorityMetadata(
+                        key,
+                        {
+                            // @ts-ignore
+                            invalidKey: "invalidValue",
+                        },
+                        TEST_CONFIG.CORRELATION_ID
+                    );
+                    browserLocalStorage.setAuthorityMetadata(
+                        key,
+                        {
+                            // @ts-ignore
+                            invalidKey: "invalidValue",
+                        },
+                        TEST_CONFIG.CORRELATION_ID
+                    );
                     expect(
-                        browserSessionStorage.getAuthorityMetadata(key)
+                        browserSessionStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getAuthorityMetadata(key)
+                        browserLocalStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
                         browserLocalStorage.getAuthorityMetadataKeys()
@@ -3119,14 +3216,28 @@ describe("BrowserCacheManager tests", () => {
                 });
 
                 it("setAuthorityMetadata() and getAuthorityMetadata() sets and returns AuthorityMetadataEntity in-memory", () => {
-                    browserSessionStorage.setAuthorityMetadata(key, testObj);
-                    browserLocalStorage.setAuthorityMetadata(key, testObj);
+                    browserSessionStorage.setAuthorityMetadata(
+                        key,
+                        testObj,
+                        TEST_CONFIG.CORRELATION_ID
+                    );
+                    browserLocalStorage.setAuthorityMetadata(
+                        key,
+                        testObj,
+                        TEST_CONFIG.CORRELATION_ID
+                    );
 
                     expect(
-                        browserSessionStorage.getAuthorityMetadata(key)
+                        browserSessionStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toEqual(testObj);
                     expect(
-                        browserLocalStorage.getAuthorityMetadata(key)
+                        browserLocalStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toEqual(testObj);
                     expect(
                         browserLocalStorage.getAuthorityMetadataKeys()
@@ -3137,14 +3248,28 @@ describe("BrowserCacheManager tests", () => {
                 });
 
                 it("clear() removes AuthorityMetadataEntity from in-memory storage", async () => {
-                    browserSessionStorage.setAuthorityMetadata(key, testObj);
-                    browserLocalStorage.setAuthorityMetadata(key, testObj);
+                    browserSessionStorage.setAuthorityMetadata(
+                        key,
+                        testObj,
+                        TEST_CONFIG.CORRELATION_ID
+                    );
+                    browserLocalStorage.setAuthorityMetadata(
+                        key,
+                        testObj,
+                        TEST_CONFIG.CORRELATION_ID
+                    );
 
                     expect(
-                        browserSessionStorage.getAuthorityMetadata(key)
+                        browserSessionStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toEqual(testObj);
                     expect(
-                        browserLocalStorage.getAuthorityMetadata(key)
+                        browserLocalStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toEqual(testObj);
                     expect(
                         browserLocalStorage.getAuthorityMetadataKeys()
@@ -3156,10 +3281,16 @@ describe("BrowserCacheManager tests", () => {
                     browserSessionStorage.clear(RANDOM_TEST_GUID);
                     browserLocalStorage.clear(RANDOM_TEST_GUID);
                     expect(
-                        browserSessionStorage.getAuthorityMetadata(key)
+                        browserSessionStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getAuthorityMetadata(key)
+                        browserLocalStorage.getAuthorityMetadata(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
                         browserLocalStorage.getAuthorityMetadataKeys().length
@@ -3174,10 +3305,16 @@ describe("BrowserCacheManager tests", () => {
                 it("getThrottlingCache returns null if key not in cache", () => {
                     const key = "not-in-cache";
                     expect(
-                        browserSessionStorage.getServerTelemetry(key)
+                        browserSessionStorage.getServerTelemetry(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getServerTelemetry(key)
+                        browserLocalStorage.getServerTelemetry(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                 });
 
@@ -3187,10 +3324,16 @@ describe("BrowserCacheManager tests", () => {
                     window.sessionStorage.setItem(key, "this is not json");
 
                     expect(
-                        browserSessionStorage.getThrottlingCache(key)
+                        browserSessionStorage.getThrottlingCache(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getThrottlingCache(key)
+                        browserLocalStorage.getThrottlingCache(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                 });
 
@@ -3210,10 +3353,16 @@ describe("BrowserCacheManager tests", () => {
                     );
 
                     expect(
-                        browserSessionStorage.getThrottlingCache(key)
+                        browserSessionStorage.getThrottlingCache(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                     expect(
-                        browserLocalStorage.getThrottlingCache(key)
+                        browserLocalStorage.getThrottlingCache(
+                            key,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                 });
 
@@ -3235,11 +3384,17 @@ describe("BrowserCacheManager tests", () => {
                     );
 
                     expect(
-                        browserSessionStorage.getThrottlingCache(testKey)
+                        browserSessionStorage.getThrottlingCache(
+                            testKey,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toEqual(testVal);
 
                     expect(
-                        browserLocalStorage.getThrottlingCache(testKey)
+                        browserLocalStorage.getThrottlingCache(
+                            testKey,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toEqual(testVal);
                 });
             });
@@ -3280,7 +3435,8 @@ describe("BrowserCacheManager tests", () => {
                         browserCrypto,
                         logger,
                         perfClient,
-                        new EventHandler()
+                        new EventHandler(),
+                        TEST_CONFIG.CORRELATION_ID
                     );
 
                     jest.spyOn(
@@ -3355,7 +3511,8 @@ describe("BrowserCacheManager tests", () => {
                         browserCrypto,
                         logger,
                         perfClient,
-                        new EventHandler()
+                        new EventHandler(),
+                        TEST_CONFIG.CORRELATION_ID
                     );
 
                     cacheManager.setInteractionInProgress(true);
@@ -3379,7 +3536,8 @@ describe("BrowserCacheManager tests", () => {
                         browserCrypto,
                         logger,
                         perfClient,
-                        new EventHandler()
+                        new EventHandler(),
+                        TEST_CONFIG.CORRELATION_ID
                     );
 
                     cacheManager.setTemporaryCache(
@@ -3401,7 +3559,8 @@ describe("BrowserCacheManager tests", () => {
                         browserCrypto,
                         logger,
                         perfClient,
-                        new EventHandler()
+                        new EventHandler(),
+                        TEST_CONFIG.CORRELATION_ID
                     );
 
                     cacheManager.setTemporaryCache(
@@ -3436,7 +3595,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             const requestParamsKey = `${CacheKeys.PREFIX}.${TEST_CONFIG.MSAL_CLIENT_ID}.${TemporaryCacheKeys.REQUEST_PARAMS}`;
             window.sessionStorage.setItem(
@@ -3469,7 +3629,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             const tokenRequest: CommonAuthorizationUrlRequest = {
                 redirectUri: `${TEST_URIS.DEFAULT_INSTANCE}`,
@@ -3484,6 +3645,7 @@ describe("BrowserCacheManager tests", () => {
 
             browserStorage.cacheAuthorizeRequest(
                 tokenRequest,
+                TEST_CONFIG.CORRELATION_ID,
                 TEST_CONFIG.TEST_VERIFIER
             );
 
@@ -3500,7 +3662,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
 
             expect(() => browserStorage.getCachedRequest()).toThrow(
@@ -3523,7 +3686,8 @@ describe("BrowserCacheManager tests", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             const tokenRequest: AuthorizationCodeRequest = {
                 redirectUri: `${TEST_URIS.DEFAULT_INSTANCE}`,

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -1035,9 +1035,12 @@ describe("BrowserCacheManager tests", () => {
                 new StubPerformanceClient(),
                 new EventHandler()
             );
-            expect(browserLocalStorage.getTemporaryCache(testTempItemKey)).toBe(
-                testTempItemValue
-            );
+            expect(
+                browserLocalStorage.getTemporaryCache(
+                    testTempItemKey,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).toBe(testTempItemValue);
         });
 
         it("setItem", () => {
@@ -2183,10 +2186,18 @@ describe("BrowserCacheManager tests", () => {
             expect(window.sessionStorage.getItem(msalCacheKey)).toBeNull();
             expect(window.localStorage.getItem(msalCacheKey)).toBeNull();
             expect(
-                browserLocalStorage.getTemporaryCache("cacheKey", true)
+                browserLocalStorage.getTemporaryCache(
+                    "cacheKey",
+                    TEST_CONFIG.CORRELATION_ID,
+                    true
+                )
             ).toBeNull();
             expect(
-                browserSessionStorage.getTemporaryCache("cacheKey", true)
+                browserSessionStorage.getTemporaryCache(
+                    "cacheKey",
+                    TEST_CONFIG.CORRELATION_ID,
+                    true
+                )
             ).toBeNull();
         });
 
@@ -3554,7 +3565,10 @@ describe("BrowserCacheManager tests", () => {
                     );
                     expect(cacheManager.getInteractionInProgress()).toBeNull();
                     expect(
-                        cacheManager.getTemporaryCache(requestParamKey)
+                        cacheManager.getTemporaryCache(
+                            requestParamKey,
+                            TEST_CONFIG.CORRELATION_ID
+                        )
                     ).toBeNull();
                 });
             });
@@ -3589,7 +3603,7 @@ describe("BrowserCacheManager tests", () => {
                 TEST_URIS.TEST_REDIR_URI
             );
 
-            browserStorage.resetRequestCache();
+            browserStorage.resetRequestCache(TEST_CONFIG.CORRELATION_ID);
 
             expect(window.sessionStorage[requestParamsKey]).toBeUndefined();
             expect(window.sessionStorage[originUriKey]).toBeUndefined();
@@ -3622,7 +3636,7 @@ describe("BrowserCacheManager tests", () => {
             );
 
             const [cachedRequest, codeVerifier] =
-                browserStorage.getCachedRequest();
+                browserStorage.getCachedRequest(TEST_CONFIG.CORRELATION_ID);
             expect(cachedRequest).toEqual(tokenRequest);
             expect(codeVerifier).toEqual(TEST_CONFIG.TEST_VERIFIER);
         });
@@ -3637,7 +3651,9 @@ describe("BrowserCacheManager tests", () => {
                 new EventHandler()
             );
 
-            expect(() => browserStorage.getCachedRequest()).toThrow(
+            expect(() =>
+                browserStorage.getCachedRequest(TEST_CONFIG.CORRELATION_ID)
+            ).toThrow(
                 new BrowserAuthError(
                     BrowserAuthErrorCodes.noTokenRequestCacheError
                 )
@@ -3674,7 +3690,9 @@ describe("BrowserCacheManager tests", () => {
                 stringifiedRequest.substring(0, stringifiedRequest.length / 2),
                 true
             );
-            expect(() => browserStorage.getCachedRequest()).toThrow(
+            expect(() =>
+                browserStorage.getCachedRequest(TEST_CONFIG.CORRELATION_ID)
+            ).toThrow(
                 new BrowserAuthError(
                     BrowserAuthErrorCodes.unableToParseTokenRequestCacheError
                 )

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -81,8 +81,7 @@ describe("TokenCache tests", () => {
             cryptoObj,
             logger,
             new StubPerformanceClient(),
-            new EventHandler(),
-            TEST_CONFIG.CORRELATION_ID
+            new EventHandler()
         );
     });
 

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -81,7 +81,8 @@ describe("TokenCache tests", () => {
             cryptoObj,
             logger,
             new StubPerformanceClient(),
-            new EventHandler()
+            new EventHandler(),
+            TEST_CONFIG.CORRELATION_ID
         );
     });
 
@@ -114,6 +115,7 @@ describe("TokenCache tests", () => {
                 AuthorityType.Default,
                 logger,
                 cryptoObj,
+                TEST_CONFIG.CORRELATION_ID,
                 testIdTokenClaims
             );
 
@@ -520,6 +522,7 @@ describe("TokenCache tests", () => {
                 AuthorityType.Default,
                 logger,
                 cryptoObj,
+                TEST_CONFIG.CORRELATION_ID,
                 testIdTokenClaims
             );
 

--- a/lib/msal-browser/test/crypto/CryptoOps.spec.ts
+++ b/lib/msal-browser/test/crypto/CryptoOps.spec.ts
@@ -2,7 +2,11 @@ import { CryptoOps } from "../../src/crypto/CryptoOps";
 import * as BrowserCrypto from "../../src/crypto/BrowserCrypto";
 import { createHash } from "crypto";
 import { PkceCodes, BaseAuthRequest, Logger } from "@azure/msal-common";
-import { RANDOM_TEST_GUID, TEST_URIS } from "../utils/StringConstants";
+import {
+    RANDOM_TEST_GUID,
+    TEST_CONFIG,
+    TEST_URIS,
+} from "../utils/StringConstants";
 import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
@@ -301,7 +305,10 @@ describe("CryptoOps.ts Unit Tests", () => {
             resourceRequestUri: TEST_URIS.TEST_AUTH_ENDPT_WITH_PARAMS,
         } as BaseAuthRequest);
         const key = mockDatabase["TestDB.keys"][pkThumbprint];
-        await cryptoObj.removeTokenBindingKey(pkThumbprint);
+        await cryptoObj.removeTokenBindingKey(
+            pkThumbprint,
+            TEST_CONFIG.CORRELATION_ID
+        );
         expect(key).not.toBe(undefined);
         expect(mockDatabase["TestDB.keys"][pkThumbprint]).toBe(undefined);
     }, 30000);

--- a/lib/msal-browser/test/crypto/SignedHttpRequest.spec.ts
+++ b/lib/msal-browser/test/crypto/SignedHttpRequest.spec.ts
@@ -3,7 +3,6 @@ import { createHash } from "crypto";
 import { AuthToken } from "@azure/msal-common";
 import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 import { base64Decode } from "../../src/encode/Base64Decode";
-import { StubPerformanceClient } from "@azure/msal-common/browser";
 import { TEST_CONFIG } from "../utils/StringConstants.js";
 
 let mockDatabase = {
@@ -56,14 +55,11 @@ describe("SignedHttpRequest.ts Unit Tests", () => {
     });
 
     it("generates expected kid", async () => {
-        const shr: SignedHttpRequest = new SignedHttpRequest(
-            {
-                resourceRequestUri: "https://consoto.com",
-                resourceRequestMethod: "GET",
-                correlationId: TEST_CONFIG.CORRELATION_ID,
-            },
-            new StubPerformanceClient()
-        );
+        const shr: SignedHttpRequest = new SignedHttpRequest({
+            resourceRequestUri: "https://consoto.com",
+            resourceRequestMethod: "GET",
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+        });
         const kid = await shr.generatePublicKeyThumbprint();
         expect(kid).toEqual("oYYABCL-q4VzKcaE6f6RQSsaXbCEEAs3qYz8lbYqqGc");
     });
@@ -73,14 +69,11 @@ describe("SignedHttpRequest.ts Unit Tests", () => {
         const nonce = "test-nonce";
         const ts = 123456;
 
-        const shr: SignedHttpRequest = new SignedHttpRequest(
-            {
-                resourceRequestUri: "https://consoto.com/path",
-                resourceRequestMethod: "GET",
-                correlationId: TEST_CONFIG.CORRELATION_ID,
-            },
-            new StubPerformanceClient()
-        );
+        const shr: SignedHttpRequest = new SignedHttpRequest({
+            resourceRequestUri: "https://consoto.com/path",
+            resourceRequestMethod: "GET",
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+        });
         const kid = await shr.generatePublicKeyThumbprint();
 
         const popToken = await shr.signRequest(payload, kid, {
@@ -102,14 +95,11 @@ describe("SignedHttpRequest.ts Unit Tests", () => {
     });
 
     it("removes keys", async () => {
-        const shr: SignedHttpRequest = new SignedHttpRequest(
-            {
-                resourceRequestUri: "https://consoto.com/path",
-                resourceRequestMethod: "GET",
-                correlationId: TEST_CONFIG.CORRELATION_ID,
-            },
-            new StubPerformanceClient()
-        );
+        const shr: SignedHttpRequest = new SignedHttpRequest({
+            resourceRequestUri: "https://consoto.com/path",
+            resourceRequestMethod: "GET",
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+        });
         const kid = await shr.generatePublicKeyThumbprint();
 
         expect(mockDatabase["TestDB.keys"][kid]).toBeDefined();

--- a/lib/msal-browser/test/crypto/SignedHttpRequest.spec.ts
+++ b/lib/msal-browser/test/crypto/SignedHttpRequest.spec.ts
@@ -1,8 +1,8 @@
-import { SignedHttpRequest } from "../../src/crypto/SignedHttpRequest";
+import { SignedHttpRequest } from "../../src/crypto/SignedHttpRequest.js";
 import { createHash } from "crypto";
 import { AuthToken } from "@azure/msal-common";
-import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
-import { base64Decode } from "../../src/encode/Base64Decode";
+import { DatabaseStorage } from "../../src/cache/DatabaseStorage.js";
+import { base64Decode } from "../../src/encode/Base64Decode.js";
 import { TEST_CONFIG } from "../utils/StringConstants.js";
 
 let mockDatabase = {
@@ -103,7 +103,7 @@ describe("SignedHttpRequest.ts Unit Tests", () => {
         const kid = await shr.generatePublicKeyThumbprint();
 
         expect(mockDatabase["TestDB.keys"][kid]).toBeDefined();
-        await shr.removeKeys(kid);
+        await shr.removeKeys(kid, TEST_CONFIG.CORRELATION_ID);
         expect(mockDatabase["TestDB.keys"][kid]).toBeUndefined();
     });
 });

--- a/lib/msal-browser/test/crypto/SignedHttpRequest.spec.ts
+++ b/lib/msal-browser/test/crypto/SignedHttpRequest.spec.ts
@@ -3,6 +3,8 @@ import { createHash } from "crypto";
 import { AuthToken } from "@azure/msal-common";
 import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 import { base64Decode } from "../../src/encode/Base64Decode";
+import { StubPerformanceClient } from "@azure/msal-common/browser";
+import { TEST_CONFIG } from "../utils/StringConstants.js";
 
 let mockDatabase = {
     "TestDB.keys": {},
@@ -54,10 +56,14 @@ describe("SignedHttpRequest.ts Unit Tests", () => {
     });
 
     it("generates expected kid", async () => {
-        const shr: SignedHttpRequest = new SignedHttpRequest({
-            resourceRequestUri: "https://consoto.com",
-            resourceRequestMethod: "GET",
-        });
+        const shr: SignedHttpRequest = new SignedHttpRequest(
+            {
+                resourceRequestUri: "https://consoto.com",
+                resourceRequestMethod: "GET",
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+            },
+            new StubPerformanceClient()
+        );
         const kid = await shr.generatePublicKeyThumbprint();
         expect(kid).toEqual("oYYABCL-q4VzKcaE6f6RQSsaXbCEEAs3qYz8lbYqqGc");
     });
@@ -67,10 +73,14 @@ describe("SignedHttpRequest.ts Unit Tests", () => {
         const nonce = "test-nonce";
         const ts = 123456;
 
-        const shr: SignedHttpRequest = new SignedHttpRequest({
-            resourceRequestUri: "https://consoto.com/path",
-            resourceRequestMethod: "GET",
-        });
+        const shr: SignedHttpRequest = new SignedHttpRequest(
+            {
+                resourceRequestUri: "https://consoto.com/path",
+                resourceRequestMethod: "GET",
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+            },
+            new StubPerformanceClient()
+        );
         const kid = await shr.generatePublicKeyThumbprint();
 
         const popToken = await shr.signRequest(payload, kid, {
@@ -92,10 +102,14 @@ describe("SignedHttpRequest.ts Unit Tests", () => {
     });
 
     it("removes keys", async () => {
-        const shr: SignedHttpRequest = new SignedHttpRequest({
-            resourceRequestUri: "https://consoto.com/path",
-            resourceRequestMethod: "GET",
-        });
+        const shr: SignedHttpRequest = new SignedHttpRequest(
+            {
+                resourceRequestUri: "https://consoto.com/path",
+                resourceRequestMethod: "GET",
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+            },
+            new StubPerformanceClient()
+        );
         const kid = await shr.generatePublicKeyThumbprint();
 
         expect(mockDatabase["TestDB.keys"][kid]).toBeDefined();

--- a/lib/msal-browser/test/custom_auth/core/CustomAuthAuthority.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/CustomAuthAuthority.spec.ts
@@ -6,6 +6,7 @@ import {
     getDefaultBrowserCacheManager,
     getDefaultLogger,
 } from "../test_resources/TestModules.js";
+import { TEST_CONFIG } from "../../utils/StringConstants.js";
 
 describe("CustomAuthAuthority", () => {
     const authorityUrl = customAuthConfig.auth.authority;
@@ -92,7 +93,10 @@ describe("CustomAuthAuthority", () => {
                     .includes(authorityMetadataEntityKey)
             ).toBe(true);
             expect(
-                browserStorage.getAuthorityMetadata(authorityMetadataEntityKey)
+                browserStorage.getAuthorityMetadata(
+                    authorityMetadataEntityKey,
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toMatchObject({
                 aliases: [authorityHostname],
                 preferred_cache: authorityHostname,

--- a/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
@@ -121,8 +121,7 @@ describe("CustomAuthSilentCacheClient", () => {
             mockCrypto,
             mockLogger,
             mockPerformanceClient,
-            mockEventHandler,
-            TEST_CONFIG.CORRELATION_ID
+            mockEventHandler
         );
 
         const authority = new CustomAuthAuthority(

--- a/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
@@ -27,7 +27,10 @@ import { DefaultScopes } from "../../../../src/custom_auth/CustomAuthConstants.j
 import { BrowserCacheManager } from "../../../../src/cache/BrowserCacheManager.js";
 import { BrowserConfiguration } from "../../../../src/config/Configuration.js";
 import { INavigationClient } from "../../../../src/navigation/INavigationClient.js";
-import { RANDOM_TEST_GUID } from "../../../utils/StringConstants.js";
+import {
+    RANDOM_TEST_GUID,
+    TEST_CONFIG,
+} from "../../../utils/StringConstants.js";
 import {
     getDefaultCrypto,
     getDefaultEventHandler,
@@ -118,7 +121,8 @@ describe("CustomAuthSilentCacheClient", () => {
             mockCrypto,
             mockLogger,
             mockPerformanceClient,
-            mockEventHandler
+            mockEventHandler,
+            TEST_CONFIG.CORRELATION_ID
         );
 
         const authority = new CustomAuthAuthority(

--- a/lib/msal-browser/test/custom_auth/test_resources/TestModules.ts
+++ b/lib/msal-browser/test/custom_auth/test_resources/TestModules.ts
@@ -72,7 +72,6 @@ export function getDefaultBrowserCacheManager(
         crypto,
         logger,
         performanceClient,
-        eventHandler,
-        TEST_CONFIG.CORRELATION_ID
+        eventHandler
     );
 }

--- a/lib/msal-browser/test/custom_auth/test_resources/TestModules.ts
+++ b/lib/msal-browser/test/custom_auth/test_resources/TestModules.ts
@@ -14,6 +14,7 @@ import {
 import { BrowserPerformanceClient } from "../../../src/telemetry/BrowserPerformanceClient.js";
 import { NavigationClient } from "../../../src/navigation/NavigationClient.js";
 import { INavigationClient } from "../../../src/navigation/INavigationClient.js";
+import { TEST_CONFIG } from "../../utils/StringConstants.js";
 
 export function getDefaultLogger(): Logger {
     return new Logger({}, "test", "1.0.0");
@@ -71,6 +72,7 @@ export function getDefaultBrowserCacheManager(
         crypto,
         logger,
         performanceClient,
-        eventHandler
+        eventHandler,
+        TEST_CONFIG.CORRELATION_ID
     );
 }

--- a/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
@@ -348,7 +348,8 @@ describe("BaseInteractionClient", () => {
                 // @ts-ignore
                 pca.navigationClient,
                 // @ts-ignore
-                pca.performanceClient
+                pca.performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             );
 
             const clientInst = interactionClient as any;
@@ -398,7 +399,8 @@ describe("BaseInteractionClient", () => {
                 // @ts-ignore
                 pca.navigationClient,
                 // @ts-ignore
-                pca.performanceClient
+                pca.performanceClient,
+                TEST_CONFIG.CORRELATION_ID
             );
 
             const clientInst = interactionClient as any;

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -112,7 +112,6 @@ describe("PopupClient", () => {
             pca.performanceClient,
             //@ts-ignore
             pca.nativeInternalStorage,
-            undefined,
             TEST_CONFIG.CORRELATION_ID
         );
     });
@@ -257,7 +256,6 @@ describe("PopupClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
-                undefined,
                 TEST_CONFIG.CORRELATION_ID
             );
 
@@ -428,6 +426,7 @@ describe("PopupClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
+                TEST_CONFIG.CORRELATION_ID,
                 nativeMessageHandler
             );
             const correlationId = BrowserUtils.createGuid();
@@ -1798,7 +1797,8 @@ describe("PopupClient", () => {
                 clientImpl.config.auth.OIDCOptions.responseMode,
                 clientImpl.config.system.pollIntervalMilliseconds,
                 clientImpl.logger,
-                clientImpl.unloadWindow
+                clientImpl.unloadWindow,
+                TEST_CONFIG.CORRELATION_ID
             ).catch((error) => {
                 expect(error.errorCode).toEqual("user_cancelled");
                 done();
@@ -1827,7 +1827,8 @@ describe("PopupClient", () => {
                 clientImpl.config.auth.OIDCOptions.responseMode,
                 clientImpl.config.system.pollIntervalMilliseconds,
                 clientImpl.logger,
-                clientImpl.unloadWindow
+                clientImpl.unloadWindow,
+                TEST_CONFIG.CORRELATION_ID
             ).then((hash) => {
                 expect(hash).toEqual("code=testCode");
                 done();
@@ -1880,7 +1881,6 @@ describe("PopupClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
-                undefined,
                 TEST_CONFIG.CORRELATION_ID
             );
             const clientImpl = popupClient as any;
@@ -1890,7 +1890,8 @@ describe("PopupClient", () => {
                 clientImpl.config.auth.OIDCOptions.responseMode,
                 clientImpl.config.system.pollIntervalMilliseconds,
                 clientImpl.logger,
-                clientImpl.unloadWindow
+                clientImpl.unloadWindow,
+                TEST_CONFIG.CORRELATION_ID
             ).catch((e) => {
                 expect(e.errorCode).toEqual(
                     BrowserAuthErrorCodes.monitorPopupTimeout
@@ -1919,7 +1920,8 @@ describe("PopupClient", () => {
                 clientImpl.config.auth.OIDCOptions.responseMode,
                 clientImpl.config.system.pollIntervalMilliseconds,
                 clientImpl.logger,
-                clientImpl.unloadWindow
+                clientImpl.unloadWindow,
+                TEST_CONFIG.CORRELATION_ID
             ).then((hash: string) => {
                 expect(hash).toEqual("#code=hello");
                 done();
@@ -1959,7 +1961,6 @@ describe("PopupClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
-                undefined,
                 TEST_CONFIG.CORRELATION_ID
             );
 
@@ -1983,7 +1984,8 @@ describe("PopupClient", () => {
                 clientImpl.config.auth.OIDCOptions.responseMode,
                 clientImpl.config.system.pollIntervalMilliseconds,
                 clientImpl.logger,
-                clientImpl.unloadWindow
+                clientImpl.unloadWindow,
+                TEST_CONFIG.CORRELATION_ID
             );
             expect(result).toEqual("?code=authCode");
         });
@@ -2005,7 +2007,8 @@ describe("PopupClient", () => {
                 clientImpl.config.auth.OIDCOptions.responseMode,
                 clientImpl.config.system.pollIntervalMilliseconds,
                 clientImpl.logger,
-                clientImpl.unloadWindow
+                clientImpl.unloadWindow,
+                TEST_CONFIG.CORRELATION_ID
             ).catch((error: AuthError) => {
                 expect(error.errorCode).toEqual("user_cancelled");
                 done();

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -1971,7 +1971,7 @@ describe("RedirectClient", () => {
             );
             await redirectClient.acquireToken(tokenRequest);
             const [cachedRequest, codeVerifier] =
-                browserStorage.getCachedRequest();
+                browserStorage.getCachedRequest(TEST_CONFIG.CORRELATION_ID);
             expect(cachedRequest.scopes).toEqual([]);
             expect(codeVerifier).toEqual(TEST_CONFIG.TEST_VERIFIER);
             expect(cachedRequest.authority).toEqual(

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -173,7 +173,8 @@ describe("RedirectClient", () => {
             //@ts-ignore
             pca.performanceClient,
             //@ts-ignore
-            pca.nativeInternalStorage
+            pca.nativeInternalStorage,
+            TEST_CONFIG.CORRELATION_ID
         );
 
         rootMeasurement = new BrowserPerformanceClient(
@@ -524,6 +525,7 @@ describe("RedirectClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
+                TEST_CONFIG.CORRELATION_ID,
                 nativeMessageHandler
             );
 
@@ -1238,7 +1240,8 @@ describe("RedirectClient", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             secondInstanceStorage.setInteractionInProgress(true);
             browserStorage.setInteractionInProgress(false);
@@ -1896,7 +1899,8 @@ describe("RedirectClient", () => {
                 browserCrypto,
                 testLogger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
 
             jest.spyOn(
@@ -1965,7 +1969,8 @@ describe("RedirectClient", () => {
                 browserCrypto,
                 testLogger,
                 new StubPerformanceClient(),
-                new EventHandler()
+                new EventHandler(),
+                TEST_CONFIG.CORRELATION_ID
             );
             await redirectClient.acquireToken(tokenRequest);
             const [cachedRequest, codeVerifier] =
@@ -2043,7 +2048,8 @@ describe("RedirectClient", () => {
                     //@ts-ignore
                     pca.performanceClient,
                     //@ts-ignore
-                    pca.nativeInternalStorage
+                    pca.nativeInternalStorage,
+                    TEST_CONFIG.CORRELATION_ID
                 );
 
                 let initiateAuthRequestSpy = jest.spyOn(

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -1240,8 +1240,7 @@ describe("RedirectClient", () => {
                 browserCrypto,
                 logger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             secondInstanceStorage.setInteractionInProgress(true);
             browserStorage.setInteractionInProgress(false);
@@ -1899,8 +1898,7 @@ describe("RedirectClient", () => {
                 browserCrypto,
                 testLogger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
 
             jest.spyOn(
@@ -1969,8 +1967,7 @@ describe("RedirectClient", () => {
                 browserCrypto,
                 testLogger,
                 new StubPerformanceClient(),
-                new EventHandler(),
-                TEST_CONFIG.CORRELATION_ID
+                new EventHandler()
             );
             await redirectClient.acquireToken(tokenRequest);
             const [cachedRequest, codeVerifier] =

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -94,7 +94,6 @@ describe("SilentIframeClient", () => {
             pca.performanceClient,
             //@ts-ignore
             pca.nativeInternalStorage,
-            undefined,
             TEST_CONFIG.CORRELATION_ID
         );
 
@@ -454,6 +453,7 @@ describe("SilentIframeClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
+                TEST_CONFIG.CORRELATION_ID,
                 nativeMessageHandler
             );
             const testServerTokenResponse = {
@@ -865,7 +865,6 @@ describe("SilentIframeClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
-                undefined,
                 TEST_CONFIG.CORRELATION_ID
             );
 
@@ -964,7 +963,6 @@ describe("SilentIframeClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
-                undefined,
                 TEST_CONFIG.CORRELATION_ID
             );
 
@@ -1070,7 +1068,6 @@ describe("SilentIframeClient", () => {
                 pca.performanceClient,
                 //@ts-ignore
                 pca.nativeInternalStorage,
-                undefined,
                 TEST_CONFIG.CORRELATION_ID
             );
 

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -150,20 +150,7 @@ const cryptoInterface = {
     },
 };
 
-const performanceClient = {
-    startMeasurement: jest.fn(),
-    endMeasurement: jest.fn(),
-    discardMeasurements: jest.fn(),
-    removePerformanceCallback: jest.fn(),
-    addPerformanceCallback: jest.fn(),
-    emitEvents: jest.fn(),
-    generateId: jest.fn(),
-    calculateQueuedTime: jest.fn(),
-    addQueueMeasurement: jest.fn(),
-    setPreQueueTime: jest.fn(),
-    addFields: jest.fn(),
-    incrementFields: jest.fn(),
-};
+const performanceClient = new StubPerformanceClient();
 
 let authorityInstance: Authority;
 let authConfig: ClientConfiguration;
@@ -197,7 +184,8 @@ describe("InteractionHandler.ts Unit Tests", () => {
             cryptoOpts,
             logger,
             new StubPerformanceClient(),
-            new EventHandler()
+            new EventHandler(),
+            TEST_CONFIG.CORRELATION_ID
         );
         authorityInstance = new Authority(
             configObj.auth.authority,
@@ -205,7 +193,8 @@ describe("InteractionHandler.ts Unit Tests", () => {
             browserStorage,
             authorityOptions,
             logger,
-            TEST_CONFIG.CORRELATION_ID
+            TEST_CONFIG.CORRELATION_ID,
+            new StubPerformanceClient()
         );
         await authorityInstance.resolveEndpointsAsync();
         authConfig = {
@@ -240,7 +229,10 @@ describe("InteractionHandler.ts Unit Tests", () => {
             },
             loggerOptions: loggerOptions,
         };
-        authCodeModule = new AuthorizationCodeClient(authConfig);
+        authCodeModule = new AuthorizationCodeClient(
+            authConfig,
+            new StubPerformanceClient()
+        );
     });
 
     afterEach(() => {

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -184,8 +184,7 @@ describe("InteractionHandler.ts Unit Tests", () => {
             cryptoOpts,
             logger,
             new StubPerformanceClient(),
-            new EventHandler(),
-            TEST_CONFIG.CORRELATION_ID
+            new EventHandler()
         );
         authorityInstance = new Authority(
             configObj.auth.authority,

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -16,6 +16,7 @@ import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
 } from "../../src/error/BrowserAuthError.js";
+import { StubPerformanceClient } from "@azure/msal-common/browser";
 
 const DEFAULT_IFRAME_TIMEOUT_MS = 6000;
 const DEFAULT_POLL_INTERVAL_MS = 30;
@@ -30,17 +31,7 @@ describe("SilentHandler.ts Unit Tests", () => {
             piiLoggingEnabled: true,
         };
         browserRequestLogger = new Logger(loggerOptions);
-        performanceClient = {
-            startMeasurement: jest.fn(),
-            endMeasurement: jest.fn(),
-            discardMeasurements: jest.fn(),
-            removePerformanceCallback: jest.fn(),
-            addPerformanceCallback: jest.fn(),
-            emitEvents: jest.fn(),
-            generateId: jest.fn(),
-            addFields: jest.fn(),
-            incrementFields: jest.fn(),
-        };
+        performanceClient = new StubPerformanceClient();
     });
 
     afterEach(() => {

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -56,7 +56,8 @@ describe("Authorize Protocol Tests", () => {
             new CryptoOps(logger, performanceClient),
             logger,
             performanceClient,
-            eventHandler
+            eventHandler,
+            TEST_CONFIG.CORRELATION_ID
         );
         let authority: Authority;
         const validRequest: CommonAuthorizationUrlRequest = {

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -56,8 +56,7 @@ describe("Authorize Protocol Tests", () => {
             new CryptoOps(logger, performanceClient),
             logger,
             performanceClient,
-            eventHandler,
-            TEST_CONFIG.CORRELATION_ID
+            eventHandler
         );
         let authority: Authority;
         const validRequest: CommonAuthorizationUrlRequest = {

--- a/lib/msal-browser/test/request/RequestHelpers.spec.ts
+++ b/lib/msal-browser/test/request/RequestHelpers.spec.ts
@@ -14,6 +14,7 @@ import {
 import * as RequestHelpers from "../../src/request/RequestHelpers.js";
 import { BrowserConfiguration } from "../../src/config/Configuration.js";
 import { SilentRequest } from "../../src/request/SilentRequest.js";
+import { TEST_CONFIG } from "../utils/StringConstants.js";
 
 describe("RequestHelpers tests", () => {
     let mockConfig: BrowserConfiguration;
@@ -49,7 +50,8 @@ describe("RequestHelpers tests", () => {
                 request,
                 mockConfig,
                 mockPerformanceClient,
-                mockLogger
+                mockLogger,
+                TEST_CONFIG.CORRELATION_ID
             );
 
             expect(result.correlationId).toBe("test-correlation-id");
@@ -75,7 +77,8 @@ describe("RequestHelpers tests", () => {
                     request,
                     mockConfig,
                     mockPerformanceClient,
-                    mockLogger
+                    mockLogger,
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).rejects.toThrowError(
                 new ClientConfigurationError(

--- a/lib/msal-browser/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-browser/test/response/ResponseHandler.spec.ts
@@ -2,6 +2,7 @@ import { Logger } from "@azure/msal-common";
 import * as ResponseHandler from "../../src/response/ResponseHandler";
 import { BrowserAuthErrorCodes } from "../../src";
 import { createBrowserAuthError } from "../../src/error/BrowserAuthError";
+import { TEST_CONFIG } from "../utils/StringConstants.js";
 
 describe("ResponseHandler tests", () => {
     describe("deserializeResponse", () => {
@@ -11,7 +12,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "#code=hello&state=state",
                     "hash",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toEqual({ code: "hello", state: "state" });
 
@@ -20,7 +22,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "code=hello&state=state",
                     "hash",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toEqual({ code: "hello", state: "state" });
 
@@ -29,7 +32,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "#error=errorCode&error_description=errorDescription",
                     "hash",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toEqual({
                 error: "errorCode",
@@ -43,7 +47,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "?code=hello&state=state",
                     "query",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toEqual({ code: "hello", state: "state" });
 
@@ -52,7 +57,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "code=hello&state=state",
                     "query",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toEqual({ code: "hello", state: "state" });
 
@@ -61,7 +67,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "?error=errorCode&error_description=errorDescription",
                     "query",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toEqual({
                 error: "errorCode",
@@ -71,13 +78,23 @@ describe("ResponseHandler tests", () => {
 
         it("Throws error if response is empty", () => {
             expect(() =>
-                ResponseHandler.deserializeResponse("#", "hash", new Logger({}))
+                ResponseHandler.deserializeResponse(
+                    "#",
+                    "hash",
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toThrowError(
                 createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError)
             );
 
             expect(() =>
-                ResponseHandler.deserializeResponse("", "hash", new Logger({}))
+                ResponseHandler.deserializeResponse(
+                    "",
+                    "hash",
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toThrowError(
                 createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError)
             );
@@ -86,14 +103,20 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "?",
                     "query",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
                 createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError)
             );
 
             expect(() =>
-                ResponseHandler.deserializeResponse("", "query", new Logger({}))
+                ResponseHandler.deserializeResponse(
+                    "",
+                    "query",
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toThrowError(
                 createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError)
             );
@@ -104,7 +127,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "#hello",
                     "hash",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
                 createBrowserAuthError(
@@ -115,7 +139,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "#key=value",
                     "hash",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
                 createBrowserAuthError(
@@ -127,7 +152,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "?hello",
                     "query",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
                 createBrowserAuthError(
@@ -139,7 +165,8 @@ describe("ResponseHandler tests", () => {
                 ResponseHandler.deserializeResponse(
                     "?key=value",
                     "query",
-                    new Logger({})
+                    new Logger({}),
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
                 createBrowserAuthError(

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -623,7 +623,7 @@ export type AuthOptions = {
 //
 // @internal
 export class Authority {
-    constructor(authority: string, networkInterface: INetworkModule, cacheManager: ICacheManager, authorityOptions: AuthorityOptions, logger: Logger, correlationId: string, performanceClient?: IPerformanceClient, managedIdentity?: boolean);
+    constructor(authority: string, networkInterface: INetworkModule, cacheManager: ICacheManager, authorityOptions: AuthorityOptions, logger: Logger, correlationId: string, performanceClient: IPerformanceClient, managedIdentity?: boolean);
     // (undocumented)
     get authorityType(): AuthorityType;
     get authorizationEndpoint(): string;
@@ -664,7 +664,7 @@ export class Authority {
     protected networkInterface: INetworkModule;
     get options(): AuthorityOptions;
     // (undocumented)
-    protected performanceClient: IPerformanceClient | undefined;
+    protected performanceClient: IPerformanceClient;
     get protocolMode(): ProtocolMode;
     // Warning: (ae-forgotten-export) The symbol "RegionDiscoveryMetadata" needs to be exported by the entry point index.d.ts
     //
@@ -807,7 +807,7 @@ const AUTHORIZATION_PENDING = "authorization_pending";
 //
 // @internal
 export class AuthorizationCodeClient extends BaseClient {
-    constructor(configuration: ClientConfiguration, performanceClient?: IPerformanceClient);
+    constructor(configuration: ClientConfiguration, performanceClient: IPerformanceClient);
     // Warning: (tsdoc-code-span-missing-delimiter) The code span is missing its closing backtick
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     acquireToken(request: CommonAuthorizationCodeRequest, authCodePayload?: AuthorizationCodePayload): Promise<AuthenticationResult>;
@@ -964,7 +964,7 @@ export type BaseAuthRequest = {
 //
 // @internal
 export abstract class BaseClient {
-    protected constructor(configuration: ClientConfiguration, performanceClient?: IPerformanceClient);
+    protected constructor(configuration: ClientConfiguration, performanceClient: IPerformanceClient);
     // (undocumented)
     authority: Authority;
     // (undocumented)
@@ -988,7 +988,7 @@ export abstract class BaseClient {
     // (undocumented)
     protected networkClient: INetworkModule;
     // (undocumented)
-    protected performanceClient?: IPerformanceClient;
+    protected performanceClient: IPerformanceClient;
     sendPostRequest<T extends ServerAuthorizationTokenResponse>(thumbprint: RequestThumbprint, tokenEndpoint: string, options: NetworkRequestOptions, correlationId: string): Promise<NetworkResponse<T>>;
     // (undocumented)
     protected serverTelemetryManager: ServerTelemetryManager | null;
@@ -1124,7 +1124,8 @@ export abstract class CacheManager implements ICacheManager {
     protected clientId: string;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    credentialMatchesFilter(entity: ValidCredentialType, filter: CredentialFilter): boolean;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    credentialMatchesFilter(entity: ValidCredentialType, filter: CredentialFilter, correlationId: string): boolean;
     // (undocumented)
     protected cryptoImpl: ICrypto;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1152,14 +1153,18 @@ export abstract class CacheManager implements ICacheManager {
     getAccountsFilteredBy(accountFilter: AccountFilter, correlationId: string): AccountEntity[];
     getAllAccounts(accountFilter: AccountFilter | undefined, correlationId: string): AccountInfo[];
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    abstract getAppMetadata(appMetadataKey: string): AppMetadataEntity | null;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    abstract getAppMetadata(appMetadataKey: string, correlationId: string): AppMetadataEntity | null;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (ae-forgotten-export) The symbol "AppMetadataFilter" needs to be exported by the entry point index.d.ts
-    getAppMetadataFilteredBy(filter: AppMetadataFilter): AppMetadataCache;
+    getAppMetadataFilteredBy(filter: AppMetadataFilter, correlationId: string): AppMetadataCache;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    abstract getAuthorityMetadata(key: string): AuthorityMetadataEntity | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    getAuthorityMetadataByAlias(host: string): AuthorityMetadataEntity | null;
+    abstract getAuthorityMetadata(key: string, correlationId: string): AuthorityMetadataEntity | null;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    getAuthorityMetadataByAlias(host: string, correlationId: string): AuthorityMetadataEntity | null;
     // (undocumented)
     abstract getAuthorityMetadataKeys(): Array<string>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1194,21 +1199,23 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract getRefreshTokenCredential(refreshTokenKey: string, correlationId: string): RefreshTokenEntity | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    abstract getServerTelemetry(serverTelemetryKey: string): ServerTelemetryEntity | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    abstract getThrottlingCache(throttlingCacheKey: string): ThrottlingEntity | null;
+    abstract getServerTelemetry(serverTelemetryKey: string, correlationId: string): ServerTelemetryEntity | null;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    abstract getThrottlingCache(throttlingCacheKey: string, correlationId: string): ThrottlingEntity | null;
     abstract getTokenKeys(): TokenKeys;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     idTokenKeyMatchesFilter(inputKey: string, filter: CredentialFilter): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    isAppMetadataFOCI(environment: string): boolean;
+    isAppMetadataFOCI(environment: string, correlationId: string): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     protected isAuthorityMetadata(key: string): boolean;
     // (undocumented)
     protected performanceClient: IPerformanceClient;
-    readAppMetadataFromCache(environment: string): AppMetadataEntity | null;
+    readAppMetadataFromCache(environment: string, correlationId: string): AppMetadataEntity | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     refreshTokenKeyMatchesFilter(inputKey: string, filter: CredentialFilter): boolean;
@@ -1243,13 +1250,15 @@ export abstract class CacheManager implements ICacheManager {
     abstract setAppMetadata(appMetadata: AppMetadataEntity, correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    abstract setAuthorityMetadata(key: string, value: AuthorityMetadataEntity): void;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    abstract setAuthorityMetadata(key: string, value: AuthorityMetadataEntity, correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract setIdTokenCredential(idToken: IdTokenEntity, correlationId: string): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract setRefreshTokenCredential(refreshToken: RefreshTokenEntity, correlationId: string): Promise<void>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract setServerTelemetry(serverTelemetryKey: string, serverTelemetry: ServerTelemetryEntity, correlationId: string): void;
@@ -1864,9 +1873,13 @@ export function createClientConfigurationError(errorCode: string): ClientConfigu
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 //
 // @internal
-function createDiscoveredInstance(authorityUri: string, networkClient: INetworkModule, cacheManager: ICacheManager, authorityOptions: AuthorityOptions, logger: Logger, correlationId: string, performanceClient?: IPerformanceClient): Promise<Authority>;
+function createDiscoveredInstance(authorityUri: string, networkClient: INetworkModule, cacheManager: ICacheManager, authorityOptions: AuthorityOptions, logger: Logger, correlationId: string, performanceClient: IPerformanceClient): Promise<Authority>;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -2200,7 +2213,7 @@ function generateAuthorityMetadataExpiresAt(): number;
 // Warning: (ae-missing-release-tag) "generateHomeAccountId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function generateHomeAccountId(serverClientInfo: string, authType: AuthorityType, logger: Logger, cryptoObj: ICrypto, idTokenClaims?: TokenClaims): string;
+function generateHomeAccountId(serverClientInfo: string, authType: AuthorityType, logger: Logger, cryptoObj: ICrypto, correlationId: string, idTokenClaims?: TokenClaims): string;
 
 // Warning: (ae-incompatible-release-tags) The symbol "getAccountInfo" is marked as @public, but its signature references "AccountEntity" which is marked as @internal
 // Warning: (ae-incompatible-release-tags) The symbol "getAccountInfo" is marked as @public, but its signature references "AccountEntity" which is marked as @internal
@@ -2667,7 +2680,7 @@ const invalidState = "invalid_state";
 // Warning: (ae-internal-missing-underscore) The name "invoke" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
-export const invoke: <T extends any[], U>(callback: (...args: T) => U, eventName: string, logger: Logger, telemetryClient?: IPerformanceClient, correlationId?: string) => (...args: T) => U;
+export const invoke: <T extends any[], U>(callback: (...args: T) => U, eventName: string, logger: Logger, telemetryClient: IPerformanceClient, correlationId: string) => (...args: T) => U;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -2677,7 +2690,7 @@ export const invoke: <T extends any[], U>(callback: (...args: T) => U, eventName
 // Warning: (ae-internal-missing-underscore) The name "invokeAsync" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
-export const invokeAsync: <T extends any[], U>(callback: (...args: T) => Promise<U>, eventName: string, logger: Logger, telemetryClient?: IPerformanceClient, correlationId?: string) => (...args: T) => Promise<U>;
+export const invokeAsync: <T extends any[], U>(callback: (...args: T) => Promise<U>, eventName: string, logger: Logger, telemetryClient: IPerformanceClient, correlationId: string) => (...args: T) => Promise<U>;
 
 // Warning: (ae-missing-release-tag) "IPerformanceClient" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2888,19 +2901,19 @@ export type LibraryStateObject = {
 // @public
 export class Logger {
     constructor(loggerOptions: LoggerOptions, packageName?: string, packageVersion?: string);
-    clone(packageName: string, packageVersion: string, correlationId?: string): Logger;
-    error(message: string, correlationId?: string): void;
-    errorPii(message: string, correlationId?: string): void;
+    clone(packageName: string, packageVersion: string): Logger;
+    error(message: string, correlationId: string): void;
+    errorPii(message: string, correlationId: string): void;
     executeCallback(level: LogLevel, message: string, containsPii: boolean): void;
-    info(message: string, correlationId?: string): void;
-    infoPii(message: string, correlationId?: string): void;
+    info(message: string, correlationId: string): void;
+    infoPii(message: string, correlationId: string): void;
     isPiiLoggingEnabled(): boolean;
-    trace(message: string, correlationId?: string): void;
-    tracePii(message: string, correlationId?: string): void;
-    verbose(message: string, correlationId?: string): void;
-    verbosePii(message: string, correlationId?: string): void;
-    warning(message: string, correlationId?: string): void;
-    warningPii(message: string, correlationId?: string): void;
+    trace(message: string, correlationId: string): void;
+    tracePii(message: string, correlationId: string): void;
+    verbose(message: string, correlationId: string): void;
+    verbosePii(message: string, correlationId: string): void;
+    warning(message: string, correlationId: string): void;
+    warningPii(message: string, correlationId: string): void;
 }
 
 // Warning: (ae-missing-release-tag) "LoggerOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3489,7 +3502,7 @@ const PopTokenGenerateCnf = "popTokenGenerateCnf";
 //
 // @internal (undocumented)
 export class PopTokenGenerator {
-    constructor(cryptoUtils: ICrypto, performanceClient?: IPerformanceClient);
+    constructor(cryptoUtils: ICrypto, performanceClient: IPerformanceClient);
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (ae-forgotten-export) The symbol "ReqCnfData" needs to be exported by the entry point index.d.ts
     generateCnf(request: SignedHttpRequestParameters, logger: Logger): Promise<ReqCnfData>;
@@ -3595,7 +3608,7 @@ export type RefreshTokenCache = Record<string, RefreshTokenEntity>;
 //
 // @internal
 export class RefreshTokenClient extends BaseClient {
-    constructor(configuration: ClientConfiguration, performanceClient?: IPerformanceClient);
+    constructor(configuration: ClientConfiguration, performanceClient: IPerformanceClient);
     // (undocumented)
     acquireToken(request: CommonRefreshTokenRequest): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -3798,7 +3811,7 @@ const RESPONSE_TYPE = "response_type";
 //
 // @internal
 export class ResponseHandler {
-    constructor(clientId: string, cacheStorage: CacheManager, cryptoObj: ICrypto, logger: Logger, serializableCache: ISerializableTokenCache | null, persistencePlugin: ICachePlugin | null);
+    constructor(clientId: string, cacheStorage: CacheManager, cryptoObj: ICrypto, logger: Logger, performanceClient: IPerformanceClient, serializableCache: ISerializableTokenCache | null, persistencePlugin: ICachePlugin | null);
     // Warning: (tsdoc-undefined-tag) The TSDoc tag "@AuthenticationResult" is not defined in this configuration
     // Warning: (tsdoc-undefined-tag) The TSDoc tag "@CacheRecord" is not defined in this configuration
     // Warning: (tsdoc-undefined-tag) The TSDoc tag "@IdToken" is not defined in this configuration
@@ -3806,13 +3819,14 @@ export class ResponseHandler {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    static generateAuthenticationResult(cryptoObj: ICrypto, authority: Authority, cacheRecord: CacheRecord, fromTokenCache: boolean, request: BaseAuthRequest, idTokenClaims?: TokenClaims, requestState?: RequestStateObject, serverTokenResponse?: ServerAuthorizationTokenResponse, requestId?: string): Promise<AuthenticationResult>;
+    static generateAuthenticationResult(cryptoObj: ICrypto, authority: Authority, cacheRecord: CacheRecord, fromTokenCache: boolean, request: BaseAuthRequest, performanceClient: IPerformanceClient, idTokenClaims?: TokenClaims, requestState?: RequestStateObject, serverTokenResponse?: ServerAuthorizationTokenResponse, requestId?: string): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     handleServerTokenResponse(serverTokenResponse: ServerAuthorizationTokenResponse, authority: Authority, reqTimestamp: number, request: BaseAuthRequest, authCodePayload?: AuthorizationCodePayload, userAssertionHash?: string, handlingRefreshTokenResponse?: boolean, forceCacheRefreshTokenResponse?: boolean, serverRequestId?: string): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    validateTokenResponse(serverResponse: ServerAuthorizationTokenResponse, refreshAccessToken?: boolean): void;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    validateTokenResponse(serverResponse: ServerAuthorizationTokenResponse, correlationId: string, refreshAccessToken?: boolean): void;
 }
 
 // Warning: (ae-missing-release-tag) "ResponseMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4074,14 +4088,14 @@ export type SignedHttpRequest = {
 //
 // @public (undocumented)
 export type SignedHttpRequestParameters = Pick<BaseAuthRequest, "resourceRequestMethod" | "resourceRequestUri" | "shrClaims" | "shrNonce" | "shrOptions"> & {
-    correlationId?: string;
+    correlationId: string;
 };
 
 // Warning: (ae-internal-missing-underscore) The name "SilentFlowClient" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
 export class SilentFlowClient extends BaseClient {
-    constructor(configuration: ClientConfiguration, performanceClient?: IPerformanceClient);
+    constructor(configuration: ClientConfiguration, performanceClient: IPerformanceClient);
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     acquireCachedToken(request: CommonSilentFlowRequest): Promise<[AuthenticationResult, CacheOutcome]>;
 }
@@ -4574,77 +4588,77 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/authority/Authority.ts:300:8 - (tsdoc-undefined-tag) The TSDoc tag "@private" is not defined in this configuration
 // src/authority/Authority.ts:315:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/Authority.ts:323:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:459:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:460:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:461:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:491:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:570:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:640:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:678:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:786:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/authority/Authority.ts:966:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:463:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:464:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:465:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:500:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:579:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:653:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:691:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:802:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/authority/Authority.ts:1000:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/AuthorityOptions.ts:25:5 - (ae-forgotten-export) The symbol "CloudInstanceDiscoveryResponse" needs to be exported by the entry point index.d.ts
-// src/cache/CacheManager.ts:321:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:322:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:587:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1494:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1495:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1509:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1510:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1530:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1531:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1540:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1541:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1557:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1558:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1572:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1573:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1606:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1607:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1621:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1622:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1633:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1634:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:336:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:337:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:605:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1567:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1568:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1582:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1583:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1603:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1604:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1613:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1614:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1630:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1631:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1645:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1646:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1657:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1658:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1675:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1676:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1684:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1685:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1699:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1700:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1701:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1720:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1721:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1740:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1741:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1752:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1711:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1712:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1723:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1724:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1735:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1736:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1753:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1761:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1754:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1778:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1779:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1798:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1799:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1818:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1819:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1830:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1831:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1839:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/utils/CacheTypes.ts:93:53 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
 // src/cache/utils/CacheTypes.ts:93:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
-// src/client/AuthorizationCodeClient.ts:147:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:148:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:205:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:439:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:178:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:264:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:265:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:304:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/SilentFlowClient.ts:164:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:151:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:152:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:210:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:446:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:183:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:270:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:271:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:310:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/SilentFlowClient.ts:167:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/ClientConfiguration.ts:51:5 - (ae-forgotten-export) The symbol "ClientCredentials" needs to be exported by the entry point index.d.ts
 // src/config/ClientConfiguration.ts:53:5 - (ae-forgotten-export) The symbol "TelemetryOptions" needs to be exported by the entry point index.d.ts
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/request/AuthenticationHeaderParser.ts:74:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:326:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:327:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:328:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:669:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:669:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:681:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:681:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:682:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceClient.ts:682:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/response/ResponseHandler.ts:340:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:341:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:342:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:679:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:679:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:691:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:691:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:692:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceClient.ts:692:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:35:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:35:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:35:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1220,6 +1220,7 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     refreshTokenKeyMatchesFilter(inputKey: string, filter: CredentialFilter): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     removeAccessToken(key: string, correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     removeAccount(account: AccountInfo, correlationId: string): void;
@@ -2458,7 +2459,8 @@ export interface ICrypto {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     base64Encode(input: string): string;
     base64UrlEncode(input: string): string;
-    clearKeystore(): Promise<boolean>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    clearKeystore(correlationId: string): Promise<boolean>;
     createNewGuid(): string;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     encodeKid(inputKid: string): string;
@@ -2467,7 +2469,8 @@ export interface ICrypto {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     hashString(plainText: string): Promise<string>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    removeTokenBindingKey(kid: string): Promise<void>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    removeTokenBindingKey(kid: string, correlationId: string): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     signJwt(payload: SignedHttpRequest, kid: string, shrOptions?: ShrOptions, correlationId?: string): Promise<string>;
 }
@@ -4601,39 +4604,39 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/cache/CacheManager.ts:336:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:337:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:605:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1567:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1568:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1582:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1569:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1583:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1603:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1584:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1604:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1613:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1605:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1614:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1630:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1615:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1631:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1645:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1632:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1646:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1684:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1647:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1685:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1699:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1686:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1700:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1711:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1701:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1712:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1723:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1713:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1724:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1735:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1725:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1736:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1753:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1737:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1754:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1778:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1755:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1779:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1798:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1780:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1799:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1818:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1800:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1819:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1830:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1820:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1831:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1839:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1832:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1840:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/utils/CacheTypes.ts:93:53 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
 // src/cache/utils/CacheTypes.ts:93:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
 // src/client/AuthorizationCodeClient.ts:151:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -79,7 +79,7 @@ export class Authority {
     // Logger object
     private logger: Logger;
     // Performance client
-    protected performanceClient: IPerformanceClient | undefined;
+    protected performanceClient: IPerformanceClient;
     // Correlation Id
     protected correlationId: string;
     // Indicates if the authority is fake, for the purpose of a Managed Identity Application
@@ -100,7 +100,7 @@ export class Authority {
         authorityOptions: AuthorityOptions,
         logger: Logger,
         correlationId: string,
-        performanceClient?: IPerformanceClient,
+        performanceClient: IPerformanceClient,
         managedIdentity?: boolean
     ) {
         this.canonicalAuthority = authority;
@@ -349,7 +349,8 @@ export class Authority {
                  */
                 if (cachedPart !== tenantId) {
                     this.logger.verbose(
-                        `Replacing tenant domain name '${cachedPart}' with id '${tenantId}'`
+                        `Replacing tenant domain name '${cachedPart}' with id '${tenantId}'`,
+                        this.correlationId
                     );
                     cachedPart = tenantId;
                 }
@@ -432,7 +433,10 @@ export class Authority {
      */
     private getCurrentMetadataEntity(): AuthorityMetadataEntity {
         let metadataEntity: AuthorityMetadataEntity | null =
-            this.cacheManager.getAuthorityMetadataByAlias(this.hostnameAndPort);
+            this.cacheManager.getAuthorityMetadataByAlias(
+                this.hostnameAndPort,
+                this.correlationId
+            );
 
         if (!metadataEntity) {
             metadataEntity = {
@@ -480,9 +484,14 @@ export class Authority {
         }
 
         const cacheKey = this.cacheManager.generateAuthorityMetadataCacheKey(
-            metadataEntity.preferred_cache
+            metadataEntity.preferred_cache,
+            this.correlationId
         );
-        this.cacheManager.setAuthorityMetadata(cacheKey, metadataEntity);
+        this.cacheManager.setAuthorityMetadata(
+            cacheKey,
+            metadataEntity,
+            this.correlationId
+        );
         this.metadata = metadataEntity;
     }
 
@@ -577,12 +586,14 @@ export class Authority {
         metadata?: OpenIdConfigResponse;
     } | null {
         this.logger.verbose(
-            "Attempting to get endpoint metadata from authority configuration"
+            "Attempting to get endpoint metadata from authority configuration",
+            this.correlationId
         );
         const configMetadata = this.getEndpointMetadataFromConfig();
         if (configMetadata) {
             this.logger.verbose(
-                "Found endpoint metadata in authority configuration"
+                "Found endpoint metadata in authority configuration",
+                this.correlationId
             );
             CacheHelpers.updateAuthorityEndpointMetadata(
                 metadataEntity,
@@ -595,7 +606,8 @@ export class Authority {
         }
 
         this.logger.verbose(
-            "Did not find endpoint metadata in the config... Attempting to get endpoint metadata from the hardcoded values."
+            "Did not find endpoint metadata in the config... Attempting to get endpoint metadata from the hardcoded values.",
+            this.correlationId
         );
 
         const hardcodedMetadata = this.getEndpointMetadataFromHardcodedValues();
@@ -611,7 +623,8 @@ export class Authority {
             };
         } else {
             this.logger.verbose(
-                "Did not find endpoint metadata in hardcoded values... Attempting to get endpoint metadata from the network metadata cache."
+                "Did not find endpoint metadata in hardcoded values... Attempting to get endpoint metadata from the network metadata cache.",
+                this.correlationId
             );
         }
 
@@ -624,10 +637,10 @@ export class Authority {
             !metadataEntityExpired
         ) {
             // No need to update
-            this.logger.verbose("Found endpoint metadata in the cache.");
+            this.logger.verbose("Found endpoint metadata in the cache.", "");
             return { source: Constants.AuthorityMetadataSource.CACHE };
         } else if (metadataEntityExpired) {
-            this.logger.verbose("The metadata entity is expired.");
+            this.logger.verbose("The metadata entity is expired.", "");
         }
 
         return null;
@@ -688,7 +701,8 @@ export class Authority {
         const openIdConfigurationEndpoint =
             this.defaultOpenIdConfigurationEndpoint;
         this.logger.verbose(
-            `Authority.getEndpointMetadataFromNetwork: attempting to retrieve OAuth endpoints from '${openIdConfigurationEndpoint}'`
+            `Authority.getEndpointMetadataFromNetwork: attempting to retrieve OAuth endpoints from '${openIdConfigurationEndpoint}'`,
+            this.correlationId
         );
 
         try {
@@ -702,13 +716,15 @@ export class Authority {
                 return response.body;
             } else {
                 this.logger.verbose(
-                    `Authority.getEndpointMetadataFromNetwork: could not parse response as OpenID configuration`
+                    `Authority.getEndpointMetadataFromNetwork: could not parse response as OpenID configuration`,
+                    this.correlationId
                 );
                 return null;
             }
         } catch (e) {
             this.logger.verbose(
-                `Authority.getEndpointMetadataFromNetwork: '${e}'`
+                `Authority.getEndpointMetadataFromNetwork: '${e}'`,
+                this.correlationId
             );
             return null;
         }
@@ -823,29 +839,34 @@ export class Authority {
         metadataEntity: AuthorityMetadataEntity
     ): Constants.AuthorityMetadataSource | null {
         this.logger.verbose(
-            "Attempting to get cloud discovery metadata  from authority configuration"
+            "Attempting to get cloud discovery metadata  from authority configuration",
+            this.correlationId
         );
         this.logger.verbosePii(
             `Known Authorities: '${
                 this.authorityOptions.knownAuthorities ||
                 Constants.NOT_APPLICABLE
-            }'`
+            }'`,
+            this.correlationId
         );
         this.logger.verbosePii(
             `Authority Metadata: '${
                 this.authorityOptions.authorityMetadata ||
                 Constants.NOT_APPLICABLE
-            }'`
+            }'`,
+            this.correlationId
         );
         this.logger.verbosePii(
             `Canonical Authority: '${
                 metadataEntity.canonical_authority || Constants.NOT_APPLICABLE
-            }'`
+            }'`,
+            this.correlationId
         );
         const metadata = this.getCloudDiscoveryMetadataFromConfig();
         if (metadata) {
             this.logger.verbose(
-                "Found cloud discovery metadata in authority configuration"
+                "Found cloud discovery metadata in authority configuration",
+                this.correlationId
             );
             CacheHelpers.updateCloudDiscoveryMetadata(
                 metadataEntity,
@@ -857,7 +878,8 @@ export class Authority {
 
         // If the cached metadata came from config but that config was not passed to this instance, we must go to hardcoded values
         this.logger.verbose(
-            "Did not find cloud discovery metadata in the config... Attempting to get cloud discovery metadata from the hardcoded values."
+            "Did not find cloud discovery metadata in the config... Attempting to get cloud discovery metadata from the hardcoded values.",
+            this.correlationId
         );
 
         const hardcodedMetadata = getCloudDiscoveryMetadataFromHardcodedValues(
@@ -865,7 +887,8 @@ export class Authority {
         );
         if (hardcodedMetadata) {
             this.logger.verbose(
-                "Found cloud discovery metadata from hardcoded values."
+                "Found cloud discovery metadata from hardcoded values.",
+                this.correlationId
             );
             CacheHelpers.updateCloudDiscoveryMetadata(
                 metadataEntity,
@@ -876,7 +899,8 @@ export class Authority {
         }
 
         this.logger.verbose(
-            "Did not find cloud discovery metadata in hardcoded values... Attempting to get cloud discovery metadata from the network metadata cache."
+            "Did not find cloud discovery metadata in hardcoded values... Attempting to get cloud discovery metadata from the network metadata cache.",
+            this.correlationId
         );
 
         const metadataEntityExpired =
@@ -886,11 +910,14 @@ export class Authority {
             metadataEntity.aliasesFromNetwork &&
             !metadataEntityExpired
         ) {
-            this.logger.verbose("Found cloud discovery metadata in the cache.");
+            this.logger.verbose(
+                "Found cloud discovery metadata in the cache.",
+                ""
+            );
             // No need to update
             return Constants.AuthorityMetadataSource.CACHE;
         } else if (metadataEntityExpired) {
-            this.logger.verbose("The metadata entity is expired.");
+            this.logger.verbose("The metadata entity is expired.", "");
         }
 
         return null;
@@ -903,7 +930,8 @@ export class Authority {
         // CIAM does not support cloud discovery metadata
         if (this.authorityType === AuthorityType.Ciam) {
             this.logger.verbose(
-                "CIAM authorities do not support cloud discovery metadata, generate the aliases from authority host."
+                "CIAM authorities do not support cloud discovery metadata, generate the aliases from authority host.",
+                this.correlationId
             );
             return Authority.createCloudDiscoveryMetadataFromHost(
                 this.hostnameAndPort
@@ -913,11 +941,13 @@ export class Authority {
         // Check if network response was provided in config
         if (this.authorityOptions.cloudDiscoveryMetadata) {
             this.logger.verbose(
-                "The cloud discovery metadata has been provided as a network response, in the config."
+                "The cloud discovery metadata has been provided as a network response, in the config.",
+                this.correlationId
             );
             try {
                 this.logger.verbose(
-                    "Attempting to parse the cloud discovery metadata."
+                    "Attempting to parse the cloud discovery metadata.",
+                    this.correlationId
                 );
                 const parsedResponse = JSON.parse(
                     this.authorityOptions.cloudDiscoveryMetadata
@@ -926,20 +956,23 @@ export class Authority {
                     parsedResponse.metadata,
                     this.hostnameAndPort
                 );
-                this.logger.verbose("Parsed the cloud discovery metadata.");
+                this.logger.verbose("Parsed the cloud discovery metadata.", "");
                 if (metadata) {
                     this.logger.verbose(
-                        "There is returnable metadata attached to the parsed cloud discovery metadata."
+                        "There is returnable metadata attached to the parsed cloud discovery metadata.",
+                        this.correlationId
                     );
                     return metadata;
                 } else {
                     this.logger.verbose(
-                        "There is no metadata attached to the parsed cloud discovery metadata."
+                        "There is no metadata attached to the parsed cloud discovery metadata.",
+                        this.correlationId
                     );
                 }
             } catch (e) {
                 this.logger.verbose(
-                    "Unable to parse the cloud discovery metadata. Throwing Invalid Cloud Discovery Metadata Error."
+                    "Unable to parse the cloud discovery metadata. Throwing Invalid Cloud Discovery Metadata Error.",
+                    this.correlationId
                 );
                 throw createClientConfigurationError(
                     ClientConfigurationErrorCodes.invalidCloudDiscoveryMetadata
@@ -950,7 +983,8 @@ export class Authority {
         // If cloudDiscoveryMetadata is empty or does not contain the host, check knownAuthorities
         if (this.isInKnownAuthorities()) {
             this.logger.verbose(
-                "The host is included in knownAuthorities. Creating new cloud discovery metadata from the host."
+                "The host is included in knownAuthorities. Creating new cloud discovery metadata from the host.",
+                this.correlationId
             );
             return Authority.createCloudDiscoveryMetadataFromHost(
                 this.hostnameAndPort
@@ -990,42 +1024,50 @@ export class Authority {
                 metadata = typedResponseBody.metadata;
 
                 this.logger.verbosePii(
-                    `tenant_discovery_endpoint is: '${typedResponseBody.tenant_discovery_endpoint}'`
+                    `tenant_discovery_endpoint is: '${typedResponseBody.tenant_discovery_endpoint}'`,
+                    this.correlationId
                 );
             } else if (isCloudInstanceDiscoveryErrorResponse(response.body)) {
                 this.logger.warning(
-                    `A CloudInstanceDiscoveryErrorResponse was returned. The cloud instance discovery network request's status code is: '${response.status}'`
+                    `A CloudInstanceDiscoveryErrorResponse was returned. The cloud instance discovery network request's status code is: '${response.status}'`,
+                    this.correlationId
                 );
 
                 typedResponseBody =
                     response.body as CloudInstanceDiscoveryErrorResponse;
                 if (typedResponseBody.error === Constants.INVALID_INSTANCE) {
                     this.logger.error(
-                        "The CloudInstanceDiscoveryErrorResponse error is invalid_instance."
+                        "The CloudInstanceDiscoveryErrorResponse error is invalid_instance.",
+                        this.correlationId
                     );
                     return null;
                 }
 
                 this.logger.warning(
-                    `The CloudInstanceDiscoveryErrorResponse error is '${typedResponseBody.error}'`
+                    `The CloudInstanceDiscoveryErrorResponse error is '${typedResponseBody.error}'`,
+                    this.correlationId
                 );
                 this.logger.warning(
-                    `The CloudInstanceDiscoveryErrorResponse error description is '${typedResponseBody.error_description}'`
+                    `The CloudInstanceDiscoveryErrorResponse error description is '${typedResponseBody.error_description}'`,
+                    this.correlationId
                 );
 
                 this.logger.warning(
-                    "Setting the value of the CloudInstanceDiscoveryMetadata (returned from the network) to []"
+                    "Setting the value of the CloudInstanceDiscoveryMetadata (returned from the network, correlationId) to []",
+                    this.correlationId
                 );
                 metadata = [];
             } else {
                 this.logger.error(
-                    "AAD did not return a CloudInstanceDiscoveryResponse or CloudInstanceDiscoveryErrorResponse"
+                    "AAD did not return a CloudInstanceDiscoveryResponse or CloudInstanceDiscoveryErrorResponse",
+                    this.correlationId
                 );
                 return null;
             }
 
             this.logger.verbose(
-                "Attempting to find a match between the developer's authority and the CloudInstanceDiscoveryMetadata returned from the network request."
+                "Attempting to find a match between the developer's authority and the CloudInstanceDiscoveryMetadata returned from the network request.",
+                this.correlationId
             );
             match = getCloudDiscoveryMetadataFromNetworkResponse(
                 metadata,
@@ -1034,12 +1076,14 @@ export class Authority {
         } catch (error) {
             if (error instanceof AuthError) {
                 this.logger.error(
-                    `There was a network error while attempting to get the cloud discovery instance metadata.\nError: '${error.errorCode}'\nError Description: '${error.errorMessage}'`
+                    `There was a network error while attempting to get the cloud discovery instance metadata.\nError: '${error.errorCode}'\nError Description: '${error.errorMessage}'`,
+                    this.correlationId
                 );
             } else {
                 const typedError = error as Error;
                 this.logger.error(
-                    `A non-MSALJS error was thrown while attempting to get the cloud instance discovery metadata.\nError: '${typedError.name}'\nError Description: '${typedError.message}'`
+                    `A non-MSALJS error was thrown while attempting to get the cloud instance discovery metadata.\nError: '${typedError.name}'\nError Description: '${typedError.message}'`,
+                    this.correlationId
                 );
             }
 
@@ -1049,10 +1093,12 @@ export class Authority {
         // Custom Domain scenario, host is trusted because Instance Discovery call succeeded
         if (!match) {
             this.logger.warning(
-                "The developer's authority was not found within the CloudInstanceDiscoveryMetadata returned from the network request."
+                "The developer's authority was not found within the CloudInstanceDiscoveryMetadata returned from the network request.",
+                this.correlationId
             );
             this.logger.verbose(
-                "Creating custom Authority for custom domain scenario."
+                "Creating custom Authority for custom domain scenario.",
+                this.correlationId
             );
 
             match = Authority.createCloudDiscoveryMetadataFromHost(

--- a/lib/msal-common/src/authority/AuthorityFactory.ts
+++ b/lib/msal-common/src/authority/AuthorityFactory.ts
@@ -24,7 +24,11 @@ import { invokeAsync } from "../utils/FunctionWrappers.js";
  *
  * @param authorityUri
  * @param networkClient
- * @param protocolMode
+ * @param cacheManager
+ * @param authorityOptions
+ * @param logger
+ * @param correlationId
+ * @param performanceClient
  * @internal
  */
 export async function createDiscoveredInstance(
@@ -34,7 +38,7 @@ export async function createDiscoveredInstance(
     authorityOptions: AuthorityOptions,
     logger: Logger,
     correlationId: string,
-    performanceClient?: IPerformanceClient
+    performanceClient: IPerformanceClient
 ): Promise<Authority> {
     const authorityUriFinal = Authority.transformCIAMAuthority(
         formatAuthorityUri(authorityUri)

--- a/lib/msal-common/src/authority/AuthorityMetadata.ts
+++ b/lib/msal-common/src/authority/AuthorityMetadata.ts
@@ -117,7 +117,8 @@ InstanceDiscoveryMetadata.metadata.forEach(
  */
 export function getAliasesFromStaticSources(
     staticAuthorityOptions: StaticAuthorityOptions,
-    logger?: Logger
+    logger: Logger,
+    correlationId: string
 ): string[] {
     let staticAliases: string[] | undefined;
     const canonicalAuthority = staticAuthorityOptions.canonicalAuthority;
@@ -127,16 +128,18 @@ export function getAliasesFromStaticSources(
         ).getUrlComponents().HostNameAndPort;
         staticAliases =
             getAliasesFromMetadata(
+                logger,
+                correlationId,
                 authorityHost,
                 staticAuthorityOptions.cloudDiscoveryMetadata?.metadata,
-                AuthorityMetadataSource.CONFIG,
-                logger
+                AuthorityMetadataSource.CONFIG
             ) ||
             getAliasesFromMetadata(
+                logger,
+                correlationId,
                 authorityHost,
                 InstanceDiscoveryMetadata.metadata,
-                AuthorityMetadataSource.HARDCODED_VALUES,
-                logger
+                AuthorityMetadataSource.HARDCODED_VALUES
             ) ||
             staticAuthorityOptions.knownAuthorities;
     }
@@ -151,12 +154,16 @@ export function getAliasesFromStaticSources(
  * @returns
  */
 export function getAliasesFromMetadata(
+    logger: Logger,
+    correlationId: string,
     authorityHost?: string,
     cloudDiscoveryMetadata?: CloudDiscoveryMetadata[],
-    source?: AuthorityMetadataSource,
-    logger?: Logger
+    source?: AuthorityMetadataSource
 ): string[] | null {
-    logger?.trace(`getAliasesFromMetadata called with source: '${source}'`);
+    logger.trace(
+        `getAliasesFromMetadata called with source: '${source}'`,
+        correlationId
+    );
     if (authorityHost && cloudDiscoveryMetadata) {
         const metadata = getCloudDiscoveryMetadataFromNetworkResponse(
             cloudDiscoveryMetadata,
@@ -164,13 +171,15 @@ export function getAliasesFromMetadata(
         );
 
         if (metadata) {
-            logger?.trace(
-                `getAliasesFromMetadata: found cloud discovery metadata in '${source}', returning aliases`
+            logger.trace(
+                `getAliasesFromMetadata: found cloud discovery metadata in '${source}', returning aliases`,
+                correlationId
             );
             return metadata.aliases;
         } else {
-            logger?.trace(
-                `getAliasesFromMetadata: did not find cloud discovery metadata in '${source}'`
+            logger.trace(
+                `getAliasesFromMetadata: did not find cloud discovery metadata in '${source}'`,
+                correlationId
             );
         }
     }

--- a/lib/msal-common/src/authority/RegionDiscovery.ts
+++ b/lib/msal-common/src/authority/RegionDiscovery.ts
@@ -20,9 +20,9 @@ export class RegionDiscovery {
     // Logger
     private logger: Logger;
     // Performance client
-    protected performanceClient: IPerformanceClient | undefined;
+    protected performanceClient: IPerformanceClient;
     // CorrelationId
-    protected correlationId: string | undefined;
+    protected correlationId: string;
     // Options for the IMDS endpoint request
     protected static IMDS_OPTIONS: ImdsOptions = {
         headers: {
@@ -33,8 +33,8 @@ export class RegionDiscovery {
     constructor(
         networkInterface: INetworkModule,
         logger: Logger,
-        performanceClient?: IPerformanceClient,
-        correlationId?: string
+        performanceClient: IPerformanceClient,
+        correlationId: string
     ) {
         this.networkInterface = networkInterface;
         this.logger = logger;

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -153,8 +153,12 @@ export abstract class CacheManager implements ICacheManager {
     /**
      * fetch appMetadata entity from the platform cache
      * @param appMetadataKey
+     * @param correlationId
      */
-    abstract getAppMetadata(appMetadataKey: string): AppMetadataEntity | null;
+    abstract getAppMetadata(
+        appMetadataKey: string,
+        correlationId: string
+    ): AppMetadataEntity | null;
 
     /**
      * set appMetadata entity to the platform cache
@@ -168,15 +172,18 @@ export abstract class CacheManager implements ICacheManager {
     /**
      * fetch server telemetry entity from the platform cache
      * @param serverTelemetryKey
+     * @param correlationId
      */
     abstract getServerTelemetry(
-        serverTelemetryKey: string
+        serverTelemetryKey: string,
+        correlationId: string
     ): ServerTelemetryEntity | null;
 
     /**
      * set server telemetry entity to the platform cache
      * @param serverTelemetryKey
      * @param serverTelemetry
+     * @param correlationId
      */
     abstract setServerTelemetry(
         serverTelemetryKey: string,
@@ -187,8 +194,12 @@ export abstract class CacheManager implements ICacheManager {
     /**
      * fetch cloud discovery metadata entity from the platform cache
      * @param key
+     * @param correlationId
      */
-    abstract getAuthorityMetadata(key: string): AuthorityMetadataEntity | null;
+    abstract getAuthorityMetadata(
+        key: string,
+        correlationId: string
+    ): AuthorityMetadataEntity | null;
 
     /**
      *
@@ -199,18 +210,22 @@ export abstract class CacheManager implements ICacheManager {
      * set cloud discovery metadata entity to the platform cache
      * @param key
      * @param value
+     * @param correlationId
      */
     abstract setAuthorityMetadata(
         key: string,
-        value: AuthorityMetadataEntity
+        value: AuthorityMetadataEntity,
+        correlationId: string
     ): void;
 
     /**
      * fetch throttling entity from the platform cache
      * @param throttlingCacheKey
+     * @param correlationId
      */
     abstract getThrottlingCache(
-        throttlingCacheKey: string
+        throttlingCacheKey: string,
+        correlationId: string
     ): ThrottlingEntity | null;
 
     /**
@@ -573,7 +588,10 @@ export abstract class CacheManager implements ICacheManager {
                 this.setAppMetadata(cacheRecord.appMetadata, correlationId);
             }
         } catch (e: unknown) {
-            this.commonLogger?.error(`CacheManager.saveCacheRecord: failed`);
+            this.commonLogger?.error(
+                `CacheManager.saveCacheRecord: failed`,
+                correlationId
+            );
             if (e instanceof AuthError) {
                 throw e;
             } else {
@@ -616,7 +634,11 @@ export abstract class CacheManager implements ICacheManager {
 
             if (
                 tokenEntity &&
-                this.credentialMatchesFilter(tokenEntity, accessTokenFilter)
+                this.credentialMatchesFilter(
+                    tokenEntity,
+                    accessTokenFilter,
+                    correlationId
+                )
             ) {
                 const tokenScopeSet = ScopeSet.fromString(tokenEntity.target);
                 if (tokenScopeSet.intersectingScopeSets(currentScopes)) {
@@ -666,7 +688,11 @@ export abstract class CacheManager implements ICacheManager {
 
             if (
                 !!accountFilter.environment &&
-                !this.matchEnvironment(entity, accountFilter.environment)
+                !this.matchEnvironment(
+                    entity,
+                    accountFilter.environment,
+                    correlationId
+                )
             ) {
                 return;
             }
@@ -725,11 +751,13 @@ export abstract class CacheManager implements ICacheManager {
      * Returns whether or not the given credential entity matches the filter
      * @param entity
      * @param filter
+     * @param correlationId
      * @returns
      */
     credentialMatchesFilter(
         entity: ValidCredentialType,
-        filter: CredentialFilter
+        filter: CredentialFilter,
+        correlationId: string
     ): boolean {
         if (!!filter.clientId && !this.matchClientId(entity, filter.clientId)) {
             return false;
@@ -755,7 +783,7 @@ export abstract class CacheManager implements ICacheManager {
 
         if (
             !!filter.environment &&
-            !this.matchEnvironment(entity, filter.environment)
+            !this.matchEnvironment(entity, filter.environment, correlationId)
         ) {
             return false;
         }
@@ -809,8 +837,12 @@ export abstract class CacheManager implements ICacheManager {
     /**
      * retrieve appMetadata matching all provided filters; if no filter is set, get all appMetadata
      * @param filter
+     * @param correlationId
      */
-    getAppMetadataFilteredBy(filter: AppMetadataFilter): AppMetadataCache {
+    getAppMetadataFilteredBy(
+        filter: AppMetadataFilter,
+        correlationId: string
+    ): AppMetadataCache {
         const allCacheKeys = this.getKeys();
         const matchingAppMetadata: AppMetadataCache = {};
 
@@ -821,7 +853,7 @@ export abstract class CacheManager implements ICacheManager {
             }
 
             // Attempt retrieval
-            const entity = this.getAppMetadata(cacheKey);
+            const entity = this.getAppMetadata(cacheKey, correlationId);
 
             if (!entity) {
                 return;
@@ -829,7 +861,11 @@ export abstract class CacheManager implements ICacheManager {
 
             if (
                 !!filter.environment &&
-                !this.matchEnvironment(entity, filter.environment)
+                !this.matchEnvironment(
+                    entity,
+                    filter.environment,
+                    correlationId
+                )
             ) {
                 return;
             }
@@ -849,9 +885,13 @@ export abstract class CacheManager implements ICacheManager {
 
     /**
      * retrieve authorityMetadata that contains a matching alias
-     * @param filter
+     * @param host
+     * @param correlationId
      */
-    getAuthorityMetadataByAlias(host: string): AuthorityMetadataEntity | null {
+    getAuthorityMetadataByAlias(
+        host: string,
+        correlationId: string
+    ): AuthorityMetadataEntity | null {
         const allCacheKeys = this.getAuthorityMetadataKeys();
         let matchedEntity = null;
 
@@ -865,7 +905,7 @@ export abstract class CacheManager implements ICacheManager {
             }
 
             // Attempt retrieval
-            const entity = this.getAuthorityMetadata(cacheKey);
+            const entity = this.getAuthorityMetadata(cacheKey, correlationId);
 
             if (!entity) {
                 return;
@@ -1011,7 +1051,10 @@ export abstract class CacheManager implements ICacheManager {
         tokenKeys?: TokenKeys,
         targetRealm?: string
     ): IdTokenEntity | null {
-        this.commonLogger.trace("CacheManager - getIdToken called");
+        this.commonLogger.trace(
+            "CacheManager - getIdToken called",
+            correlationId
+        );
         const idTokenFilter: CredentialFilter = {
             homeAccountId: account.homeAccountId,
             environment: account.environment,
@@ -1029,7 +1072,10 @@ export abstract class CacheManager implements ICacheManager {
         const numIdTokens = idTokenMap.size;
 
         if (numIdTokens < 1) {
-            this.commonLogger.info("CacheManager:getIdToken - No token found");
+            this.commonLogger.info(
+                "CacheManager:getIdToken - No token found",
+                correlationId
+            );
             return null;
         } else if (numIdTokens > 1) {
             let tokensToBeRemoved: Map<string, IdTokenEntity> = idTokenMap;
@@ -1047,12 +1093,14 @@ export abstract class CacheManager implements ICacheManager {
                 const numHomeIdTokens = homeIdTokenMap.size;
                 if (numHomeIdTokens < 1) {
                     this.commonLogger.info(
-                        "CacheManager:getIdToken - Multiple ID tokens found for account but none match account entity tenant id, returning first result"
+                        "CacheManager:getIdToken - Multiple ID tokens found for account but none match account entity tenant id, returning first result",
+                        correlationId
                     );
                     return idTokenMap.values().next().value;
                 } else if (numHomeIdTokens === 1) {
                     this.commonLogger.info(
-                        "CacheManager:getIdToken - Multiple ID tokens found for account, defaulting to home tenant profile"
+                        "CacheManager:getIdToken - Multiple ID tokens found for account, defaulting to home tenant profile",
+                        correlationId
                     );
                     return homeIdTokenMap.values().next().value;
                 } else {
@@ -1062,7 +1110,8 @@ export abstract class CacheManager implements ICacheManager {
             }
             // Multiple tokens for a single tenant profile, remove all and return null
             this.commonLogger.info(
-                "CacheManager:getIdToken - Multiple matching ID tokens found, clearing them"
+                "CacheManager:getIdToken - Multiple matching ID tokens found, clearing them",
+                correlationId
             );
             tokensToBeRemoved.forEach((idToken, key) => {
                 this.removeIdToken(key, correlationId);
@@ -1074,7 +1123,10 @@ export abstract class CacheManager implements ICacheManager {
             return null;
         }
 
-        this.commonLogger.info("CacheManager:getIdToken - Returning ID token");
+        this.commonLogger.info(
+            "CacheManager:getIdToken - Returning ID token",
+            correlationId
+        );
         return idTokenMap.values().next().value;
     }
 
@@ -1105,7 +1157,10 @@ export abstract class CacheManager implements ICacheManager {
                 return;
             }
             const idToken = this.getIdTokenCredential(key, correlationId);
-            if (idToken && this.credentialMatchesFilter(idToken, filter)) {
+            if (
+                idToken &&
+                this.credentialMatchesFilter(idToken, filter, correlationId)
+            ) {
                 idTokens.set(key, idToken);
             }
         });
@@ -1219,7 +1274,11 @@ export abstract class CacheManager implements ICacheManager {
                 // Validate value
                 if (
                     accessToken &&
-                    this.credentialMatchesFilter(accessToken, accessTokenFilter)
+                    this.credentialMatchesFilter(
+                        accessToken,
+                        accessTokenFilter,
+                        correlationId
+                    )
                 ) {
                     accessTokens.push(accessToken);
                 }
@@ -1334,7 +1393,7 @@ export abstract class CacheManager implements ICacheManager {
             );
             if (
                 accessToken &&
-                this.credentialMatchesFilter(accessToken, filter)
+                this.credentialMatchesFilter(accessToken, filter, correlationId)
             ) {
                 accessTokens.push(accessToken);
             }
@@ -1357,7 +1416,10 @@ export abstract class CacheManager implements ICacheManager {
         correlationId: string,
         tokenKeys?: TokenKeys
     ): RefreshTokenEntity | null {
-        this.commonLogger.trace("CacheManager - getRefreshToken called");
+        this.commonLogger.trace(
+            "CacheManager - getRefreshToken called",
+            correlationId
+        );
         const id = familyRT ? Constants.THE_FAMILY_ID : undefined;
         const refreshTokenFilter: CredentialFilter = {
             homeAccountId: account.homeAccountId,
@@ -1384,7 +1446,8 @@ export abstract class CacheManager implements ICacheManager {
                     refreshToken &&
                     this.credentialMatchesFilter(
                         refreshToken,
-                        refreshTokenFilter
+                        refreshTokenFilter,
+                        correlationId
                     )
                 ) {
                     refreshTokens.push(refreshToken);
@@ -1395,7 +1458,8 @@ export abstract class CacheManager implements ICacheManager {
         const numRefreshTokens = refreshTokens.length;
         if (numRefreshTokens < 1) {
             this.commonLogger.info(
-                "CacheManager:getRefreshToken - No refresh token found."
+                "CacheManager:getRefreshToken - No refresh token found.",
+                correlationId
             );
             return null;
         }
@@ -1409,7 +1473,8 @@ export abstract class CacheManager implements ICacheManager {
         }
 
         this.commonLogger.info(
-            "CacheManager:getRefreshToken - returning refresh token"
+            "CacheManager:getRefreshToken - returning refresh token",
+            correlationId
         );
         return refreshTokens[0] as RefreshTokenEntity;
     }
@@ -1453,14 +1518,19 @@ export abstract class CacheManager implements ICacheManager {
     /**
      * Retrieve AppMetadataEntity from cache
      */
-    readAppMetadataFromCache(environment: string): AppMetadataEntity | null {
+    readAppMetadataFromCache(
+        environment: string,
+        correlationId: string
+    ): AppMetadataEntity | null {
         const appMetadataFilter: AppMetadataFilter = {
             environment,
             clientId: this.clientId,
         };
 
-        const appMetadata: AppMetadataCache =
-            this.getAppMetadataFilteredBy(appMetadataFilter);
+        const appMetadata: AppMetadataCache = this.getAppMetadataFilteredBy(
+            appMetadataFilter,
+            correlationId
+        );
         const appMetadataEntries: AppMetadataEntity[] = Object.keys(
             appMetadata
         ).map((key) => appMetadata[key]);
@@ -1482,8 +1552,11 @@ export abstract class CacheManager implements ICacheManager {
      * @param environment
      * @param clientId
      */
-    isAppMetadataFOCI(environment: string): boolean {
-        const appMetadata = this.readAppMetadataFromCache(environment);
+    isAppMetadataFOCI(environment: string, correlationId: string): boolean {
+        const appMetadata = this.readAppMetadataFromCache(
+            environment,
+            correlationId
+        );
         return !!(
             appMetadata && appMetadata.familyId === Constants.THE_FAMILY_ID
         );
@@ -1574,13 +1647,15 @@ export abstract class CacheManager implements ICacheManager {
      */
     private matchEnvironment(
         entity: AccountEntity | CredentialEntity | AppMetadataEntity,
-        environment: string
+        environment: string,
+        correlationId: string
     ): boolean {
         // Check static authority options first for cases where authority metadata has not been resolved and cached yet
         if (this.staticAuthorityOptions) {
             const staticAliases = getAliasesFromStaticSources(
                 this.staticAuthorityOptions,
-                this.commonLogger
+                this.commonLogger,
+                correlationId
             );
             if (
                 staticAliases.includes(environment) &&
@@ -1591,7 +1666,10 @@ export abstract class CacheManager implements ICacheManager {
         }
 
         // Query metadata cache if no static authority configuration has aliases that match enviroment
-        const cloudMetadata = this.getAuthorityMetadataByAlias(environment);
+        const cloudMetadata = this.getAuthorityMetadataByAlias(
+            environment,
+            correlationId
+        );
         if (
             cloudMetadata &&
             cloudMetadata.aliases.indexOf(entity.environment) > -1

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -981,7 +981,8 @@ export abstract class CacheManager implements ICacheManager {
 
     /**
      * returns a boolean if the given credential is removed
-     * @param credential
+     * @param key
+     * @param correlationId
      */
     removeAccessToken(key: string, correlationId: string): void {
         const credential = this.getAccessTokenCredential(key, correlationId);
@@ -1007,7 +1008,7 @@ export abstract class CacheManager implements ICacheManager {
 
                 if (kid) {
                     void this.cryptoImpl
-                        .removeTokenBindingKey(kid)
+                        .removeTokenBindingKey(kid, correlationId)
                         .catch(() => {
                             this.commonLogger.error(
                                 `Failed to remove token binding key '${kid}'`,

--- a/lib/msal-common/src/cache/interface/ICacheManager.ts
+++ b/lib/msal-common/src/cache/interface/ICacheManager.ts
@@ -20,18 +20,21 @@ export interface ICacheManager {
     /**
      * fetch the account entity from the platform cache
      * @param accountKey
+     * @param correlationId
      */
     getAccount(accountKey: string, correlationId: string): AccountEntity | null;
 
     /**
      * set account entity in the platform cache
      * @param account
+     * @param correlationId
      */
     setAccount(account: AccountEntity, correlationId: string): Promise<void>;
 
     /**
      * fetch the idToken entity from the platform cache
      * @param idTokenKey
+     * @param correlationId
      */
     getIdTokenCredential(
         idTokenKey: string,
@@ -41,6 +44,7 @@ export interface ICacheManager {
     /**
      * set idToken entity to the platform cache
      * @param idToken
+     * @param correlationId
      */
     setIdTokenCredential(
         idToken: IdTokenEntity,
@@ -50,6 +54,7 @@ export interface ICacheManager {
     /**
      * fetch the idToken entity from the platform cache
      * @param accessTokenKey
+     * @param correlationId
      */
     getAccessTokenCredential(
         accessTokenKey: string,
@@ -59,6 +64,7 @@ export interface ICacheManager {
     /**
      * set idToken entity to the platform cache
      * @param accessToken
+     * @param correlationId
      */
     setAccessTokenCredential(
         accessToken: AccessTokenEntity,
@@ -68,6 +74,7 @@ export interface ICacheManager {
     /**
      * fetch the idToken entity from the platform cache
      * @param refreshTokenKey
+     * @param correlationId
      */
     getRefreshTokenCredential(
         refreshTokenKey: string,
@@ -77,6 +84,7 @@ export interface ICacheManager {
     /**
      * set idToken entity to the platform cache
      * @param refreshToken
+     * @param correlationId
      */
     setRefreshTokenCredential(
         refreshToken: RefreshTokenEntity,
@@ -86,27 +94,35 @@ export interface ICacheManager {
     /**
      * fetch appMetadata entity from the platform cache
      * @param appMetadataKey
+     * @param correlationId
      */
-    getAppMetadata(appMetadataKey: string): AppMetadataEntity | null;
+    getAppMetadata(
+        appMetadataKey: string,
+        correlationId: string
+    ): AppMetadataEntity | null;
 
     /**
      * set appMetadata entity to the platform cache
      * @param appMetadata
+     * @param correlationId
      */
     setAppMetadata(appMetadata: AppMetadataEntity, correlationId: string): void;
 
     /**
      * fetch server telemetry entity from the platform cache
      * @param serverTelemetryKey
+     * @param correlationId
      */
     getServerTelemetry(
-        serverTelemetryKey: string
+        serverTelemetryKey: string,
+        correlationId: string
     ): ServerTelemetryEntity | null;
 
     /**
      * set server telemetry entity to the platform cache
      * @param serverTelemetryKey
      * @param serverTelemetry
+     * @param correlationId
      */
     setServerTelemetry(
         serverTelemetryKey: string,
@@ -117,43 +133,66 @@ export interface ICacheManager {
     /**
      * fetch cloud discovery metadata entity from the platform cache
      * @param key
+     * @param correlationId
      */
-    getAuthorityMetadata(key: string): AuthorityMetadataEntity | null;
+    getAuthorityMetadata(
+        key: string,
+        correlationId: string
+    ): AuthorityMetadataEntity | null;
 
     /**
      * Get cache keys for authority metadata
+     * @param correlationId
      */
-    getAuthorityMetadataKeys(): Array<string>;
+    getAuthorityMetadataKeys(correlationId: string): Array<string>;
 
     /**
      * set cloud discovery metadata entity to the platform cache
      * @param key
      * @param value
+     * @param correlationId
      */
-    setAuthorityMetadata(key: string, value: AuthorityMetadataEntity): void;
+    setAuthorityMetadata(
+        key: string,
+        value: AuthorityMetadataEntity,
+        correlationId: string
+    ): void;
 
     /**
      * Provide an alias to find a matching AuthorityMetadataEntity in cache
      * @param host
+     * @param correlationId
      */
-    getAuthorityMetadataByAlias(host: string): AuthorityMetadataEntity | null;
+    getAuthorityMetadataByAlias(
+        host: string,
+        correlationId: string
+    ): AuthorityMetadataEntity | null;
 
     /**
      * given an authority generates the cache key for authorityMetadata
      * @param authority
+     * @param correlationId
      */
-    generateAuthorityMetadataCacheKey(authority: string): string;
+    generateAuthorityMetadataCacheKey(
+        authority: string,
+        correlationId: string
+    ): string;
 
     /**
      * fetch throttling entity from the platform cache
      * @param throttlingCacheKey
+     * @param correlationId
      */
-    getThrottlingCache(throttlingCacheKey: string): ThrottlingEntity | null;
+    getThrottlingCache(
+        throttlingCacheKey: string,
+        correlationId: string
+    ): ThrottlingEntity | null;
 
     /**
      * set throttling entity to the platform cache
      * @param throttlingCacheKey
      * @param throttlingCache
+     * @param correlationId
      */
     setThrottlingCache(
         throttlingCacheKey: string,
@@ -163,12 +202,16 @@ export interface ICacheManager {
 
     /**
      * Returns all accounts in cache
+     * @param filter
+     * @param correlationId
      */
     getAllAccounts(filter: AccountFilter, correlationId: string): AccountInfo[];
 
     /**
      * saves a cache record
      * @param cacheRecord
+     * @param correlationId
+     * @param storeInCache
      */
     saveCacheRecord(
         cacheRecord: CacheRecord,
@@ -178,9 +221,8 @@ export interface ICacheManager {
 
     /**
      * retrieve accounts matching all provided filters; if no filter is set, get all accounts
-     * @param homeAccountId
-     * @param environment
-     * @param realm
+     * @param filter
+     * @param correlationId
      */
     getAccountsFilteredBy(
         filter: AccountFilter,
@@ -190,6 +232,7 @@ export interface ICacheManager {
     /**
      * Get AccountInfo object based on provided filters
      * @param filter
+     * @param correlationId
      */
     getAccountInfoFilteredBy(
         filter: AccountFilter,
@@ -198,33 +241,39 @@ export interface ICacheManager {
 
     /**
      * Removes all accounts and related tokens from cache.
+     * @param correlationId
      */
     removeAllAccounts(correlationId: string): void;
 
     /**
      * returns a boolean if the given account is removed
      * @param account
+     * @param correlationId
      */
     removeAccount(account: AccountInfo, correlationId: string): void;
 
     /**
      * returns a boolean if the given account is removed
      * @param account
+     * @param correlationId
      */
     removeAccountContext(account: AccountInfo, correlationId: string): void;
 
     /**
      * @param key
+     * @param correlationId
      */
     removeIdToken(key: string, correlationId: string): void;
 
     /**
      * @param key
+     * @param correlationId
      */
     removeAccessToken(key: string, correlationId: string): void;
 
     /**
      * @param key
+     * @param correlationId
      */
     removeRefreshToken(key: string, correlationId: string): void;
 }

--- a/lib/msal-common/src/cache/utils/AccountEntityUtils.ts
+++ b/lib/msal-common/src/cache/utils/AccountEntityUtils.ts
@@ -206,6 +206,7 @@ export function generateHomeAccountId(
     authType: AuthorityType,
     logger: Logger,
     cryptoObj: ICrypto,
+    correlationId: string,
     idTokenClaims?: TokenClaims
 ): string {
     // since ADFS/DSTS do not have tid and does not set client_info
@@ -222,7 +223,7 @@ export function generateHomeAccountId(
                 }
             } catch (e) {}
         }
-        logger.warning("No client info in response");
+        logger.warning("No client info in response", correlationId);
     }
 
     // default to "sub" claim

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -55,7 +55,7 @@ export class AuthorizationCodeClient extends BaseClient {
 
     constructor(
         configuration: ClientConfiguration,
-        performanceClient?: IPerformanceClient
+        performanceClient: IPerformanceClient
     ) {
         super(configuration, performanceClient);
         this.oidcDefaultScopes =
@@ -95,12 +95,16 @@ export class AuthorizationCodeClient extends BaseClient {
             this.cacheManager,
             this.cryptoUtils,
             this.logger,
+            this.performanceClient,
             this.config.serializableCache,
             this.config.persistencePlugin
         );
 
         // Validate response. This function throws a server error if an error is returned by the server.
-        responseHandler.validateTokenResponse(response.body);
+        responseHandler.validateTokenResponse(
+            response.body,
+            request.correlationId
+        );
 
         return invokeAsync(
             responseHandler.handleServerTokenResponse.bind(responseHandler),
@@ -178,7 +182,8 @@ export class AuthorizationCodeClient extends BaseClient {
                 };
             } catch (e) {
                 this.logger.verbose(
-                    `Could not parse client info for CCS Header: '${e}'`
+                    `Could not parse client info for CCS Header: '${e}'`,
+                    request.correlationId
                 );
             }
         }
@@ -364,7 +369,8 @@ export class AuthorizationCodeClient extends BaseClient {
                 };
             } catch (e) {
                 this.logger.verbose(
-                    `Could not parse client info for CCS Header: '${e}'`
+                    `Could not parse client info for CCS Header: '${e}'`,
+                    request.correlationId
                 );
             }
         } else {
@@ -385,7 +391,8 @@ export class AuthorizationCodeClient extends BaseClient {
                         );
                     } catch (e) {
                         this.logger.verbose(
-                            `Could not parse home account ID for CCS Header: '${e}'`
+                            `Could not parse home account ID for CCS Header: '${e}'`,
+                            request.correlationId
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/BaseClient.ts
+++ b/lib/msal-common/src/client/BaseClient.ts
@@ -66,11 +66,11 @@ export abstract class BaseClient {
     public authority: Authority;
 
     // Performance telemetry client
-    protected performanceClient?: IPerformanceClient;
+    protected performanceClient: IPerformanceClient;
 
     protected constructor(
         configuration: ClientConfiguration,
-        performanceClient?: IPerformanceClient
+        performanceClient: IPerformanceClient
     ) {
         // Set the configuration
         this.config = buildClientConfiguration(configuration);
@@ -117,7 +117,8 @@ export abstract class BaseClient {
                         ] = `Oid:${clientInfo.uid}@${clientInfo.utid}`;
                     } catch (e) {
                         this.logger.verbose(
-                            `Could not parse home account ID for CCS Header: '${e}'`
+                            `Could not parse home account ID for CCS Header: '${e}'`,
+                            ""
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -55,7 +55,7 @@ const DEFAULT_REFRESH_TOKEN_EXPIRATION_OFFSET_SECONDS = 300; // 5 Minutes
 export class RefreshTokenClient extends BaseClient {
     constructor(
         configuration: ClientConfiguration,
-        performanceClient?: IPerformanceClient
+        performanceClient: IPerformanceClient
     ) {
         super(configuration, performanceClient);
     }
@@ -79,10 +79,14 @@ export class RefreshTokenClient extends BaseClient {
             this.cacheManager,
             this.cryptoUtils,
             this.logger,
+            this.performanceClient,
             this.config.serializableCache,
             this.config.persistencePlugin
         );
-        responseHandler.validateTokenResponse(response.body);
+        responseHandler.validateTokenResponse(
+            response.body,
+            request.correlationId
+        );
 
         return invokeAsync(
             responseHandler.handleServerTokenResponse.bind(responseHandler),
@@ -125,7 +129,8 @@ export class RefreshTokenClient extends BaseClient {
 
         // try checking if FOCI is enabled for the given application
         const isFOCI = this.cacheManager.isAppMetadataFOCI(
-            request.account.environment
+            request.account.environment,
+            request.correlationId
         );
 
         // if the app is part of the family, retrive a Family refresh token if present and make a refreshTokenRequest
@@ -244,7 +249,8 @@ export class RefreshTokenClient extends BaseClient {
                 if (e.subError === InteractionRequiredAuthErrorCodes.badToken) {
                     // Remove bad refresh token from cache
                     this.logger.verbose(
-                        "acquireTokenWithRefreshToken: bad refresh token, removing from cache"
+                        "acquireTokenWithRefreshToken: bad refresh token, removing from cache",
+                        request.correlationId
                     );
                     const badRefreshTokenKey =
                         this.cacheManager.generateCredentialKey(refreshToken);
@@ -448,7 +454,8 @@ export class RefreshTokenClient extends BaseClient {
                         );
                     } catch (e) {
                         this.logger.verbose(
-                            `Could not parse home account ID for CCS Header: '${e}'`
+                            `Could not parse home account ID for CCS Header: '${e}'`,
+                            request.correlationId
                         );
                     }
                     break;

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -27,7 +27,7 @@ import { getTenantFromAuthorityString } from "../authority/Authority.js";
 export class SilentFlowClient extends BaseClient {
     constructor(
         configuration: ClientConfiguration,
-        performanceClient?: IPerformanceClient
+        performanceClient: IPerformanceClient
     ) {
         super(configuration, performanceClient);
     }
@@ -119,8 +119,10 @@ export class SilentFlowClient extends BaseClient {
                 requestTenantId
             ),
             refreshToken: null,
-            appMetadata:
-                this.cacheManager.readAppMetadataFromCache(environment),
+            appMetadata: this.cacheManager.readAppMetadataFromCache(
+                environment,
+                request.correlationId
+            ),
         };
 
         this.setCacheOutcome(lastCacheOutcome, request.correlationId);
@@ -154,7 +156,8 @@ export class SilentFlowClient extends BaseClient {
         );
         if (cacheOutcome !== CacheOutcome.NOT_APPLICABLE) {
             this.logger.info(
-                `Token refresh is required due to cache outcome: '${cacheOutcome}'`
+                `Token refresh is required due to cache outcome: '${cacheOutcome}'`,
+                correlationId || ""
             );
         }
     }
@@ -193,6 +196,7 @@ export class SilentFlowClient extends BaseClient {
             cacheRecord,
             true,
             request,
+            this.performanceClient,
             idTokenClaims
         );
     }

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -157,7 +157,7 @@ export class SilentFlowClient extends BaseClient {
         if (cacheOutcome !== CacheOutcome.NOT_APPLICABLE) {
             this.logger.info(
                 `Token refresh is required due to cache outcome: '${cacheOutcome}'`,
-                correlationId || ""
+                correlationId
             );
         }
     }

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -28,7 +28,7 @@ export type SignedHttpRequestParameters = Pick<
     | "shrNonce"
     | "shrOptions"
 > & {
-    correlationId?: string;
+    correlationId: string;
 };
 
 /**

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -69,12 +69,14 @@ export interface ICrypto {
     /**
      * Removes cryptographic keypair from key store matching the keyId passed in
      * @param kid
+     * @param correlationId
      */
-    removeTokenBindingKey(kid: string): Promise<void>;
+    removeTokenBindingKey(kid: string, correlationId: string): Promise<void>;
     /**
      * Removes all cryptographic keys from IndexedDB storage
+     * @param correlationId
      */
-    clearKeystore(): Promise<boolean>;
+    clearKeystore(correlationId: string): Promise<boolean>;
     /**
      * Returns a signed proof-of-possession token with a given acces token that contains a cnf claim with the required kid.
      * @param accessToken

--- a/lib/msal-common/src/crypto/PopTokenGenerator.ts
+++ b/lib/msal-common/src/crypto/PopTokenGenerator.ts
@@ -37,9 +37,9 @@ export type KeyLocation = (typeof KeyLocation)[keyof typeof KeyLocation];
 /** @internal */
 export class PopTokenGenerator {
     private cryptoUtils: ICrypto;
-    private performanceClient?: IPerformanceClient;
+    private performanceClient: IPerformanceClient;
 
-    constructor(cryptoUtils: ICrypto, performanceClient?: IPerformanceClient) {
+    constructor(cryptoUtils: ICrypto, performanceClient: IPerformanceClient) {
         this.cryptoUtils = cryptoUtils;
         this.performanceClient = performanceClient;
     }

--- a/lib/msal-common/src/exports-node-only.ts
+++ b/lib/msal-common/src/exports-node-only.ts
@@ -29,3 +29,4 @@ export {
 } from "./response/DeviceCodeResponse.js";
 export { getClientAssertion } from "./utils/ClientAssertionUtils.js";
 export { IGuidGenerator } from "./crypto/IGuidGenerator.js";
+export { StubPerformanceClient } from "./telemetry/performance/StubPerformanceClient.js";

--- a/lib/msal-common/src/logger/Logger.ts
+++ b/lib/msal-common/src/logger/Logger.ts
@@ -12,7 +12,7 @@ export type LoggerMessageOptions = {
     logLevel: LogLevel;
     containsPii?: boolean;
     context?: string;
-    correlationId?: string;
+    correlationId: string;
 };
 
 /**
@@ -37,9 +37,6 @@ export interface ILoggerCallback {
  * Class which facilitates logging of messages to a specific place.
  */
 export class Logger {
-    // Correlation ID for request, usually set by user.
-    private correlationId: string;
-
     // Current log level, defaults to info.
     private level: LogLevel = LogLevel.Info;
 
@@ -72,7 +69,6 @@ export class Logger {
             typeof setLoggerOptions.logLevel === "number"
                 ? setLoggerOptions.logLevel
                 : LogLevel.Info;
-        this.correlationId = setLoggerOptions.correlationId || "";
         this.packageName = packageName || "";
         this.packageVersion = packageVersion || "";
     }
@@ -90,17 +86,12 @@ export class Logger {
     /**
      * Create new Logger with existing configurations.
      */
-    public clone(
-        packageName: string,
-        packageVersion: string,
-        correlationId?: string
-    ): Logger {
+    public clone(packageName: string, packageVersion: string): Logger {
         return new Logger(
             {
                 loggerCallback: this.localCallback,
                 piiLoggingEnabled: this.piiLoggingEnabled,
                 logLevel: this.level,
-                correlationId: correlationId || this.correlationId,
             },
             packageName,
             packageVersion
@@ -123,9 +114,7 @@ export class Logger {
         const timestamp = new Date().toUTCString();
 
         // Add correlationId to logs if set, correlationId provided on log messages take precedence
-        const logHeader = `[${timestamp}] : [${
-            options.correlationId || this.correlationId || ""
-        }]`;
+        const logHeader = `[${timestamp}] : [${options.correlationId}]`;
 
         const log = `${logHeader} : ${this.packageName}@${
             this.packageVersion
@@ -154,110 +143,110 @@ export class Logger {
     /**
      * Logs error messages.
      */
-    error(message: string, correlationId?: string): void {
+    error(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Error,
             containsPii: false,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs error messages with PII.
      */
-    errorPii(message: string, correlationId?: string): void {
+    errorPii(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Error,
             containsPii: true,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs warning messages.
      */
-    warning(message: string, correlationId?: string): void {
+    warning(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Warning,
             containsPii: false,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs warning messages with PII.
      */
-    warningPii(message: string, correlationId?: string): void {
+    warningPii(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Warning,
             containsPii: true,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs info messages.
      */
-    info(message: string, correlationId?: string): void {
+    info(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Info,
             containsPii: false,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs info messages with PII.
      */
-    infoPii(message: string, correlationId?: string): void {
+    infoPii(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Info,
             containsPii: true,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs verbose messages.
      */
-    verbose(message: string, correlationId?: string): void {
+    verbose(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Verbose,
             containsPii: false,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs verbose messages with PII.
      */
-    verbosePii(message: string, correlationId?: string): void {
+    verbosePii(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Verbose,
             containsPii: true,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs trace messages.
      */
-    trace(message: string, correlationId?: string): void {
+    trace(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Trace,
             containsPii: false,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 
     /**
      * Logs trace messages with PII.
      */
-    tracePii(message: string, correlationId?: string): void {
+    tracePii(message: string, correlationId: string): void {
         this.logMessage(message, {
             logLevel: LogLevel.Trace,
             containsPii: true,
-            correlationId: correlationId || "",
+            correlationId: correlationId,
         });
     }
 

--- a/lib/msal-common/src/network/ThrottlingUtils.ts
+++ b/lib/msal-common/src/network/ThrottlingUtils.ts
@@ -36,7 +36,7 @@ export class ThrottlingUtils {
         correlationId: string
     ): void {
         const key = ThrottlingUtils.generateThrottlingStorageKey(thumbprint);
-        const value = cacheManager.getThrottlingCache(key);
+        const value = cacheManager.getThrottlingCache(key, correlationId);
 
         if (value) {
             if (value.throttleTime < Date.now()) {

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -93,7 +93,8 @@ export function getStandardAuthorizeRequestParameters(
         if (request.sid && request.prompt === PromptValue.NONE) {
             // SessionID is only used in silent calls
             logger.verbose(
-                "createAuthCodeUrlQueryString: Prompt is none, adding sid from request"
+                "createAuthCodeUrlQueryString: Prompt is none, adding sid from request",
+                request.correlationId
             );
             RequestParameterBuilder.addSid(parameters, request.sid);
             performanceClient?.addFields(
@@ -106,7 +107,8 @@ export function getStandardAuthorizeRequestParameters(
 
             if (accountLoginHintClaim && request.domainHint) {
                 logger.warning(
-                    `AuthorizationCodeClient.createAuthCodeUrlQueryString: "domainHint" param is set, skipping opaque "login_hint" claim. Please consider not passing domainHint`
+                    `AuthorizationCodeClient.createAuthCodeUrlQueryString: "domainHint" param is set, skipping opaque "login_hint" claim. Please consider not passing domainHint`,
+                    request.correlationId
                 );
                 accountLoginHintClaim = null;
             }
@@ -114,7 +116,8 @@ export function getStandardAuthorizeRequestParameters(
             // If login_hint claim is present, use it over sid/username
             if (accountLoginHintClaim) {
                 logger.verbose(
-                    "createAuthCodeUrlQueryString: login_hint claim present on account"
+                    "createAuthCodeUrlQueryString: login_hint claim present on account",
+                    request.correlationId
                 );
                 RequestParameterBuilder.addLoginHint(
                     parameters,
@@ -131,7 +134,8 @@ export function getStandardAuthorizeRequestParameters(
                     RequestParameterBuilder.addCcsOid(parameters, clientInfo);
                 } catch (e) {
                     logger.verbose(
-                        "createAuthCodeUrlQueryString: Could not parse home account ID for CCS Header"
+                        "createAuthCodeUrlQueryString: Could not parse home account ID for CCS Header",
+                        request.correlationId
                     );
                 }
             } else if (accountSid && request.prompt === PromptValue.NONE) {
@@ -140,7 +144,8 @@ export function getStandardAuthorizeRequestParameters(
                  * SessionId is only used in silent calls
                  */
                 logger.verbose(
-                    "createAuthCodeUrlQueryString: Prompt is none, adding sid from account"
+                    "createAuthCodeUrlQueryString: Prompt is none, adding sid from account",
+                    request.correlationId
                 );
                 RequestParameterBuilder.addSid(parameters, accountSid);
                 performanceClient?.addFields(
@@ -154,12 +159,14 @@ export function getStandardAuthorizeRequestParameters(
                     RequestParameterBuilder.addCcsOid(parameters, clientInfo);
                 } catch (e) {
                     logger.verbose(
-                        "createAuthCodeUrlQueryString: Could not parse home account ID for CCS Header"
+                        "createAuthCodeUrlQueryString: Could not parse home account ID for CCS Header",
+                        request.correlationId
                     );
                 }
             } else if (request.loginHint) {
                 logger.verbose(
-                    "createAuthCodeUrlQueryString: Adding login_hint from request"
+                    "createAuthCodeUrlQueryString: Adding login_hint from request",
+                    request.correlationId
                 );
                 RequestParameterBuilder.addLoginHint(
                     parameters,
@@ -176,7 +183,8 @@ export function getStandardAuthorizeRequestParameters(
             } else if (request.account.username) {
                 // Fallback to account username if provided
                 logger.verbose(
-                    "createAuthCodeUrlQueryString: Adding login_hint from account"
+                    "createAuthCodeUrlQueryString: Adding login_hint from account",
+                    request.correlationId
                 );
                 RequestParameterBuilder.addLoginHint(
                     parameters,
@@ -193,13 +201,15 @@ export function getStandardAuthorizeRequestParameters(
                     RequestParameterBuilder.addCcsOid(parameters, clientInfo);
                 } catch (e) {
                     logger.verbose(
-                        "createAuthCodeUrlQueryString: Could not parse home account ID for CCS Header"
+                        "createAuthCodeUrlQueryString: Could not parse home account ID for CCS Header",
+                        request.correlationId
                     );
                 }
             }
         } else if (request.loginHint) {
             logger.verbose(
-                "createAuthCodeUrlQueryString: No account, adding login_hint from request"
+                "createAuthCodeUrlQueryString: No account, adding login_hint from request",
+                request.correlationId
             );
             RequestParameterBuilder.addLoginHint(parameters, request.loginHint);
             RequestParameterBuilder.addCcsUpn(parameters, request.loginHint);
@@ -210,7 +220,8 @@ export function getStandardAuthorizeRequestParameters(
         }
     } else {
         logger.verbose(
-            "createAuthCodeUrlQueryString: Prompt is select_account, ignoring account hints"
+            "createAuthCodeUrlQueryString: Prompt is select_account, ignoring account hints",
+            request.correlationId
         );
     }
 

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -46,6 +46,7 @@ import {
 import * as CacheHelpers from "../cache/utils/CacheHelpers.js";
 import * as TimeUtils from "../utils/TimeUtils.js";
 import * as AccountEntityUtils from "../cache/utils/AccountEntityUtils.js";
+import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
 
 /**
  * Class that handles response parsing.
@@ -57,6 +58,7 @@ export class ResponseHandler {
     private cryptoObj: ICrypto;
     private logger: Logger;
     private homeAccountIdentifier: string;
+    private performanceClient: IPerformanceClient;
     private serializableCache: ISerializableTokenCache | null;
     private persistencePlugin: ICachePlugin | null;
 
@@ -65,6 +67,7 @@ export class ResponseHandler {
         cacheStorage: CacheManager,
         cryptoObj: ICrypto,
         logger: Logger,
+        performanceClient: IPerformanceClient,
         serializableCache: ISerializableTokenCache | null,
         persistencePlugin: ICachePlugin | null
     ) {
@@ -72,6 +75,7 @@ export class ResponseHandler {
         this.cacheStorage = cacheStorage;
         this.cryptoObj = cryptoObj;
         this.logger = logger;
+        this.performanceClient = performanceClient;
         this.serializableCache = serializableCache;
         this.persistencePlugin = persistencePlugin;
     }
@@ -79,10 +83,12 @@ export class ResponseHandler {
     /**
      * Function which validates server authorization token response.
      * @param serverResponse
+     * @param correlationId
      * @param refreshAccessToken
      */
     validateTokenResponse(
         serverResponse: ServerAuthorizationTokenResponse,
+        correlationId: string,
         refreshAccessToken?: boolean
     ): void {
         // Check for error
@@ -122,7 +128,8 @@ export class ResponseHandler {
                 serverResponse.status <= Constants.HTTP_SERVER_ERROR_RANGE_END
             ) {
                 this.logger.warning(
-                    `executeTokenRequest:validateTokenResponse - AAD is currently unavailable and the access token is unable to be refreshed.\n${serverError}`
+                    `executeTokenRequest:validateTokenResponse - AAD is currently unavailable and the access token is unable to be refreshed.\n${serverError}`,
+                    correlationId
                 );
 
                 // don't throw an exception, but alert the user via a log that the token was unable to be refreshed
@@ -136,7 +143,8 @@ export class ResponseHandler {
                 serverResponse.status <= Constants.HTTP_CLIENT_ERROR_RANGE_END
             ) {
                 this.logger.warning(
-                    `executeTokenRequest:validateTokenResponse - AAD is currently available but is unable to refresh the access token.\n${serverError}`
+                    `executeTokenRequest:validateTokenResponse - AAD is currently available but is unable to refresh the access token.\n${serverError}`,
+                    correlationId
                 );
 
                 // don't throw an exception, but alert the user via a log that the token was unable to be refreshed
@@ -218,6 +226,7 @@ export class ResponseHandler {
             authority.authorityType,
             this.logger,
             this.cryptoObj,
+            request.correlationId,
             idTokenClaims
         );
 
@@ -247,7 +256,8 @@ export class ResponseHandler {
         try {
             if (this.persistencePlugin && this.serializableCache) {
                 this.logger.verbose(
-                    "Persistence enabled, calling beforeCacheAccess"
+                    "Persistence enabled, calling beforeCacheAccess",
+                    request.correlationId
                 );
                 cacheContext = new TokenCacheContext(
                     this.serializableCache,
@@ -275,7 +285,8 @@ export class ResponseHandler {
                 );
                 if (!account) {
                     this.logger.warning(
-                        "Account used to refresh tokens not in persistence, refreshed tokens will not be stored in the cache"
+                        "Account used to refresh tokens not in persistence, refreshed tokens will not be stored in the cache",
+                        request.correlationId
                     );
                     return await ResponseHandler.generateAuthenticationResult(
                         this.cryptoObj,
@@ -283,6 +294,7 @@ export class ResponseHandler {
                         cacheRecord,
                         false,
                         request,
+                        this.performanceClient,
                         idTokenClaims,
                         requestStateObj,
                         undefined,
@@ -302,7 +314,8 @@ export class ResponseHandler {
                 cacheContext
             ) {
                 this.logger.verbose(
-                    "Persistence enabled, calling afterCacheAccess"
+                    "Persistence enabled, calling afterCacheAccess",
+                    request.correlationId
                 );
                 await this.persistencePlugin.afterCacheAccess(cacheContext);
             }
@@ -314,6 +327,7 @@ export class ResponseHandler {
             cacheRecord,
             false,
             request,
+            this.performanceClient,
             idTokenClaims,
             requestStateObj,
             serverTokenResponse,
@@ -484,6 +498,7 @@ export class ResponseHandler {
         cacheRecord: CacheRecord,
         fromTokenCache: boolean,
         request: BaseAuthRequest,
+        performanceClient: IPerformanceClient,
         idTokenClaims?: TokenClaims,
         requestState?: RequestStateObject,
         serverTokenResponse?: ServerAuthorizationTokenResponse,
@@ -507,7 +522,7 @@ export class ResponseHandler {
                 !request.popKid
             ) {
                 const popTokenGenerator: PopTokenGenerator =
-                    new PopTokenGenerator(cryptoObj);
+                    new PopTokenGenerator(cryptoObj, performanceClient);
                 const { secret, keyId } = cacheRecord.accessToken;
 
                 if (!keyId) {
@@ -605,7 +620,7 @@ export function buildAccountToCache(
     nativeAccountId?: string,
     logger?: Logger
 ): AccountEntity {
-    logger?.verbose("setCachedAccount called");
+    logger?.verbose("setCachedAccount called", correlationId);
 
     // Check if base account is already cached
     const accountKeys = cacheStorage.getAccountKeys();

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -611,7 +611,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
             if (cb.toString() === callback.toString()) {
                 this.logger.warning(
                     `PerformanceClient: Performance callback is already registered with id: ${id}`,
-                    this.generateId()
+                    ""
                 );
                 return id;
             }
@@ -621,7 +621,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
         this.callbacks.set(callbackId, callback);
         this.logger.verbose(
             `PerformanceClient: Performance callback registered with id: '${callbackId}'`,
-            this.generateId()
+            ""
         );
 
         return callbackId;
@@ -639,12 +639,12 @@ export abstract class PerformanceClient implements IPerformanceClient {
         if (result) {
             this.logger.verbose(
                 `PerformanceClient: Performance callback '${callbackId}' removed.`,
-                this.generateId()
+                ""
             );
         } else {
             this.logger.verbose(
                 `PerformanceClient: Performance callback '${callbackId}' not removed.`,
-                this.generateId()
+                ""
             );
         }
 

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -500,7 +500,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
         fields: { [key: string]: {} | undefined },
         correlationId: string
     ): void {
-        this.logger.trace("PerformanceClient: Updating static fields");
+        this.logger.trace(
+            "PerformanceClient: Updating static fields",
+            correlationId
+        );
         const event = this.eventsByCorrelationId.get(correlationId);
         if (event) {
             this.eventsByCorrelationId.set(correlationId, {
@@ -524,7 +527,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
         fields: { [key: string]: number | undefined },
         correlationId: string
     ): void {
-        this.logger.trace("PerformanceClient: Updating counters");
+        this.logger.trace(
+            "PerformanceClient: Updating counters",
+            correlationId
+        );
         const event = this.eventsByCorrelationId.get(correlationId);
         if (event) {
             for (const counter in fields) {
@@ -604,7 +610,8 @@ export abstract class PerformanceClient implements IPerformanceClient {
         for (const [id, cb] of this.callbacks) {
             if (cb.toString() === callback.toString()) {
                 this.logger.warning(
-                    `PerformanceClient: Performance callback is already registered with id: ${id}`
+                    `PerformanceClient: Performance callback is already registered with id: ${id}`,
+                    this.generateId()
                 );
                 return id;
             }
@@ -613,7 +620,8 @@ export abstract class PerformanceClient implements IPerformanceClient {
         const callbackId = this.generateId();
         this.callbacks.set(callbackId, callback);
         this.logger.verbose(
-            `PerformanceClient: Performance callback registered with id: '${callbackId}'`
+            `PerformanceClient: Performance callback registered with id: '${callbackId}'`,
+            this.generateId()
         );
 
         return callbackId;
@@ -630,11 +638,13 @@ export abstract class PerformanceClient implements IPerformanceClient {
 
         if (result) {
             this.logger.verbose(
-                `PerformanceClient: Performance callback '${callbackId}' removed.`
+                `PerformanceClient: Performance callback '${callbackId}' removed.`,
+                this.generateId()
             );
         } else {
             this.logger.verbose(
-                `PerformanceClient: Performance callback '${callbackId}' not removed.`
+                `PerformanceClient: Performance callback '${callbackId}' not removed.`,
+                this.generateId()
             );
         }
 

--- a/lib/msal-common/src/telemetry/server/ServerTelemetryManager.ts
+++ b/lib/msal-common/src/telemetry/server/ServerTelemetryManager.ts
@@ -230,7 +230,8 @@ export class ServerTelemetryManager {
             cacheHits: 0,
         };
         const lastRequests = this.cacheManager.getServerTelemetry(
-            this.telemetryCacheKey
+            this.telemetryCacheKey,
+            this.correlationId
         ) as ServerTelemetryEntity;
 
         return lastRequests || initialValue;

--- a/lib/msal-common/src/utils/FunctionWrappers.ts
+++ b/lib/msal-common/src/utils/FunctionWrappers.ts
@@ -22,38 +22,35 @@ export const invoke = <T extends Array<any>, U>(
     callback: (...args: T) => U,
     eventName: string,
     logger: Logger,
-    telemetryClient?: IPerformanceClient,
-    correlationId?: string
+    telemetryClient: IPerformanceClient,
+    correlationId: string
 ) => {
     return (...args: T): U => {
-        logger.trace(`Executing function '${eventName}'`);
-        const inProgressEvent = telemetryClient?.startMeasurement(
+        logger.trace(`Executing function '${eventName}'`, correlationId);
+        const inProgressEvent = telemetryClient.startMeasurement(
             eventName,
             correlationId
         );
         if (correlationId) {
             // Track number of times this API is called in a single request
             const eventCount = eventName + "CallCount";
-            telemetryClient?.incrementFields(
-                { [eventCount]: 1 },
-                correlationId
-            );
+            telemetryClient.incrementFields({ [eventCount]: 1 }, correlationId);
         }
         try {
             const result = callback(...args);
-            inProgressEvent?.end({
+            inProgressEvent.end({
                 success: true,
             });
-            logger.trace(`Returning result from '${eventName}'`);
+            logger.trace(`Returning result from '${eventName}'`, correlationId);
             return result;
         } catch (e) {
-            logger.trace(`Error occurred in '${eventName}'`);
+            logger.trace(`Error occurred in '${eventName}'`, correlationId);
             try {
-                logger.trace(JSON.stringify(e));
+                logger.trace(JSON.stringify(e), correlationId);
             } catch (e) {
-                logger.trace("Unable to print error message.");
+                logger.trace("Unable to print error message.", correlationId);
             }
-            inProgressEvent?.end(
+            inProgressEvent.end(
                 {
                     success: false,
                 },
@@ -81,39 +78,42 @@ export const invokeAsync = <T extends Array<any>, U>(
     callback: (...args: T) => Promise<U>,
     eventName: string,
     logger: Logger,
-    telemetryClient?: IPerformanceClient,
-    correlationId?: string
+    telemetryClient: IPerformanceClient,
+    correlationId: string
 ) => {
     return (...args: T): Promise<U> => {
-        logger.trace(`Executing function '${eventName}'`);
-        const inProgressEvent = telemetryClient?.startMeasurement(
+        logger.trace(`Executing function '${eventName}'`, correlationId);
+        const inProgressEvent = telemetryClient.startMeasurement(
             eventName,
             correlationId
         );
         if (correlationId) {
             // Track number of times this API is called in a single request
             const eventCount = eventName + "CallCount";
-            telemetryClient?.incrementFields(
-                { [eventCount]: 1 },
-                correlationId
-            );
+            telemetryClient.incrementFields({ [eventCount]: 1 }, correlationId);
         }
         return callback(...args)
             .then((response) => {
-                logger.trace(`Returning result from '${eventName}'`);
-                inProgressEvent?.end({
+                logger.trace(
+                    `Returning result from '${eventName}'`,
+                    correlationId
+                );
+                inProgressEvent.end({
                     success: true,
                 });
                 return response;
             })
             .catch((e) => {
-                logger.trace(`Error occurred in '${eventName}'`);
+                logger.trace(`Error occurred in '${eventName}'`, correlationId);
                 try {
-                    logger.trace(JSON.stringify(e));
+                    logger.trace(JSON.stringify(e), correlationId);
                 } catch (e) {
-                    logger.trace("Unable to print error message.");
+                    logger.trace(
+                        "Unable to print error message.",
+                        correlationId
+                    );
                 }
-                inProgressEvent?.end(
+                inProgressEvent.end(
                     {
                         success: false,
                     },

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -120,7 +120,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             expect(authority.canonicalAuthority).toBe(
                 `${Constants.DEFAULT_AUTHORITY}`
@@ -153,7 +154,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     )
             ).toThrow(
                 new ClientConfigurationError(
@@ -168,7 +170,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     )
             ).toThrow(
                 new ClientConfigurationError(
@@ -183,7 +186,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     )
             ).toThrow(
                 new ClientConfigurationError(
@@ -218,7 +222,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
         });
 
@@ -352,7 +357,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 expect(() => authority.authorizationEndpoint).toThrowError(
                     createClientAuthError(
@@ -406,7 +412,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         knownAuthorities: ["msidlabb2c.b2clogin.com"],
                     },
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 await authority.resolveEndpointsAsync();
@@ -419,7 +426,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         knownAuthorities: ["msidlabb2c.b2clogin.com"],
                     },
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 await secondAuthority.resolveEndpointsAsync();
@@ -480,7 +488,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 await authority.resolveEndpointsAsync();
 
@@ -525,7 +534,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         knownAuthorities: ["msidlabb2c.b2clogin.com"],
                     },
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 await customAuthority.resolveEndpointsAsync();
 
@@ -572,7 +582,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 await customAuthority.resolveEndpointsAsync();
 
@@ -652,7 +663,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             await authority.resolveEndpointsAsync();
 
@@ -708,7 +720,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     },
                 },
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             await authority.resolveEndpointsAsync();
 
@@ -769,7 +782,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     },
                 },
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             await authority.resolveEndpointsAsync();
 
@@ -827,7 +841,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     },
                 },
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             await authority.resolveEndpointsAsync();
 
@@ -883,7 +898,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     },
                 },
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             await authority.resolveEndpointsAsync();
 
@@ -934,7 +950,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
         });
 
@@ -1013,7 +1030,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     options,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 await authority.resolveEndpointsAsync();
 
@@ -1096,7 +1114,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     options,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 authority.resolveEndpointsAsync().catch((e) => {
                     expect(e).toBeInstanceOf(ClientConfigurationError);
@@ -1127,7 +1146,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     options,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 await authority.resolveEndpointsAsync();
 
@@ -1159,7 +1179,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     customAuthorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 await authority.resolveEndpointsAsync();
@@ -1217,7 +1238,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     customAuthorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 await authority.resolveEndpointsAsync();
@@ -1300,7 +1322,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     customAuthorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 await authority.resolveEndpointsAsync();
 
@@ -1349,7 +1372,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 // Force hardcoded metadata to return null
@@ -1440,7 +1464,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 // Force hardcoded metadata to return null
@@ -1524,7 +1549,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 getEndpointMetadataFromHarcodedValuesSpy.mockReturnValue(null);
 
@@ -1607,7 +1633,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 // Force hardcoded metadata to return null
                 getEndpointMetadataFromHarcodedValuesSpy.mockReturnValue(null);
@@ -1642,7 +1669,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 await authority.resolveEndpointsAsync();
                 expect(
@@ -1710,7 +1738,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 await authority.resolveEndpointsAsync();
@@ -1759,7 +1788,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 await authority.resolveEndpointsAsync();
 
@@ -1856,7 +1886,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     );
 
                     await authority.resolveEndpointsAsync();
@@ -1906,7 +1937,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     );
 
                     const hardcodedCloudDiscoveryMetadata =
@@ -1974,7 +2006,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     );
 
                     getCloudDiscoveryMetadataFromHarcodedValuesSpy.mockReturnValue(
@@ -2057,7 +2090,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     );
                     getCloudDiscoveryMetadataFromHarcodedValuesSpy.mockReturnValue(
                         null
@@ -2109,7 +2143,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     );
 
                     getCloudDiscoveryMetadataFromHarcodedValuesSpy.mockReturnValue(
@@ -2193,7 +2228,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     );
 
                     await authority.resolveEndpointsAsync();
@@ -2258,7 +2294,8 @@ describe("Authority.ts Class Unit Tests", () => {
                         mockStorage,
                         authorityOptions,
                         logger,
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     );
 
                     await authority.resolveEndpointsAsync();
@@ -2312,7 +2349,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
                 authority.resolveEndpointsAsync().catch((e) => {
                     expect(e).toBeInstanceOf(ClientConfigurationError);
@@ -2352,7 +2390,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 authority.resolveEndpointsAsync().catch((e) => {
@@ -2403,7 +2442,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 authority.resolveEndpointsAsync().catch((e) => {
@@ -2448,7 +2488,8 @@ describe("Authority.ts Class Unit Tests", () => {
                     mockStorage,
                     authorityOptions,
                     logger,
-                    TEST_CONFIG.CORRELATION_ID
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
                 );
 
                 await authority.resolveEndpointsAsync();
@@ -2474,7 +2515,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
 
             await authority.resolveEndpointsAsync();
@@ -2493,7 +2535,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 { ...authorityOptions, knownAuthorities: [authorityUrl] },
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             jest.spyOn(
                 networkInterface,
@@ -2519,7 +2562,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 { ...authorityOptions, knownAuthorities: [authorityUrl] },
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
 
             await authority.resolveEndpointsAsync();
@@ -2538,7 +2582,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
 
             await authority.resolveEndpointsAsync();
@@ -2556,7 +2601,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
 
             await authority.resolveEndpointsAsync();
@@ -2581,7 +2627,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 options,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
             jest.spyOn(
                 networkInterface,
@@ -2612,7 +2659,8 @@ describe("Authority.ts Class Unit Tests", () => {
                 mockStorage,
                 options,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
 
             await authority.resolveEndpointsAsync();

--- a/lib/msal-common/test/authority/AuthorityFactory.spec.ts
+++ b/lib/msal-common/test/authority/AuthorityFactory.spec.ts
@@ -15,7 +15,7 @@ import {
     ClientAuthError,
     ClientAuthErrorCodes,
 } from "../../src/error/ClientAuthError";
-import { Logger, LogLevel } from "../../src";
+import { Logger, LogLevel, StubPerformanceClient } from "../../src";
 
 const loggerOptions = {
     loggerCallback: (): void => {},
@@ -71,7 +71,8 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
         expect(authorityInstance.authorityType).toBe(AuthorityType.Default);
         expect(authorityInstance instanceof Authority);
@@ -88,7 +89,8 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
             mockStorage,
             authorityOptions,
             logger,
-            TEST_CONFIG.CORRELATION_ID
+            TEST_CONFIG.CORRELATION_ID,
+            new StubPerformanceClient()
         ).catch((e) => {
             expect(e).toBeInstanceOf(ClientAuthError);
             expect(e.errorCode).toBe(
@@ -110,7 +112,8 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
         expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
         expect(authorityInstance.canonicalAuthority).toBe(
@@ -131,7 +134,8 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
         expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
         expect(authorityInstance.canonicalAuthority).toBe(
@@ -152,7 +156,8 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
         expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
         expect(authorityInstance.canonicalAuthority).toBe(
@@ -173,7 +178,8 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
         expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
         expect(authorityInstance.canonicalAuthority).toBe(
@@ -194,7 +200,8 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
                 mockStorage,
                 authorityOptions,
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
         expect(authorityInstance.authorityType).toBe(AuthorityType.Ciam);
         expect(authorityInstance.canonicalAuthority).toBe(

--- a/lib/msal-common/test/authority/AuthorityMetadata.spec.ts
+++ b/lib/msal-common/test/authority/AuthorityMetadata.spec.ts
@@ -1,4 +1,4 @@
-import { StaticAuthorityOptions, Constants } from "../../src";
+import { StaticAuthorityOptions, Constants, LogLevel, Logger } from "../../src";
 import {
     InstanceDiscoveryMetadata,
     getAliasesFromStaticSources,
@@ -19,6 +19,13 @@ const TENANTS = [
 ];
 const CLOUD_KEYS = Object.keys(CLOUD_HOSTS);
 
+const loggerOptions = {
+    loggerCallback: (): void => {},
+    piiLoggingEnabled: true,
+    logLevel: LogLevel.Verbose,
+};
+const logger = new Logger(loggerOptions);
+
 describe("AuthorityMetadata.ts Unit Tests", () => {
     describe("getAliasesFromStaticSources()", () => {
         describe("from config CloudDiscoveryMetadataResponse", () => {
@@ -34,7 +41,11 @@ describe("AuthorityMetadata.ts Unit Tests", () => {
                                 tenant
                             );
                         expect(
-                            getAliasesFromStaticSources(staticAuthorityOptions)
+                            getAliasesFromStaticSources(
+                                staticAuthorityOptions,
+                                logger,
+                                TEST_CONFIG.CORRELATION_ID
+                            )
                         ).toEqual(METADATA_ALIASES[cloudKey]);
                     });
                 });
@@ -52,7 +63,11 @@ describe("AuthorityMetadata.ts Unit Tests", () => {
                             ),
                         };
                         expect(
-                            getAliasesFromStaticSources(staticAuthorityOptions)
+                            getAliasesFromStaticSources(
+                                staticAuthorityOptions,
+                                logger,
+                                TEST_CONFIG.CORRELATION_ID
+                            )
                         ).toEqual(METADATA_ALIASES[cloudKey]);
                     });
                 });

--- a/lib/msal-common/test/cache/AccountEntityUtils.spec.ts
+++ b/lib/msal-common/test/cache/AccountEntityUtils.spec.ts
@@ -77,7 +77,8 @@ const authority = new Authority(
     new MockStorageClass("client-id", mockCrypto, logger, performanceClient),
     authorityOptions,
     logger,
-    TEST_CONFIG.CORRELATION_ID
+    TEST_CONFIG.CORRELATION_ID,
+    new StubPerformanceClient()
 );
 
 describe("AccountEntityUtils.ts Unit Tests", () => {
@@ -118,6 +119,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
             AuthorityType.Default,
             logger,
             cryptoInterface,
+            TEST_CONFIG.CORRELATION_ID,
             idTokenClaims
         );
 
@@ -157,6 +159,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
             AuthorityType.Default,
             logger,
             cryptoInterface,
+            TEST_CONFIG.CORRELATION_ID,
             idTokenClaims
         );
 
@@ -196,6 +199,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
             AuthorityType.Default,
             logger,
             cryptoInterface,
+            TEST_CONFIG.CORRELATION_ID,
             idTokenClaims
         );
 
@@ -228,7 +232,8 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
             ),
             authorityOptions,
             logger,
-            TEST_CONFIG.CORRELATION_ID
+            TEST_CONFIG.CORRELATION_ID,
+            new StubPerformanceClient()
         );
 
         // Set up stubs
@@ -248,6 +253,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
             AuthorityType.Default,
             logger,
             cryptoInterface,
+            TEST_CONFIG.CORRELATION_ID,
             idTokenClaims
         );
 
@@ -286,7 +292,8 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 authorityMetadata: "",
             },
             logger,
-            TEST_CONFIG.CORRELATION_ID
+            TEST_CONFIG.CORRELATION_ID,
+            new StubPerformanceClient()
         );
 
         // Set up stubs
@@ -406,6 +413,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 AuthorityType.Default,
                 logger,
                 cryptoInterface,
+                TEST_CONFIG.CORRELATION_ID,
                 idTokenClaims
             );
 
@@ -633,7 +641,8 @@ describe("AccountEntityUtils.ts Unit Tests for ADFS", () => {
             ),
             authorityOptions,
             logger,
-            TEST_CONFIG.CORRELATION_ID
+            TEST_CONFIG.CORRELATION_ID,
+            new StubPerformanceClient()
         );
 
         // Set up stubs
@@ -694,7 +703,8 @@ describe("AccountEntityUtils.ts Unit Tests for ADFS", () => {
             ),
             authorityOptions,
             logger,
-            TEST_CONFIG.CORRELATION_ID
+            TEST_CONFIG.CORRELATION_ID,
+            new StubPerformanceClient()
         );
 
         // Set up stubs

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -994,16 +994,21 @@ describe("CacheManager.ts test cases", () => {
         it("homeAccountId filter", () => {
             // filter by homeAccountId
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    homeAccountId: testIdToken.homeAccountId,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        homeAccountId: testIdToken.homeAccountId,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(true);
             expect(
                 mockCache.cacheManager.credentialMatchesFilter(
                     testAccessToken,
                     {
                         homeAccountId: testAccessToken.homeAccountId,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
             expect(
@@ -1011,22 +1016,28 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         homeAccountId: testRefreshToken.homeAccountId,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
 
             // Test failure cases
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    homeAccountId: "someuid.someutid",
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        homeAccountId: "someuid.someutid",
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
             expect(
                 mockCache.cacheManager.credentialMatchesFilter(
                     testAccessToken,
                     {
                         homeAccountId: "someuid.someutid",
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
             expect(
@@ -1034,7 +1045,8 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         homeAccountId: "someuid.someutid",
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
         });
@@ -1047,7 +1059,8 @@ describe("CacheManager.ts test cases", () => {
                         testIdToken,
                         {
                             environment: testIdToken.environment,
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(true);
                 expect(
@@ -1055,7 +1068,8 @@ describe("CacheManager.ts test cases", () => {
                         testAccessToken,
                         {
                             environment: testAccessToken.environment,
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(true);
                 expect(
@@ -1063,7 +1077,8 @@ describe("CacheManager.ts test cases", () => {
                         testRefreshToken,
                         {
                             environment: testRefreshToken.environment,
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(true);
 
@@ -1073,7 +1088,8 @@ describe("CacheManager.ts test cases", () => {
                         testIdToken,
                         {
                             environment: "wrong.contoso.com",
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(false);
                 expect(
@@ -1081,7 +1097,8 @@ describe("CacheManager.ts test cases", () => {
                         testAccessToken,
                         {
                             environment: "wrong.contoso.com",
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(false);
                 expect(
@@ -1089,7 +1106,8 @@ describe("CacheManager.ts test cases", () => {
                         testRefreshToken,
                         {
                             environment: "wrong.contoso.com",
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(false);
             });
@@ -1109,7 +1127,8 @@ describe("CacheManager.ts test cases", () => {
                             testIdToken,
                             {
                                 environment: testIdToken.environment,
-                            }
+                            },
+                            TEST_CONFIG.CORRELATION_ID
                         )
                     ).toBe(true);
                 });
@@ -1120,7 +1139,8 @@ describe("CacheManager.ts test cases", () => {
                             testAccessToken,
                             {
                                 environment: testAccessToken.environment,
-                            }
+                            },
+                            TEST_CONFIG.CORRELATION_ID
                         )
                     ).toBe(true);
                 });
@@ -1131,7 +1151,8 @@ describe("CacheManager.ts test cases", () => {
                             testRefreshToken,
                             {
                                 environment: testRefreshToken.environment,
-                            }
+                            },
+                            TEST_CONFIG.CORRELATION_ID
                         )
                     ).toBe(true);
                 });
@@ -1143,7 +1164,8 @@ describe("CacheManager.ts test cases", () => {
                             testRefreshToken,
                             {
                                 environment: testRefreshToken.environment,
-                            }
+                            },
+                            TEST_CONFIG.CORRELATION_ID
                         )
                     ).toBe(true);
                 });
@@ -1154,7 +1176,8 @@ describe("CacheManager.ts test cases", () => {
                             testAccessToken,
                             {
                                 environment: "wrong.contoso.com",
-                            }
+                            },
+                            TEST_CONFIG.CORRELATION_ID
                         )
                     ).toBe(false);
                 });
@@ -1165,7 +1188,8 @@ describe("CacheManager.ts test cases", () => {
                             testRefreshToken,
                             {
                                 environment: "wrong.contoso.com",
-                            }
+                            },
+                            TEST_CONFIG.CORRELATION_ID
                         )
                     ).toBe(false);
                 });
@@ -1182,7 +1206,8 @@ describe("CacheManager.ts test cases", () => {
                         testIdToken,
                         {
                             environment: testIdToken.environment,
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(true);
                 expect(
@@ -1190,7 +1215,8 @@ describe("CacheManager.ts test cases", () => {
                         testAccessToken,
                         {
                             environment: testAccessToken.environment,
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(true);
                 expect(
@@ -1198,7 +1224,8 @@ describe("CacheManager.ts test cases", () => {
                         testRefreshToken,
                         {
                             environment: testRefreshToken.environment,
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(true);
 
@@ -1208,7 +1235,8 @@ describe("CacheManager.ts test cases", () => {
                         testIdToken,
                         {
                             environment: "wrong.contoso.com",
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(false);
                 expect(
@@ -1216,7 +1244,8 @@ describe("CacheManager.ts test cases", () => {
                         testAccessToken,
                         {
                             environment: "wrong.contoso.com",
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(false);
                 expect(
@@ -1224,7 +1253,8 @@ describe("CacheManager.ts test cases", () => {
                         testRefreshToken,
                         {
                             environment: "wrong.contoso.com",
-                        }
+                        },
+                        TEST_CONFIG.CORRELATION_ID
                     )
                 ).toBe(false);
             });
@@ -1233,16 +1263,21 @@ describe("CacheManager.ts test cases", () => {
         it("realm filter", () => {
             // filter by realm
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    realm: testIdToken.realm,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        realm: testIdToken.realm,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(true);
             expect(
                 mockCache.cacheManager.credentialMatchesFilter(
                     testAccessToken,
                     {
                         realm: testAccessToken.realm,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
             expect(
@@ -1250,22 +1285,28 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         realm: testRefreshToken.realm,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
 
             // Test failure cases
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    realm: "fake-realm",
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        realm: "fake-realm",
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
             expect(
                 mockCache.cacheManager.credentialMatchesFilter(
                     testAccessToken,
                     {
                         realm: "fake-realm",
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
             expect(
@@ -1273,7 +1314,8 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         realm: "fake-realm",
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
         });
@@ -1281,16 +1323,21 @@ describe("CacheManager.ts test cases", () => {
         it("credentialType filter", () => {
             // filter by credentialType
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    credentialType: CredentialType.ID_TOKEN,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        credentialType: CredentialType.ID_TOKEN,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(true);
             expect(
                 mockCache.cacheManager.credentialMatchesFilter(
                     testAccessToken,
                     {
                         credentialType: CredentialType.ACCESS_TOKEN,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
             expect(
@@ -1298,20 +1345,29 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         credentialType: CredentialType.REFRESH_TOKEN,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
 
             // Test failure cases
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    credentialType: CredentialType.ACCESS_TOKEN,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        credentialType: CredentialType.ACCESS_TOKEN,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    credentialType: CredentialType.REFRESH_TOKEN,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        credentialType: CredentialType.REFRESH_TOKEN,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
 
             expect(
@@ -1319,7 +1375,8 @@ describe("CacheManager.ts test cases", () => {
                     testAccessToken,
                     {
                         credentialType: CredentialType.ID_TOKEN,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
             expect(
@@ -1327,7 +1384,8 @@ describe("CacheManager.ts test cases", () => {
                     testAccessToken,
                     {
                         credentialType: CredentialType.REFRESH_TOKEN,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
 
@@ -1336,7 +1394,8 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         credentialType: CredentialType.ID_TOKEN,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
             expect(
@@ -1344,7 +1403,8 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         credentialType: CredentialType.ACCESS_TOKEN,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
         });
@@ -1357,15 +1417,23 @@ describe("CacheManager.ts test cases", () => {
                 RANDOM_TEST_GUID
             );
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(accessToken[0], {
-                    credentialType: CredentialType.ACCESS_TOKEN,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    accessToken[0],
+                    {
+                        credentialType: CredentialType.ACCESS_TOKEN,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(true);
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(accessToken[0], {
-                    credentialType:
-                        CredentialType.ACCESS_TOKEN_WITH_AUTH_SCHEME,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    accessToken[0],
+                    {
+                        credentialType:
+                            CredentialType.ACCESS_TOKEN_WITH_AUTH_SCHEME,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
 
             const accessTokenWithAuthScheme =
@@ -1379,7 +1447,8 @@ describe("CacheManager.ts test cases", () => {
             expect(
                 mockCache.cacheManager.credentialMatchesFilter(
                     accessTokenWithAuthScheme[0],
-                    { credentialType: CredentialType.ACCESS_TOKEN }
+                    { credentialType: CredentialType.ACCESS_TOKEN },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
             expect(
@@ -1388,7 +1457,8 @@ describe("CacheManager.ts test cases", () => {
                     {
                         credentialType:
                             CredentialType.ACCESS_TOKEN_WITH_AUTH_SCHEME,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
         });
@@ -1396,16 +1466,21 @@ describe("CacheManager.ts test cases", () => {
         it("clientId filter", () => {
             // filter by clientId
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    clientId: testIdToken.clientId,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        clientId: testIdToken.clientId,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(true);
             expect(
                 mockCache.cacheManager.credentialMatchesFilter(
                     testAccessToken,
                     {
                         clientId: testAccessToken.clientId,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
             expect(
@@ -1413,22 +1488,28 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         clientId: testRefreshToken.clientId,
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
 
             // Test failure cases
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(testIdToken, {
-                    clientId: "wrong_client_id",
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    testIdToken,
+                    {
+                        clientId: "wrong_client_id",
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
             expect(
                 mockCache.cacheManager.credentialMatchesFilter(
                     testAccessToken,
                     {
                         clientId: "wrong_client_id",
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
             expect(
@@ -1436,7 +1517,8 @@ describe("CacheManager.ts test cases", () => {
                     testRefreshToken,
                     {
                         clientId: "wrong_client_id",
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
         });
@@ -1450,7 +1532,8 @@ describe("CacheManager.ts test cases", () => {
                         target: ScopeSet.createSearchScopes(
                             testAccessToken.target.split(" ")
                         ),
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(true);
 
@@ -1460,7 +1543,8 @@ describe("CacheManager.ts test cases", () => {
                     testAccessToken,
                     {
                         target: ScopeSet.createSearchScopes(["wrong_scope"]),
-                    }
+                    },
+                    TEST_CONFIG.CORRELATION_ID
                 )
             ).toBe(false);
         });
@@ -1475,19 +1559,31 @@ describe("CacheManager.ts test cases", () => {
                 RANDOM_TEST_GUID
             );
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(accessToken[0], {
-                    tokenType: AuthenticationScheme.BEARER,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    accessToken[0],
+                    {
+                        tokenType: AuthenticationScheme.BEARER,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(true);
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(accessToken[0], {
-                    tokenType: AuthenticationScheme.POP,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    accessToken[0],
+                    {
+                        tokenType: AuthenticationScheme.POP,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(accessToken[0], {
-                    tokenType: AuthenticationScheme.SSH,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    accessToken[0],
+                    {
+                        tokenType: AuthenticationScheme.SSH,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
 
             const popToken = mockCache.cacheManager.getAccessTokensByFilter(
@@ -1499,19 +1595,31 @@ describe("CacheManager.ts test cases", () => {
                 RANDOM_TEST_GUID
             );
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(popToken[0], {
-                    tokenType: AuthenticationScheme.BEARER,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    popToken[0],
+                    {
+                        tokenType: AuthenticationScheme.BEARER,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(popToken[0], {
-                    tokenType: AuthenticationScheme.POP,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    popToken[0],
+                    {
+                        tokenType: AuthenticationScheme.POP,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(true);
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(popToken[0], {
-                    tokenType: AuthenticationScheme.SSH,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    popToken[0],
+                    {
+                        tokenType: AuthenticationScheme.SSH,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
 
             const sshToken = mockCache.cacheManager.getAccessTokensByFilter(
@@ -1523,19 +1631,31 @@ describe("CacheManager.ts test cases", () => {
                 RANDOM_TEST_GUID
             );
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(sshToken[0], {
-                    tokenType: AuthenticationScheme.BEARER,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    sshToken[0],
+                    {
+                        tokenType: AuthenticationScheme.BEARER,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(sshToken[0], {
-                    tokenType: AuthenticationScheme.POP,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    sshToken[0],
+                    {
+                        tokenType: AuthenticationScheme.POP,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(false);
             expect(
-                mockCache.cacheManager.credentialMatchesFilter(sshToken[0], {
-                    tokenType: AuthenticationScheme.SSH,
-                })
+                mockCache.cacheManager.credentialMatchesFilter(
+                    sshToken[0],
+                    {
+                        tokenType: AuthenticationScheme.SSH,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                )
             ).toBe(true);
         });
     });
@@ -1613,7 +1733,8 @@ describe("CacheManager.ts test cases", () => {
 
         const cachedAppMetadata =
             mockCache.cacheManager.readAppMetadataFromCache(
-                CACHE_MOCKS.MOCK_ACCOUNT_INFO.environment
+                CACHE_MOCKS.MOCK_ACCOUNT_INFO.environment,
+                TEST_CONFIG.CORRELATION_ID
             ) as AppMetadataEntity;
         if (!cachedAppMetadata) {
             throw TestError.createTestSetupError(

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -32,10 +32,16 @@ import {
     CcsCredentialType,
     ClientConfigurationErrorCodes,
     createClientConfigurationError,
+    StubPerformanceClient,
 } from "../../src/index.js";
 import { ProtocolMode } from "../../src/authority/ProtocolMode.js";
 
 describe("AuthorizationCodeClient unit tests", () => {
+    let stubPerformanceClient: StubPerformanceClient;
+    beforeEach(async () => {
+        stubPerformanceClient = new StubPerformanceClient();
+    });
+
     afterEach(() => {
         jest.restoreAllMocks();
     });
@@ -48,7 +54,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             ).mockResolvedValue(DEFAULT_OPENID_CONFIG_RESPONSE.body);
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             expect(client).not.toBeNull();
             expect(client instanceof AuthorizationCodeClient).toBe(true);
             expect(client instanceof BaseClient).toBe(true);
@@ -67,7 +76,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 <any>"getEndpointMetadataFromNetwork"
             ).mockResolvedValue(DEFAULT_OPENID_CONFIG_RESPONSE.body);
 
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             await expect(
                 // @ts-ignore
@@ -95,7 +107,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                     "configuration storageInterface not initialized correctly."
                 );
             }
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const codeRequest: CommonAuthorizationCodeRequest = {
                 redirectUri: TEST_URIS.TEST_REDIR_URI,
@@ -209,7 +224,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -330,7 +348,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -446,7 +467,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -540,7 +564,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -637,7 +664,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -736,7 +766,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -920,7 +953,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -1052,7 +1088,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 }
             });
 
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authorizationCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -1095,7 +1134,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 }
             });
 
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authorizationCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -1139,7 +1181,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                     "configuration cryptoInterface or systemOptions not initialized correctly."
                 );
             }
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
@@ -1182,7 +1227,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                     "configuration cryptoInterface or systemOptions not initialized correctly."
                 );
             }
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
@@ -1207,7 +1255,7 @@ describe("AuthorizationCodeClient unit tests", () => {
         it("Doesnt add redirect_uri when hybridSpa flag is set", (done) => {
             class TestAuthorizationCodeClient extends AuthorizationCodeClient {
                 constructor(config: ClientConfiguration) {
-                    super(config);
+                    super(config, stubPerformanceClient);
                     this.includeRedirectUri = false;
                 }
             }
@@ -1354,7 +1402,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                     }
                 }
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authenticationScheme: Constants.AuthenticationScheme.POP,
                 authority: Constants.DEFAULT_AUTHORITY,
@@ -1543,7 +1594,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                     }
                 }
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authenticationScheme: Constants.AuthenticationScheme.SSH,
                 authority: Constants.DEFAULT_AUTHORITY,
@@ -1727,7 +1781,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                     }
                 }
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authenticationScheme: Constants.AuthenticationScheme.SSH,
                 authority: Constants.DEFAULT_AUTHORITY,
@@ -1834,7 +1891,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -1941,7 +2001,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -2025,7 +2088,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -2089,7 +2155,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
             );
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
             const authCodeRequest: CommonAuthorizationCodeRequest = {
                 authority: Constants.DEFAULT_AUTHORITY,
                 scopes: [
@@ -2122,24 +2191,10 @@ describe("AuthorizationCodeClient unit tests", () => {
         });
 
         it("includes the http version in Authorization code client measurement(AT) when received in server response", async () => {
-            const performanceClient = {
-                startMeasurement: jest.fn(),
-                endMeasurement: jest.fn(),
-                addFields: jest.fn(),
-                incrementFields: jest.fn(),
-                discardMeasurements: jest.fn(),
-                removePerformanceCallback: jest.fn(),
-                addPerformanceCallback: jest.fn(),
-                emitEvents: jest.fn(),
-                generateId: jest.fn(),
-                calculateQueuedTime: jest.fn(),
-                addQueueMeasurement: jest.fn(),
-                setPreQueueTime: jest.fn(),
-            };
-
+            const addFieldsSpy = jest.spyOn(stubPerformanceClient, "addFields");
             const client = new AuthorizationCodeClient(
                 config,
-                performanceClient
+                stubPerformanceClient
             );
             jest.spyOn(
                 Authority.prototype,
@@ -2190,7 +2245,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 nonce: idTokenClaims.nonce,
             });
 
-            expect(performanceClient.addFields).toHaveBeenCalledWith(
+            expect(addFieldsSpy).toHaveBeenCalledWith(
                 {
                     httpVerToken: "xMsHttpVer",
                     refreshTokenSize:
@@ -2203,23 +2258,10 @@ describe("AuthorizationCodeClient unit tests", () => {
         });
 
         it("does not add http version to the measurement when not received in server response", async () => {
-            const performanceClient = {
-                startMeasurement: jest.fn(),
-                endMeasurement: jest.fn(),
-                addFields: jest.fn(),
-                incrementFields: jest.fn(),
-                discardMeasurements: jest.fn(),
-                removePerformanceCallback: jest.fn(),
-                addPerformanceCallback: jest.fn(),
-                emitEvents: jest.fn(),
-                generateId: jest.fn(),
-                calculateQueuedTime: jest.fn(),
-                addQueueMeasurement: jest.fn(),
-                setPreQueueTime: jest.fn(),
-            };
+            const addFieldsSpy = jest.spyOn(stubPerformanceClient, "addFields");
             const client = new AuthorizationCodeClient(
                 config,
-                performanceClient
+                stubPerformanceClient
             );
             jest.spyOn(
                 Authority.prototype,
@@ -2270,7 +2312,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 nonce: idTokenClaims.nonce,
             });
 
-            expect(performanceClient.addFields).toHaveBeenCalledWith(
+            expect(addFieldsSpy).toHaveBeenCalledWith(
                 {
                     httpVerToken: "",
                     refreshTokenSize:
@@ -2480,7 +2522,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             ).mockResolvedValue(DEFAULT_OPENID_CONFIG_RESPONSE.body);
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const logoutUri = client.getLogoutUri({
                 account: null,
@@ -2502,7 +2547,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             ).mockResolvedValue(DEFAULT_OPENID_CONFIG_RESPONSE.body);
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const logoutUri = client.getLogoutUri({
                 correlationId: RANDOM_TEST_GUID,
@@ -2540,7 +2588,10 @@ describe("AuthorizationCodeClient unit tests", () => {
             });
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const logoutUri = client.getLogoutUri({
                 correlationId: RANDOM_TEST_GUID,
@@ -2569,7 +2620,10 @@ describe("AuthorizationCodeClient unit tests", () => {
         it("pick up default client_id", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const queryString =
                 // @ts-ignore
@@ -2586,7 +2640,10 @@ describe("AuthorizationCodeClient unit tests", () => {
         it("pick up extra query client_id param", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const queryString =
                 // @ts-ignore
@@ -2604,7 +2661,10 @@ describe("AuthorizationCodeClient unit tests", () => {
         it("pick up broker params", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const queryString =
                 // @ts-ignore
@@ -2626,7 +2686,10 @@ describe("AuthorizationCodeClient unit tests", () => {
         it("broker params take precedence over token body params", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new AuthorizationCodeClient(config);
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
 
             const queryString =
                 // @ts-ignore

--- a/lib/msal-common/test/client/BaseClient.spec.ts
+++ b/lib/msal-common/test/client/BaseClient.spec.ts
@@ -25,10 +25,11 @@ import {
     ClientAuthError,
     ClientAuthErrorCodes,
 } from "../../src/error/ClientAuthError.js";
+import { StubPerformanceClient } from "../../src/index.js";
 
 class TestClient extends BaseClient {
     constructor(config: ClientConfiguration) {
-        super(config);
+        super(config, new StubPerformanceClient());
     }
 
     getLogger() {

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -35,11 +35,11 @@ import {
     CACHE_KEY_SEPARATOR,
     CredentialType,
     SKU,
+    EncodingTypes,
 } from "../../src/utils/Constants.js";
 import { AuthorityOptions } from "../../src/authority/AuthorityOptions.js";
 import { TokenKeys } from "../../src/cache/utils/CacheTypes.js";
 import * as AccountEntityUtils from "../../src/cache/utils/AccountEntityUtils.js";
-import { EncodingTypes } from "../../src/utils/Constants.js";
 import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 import { CredentialEntity } from "../../src/cache/entities/CredentialEntity.js";
 import { AccountInfo } from "../../src/account/AccountInfo.js";
@@ -409,7 +409,8 @@ export async function getDiscoveredAuthority(
         mockStorage,
         authorityOptions,
         logger,
-        TEST_CONFIG.CORRELATION_ID
+        TEST_CONFIG.CORRELATION_ID,
+        new StubPerformanceClient()
     );
 
     await authority.resolveEndpointsAsync().catch((error) => {

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -228,7 +228,10 @@ describe("RefreshTokenClient unit tests", () => {
                 done();
             });
 
-            const client = new RefreshTokenClient(config);
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
 
             const refreshTokenRequest: CommonRefreshTokenRequest = {
                 scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
@@ -980,21 +983,11 @@ describe("RefreshTokenClient unit tests", () => {
         });
 
         it("includes the http version in Refresh token client(AT) measurement when received in server response", async () => {
-            const performanceClient = {
-                startMeasurement: jest.fn(),
-                endMeasurement: jest.fn(),
-                discardMeasurements: jest.fn(),
-                removePerformanceCallback: jest.fn(),
-                addPerformanceCallback: jest.fn(),
-                emitEvents: jest.fn(),
-                generateId: jest.fn(),
-                calculateQueuedTime: jest.fn(),
-                addQueueMeasurement: jest.fn(),
-                setPreQueueTime: jest.fn(),
-                addFields: jest.fn(),
-                incrementFields: jest.fn(),
-            };
-            const client = new RefreshTokenClient(config, performanceClient);
+            const addFieldsSpy = jest.spyOn(stubPerformanceClient, "addFields");
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
             jest.spyOn(
                 // @ts-ignore
                 client.networkClient,
@@ -1011,7 +1004,7 @@ describe("RefreshTokenClient unit tests", () => {
             };
             await client.acquireToken(refreshTokenRequest);
 
-            expect(performanceClient.addFields).toHaveBeenCalledWith(
+            expect(addFieldsSpy).toHaveBeenCalledWith(
                 {
                     httpVerToken: "xMsHttpVer",
                     refreshTokenSize:
@@ -1024,21 +1017,11 @@ describe("RefreshTokenClient unit tests", () => {
         });
 
         it("does not add http version to the measurement when not received in server response", async () => {
-            const performanceClient = {
-                startMeasurement: jest.fn(),
-                endMeasurement: jest.fn(),
-                discardMeasurements: jest.fn(),
-                removePerformanceCallback: jest.fn(),
-                addPerformanceCallback: jest.fn(),
-                emitEvents: jest.fn(),
-                generateId: jest.fn(),
-                calculateQueuedTime: jest.fn(),
-                addQueueMeasurement: jest.fn(),
-                setPreQueueTime: jest.fn(),
-                addFields: jest.fn(),
-                incrementFields: jest.fn(),
-            };
-            const client = new RefreshTokenClient(config, performanceClient);
+            const addFieldsSpy = jest.spyOn(stubPerformanceClient, "addFields");
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
             jest.spyOn(
                 // @ts-ignore
                 client.networkClient,
@@ -1055,7 +1038,7 @@ describe("RefreshTokenClient unit tests", () => {
             };
             await client.acquireToken(refreshTokenRequest);
 
-            expect(performanceClient.addFields).toHaveBeenCalledWith(
+            expect(addFieldsSpy).toHaveBeenCalledWith(
                 {
                     httpVerToken: "",
                     refreshTokenSize:
@@ -1565,7 +1548,10 @@ describe("RefreshTokenClient unit tests", () => {
         it("pick up broker params", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new RefreshTokenClient(config);
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
 
             const queryString =
                 // @ts-ignore
@@ -1587,7 +1573,10 @@ describe("RefreshTokenClient unit tests", () => {
         it("broker params take precedence over token body params", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
-            const client = new RefreshTokenClient(config);
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
 
             const queryString =
                 // @ts-ignore

--- a/lib/msal-common/test/crypto/PopTokenGenerator.spec.ts
+++ b/lib/msal-common/test/crypto/PopTokenGenerator.spec.ts
@@ -13,6 +13,7 @@ import { AuthenticationScheme } from "../../src/utils/Constants.js";
 import { SignedHttpRequest } from "../../src/crypto/SignedHttpRequest.js";
 import { Logger } from "../../src/logger/Logger.js";
 import { mockCrypto } from "../client/ClientTestUtils.js";
+import { StubPerformanceClient } from "../../src/index.js";
 
 describe("PopTokenGenerator Unit Tests", () => {
     afterEach(() => {
@@ -30,7 +31,10 @@ describe("PopTokenGenerator Unit Tests", () => {
             resourceRequestUrl: TEST_URIS.TEST_RESOURCE_ENDPT_WITH_PARAMS,
         };
         it("Generates the req_cnf correctly", async () => {
-            const popTokenGenerator = new PopTokenGenerator(cryptoInterface);
+            const popTokenGenerator = new PopTokenGenerator(
+                cryptoInterface,
+                new StubPerformanceClient()
+            );
             const reqCnfData = await popTokenGenerator.generateCnf(
                 testRequest,
                 new Logger({})
@@ -57,7 +61,10 @@ describe("PopTokenGenerator Unit Tests", () => {
         });
 
         it("Signs the proof-of-possession JWT token with all PoP parameters in the request", (done) => {
-            const popTokenGenerator = new PopTokenGenerator(cryptoInterface);
+            const popTokenGenerator = new PopTokenGenerator(
+                cryptoInterface,
+                new StubPerformanceClient()
+            );
             const accessToken = TEST_POP_VALUES.SAMPLE_POP_AT;
             const resourceReqMethod = "POST";
             const resourceUrl = TEST_URIS.TEST_RESOURCE_ENDPT_WITH_PARAMS;
@@ -105,7 +112,10 @@ describe("PopTokenGenerator Unit Tests", () => {
         });
 
         it("Signs the proof-of-possession JWT token when PoP parameters are undefined", (done) => {
-            const popTokenGenerator = new PopTokenGenerator(cryptoInterface);
+            const popTokenGenerator = new PopTokenGenerator(
+                cryptoInterface,
+                new StubPerformanceClient()
+            );
             const accessToken = TEST_POP_VALUES.SAMPLE_POP_AT;
             const currTime = TimeUtils.nowSeconds();
             cryptoInterface.signJwt = (

--- a/lib/msal-common/test/logger/Logger.spec.ts
+++ b/lib/msal-common/test/logger/Logger.spec.ts
@@ -1,5 +1,6 @@
 import { LoggerOptions } from "../../src/config/ClientConfiguration.js";
 import { LogLevel, Logger } from "../../src/logger/Logger.js";
+import { TEST_CONFIG } from "../test_kit/StringConstants.js";
 
 describe("Logger.ts Class Unit Tests", () => {
     let loggerOptions: LoggerOptions;
@@ -38,11 +39,11 @@ describe("Logger.ts Class Unit Tests", () => {
         it("Creates a logger with level Error", () => {
             const options = { ...loggerOptions, logLevel: LogLevel.Error };
             const logger = new Logger(options);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBe(undefined);
             expect(logStore[LogLevel.Info]).toBe(undefined);
@@ -53,11 +54,11 @@ describe("Logger.ts Class Unit Tests", () => {
         it("Creates a logger with level Warning", () => {
             const options = { ...loggerOptions, logLevel: LogLevel.Warning };
             const logger = new Logger(options);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBeTruthy();
             expect(logStore[LogLevel.Info]).toBe(undefined);
@@ -68,11 +69,11 @@ describe("Logger.ts Class Unit Tests", () => {
         it("Creates a logger with level Info", () => {
             const options = { ...loggerOptions, logLevel: LogLevel.Info };
             const logger = new Logger(options);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBeTruthy();
             expect(logStore[LogLevel.Info]).toBeTruthy();
@@ -83,11 +84,11 @@ describe("Logger.ts Class Unit Tests", () => {
         it("Creates a logger with level Verbose", () => {
             const options = { ...loggerOptions, logLevel: LogLevel.Verbose };
             const logger = new Logger(options);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBeTruthy();
             expect(logStore[LogLevel.Info]).toBeTruthy();
@@ -98,11 +99,11 @@ describe("Logger.ts Class Unit Tests", () => {
         it("Creates a logger with level Trace", () => {
             const options = { ...loggerOptions, logLevel: LogLevel.Trace };
             const logger = new Logger(options);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBeTruthy();
             expect(logStore[LogLevel.Info]).toBeTruthy();
@@ -122,11 +123,11 @@ describe("Logger.ts Class Unit Tests", () => {
                 piiLoggingEnabled: true,
             };
             const logger = new Logger(loggerOptions);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBeTruthy();
             expect(logStore[LogLevel.Info]).toBeTruthy();
@@ -148,11 +149,11 @@ describe("Logger.ts Class Unit Tests", () => {
                 logLevel: "Verbose",
             };
             const logger = new Logger(loggerOptions);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBeTruthy();
             expect(logStore[LogLevel.Info]).toBeTruthy();
@@ -174,11 +175,11 @@ describe("Logger.ts Class Unit Tests", () => {
                 logLevel: [LogLevel.Verbose],
             };
             const logger = new Logger(loggerOptions);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBeTruthy();
             expect(logStore[LogLevel.Info]).toBeTruthy();
@@ -200,11 +201,11 @@ describe("Logger.ts Class Unit Tests", () => {
                 logLevel: null,
             };
             const logger = new Logger(loggerOptions);
-            logger.error("Message");
-            logger.warning("Message");
-            logger.info("Message");
-            logger.verbose("Message");
-            logger.trace("Message");
+            logger.error("Message", "");
+            logger.warning("Message", "");
+            logger.info("Message", "");
+            logger.verbose("Message", "");
+            logger.trace("Message", "");
             expect(logStore[LogLevel.Error]).toBeTruthy();
             expect(logStore[LogLevel.Warning]).toBeTruthy();
             expect(logStore[LogLevel.Info]).toBeTruthy();
@@ -225,7 +226,7 @@ describe("Logger.ts Class Unit Tests", () => {
         it("Creates a new logger with package name and package version", () => {
             const logger = new Logger(loggerOptions);
             const loggerClone = logger.clone("msal-common", "2.0.0");
-            loggerClone.info("Message");
+            loggerClone.info("Message", TEST_CONFIG.CORRELATION_ID);
             expect(logStore[LogLevel.Info]).toContain("msal-common");
             expect(logStore[LogLevel.Info]).toContain("2.0.0");
             expect(logStore[LogLevel.Info]).toContain("msal-common@2.0.0");
@@ -244,7 +245,7 @@ describe("Logger.ts Class Unit Tests", () => {
         it("Creates a new logger with package name and package version", () => {
             const logger = new Logger(loggerOptions);
             const loggerClone = logger.clone("msal-common", "2.0.0");
-            loggerClone.info("Message");
+            loggerClone.info("Message", TEST_CONFIG.CORRELATION_ID);
             expect(logStore[LogLevel.Info]).toContain("msal-common");
             expect(logStore[LogLevel.Info]).toContain("2.0.0");
             expect(logStore[LogLevel.Info]).toContain("msal-common@2.0.0");
@@ -267,7 +268,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.error("Message");
+            logger.error("Message", "");
             expect(executeCbSpy).toHaveBeenCalledWith(
                 LogLevel.Error,
                 expect.anything(),
@@ -282,7 +283,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.errorPii("Message");
+            logger.errorPii("Message", TEST_CONFIG.CORRELATION_ID);
             expect(executeCbSpy).toHaveBeenCalledWith(
                 LogLevel.Error,
                 expect.anything(),
@@ -298,7 +299,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.errorPii("Message");
+            logger.errorPii("Message", TEST_CONFIG.CORRELATION_ID);
             expect(executeCbSpy).not.toHaveBeenCalled();
         });
     });
@@ -311,7 +312,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.warning("Message");
+            logger.warning("Message", "");
             expect(executeCbSpy).toHaveBeenCalledWith(
                 LogLevel.Warning,
                 expect.anything(),
@@ -326,7 +327,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.warningPii("Message");
+            logger.warningPii("Message", TEST_CONFIG.CORRELATION_ID);
             expect(executeCbSpy).toHaveBeenCalledWith(
                 LogLevel.Warning,
                 expect.anything(),
@@ -342,7 +343,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.warningPii("Message");
+            logger.warningPii("Message", TEST_CONFIG.CORRELATION_ID);
             expect(executeCbSpy).not.toHaveBeenCalled();
         });
     });
@@ -355,7 +356,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.info("Message");
+            logger.info("Message", "");
             expect(executeCbSpy).toHaveBeenCalledWith(
                 LogLevel.Info,
                 expect.anything(),
@@ -370,7 +371,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.infoPii("Message");
+            logger.infoPii("Message", TEST_CONFIG.CORRELATION_ID);
             expect(executeCbSpy).toHaveBeenCalledWith(
                 LogLevel.Info,
                 expect.anything(),
@@ -386,7 +387,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.infoPii("Message");
+            logger.infoPii("Message", TEST_CONFIG.CORRELATION_ID);
             expect(executeCbSpy).not.toHaveBeenCalled();
         });
     });
@@ -399,7 +400,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.verbose("Message");
+            logger.verbose("Message", "");
             expect(executeCbSpy).toHaveBeenCalledWith(
                 LogLevel.Verbose,
                 expect.anything(),
@@ -414,7 +415,7 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.verbosePii("Message");
+            logger.verbosePii("Message", "");
             expect(executeCbSpy).toHaveBeenCalledWith(
                 LogLevel.Verbose,
                 expect.anything(),
@@ -430,51 +431,17 @@ describe("Logger.ts Class Unit Tests", () => {
             );
 
             const logger = new Logger(loggerOptions);
-            logger.verbosePii("Message");
+            logger.verbosePii("Message", "");
             expect(executeCbSpy).not.toHaveBeenCalled();
         });
     });
 
     describe("CorrelationId tests", () => {
-        it("CorrelationId is included in log message if set on Logger configurations", () => {
-            const testCorrelationId = "12345";
-            const logger = new Logger({
-                ...loggerOptions,
-                correlationId: testCorrelationId,
-            });
-
-            logger.verbose("Message");
-            expect(logStore[LogLevel.Verbose]).toContain(testCorrelationId);
-        });
-
         it("CorrelationId is included in log message if passed in log message", () => {
             const testCorrelationId = "23456";
             const logger = new Logger(loggerOptions);
 
             logger.verbose("Message", testCorrelationId);
-            expect(logStore[LogLevel.Verbose]).toContain(testCorrelationId);
-        });
-
-        it("CorrelationId passed in log message takes precedence over correlationId in Logger configurations", () => {
-            const optionsCorrelationId = "34567";
-            const testCorrelationId = "45678";
-            const logger = new Logger({
-                ...loggerOptions,
-                correlationId: optionsCorrelationId,
-            });
-
-            logger.verbose("Message", testCorrelationId);
-            expect(logStore[LogLevel.Verbose]).toContain(testCorrelationId);
-            expect(logStore[LogLevel.Verbose]).not.toContain(
-                optionsCorrelationId
-            );
-        });
-
-        it("CorrelationId on Logger will be used if an empty string is passed in the log message", () => {
-            const testCorrelationId = "56789";
-            const logger = new Logger(loggerOptions, testCorrelationId);
-
-            logger.verbose("Message", "");
             expect(logStore[LogLevel.Verbose]).toContain(testCorrelationId);
         });
     });

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -124,8 +124,11 @@ const testAuthority = new Authority(
     testCacheManager,
     authorityOptions,
     logger,
-    TEST_CONFIG.CORRELATION_ID
+    TEST_CONFIG.CORRELATION_ID,
+    new StubPerformanceClient()
 );
+
+const stubPerformanceClient = new StubPerformanceClient();
 
 describe("ResponseHandler.ts", () => {
     let preferredCacheStub: jest.SpyInstance;
@@ -169,6 +172,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -227,6 +231,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -294,6 +299,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -360,6 +366,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -413,6 +420,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -456,7 +464,8 @@ describe("ResponseHandler.ts", () => {
                     authorityMetadata: "",
                 },
                 logger,
-                TEST_CONFIG.CORRELATION_ID
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
             );
 
             const timestamp = TimeUtils.nowSeconds();
@@ -472,6 +481,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -525,6 +535,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -572,6 +583,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -619,6 +631,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -650,6 +663,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -678,12 +692,16 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
 
             try {
-                responseHandler.validateTokenResponse(testTokenResponse);
+                responseHandler.validateTokenResponse(
+                    testTokenResponse,
+                    TEST_CONFIG.CORRELATION_ID
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 const serverError = e as ServerError;
@@ -710,12 +728,16 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
 
             try {
-                responseHandler.validateTokenResponse(testTokenResponse);
+                responseHandler.validateTokenResponse(
+                    testTokenResponse,
+                    TEST_CONFIG.CORRELATION_ID
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(InteractionRequiredAuthError);
                 const serverError = e as InteractionRequiredAuthError;
@@ -742,12 +764,16 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
 
             try {
-                responseHandler.validateTokenResponse(testTokenResponse);
+                responseHandler.validateTokenResponse(
+                    testTokenResponse,
+                    TEST_CONFIG.CORRELATION_ID
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 const serverError = e as ServerError;
@@ -774,12 +800,16 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
 
             try {
-                responseHandler.validateTokenResponse(testTokenResponse);
+                responseHandler.validateTokenResponse(
+                    testTokenResponse,
+                    TEST_CONFIG.CORRELATION_ID
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 const serverError = e as ServerError;
@@ -817,6 +847,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -863,6 +894,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -909,6 +941,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );
@@ -952,6 +985,7 @@ describe("ResponseHandler.ts", () => {
                 testCacheManager,
                 cryptoInterface,
                 logger,
+                stubPerformanceClient,
                 null,
                 null
             );

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 import { AccessTokenCache } from '@azure/msal-common/node';
 import { AccessTokenEntity } from '@azure/msal-common/node';
 import { AccountCache } from '@azure/msal-common/node';

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AccessTokenCache } from '@azure/msal-common/node';
 import { AccessTokenEntity } from '@azure/msal-common/node';
 import { AccountCache } from '@azure/msal-common/node';

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -25,13 +25,12 @@ import { AuthorizationCodePayload } from '@azure/msal-common/node';
 import { AuthorizeResponse } from '@azure/msal-common/node';
 import { AzureCloudInstance } from '@azure/msal-common/node';
 import { AzureCloudOptions } from '@azure/msal-common/node';
-import { AzureRegion } from '@azure/msal-common';
+import { AzureRegion } from '@azure/msal-common/node';
 import { AzureRegionConfiguration } from '@azure/msal-common/node';
-import { BaseAuthRequest } from '@azure/msal-common';
-import { BaseAuthRequest as BaseAuthRequest_2 } from '@azure/msal-common/node';
+import { BaseAuthRequest } from '@azure/msal-common/node';
 import { BaseClient } from '@azure/msal-common/node';
 import { CacheManager } from '@azure/msal-common/node';
-import { ClientAssertion as ClientAssertion_2 } from '@azure/msal-common';
+import { ClientAssertion as ClientAssertion_2 } from '@azure/msal-common/node';
 import { ClientAssertionCallback } from '@azure/msal-common/node';
 import { ClientAuthError } from '@azure/msal-common/node';
 import { ClientAuthErrorCodes } from '@azure/msal-common/node';
@@ -44,8 +43,7 @@ import { CommonRefreshTokenRequest } from '@azure/msal-common/node';
 import { CommonSilentFlowRequest } from '@azure/msal-common/node';
 import { Constants } from '@azure/msal-common/node';
 import { CredentialEntity } from '@azure/msal-common/node';
-import { DeviceCodeResponse } from '@azure/msal-common';
-import { DeviceCodeResponse as DeviceCodeResponse_2 } from '@azure/msal-common/node';
+import { DeviceCodeResponse } from '@azure/msal-common/node';
 import http from 'http';
 import https from 'https';
 import { IAppTokenProvider } from '@azure/msal-common/node';
@@ -72,7 +70,7 @@ import { ServerError } from '@azure/msal-common/node';
 import { ServerTelemetryEntity } from '@azure/msal-common/node';
 import { ServerTelemetryManager } from '@azure/msal-common/node';
 import { StaticAuthorityOptions } from '@azure/msal-common/node';
-import { StringDict } from '@azure/msal-common';
+import { StringDict } from '@azure/msal-common/node';
 import { ThrottlingEntity } from '@azure/msal-common/node';
 import { TokenCacheContext } from '@azure/msal-common/node';
 import { TokenKeys } from '@azure/msal-common/node';
@@ -148,7 +146,7 @@ export abstract class ClientApplication {
     getAuthCodeUrl(request: AuthorizationUrlRequest): Promise<string>;
     getLogger(): Logger;
     getTokenCache(): TokenCache;
-    protected initializeBaseRequest(authRequest: Partial<BaseAuthRequest_2>): Promise<BaseAuthRequest_2>;
+    protected initializeBaseRequest(authRequest: Partial<BaseAuthRequest>): Promise<BaseAuthRequest>;
     protected initializeServerTelemetryManager(apiId: number, correlationId: string, forceRefresh?: boolean): ServerTelemetryManager;
     protected logger: Logger;
     setLogger(logger: Logger): void;
@@ -245,7 +243,7 @@ export class DeviceCodeClient extends BaseClient {
 // @public
 export type DeviceCodeRequest = Partial<Omit<CommonDeviceCodeRequest, "scopes" | "deviceCodeCallback" | "resourceRequestMethod" | "resourceRequestUri" | "storeInCache">> & {
     scopes: Array<string>;
-    deviceCodeCallback: (response: DeviceCodeResponse_2) => void;
+    deviceCodeCallback: (response: DeviceCodeResponse) => void;
 };
 
 // @public

--- a/lib/msal-node/src/cache/NodeStorage.ts
+++ b/lib/msal-node/src/cache/NodeStorage.ts
@@ -23,6 +23,7 @@ import {
     AccountEntityUtils,
     CredentialEntity,
     AccountInfo,
+    StubPerformanceClient,
 } from "@azure/msal-common/node";
 
 import { Deserializer } from "./serializer/Deserializer.js";
@@ -32,7 +33,6 @@ import {
     JsonCache,
     CacheKVStore,
 } from "./serializer/SerializerTypes.js";
-import { StubPerformanceClient } from "@azure/msal-common";
 import { generateAccountKey, generateCredentialKey } from "./CacheHelpers.js";
 
 /**

--- a/lib/msal-node/src/cache/NodeStorage.ts
+++ b/lib/msal-node/src/cache/NodeStorage.ts
@@ -137,7 +137,7 @@ export class NodeStorage extends CacheManager {
      * gets the current in memory cache for the client
      */
     getInMemoryCache(): InMemoryCache {
-        this.logger.trace("Getting in-memory cache");
+        this.logger.trace("Getting in-memory cache", "");
 
         // convert the cache key value store to inMemoryCache
         const inMemoryCache = this.cacheToInMemoryCache(this.getCache());
@@ -149,7 +149,7 @@ export class NodeStorage extends CacheManager {
      * @param inMemoryCache - key value map in memory
      */
     setInMemoryCache(inMemoryCache: InMemoryCache): void {
-        this.logger.trace("Setting in-memory cache");
+        this.logger.trace("Setting in-memory cache", "");
 
         // convert and append the inMemoryCache to cacheKVStore
         const cache = this.inMemoryCacheToCache(inMemoryCache);
@@ -162,7 +162,7 @@ export class NodeStorage extends CacheManager {
      * get the current cache key-value store
      */
     getCache(): CacheKVStore {
-        this.logger.trace("Getting cache key-value store");
+        this.logger.trace("Getting cache key-value store", "");
         return this.cache;
     }
 
@@ -171,7 +171,7 @@ export class NodeStorage extends CacheManager {
      * @param cacheMap - key value map
      */
     setCache(cache: CacheKVStore): void {
-        this.logger.trace("Setting cache key value store");
+        this.logger.trace("Setting cache key value store", "");
         this.cache = cache;
 
         // mark change in cache
@@ -183,7 +183,7 @@ export class NodeStorage extends CacheManager {
      * @param key - lookup key for the cache entry
      */
     getItem(key: string): ValidCacheType {
-        this.logger.tracePii(`Item key: ${key}`);
+        this.logger.tracePii(`Item key: ${key}`, "");
 
         // read cache
         const cache = this.getCache();
@@ -196,7 +196,7 @@ export class NodeStorage extends CacheManager {
      * @param value - value of the cache entry
      */
     setItem(key: string, value: ValidCacheType): void {
-        this.logger.tracePii(`Item key: ${key}`);
+        this.logger.tracePii(`Item key: ${key}`, "");
 
         // read cache
         const cache = this.getCache();
@@ -453,7 +453,7 @@ export class NodeStorage extends CacheManager {
      * @param inMemory - key value map of the cache
      */
     removeItem(key: string): boolean {
-        this.logger.tracePii(`Item key: ${key}`);
+        this.logger.tracePii(`Item key: ${key}`, "");
 
         // read inMemoryCache
         let result: boolean = false;
@@ -492,7 +492,7 @@ export class NodeStorage extends CacheManager {
      * Gets all keys in window.
      */
     getKeys(): string[] {
-        this.logger.trace("Retrieving all cache keys");
+        this.logger.trace("Retrieving all cache keys", "");
 
         // read cache
         const cache = this.getCache();
@@ -503,7 +503,7 @@ export class NodeStorage extends CacheManager {
      * Clears all cache entries created by MSAL (except tokens).
      */
     clear(): void {
-        this.logger.trace("Clearing cache entries created by MSAL");
+        this.logger.trace("Clearing cache entries created by MSAL", "");
 
         // read inMemoryCache
         const cacheKeys = this.getKeys();
@@ -548,12 +548,14 @@ export class NodeStorage extends CacheManager {
                 this.removeItem(currentCacheKey);
                 this.setItem(updatedCacheKey, cacheItem);
                 this.logger.verbose(
-                    `Updated an outdated ${credential.credentialType} cache key`
+                    `Updated an outdated ${credential.credentialType} cache key`,
+                    ""
                 );
                 return updatedCacheKey;
             } else {
                 this.logger.error(
-                    `Attempted to update an outdated ${credential.credentialType} cache key but no item matching the outdated key was found in storage`
+                    `Attempted to update an outdated ${credential.credentialType} cache key but no item matching the outdated key was found in storage`,
+                    ""
                 );
             }
         }

--- a/lib/msal-node/src/cache/TokenCache.ts
+++ b/lib/msal-node/src/cache/TokenCache.ts
@@ -71,20 +71,20 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
      * Serializes in memory cache to JSON
      */
     serialize(): string {
-        this.logger.trace("Serializing in-memory cache");
+        this.logger.trace("Serializing in-memory cache", "");
         let finalState = Serializer.serializeAllCache(
             this.storage.getInMemoryCache() as InMemoryCache
         );
 
         // if cacheSnapshot not null or empty, merge
         if (this.cacheSnapshot) {
-            this.logger.trace("Reading cache snapshot from disk");
+            this.logger.trace("Reading cache snapshot from disk", "");
             finalState = this.mergeState(
                 JSON.parse(this.cacheSnapshot),
                 finalState
             );
         } else {
-            this.logger.trace("No cache snapshot to merge");
+            this.logger.trace("No cache snapshot to merge", "");
         }
         this.cacheHasChanged = false;
 
@@ -96,17 +96,17 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
      * @param cache - blob formatted cache
      */
     deserialize(cache: string): void {
-        this.logger.trace("Deserializing JSON to in-memory cache");
+        this.logger.trace("Deserializing JSON to in-memory cache", "");
         this.cacheSnapshot = cache;
 
         if (this.cacheSnapshot) {
-            this.logger.trace("Reading cache snapshot from disk");
+            this.logger.trace("Reading cache snapshot from disk", "");
             const deserializedCache = Deserializer.deserializeAllCache(
                 this.overlayDefaults(JSON.parse(this.cacheSnapshot))
             );
             this.storage.setInMemoryCache(deserializedCache);
         } else {
-            this.logger.trace("No cache snapshot to deserialize");
+            this.logger.trace("No cache snapshot to deserialize", "");
         }
     }
 
@@ -133,7 +133,7 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
     async getAllAccounts(
         correlationId: string = new CryptoProvider().createNewGuid()
     ): Promise<AccountInfo[]> {
-        this.logger.trace("getAllAccounts called");
+        this.logger.trace("getAllAccounts called", correlationId);
         let cacheContext;
         try {
             if (this.persistence) {
@@ -198,7 +198,7 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
         account: AccountInfo,
         correlationId?: string
     ): Promise<void> {
-        this.logger.trace("removeAccount called");
+        this.logger.trace("removeAccount called", correlationId || "");
         let cacheContext;
         try {
             if (this.persistence) {
@@ -222,11 +222,15 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
     async overwriteCache(): Promise<void> {
         if (!this.persistence) {
             this.logger.info(
-                "No persistence layer specified, cache cannot be overwritten"
+                "No persistence layer specified, cache cannot be overwritten",
+                ""
             );
             return;
         }
-        this.logger.info("Overwriting in-memory cache with persistent cache");
+        this.logger.info(
+            "Overwriting in-memory cache with persistent cache",
+            ""
+        );
         this.storage.clear();
         const cacheContext = new TokenCacheContext(this, false);
         await this.persistence.beforeCacheAccess(cacheContext);
@@ -251,7 +255,7 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
         oldState: JsonCache,
         currentState: JsonCache
     ): JsonCache {
-        this.logger.trace("Merging in-memory cache with cache snapshot");
+        this.logger.trace("Merging in-memory cache with cache snapshot", "");
         const stateAfterRemoval = this.mergeRemovals(oldState, currentState);
         return this.mergeUpdates(stateAfterRemoval, currentState);
     }
@@ -302,7 +306,7 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
      * @param newState - updated cache
      */
     private mergeRemovals(oldState: JsonCache, newState: JsonCache): JsonCache {
-        this.logger.trace("Remove updated entries in cache");
+        this.logger.trace("Remove updated entries in cache", "");
         const accounts = oldState.Account
             ? this.mergeRemovalsDict<SerializedAccountEntity>(
                   oldState.Account,
@@ -367,7 +371,7 @@ export class TokenCache implements ISerializableTokenCache, ITokenCache {
      * @param passedInCache - cache read from the blob
      */
     private overlayDefaults(passedInCache: JsonCache): JsonCache {
-        this.logger.trace("Overlaying input cache with the default cache");
+        this.logger.trace("Overlaying input cache with the default cache", "");
         return {
             Account: {
                 ...defaultSerializedCache.Account,

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -32,6 +32,7 @@ import {
     ClientAssertionCallback,
     Constants,
     ClientAuthError,
+    StubPerformanceClient,
 } from "@azure/msal-common/node";
 import {
     Configuration,
@@ -53,7 +54,6 @@ import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePassword
 import { NodeAuthError } from "../error/NodeAuthError.js";
 import { UsernamePasswordClient } from "./UsernamePasswordClient.js";
 import { getAuthCodeRequestUrl } from "../protocol/Authorize.js";
-import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * Base abstract class for all ClientApplications - public and confidential

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -53,6 +53,7 @@ import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePassword
 import { NodeAuthError } from "../error/NodeAuthError.js";
 import { UsernamePasswordClient } from "./UsernamePasswordClient.js";
 import { getAuthCodeRequestUrl } from "../protocol/Authorize.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * Base abstract class for all ClientApplications - public and confidential
@@ -120,7 +121,7 @@ export abstract class ClientApplication {
      * `acquireTokenByCode(AuthorizationCodeRequest)`.
      */
     async getAuthCodeUrl(request: AuthorizationUrlRequest): Promise<string> {
-        this.logger.info("getAuthCodeUrl called", request.correlationId);
+        this.logger.info("getAuthCodeUrl called", request.correlationId || "");
         const validRequest: CommonAuthorizationUrlRequest = {
             ...request,
             ...(await this.initializeBaseRequest(request)),
@@ -156,9 +157,15 @@ export abstract class ClientApplication {
         request: AuthorizationCodeRequest,
         authCodePayLoad?: AuthorizationCodePayload
     ): Promise<AuthenticationResult> {
-        this.logger.info("acquireTokenByCode called");
+        this.logger.info(
+            "acquireTokenByCode called",
+            request.correlationId || ""
+        );
         if (request.state && authCodePayLoad) {
-            this.logger.info("acquireTokenByCode - validating state");
+            this.logger.info(
+                "acquireTokenByCode - validating state",
+                request.correlationId || ""
+            );
             this.validateState(request.state, authCodePayLoad.state || "");
             // eslint-disable-next-line no-param-reassign
             authCodePayLoad = { ...authCodePayLoad, state: "" };
@@ -187,7 +194,8 @@ export abstract class ClientApplication {
                 serverTelemetryManager
             );
             const authorizationCodeClient = new AuthorizationCodeClient(
-                authClientConfig
+                authClientConfig,
+                new StubPerformanceClient()
             );
             this.logger.verbose(
                 "Auth code client created",
@@ -218,7 +226,7 @@ export abstract class ClientApplication {
     ): Promise<AuthenticationResult | null> {
         this.logger.info(
             "acquireTokenByRefreshToken called",
-            request.correlationId
+            request.correlationId || ""
         );
         const validRequest: CommonRefreshTokenRequest = {
             ...request,
@@ -245,7 +253,8 @@ export abstract class ClientApplication {
                     serverTelemetryManager
                 );
             const refreshTokenClient = new RefreshTokenClient(
-                refreshTokenClientConfig
+                refreshTokenClientConfig,
+                new StubPerformanceClient()
             );
             this.logger.verbose(
                 "Refresh token client created",
@@ -298,7 +307,10 @@ export abstract class ClientApplication {
                     validRequest.redirectUri || "",
                     serverTelemetryManager
                 );
-            const silentFlowClient = new SilentFlowClient(clientConfiguration);
+            const silentFlowClient = new SilentFlowClient(
+                clientConfiguration,
+                new StubPerformanceClient()
+            );
             this.logger.verbose(
                 "Silent flow client created",
                 validRequest.correlationId
@@ -318,7 +330,8 @@ export abstract class ClientApplication {
                         ClientAuthErrorCodes.tokenRefreshRequired
                 ) {
                     const refreshTokenClient = new RefreshTokenClient(
-                        clientConfiguration
+                        clientConfiguration,
+                        new StubPerformanceClient()
                     );
                     return refreshTokenClient.acquireTokenByRefreshToken(
                         validRequest
@@ -350,11 +363,13 @@ export abstract class ClientApplication {
 
         if (cacheOutcome === Constants.CacheOutcome.PROACTIVELY_REFRESHED) {
             this.logger.info(
-                "ClientApplication:acquireCachedTokenSilent - Cached access token's refreshOn property has been exceeded'. It's not expired, but must be refreshed."
+                "ClientApplication:acquireCachedTokenSilent - Cached access token's refreshOn property has been exceeded'. It's not expired, but must be refreshed.",
+                validRequest.correlationId
             );
             // refresh the access token in the background
             const refreshTokenClient = new RefreshTokenClient(
-                clientConfiguration
+                clientConfiguration,
+                new StubPerformanceClient()
             );
 
             try {
@@ -386,7 +401,7 @@ export abstract class ClientApplication {
     ): Promise<AuthenticationResult | null> {
         this.logger.info(
             "acquireTokenByUsernamePassword called",
-            request.correlationId
+            request.correlationId || ""
         );
         const validRequest: CommonUsernamePasswordRequest = {
             ...request,
@@ -431,7 +446,7 @@ export abstract class ClientApplication {
      * Gets the token cache for the application.
      */
     getTokenCache(): TokenCache {
-        this.logger.info("getTokenCache called");
+        this.logger.info("getTokenCache called", "");
         return this.tokenCache;
     }
 
@@ -564,10 +579,9 @@ export abstract class ClientApplication {
     protected async initializeBaseRequest(
         authRequest: Partial<BaseAuthRequest>
     ): Promise<BaseAuthRequest> {
-        this.logger.verbose(
-            "initializeRequestScopes called",
-            authRequest.correlationId
-        );
+        const correlationId =
+            authRequest.correlationId || this.cryptoProvider.createNewGuid();
+        this.logger.verbose("initializeRequestScopes called", correlationId);
         // Default authenticationScheme to Bearer, log that POP isn't supported yet
         if (
             authRequest.authenticationScheme &&
@@ -576,7 +590,7 @@ export abstract class ClientApplication {
         ) {
             this.logger.verbose(
                 "Authentication Scheme 'pop' is not supported yet, setting Authentication Scheme to 'Bearer' for request",
-                authRequest.correlationId
+                correlationId
             );
         }
 
@@ -589,9 +603,7 @@ export abstract class ClientApplication {
                 ...((authRequest && authRequest.scopes) || []),
                 ...Constants.OIDC_DEFAULT_SCOPES,
             ],
-            correlationId:
-                (authRequest && authRequest.correlationId) ||
-                this.cryptoProvider.createNewGuid(),
+            correlationId,
             authority: authRequest.authority || this.config.auth.authority,
         };
     }
@@ -650,7 +662,8 @@ export abstract class ClientApplication {
             this.storage,
             authorityOptions,
             this.logger,
-            requestCorrelationId
+            requestCorrelationId,
+            new StubPerformanceClient()
         );
     }
 

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -29,13 +29,13 @@ import {
     ClientAssertion,
     getClientAssertion,
     UrlUtils,
+    StubPerformanceClient,
 } from "@azure/msal-common/node";
 import {
     ManagedIdentityConfiguration,
     ManagedIdentityNodeConfiguration,
 } from "../config/Configuration.js";
 import { CommonClientCredentialRequest } from "../request/CommonClientCredentialRequest.js";
-import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * OAuth2.0 client credential grant

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -35,6 +35,7 @@ import {
     ManagedIdentityNodeConfiguration,
 } from "../config/Configuration.js";
 import { CommonClientCredentialRequest } from "../request/CommonClientCredentialRequest.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * OAuth2.0 client credential grant
@@ -47,7 +48,7 @@ export class ClientCredentialClient extends BaseClient {
         configuration: ClientConfiguration,
         appTokenProvider?: IAppTokenProvider
     ) {
-        super(configuration);
+        super(configuration, new StubPerformanceClient());
         this.appTokenProvider = appTokenProvider;
     }
 
@@ -79,7 +80,8 @@ export class ClientCredentialClient extends BaseClient {
                 Constants.CacheOutcome.PROACTIVELY_REFRESHED
             ) {
                 this.logger.info(
-                    "ClientCredentialClient:getCachedAuthenticationResult - Cached access token's refreshOn property has been exceeded'. It's not expired, but must be refreshed."
+                    "ClientCredentialClient:getCachedAuthenticationResult - Cached access token's refreshOn property has been exceeded'. It's not expired, but must be refreshed.",
+                    request.correlationId
                 );
 
                 // refresh the access token in the background
@@ -195,7 +197,8 @@ export class ClientCredentialClient extends BaseClient {
                     appMetadata: null,
                 },
                 true,
-                request
+                request,
+                this.performanceClient
             ),
             lastCacheOutcome,
         ];
@@ -249,7 +252,10 @@ export class ClientCredentialClient extends BaseClient {
         let reqTimestamp: number;
 
         if (this.appTokenProvider) {
-            this.logger.info("Using appTokenProvider extensibility.");
+            this.logger.info(
+                "Using appTokenProvider extensibility.",
+                request.correlationId
+            );
 
             const appTokenPropviderParameters = {
                 correlationId: request.correlationId,
@@ -293,7 +299,8 @@ export class ClientCredentialClient extends BaseClient {
             };
 
             this.logger.info(
-                "Sending token request to endpoint: " + authority.tokenEndpoint
+                "Sending token request to endpoint: " + authority.tokenEndpoint,
+                request.correlationId
             );
 
             reqTimestamp = TimeUtils.nowSeconds();
@@ -314,12 +321,14 @@ export class ClientCredentialClient extends BaseClient {
             this.cacheManager,
             this.cryptoUtils,
             this.logger,
+            this.performanceClient,
             this.config.serializableCache,
             this.config.persistencePlugin
         );
 
         responseHandler.validateTokenResponse(
             serverTokenResponse,
+            request.correlationId,
             refreshAccessToken
         );
 

--- a/lib/msal-node/src/client/ConfidentialClientApplication.ts
+++ b/lib/msal-node/src/client/ConfidentialClientApplication.ts
@@ -145,7 +145,7 @@ export class ConfidentialClientApplication
     ): Promise<AuthenticationResult | null> {
         this.logger.info(
             "acquireTokenByClientCredential called",
-            request.correlationId
+            request.correlationId || ""
         );
 
         // If there is a client assertion present in the request, it overrides the one present in the client configuration
@@ -268,7 +268,7 @@ export class ConfidentialClientApplication
     ): Promise<AuthenticationResult | null> {
         this.logger.info(
             "acquireTokenOnBehalfOf called",
-            request.correlationId
+            request.correlationId || ""
         );
         const validRequest: CommonOnBehalfOfRequest = {
             ...request,

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -21,10 +21,10 @@ import {
     createAuthError,
     createClientAuthError,
     Constants,
+    StubPerformanceClient,
 } from "@azure/msal-common/node";
 import { CommonDeviceCodeRequest } from "../request/CommonDeviceCodeRequest.js";
 import * as NodeClientAuthErrorCodes from "../error/ClientAuthErrorCodes.js";
-import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * OAuth2.0 Device code client

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -24,6 +24,7 @@ import {
 } from "@azure/msal-common/node";
 import { CommonDeviceCodeRequest } from "../request/CommonDeviceCodeRequest.js";
 import * as NodeClientAuthErrorCodes from "../error/ClientAuthErrorCodes.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * OAuth2.0 Device code client
@@ -31,7 +32,7 @@ import * as NodeClientAuthErrorCodes from "../error/ClientAuthErrorCodes.js";
  */
 export class DeviceCodeClient extends BaseClient {
     constructor(configuration: ClientConfiguration) {
-        super(configuration);
+        super(configuration, new StubPerformanceClient());
     }
 
     /**
@@ -55,12 +56,13 @@ export class DeviceCodeClient extends BaseClient {
             this.cacheManager,
             this.cryptoUtils,
             this.logger,
+            this.performanceClient,
             this.config.serializableCache,
             this.config.persistencePlugin
         );
 
         // Validate response. This function throws a server error if an error is returned by the server.
-        responseHandler.validateTokenResponse(response);
+        responseHandler.validateTokenResponse(response, request.correlationId);
         return responseHandler.handleServerTokenResponse(
             response,
             this.authority,
@@ -215,7 +217,8 @@ export class DeviceCodeClient extends BaseClient {
     ): boolean {
         if (userSpecifiedCancelFlag) {
             this.logger.error(
-                "Token request cancelled by setting DeviceCodeRequest.cancel = true"
+                "Token request cancelled by setting DeviceCodeRequest.cancel = true",
+                ""
             );
             throw createClientAuthError(
                 NodeClientAuthErrorCodes.deviceCodePollingCancelled
@@ -226,7 +229,8 @@ export class DeviceCodeClient extends BaseClient {
             TimeUtils.nowSeconds() > userSpecifiedTimeout
         ) {
             this.logger.error(
-                `User defined timeout for device code polling reached. The timeout was set for ${userSpecifiedTimeout}`
+                `User defined timeout for device code polling reached. The timeout was set for ${userSpecifiedTimeout}`,
+                ""
             );
             throw createClientAuthError(
                 NodeClientAuthErrorCodes.userTimeoutReached
@@ -234,11 +238,13 @@ export class DeviceCodeClient extends BaseClient {
         } else if (TimeUtils.nowSeconds() > deviceCodeExpirationTime) {
             if (userSpecifiedTimeout) {
                 this.logger.verbose(
-                    `User specified timeout ignored as the device code has expired before the timeout elapsed. The user specified timeout was set for ${userSpecifiedTimeout}`
+                    `User specified timeout ignored as the device code has expired before the timeout elapsed. The user specified timeout was set for ${userSpecifiedTimeout}`,
+                    ""
                 );
             }
             this.logger.error(
-                `Device code expired. Expiration time of device code was ${deviceCodeExpirationTime}`
+                `Device code expired. Expiration time of device code was ${deviceCodeExpirationTime}`,
+                ""
             );
             throw createClientAuthError(
                 NodeClientAuthErrorCodes.deviceCodeExpired
@@ -309,13 +315,15 @@ export class DeviceCodeClient extends BaseClient {
                 // user authorization is pending. Sleep for polling interval and try again
                 if (response.body.error === Constants.AUTHORIZATION_PENDING) {
                     this.logger.info(
-                        "Authorization pending. Continue polling."
+                        "Authorization pending. Continue polling.",
+                        request.correlationId
                     );
                     await TimeUtils.delay(pollingIntervalMilli);
                 } else {
                     // for any other error, throw
                     this.logger.info(
-                        "Unexpected error in polling from the server"
+                        "Unexpected error in polling from the server",
+                        request.correlationId
                     );
                     throw createAuthError(
                         AuthErrorCodes.postRequestFailed,
@@ -324,7 +332,8 @@ export class DeviceCodeClient extends BaseClient {
                 }
             } else {
                 this.logger.verbose(
-                    "Authorization completed successfully. Polling stopped."
+                    "Authorization completed successfully. Polling stopped.",
+                    request.correlationId
                 );
                 return response.body;
             }
@@ -334,7 +343,10 @@ export class DeviceCodeClient extends BaseClient {
          * The above code should've thrown by this point, but to satisfy TypeScript,
          * and in the rare case the conditionals in continuePolling() may not catch everything...
          */
-        this.logger.error("Polling stopped for unknown reasons.");
+        this.logger.error(
+            "Polling stopped for unknown reasons.",
+            request.correlationId
+        );
         throw createClientAuthError(
             NodeClientAuthErrorCodes.deviceCodeUnknownError
         );

--- a/lib/msal-node/src/client/ManagedIdentityApplication.ts
+++ b/lib/msal-node/src/client/ManagedIdentityApplication.ts
@@ -17,6 +17,7 @@ import {
     createClientConfigurationError,
     ClientConfigurationErrorCodes,
     Constants,
+    StubPerformanceClient,
 } from "@azure/msal-common/node";
 import {
     ManagedIdentityConfiguration,
@@ -36,7 +37,6 @@ import {
 } from "../utils/Constants.js";
 import { ManagedIdentityId } from "../config/ManagedIdentityId.js";
 import { HashUtils } from "../crypto/HashUtils.js";
-import { StubPerformanceClient } from "@azure/msal-common";
 
 const SOURCES_THAT_SUPPORT_TOKEN_REVOCATION: Array<ManagedIdentitySourceNames> =
     [ManagedIdentitySourceNames.SERVICE_FABRIC];

--- a/lib/msal-node/src/client/ManagedIdentityApplication.ts
+++ b/lib/msal-node/src/client/ManagedIdentityApplication.ts
@@ -36,6 +36,7 @@ import {
 } from "../utils/Constants.js";
 import { ManagedIdentityId } from "../config/ManagedIdentityId.js";
 import { HashUtils } from "../crypto/HashUtils.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 const SOURCES_THAT_SUPPORT_TOKEN_REVOCATION: Array<ManagedIdentitySourceNames> =
     [ManagedIdentitySourceNames.SERVICE_FABRIC];
@@ -102,7 +103,7 @@ export class ManagedIdentityApplication {
             fakeAuthorityOptions,
             this.logger,
             this.cryptoProvider.createNewGuid(), // correlationID
-            undefined,
+            new StubPerformanceClient(),
             true
         );
 
@@ -207,7 +208,8 @@ export class ManagedIdentityApplication {
                 Constants.CacheOutcome.PROACTIVELY_REFRESHED
             ) {
                 this.logger.info(
-                    "ClientCredentialClient:getCachedAuthenticationResult - Cached access token's refreshOn property has been exceeded'. It's not expired, but must be refreshed."
+                    "ClientCredentialClient:getCachedAuthenticationResult - Cached access token's refreshOn property has been exceeded'. It's not expired, but must be refreshed.",
+                    managedIdentityRequest.correlationId
                 );
 
                 // force refresh; will run in the background

--- a/lib/msal-node/src/client/ManagedIdentitySources/AppService.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/AppService.ts
@@ -75,7 +75,8 @@ export class AppService extends BaseManagedIdentitySource {
         // if either of the identity endpoint or identity header variables are undefined, this MSI provider is unavailable.
         if (!identityEndpoint || !identityHeader) {
             logger.info(
-                `[Managed Identity] ${ManagedIdentitySourceNames.APP_SERVICE} managed identity is unavailable because one or both of the '${ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER}' and '${ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT}' environment variables are not defined.`
+                `[Managed Identity] ${ManagedIdentitySourceNames.APP_SERVICE} managed identity is unavailable because one or both of the '${ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER}' and '${ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT}' environment variables are not defined.`,
+                ""
             );
             return null;
         }
@@ -89,7 +90,8 @@ export class AppService extends BaseManagedIdentitySource {
             );
 
         logger.info(
-            `[Managed Identity] Environment variables validation passed for ${ManagedIdentitySourceNames.APP_SERVICE} managed identity. Endpoint URI: ${validatedIdentityEndpoint}. Creating ${ManagedIdentitySourceNames.APP_SERVICE} managed identity.`
+            `[Managed Identity] Environment variables validation passed for ${ManagedIdentitySourceNames.APP_SERVICE} managed identity. Endpoint URI: ${validatedIdentityEndpoint}. Creating ${ManagedIdentitySourceNames.APP_SERVICE} managed identity.`,
+            ""
         );
 
         return new AppService(

--- a/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
@@ -136,7 +136,8 @@ export class AzureArc extends BaseManagedIdentitySource {
         // if either of the identity or imds endpoints are undefined (even after himds file detection)
         if (!identityEndpoint || !imdsEndpoint) {
             logger.info(
-                `[Managed Identity] ${ManagedIdentitySourceNames.AZURE_ARC} managed identity is unavailable through environment variables because one or both of '${ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT}' and '${ManagedIdentityEnvironmentVariableNames.IMDS_ENDPOINT}' are not defined. ${ManagedIdentitySourceNames.AZURE_ARC} managed identity is also unavailable through file detection.`
+                `[Managed Identity] ${ManagedIdentitySourceNames.AZURE_ARC} managed identity is unavailable through environment variables because one or both of '${ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT}' and '${ManagedIdentityEnvironmentVariableNames.IMDS_ENDPOINT}' are not defined. ${ManagedIdentitySourceNames.AZURE_ARC} managed identity is also unavailable through file detection.`,
+                ""
             );
 
             return null;
@@ -145,7 +146,8 @@ export class AzureArc extends BaseManagedIdentitySource {
         // check if the imds endpoint is set to the default for file detection
         if (imdsEndpoint === HIMDS_EXECUTABLE_HELPER_STRING) {
             logger.info(
-                `[Managed Identity] ${ManagedIdentitySourceNames.AZURE_ARC} managed identity is available through file detection. Defaulting to known ${ManagedIdentitySourceNames.AZURE_ARC} endpoint: ${DEFAULT_AZURE_ARC_IDENTITY_ENDPOINT}. Creating ${ManagedIdentitySourceNames.AZURE_ARC} managed identity.`
+                `[Managed Identity] ${ManagedIdentitySourceNames.AZURE_ARC} managed identity is available through file detection. Defaulting to known ${ManagedIdentitySourceNames.AZURE_ARC} endpoint: ${DEFAULT_AZURE_ARC_IDENTITY_ENDPOINT}. Creating ${ManagedIdentitySourceNames.AZURE_ARC} managed identity.`,
+                ""
             );
         } else {
             // otherwise, both the identity and imds endpoints are defined without file detection; validate them
@@ -170,7 +172,8 @@ export class AzureArc extends BaseManagedIdentitySource {
             );
 
             logger.info(
-                `[Managed Identity] Environment variables validation passed for ${ManagedIdentitySourceNames.AZURE_ARC} managed identity. Endpoint URI: ${validatedIdentityEndpoint}. Creating ${ManagedIdentitySourceNames.AZURE_ARC} managed identity.`
+                `[Managed Identity] Environment variables validation passed for ${ManagedIdentitySourceNames.AZURE_ARC} managed identity. Endpoint URI: ${validatedIdentityEndpoint}. Creating ${ManagedIdentitySourceNames.AZURE_ARC} managed identity.`,
+                ""
             );
         }
 
@@ -302,7 +305,8 @@ export class AzureArc extends BaseManagedIdentitySource {
             const authHeaderValue = `Basic ${secret}`;
 
             this.logger.info(
-                `[Managed Identity] Adding authorization header to the request.`
+                `[Managed Identity] Adding authorization header to the request.`,
+                ""
             );
             networkRequest.headers[
                 ManagedIdentityHeaders.AUTHORIZATION_HEADER_NAME

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -36,6 +36,7 @@ import {
 } from "../../error/ManagedIdentityError.js";
 import { isIso8601 } from "../../utils/TimeUtils.js";
 import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * Managed Identity User Assigned Id Query Parameter Names
@@ -151,7 +152,8 @@ export abstract class BaseManagedIdentitySource {
 
         if (managedIdentityRequest.revokedTokenSha256Hash) {
             this.logger.info(
-                `[Managed Identity] The following claims are present in the request: ${managedIdentityRequest.claims}`
+                `[Managed Identity] The following claims are present in the request: ${managedIdentityRequest.claims}`,
+                ""
             );
 
             networkRequest.queryParameters[
@@ -164,7 +166,8 @@ export abstract class BaseManagedIdentitySource {
                 managedIdentityRequest.clientCapabilities.toString();
 
             this.logger.info(
-                `[Managed Identity] The following client capabilities are present in the request: ${clientCapabilities}`
+                `[Managed Identity] The following client capabilities are present in the request: ${clientCapabilities}`,
+                ""
             );
 
             networkRequest.queryParameters[
@@ -227,6 +230,7 @@ export abstract class BaseManagedIdentitySource {
             this.nodeStorage,
             this.cryptoProvider,
             this.logger,
+            new StubPerformanceClient(),
             null,
             null
         );
@@ -241,6 +245,7 @@ export abstract class BaseManagedIdentitySource {
 
         responseHandler.validateTokenResponse(
             serverTokenResponse,
+            serverTokenResponse.correlation_id || "",
             refreshAccessToken
         );
 
@@ -263,7 +268,8 @@ export abstract class BaseManagedIdentitySource {
                 this.logger.info(
                     `[Managed Identity] [API version ${
                         usesApi2017 ? "2017+" : "2019+"
-                    }] Adding user assigned client id to the request.`
+                    }] Adding user assigned client id to the request.`,
+                    ""
                 );
                 // The Machine Learning source uses the 2017-09-01 API version, which uses "clientid" instead of "client_id"
                 return usesApi2017
@@ -272,7 +278,8 @@ export abstract class BaseManagedIdentitySource {
 
             case ManagedIdentityIdType.USER_ASSIGNED_RESOURCE_ID:
                 this.logger.info(
-                    "[Managed Identity] Adding user assigned resource id to the request."
+                    "[Managed Identity] Adding user assigned resource id to the request.",
+                    ""
                 );
                 return isImds
                     ? ManagedIdentityUserAssignedIdQueryParameterNames.MANAGED_IDENTITY_RESOURCE_ID_IMDS
@@ -280,7 +287,8 @@ export abstract class BaseManagedIdentitySource {
 
             case ManagedIdentityIdType.USER_ASSIGNED_OBJECT_ID:
                 this.logger.info(
-                    "[Managed Identity] Adding user assigned object id to the request."
+                    "[Managed Identity] Adding user assigned object id to the request.",
+                    ""
                 );
                 return ManagedIdentityUserAssignedIdQueryParameterNames.MANAGED_IDENTITY_OBJECT_ID;
             default:
@@ -300,7 +308,8 @@ export abstract class BaseManagedIdentitySource {
             return new UrlString(envVariable).urlString;
         } catch (error) {
             logger.info(
-                `[Managed Identity] ${sourceName} managed identity is unavailable because the '${envVariableStringName}' environment variable is malformed.`
+                `[Managed Identity] ${sourceName} managed identity is unavailable because the '${envVariableStringName}' environment variable is malformed.`,
+                ""
             );
 
             throw createManagedIdentityError(

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -18,6 +18,7 @@ import {
     AuthenticationResult,
     UrlString,
     Constants,
+    StubPerformanceClient,
 } from "@azure/msal-common/node";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import { ManagedIdentityRequestParameters } from "../../config/ManagedIdentityRequestParameters.js";
@@ -36,7 +37,6 @@ import {
 } from "../../error/ManagedIdentityError.js";
 import { isIso8601 } from "../../utils/TimeUtils.js";
 import { HttpClientWithRetries } from "../../network/HttpClientWithRetries.js";
-import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * Managed Identity User Assigned Id Query Parameter Names

--- a/lib/msal-node/src/client/ManagedIdentitySources/CloudShell.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/CloudShell.ts
@@ -67,7 +67,8 @@ export class CloudShell extends BaseManagedIdentitySource {
         // if the msi endpoint environment variable is undefined, this MSI provider is unavailable.
         if (!msiEndpoint) {
             logger.info(
-                `[Managed Identity] ${ManagedIdentitySourceNames.CLOUD_SHELL} managed identity is unavailable because the '${ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT} environment variable is not defined.`
+                `[Managed Identity] ${ManagedIdentitySourceNames.CLOUD_SHELL} managed identity is unavailable because the '${ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT} environment variable is not defined.`,
+                ""
             );
             return null;
         }
@@ -81,7 +82,8 @@ export class CloudShell extends BaseManagedIdentitySource {
             );
 
         logger.info(
-            `[Managed Identity] Environment variable validation passed for ${ManagedIdentitySourceNames.CLOUD_SHELL} managed identity. Endpoint URI: ${validatedMsiEndpoint}. Creating ${ManagedIdentitySourceNames.CLOUD_SHELL} managed identity.`
+            `[Managed Identity] Environment variable validation passed for ${ManagedIdentitySourceNames.CLOUD_SHELL} managed identity. Endpoint URI: ${validatedMsiEndpoint}. Creating ${ManagedIdentitySourceNames.CLOUD_SHELL} managed identity.`,
+            ""
         );
 
         if (

--- a/lib/msal-node/src/client/ManagedIdentitySources/Imds.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/Imds.ts
@@ -94,7 +94,8 @@ export class Imds extends BaseManagedIdentitySource {
                         ManagedIdentityEnvironmentVariableNames
                             .AZURE_POD_IDENTITY_AUTHORITY_HOST
                     ]
-                }`
+                }`,
+                ""
             );
             validatedIdentityEndpoint = Imds.getValidatedEnvVariableUrlString(
                 ManagedIdentityEnvironmentVariableNames.AZURE_POD_IDENTITY_AUTHORITY_HOST,
@@ -109,7 +110,8 @@ export class Imds extends BaseManagedIdentitySource {
             );
         } else {
             logger.info(
-                `[Managed Identity] Unable to find ${ManagedIdentityEnvironmentVariableNames.AZURE_POD_IDENTITY_AUTHORITY_HOST} environment variable for ${ManagedIdentitySourceNames.IMDS}, using the default endpoint.`
+                `[Managed Identity] Unable to find ${ManagedIdentityEnvironmentVariableNames.AZURE_POD_IDENTITY_AUTHORITY_HOST} environment variable for ${ManagedIdentitySourceNames.IMDS}, using the default endpoint.`,
+                ""
             );
             validatedIdentityEndpoint = DEFAULT_IMDS_ENDPOINT;
         }

--- a/lib/msal-node/src/client/ManagedIdentitySources/MachineLearning.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/MachineLearning.ts
@@ -72,7 +72,8 @@ export class MachineLearning extends BaseManagedIdentitySource {
         // if either of the MSI endpoint or MSI secret variables are undefined, this MSI provider is unavailable.
         if (!msiEndpoint || !secret) {
             logger.info(
-                `[Managed Identity] ${ManagedIdentitySourceNames.MACHINE_LEARNING} managed identity is unavailable because one or both of the '${ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT}' and '${ManagedIdentityEnvironmentVariableNames.MSI_SECRET}' environment variables are not defined.`
+                `[Managed Identity] ${ManagedIdentitySourceNames.MACHINE_LEARNING} managed identity is unavailable because one or both of the '${ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT}' and '${ManagedIdentityEnvironmentVariableNames.MSI_SECRET}' environment variables are not defined.`,
+                ""
             );
             return null;
         }
@@ -86,7 +87,8 @@ export class MachineLearning extends BaseManagedIdentitySource {
             );
 
         logger.info(
-            `[Managed Identity] Environment variables validation passed for ${ManagedIdentitySourceNames.MACHINE_LEARNING} managed identity. Endpoint URI: ${validatedMsiEndpoint}. Creating ${ManagedIdentitySourceNames.MACHINE_LEARNING} managed identity.`
+            `[Managed Identity] Environment variables validation passed for ${ManagedIdentitySourceNames.MACHINE_LEARNING} managed identity. Endpoint URI: ${validatedMsiEndpoint}. Creating ${ManagedIdentitySourceNames.MACHINE_LEARNING} managed identity.`,
+            ""
         );
 
         return new MachineLearning(

--- a/lib/msal-node/src/client/ManagedIdentitySources/ServiceFabric.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/ServiceFabric.ts
@@ -103,7 +103,8 @@ export class ServiceFabric extends BaseManagedIdentitySource {
 
         if (!identityEndpoint || !identityHeader || !identityServerThumbprint) {
             logger.info(
-                `[Managed Identity] ${ManagedIdentitySourceNames.SERVICE_FABRIC} managed identity is unavailable because one or all of the '${ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER}', '${ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT}' or '${ManagedIdentityEnvironmentVariableNames.IDENTITY_SERVER_THUMBPRINT}' environment variables are not defined.`
+                `[Managed Identity] ${ManagedIdentitySourceNames.SERVICE_FABRIC} managed identity is unavailable because one or all of the '${ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER}', '${ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT}' or '${ManagedIdentityEnvironmentVariableNames.IDENTITY_SERVER_THUMBPRINT}' environment variables are not defined.`,
+                ""
             );
             return null;
         }
@@ -117,14 +118,16 @@ export class ServiceFabric extends BaseManagedIdentitySource {
             );
 
         logger.info(
-            `[Managed Identity] Environment variables validation passed for ${ManagedIdentitySourceNames.SERVICE_FABRIC} managed identity. Endpoint URI: ${validatedIdentityEndpoint}. Creating ${ManagedIdentitySourceNames.SERVICE_FABRIC} managed identity.`
+            `[Managed Identity] Environment variables validation passed for ${ManagedIdentitySourceNames.SERVICE_FABRIC} managed identity. Endpoint URI: ${validatedIdentityEndpoint}. Creating ${ManagedIdentitySourceNames.SERVICE_FABRIC} managed identity.`,
+            ""
         );
 
         if (
             managedIdentityId.idType !== ManagedIdentityIdType.SYSTEM_ASSIGNED
         ) {
             logger.warning(
-                `[Managed Identity] ${ManagedIdentitySourceNames.SERVICE_FABRIC} user assigned managed identity is configured in the cluster, not during runtime. See also: https://learn.microsoft.com/en-us/azure/service-fabric/configure-existing-cluster-enable-managed-identity-token-service.`
+                `[Managed Identity] ${ManagedIdentitySourceNames.SERVICE_FABRIC} user assigned managed identity is configured in the cluster, not during runtime. See also: https://learn.microsoft.com/en-us/azure/service-fabric/configure-existing-cluster-enable-managed-identity-token-service.`,
+                ""
             );
         }
 

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -28,10 +28,10 @@ import {
     ClientAssertion,
     getClientAssertion,
     UrlUtils,
+    StubPerformanceClient,
 } from "@azure/msal-common/node";
 import { EncodingUtils } from "../utils/EncodingUtils.js";
 import { CommonOnBehalfOfRequest } from "../request/CommonOnBehalfOfRequest.js";
-import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * On-Behalf-Of client

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -31,6 +31,7 @@ import {
 } from "@azure/msal-common/node";
 import { EncodingUtils } from "../utils/EncodingUtils.js";
 import { CommonOnBehalfOfRequest } from "../request/CommonOnBehalfOfRequest.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * On-Behalf-Of client
@@ -41,7 +42,7 @@ export class OnBehalfOfClient extends BaseClient {
     private userAssertionHash: string;
 
     constructor(configuration: ClientConfiguration) {
-        super(configuration);
+        super(configuration, new StubPerformanceClient());
     }
 
     /**
@@ -100,7 +101,8 @@ export class OnBehalfOfClient extends BaseClient {
                 Constants.CacheOutcome.NO_CACHED_ACCESS_TOKEN
             );
             this.logger.info(
-                "SilentFlowClient:acquireCachedToken - No access token found in cache for the given properties."
+                "SilentFlowClient:acquireCachedToken - No access token found in cache for the given properties.",
+                request.correlationId
             );
             throw createClientAuthError(
                 ClientAuthErrorCodes.tokenRefreshRequired
@@ -116,7 +118,8 @@ export class OnBehalfOfClient extends BaseClient {
                 Constants.CacheOutcome.CACHED_ACCESS_TOKEN_EXPIRED
             );
             this.logger.info(
-                `OnbehalfofFlow:getCachedAuthenticationResult - Cached access token is expired or will expire within ${this.config.systemOptions.tokenRenewalOffsetSeconds} seconds.`
+                `OnbehalfofFlow:getCachedAuthenticationResult - Cached access token is expired or will expire within ${this.config.systemOptions.tokenRenewalOffsetSeconds} seconds.`,
+                request.correlationId
             );
             throw createClientAuthError(
                 ClientAuthErrorCodes.tokenRefreshRequired
@@ -167,6 +170,7 @@ export class OnBehalfOfClient extends BaseClient {
             },
             true,
             request,
+            this.performanceClient,
             idTokenClaims
         );
     }
@@ -292,11 +296,15 @@ export class OnBehalfOfClient extends BaseClient {
             this.cacheManager,
             this.cryptoUtils,
             this.logger,
+            this.performanceClient,
             this.config.serializableCache,
             this.config.persistencePlugin
         );
 
-        responseHandler.validateTokenResponse(response.body);
+        responseHandler.validateTokenResponse(
+            response.body,
+            request.correlationId
+        );
         const tokenResponse = await responseHandler.handleServerTokenResponse(
             response.body,
             this.authority,

--- a/lib/msal-node/src/client/PublicClientApplication.ts
+++ b/lib/msal-node/src/client/PublicClientApplication.ts
@@ -75,7 +75,8 @@ export class PublicClientApplication
                 );
             } else {
                 this.logger.warning(
-                    "NativeBroker implementation was provided but the broker is unavailable."
+                    "NativeBroker implementation was provided but the broker is unavailable.",
+                    ""
                 );
             }
         }
@@ -99,7 +100,7 @@ export class PublicClientApplication
     ): Promise<AuthenticationResult | null> {
         this.logger.info(
             "acquireTokenByDeviceCode called",
-            request.correlationId
+            request.correlationId || ""
         );
         const validRequest: CommonDeviceCodeRequest = Object.assign(
             request,

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -23,6 +23,7 @@ import {
     getClientAssertion,
 } from "@azure/msal-common/node";
 import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePasswordRequest.js";
+import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * Oauth2.0 Password grant client
@@ -32,7 +33,7 @@ import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePassword
  */
 export class UsernamePasswordClient extends BaseClient {
     constructor(configuration: ClientConfiguration) {
-        super(configuration);
+        super(configuration, new StubPerformanceClient());
     }
 
     /**
@@ -43,7 +44,10 @@ export class UsernamePasswordClient extends BaseClient {
     async acquireToken(
         request: CommonUsernamePasswordRequest
     ): Promise<AuthenticationResult | null> {
-        this.logger.info("in acquireToken call in username-password client");
+        this.logger.info(
+            "in acquireToken call in username-password client",
+            request.correlationId
+        );
 
         const reqTimestamp = TimeUtils.nowSeconds();
         const response = await this.executeTokenRequest(
@@ -56,12 +60,16 @@ export class UsernamePasswordClient extends BaseClient {
             this.cacheManager,
             this.cryptoUtils,
             this.logger,
+            this.performanceClient,
             this.config.serializableCache,
             this.config.persistencePlugin
         );
 
         // Validate response. This function throws a server error if an error is returned by the server.
-        responseHandler.validateTokenResponse(response.body);
+        responseHandler.validateTokenResponse(
+            response.body,
+            request.correlationId
+        );
         const tokenResponse = responseHandler.handleServerTokenResponse(
             response.body,
             this.authority,

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -21,9 +21,9 @@ import {
     UrlString,
     UrlUtils,
     getClientAssertion,
+    StubPerformanceClient,
 } from "@azure/msal-common/node";
 import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePasswordRequest.js";
-import { StubPerformanceClient } from "@azure/msal-common";
 
 /**
  * Oauth2.0 Password grant client

--- a/lib/msal-node/src/request/CommonClientCredentialRequest.ts
+++ b/lib/msal-node/src/request/CommonClientCredentialRequest.ts
@@ -7,7 +7,7 @@ import {
     BaseAuthRequest,
     AzureRegion,
     ClientAssertion,
-} from "@azure/msal-common";
+} from "@azure/msal-common/node";
 
 /**
  * CommonClientCredentialRequest

--- a/lib/msal-node/src/request/CommonDeviceCodeRequest.ts
+++ b/lib/msal-node/src/request/CommonDeviceCodeRequest.ts
@@ -7,7 +7,7 @@ import {
     DeviceCodeResponse,
     StringDict,
     BaseAuthRequest,
-} from "@azure/msal-common";
+} from "@azure/msal-common/node";
 
 /**
  * Parameters for Oauth2 device code flow.

--- a/lib/msal-node/src/request/CommonOnBehalfOfRequest.ts
+++ b/lib/msal-node/src/request/CommonOnBehalfOfRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BaseAuthRequest } from "@azure/msal-common";
+import { BaseAuthRequest } from "@azure/msal-common/node";
 
 /**
  * - scopes                  - Array of scopes the application is requesting access to.

--- a/lib/msal-node/src/request/CommonUsernamePasswordRequest.ts
+++ b/lib/msal-node/src/request/CommonUsernamePasswordRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BaseAuthRequest } from "@azure/msal-common";
+import { BaseAuthRequest } from "@azure/msal-common/node";
 
 /**
  * CommonUsernamePassword parameters passed by the user to retrieve credentials

--- a/lib/msal-node/src/retry/DefaultManagedIdentityRetryPolicy.ts
+++ b/lib/msal-node/src/retry/DefaultManagedIdentityRetryPolicy.ts
@@ -52,7 +52,8 @@ export class DefaultManagedIdentityRetryPolicy implements IHttpRetryPolicy {
             logger.verbose(
                 `Retrying request in ${retryAfterDelay}ms (retry attempt: ${
                     currentRetry + 1
-                })`
+                })`,
+                ""
             );
 
             // pause execution for the calculated delay

--- a/lib/msal-node/src/retry/DefaultManagedIdentityRetryPolicy.ts
+++ b/lib/msal-node/src/retry/DefaultManagedIdentityRetryPolicy.ts
@@ -4,7 +4,7 @@
  */
 
 import { IncomingHttpHeaders } from "http";
-import { Constants, Logger } from "@azure/msal-common";
+import { Constants, Logger } from "@azure/msal-common/node";
 import { IHttpRetryPolicy } from "./IHttpRetryPolicy.js";
 import { LinearRetryStrategy } from "./LinearRetryStrategy.js";
 

--- a/lib/msal-node/src/retry/IHttpRetryPolicy.ts
+++ b/lib/msal-node/src/retry/IHttpRetryPolicy.ts
@@ -4,7 +4,7 @@
  */
 
 import { IncomingHttpHeaders } from "http";
-import { Logger } from "@azure/msal-common";
+import { Logger } from "@azure/msal-common/node";
 
 export interface IHttpRetryPolicy {
     _isNewRequest?: boolean;

--- a/lib/msal-node/src/retry/ImdsRetryPolicy.ts
+++ b/lib/msal-node/src/retry/ImdsRetryPolicy.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Constants, Logger } from "@azure/msal-common";
+import { Constants, Logger } from "@azure/msal-common/node";
 import { ExponentialRetryStrategy } from "./ExponentialRetryStrategy.js";
 import { IHttpRetryPolicy } from "./IHttpRetryPolicy.js";
 

--- a/lib/msal-node/src/retry/ImdsRetryPolicy.ts
+++ b/lib/msal-node/src/retry/ImdsRetryPolicy.ts
@@ -104,7 +104,8 @@ export class ImdsRetryPolicy implements IHttpRetryPolicy {
             logger.verbose(
                 `Retrying request in ${retryAfterDelay}ms (retry attempt: ${
                     currentRetry + 1
-                })`
+                })`,
+                ""
             );
 
             // pause execution for the calculated delay

--- a/lib/msal-node/test/client/ClientTestUtils.ts
+++ b/lib/msal-node/test/client/ClientTestUtils.ts
@@ -326,7 +326,8 @@ export class ClientTestUtils {
             mockStorage,
             authorityOptions,
             logger,
-            TEST_CONFIG.CORRELATION_ID
+            TEST_CONFIG.CORRELATION_ID,
+            new StubPerformanceClient()
         );
 
         await authority.resolveEndpointsAsync().catch(() => {

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -161,7 +161,11 @@ describe("PublicClientApplication", () => {
             getMsalCommonAutoMock().AuthorizationCodeClient;
 
         jest.spyOn(msalCommon, "AuthorizationCodeClient").mockImplementation(
-            (config) => new MockAuthorizationCodeClient(config)
+            (config) =>
+                new MockAuthorizationCodeClient(
+                    config,
+                    new StubPerformanceClient()
+                )
         );
 
         const authApp = new PublicClientApplication(appConfig);
@@ -187,7 +191,11 @@ describe("PublicClientApplication", () => {
             getMsalCommonAutoMock().AuthorizationCodeClient;
 
         jest.spyOn(msalCommon, "AuthorizationCodeClient").mockImplementation(
-            (config) => new MockAuthorizationCodeClient(config)
+            (config) =>
+                new MockAuthorizationCodeClient(
+                    config,
+                    new StubPerformanceClient()
+                )
         );
 
         const authApp = new PublicClientApplication(appConfig);
@@ -214,7 +222,11 @@ describe("PublicClientApplication", () => {
             getMsalCommonAutoMock().AuthorizationCodeClient;
 
         jest.spyOn(msalCommon, "AuthorizationCodeClient").mockImplementation(
-            (config) => new MockAuthorizationCodeClient(config)
+            (config) =>
+                new MockAuthorizationCodeClient(
+                    config,
+                    new StubPerformanceClient()
+                )
         );
 
         const authApp = new PublicClientApplication(appConfig);
@@ -232,7 +244,8 @@ describe("PublicClientApplication", () => {
         const mockRefreshTokenClient =
             getMsalCommonAutoMock().RefreshTokenClient;
         jest.spyOn(msalCommon, "RefreshTokenClient").mockImplementation(
-            (config) => new mockRefreshTokenClient(config)
+            (config) =>
+                new mockRefreshTokenClient(config, new StubPerformanceClient())
         );
 
         const authApp = new PublicClientApplication(appConfig);
@@ -300,7 +313,8 @@ describe("PublicClientApplication", () => {
 
             const silentFlowClient = getMsalCommonAutoMock().SilentFlowClient;
             jest.spyOn(msalCommon, "SilentFlowClient").mockImplementation(
-                (config) => new silentFlowClient(config)
+                (config) =>
+                    new silentFlowClient(config, new StubPerformanceClient())
             );
             jest.spyOn(
                 silentFlowClient.prototype,
@@ -420,7 +434,8 @@ describe("PublicClientApplication", () => {
 
             const silentFlowClient = getMsalCommonAutoMock().SilentFlowClient;
             jest.spyOn(msalCommon, "SilentFlowClient").mockImplementation(
-                (config) => new silentFlowClient(config)
+                (config) =>
+                    new silentFlowClient(config, new StubPerformanceClient())
             );
 
             let acquireCachedTokenSpy = jest
@@ -644,7 +659,11 @@ describe("PublicClientApplication", () => {
                 msalCommon,
                 "AuthorizationCodeClient"
             ).mockImplementation(
-                (config) => new MockAuthorizationCodeClient(config)
+                (config) =>
+                    new MockAuthorizationCodeClient(
+                        config,
+                        new StubPerformanceClient()
+                    )
             );
 
             jest.spyOn(
@@ -716,7 +735,11 @@ describe("PublicClientApplication", () => {
                 msalCommon,
                 "AuthorizationCodeClient"
             ).mockImplementation(
-                (config) => new MockAuthorizationCodeClient(config)
+                (config) =>
+                    new MockAuthorizationCodeClient(
+                        config,
+                        new StubPerformanceClient()
+                    )
             );
 
             jest.spyOn(
@@ -790,7 +813,11 @@ describe("PublicClientApplication", () => {
                 msalCommon,
                 "AuthorizationCodeClient"
             ).mockImplementation(
-                (config) => new MockAuthorizationCodeClient(config)
+                (config) =>
+                    new MockAuthorizationCodeClient(
+                        config,
+                        new StubPerformanceClient()
+                    )
             );
 
             jest.spyOn(
@@ -941,7 +968,11 @@ describe("PublicClientApplication", () => {
                 msalCommon,
                 "AuthorizationCodeClient"
             ).mockImplementation(
-                (config) => new MockAuthorizationCodeClient(config)
+                (config) =>
+                    new MockAuthorizationCodeClient(
+                        config,
+                        new StubPerformanceClient()
+                    )
             );
 
             jest.spyOn(
@@ -1006,7 +1037,11 @@ describe("PublicClientApplication", () => {
                 msalCommon,
                 "AuthorizationCodeClient"
             ).mockImplementation(
-                (config) => new MockAuthorizationCodeClient(config)
+                (config) =>
+                    new MockAuthorizationCodeClient(
+                        config,
+                        new StubPerformanceClient()
+                    )
             );
 
             jest.spyOn(
@@ -1057,7 +1092,8 @@ describe("PublicClientApplication", () => {
                             authorityMetadata: "",
                         },
                         new Logger({}),
-                        TEST_CONFIG.CORRELATION_ID
+                        TEST_CONFIG.CORRELATION_ID,
+                        new StubPerformanceClient()
                     )
                 );
 
@@ -1260,7 +1296,10 @@ describe("PublicClientApplication", () => {
                 expect(config.authOptions.authority.canonicalAuthority).toEqual(
                     TEST_CONSTANTS.DEFAULT_AUTHORITY
                 );
-                return new mockRefreshTokenClient(config);
+                return new mockRefreshTokenClient(
+                    config,
+                    new StubPerformanceClient()
+                );
             }
         );
 
@@ -1284,7 +1323,10 @@ describe("PublicClientApplication", () => {
                 expect(config.authOptions.authority.canonicalAuthority).toEqual(
                     TEST_CONSTANTS.ALTERNATE_AUTHORITY
                 );
-                return new mockRefreshTokenClient(config);
+                return new mockRefreshTokenClient(
+                    config,
+                    new StubPerformanceClient()
+                );
             }
         );
 
@@ -1318,7 +1360,10 @@ describe("PublicClientApplication", () => {
                 expect(config.authOptions.authority.canonicalAuthority).toEqual(
                     TEST_CONSTANTS.USGOV_AUTHORITY
                 );
-                return new mockRefreshTokenClient(config);
+                return new mockRefreshTokenClient(
+                    config,
+                    new StubPerformanceClient()
+                );
             }
         );
 
@@ -1353,7 +1398,10 @@ describe("PublicClientApplication", () => {
                 expect(config.authOptions.authority.canonicalAuthority).toEqual(
                     TEST_CONSTANTS.USGOV_AUTHORITY
                 );
-                return new mockRefreshTokenClient(config);
+                return new mockRefreshTokenClient(
+                    config,
+                    new StubPerformanceClient()
+                );
             }
         );
 
@@ -1383,14 +1431,14 @@ describe("PublicClientApplication", () => {
 
         expect(authApp.getLogger()).toEqual(logger);
 
-        authApp.getLogger().info("Message");
+        authApp.getLogger().info("Message", "");
     });
 
     test("logger undefined", async () => {
         const authApp = new PublicClientApplication(testAppConfig);
 
         expect(authApp.getLogger()).toBeDefined();
-        expect(authApp.getLogger().info("Test logger")).toEqual(undefined);
+        expect(authApp.getLogger().info("Test logger", "")).toEqual(undefined);
     });
 
     test("should throw an error if state is not provided", async () => {
@@ -1413,7 +1461,11 @@ describe("PublicClientApplication", () => {
             getMsalCommonAutoMock().AuthorizationCodeClient;
 
         jest.spyOn(msalCommon, "AuthorizationCodeClient").mockImplementation(
-            (config) => new MockAuthorizationCodeClient(config)
+            (config) =>
+                new MockAuthorizationCodeClient(
+                    config,
+                    new StubPerformanceClient()
+                )
         );
 
         const mockInfo = jest.fn();
@@ -1461,7 +1513,11 @@ describe("PublicClientApplication", () => {
             getMsalCommonAutoMock().AuthorizationCodeClient;
 
         jest.spyOn(msalCommon, "AuthorizationCodeClient").mockImplementation(
-            (config) => new MockAuthorizationCodeClient(config)
+            (config) =>
+                new MockAuthorizationCodeClient(
+                    config,
+                    new StubPerformanceClient()
+                )
         );
 
         const mockInfo = jest.fn();

--- a/lib/msal-react/src/MsalProvider.tsx
+++ b/lib/msal-react/src/MsalProvider.tsx
@@ -64,7 +64,8 @@ const reducer = (
             if (previousState.inProgress === InteractionStatus.Startup) {
                 newInProgress = InteractionStatus.None;
                 payload.logger.info(
-                    "MsalProvider - handleRedirectPromise resolved, setting inProgress to 'none'", ""
+                    "MsalProvider - handleRedirectPromise resolved, setting inProgress to 'none'",
+                    ""
                 );
             }
             break;
@@ -76,7 +77,8 @@ const reducer = (
             );
             if (status) {
                 payload.logger.info(
-                    `MsalProvider - '${message.eventType}' results in setting inProgress from '${previousState.inProgress}' to '${status}'`, ""
+                    `MsalProvider - '${message.eventType}' results in setting inProgress from '${previousState.inProgress}' to '${status}'`,
+                    ""
                 );
                 newInProgress = status;
             }
@@ -158,7 +160,8 @@ export function MsalProvider({
             }
         );
         logger.verbose(
-            `MsalProvider - Registered event callback with id: '${callbackId}'`, ""
+            `MsalProvider - Registered event callback with id: '${callbackId}'`,
+            ""
         );
 
         instance
@@ -193,7 +196,8 @@ export function MsalProvider({
             // Remove callback when component unmounts or accounts change
             if (callbackId) {
                 logger.verbose(
-                    `MsalProvider - Removing event callback '${callbackId}'`, ""
+                    `MsalProvider - Removing event callback '${callbackId}'`,
+                    ""
                 );
                 instance.removeEventCallback(callbackId);
             }

--- a/lib/msal-react/src/MsalProvider.tsx
+++ b/lib/msal-react/src/MsalProvider.tsx
@@ -64,7 +64,7 @@ const reducer = (
             if (previousState.inProgress === InteractionStatus.Startup) {
                 newInProgress = InteractionStatus.None;
                 payload.logger.info(
-                    "MsalProvider - handleRedirectPromise resolved, setting inProgress to 'none'"
+                    "MsalProvider - handleRedirectPromise resolved, setting inProgress to 'none'", ""
                 );
             }
             break;
@@ -76,7 +76,7 @@ const reducer = (
             );
             if (status) {
                 payload.logger.info(
-                    `MsalProvider - '${message.eventType}' results in setting inProgress from '${previousState.inProgress}' to '${status}'`
+                    `MsalProvider - '${message.eventType}' results in setting inProgress from '${previousState.inProgress}' to '${status}'`, ""
                 );
                 newInProgress = status;
             }
@@ -158,7 +158,7 @@ export function MsalProvider({
             }
         );
         logger.verbose(
-            `MsalProvider - Registered event callback with id: '${callbackId}'`
+            `MsalProvider - Registered event callback with id: '${callbackId}'`, ""
         );
 
         instance
@@ -193,7 +193,7 @@ export function MsalProvider({
             // Remove callback when component unmounts or accounts change
             if (callbackId) {
                 logger.verbose(
-                    `MsalProvider - Removing event callback '${callbackId}'`
+                    `MsalProvider - Removing event callback '${callbackId}'`, ""
                 );
                 instance.removeEventCallback(callbackId);
             }

--- a/lib/msal-react/src/hooks/useAccount.ts
+++ b/lib/msal-react/src/hooks/useAccount.ts
@@ -62,7 +62,7 @@ export function useAccount(
                         true
                     )
                 ) {
-                    logger.info("useAccount - Updating account");
+                    logger.info("useAccount - Updating account", "");
                     return nextAccount;
                 }
 

--- a/lib/msal-react/src/hooks/useMsalAuthentication.ts
+++ b/lib/msal-react/src/hooks/useMsalAuthentication.ts
@@ -17,6 +17,7 @@ import {
     SilentRequest,
     InteractionRequiredAuthError,
     OIDC_DEFAULT_SCOPES,
+    BrowserUtils
 } from "@azure/msal-browser";
 import { useIsAuthenticated } from "./useIsAuthenticated.js";
 import { AccountIdentifiers } from "../types/AccountIdentifiers.js";
@@ -98,19 +99,19 @@ export function useMsalAuthentication(
             switch (loginType) {
                 case InteractionType.Popup:
                     logger.verbose(
-                        "useMsalAuthentication - Calling loginPopup"
+                        "useMsalAuthentication - Calling loginPopup", callbackRequest?.correlationId || ""
                     );
                     return instance.loginPopup(loginRequest as PopupRequest);
                 case InteractionType.Redirect:
                     // This promise is not expected to resolve due to full frame redirect
                     logger.verbose(
-                        "useMsalAuthentication - Calling loginRedirect"
+                        "useMsalAuthentication - Calling loginRedirect", callbackRequest?.correlationId || ""
                     );
                     return instance
                         .loginRedirect(loginRequest as RedirectRequest)
                         .then(null);
                 case InteractionType.Silent:
-                    logger.verbose("useMsalAuthentication - Calling ssoSilent");
+                    logger.verbose("useMsalAuthentication - Calling ssoSilent", callbackRequest?.correlationId || "");
                     return instance.ssoSilent(loginRequest as SsoSilentRequest);
                 default:
                     throw ReactAuthError.createInvalidInteractionTypeError();
@@ -131,14 +132,14 @@ export function useMsalAuthentication(
 
             if (callbackRequest) {
                 logger.trace(
-                    "useMsalAuthentication - acquireToken - Using request provided in the callback"
+                    "useMsalAuthentication - acquireToken - Using request provided in the callback", callbackRequest.correlationId || ""
                 );
                 tokenRequest = {
                     ...callbackRequest,
                 };
             } else if (authenticationRequest) {
                 logger.trace(
-                    "useMsalAuthentication - acquireToken - Using request provided in the hook"
+                    "useMsalAuthentication - acquireToken - Using request provided in the hook", authenticationRequest.correlationId || ""
                 );
                 tokenRequest = {
                     ...authenticationRequest,
@@ -146,23 +147,26 @@ export function useMsalAuthentication(
                 };
             } else {
                 logger.trace(
-                    "useMsalAuthentication - acquireToken - No request object provided, using default request."
+                    "useMsalAuthentication - acquireToken - No request object provided, using default request.", ""
                 );
                 tokenRequest = {
                     scopes: OIDC_DEFAULT_SCOPES,
                 };
             }
 
+            const correlationId = tokenRequest.correlationId || BrowserUtils.createGuid();
+            tokenRequest.correlationId = correlationId;
+
             if (!tokenRequest.account && account) {
                 logger.trace(
-                    "useMsalAuthentication - acquireToken - Attaching account to request"
+                    "useMsalAuthentication - acquireToken - Attaching account to request", correlationId
                 );
                 tokenRequest.account = account;
             }
 
             const getToken = async (): Promise<AuthenticationResult | null> => {
                 logger.verbose(
-                    "useMsalAuthentication - Calling acquireTokenSilent"
+                    "useMsalAuthentication - Calling acquireTokenSilent", correlationId
                 );
                 return instance
                     .acquireTokenSilent(tokenRequest)
@@ -170,7 +174,7 @@ export function useMsalAuthentication(
                         if (e instanceof InteractionRequiredAuthError) {
                             if (!interactionInProgress.current) {
                                 logger.error(
-                                    "useMsalAuthentication - Interaction required, falling back to interaction"
+                                    "useMsalAuthentication - Interaction required, falling back to interaction", correlationId
                                 );
                                 return login(
                                     fallbackInteractionType,
@@ -178,7 +182,7 @@ export function useMsalAuthentication(
                                 );
                             } else {
                                 logger.error(
-                                    "useMsalAuthentication - Interaction required but is already in progress. Please try again, if needed, after interaction completes."
+                                    "useMsalAuthentication - Interaction required but is already in progress. Please try again, if needed, after interaction completes.", correlationId
                                 );
                                 throw ReactAuthError.createUnableToFallbackToInteractionError();
                             }
@@ -235,13 +239,13 @@ export function useMsalAuthentication(
             }
         );
         logger.verbose(
-            `useMsalAuthentication - Registered event callback with id: '${callbackId}'`
+            `useMsalAuthentication - Registered event callback with id: '${callbackId}'`, ""
         );
 
         return () => {
             if (callbackId) {
                 logger.verbose(
-                    `useMsalAuthentication - Removing event callback '${callbackId}'`
+                    `useMsalAuthentication - Removing event callback '${callbackId}'`, ""
                 );
                 instance.removeEventCallback(callbackId);
             }
@@ -256,7 +260,7 @@ export function useMsalAuthentication(
             if (!isAuthenticated) {
                 shouldAcquireToken.current = false;
                 logger.info(
-                    "useMsalAuthentication - No user is authenticated, attempting to login"
+                    "useMsalAuthentication - No user is authenticated, attempting to login", ""
                 );
                 login().catch(() => {
                     // Errors are saved in state above
@@ -265,7 +269,7 @@ export function useMsalAuthentication(
             } else if (account) {
                 shouldAcquireToken.current = false;
                 logger.info(
-                    "useMsalAuthentication - User is authenticated, attempting to acquire token"
+                    "useMsalAuthentication - User is authenticated, attempting to acquire token", ""
                 );
                 acquireToken().catch(() => {
                     // Errors are saved in state above

--- a/lib/msal-react/src/hooks/useMsalAuthentication.ts
+++ b/lib/msal-react/src/hooks/useMsalAuthentication.ts
@@ -17,7 +17,7 @@ import {
     SilentRequest,
     InteractionRequiredAuthError,
     OIDC_DEFAULT_SCOPES,
-    BrowserUtils
+    BrowserUtils,
 } from "@azure/msal-browser";
 import { useIsAuthenticated } from "./useIsAuthenticated.js";
 import { AccountIdentifiers } from "../types/AccountIdentifiers.js";
@@ -99,19 +99,24 @@ export function useMsalAuthentication(
             switch (loginType) {
                 case InteractionType.Popup:
                     logger.verbose(
-                        "useMsalAuthentication - Calling loginPopup", callbackRequest?.correlationId || ""
+                        "useMsalAuthentication - Calling loginPopup",
+                        callbackRequest?.correlationId || ""
                     );
                     return instance.loginPopup(loginRequest as PopupRequest);
                 case InteractionType.Redirect:
                     // This promise is not expected to resolve due to full frame redirect
                     logger.verbose(
-                        "useMsalAuthentication - Calling loginRedirect", callbackRequest?.correlationId || ""
+                        "useMsalAuthentication - Calling loginRedirect",
+                        callbackRequest?.correlationId || ""
                     );
                     return instance
                         .loginRedirect(loginRequest as RedirectRequest)
                         .then(null);
                 case InteractionType.Silent:
-                    logger.verbose("useMsalAuthentication - Calling ssoSilent", callbackRequest?.correlationId || "");
+                    logger.verbose(
+                        "useMsalAuthentication - Calling ssoSilent",
+                        callbackRequest?.correlationId || ""
+                    );
                     return instance.ssoSilent(loginRequest as SsoSilentRequest);
                 default:
                     throw ReactAuthError.createInvalidInteractionTypeError();
@@ -132,14 +137,16 @@ export function useMsalAuthentication(
 
             if (callbackRequest) {
                 logger.trace(
-                    "useMsalAuthentication - acquireToken - Using request provided in the callback", callbackRequest.correlationId || ""
+                    "useMsalAuthentication - acquireToken - Using request provided in the callback",
+                    callbackRequest.correlationId || ""
                 );
                 tokenRequest = {
                     ...callbackRequest,
                 };
             } else if (authenticationRequest) {
                 logger.trace(
-                    "useMsalAuthentication - acquireToken - Using request provided in the hook", authenticationRequest.correlationId || ""
+                    "useMsalAuthentication - acquireToken - Using request provided in the hook",
+                    authenticationRequest.correlationId || ""
                 );
                 tokenRequest = {
                     ...authenticationRequest,
@@ -147,26 +154,30 @@ export function useMsalAuthentication(
                 };
             } else {
                 logger.trace(
-                    "useMsalAuthentication - acquireToken - No request object provided, using default request.", ""
+                    "useMsalAuthentication - acquireToken - No request object provided, using default request.",
+                    ""
                 );
                 tokenRequest = {
                     scopes: OIDC_DEFAULT_SCOPES,
                 };
             }
 
-            const correlationId = tokenRequest.correlationId || BrowserUtils.createGuid();
+            const correlationId =
+                tokenRequest.correlationId || BrowserUtils.createGuid();
             tokenRequest.correlationId = correlationId;
 
             if (!tokenRequest.account && account) {
                 logger.trace(
-                    "useMsalAuthentication - acquireToken - Attaching account to request", correlationId
+                    "useMsalAuthentication - acquireToken - Attaching account to request",
+                    correlationId
                 );
                 tokenRequest.account = account;
             }
 
             const getToken = async (): Promise<AuthenticationResult | null> => {
                 logger.verbose(
-                    "useMsalAuthentication - Calling acquireTokenSilent", correlationId
+                    "useMsalAuthentication - Calling acquireTokenSilent",
+                    correlationId
                 );
                 return instance
                     .acquireTokenSilent(tokenRequest)
@@ -174,7 +185,8 @@ export function useMsalAuthentication(
                         if (e instanceof InteractionRequiredAuthError) {
                             if (!interactionInProgress.current) {
                                 logger.error(
-                                    "useMsalAuthentication - Interaction required, falling back to interaction", correlationId
+                                    "useMsalAuthentication - Interaction required, falling back to interaction",
+                                    correlationId
                                 );
                                 return login(
                                     fallbackInteractionType,
@@ -182,7 +194,8 @@ export function useMsalAuthentication(
                                 );
                             } else {
                                 logger.error(
-                                    "useMsalAuthentication - Interaction required but is already in progress. Please try again, if needed, after interaction completes.", correlationId
+                                    "useMsalAuthentication - Interaction required but is already in progress. Please try again, if needed, after interaction completes.",
+                                    correlationId
                                 );
                                 throw ReactAuthError.createUnableToFallbackToInteractionError();
                             }
@@ -239,13 +252,15 @@ export function useMsalAuthentication(
             }
         );
         logger.verbose(
-            `useMsalAuthentication - Registered event callback with id: '${callbackId}'`, ""
+            `useMsalAuthentication - Registered event callback with id: '${callbackId}'`,
+            ""
         );
 
         return () => {
             if (callbackId) {
                 logger.verbose(
-                    `useMsalAuthentication - Removing event callback '${callbackId}'`, ""
+                    `useMsalAuthentication - Removing event callback '${callbackId}'`,
+                    ""
                 );
                 instance.removeEventCallback(callbackId);
             }
@@ -260,7 +275,8 @@ export function useMsalAuthentication(
             if (!isAuthenticated) {
                 shouldAcquireToken.current = false;
                 logger.info(
-                    "useMsalAuthentication - No user is authenticated, attempting to login", ""
+                    "useMsalAuthentication - No user is authenticated, attempting to login",
+                    ""
                 );
                 login().catch(() => {
                     // Errors are saved in state above
@@ -269,7 +285,8 @@ export function useMsalAuthentication(
             } else if (account) {
                 shouldAcquireToken.current = false;
                 logger.info(
-                    "useMsalAuthentication - User is authenticated, attempting to acquire token", ""
+                    "useMsalAuthentication - User is authenticated, attempting to acquire token",
+                    ""
                 );
                 acquireToken().catch(() => {
                     // Errors are saved in state above


### PR DESCRIPTION
- Make correlation id mandatory for Logger calls.
- Remove correlation id from Logger constructor.
- Make performance client mandatory in various classes and functions.