### PR TITLE
[v5] Update beachball filter logic

### DIFF
--- a/.github/workflows/beachball-check.yml
+++ b/.github/workflows/beachball-check.yml
@@ -20,7 +20,7 @@ jobs:
         permissions:
             contents: read # for actions/checkout to fetch code
             pull-requests: read # for dorny/paths-filter to read pull requests
-        if: github.actor != 'dependabot[bot]' && github.head_ref != 'release-staging' && github.head_ref != '3p-release-staging' && !contains(github.head_ref, 'post-release')
+        if: github.actor != 'dependabot[bot]' && !contains(github.head_ref, 'post-release') && !contains(github.head_ref, 'release-staging')
         runs-on: ubuntu-latest
         env:
             BEACHBALL: 1


### PR DESCRIPTION
New branch naming isn't caught by the existing beachball branch filter, causing beachball check not to be skipped in post-release PRs.