### PR TITLE
Deprecate tokenQueryParameters in msal-node

### DIFF
--- a/change/@azure-msal-node-1d9af4a3-fa9f-4d52-922b-4722009998f2.json
+++ b/change/@azure-msal-node-1d9af4a3-fa9f-4d52-922b-4722009998f2.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Deprecate tokenQueryParameters in msal-node",
+  "comment": "Deprecate tokenQueryParameters in msal-node (#8134)",
   "packageName": "@azure/msal-node",
   "email": "avdunn@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-node-9c8208b9-9c5c-453a-b8df-227bc52e8acf.json
+++ b/change/@azure-msal-node-9c8208b9-9c5c-453a-b8df-227bc52e8acf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Deprecate tokenQueryParameters in msal-node",
+  "packageName": "@azure/msal-node",
+  "email": "avdunn@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -78,6 +78,7 @@ import { ServerError } from '@azure/msal-common/node';
 import { ServerTelemetryEntity } from '@azure/msal-common/node';
 import { ServerTelemetryManager } from '@azure/msal-common/node';
 import { StaticAuthorityOptions } from '@azure/msal-common/node';
+import { StringDict } from '@azure/msal-common/node';
 import { ThrottlingEntity } from '@azure/msal-common/node';
 import { TokenCacheContext } from '@azure/msal-common/node';
 import { TokenKeys } from '@azure/msal-common/node';
@@ -101,17 +102,19 @@ export { AuthErrorMessage }
 export { AuthorizationCodePayload }
 
 // @public
-export type AuthorizationCodeRequest = Partial<Omit<CommonAuthorizationCodeRequest, "scopes" | "redirectUri" | "code" | "authenticationScheme" | "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "storeInCache">> & {
+export type AuthorizationCodeRequest = Partial<Omit<CommonAuthorizationCodeRequest, "scopes" | "redirectUri" | "code" | "authenticationScheme" | "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "storeInCache" | "tokenQueryParameters">> & {
     scopes: Array<string>;
     redirectUri: string;
     code: string;
     state?: string;
+    tokenQueryParameters?: StringDict;
 };
 
 // @public
-export type AuthorizationUrlRequest = Partial<Omit<CommonAuthorizationUrlRequest, "scopes" | "redirectUri" | "resourceRequestMethod" | "resourceRequestUri" | "authenticationScheme" | "requestedClaimsHash" | "storeInCache">> & {
+export type AuthorizationUrlRequest = Partial<Omit<CommonAuthorizationUrlRequest, "scopes" | "redirectUri" | "resourceRequestMethod" | "resourceRequestUri" | "authenticationScheme" | "requestedClaimsHash" | "storeInCache" | "tokenQueryParameters">> & {
     scopes: Array<string>;
     redirectUri: string;
+    tokenQueryParameters?: StringDict;
 };
 
 export { AuthorizeResponse }
@@ -198,8 +201,9 @@ export class ClientCredentialClient extends BaseClient {
 }
 
 // @public
-export type ClientCredentialRequest = Partial<Omit<CommonClientCredentialRequest, "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "clientAssertion" | "storeInCache">> & {
+export type ClientCredentialRequest = Partial<Omit<CommonClientCredentialRequest, "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "clientAssertion" | "storeInCache" | "tokenQueryParameters">> & {
     clientAssertion?: string | ClientAssertionCallback;
+    tokenQueryParameters?: StringDict;
 };
 
 // @public
@@ -325,13 +329,14 @@ export { InteractionRequiredAuthErrorCodes }
 export { InteractionRequiredAuthErrorMessage }
 
 // @public
-export type InteractiveRequest = Partial<Omit<CommonAuthorizationUrlRequest, "scopes" | "requestedClaimsHash" | "storeInCache">> & {
+export type InteractiveRequest = Partial<Omit<CommonAuthorizationUrlRequest, "scopes" | "requestedClaimsHash" | "storeInCache" | "tokenQueryParameters">> & {
     openBrowser: (url: string) => Promise<void>;
     scopes?: Array<string>;
     successTemplate?: string;
     errorTemplate?: string;
     windowHandle?: Buffer;
     loopbackClient?: ILoopbackClient;
+    tokenQueryParameters?: StringDict;
 };
 
 declare namespace internals {
@@ -478,9 +483,10 @@ export class OnBehalfOfClient extends BaseClient {
 }
 
 // @public
-export type OnBehalfOfRequest = Partial<Omit<CommonOnBehalfOfRequest, "oboAssertion" | "scopes" | "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "storeInCache">> & {
+export type OnBehalfOfRequest = Partial<Omit<CommonOnBehalfOfRequest, "oboAssertion" | "scopes" | "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "storeInCache" | "tokenQueryParameters">> & {
     oboAssertion: string;
     scopes: Array<string>;
+    tokenQueryParameters?: StringDict;
 };
 
 export { PromptValue }
@@ -497,11 +503,12 @@ export class PublicClientApplication extends ClientApplication implements IPubli
     signOut(request: SignOutRequest): Promise<void>;
 }
 
-// @public
-export type RefreshTokenRequest = Partial<Omit<CommonRefreshTokenRequest, "scopes" | "refreshToken" | "authenticationScheme" | "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "storeInCache">> & {
+// @public @deprecated
+export type RefreshTokenRequest = Partial<Omit<CommonRefreshTokenRequest, "scopes" | "refreshToken" | "authenticationScheme" | "resourceRequestMethod" | "resourceRequestUri" | "requestedClaimsHash" | "storeInCache" | "tokenQueryParameters">> & {
     scopes: Array<string>;
     refreshToken: string;
     forceCache?: boolean;
+    tokenQueryParameters?: StringDict;
 };
 
 export { ResponseMode }
@@ -590,9 +597,10 @@ export type SignOutRequest = {
 };
 
 // @public
-export type SilentFlowRequest = Partial<Omit<CommonSilentFlowRequest, "account" | "scopes" | "requestedClaimsHash" | "storeInCache">> & {
+export type SilentFlowRequest = Partial<Omit<CommonSilentFlowRequest, "account" | "scopes" | "requestedClaimsHash" | "storeInCache" | "tokenQueryParameters">> & {
     account: AccountInfo;
     scopes: Array<string>;
+    tokenQueryParameters?: StringDict;
 };
 
 // @public
@@ -620,11 +628,12 @@ export class UsernamePasswordClient extends BaseClient {
     acquireToken(request: CommonUsernamePasswordRequest): Promise<AuthenticationResult | null>;
 }
 
-// @public
-export type UsernamePasswordRequest = Partial<Omit<CommonUsernamePasswordRequest, "scopes" | "resourceRequestMethod" | "resourceRequestUri" | "username" | "password" | "requestedClaimsHash" | "storeInCache">> & {
+// @public @deprecated
+export type UsernamePasswordRequest = Partial<Omit<CommonUsernamePasswordRequest, "scopes" | "resourceRequestMethod" | "resourceRequestUri" | "username" | "password" | "requestedClaimsHash" | "storeInCache" | "tokenQueryParameters">> & {
     scopes: Array<string>;
     username: string;
     password: string;
+    tokenQueryParameters?: StringDict;
 };
 
 export { ValidCacheType }

--- a/lib/msal-node/src/request/AuthorizationCodeRequest.ts
+++ b/lib/msal-node/src/request/AuthorizationCodeRequest.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { CommonAuthorizationCodeRequest } from "@azure/msal-common/node";
+import {
+    CommonAuthorizationCodeRequest,
+    StringDict,
+} from "@azure/msal-common/node";
 
 /**
  * Request object passed by user to acquire a token from the server exchanging a valid authorization code (second leg of OAuth2.0 Authorization Code flow)
@@ -30,10 +33,17 @@ export type AuthorizationCodeRequest = Partial<
         | "resourceRequestUri"
         | "requestedClaimsHash"
         | "storeInCache"
+        | "tokenQueryParameters"
     >
 > & {
     scopes: Array<string>;
     redirectUri: string;
     code: string;
     state?: string;
+    /**
+     * @deprecated String to string map of custom query parameters added to the /token call.
+     * This feature is being deprecated and not recommended for production scenarios.
+     * It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    tokenQueryParameters?: StringDict;
 };

--- a/lib/msal-node/src/request/AuthorizationUrlRequest.ts
+++ b/lib/msal-node/src/request/AuthorizationUrlRequest.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { CommonAuthorizationUrlRequest } from "@azure/msal-common/node";
+import {
+    CommonAuthorizationUrlRequest,
+    StringDict,
+} from "@azure/msal-common/node";
 
 /**
  * Request object passed by user to retrieve a Code from the server (first leg of authorization code grant flow)
@@ -43,8 +46,15 @@ export type AuthorizationUrlRequest = Partial<
         | "authenticationScheme"
         | "requestedClaimsHash"
         | "storeInCache"
+        | "tokenQueryParameters"
     >
 > & {
     scopes: Array<string>;
     redirectUri: string;
+    /**
+     * @deprecated String to string map of custom query parameters added to the /token call.
+     * This feature is being deprecated and not recommended for production scenarios.
+     * It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    tokenQueryParameters?: StringDict;
 };

--- a/lib/msal-node/src/request/ClientCredentialRequest.ts
+++ b/lib/msal-node/src/request/ClientCredentialRequest.ts
@@ -6,6 +6,7 @@
 import {
     ClientAssertionCallback,
     CommonClientCredentialRequest,
+    StringDict,
 } from "@azure/msal-common/node";
 
 /**
@@ -26,7 +27,14 @@ export type ClientCredentialRequest = Partial<
         | "requestedClaimsHash"
         | "clientAssertion"
         | "storeInCache"
+        | "tokenQueryParameters"
     >
 > & {
     clientAssertion?: string | ClientAssertionCallback;
+    /**
+     * @deprecated String to string map of custom query parameters added to the /token call.
+     * This feature is being deprecated and not recommended for production scenarios.
+     * It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    tokenQueryParameters?: StringDict;
 };

--- a/lib/msal-node/src/request/InteractiveRequest.ts
+++ b/lib/msal-node/src/request/InteractiveRequest.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { CommonAuthorizationUrlRequest } from "@azure/msal-common/node";
+import {
+    CommonAuthorizationUrlRequest,
+    StringDict,
+} from "@azure/msal-common/node";
 import { ILoopbackClient } from "../network/ILoopbackClient.js";
 
 /**
@@ -20,7 +23,10 @@ import { ILoopbackClient } from "../network/ILoopbackClient.js";
 export type InteractiveRequest = Partial<
     Omit<
         CommonAuthorizationUrlRequest,
-        "scopes" | "requestedClaimsHash" | "storeInCache"
+        | "scopes"
+        | "requestedClaimsHash"
+        | "storeInCache"
+        | "tokenQueryParameters"
     >
 > & {
     openBrowser: (url: string) => Promise<void>;
@@ -29,4 +35,10 @@ export type InteractiveRequest = Partial<
     errorTemplate?: string;
     windowHandle?: Buffer; // Relevant only to brokered requests
     loopbackClient?: ILoopbackClient;
+    /**
+     * @deprecated String to string map of custom query parameters added to the /token call.
+     * This feature is being deprecated and not recommended for production scenarios.
+     * It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    tokenQueryParameters?: StringDict;
 };

--- a/lib/msal-node/src/request/OnBehalfOfRequest.ts
+++ b/lib/msal-node/src/request/OnBehalfOfRequest.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { CommonOnBehalfOfRequest } from "@azure/msal-common/node";
+import { 
+    CommonOnBehalfOfRequest, 
+    StringDict,
+} from "@azure/msal-common/node";
 
 /**
  * - scopes                  - Array of scopes the application is requesting access to.
@@ -23,8 +26,15 @@ export type OnBehalfOfRequest = Partial<
         | "resourceRequestUri"
         | "requestedClaimsHash"
         | "storeInCache"
+        | "tokenQueryParameters"
     >
 > & {
     oboAssertion: string;
     scopes: Array<string>;
+    /**
+     * @deprecated String to string map of custom query parameters added to the /token call.
+     * This feature is being deprecated and not recommended for production scenarios.
+     * It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    tokenQueryParameters?: StringDict;
 };

--- a/lib/msal-node/src/request/RefreshTokenRequest.ts
+++ b/lib/msal-node/src/request/RefreshTokenRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { CommonRefreshTokenRequest } from "@azure/msal-common/node";
+import { CommonRefreshTokenRequest, StringDict } from "@azure/msal-common/node";
 
 /**
  * CommonRefreshTokenRequest
@@ -12,7 +12,7 @@ import { CommonRefreshTokenRequest } from "@azure/msal-common/node";
  * - authority               - URL of the authority, the security token service (STS) from which MSAL will acquire tokens.
  * - correlationId           - Unique GUID set per request to trace a request end-to-end for telemetry purposes.
  * - refreshToken            - A refresh token returned from a previous request to the Identity provider.
- * - tokenQueryParameters    - String to string map of custom query parameters added to the /token call
+ * - tokenQueryParameters    - @deprecated String to string map of custom query parameters added to the /token call. This feature is being deprecated and not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
  * - forceCache              - Force MSAL to cache a refresh token flow response when there is no account in the cache. Used for migration scenarios.
  * @public
  */
@@ -26,9 +26,16 @@ export type RefreshTokenRequest = Partial<
         | "resourceRequestUri"
         | "requestedClaimsHash"
         | "storeInCache"
+        | "tokenQueryParameters"
     >
 > & {
     scopes: Array<string>;
     refreshToken: string;
     forceCache?: boolean;
+    /**
+     * @deprecated String to string map of custom query parameters added to the /token call.
+     * This feature is being deprecated and not recommended for production scenarios.
+     * It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    tokenQueryParameters?: StringDict;
 };

--- a/lib/msal-node/src/request/SilentFlowRequest.ts
+++ b/lib/msal-node/src/request/SilentFlowRequest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AccountInfo, CommonSilentFlowRequest } from "@azure/msal-common/node";
+import { AccountInfo, CommonSilentFlowRequest, StringDict } from "@azure/msal-common/node";
 
 /**
  * SilentFlow parameters passed by the user to retrieve credentials silently
@@ -19,9 +19,15 @@ import { AccountInfo, CommonSilentFlowRequest } from "@azure/msal-common/node";
 export type SilentFlowRequest = Partial<
     Omit<
         CommonSilentFlowRequest,
-        "account" | "scopes" | "requestedClaimsHash" | "storeInCache"
+        "account" | "scopes" | "requestedClaimsHash" | "storeInCache" | "tokenQueryParameters"
     >
 > & {
     account: AccountInfo;
     scopes: Array<string>;
+    /**
+     * @deprecated String to string map of custom query parameters added to the /token call. 
+     * This feature is being deprecated and not recommended for production scenarios. 
+     * It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    tokenQueryParameters?: StringDict;
 };

--- a/lib/msal-node/src/request/UsernamePasswordRequest.ts
+++ b/lib/msal-node/src/request/UsernamePasswordRequest.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { CommonUsernamePasswordRequest } from "@azure/msal-common/node";
+import {
+    CommonUsernamePasswordRequest,
+    StringDict,
+} from "@azure/msal-common/node";
 
 /**
  * UsernamePassword parameters passed by the user to retrieve credentials
@@ -15,7 +18,7 @@ import { CommonUsernamePasswordRequest } from "@azure/msal-common/node";
  * - correlationId          - Unique GUID set per request to trace a request end-to-end for telemetry purposes.
  * - username               - username of the client
  * - password               - credentials
- * - tokenQueryParameters   - String to string map of custom query parameters added to the /token call
+ * - tokenQueryParameters   - @deprecated String to string map of custom query parameters added to the /token call. This feature is being deprecated and not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
  * @public
  */
 export type UsernamePasswordRequest = Partial<
@@ -28,9 +31,16 @@ export type UsernamePasswordRequest = Partial<
         | "password"
         | "requestedClaimsHash"
         | "storeInCache"
+        | "tokenQueryParameters"
     >
 > & {
     scopes: Array<string>;
     username: string;
     password: string;
+    /**
+     * @deprecated String to string map of custom query parameters added to the /token call.
+     * This feature is being deprecated and not recommended for production scenarios.
+     * It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    tokenQueryParameters?: StringDict;
 };


### PR DESCRIPTION
Deprecates the extraQueryParameters API according to KR [3310905](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3310905), similar to what was done in MSAL.NET and MSAL Java: 
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5536
https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1001

This API was meant for niche scenarios which the library did not explicitly cover, and not really meant for production. It can affect the contents and validity of tokens but were not used in our caching scheme which led to bad caching behavior: if the extra query parameters changed between requests we could return tokens that were not valid for the latest set of parameters.

Therefore we are deprecating the current API and, if there is a need for it, may add a new API in the future to perform similar behavior in a more robust way.