### PR TITLE
[v5] EAR Fallback

### DIFF
--- a/change/@azure-msal-browser-4f3a98d7-107e-408d-9c61-d900f19355dd.json
+++ b/change/@azure-msal-browser-4f3a98d7-107e-408d-9c61-d900f19355dd.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "EAR flow falls back to auth code when /authorize returns code",
+  "comment": "EAR flow falls back to auth code when /authorize returns code [#8156](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8156)",
   "packageName": "@azure/msal-browser",
   "email": "thomas.norling@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-4f3a98d7-107e-408d-9c61-d900f19355dd.json
+++ b/change/@azure-msal-browser-4f3a98d7-107e-408d-9c61-d900f19355dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "EAR flow falls back to auth code when /authorize returns code",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -276,7 +276,7 @@ export class PopupClient extends StandardInteractionClient {
         validRequest.platformBroker = isPlatformBroker;
 
         if (this.config.system.protocolMode === ProtocolMode.EAR) {
-            return this.executeEarFlow(validRequest, popupParams);
+            return this.executeEarFlow(validRequest, popupParams, pkceCodes);
         } else {
             return this.executeCodeFlow(validRequest, popupParams, pkceCodes);
         }
@@ -432,7 +432,8 @@ export class PopupClient extends StandardInteractionClient {
      */
     async executeEarFlow(
         request: CommonAuthorizationUrlRequest,
-        popupParams: PopupParams
+        popupParams: PopupParams,
+        pkceCodes?: PkceCodes
     ): Promise<AuthenticationResult> {
         const {
             correlationId,
@@ -467,9 +468,19 @@ export class PopupClient extends StandardInteractionClient {
             this.performanceClient,
             correlationId
         )();
+        const pkce =
+            pkceCodes ||
+            (await invokeAsync(
+                generatePkceCodes,
+                BrowserPerformanceEvents.GeneratePkceCodes,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(this.performanceClient, this.logger, correlationId));
         const popupRequest = {
             ...request,
             earJwk: earJwk,
+            codeChallenge: pkce.challenge,
         };
         const popupWindow =
             popupParams.popup || this.openPopup("about:blank", popupParams);
@@ -514,25 +525,69 @@ export class PopupClient extends StandardInteractionClient {
             this.correlationId
         );
 
-        return invokeAsync(
-            Authorize.handleResponseEAR,
-            BrowserPerformanceEvents.HandleResponseEar,
-            this.logger,
-            this.performanceClient,
-            correlationId
-        )(
-            popupRequest,
-            serverParams,
-            ApiId.acquireTokenPopup,
-            this.config,
-            discoveredAuthority,
-            this.browserStorage,
-            this.nativeStorage,
-            this.eventHandler,
-            this.logger,
-            this.performanceClient,
-            this.platformAuthProvider
-        );
+        if (!serverParams.ear_jwe && serverParams.code) {
+            const authClient = await invokeAsync(
+                this.createAuthCodeClient.bind(this),
+                BrowserPerformanceEvents.StandardInteractionClientCreateAuthCodeClient,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )({
+                serverTelemetryManager: initializeServerTelemetryManager(
+                    ApiId.acquireTokenPopup,
+                    this.config.auth.clientId,
+                    correlationId,
+                    this.browserStorage,
+                    this.logger
+                ),
+                requestAuthority: request.authority,
+                requestAzureCloudOptions: request.azureCloudOptions,
+                requestExtraQueryParameters: request.extraQueryParameters,
+                account: request.account,
+                authority: discoveredAuthority,
+            });
+
+            return invokeAsync(
+                Authorize.handleResponseCode,
+                BrowserPerformanceEvents.HandleResponseCode,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(
+                popupRequest,
+                serverParams,
+                pkce.verifier,
+                ApiId.acquireTokenPopup,
+                this.config,
+                authClient,
+                this.browserStorage,
+                this.nativeStorage,
+                this.eventHandler,
+                this.logger,
+                this.performanceClient,
+                this.platformAuthProvider
+            );
+        } else {
+            return invokeAsync(
+                Authorize.handleResponseEAR,
+                BrowserPerformanceEvents.HandleResponseEar,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(
+                popupRequest,
+                serverParams,
+                ApiId.acquireTokenPopup,
+                this.config,
+                discoveredAuthority,
+                this.browserStorage,
+                this.nativeStorage,
+                this.eventHandler,
+                this.logger,
+                this.performanceClient,
+                this.platformAuthProvider
+            );
+        }
     }
 
     async executeCodeFlowWithPost(

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -319,6 +319,7 @@ export class RedirectClient extends StandardInteractionClient {
 
         this.browserStorage.cacheAuthorizeRequest(
             redirectRequest,
+            this.correlationId,
             pkceCodes.verifier
         );
 

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -303,13 +303,23 @@ export class RedirectClient extends StandardInteractionClient {
             this.performanceClient,
             correlationId
         )();
+        const pkceCodes = await invokeAsync(
+            generatePkceCodes,
+            BrowserPerformanceEvents.GeneratePkceCodes,
+            this.logger,
+            this.performanceClient,
+            correlationId
+        )(this.performanceClient, this.logger, correlationId);
+
         const redirectRequest = {
             ...request,
             earJwk: earJwk,
+            codeChallenge: pkceCodes.challenge,
         };
+
         this.browserStorage.cacheAuthorizeRequest(
             redirectRequest,
-            this.correlationId
+            pkceCodes.verifier
         );
 
         const form = await Authorize.getEARForm(

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -265,9 +265,17 @@ export class SilentIframeClient extends StandardInteractionClient {
             this.performanceClient,
             correlationId
         )();
+        const pkceCodes = await invokeAsync(
+            generatePkceCodes,
+            BrowserPerformanceEvents.GeneratePkceCodes,
+            this.logger,
+            this.performanceClient,
+            correlationId
+        )(this.performanceClient, this.logger, correlationId);
         const silentRequest = {
             ...request,
             earJwk: earJwk,
+            codeChallenge: pkceCodes.challenge,
         };
         const msalFrame = await invokeAsync(
             initiateEarRequest,
@@ -309,25 +317,70 @@ export class SilentIframeClient extends StandardInteractionClient {
             correlationId
         )(responseString, responseType, this.logger, this.correlationId);
 
-        return invokeAsync(
-            Authorize.handleResponseEAR,
-            BrowserPerformanceEvents.HandleResponseEar,
-            this.logger,
-            this.performanceClient,
-            correlationId
-        )(
-            silentRequest,
-            serverParams,
-            this.apiId,
-            this.config,
-            discoveredAuthority,
-            this.browserStorage,
-            this.nativeStorage,
-            this.eventHandler,
-            this.logger,
-            this.performanceClient,
-            this.platformAuthProvider
-        );
+        if (!serverParams.ear_jwe && serverParams.code) {
+            // If server doesn't support EAR, they may fallback to auth code flow instead
+            const authClient = await invokeAsync(
+                this.createAuthCodeClient.bind(this),
+                BrowserPerformanceEvents.StandardInteractionClientCreateAuthCodeClient,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )({
+                serverTelemetryManager: initializeServerTelemetryManager(
+                    this.apiId,
+                    this.config.auth.clientId,
+                    correlationId,
+                    this.browserStorage,
+                    this.logger
+                ),
+                requestAuthority: request.authority,
+                requestAzureCloudOptions: request.azureCloudOptions,
+                requestExtraQueryParameters: request.extraQueryParameters,
+                account: request.account,
+                authority: discoveredAuthority,
+            });
+
+            return invokeAsync(
+                Authorize.handleResponseCode,
+                BrowserPerformanceEvents.HandleResponseCode,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(
+                silentRequest,
+                serverParams,
+                pkceCodes.verifier,
+                this.apiId,
+                this.config,
+                authClient,
+                this.browserStorage,
+                this.nativeStorage,
+                this.eventHandler,
+                this.logger,
+                this.performanceClient,
+                this.platformAuthProvider
+            );
+        } else {
+            return invokeAsync(
+                Authorize.handleResponseEAR,
+                BrowserPerformanceEvents.HandleResponseEar,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(
+                silentRequest,
+                serverParams,
+                this.apiId,
+                this.config,
+                discoveredAuthority,
+                this.browserStorage,
+                this.nativeStorage,
+                this.eventHandler,
+                this.logger,
+                this.performanceClient,
+                this.platformAuthProvider
+            );
+        }
     }
 
     /**

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -20,6 +20,7 @@ import {
     ICrypto,
     Logger,
     IPerformanceClient,
+    Authority,
 } from "@azure/msal-common/browser";
 import {
     BaseInteractionClient,
@@ -199,6 +200,7 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
         requestAzureCloudOptions?: AzureCloudOptions;
         requestExtraQueryParameters?: StringDict;
         account?: AccountInfo;
+        authority?: Authority;
     }): Promise<AuthorizationCodeClient> {
         // Create auth module.
         const clientConfig = await invokeAsync(
@@ -231,6 +233,7 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
         requestAzureCloudOptions?: AzureCloudOptions;
         requestExtraQueryParameters?: StringDict;
         account?: AccountInfo;
+        authority?: Authority;
     }): Promise<ClientConfiguration> {
         const {
             serverTelemetryManager,
@@ -240,23 +243,25 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
             account,
         } = params;
 
-        const discoveredAuthority = await invokeAsync(
-            getDiscoveredAuthority,
-            BrowserPerformanceEvents.StandardInteractionClientGetDiscoveredAuthority,
-            this.logger,
-            this.performanceClient,
-            this.correlationId
-        )(
-            this.config,
-            this.correlationId,
-            this.performanceClient,
-            this.browserStorage,
-            this.logger,
-            requestAuthority,
-            requestAzureCloudOptions,
-            requestExtraQueryParameters,
-            account
-        );
+        const discoveredAuthority =
+            params.authority ||
+            (await invokeAsync(
+                getDiscoveredAuthority,
+                BrowserPerformanceEvents.StandardInteractionClientGetDiscoveredAuthority,
+                this.logger,
+                this.performanceClient,
+                this.correlationId
+            )(
+                this.config,
+                this.correlationId,
+                this.performanceClient,
+                this.browserStorage,
+                this.logger,
+                requestAuthority,
+                requestAzureCloudOptions,
+                requestExtraQueryParameters,
+                account
+            ));
         const logger = this.config.system.loggerOptions;
 
         return {

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -198,6 +198,13 @@ export async function getEARForm(
     );
     RequestParameterBuilder.addEARParameters(parameters, request.earJwk);
 
+    // Also add codeChallenge as backup in case EAR is not supported
+    RequestParameterBuilder.addCodeChallengeParams(
+        parameters,
+        request.codeChallenge,
+        Constants.S256_CODE_CHALLENGE_METHOD
+    );
+
     RequestParameterBuilder.addExtraParameters(parameters, {
         ...request.extraParameters,
     });

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -961,6 +961,40 @@ describe("PopupClient", () => {
                 expect(earFormSpy).toHaveBeenCalled();
             });
 
+            it("EAR flow falls back to Auth Code if service returns code instead of ear_jwe", async () => {
+                const validRequest: PopupRequest = {
+                    authority: TEST_CONFIG.validAuthority,
+                    scopes: ["openid", "profile", "offline_access"],
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
+                    redirectUri: window.location.href,
+                    state: TEST_STATE_VALUES.USER_STATE,
+                    nonce: ID_TOKEN_CLAIMS.nonce,
+                };
+                jest.spyOn(ProtocolUtils, "setRequestState").mockReturnValue(
+                    TEST_STATE_VALUES.TEST_STATE_POPUP
+                );
+                jest.spyOn(
+                    PopupClient.prototype,
+                    "openSizedPopup"
+                ).mockReturnValue(popupWindow);
+                const earFormSpy = jest
+                    .spyOn(HTMLFormElement.prototype, "submit")
+                    .mockImplementation(() => {
+                        // Suppress navigation
+                    });
+                jest.spyOn(PopupUtils, "monitorPopupForHash").mockResolvedValue(
+                    `#code=validCode&state=${TEST_STATE_VALUES.TEST_STATE_POPUP}`
+                );
+                jest.spyOn(
+                    AuthorizeProtocol,
+                    "handleResponseCode"
+                ).mockResolvedValue(getTestAuthenticationResult());
+
+                const result = await pca.acquireTokenPopup(validRequest);
+                expect(result).toEqual(getTestAuthenticationResult());
+                expect(earFormSpy).toHaveBeenCalled();
+            });
+
             it("throws error when ProtocolMode is set to EAR and httpMethod is set to GET", async () => {
                 const validRequest: PopupRequest = {
                     authority: TEST_CONFIG.validAuthority,

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -3254,6 +3254,37 @@ describe("RedirectClient", () => {
             pca.acquireTokenRedirect(validRequest).catch(() => {});
         });
 
+        it("EAR flow falls back to Auth Code if service returns code instead of ear_jwe", (done) => {
+            const validRequest: RedirectRequest = {
+                authority: TEST_CONFIG.validAuthority,
+                scopes: ["openid", "profile", "offline_access"],
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                redirectUri: window.location.href,
+                state: TEST_STATE_VALUES.USER_STATE,
+                nonce: ID_TOKEN_CLAIMS.nonce,
+            };
+            jest.spyOn(ProtocolUtils, "setRequestState").mockReturnValue(
+                TEST_STATE_VALUES.TEST_STATE_REDIRECT
+            );
+            jest.spyOn(
+                AuthorizeProtocol,
+                "handleResponseCode"
+            ).mockResolvedValue(getTestAuthenticationResult());
+            jest.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(
+                () => {
+                    // Supress navigation
+                    pca.handleRedirectPromise({
+                        hash: `#code=validCode&state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}`,
+                    }).then((result) => {
+                        expect(result).toEqual(getTestAuthenticationResult());
+                        done();
+                    });
+                }
+            );
+
+            pca.acquireTokenRedirect(validRequest).catch(() => {});
+        });
+
         it("Throws a timeout error if the form post failed to redirect within the alloted time", async () => {
             const validRequest: RedirectRequest = {
                 scopes: ["openid", "profile", "offline_access"],

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -1418,6 +1418,31 @@ describe("SilentIframeClient", () => {
                 expect(earFormSpy).toHaveBeenCalled();
             });
 
+            it("EAR flow falls back to Auth Code if service returns code instead of ear_jwe", async () => {
+                jest.restoreAllMocks();
+                jest.spyOn(ProtocolUtils, "setRequestState").mockReturnValue(
+                    TEST_STATE_VALUES.TEST_STATE_SILENT
+                );
+
+                jest.spyOn(
+                    SilentHandler,
+                    "monitorIframeForHash"
+                ).mockResolvedValue(
+                    `#code=validCode&state=${TEST_STATE_VALUES.TEST_STATE_SILENT}`
+                );
+                jest.spyOn(
+                    AuthorizeProtocol,
+                    "handleResponseCode"
+                ).mockResolvedValue(getTestAuthenticationResult());
+                const earFormSpy = jest
+                    .spyOn(SilentHandler, "initiateEarRequest")
+                    .mockResolvedValue(document.createElement("iframe"));
+
+                const result = await pca.ssoSilent(validRequest);
+                expect(result).toEqual(getTestAuthenticationResult());
+                expect(earFormSpy).toHaveBeenCalled();
+            });
+
             it("throws if protocolMode is set to EAR and httpMethod is set to GET", async () => {
                 await expect(
                     pca.ssoSilent({

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -68,6 +68,7 @@ describe("Authorize Protocol Tests", () => {
             nonce: ID_TOKEN_CLAIMS.nonce,
             responseMode: Constants.ResponseMode.FRAGMENT,
             earJwk: validEarJWK,
+            codeChallenge: "code-challenge",
             extraQueryParameters: {
                 extraKey1: "extraVal1",
                 extraKey2: "extraVal2",
@@ -178,6 +179,14 @@ describe("Authorize Protocol Tests", () => {
                 checkInputProperties(
                     AADServerParamKeys.EAR_JWE_CRYPTO,
                     "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0"
+                );
+                checkInputProperties(
+                    AADServerParamKeys.CODE_CHALLENGE,
+                    validRequest.codeChallenge!
+                );
+                checkInputProperties(
+                    AADServerParamKeys.CODE_CHALLENGE_METHOD,
+                    "S256"
                 );
                 checkInputProperties(
                     AADServerParamKeys.X_CLIENT_SKU,


### PR DESCRIPTION
This pull request enhances the EAR (Encrypted Authorization Request) authentication flow in `@azure/msal-browser` by enabling a fallback to the standard authorization code flow when the authorization server does not support EAR and returns an authorization code instead. It also improves PKCE (Proof Key for Code Exchange) handling and adds comprehensive tests to ensure correct fallback behavior. The changes ensure a more robust and interoperable authentication experience.

**EAR Flow Improvements and Fallback Logic:**

* Updated the EAR flow in `PopupClient`, `RedirectClient`, and `SilentIframeClient` to detect when the server returns an authorization code instead of an EAR token, and to automatically fall back to the standard authorization code flow in such cases. This includes passing PKCE parameters and handling the response appropriately. [[1]](diffhunk://#diff-3f43afd5556603a80064728bd701519ec2e22979f09ae6095b7fdea0507ad593R528-R570) [[2]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faR320-R363) [[3]](diffhunk://#diff-06ec3818a1cb128320c6ece84eed04190a54c03a09a455ca2d5c6947e29d5de1R306-R322)

* Modified the EAR request generation to always include PKCE code challenge parameters as a backup, ensuring a seamless transition to auth code flow if EAR is not supported by the server.

**PKCE and Authority Handling Enhancements:**

* Refactored PKCE code generation to ensure PKCE codes are always available for both EAR and fallback flows. Also, updated the authority discovery logic to allow passing a pre-discovered authority, improving efficiency and flexibility. [[1]](diffhunk://#diff-3f43afd5556603a80064728bd701519ec2e22979f09ae6095b7fdea0507ad593R471-R483) [[2]](diffhunk://#diff-08cf22a8c9098053582d32ec25dad54e2ab9e5ea54242db2a55b261ee0e67349R203) [[3]](diffhunk://#diff-08cf22a8c9098053582d32ec25dad54e2ab9e5ea54242db2a55b261ee0e67349R236) [[4]](diffhunk://#diff-08cf22a8c9098053582d32ec25dad54e2ab9e5ea54242db2a55b261ee0e67349L243-R248) [[5]](diffhunk://#diff-08cf22a8c9098053582d32ec25dad54e2ab9e5ea54242db2a55b261ee0e67349L259-R264)

**Testing and Validation:**

* Added and updated unit tests for `PopupClient`, `RedirectClient`, and `SilentIframeClient` to verify that the EAR flow correctly falls back to the authorization code flow when the server returns a code. Also, updated protocol tests to check for the inclusion of PKCE parameters in EAR requests. [[1]](diffhunk://#diff-0e4f86d8a16dd8be09b5f3b33d82dafe4c4325e3fd92b994120b0290beb0c2d6R964-R997) [[2]](diffhunk://#diff-6892d11e0bf0f9de499d836141fe1b0e7fe40f2b7d1d28e57830a083ba0080a4R3257-R3287) [[3]](diffhunk://#diff-ee3bc256edbe0cc9b07264ac953b539bf0be0c3737eb24a91cf11b35e20086a3R1421-R1445) [[4]](diffhunk://#diff-383f979b9a05a2d7fe02052138e8087f6ca2167e78d44dc4d41c391463d4da04R71) [[5]](diffhunk://#diff-383f979b9a05a2d7fe02052138e8087f6ca2167e78d44dc4d41c391463d4da04R183-R190)

**Release and Metadata:**

* Updated the package change log to document the new fallback behavior for the EAR flow, indicating a patch release.