### PR TITLE
Authority mismatch instrumentation

### DIFF
--- a/change/@azure-msal-browser-8d6fcd39-1f3b-4b4d-81e6-b729b83cdd7e.json
+++ b/change/@azure-msal-browser-8d6fcd39-1f3b-4b4d-81e6-b729b83cdd7e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Authority mismatch instrumentation #8212",
+  "comment": "Authority mismatch instrumentation [#8212](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8212)",
   "packageName": "@azure/msal-browser",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-8d6fcd39-1f3b-4b4d-81e6-b729b83cdd7e.json
+++ b/change/@azure-msal-browser-8d6fcd39-1f3b-4b4d-81e6-b729b83cdd7e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Authority mismatch instrumentation",
+  "comment": "Authority mismatch instrumentation #8212",
   "packageName": "@azure/msal-browser",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-8d6fcd39-1f3b-4b4d-81e6-b729b83cdd7e.json
+++ b/change/@azure-msal-browser-8d6fcd39-1f3b-4b4d-81e6-b729b83cdd7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Authority mismatch instrumentation",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-adda0fb4-dea9-4116-b965-68b15040c909.json
+++ b/change/@azure-msal-common-adda0fb4-dea9-4116-b965-68b15040c909.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Authority mismatch instrumentation",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-adda0fb4-dea9-4116-b965-68b15040c909.json
+++ b/change/@azure-msal-common-adda0fb4-dea9-4116-b965-68b15040c909.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Authority mismatch instrumentation #8212",
+  "comment": "Authority mismatch instrumentation [#8212](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8212)",
   "packageName": "@azure/msal-common",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-adda0fb4-dea9-4116-b965-68b15040c909.json
+++ b/change/@azure-msal-common-adda0fb4-dea9-4116-b965-68b15040c909.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Authority mismatch instrumentation",
+  "comment": "Authority mismatch instrumentation #8212",
   "packageName": "@azure/msal-common",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -236,8 +236,12 @@ export abstract class BaseInteractionClient {
 
         if (account && !discoveredAuthority.isAlias(account.environment)) {
             const normalizeValue = (value: string | undefined): string => {
-                if (!value || value.trim() === "") {
-                    return value === undefined ? "(undefined)" : "(empty string)";
+                if (value === undefined) {
+                    return "(undefined)";
+                }
+
+                if (value.trim() === "") {
+                    return "(empty string)";
                 }
                 return value;
             };

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -248,7 +248,9 @@ export abstract class BaseInteractionClient {
 
             this.performanceClient.addFields(
                 {
-                    discoveredAuthority: normalizeValue(discoveredAuthority.canonicalAuthority),
+                    discoveredAuthority: normalizeValue(
+                        discoveredAuthority.canonicalAuthority
+                    ),
                     accountEnvironment: normalizeValue(account.environment),
                 },
                 this.correlationId

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -235,6 +235,20 @@ export abstract class BaseInteractionClient {
         );
 
         if (account && !discoveredAuthority.isAlias(account.environment)) {
+            const normalizeValue = (value: string | undefined): string => {
+                if (!value || value.trim() === "") {
+                    return value === undefined ? "(undefined)" : "(empty string)";
+                }
+                return value;
+            };
+
+            this.performanceClient.addFields(
+                {
+                    discoveredAuthority: normalizeValue(discoveredAuthority.canonicalAuthority),
+                    accountEnvironment: normalizeValue(account.environment),
+                },
+                this.correlationId
+            );
             throw createClientConfigurationError(
                 ClientConfigurationErrorCodes.authorityMismatch
             );

--- a/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
@@ -269,6 +269,154 @@ describe("BaseInteractionClient", () => {
                 });
         });
 
+        it("Adds telemetry fields when authority mismatch occurs with valid values", async () => {
+            const testAccount = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows-ppe.net",
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com",
+                loginHint: "loginHint",
+            };
+
+            // @ts-ignore
+            const addFieldsSpy = jest.spyOn(testClient.performanceClient, "addFields");
+
+            await testClient
+                // @ts-ignore
+                .getDiscoveredAuthority({
+                    requestAuthority:
+                        "https://login.microsoftonline.com/common",
+                    account: testAccount,
+                })
+                .catch((error) => {
+                    expect(error).toStrictEqual(
+                        createClientConfigurationError(
+                            ClientConfigurationErrorCodes.authorityMismatch
+                        )
+                    );
+                });
+
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    discoveredAuthority: "https://login.microsoftonline.com/common/",
+                    accountEnvironment: "login.windows-ppe.net",
+                }),
+                expect.any(String)
+            );
+        });
+
+        it("Adds telemetry with normalized values when account environment is undefined", async () => {
+            const testAccount = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: undefined as any,
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com",
+                loginHint: "loginHint",
+            };
+
+            // @ts-ignore
+            const addFieldsSpy = jest.spyOn(testClient.performanceClient, "addFields");
+
+            await testClient
+                // @ts-ignore
+                .getDiscoveredAuthority({
+                    requestAuthority:
+                        "https://login.microsoftonline.com/common",
+                    account: testAccount,
+                })
+                .catch((error) => {
+                    expect(error).toStrictEqual(
+                        createClientConfigurationError(
+                            ClientConfigurationErrorCodes.authorityMismatch
+                        )
+                    );
+                });
+
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    discoveredAuthority: "https://login.microsoftonline.com/common/",
+                    accountEnvironment: "(undefined)",
+                }),
+                expect.any(String)
+            );
+        });
+
+        it("Adds telemetry with normalized values when account environment is empty string", async () => {
+            const testAccount = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "",
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com",
+                loginHint: "loginHint",
+            };
+
+            // @ts-ignore
+            const addFieldsSpy = jest.spyOn(testClient.performanceClient, "addFields");
+
+            await testClient
+                // @ts-ignore
+                .getDiscoveredAuthority({
+                    requestAuthority:
+                        "https://login.microsoftonline.com/common",
+                    account: testAccount,
+                })
+                .catch((error) => {
+                    expect(error).toStrictEqual(
+                        createClientConfigurationError(
+                            ClientConfigurationErrorCodes.authorityMismatch
+                        )
+                    );
+                });
+
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    discoveredAuthority: "https://login.microsoftonline.com/common/",
+                    accountEnvironment: "(empty string)",
+                }),
+                expect.any(String)
+            );
+        });
+
+        it("Adds telemetry with normalized values when account environment is whitespace-only", async () => {
+            const testAccount = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "   ",
+                tenantId: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                username: "AbeLi@microsoft.com",
+                loginHint: "loginHint",
+            };
+
+            // @ts-ignore
+            const addFieldsSpy = jest.spyOn(testClient.performanceClient, "addFields");
+
+            await testClient
+                // @ts-ignore
+                .getDiscoveredAuthority({
+                    requestAuthority:
+                        "https://login.microsoftonline.com/common",
+                    account: testAccount,
+                })
+                .catch((error) => {
+                    expect(error).toStrictEqual(
+                        createClientConfigurationError(
+                            ClientConfigurationErrorCodes.authorityMismatch
+                        )
+                    );
+                });
+
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    discoveredAuthority: "https://login.microsoftonline.com/common/",
+                    accountEnvironment: "(empty string)",
+                }),
+                expect.any(String)
+            );
+        });
+
         it("Does not throw error when authority in request or MSAL config matches with environment set for account", (done) => {
             const testAccount = {
                 homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,

--- a/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
@@ -280,7 +280,10 @@ describe("BaseInteractionClient", () => {
             };
 
             // @ts-ignore
-            const addFieldsSpy = jest.spyOn(testClient.performanceClient, "addFields");
+            const addFieldsSpy = jest.spyOn(
+                testClient.performanceClient,
+                "addFields"
+            );
 
             await testClient
                 // @ts-ignore
@@ -299,7 +302,8 @@ describe("BaseInteractionClient", () => {
 
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    discoveredAuthority: "https://login.microsoftonline.com/common/",
+                    discoveredAuthority:
+                        "https://login.microsoftonline.com/common/",
                     accountEnvironment: "login.windows-ppe.net",
                 }),
                 expect.any(String)
@@ -317,7 +321,10 @@ describe("BaseInteractionClient", () => {
             };
 
             // @ts-ignore
-            const addFieldsSpy = jest.spyOn(testClient.performanceClient, "addFields");
+            const addFieldsSpy = jest.spyOn(
+                testClient.performanceClient,
+                "addFields"
+            );
 
             await testClient
                 // @ts-ignore
@@ -336,7 +343,8 @@ describe("BaseInteractionClient", () => {
 
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    discoveredAuthority: "https://login.microsoftonline.com/common/",
+                    discoveredAuthority:
+                        "https://login.microsoftonline.com/common/",
                     accountEnvironment: "(undefined)",
                 }),
                 expect.any(String)
@@ -354,7 +362,10 @@ describe("BaseInteractionClient", () => {
             };
 
             // @ts-ignore
-            const addFieldsSpy = jest.spyOn(testClient.performanceClient, "addFields");
+            const addFieldsSpy = jest.spyOn(
+                testClient.performanceClient,
+                "addFields"
+            );
 
             await testClient
                 // @ts-ignore
@@ -373,7 +384,8 @@ describe("BaseInteractionClient", () => {
 
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    discoveredAuthority: "https://login.microsoftonline.com/common/",
+                    discoveredAuthority:
+                        "https://login.microsoftonline.com/common/",
                     accountEnvironment: "(empty string)",
                 }),
                 expect.any(String)
@@ -391,7 +403,10 @@ describe("BaseInteractionClient", () => {
             };
 
             // @ts-ignore
-            const addFieldsSpy = jest.spyOn(testClient.performanceClient, "addFields");
+            const addFieldsSpy = jest.spyOn(
+                testClient.performanceClient,
+                "addFields"
+            );
 
             await testClient
                 // @ts-ignore
@@ -410,7 +425,8 @@ describe("BaseInteractionClient", () => {
 
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    discoveredAuthority: "https://login.microsoftonline.com/common/",
+                    discoveredAuthority:
+                        "https://login.microsoftonline.com/common/",
                     accountEnvironment: "(empty string)",
                 }),
                 expect.any(String)

--- a/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
@@ -281,7 +281,7 @@ describe("BaseInteractionClient", () => {
 
             // @ts-ignore
             const addFieldsSpy = jest.spyOn(
-                testClient.performanceClient,
+                (testClient as any).performanceClient,
                 "addFields"
             );
 
@@ -322,7 +322,7 @@ describe("BaseInteractionClient", () => {
 
             // @ts-ignore
             const addFieldsSpy = jest.spyOn(
-                testClient.performanceClient,
+                (testClient as any).performanceClient,
                 "addFields"
             );
 
@@ -363,7 +363,7 @@ describe("BaseInteractionClient", () => {
 
             // @ts-ignore
             const addFieldsSpy = jest.spyOn(
-                testClient.performanceClient,
+                (testClient as any).performanceClient,
                 "addFields"
             );
 
@@ -404,7 +404,7 @@ describe("BaseInteractionClient", () => {
 
             // @ts-ignore
             const addFieldsSpy = jest.spyOn(
-                testClient.performanceClient,
+                (testClient as any).performanceClient,
                 "addFields"
             );
 

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -3505,6 +3505,8 @@ export type PerformanceEvent = {
     cacheAtCount?: number;
     scenarioId?: string;
     accountType?: "AAD" | "MSA" | "B2C";
+    discoveredAuthority?: string;
+    accountEnvironment?: string;
     retryError?: string;
     embeddedClientId?: string;
     embeddedRedirectUri?: string;
@@ -4821,8 +4823,8 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/telemetry/performance/PerformanceEvent.ts:815:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:815:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:815:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:889:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:889:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:889:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:893:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:893:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:893:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -147,7 +147,7 @@ export class AccountEntity {
             accountDetails.environment ||
             (authority && authority.getPreferredCache());
 
-        if (!env) {
+        if (!env || env === "") {
             throw createClientAuthError(
                 ClientAuthErrorCodes.invalidCacheEnvironment
             );

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -147,7 +147,7 @@ export class AccountEntity {
             accountDetails.environment ||
             (authority && authority.getPreferredCache());
 
-        if (!env || env === "") {
+        if (!env || env.trim() === "") {
             throw createClientAuthError(
                 ClientAuthErrorCodes.invalidCacheEnvironment
             );

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -354,7 +354,7 @@ export class ResponseHandler {
         authCodePayload?: AuthorizationCodePayload
     ): CacheRecord {
         const env = authority.getPreferredCache();
-        if (!env || env === "") {
+        if (!env || env.trim() === "") {
             throw createClientAuthError(
                 ClientAuthErrorCodes.invalidCacheEnvironment
             );

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -354,7 +354,7 @@ export class ResponseHandler {
         authCodePayload?: AuthorizationCodePayload
     ): CacheRecord {
         const env = authority.getPreferredCache();
-        if (!env) {
+        if (!env || env === "") {
             throw createClientAuthError(
                 ClientAuthErrorCodes.invalidCacheEnvironment
             );

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -883,6 +883,10 @@ export type PerformanceEvent = {
 
     accountType?: "AAD" | "MSA" | "B2C";
 
+    // Discovered authority and passed in account's authority/environment values
+    discoveredAuthority?: string;
+    accountEnvironment?: string;
+
     /**
      * Server error that triggers a request retry
      *

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -1032,7 +1032,7 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
                     {
                         homeAccountId,
                         idTokenClaims: idTokenClaims,
-                        environment: "", // Explicitly passing empty string, but it's falsy so falls through to authority
+                        environment: "", // Explicitly passing empty string; authority.getPreferredCache() also returns "", so validation treats env as invalid and throws
                     },
                     authority
                 );

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -945,4 +945,131 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         expect(acc.localAccountId).toBe(idTokenClaims.sub);
         expect(AccountEntity.isAccountEntity(acc)).toEqual(true);
     });
+
+    describe("createAccount error scenarios", () => {
+        const idTokenClaims = {
+            ver: "2.0",
+            iss: `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
+            sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+            exp: 1536361411,
+            name: "Abe Lincoln",
+            preferred_username: "AbeLi@microsoft.com",
+            oid: "00000000-0000-0000-66f3-3332eca7ea81",
+            tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+            nonce: "123523",
+        };
+
+        it("throws invalidCacheEnvironment when authority.getPreferredCache() returns empty string and no environment provided", () => {
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue("");
+            
+            const homeAccountId = AccountEntity.generateHomeAccountId(
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+                AuthorityType.Default,
+                logger,
+                cryptoInterface,
+                idTokenClaims
+            );
+
+            expect(() => {
+                AccountEntity.createAccount(
+                    {
+                        homeAccountId,
+                        idTokenClaims: idTokenClaims,
+                    },
+                    authority
+                );
+            }).toThrow("invalid_cache_environment");
+        });
+
+        it("throws invalidCacheEnvironment when authority.getPreferredCache() returns undefined and no environment provided", () => {
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(undefined as any);
+            
+            const homeAccountId = AccountEntity.generateHomeAccountId(
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+                AuthorityType.Default,
+                logger,
+                cryptoInterface,
+                idTokenClaims
+            );
+
+            expect(() => {
+                AccountEntity.createAccount(
+                    {
+                        homeAccountId,
+                        idTokenClaims: idTokenClaims,
+                    },
+                    authority
+                );
+            }).toThrow("invalid_cache_environment");
+        });
+
+        it("throws invalidCacheEnvironment when accountDetails.environment is empty string and authority.getPreferredCache() also returns empty string", () => {
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue("");
+            
+            const homeAccountId = AccountEntity.generateHomeAccountId(
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+                AuthorityType.Default,
+                logger,
+                cryptoInterface,
+                idTokenClaims
+            );
+
+            expect(() => {
+                AccountEntity.createAccount(
+                    {
+                        homeAccountId,
+                        idTokenClaims: idTokenClaims,
+                        environment: "", // Explicitly passing empty string, but it's falsy so falls through to authority
+                    },
+                    authority
+                );
+            }).toThrow("invalid_cache_environment");
+        });
+
+        it("uses accountDetails.environment when provided, even if authority.getPreferredCache() would fail", () => {
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue("");
+            
+            const homeAccountId = AccountEntity.generateHomeAccountId(
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+                AuthorityType.Default,
+                logger,
+                cryptoInterface,
+                idTokenClaims
+            );
+
+            // Should NOT throw because accountDetails.environment is provided
+            const acc = AccountEntity.createAccount(
+                {
+                    homeAccountId,
+                    idTokenClaims: idTokenClaims,
+                    environment: "custom.environment.com",
+                },
+                authority
+            );
+
+            expect(acc.environment).toBe("custom.environment.com");
+        });
+
+        it("throws invalidCacheEnvironment when authority.getPreferredCache() returns null and no environment in accountDetails", () => {
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(null as any);
+            
+            const homeAccountId = AccountEntity.generateHomeAccountId(
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+                AuthorityType.Default,
+                logger,
+                cryptoInterface,
+                idTokenClaims
+            );
+
+            expect(() => {
+                AccountEntity.createAccount(
+                    {
+                        homeAccountId,
+                        idTokenClaims: idTokenClaims,
+                    },
+                    authority
+                );
+            }).toThrow("invalid_cache_environment");
+        });
+    });
 });

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -824,6 +824,10 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
             "myadfs.com"
         );
     });
+    
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
 
     it("creates a generic ADFS account", () => {
         const authorityOptions: AuthorityOptions = {

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -824,7 +824,7 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
             "myadfs.com"
         );
     });
-    
+
     afterEach(() => {
         jest.restoreAllMocks();
     });
@@ -964,8 +964,11 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         };
 
         it("throws invalidCacheEnvironment when authority.getPreferredCache() returns empty string and no environment provided", () => {
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue("");
-            
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue("");
+
             const homeAccountId = AccountEntity.generateHomeAccountId(
                 TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
                 AuthorityType.Default,
@@ -986,8 +989,11 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         });
 
         it("throws invalidCacheEnvironment when authority.getPreferredCache() returns undefined and no environment provided", () => {
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(undefined as any);
-            
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue(undefined as any);
+
             const homeAccountId = AccountEntity.generateHomeAccountId(
                 TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
                 AuthorityType.Default,
@@ -1008,8 +1014,11 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         });
 
         it("throws invalidCacheEnvironment when accountDetails.environment is empty string and authority.getPreferredCache() also returns empty string", () => {
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue("");
-            
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue("");
+
             const homeAccountId = AccountEntity.generateHomeAccountId(
                 TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
                 AuthorityType.Default,
@@ -1031,8 +1040,11 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         });
 
         it("uses accountDetails.environment when provided, even if authority.getPreferredCache() would fail", () => {
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue("");
-            
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue("");
+
             const homeAccountId = AccountEntity.generateHomeAccountId(
                 TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
                 AuthorityType.Default,
@@ -1055,8 +1067,11 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         });
 
         it("throws invalidCacheEnvironment when authority.getPreferredCache() returns null and no environment in accountDetails", () => {
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(null as any);
-            
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue(null as any);
+
             const homeAccountId = AccountEntity.generateHomeAccountId(
                 TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
                 AuthorityType.Default,

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -818,6 +818,171 @@ describe("AccountEntity.ts Unit Tests", () => {
     });
 });
 
+// Generic tests for environment validation in createAccount
+describe("createAccount environment error scenarios", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const idTokenClaims = {
+        ver: "2.0",
+        iss: `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
+        sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+        exp: 1536361411,
+        name: "Abe Lincoln",
+        preferred_username: "AbeLi@microsoft.com",
+        oid: "00000000-0000-0000-66f3-3332eca7ea81",
+        tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+        nonce: "123523",
+    };
+
+    it("throws invalidCacheEnvironment when authority.getPreferredCache() returns empty string and no environment provided", () => {
+        jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+            ""
+        );
+
+        const homeAccountId = AccountEntity.generateHomeAccountId(
+            TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+            AuthorityType.Default,
+            logger,
+            cryptoInterface,
+            idTokenClaims
+        );
+
+        expect(() => {
+            AccountEntity.createAccount(
+                {
+                    homeAccountId,
+                    idTokenClaims: idTokenClaims,
+                },
+                authority
+            );
+        }).toThrow("invalid_cache_environment");
+    });
+
+    it("throws invalidCacheEnvironment when authority.getPreferredCache() returns whitespace-only string and no environment provided", () => {
+        jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+            " "
+        );
+
+        const homeAccountId = AccountEntity.generateHomeAccountId(
+            TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+            AuthorityType.Default,
+            logger,
+            cryptoInterface,
+            idTokenClaims
+        );
+
+        expect(() => {
+            AccountEntity.createAccount(
+                {
+                    homeAccountId,
+                    idTokenClaims: idTokenClaims,
+                },
+                authority
+            );
+        }).toThrow("invalid_cache_environment");
+    });
+
+    it("throws invalidCacheEnvironment when authority.getPreferredCache() returns undefined and no environment provided", () => {
+        jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+            undefined as any
+        );
+
+        const homeAccountId = AccountEntity.generateHomeAccountId(
+            TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+            AuthorityType.Default,
+            logger,
+            cryptoInterface,
+            idTokenClaims
+        );
+
+        expect(() => {
+            AccountEntity.createAccount(
+                {
+                    homeAccountId,
+                    idTokenClaims: idTokenClaims,
+                },
+                authority
+            );
+        }).toThrow("invalid_cache_environment");
+    });
+
+    it("throws invalidCacheEnvironment when accountDetails.environment is empty string and authority.getPreferredCache() also returns empty string", () => {
+        jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+            ""
+        );
+
+        const homeAccountId = AccountEntity.generateHomeAccountId(
+            TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+            AuthorityType.Default,
+            logger,
+            cryptoInterface,
+            idTokenClaims
+        );
+
+        expect(() => {
+            AccountEntity.createAccount(
+                {
+                    homeAccountId,
+                    idTokenClaims: idTokenClaims,
+                    environment: "",
+                },
+                authority
+            );
+        }).toThrow("invalid_cache_environment");
+    });
+
+    it("uses accountDetails.environment when provided, even if authority.getPreferredCache() would fail", () => {
+        jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+            ""
+        );
+
+        const homeAccountId = AccountEntity.generateHomeAccountId(
+            TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+            AuthorityType.Default,
+            logger,
+            cryptoInterface,
+            idTokenClaims
+        );
+
+        const acc = AccountEntity.createAccount(
+            {
+                homeAccountId,
+                idTokenClaims: idTokenClaims,
+                environment: "custom.environment.com",
+            },
+            authority
+        );
+
+        expect(acc.environment).toBe("custom.environment.com");
+    });
+
+    it("throws invalidCacheEnvironment when authority.getPreferredCache() returns null and no environment in accountDetails", () => {
+        jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+            null as any
+        );
+
+        const homeAccountId = AccountEntity.generateHomeAccountId(
+            TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+            AuthorityType.Default,
+            logger,
+            cryptoInterface,
+            idTokenClaims
+        );
+
+        expect(() => {
+            AccountEntity.createAccount(
+                {
+                    homeAccountId,
+                    idTokenClaims: idTokenClaims,
+                },
+                authority
+            );
+        }).toThrow("invalid_cache_environment");
+    });
+});
+
 describe("AccountEntity.ts Unit Tests for ADFS", () => {
     beforeEach(() => {
         jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
@@ -948,147 +1113,5 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         expect(acc.authorityType).toBe(CacheAccountType.ADFS_ACCOUNT_TYPE);
         expect(acc.localAccountId).toBe(idTokenClaims.sub);
         expect(AccountEntity.isAccountEntity(acc)).toEqual(true);
-    });
-
-    describe("createAccount error scenarios", () => {
-        const idTokenClaims = {
-            ver: "2.0",
-            iss: `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
-            sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
-            exp: 1536361411,
-            name: "Abe Lincoln",
-            preferred_username: "AbeLi@microsoft.com",
-            oid: "00000000-0000-0000-66f3-3332eca7ea81",
-            tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
-            nonce: "123523",
-        };
-
-        it("throws invalidCacheEnvironment when authority.getPreferredCache() returns empty string and no environment provided", () => {
-            jest.spyOn(
-                Authority.prototype,
-                "getPreferredCache"
-            ).mockReturnValue("");
-
-            const homeAccountId = AccountEntity.generateHomeAccountId(
-                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
-                AuthorityType.Default,
-                logger,
-                cryptoInterface,
-                idTokenClaims
-            );
-
-            expect(() => {
-                AccountEntity.createAccount(
-                    {
-                        homeAccountId,
-                        idTokenClaims: idTokenClaims,
-                    },
-                    authority
-                );
-            }).toThrow("invalid_cache_environment");
-        });
-
-        it("throws invalidCacheEnvironment when authority.getPreferredCache() returns undefined and no environment provided", () => {
-            jest.spyOn(
-                Authority.prototype,
-                "getPreferredCache"
-            ).mockReturnValue(undefined as any);
-
-            const homeAccountId = AccountEntity.generateHomeAccountId(
-                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
-                AuthorityType.Default,
-                logger,
-                cryptoInterface,
-                idTokenClaims
-            );
-
-            expect(() => {
-                AccountEntity.createAccount(
-                    {
-                        homeAccountId,
-                        idTokenClaims: idTokenClaims,
-                    },
-                    authority
-                );
-            }).toThrow("invalid_cache_environment");
-        });
-
-        it("throws invalidCacheEnvironment when accountDetails.environment is empty string and authority.getPreferredCache() also returns empty string", () => {
-            jest.spyOn(
-                Authority.prototype,
-                "getPreferredCache"
-            ).mockReturnValue("");
-
-            const homeAccountId = AccountEntity.generateHomeAccountId(
-                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
-                AuthorityType.Default,
-                logger,
-                cryptoInterface,
-                idTokenClaims
-            );
-
-            expect(() => {
-                AccountEntity.createAccount(
-                    {
-                        homeAccountId,
-                        idTokenClaims: idTokenClaims,
-                        environment: "", // Explicitly passing empty string; authority.getPreferredCache() also returns "", so validation treats env as invalid and throws
-                    },
-                    authority
-                );
-            }).toThrow("invalid_cache_environment");
-        });
-
-        it("uses accountDetails.environment when provided, even if authority.getPreferredCache() would fail", () => {
-            jest.spyOn(
-                Authority.prototype,
-                "getPreferredCache"
-            ).mockReturnValue("");
-
-            const homeAccountId = AccountEntity.generateHomeAccountId(
-                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
-                AuthorityType.Default,
-                logger,
-                cryptoInterface,
-                idTokenClaims
-            );
-
-            // Should NOT throw because accountDetails.environment is provided
-            const acc = AccountEntity.createAccount(
-                {
-                    homeAccountId,
-                    idTokenClaims: idTokenClaims,
-                    environment: "custom.environment.com",
-                },
-                authority
-            );
-
-            expect(acc.environment).toBe("custom.environment.com");
-        });
-
-        it("throws invalidCacheEnvironment when authority.getPreferredCache() returns null and no environment in accountDetails", () => {
-            jest.spyOn(
-                Authority.prototype,
-                "getPreferredCache"
-            ).mockReturnValue(null as any);
-
-            const homeAccountId = AccountEntity.generateHomeAccountId(
-                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
-                AuthorityType.Default,
-                logger,
-                cryptoInterface,
-                idTokenClaims
-            );
-
-            expect(() => {
-                AccountEntity.createAccount(
-                    {
-                        homeAccountId,
-                        idTokenClaims: idTokenClaims,
-                    },
-                    authority
-                );
-            }).toThrow("invalid_cache_environment");
-        });
     });
 });


### PR DESCRIPTION
This pull request enhances authority/environment validation and telemetry in the MSAL libraries, improving error handling and diagnostics around authority mismatches and cache environment issues. It introduces stricter checks for empty or undefined environment values, ensures telemetry is recorded with normalized values, and adds comprehensive test coverage for these scenarios.

**Authority/environment validation and error handling:**
- Updated `AccountEntity` and `ResponseHandler` to throw an `invalid_cache_environment` error if the environment is empty or consists only of whitespace, not just when undefined. This prevents invalid or ambiguous environment values from being used. [[1]](diffhunk://#diff-da4164a905f1d02bf5f1bb1a4b7d8ff766b88eeb796a42b27b88f67e30cb3f17L150-R150) [[2]](diffhunk://#diff-e7645604421092f76d09943662ec9f80a9c22dc2b3a0ff05189f985bb0e5c444L357-R357)
- Added new unit tests in `AccountEntity.spec.ts` to cover error scenarios when the environment is empty, undefined, or null, and to verify correct behavior when a valid environment is provided.

**Telemetry and instrumentation improvements:**
- Enhanced authority mismatch handling in `BaseInteractionClient` to record telemetry fields for `discoveredAuthority` and `accountEnvironment`, normalizing undefined or empty values for better diagnostics.
- Extended the `PerformanceEvent` type to include the new telemetry fields `discoveredAuthority` and `accountEnvironment`.
- Added new tests in `BaseInteractionClient.spec.ts` to verify that telemetry is correctly recorded with normalized values for various account environment edge cases (undefined, empty string, whitespace).

**Changelog updates:**
- Added changelog entries for both `@azure/msal-common` and `@azure/msal-browser` documenting the authority mismatch instrumentation work. [[1]](diffhunk://#diff-88259da5a5414bac38fee37a1ffab7bdfde00d08b79de6750d28748e74eea930R1-R7) [[2]](diffhunk://#diff-7c8546bbf5af6ab7a54d2d8968fa252e3733d756c6cf865b4315eea2ac668d2dR1-R7)

**Test maintenance:**
- Ensured proper cleanup of mocks in `AccountEntity.spec.ts` by restoring all mocks after each test, preventing test interference.