### PR TITLE
Add accountSource when caching an account

### DIFF
--- a/change/@azure-msal-browser-1145035b-3987-40b0-aa28-833a1eaff8cd.json
+++ b/change/@azure-msal-browser-1145035b-3987-40b0-aa28-833a1eaff8cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": " Add accountSource when caching an account #8213",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-1145035b-3987-40b0-aa28-833a1eaff8cd.json
+++ b/change/@azure-msal-browser-1145035b-3987-40b0-aa28-833a1eaff8cd.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": " Add accountSource when caching an account #8213",
+  "comment": "Add accountSource when caching an account [#8213](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8213)",
   "packageName": "@azure/msal-browser",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-66533c87-d4a2-4bbc-a945-dd29a31aefdd.json
+++ b/change/@azure-msal-common-66533c87-d4a2-4bbc-a945-dd29a31aefdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add accountSource when caching an account #8213",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-66533c87-d4a2-4bbc-a945-dd29a31aefdd.json
+++ b/change/@azure-msal-common-66533c87-d4a2-4bbc-a945-dd29a31aefdd.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add accountSource when caching an account #8213",
+  "comment": "Add accountSource when caching an account [#8213](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8213)",
   "packageName": "@azure/msal-common",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-node-08f73185-611d-41d3-80cd-5f09a114593a.json
+++ b/change/@azure-msal-node-08f73185-611d-41d3-80cd-5f09a114593a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add accountSource to testconstants in Node tests",
+  "packageName": "@azure/msal-node",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-node-08f73185-611d-41d3-80cd-5f09a114593a.json
+++ b/change/@azure-msal-node-08f73185-611d-41d3-80cd-5f09a114593a.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Add accountSource when caching an account 8213",
+  "comment": "Add accountSource when caching an account [#8213](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8213)",
   "packageName": "@azure/msal-node",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "none"

--- a/change/@azure-msal-node-08f73185-611d-41d3-80cd-5f09a114593a.json
+++ b/change/@azure-msal-node-08f73185-611d-41d3-80cd-5f09a114593a.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Add accountSource to testconstants in Node tests",
+  "comment": "Add accountSource when caching an account 8213",
   "packageName": "@azure/msal-node",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "none"

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -185,9 +185,10 @@ export class TokenCache implements ITokenCache {
         this.logger.verbose("TokenCache - loading account");
 
         if (request.account) {
-            const accountEntity = AccountEntity.createFromAccountInfo(
-                request.account
-            );
+            const accountEntity = AccountEntity.createFromAccountInfo({
+                ...request.account,
+                accountSource: "external",
+            });
             await this.storage.setAccount(
                 accountEntity,
                 correlationId,
@@ -225,7 +226,8 @@ export class TokenCache implements ITokenCache {
             claimsTenantId,
             undefined, // authCodePayload
             undefined, // nativeAccountId
-            this.logger
+            this.logger,
+            "external" // accountSource
         );
 
         await this.storage.setAccount(

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -932,7 +932,10 @@ export class NestedAppAuthController implements IController {
         this.logger.verbose("hydrateCache called");
 
         const accountEntity = AccountEntity.createFromAccountInfo(
-            result.account,
+            {
+                ...result.account,
+                accountSource: "naa",
+            },
             result.cloudGraphHostName,
             result.msGraphHost
         );

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -2108,6 +2108,7 @@ export class StandardController implements IController {
                         fromCache: result.fromCache,
                         accessTokenSize: result.accessToken.length,
                         idTokenSize: result.idToken.length,
+                        accountSource: account.accountSource,
                     },
                     undefined,
                     result.account
@@ -2127,6 +2128,7 @@ export class StandardController implements IController {
                 atsMeasurement.end(
                     {
                         success: false,
+                        accountSource: account.accountSource,
                     },
                     error,
                     account

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1620,7 +1620,10 @@ export class StandardController implements IController {
 
         // Account gets saved to browser storage regardless of native or not
         const accountEntity = AccountEntity.createFromAccountInfo(
-            result.account,
+            {
+                ...result.account,
+                accountSource: "pwb",
+            },
             result.cloudGraphHostName,
             result.msGraphHost
         );

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -517,7 +517,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             idTokenClaims.tid,
             undefined, // auth code payload
             response.account.id,
-            this.logger
+            this.logger,
+            "platform_broker" // accountSource - response from native/platform broker (WAM)
         );
 
         // Ensure expires_in is in number format

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -7699,7 +7699,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
     describe("hydrateCache tests", () => {
         const testAccount: AccountInfo = {
             ...AccountEntity.getAccountInfo(
-                buildAccountFromIdTokenClaims(ID_TOKEN_CLAIMS)
+                buildAccountFromIdTokenClaims(ID_TOKEN_CLAIMS, undefined, {
+                    accountSource: "pwb",
+                })
             ),
             idTokenClaims: ID_TOKEN_CLAIMS,
             idToken: TEST_TOKENS.IDTOKEN_V2,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -6281,6 +6281,60 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca.acquireTokenSilent(silentRequest);
         });
 
+        it("emits accountSource in performance event when account has accountSource", (done) => {
+            const testIdTokenClaims: TokenClaims = {
+                ver: "2.0",
+                iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                name: "Abe Lincoln",
+                preferred_username: "AbeLi@microsoft.com",
+                oid: "00000000-0000-0000-66f3-3332eca7ea81",
+                tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                nonce: "123523",
+                login_hint: "testLoginHint",
+            };
+
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || "",
+                loginHint: testIdTokenClaims.login_hint,
+                idTokenClaims: { ...testIdTokenClaims },
+                accountSource: "external",
+            };
+
+            jest.spyOn(ProtocolUtils, "setRequestState").mockReturnValue(
+                TEST_STATE_VALUES.TEST_STATE_SILENT
+            );
+            const silentRequest: SilentRequest = {
+                scopes: ["User.Read"],
+                account: testAccount,
+                correlationId: RANDOM_TEST_GUID,
+            };
+
+            jest.spyOn(
+                StandardController.prototype,
+                <any>"acquireTokenSilentAsync"
+            ).mockResolvedValue({
+                fromCache: true,
+                accessToken: "abc",
+                idToken: "defg",
+                account: testAccount,
+            });
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].accountSource).toBe("external");
+
+                pca.removePerformanceCallback(callbackId);
+                done();
+            });
+
+            pca.acquireTokenSilent(silentRequest);
+        });
+
         it("emits expect performance event when successful in case of network request", (done) => {
             const testAccount: AccountInfo = {
                 homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -536,5 +536,35 @@ describe("TokenCache tests", () => {
                 false
             );
         });
+
+        it("sets accountSource to 'external' when loading external tokens", async () => {
+            const setAccountSpy = jest.spyOn(
+                BrowserCacheManager.prototype,
+                "setAccount"
+            );
+            const request: SilentRequest = {
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                authority: `${TEST_URIS.DEFAULT_INSTANCE}${TEST_CONFIG.TENANT}`,
+            };
+            const response: ExternalTokenResponse = {
+                id_token: testIdToken,
+            };
+            const options: LoadTokenOptions = {
+                clientInfo: testClientInfo,
+            };
+
+            const result = await tokenCache.loadExternalTokens(
+                request,
+                response,
+                options
+            );
+
+            expect(result.account?.accountSource).toBe("external");
+            expect(setAccountSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ accountSource: "external" }),
+                expect.anything(),
+                expect.anything()
+            );
+        });
     });
 });

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -217,7 +217,10 @@ describe("TokenCache tests", () => {
             const accountEntity = buildAccountFromIdTokenClaims(
                 ID_TOKEN_CLAIMS,
                 undefined,
-                { environment: testEnvironment }
+                {
+                    environment: testEnvironment,
+                    accountSource: "external",
+                }
             );
             const testAccountInfo = AccountEntity.getAccountInfo(accountEntity);
             const testAccountKey =

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -100,6 +100,7 @@ const TEST_ACCOUNT_INFO: AccountInfo = {
     ...AccountEntity.getAccountInfo(testAccountEntity),
     idTokenClaims: ID_TOKEN_CLAIMS,
     idToken: TEST_TOKENS.IDTOKEN_V2,
+    accountSource: "platform_broker",
 };
 
 const TEST_ID_TOKEN: IdTokenEntity = buildIdToken(

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -714,6 +714,7 @@ describe("SilentIframeClient", () => {
                 ]),
                 idTokenClaims: ID_TOKEN_CLAIMS,
                 idToken: TEST_TOKENS.IDTOKEN_V2,
+                accountSource: "msal",
             };
             const testTokenResponse: AuthenticationResult = {
                 authority: TEST_CONFIG.validAuthority,

--- a/lib/msal-browser/test/utils/StringConstants.ts
+++ b/lib/msal-browser/test/utils/StringConstants.ts
@@ -554,6 +554,7 @@ export const TEST_ACCOUNT_INFO: AccountInfo = {
     name: ID_TOKEN_CLAIMS.name,
     nativeAccountId: undefined,
     tenantProfiles: testTenantProfilesMap,
+    accountSource: "msal",
 };
 
 export function getTestAuthenticationResult(): AuthenticationResult {

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -127,6 +127,8 @@ export class AccountEntity {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static accountInfoIsEqual(accountA: AccountInfo | null, accountB: AccountInfo | null, compareClaims?: boolean): boolean;
     // (undocumented)
+    accountSource?: AccountSource;
+    // (undocumented)
     authorityType: string;
     // (undocumented)
     clientInfo?: string;
@@ -142,13 +144,12 @@ export class AccountEntity {
         environment?: string;
         nativeAccountId?: string;
         tenantProfiles?: Array<TenantProfile>;
+        accountSource?: AccountSource;
     }, authority: Authority, base64Decode?: (input: string) => string): AccountEntity;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static createFromAccountInfo(accountInfo: AccountInfo, cloudGraphHostName?: string, msGraphHost?: string): AccountEntity;
-    // Warning: (ae-forgotten-export) The symbol "DataBoundary" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     dataBoundary?: DataBoundary;
     // (undocumented)
@@ -219,7 +220,13 @@ export type AccountInfo = {
     authorityType?: string;
     tenantProfiles?: Map<string, TenantProfile>;
     dataBoundary?: DataBoundary;
+    accountSource?: AccountSource;
 };
+
+// Warning: (ae-missing-release-tag) "AccountSource" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type AccountSource = "msal" | "external" | "pwb" | "naa" | "platform_broker";
 
 // Warning: (ae-missing-release-tag) "ActiveAccountFilters" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -974,7 +981,7 @@ const BROKER_REDIRECT_URI = "brk_redirect_uri";
 // Warning: (ae-missing-release-tag) "buildAccountToCache" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function buildAccountToCache(cacheStorage: CacheManager, authority: Authority, homeAccountId: string, base64Decode: (input: string) => string, correlationId: string, idTokenClaims?: TokenClaims, clientInfo?: string, environment?: string, claimsTenantId?: string | null, authCodePayload?: AuthorizationCodePayload, nativeAccountId?: string, logger?: Logger): AccountEntity;
+export function buildAccountToCache(cacheStorage: CacheManager, authority: Authority, homeAccountId: string, base64Decode: (input: string) => string, correlationId: string, idTokenClaims?: TokenClaims, clientInfo?: string, environment?: string, claimsTenantId?: string | null, authCodePayload?: AuthorizationCodePayload, nativeAccountId?: string, logger?: Logger, accountSource?: AccountSource): AccountEntity;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -2120,6 +2127,11 @@ export const CredentialType: {
 
 // @public (undocumented)
 export type CredentialType = (typeof CredentialType)[keyof typeof CredentialType];
+
+// Warning: (ae-missing-release-tag) "DataBoundary" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DataBoundary = "EU" | "None";
 
 // Warning: (ae-missing-release-tag) "DEFAULT_CRYPTO_IMPLEMENTATION" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3522,6 +3534,7 @@ export type PerformanceEvent = {
     sameClientIdInstanceCount?: number;
     navigateCallbackResult?: boolean;
     dataBoundary?: DataBoundary;
+    accountSource?: AccountSource;
 };
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@export" is not defined in this configuration
@@ -4727,9 +4740,9 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/request/AuthenticationHeaderParser.ts:74:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:343:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:344:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:345:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:346:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceClient.ts:942:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceClient.ts:942:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
 // src/telemetry/performance/PerformanceClient.ts:954:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/account/AccountInfo.ts
+++ b/lib/msal-common/src/account/AccountInfo.ts
@@ -35,7 +35,7 @@ export type AccountSource =
  * - nativeAccountId        - The user's native account ID
  * - tenantProfiles         - Map of tenant profile objects for each tenant that the account has authenticated with in the browser
  * - dataBoundary           - Data boundary extracted from clientInfo
- * - accountSource          - Source of how the account was created (msal, external, broker, pwb, naa, or platform_broker)
+ * - accountSource          - Source of how the account was created (msal, external, pwb, naa, or platform_broker)
  */
 export type AccountInfo = {
     homeAccountId: string;

--- a/lib/msal-common/src/account/AccountInfo.ts
+++ b/lib/msal-common/src/account/AccountInfo.ts
@@ -8,6 +8,21 @@ import { TokenClaims } from "./TokenClaims.js";
 export type DataBoundary = "EU" | "None";
 
 /**
+ * Indicates the source of how an account was created and cached.
+ * - "msal" - Account was created directly by MSAL from a network token response
+ * - "external" - Account was loaded from an external source via loadExternalTokens
+ * - "pwb" - Account was cached from a pairwise broker response (e.g., PairwiseBrokerApplication)
+ * - "naa" - Account was cached from a nested app auth host response (e.g., EmbeddedClientApplication)
+ * - "platform_broker" - Account was cached from a native/platform broker response (e.g., WAM)
+ */
+export type AccountSource =
+    | "msal"
+    | "external"
+    | "pwb"
+    | "naa"
+    | "platform_broker";
+
+/**
  * Account object with the following signature:
  * - homeAccountId          - Home account identifier for this account object
  * - environment            - Entity which issued the token represented by the domain of the issuer (e.g. login.microsoftonline.com)
@@ -20,6 +35,7 @@ export type DataBoundary = "EU" | "None";
  * - nativeAccountId        - The user's native account ID
  * - tenantProfiles         - Map of tenant profile objects for each tenant that the account has authenticated with in the browser
  * - dataBoundary           - Data boundary extracted from clientInfo
+ * - accountSource          - Source of how the account was created (msal, external, broker, pwb, naa, or platform_broker)
  */
 export type AccountInfo = {
     homeAccountId: string;
@@ -43,6 +59,7 @@ export type AccountInfo = {
     authorityType?: string;
     tenantProfiles?: Map<string, TenantProfile>;
     dataBoundary?: DataBoundary;
+    accountSource?: AccountSource;
 };
 
 /**

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -12,6 +12,7 @@ import {
     TenantProfile,
     buildTenantProfile,
     DataBoundary,
+    AccountSource,
 } from "../../account/AccountInfo.js";
 import {
     createClientAuthError,
@@ -66,6 +67,7 @@ export class AccountEntity {
     tenantProfiles?: Array<TenantProfile>;
     lastUpdatedAt: string;
     dataBoundary?: DataBoundary;
+    accountSource?: AccountSource;
 
     /**
      * Returns the AccountInfo interface for this account.
@@ -88,6 +90,7 @@ export class AccountEntity {
                 })
             ),
             dataBoundary: accountEntity.dataBoundary,
+            accountSource: accountEntity.accountSource,
         };
     }
 
@@ -112,6 +115,7 @@ export class AccountEntity {
             environment?: string;
             nativeAccountId?: string;
             tenantProfiles?: Array<TenantProfile>;
+            accountSource?: AccountSource;
         },
         authority: Authority,
         base64Decode?: (input: string) => string
@@ -198,6 +202,8 @@ export class AccountEntity {
             account.tenantProfiles = [tenantProfile];
         }
 
+        account.accountSource = accountDetails.accountSource;
+
         return account;
     }
 
@@ -235,6 +241,7 @@ export class AccountEntity {
             accountInfo.tenantProfiles?.values() || []
         );
         account.dataBoundary = accountInfo.dataBoundary;
+        account.accountSource = accountInfo.accountSource;
 
         return account;
     }

--- a/lib/msal-common/src/exports-common.ts
+++ b/lib/msal-common/src/exports-common.ts
@@ -38,6 +38,8 @@ export {
     updateAccountTenantProfileData,
     tenantIdMatchesHomeTenant,
     buildTenantProfile,
+    AccountSource,
+    DataBoundary,
 } from "./account/AccountInfo.js";
 export {
     TokenClaims,

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -53,6 +53,7 @@ import {
     AccountInfo,
     buildTenantProfile,
     updateAccountTenantProfileData,
+    AccountSource,
 } from "../account/AccountInfo.js";
 import * as CacheHelpers from "../cache/utils/CacheHelpers.js";
 import * as TimeUtils from "../utils/TimeUtils.js";
@@ -628,7 +629,8 @@ export function buildAccountToCache(
     claimsTenantId?: string | null,
     authCodePayload?: AuthorizationCodePayload,
     nativeAccountId?: string,
-    logger?: Logger
+    logger?: Logger,
+    accountSource?: AccountSource
 ): AccountEntity {
     logger?.verbose("setCachedAccount called");
 
@@ -654,6 +656,7 @@ export function buildAccountToCache(
                 cloudGraphHostName: authCodePayload?.cloud_graph_host_name,
                 msGraphHost: authCodePayload?.msgraph_host,
                 nativeAccountId: nativeAccountId,
+                accountSource: accountSource ?? "msal",
             },
             authority,
             base64Decode

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { DataBoundary } from "../../account/AccountInfo.js";
+import { AccountSource, DataBoundary } from "../../account/AccountInfo.js";
 
 /**
  * Enumeration of operations that are instrumented by have their performance measured by the PerformanceClient.
@@ -916,6 +916,11 @@ export type PerformanceEvent = {
     navigateCallbackResult?: boolean;
 
     dataBoundary?: DataBoundary;
+
+    /**
+     * Source of how the account was created (msal, external, pwb, naa, platform_broker)
+     */
+    accountSource?: AccountSource;
 };
 
 export type PerformanceEventContext = {

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -945,4 +945,129 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
         expect(acc.localAccountId).toBe(idTokenClaims.sub);
         expect(AccountEntity.isAccountEntity(acc)).toEqual(true);
     });
+
+    describe("accountSource", () => {
+        const idTokenClaims = {
+            ver: "2.0",
+            iss: `${TEST_URIS.DEFAULT_INSTANCE}9188040d-6c67-4c5b-b112-36a304b66dad/v2.0`,
+            sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+            exp: 1536361411,
+            name: "Abe Lincoln",
+            preferred_username: "AbeLi@microsoft.com",
+            oid: "00000000-0000-0000-66f3-3332eca7ea81",
+            tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+            nonce: "123523",
+        };
+
+        it("createAccount does not set accountSource when not provided", () => {
+            const homeAccountId = AccountEntity.generateHomeAccountId(
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+                AuthorityType.Default,
+                logger,
+                cryptoInterface,
+                idTokenClaims
+            );
+
+            const acc = AccountEntity.createAccount(
+                {
+                    homeAccountId,
+                    idTokenClaims: idTokenClaims,
+                },
+                authority
+            );
+
+            expect(acc.accountSource).toBeUndefined();
+            expect(
+                AccountEntity.getAccountInfo(acc).accountSource
+            ).toBeUndefined();
+        });
+
+        it("createAccount sets accountSource when provided", () => {
+            const homeAccountId = AccountEntity.generateHomeAccountId(
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
+                AuthorityType.Default,
+                logger,
+                cryptoInterface,
+                idTokenClaims
+            );
+
+            const acc = AccountEntity.createAccount(
+                {
+                    homeAccountId,
+                    idTokenClaims: idTokenClaims,
+                    accountSource: "platform_broker",
+                },
+                authority
+            );
+
+            expect(acc.accountSource).toBe("platform_broker");
+            expect(AccountEntity.getAccountInfo(acc).accountSource).toBe(
+                "platform_broker"
+            );
+        });
+
+        it("createFromAccountInfo preserves accountSource from AccountInfo", () => {
+            const testAccountInfo: AccountInfo = {
+                homeAccountId:
+                    TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID,
+                environment: PREFERRED_CACHE_ALIAS,
+                tenantId: idTokenClaims.tid,
+                username: "AbeLi@microsoft.com",
+                localAccountId: idTokenClaims.oid,
+                accountSource: "external",
+            };
+
+            const acc = AccountEntity.createFromAccountInfo(testAccountInfo);
+
+            expect(acc.accountSource).toBe("external");
+            expect(AccountEntity.getAccountInfo(acc).accountSource).toBe(
+                "external"
+            );
+        });
+
+        it("createFromAccountInfo does not set accountSource when not provided", () => {
+            const testAccountInfo: AccountInfo = {
+                homeAccountId:
+                    TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID,
+                environment: PREFERRED_CACHE_ALIAS,
+                tenantId: idTokenClaims.tid,
+                username: "AbeLi@microsoft.com",
+                localAccountId: idTokenClaims.oid,
+            };
+
+            const acc = AccountEntity.createFromAccountInfo(testAccountInfo);
+
+            expect(acc.accountSource).toBeUndefined();
+            expect(
+                AccountEntity.getAccountInfo(acc).accountSource
+            ).toBeUndefined();
+        });
+
+        it("getAccountInfo returns accountSource for all valid values", () => {
+            const accountSources = [
+                "msal",
+                "external",
+                "pwb",
+                "naa",
+                "platform_broker",
+            ] as const;
+
+            accountSources.forEach((source) => {
+                const testAccountInfo: AccountInfo = {
+                    homeAccountId:
+                        TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID,
+                    environment: PREFERRED_CACHE_ALIAS,
+                    tenantId: idTokenClaims.tid,
+                    username: "AbeLi@microsoft.com",
+                    localAccountId: idTokenClaims.oid,
+                    accountSource: source,
+                };
+
+                const acc = AccountEntity.createFromAccountInfo(testAccountInfo);
+                const accountInfo = AccountEntity.getAccountInfo(acc);
+
+                expect(accountInfo.accountSource).toBe(source);
+            });
+        });
+    });
 });

--- a/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
+++ b/lib/msal-common/test/cache/entities/AccountEntity.spec.ts
@@ -1063,7 +1063,8 @@ describe("AccountEntity.ts Unit Tests for ADFS", () => {
                     accountSource: source,
                 };
 
-                const acc = AccountEntity.createFromAccountInfo(testAccountInfo);
+                const acc =
+                    AccountEntity.createFromAccountInfo(testAccountInfo);
                 const accountInfo = AccountEntity.getAccountInfo(acc);
 
                 expect(accountInfo.accountSource).toBe(source);

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -1,5 +1,8 @@
 import { ServerAuthorizationTokenResponse } from "../../src/response/ServerAuthorizationTokenResponse.js";
-import { ResponseHandler } from "../../src/response/ResponseHandler.js";
+import {
+    ResponseHandler,
+    buildAccountToCache,
+} from "../../src/response/ResponseHandler.js";
 import {
     AUTHENTICATION_RESULT,
     ID_TOKEN_CLAIMS,
@@ -975,6 +978,112 @@ describe("ResponseHandler.ts", () => {
                     CacheErrorMessages[CacheErrorCodes.cacheErrorUnknown]
                 );
             }
+        });
+    });
+
+    describe("buildAccountToCache", () => {
+        it("defaults accountSource to 'msal' when not provided", () => {
+            jest.restoreAllMocks();
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+                "login.microsoftonline.com"
+            );
+
+            const account = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID,
+                cryptoInterface.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                ID_TOKEN_CLAIMS as TokenClaims,
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
+                undefined, // environment
+                undefined, // claimsTenantId
+                undefined, // authCodePayload
+                undefined, // nativeAccountId
+                logger,
+                undefined // accountSource - not provided
+            );
+
+            expect(account.accountSource).toBe("msal");
+        });
+
+        it("sets accountSource to provided value", () => {
+            jest.restoreAllMocks();
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+                "login.microsoftonline.com"
+            );
+
+            const account = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID,
+                cryptoInterface.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                ID_TOKEN_CLAIMS as TokenClaims,
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
+                undefined, // environment
+                undefined, // claimsTenantId
+                undefined, // authCodePayload
+                undefined, // nativeAccountId
+                logger,
+                "platform_broker"
+            );
+
+            expect(account.accountSource).toBe("platform_broker");
+        });
+
+        it("sets accountSource to 'external' for external tokens", () => {
+            jest.restoreAllMocks();
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+                "login.microsoftonline.com"
+            );
+
+            const account = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID,
+                cryptoInterface.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                ID_TOKEN_CLAIMS as TokenClaims,
+                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
+                undefined, // environment
+                undefined, // claimsTenantId
+                undefined, // authCodePayload
+                undefined, // nativeAccountId
+                logger,
+                "external"
+            );
+
+            expect(account.accountSource).toBe("external");
+        });
+
+        it("sets accountSource for all valid broker types", () => {
+            jest.restoreAllMocks();
+            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
+                "login.microsoftonline.com"
+            );
+
+            const brokerSources = ["pwb", "naa", "platform_broker"] as const;
+
+            brokerSources.forEach((source) => {
+                const account = buildAccountToCache(
+                    testCacheManager,
+                    testAuthority,
+                    TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID,
+                    cryptoInterface.base64Decode,
+                    TEST_CONFIG.CORRELATION_ID,
+                    ID_TOKEN_CLAIMS as TokenClaims,
+                    TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
+                    undefined, // environment
+                    undefined, // claimsTenantId
+                    undefined, // authCodePayload
+                    undefined, // nativeAccountId
+                    logger,
+                    source
+                );
+
+                expect(account.accountSource).toBe(source);
+            });
         });
     });
 });

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -984,9 +984,10 @@ describe("ResponseHandler.ts", () => {
     describe("buildAccountToCache", () => {
         it("defaults accountSource to 'msal' when not provided", () => {
             jest.restoreAllMocks();
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
-                "login.microsoftonline.com"
-            );
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue("login.microsoftonline.com");
 
             const account = buildAccountToCache(
                 testCacheManager,
@@ -1009,9 +1010,10 @@ describe("ResponseHandler.ts", () => {
 
         it("sets accountSource to provided value", () => {
             jest.restoreAllMocks();
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
-                "login.microsoftonline.com"
-            );
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue("login.microsoftonline.com");
 
             const account = buildAccountToCache(
                 testCacheManager,
@@ -1034,9 +1036,10 @@ describe("ResponseHandler.ts", () => {
 
         it("sets accountSource to 'external' for external tokens", () => {
             jest.restoreAllMocks();
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
-                "login.microsoftonline.com"
-            );
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue("login.microsoftonline.com");
 
             const account = buildAccountToCache(
                 testCacheManager,
@@ -1059,9 +1062,10 @@ describe("ResponseHandler.ts", () => {
 
         it("sets accountSource for all valid broker types", () => {
             jest.restoreAllMocks();
-            jest.spyOn(Authority.prototype, "getPreferredCache").mockReturnValue(
-                "login.microsoftonline.com"
-            );
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue("login.microsoftonline.com");
 
             const brokerSources = ["pwb", "naa", "platform_broker"] as const;
 

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -1034,32 +1034,6 @@ describe("ResponseHandler.ts", () => {
             expect(account.accountSource).toBe("platform_broker");
         });
 
-        it("sets accountSource to 'external' for external tokens", () => {
-            jest.restoreAllMocks();
-            jest.spyOn(
-                Authority.prototype,
-                "getPreferredCache"
-            ).mockReturnValue("login.microsoftonline.com");
-
-            const account = buildAccountToCache(
-                testCacheManager,
-                testAuthority,
-                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID,
-                cryptoInterface.base64Decode,
-                TEST_CONFIG.CORRELATION_ID,
-                ID_TOKEN_CLAIMS as TokenClaims,
-                TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
-                undefined, // environment
-                undefined, // claimsTenantId
-                undefined, // authCodePayload
-                undefined, // nativeAccountId
-                logger,
-                "external"
-            );
-
-            expect(account.accountSource).toBe("external");
-        });
-
         it("sets accountSource for all valid broker types", () => {
             jest.restoreAllMocks();
             jest.spyOn(

--- a/lib/msal-node/test/utils/TestConstants.ts
+++ b/lib/msal-node/test/utils/TestConstants.ts
@@ -258,6 +258,7 @@ export const mockAccountInfo: AccountInfo = {
         ],
     ]),
     dataBoundary: undefined,
+    accountSource: undefined,
 };
 
 export const mockNativeAccountInfo: AccountInfo = {


### PR DESCRIPTION
This pull request introduces support for tracking the source of accounts cached by MSAL, through a new `accountSource` property. This property is now included in the `AccountInfo` and `AccountEntity` types, and is set appropriately throughout the codebase depending on how the account was created or loaded (e.g., from MSAL, an external source, or a broker). The changes also ensure that `accountSource` is emitted in performance events and tested accordingly.

**Account source tracking and propagation:**

* Added a new `AccountSource` type and `accountSource` property to `AccountInfo` and `AccountEntity`, allowing the source of an account (such as `"msal"`, `"external"`, `"pwb"`, `"naa"`, or `"platform_broker"`) to be tracked throughout the authentication flow. [[1]](diffhunk://#diff-e084ebe1eb271b062833ecd25c476acd22e5b0a36c69a39520506e5c46ebaa53R10-R24) [[2]](diffhunk://#diff-e084ebe1eb271b062833ecd25c476acd22e5b0a36c69a39520506e5c46ebaa53R38) [[3]](diffhunk://#diff-e084ebe1eb271b062833ecd25c476acd22e5b0a36c69a39520506e5c46ebaa53R62) [[4]](diffhunk://#diff-da4164a905f1d02bf5f1bb1a4b7d8ff766b88eeb796a42b27b88f67e30cb3f17R70) [[5]](diffhunk://#diff-da4164a905f1d02bf5f1bb1a4b7d8ff766b88eeb796a42b27b88f67e30cb3f17R93) [[6]](diffhunk://#diff-da4164a905f1d02bf5f1bb1a4b7d8ff766b88eeb796a42b27b88f67e30cb3f17R118) [[7]](diffhunk://#diff-da4164a905f1d02bf5f1bb1a4b7d8ff766b88eeb796a42b27b88f67e30cb3f17R205-R206) [[8]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R130-R131) [[9]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R147-L151) [[10]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R223-R230)
* Updated account creation and caching logic in `TokenCache`, `StandardController`, `NestedAppAuthController`, and `PlatformAuthInteractionClient` to set the appropriate `accountSource` value based on the context (e.g., `"external"` for external tokens, `"pwb"` for pairwise broker, etc.). [[1]](diffhunk://#diff-5f7831e13b2c981db1cd1b03fed5d4c547c6e15d722bedf343e48d5c98d22f8fL188-R191) [[2]](diffhunk://#diff-5f7831e13b2c981db1cd1b03fed5d4c547c6e15d722bedf343e48d5c98d22f8fL228-R230) [[3]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8L935-R938) [[4]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fL1623-R1626) [[5]](diffhunk://#diff-244dfa122d07581eab88090f1afcda16eadd373c130463c14fa5d42598c4c2e7L520-R521)

**Performance telemetry enhancements:**

* Modified performance event emission to include the `accountSource` property, allowing for more granular telemetry and debugging. [[1]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR2111) [[2]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR2131) [[3]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R3537)

**API and codebase updates:**

* Updated the public API documentation and type signatures to reflect the addition of `accountSource`, and extended the `buildAccountToCache` function to accept an `accountSource` parameter.
* Added the `DataBoundary` type to the public API for completeness.

**Testing improvements:**

* Added new unit tests to verify that `accountSource` is correctly set and emitted in performance events and when loading external tokens. [[1]](diffhunk://#diff-f936803be34376b4fc36745b78ec5110b6e3b420d907b033fa6924453d2815d5R6284-R6337) [[2]](diffhunk://#diff-44274fc7d579dfe62b39dd8d6cfdefd0ba9d6e0418a5a117465ea49893244c1eR539-R568)

**Changelog entries:**

* Added changelog entries for both `@azure/msal-browser` and `@azure/msal-common` packages documenting the addition of `accountSource` when caching an account. [[1]](diffhunk://#diff-d4997caf4e5c4cb0ef34a0c6db4e10f039a53f77816825f9e4b8f29dc29eb059R1-R7) [[2]](diffhunk://#diff-d75650a42bbdd459c71e1f8512360989211d0df8d54c24983977a328eab64853R1-R7)