### PR TITLE
Track ApiId when getting and setting accounts in cache

### DIFF
--- a/change/@azure-msal-browser-65752c17-02ce-4a03-a2e0-486bd52252d4.json
+++ b/change/@azure-msal-browser-65752c17-02ce-4a03-a2e0-486bd52252d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Track ApiId when setting/getting accounts",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-88d25b3c-41ef-46f9-a62d-3e1ddc67ba05.json
+++ b/change/@azure-msal-common-88d25b3c-41ef-46f9-a62d-3e1ddc67ba05.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Track APIId when setting/getting accounts",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-88d25b3c-41ef-46f9-a62d-3e1ddc67ba05.json
+++ b/change/@azure-msal-common-88d25b3c-41ef-46f9-a62d-3e1ddc67ba05.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Track APIId when setting/getting accounts",
+  "comment": "Track ApiId when setting/getting accounts",
   "packageName": "@azure/msal-common",
   "email": "thomas.norling@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-node-1eb99364-b32d-40e5-b186-471420892920.json
+++ b/change/@azure-msal-node-1eb99364-b32d-40e5-b186-471420892920.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Track ApiId when setting/getting accounts",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -87,6 +87,8 @@ export const ApiId: {
     readonly acquireTokenSilent_silentFlow: 61;
     readonly logout: 961;
     readonly logoutPopup: 962;
+    readonly hydrateCache: 963;
+    readonly loadExternalTokens: 964;
 };
 
 // @public (undocumented)

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -48,6 +48,8 @@ import {
     createBrowserAuthError,
 } from "../error/BrowserAuthError.js";
 import {
+    ApiId,
+    apiIdToName,
     BrowserCacheLocation,
     InMemoryCacheKeys,
     INTERACTION_TYPE,
@@ -1045,6 +1047,13 @@ export class BrowserCacheManager extends CacheManager {
             return null;
         }
 
+        this.performanceClient.addFields(
+            {
+                accountCachedBy: apiIdToName(parsedAccount.cachedByApiId),
+            },
+            correlationId
+        );
+
         return CacheManager.toObject<AccountEntity>(
             new AccountEntity(),
             parsedAccount
@@ -1058,7 +1067,8 @@ export class BrowserCacheManager extends CacheManager {
     async setAccount(
         account: AccountEntity,
         correlationId: string,
-        kmsi: boolean
+        kmsi: boolean,
+        apiId: number
     ): Promise<void> {
         this.logger.trace("BrowserCacheManager.setAccount called");
         const key = this.generateAccountKey(
@@ -1066,6 +1076,7 @@ export class BrowserCacheManager extends CacheManager {
         );
         const timestamp = Date.now().toString();
         account.lastUpdatedAt = timestamp;
+        account.cachedByApiId = apiId;
         await this.setUserData(
             key,
             JSON.stringify(account),
@@ -2279,7 +2290,8 @@ export class BrowserCacheManager extends CacheManager {
             result.correlationId,
             AuthToken.isKmsi(
                 AuthToken.extractTokenClaims(result.idToken, base64Decode)
-            )
+            ),
+            ApiId.hydrateCache
         );
     }
 
@@ -2293,6 +2305,7 @@ export class BrowserCacheManager extends CacheManager {
         cacheRecord: CacheRecord,
         correlationId: string,
         kmsi: boolean,
+        apiId: ApiId,
         storeInCache?: StoreInCache
     ): Promise<void> {
         try {
@@ -2300,6 +2313,7 @@ export class BrowserCacheManager extends CacheManager {
                 cacheRecord,
                 correlationId,
                 kmsi,
+                apiId,
                 storeInCache
             );
         } catch (e) {

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -32,6 +32,7 @@ import {
 import type { AuthenticationResult } from "../response/AuthenticationResult.js";
 import { base64Decode } from "../encode/Base64Decode.js";
 import * as BrowserCrypto from "../crypto/BrowserCrypto.js";
+import { ApiId } from "../utils/BrowserConstants.js";
 
 export type LoadTokenOptions = {
     clientInfo?: string;
@@ -191,7 +192,8 @@ export class TokenCache implements ITokenCache {
             await this.storage.setAccount(
                 accountEntity,
                 correlationId,
-                AuthToken.isKmsi(idTokenClaims || {})
+                AuthToken.isKmsi(idTokenClaims || {}),
+                ApiId.loadExternalTokens
             );
             return accountEntity;
         } else if (!authority || (!clientInfo && !idTokenClaims)) {
@@ -231,7 +233,8 @@ export class TokenCache implements ITokenCache {
         await this.storage.setAccount(
             cachedAccount,
             correlationId,
-            AuthToken.isKmsi(idTokenClaims || {})
+            AuthToken.isKmsi(idTokenClaims || {}),
+            ApiId.loadExternalTokens
         );
         return cachedAccount;
     }

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -939,7 +939,8 @@ export class NestedAppAuthController implements IController {
         await this.browserStorage.setAccount(
             accountEntity,
             result.correlationId,
-            AuthToken.isKmsi(result.idTokenClaims)
+            AuthToken.isKmsi(result.idTokenClaims),
+            ApiId.hydrateCache
         );
         return this.browserStorage.hydrateCache(result, request);
     }

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1627,7 +1627,8 @@ export class StandardController implements IController {
         await this.browserStorage.setAccount(
             accountEntity,
             result.correlationId,
-            AuthToken.isKmsi(result.idTokenClaims)
+            AuthToken.isKmsi(result.idTokenClaims),
+            ApiId.hydrateCache
         );
 
         if (result.fromNativeBroker) {

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import * as PublicApiId from "../../core/telemetry/PublicApiId.js";
 import { ICustomAuthApiClient } from "../network_client/custom_auth_api/ICustomAuthApiClient.js";
 import { MethodNotImplementedError } from "../error/MethodNotImplementedError.js";
 import { CustomAuthAuthority } from "../CustomAuthAuthority.js";
@@ -97,7 +98,8 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
     protected async handleTokenResponse(
         tokenResponse: SignInTokenResponse,
         requestScopes: string[],
-        correlationId: string
+        correlationId: string,
+        apiId: number
     ): Promise<AuthenticationResult> {
         this.logger.verbose("Processing token response.", correlationId);
 
@@ -114,7 +116,8 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
                     correlationId:
                         tokenResponse.correlation_id ?? correlationId,
                     scopes: requestScopes,
-                }
+                },
+                apiId
             );
 
         return result as AuthenticationResult;

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import * as PublicApiId from "../../core/telemetry/PublicApiId.js";
 import { ICustomAuthApiClient } from "../network_client/custom_auth_api/ICustomAuthApiClient.js";
 import { MethodNotImplementedError } from "../error/MethodNotImplementedError.js";
 import { CustomAuthAuthority } from "../CustomAuthAuthority.js";

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/jit/JitClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/jit/JitClient.ts
@@ -154,7 +154,8 @@ export class JitClient extends CustomAuthInteractionClientBase {
         const authResult = await this.handleTokenResponse(
             tokenResponse,
             scopes,
-            tokenResponse.correlation_id || continueResponse.correlation_id
+            tokenResponse.correlation_id || continueResponse.correlation_id,
+            apiId
         );
 
         return createJitCompletedResult({

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/mfa/MfaClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/mfa/MfaClient.ts
@@ -137,7 +137,8 @@ export class MfaClient extends CustomAuthInteractionClientBase {
         const result = await this.handleTokenResponse(
             tokenResponse,
             scopes,
-            tokenResponse.correlation_id ?? parameters.correlationId
+            tokenResponse.correlation_id ?? parameters.correlationId,
+            apiId
         );
 
         return createMfaCompletedResult({

--- a/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
@@ -89,7 +89,8 @@ export class CustomAuthSilentCacheClient extends CustomAuthInteractionClientBase
 
                 const refreshTokenResult =
                     await refreshTokenClient.acquireTokenByRefreshToken(
-                        silentRequest
+                        silentRequest,
+                        PublicApiId.ACCOUNT_GET_ACCESS_TOKEN
                     );
 
                 this.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
@@ -176,7 +176,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
                 ),
             scopes,
             parameters.correlationId,
-            telemetryManager
+            telemetryManager,
+            apiId
         );
     }
 
@@ -220,7 +221,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
                 ),
             scopes,
             parameters.correlationId,
-            telemetryManager
+            telemetryManager,
+            apiId
         );
     }
 
@@ -263,7 +265,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
                 ),
             scopes,
             parameters.correlationId,
-            telemetryManager
+            telemetryManager,
+            apiId
         );
     }
 
@@ -279,7 +282,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
         tokenEndpointCaller: () => Promise<SignInTokenResponse>,
         scopes: string[],
         correlationId: string,
-        telemetryManager: ServerTelemetryManager
+        telemetryManager: ServerTelemetryManager,
+        apiId: number
     ): Promise<
         | SignInCompletedResult
         | SignInJitRequiredResult
@@ -301,7 +305,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             const authResult = await this.handleTokenResponse(
                 tokenResponse,
                 scopes,
-                correlationId
+                correlationId,
+                apiId
             );
 
             return createSignInCompleteResult({

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -741,7 +741,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         await this.browserStorage.setAccount(
             accountEntity,
             this.correlationId,
-            kmsi
+            kmsi,
+            this.apiId
         );
         // Remove any existing cached tokens for this account in browser storage
         this.browserStorage.removeAccountContext(
@@ -817,6 +818,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             nativeCacheRecord,
             this.correlationId,
             AuthToken.isKmsi(idTokenClaims),
+            this.apiId,
             request.storeInCache
         );
     }

--- a/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
@@ -136,6 +136,7 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
                     cloud_instance_host_name: request.cloudInstanceHostName,
                 },
                 silentRequest,
+                this.apiId,
                 false
             );
         } catch (e) {

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -74,11 +74,13 @@ export class SilentRefreshClient extends StandardInteractionClient {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(silentRequest).catch((e: AuthError) => {
-            (e as AuthError).setCorrelationId(this.correlationId);
-            serverTelemetryManager.cacheFailedRequest(e);
-            throw e;
-        }) as Promise<AuthenticationResult>;
+        )(silentRequest, ApiId.acquireTokenSilent_silentFlow).catch(
+            (e: AuthError) => {
+                (e as AuthError).setCorrelationId(this.correlationId);
+                serverTelemetryManager.cacheFailedRequest(e);
+                throw e;
+            }
+        ) as Promise<AuthenticationResult>;
     }
 
     /**

--- a/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
@@ -25,6 +25,7 @@ import {
     BrowserAuthErrorCodes,
 } from "../error/BrowserAuthError.js";
 import { AuthenticationResult } from "../response/AuthenticationResult.js";
+import { ApiId } from "../utils/BrowserConstants.js";
 
 /**
  * Abstract class which defines operations for a browser interaction handling class.
@@ -56,7 +57,8 @@ export class InteractionHandler {
      */
     async handleCodeResponse(
         response: AuthorizeResponse,
-        request: CommonAuthorizationUrlRequest
+        request: CommonAuthorizationUrlRequest,
+        apiId: ApiId
     ): Promise<AuthenticationResult> {
         this.performanceClient.addQueueMeasurement(
             PerformanceEvents.HandleCodeResponse,
@@ -89,7 +91,7 @@ export class InteractionHandler {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(authCodeResponse, request);
+        )(authCodeResponse, request, apiId);
     }
 
     /**
@@ -103,6 +105,7 @@ export class InteractionHandler {
     async handleCodeResponseFromServer(
         authCodeResponse: AuthorizationCodePayload,
         request: CommonAuthorizationUrlRequest,
+        apiId: ApiId,
         validateNonce: boolean = true
     ): Promise<AuthenticationResult> {
         this.performanceClient.addQueueMeasurement(
@@ -152,7 +155,11 @@ export class InteractionHandler {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(this.authCodeRequest, authCodeResponse)) as AuthenticationResult;
+        )(
+            this.authCodeRequest,
+            apiId,
+            authCodeResponse
+        )) as AuthenticationResult;
         return tokenResponse;
     }
 

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -438,7 +438,7 @@ export async function handleResponseCode(
         logger,
         performanceClient,
         request.correlationId
-    )(response, request);
+    )(response, request, apiId);
 
     return result;
 }
@@ -556,6 +556,7 @@ export async function handleResponseEAR(
         authority,
         TimeUtils.nowSeconds(),
         request,
+        apiId,
         additionalData,
         undefined,
         undefined,

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -112,9 +112,9 @@ export type InMemoryCacheKeys =
 
 /**
  * API Codes for Telemetry purposes.
- * Before adding a new code you must claim it in the MSAL Telemetry tracker as these number spaces are shared across all MSALs
  * 0-99 Silent Flow
  * 800-899 Auth Code Flow
+ * 900-999 Miscellaneous
  */
 export const ApiId = {
     acquireTokenRedirect: 861,
@@ -126,8 +126,34 @@ export const ApiId = {
     acquireTokenSilent_silentFlow: 61,
     logout: 961,
     logoutPopup: 962,
+    hydrateCache: 963,
+    loadExternalTokens: 964,
 } as const;
 export type ApiId = (typeof ApiId)[keyof typeof ApiId];
+
+/**
+ * API Names for Telemetry purposes.
+ */
+export const ApiName = {
+    861: "acquireTokenRedirect",
+    862: "acquireTokenPopup",
+    863: "ssoSilent",
+    864: "acquireTokenSilent_authCode",
+    865: "handleRedirectPromise",
+    866: "acquireTokenByCode",
+    61: "acquireTokenSilent_silentFlow",
+    961: "logout",
+    962: "logoutPopup",
+    963: "hydrateCache",
+    964: "loadExternalTokens",
+} as const satisfies Record<ApiId, string>;
+
+export const apiIdToName = (id: number | undefined): string => {
+    if (typeof id === "number" && id in ApiName) {
+        return ApiName[id as ApiId];
+    }
+    return "unknown";
+};
 
 /*
  * Interaction type of the API - used for state and telemetry

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -2588,10 +2588,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 cachedByApiId: ApiId.acquireTokenSilent_silentFlow,
                 environment: "login.microsoftonline.com",
             });
-            // @ts-ignore access test-only browserStorage
-            const browserStorage = localPca.controller
-            // @ts-ignore access test-only browserStorage
-                .browserStorage as BrowserCacheManager;
+            const browserStorage =
+                // @ts-ignore access test-only browserStorage
+                localPca.controller.browserStorage as BrowserCacheManager;
             await browserStorage.setAccount(
                 accountEntity,
                 RANDOM_TEST_GUID,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -20,6 +20,9 @@ import {
     TEST_URIS,
     testLogoutUrl,
     verifyUrl,
+    TEST_ACCOUNT_ENTITY,
+    TEST_ID_TOKEN_ENTITY,
+    TEST_ACCESS_TOKEN_ENTITY,
 } from "../utils/StringConstants.js";
 import {
     AccountEntity,
@@ -64,6 +67,7 @@ import {
     TemporaryCacheKeys,
     WrapperSKU,
 } from "../../src/utils/BrowserConstants.js";
+import { apiIdToName } from "../../src/utils/BrowserConstants.js";
 import { CryptoOps } from "../../src/crypto/CryptoOps.js";
 import * as BrowserCrypto from "../../src/crypto/BrowserCrypto.js";
 import * as PkceGenerator from "../../src/crypto/PkceGenerator.js";
@@ -2558,6 +2562,69 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     throw new Error("success path should not be reached");
                 })
                 .catch((e) => {});
+        });
+
+        it("emits accountCachedBy telemetry for acquireTokenSilent cache hit", async () => {
+            window.sessionStorage.clear();
+            const perfClient = new StubPerformanceClient();
+            const addFieldsSpy = jest.spyOn(perfClient, "addFields");
+            const localPca = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                },
+                telemetry: {
+                    client: perfClient,
+                    application: {
+                        appName: TEST_CONFIG.applicationName,
+                        appVersion: TEST_CONFIG.applicationVersion,
+                    },
+                },
+            });
+
+            await localPca.initialize();
+
+            const accountEntity = new AccountEntity();
+            Object.assign(accountEntity, TEST_ACCOUNT_ENTITY, {
+                cachedByApiId: ApiId.acquireTokenSilent_silentFlow,
+                environment: "login.microsoftonline.com",
+            });
+            // @ts-ignore access test-only browserStorage
+            const browserStorage = localPca.controller.browserStorage as BrowserCacheManager;
+            await browserStorage.setAccount(
+                accountEntity,
+                RANDOM_TEST_GUID,
+                false,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            const idTokenEntity = { ...TEST_ID_TOKEN_ENTITY, environment: "login.microsoftonline.com" };
+            await browserStorage.setIdTokenCredential(
+                idTokenEntity,
+                RANDOM_TEST_GUID,
+                false
+            );
+            const accessTokenEntity = { ...TEST_ACCESS_TOKEN_ENTITY, environment: "login.microsoftonline.com" };
+            await browserStorage.setAccessTokenCredential(
+                accessTokenEntity,
+                RANDOM_TEST_GUID,
+                false
+            );
+
+            const accountInfo = localPca.getAllAccounts()[0];
+            expect(accountInfo).toBeDefined();
+
+            try {
+                const result = await localPca.acquireTokenSilent({
+                    scopes: ["user.read", "mail.read"],
+                    account: accountInfo!,
+                });
+                expect(result.accessToken).toBe(TEST_TOKENS.ACCESS_TOKEN);
+            } catch (e) {
+                // ignore errors from iframe fallbacks; we only care that getAccount telemetry was emitted
+            }
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                { accountCachedBy: apiIdToName(ApiId.acquireTokenSilent_silentFlow) },
+                expect.any(String)
+            );
         });
     });
 

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -2589,20 +2589,27 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 environment: "login.microsoftonline.com",
             });
             // @ts-ignore access test-only browserStorage
-            const browserStorage = localPca.controller.browserStorage as BrowserCacheManager;
+            const browserStorage = localPca.controller
+                .browserStorage as BrowserCacheManager;
             await browserStorage.setAccount(
                 accountEntity,
                 RANDOM_TEST_GUID,
                 false,
                 ApiId.acquireTokenSilent_silentFlow
             );
-            const idTokenEntity = { ...TEST_ID_TOKEN_ENTITY, environment: "login.microsoftonline.com" };
+            const idTokenEntity = {
+                ...TEST_ID_TOKEN_ENTITY,
+                environment: "login.microsoftonline.com",
+            };
             await browserStorage.setIdTokenCredential(
                 idTokenEntity,
                 RANDOM_TEST_GUID,
                 false
             );
-            const accessTokenEntity = { ...TEST_ACCESS_TOKEN_ENTITY, environment: "login.microsoftonline.com" };
+            const accessTokenEntity = {
+                ...TEST_ACCESS_TOKEN_ENTITY,
+                environment: "login.microsoftonline.com",
+            };
             await browserStorage.setAccessTokenCredential(
                 accessTokenEntity,
                 RANDOM_TEST_GUID,
@@ -2622,7 +2629,11 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 // ignore errors from iframe fallbacks; we only care that getAccount telemetry was emitted
             }
             expect(addFieldsSpy).toHaveBeenCalledWith(
-                { accountCachedBy: apiIdToName(ApiId.acquireTokenSilent_silentFlow) },
+                {
+                    accountCachedBy: apiIdToName(
+                        ApiId.acquireTokenSilent_silentFlow
+                    ),
+                },
                 expect.any(String)
             );
         });

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -2590,6 +2590,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             });
             // @ts-ignore access test-only browserStorage
             const browserStorage = localPca.controller
+            // @ts-ignore access test-only browserStorage
                 .browserStorage as BrowserCacheManager;
             await browserStorage.setAccount(
                 accountEntity,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -748,14 +748,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     }
                 }
             );
-            const response = await pca.handleRedirectPromise();
+            const response = await (pca as any).handleRedirectPromise();
             expect(response?.idToken).not.toBeNull();
             expect(response).toEqual(testTokenResponse);
             expect(redirectClientSpy).toHaveBeenCalledTimes(1);
             expect(loginSuccessFired).toBe(true);
         });
 
-        it("Calls RedirectClient.handleRedirectPromise and emits telemetry event", (done) => {
+        it("Calls RedirectClient.handleRedirectPromise and emits telemetry event", async () => {
             const testAccount = BASIC_TEST_ACCOUNT_INFO;
             const testTokenResponse: AuthenticationResult = {
                 authority: TEST_CONFIG.validAuthority,
@@ -787,23 +787,36 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 "handleRedirectPromise"
             ).mockResolvedValue(testTokenResponse);
 
-            const callbackId = pca.addPerformanceCallback((events) => {
-                expect(events.length).toEqual(1);
-                const event = events[0];
-                expect(event.name).toBe(PerformanceEvents.AcquireTokenRedirect);
-                expect(event.correlationId).toBeDefined();
-                expect(event.success).toBeTruthy();
-                expect(
-                    event["handleRedirectPromiseDurationMs"]
-                ).toBeGreaterThanOrEqual(0);
-                expect(event["handleRedirectPromiseCallCount"]).toEqual(1);
-                expect(event.success).toBeTruthy();
-                expect(event.accountType).toEqual(undefined);
-                pca.removePerformanceCallback(callbackId);
-                done();
+            let callbackId: string;
+            const callbackPromise = new Promise<void>((resolve, reject) => {
+                callbackId = pca.addPerformanceCallback((events) => {
+                    try {
+                        expect(events.length).toEqual(1);
+                        const event = events[0];
+                        expect(event.name).toBe(
+                            PerformanceEvents.AcquireTokenRedirect
+                        );
+                        expect(event.correlationId).toBeDefined();
+                        expect(event.success).toBeTruthy();
+                        expect(
+                            event["handleRedirectPromiseDurationMs"]
+                        ).toBeGreaterThanOrEqual(0);
+                        expect(event["handleRedirectPromiseCallCount"]).toEqual(
+                            1
+                        );
+                        expect(event.success).toBeTruthy();
+                        expect(event.accountType).toEqual(undefined);
+                        resolve();
+                    } catch (e) {
+                        reject(e);
+                    } finally {
+                        pca.removePerformanceCallback(callbackId);
+                    }
+                });
             });
 
-            pca.handleRedirectPromise();
+            await (pca as any).handleRedirectPromise();
+            await callbackPromise;
         });
 
         it("cleans temporary cache and rethrows if error is thrown", (done) => {
@@ -889,7 +902,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 windowTitleSubstring: "test window",
             };
             // @ts-ignore
-            pca.browserStorage.setTemporaryCache(
+            (pca as any).browserStorage.setTemporaryCache(
                 TemporaryCacheKeys.NATIVE_REQUEST,
                 JSON.stringify(nativeRequest),
                 true
@@ -1010,7 +1023,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     windowTitleSubstring: "test window",
                 };
                 // @ts-ignore
-                pca.browserStorage.setTemporaryCache(
+                (pca as any).browserStorage.setTemporaryCache(
                     TemporaryCacheKeys.NATIVE_REQUEST,
                     JSON.stringify(nativeRequest),
                     true
@@ -2019,7 +2032,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .catch((e) => {
                     expect(
                         // @ts-ignore
-                        pca.browserStorage.getInteractionInProgress()
+                        (pca as any).browserStorage.getInteractionInProgress()
                     ).toBeFalsy();
                     expect(e.message).toEqual("testError");
                 });
@@ -3034,7 +3047,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .catch((e) => {
                     expect(
                         // @ts-ignore
-                        pca.browserStorage.getInteractionInProgress()
+                        (pca as any).browserStorage.getInteractionInProgress()
                     ).toBeFalsy();
                 });
             expect(nativeAcquireTokenSpy).toHaveBeenCalledTimes(1);
@@ -5064,7 +5077,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 silentRequest3,
             ]);
 
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest);
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedTokenRequest,
+                ApiId.acquireTokenSilent_silentFlow
+            );
             expect(atsSpy).toHaveBeenCalledTimes(1);
             expect(silentATStub).toHaveBeenCalledTimes(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);
@@ -5187,7 +5203,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 silentRequest3,
             ]);
 
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest);
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedTokenRequest,
+                ApiId.acquireTokenSilent_silentFlow
+            );
             expect(atsSpy).toHaveBeenCalledTimes(1);
             expect(silentATStub).toHaveBeenCalledTimes(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);
@@ -5353,17 +5372,19 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             };
 
             const expectedSshCertificateRequest1: CommonSilentFlowRequest = {
-                ...sshCertRequest1,
                 scopes: ["User.Read"],
+                account: testAccount,
                 authority: `${Constants.DEFAULT_AUTHORITY}`,
+                authenticationScheme: AuthenticationScheme.BEARER,
                 correlationId: RANDOM_TEST_GUID,
                 forceRefresh: false,
             };
 
             const expectedSshCertificateRequest2: CommonSilentFlowRequest = {
-                ...sshCertRequest2,
                 scopes: ["Mail.Read"],
+                account: testAccount,
                 authority: `${Constants.DEFAULT_AUTHORITY}`,
+                authenticationScheme: AuthenticationScheme.BEARER,
                 correlationId: RANDOM_TEST_GUID,
                 forceRefresh: false,
             };
@@ -5392,15 +5413,29 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 sshCertSilentRequest3,
             ]);
 
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest2);
-            expect(silentATStub).toHaveBeenCalledWith(expectedPopTokenRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(expectedPopTokenRequest2);
             expect(silentATStub).toHaveBeenCalledWith(
-                expectedSshCertificateRequest1
+                expectedTokenRequest1,
+                ApiId.acquireTokenSilent_silentFlow
             );
             expect(silentATStub).toHaveBeenCalledWith(
-                expectedSshCertificateRequest2
+                expectedTokenRequest2,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedPopTokenRequest1,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedPopTokenRequest2,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedSshCertificateRequest1,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedSshCertificateRequest2,
+                ApiId.acquireTokenSilent_silentFlow
             );
             expect(silentATStub).toHaveBeenCalledTimes(6);
         });
@@ -5569,28 +5604,29 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             };
 
             const expectedSshCertificateRequest1: CommonSilentFlowRequest = {
-                ...sshCertRequest1,
                 scopes: ["User.Read"],
+                account: testAccount,
                 authority: `${Constants.DEFAULT_AUTHORITY}`,
+                authenticationScheme: AuthenticationScheme.BEARER,
                 correlationId: RANDOM_TEST_GUID,
                 forceRefresh: false,
             };
 
             const expectedSshCertificateRequest2: CommonSilentFlowRequest = {
-                ...sshCertRequest2,
                 scopes: ["Mail.Read"],
+                account: testAccount,
                 authority: `${Constants.DEFAULT_AUTHORITY}`,
+                authenticationScheme: AuthenticationScheme.BEARER,
                 correlationId: RANDOM_TEST_GUID,
                 forceRefresh: false,
             };
-
-            // Requests with claims
             const claimsRequest1: CommonSilentFlowRequest = {
                 scopes: ["User.Read"],
                 account: testAccount,
                 authority: TEST_CONFIG.validAuthority,
                 authenticationScheme: AuthenticationScheme.BEARER,
                 claims: JSON.stringify({ claim1: "claim1" }),
+                requestedClaimsHash: TEST_CRYPTO_VALUES.TEST_SHA256_HASH,
                 correlationId: TEST_CONFIG.CORRELATION_ID,
                 forceRefresh: false,
             };
@@ -5611,8 +5647,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["User.Read"],
                 authority: `${Constants.DEFAULT_AUTHORITY}`,
                 correlationId: RANDOM_TEST_GUID,
-                claims: JSON.stringify({ claim1: "claim1" }),
-                requestedClaimsHash: TEST_CRYPTO_VALUES.TEST_SHA256_HASH,
                 forceRefresh: false,
             };
 
@@ -5621,8 +5655,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 scopes: ["User.Read"],
                 authority: `${Constants.DEFAULT_AUTHORITY}`,
                 correlationId: RANDOM_TEST_GUID,
-                claims: JSON.stringify({ claim2: "claim2" }),
-                requestedClaimsHash: TEST_CRYPTO_VALUES.TEST_SHA256_HASH,
                 forceRefresh: false,
             };
 
@@ -5656,18 +5688,38 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 claimsSilentRequest3,
             ]);
 
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest2);
-            expect(silentATStub).toHaveBeenCalledWith(expectedPopTokenRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(expectedPopTokenRequest2);
             expect(silentATStub).toHaveBeenCalledWith(
-                expectedSshCertificateRequest1
+                expectedTokenRequest1,
+                ApiId.acquireTokenSilent_silentFlow
             );
             expect(silentATStub).toHaveBeenCalledWith(
-                expectedSshCertificateRequest2
+                expectedTokenRequest2,
+                ApiId.acquireTokenSilent_silentFlow
             );
-            expect(silentATStub).toHaveBeenCalledWith(expectedClaimsRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(expectedClaimsRequest2);
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedPopTokenRequest1,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedPopTokenRequest2,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedSshCertificateRequest1,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedSshCertificateRequest2,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedClaimsRequest1,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedClaimsRequest2,
+                ApiId.acquireTokenSilent_silentFlow
+            );
             expect(silentATStub).toHaveBeenCalledTimes(8);
         });
 
@@ -5753,8 +5805,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const silentRequest3 = pca.acquireTokenSilent(tokenRequest2);
             await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
 
-            expect(silentATStub).toHaveBeenCalledWith(tokenRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(tokenRequest2);
+            expect(silentATStub).toHaveBeenCalledWith(
+                tokenRequest1,
+                ApiId.acquireTokenSilent_silentFlow
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                tokenRequest2,
+                ApiId.acquireTokenSilent_silentFlow
+            );
             expect(silentATStub).toHaveBeenCalledTimes(2);
         });
 
@@ -6927,9 +6985,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             await pca.initialize();
 
             // @ts-ignore
-            await pca.browserStorage.setAccount(testAccount);
+            await (pca as any).browserStorage.setAccount(testAccount);
             // @ts-ignore
-            await pca.browserStorage.setIdTokenCredential(testIdToken);
+            await (pca as any).browserStorage.setIdTokenCredential(testIdToken);
         });
 
         afterEach(() => {
@@ -7000,15 +7058,15 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             await pca.initialize();
 
             // @ts-ignore
-            await pca.browserStorage.setAccount(testAccount1);
+            await (pca as any).browserStorage.setAccount(testAccount1);
             // @ts-ignore
-            await pca.browserStorage.setAccount(testAccount2);
+            await (pca as any).browserStorage.setAccount(testAccount2);
 
             // @ts-ignore
-            await pca.browserStorage.setIdTokenCredential(idToken1);
+            await (pca as any).browserStorage.setIdTokenCredential(idToken1);
 
             // @ts-ignore
-            await pca.browserStorage.setIdTokenCredential(idToken2);
+            await (pca as any).browserStorage.setIdTokenCredential(idToken2);
         });
 
         afterEach(() => {
@@ -7368,14 +7426,14 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca = (pca as any).controller;
             await pca.initialize();
             // @ts-ignore
-            await pca.browserStorage.setAccount(testAccount1);
+            await (pca as any).browserStorage.setAccount(testAccount1);
             // @ts-ignore
-            await pca.browserStorage.setAccount(testAccount2);
+            await (pca as any).browserStorage.setAccount(testAccount2);
 
             // @ts-ignore
-            await pca.browserStorage.setIdTokenCredential(idToken1);
+            await (pca as any).browserStorage.setIdTokenCredential(idToken1);
             // @ts-ignore
-            await pca.browserStorage.setIdTokenCredential(idToken2);
+            await (pca as any).browserStorage.setIdTokenCredential(idToken2);
         });
 
         afterEach(() => {
@@ -7635,7 +7693,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca = (pca as any).controller;
 
             // @ts-ignore
-            expect(pca.browserStorage.getWrapperMetadata()).toEqual([
+            expect((pca as any).browserStorage.getWrapperMetadata()).toEqual([
                 WrapperSKU.React,
                 "1.0.0",
             ]);
@@ -7682,6 +7740,16 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     // This is expected to throw because cache is empty, swallow error
                 });
             await pca.hydrateCache(testAuthenticationResult, request);
+
+            const browserStorageInstance =
+                (pca as any).controller?.browserStorage ?? browserStorage;
+            const accountKey =
+                browserStorageInstance.generateAccountKey(testAccount);
+            const accountEntity = await browserStorageInstance.getAccount(
+                accountKey,
+                RANDOM_TEST_GUID
+            );
+            expect(accountEntity?.cachedByApiId).toBe(ApiId.hydrateCache);
 
             const result = await pca.acquireTokenSilent(request); // Get tokens from the cache
             expect(result.accessToken).toEqual(
@@ -8067,7 +8135,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             secondBrowserStorageInstance.setAccount(
                 accountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                ApiId.acquireTokenSilent_authCode
             );
         });
 
@@ -8093,7 +8162,12 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca.enableAccountStorageEvents();
 
             secondBrowserStorageInstance
-                .setAccount(accountEntity, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(
+                    accountEntity,
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    ApiId.acquireTokenSilent_authCode
+                )
                 .then(() => {
                     // Ensure account is present in the cache before removing it
                     secondBrowserStorageInstance.removeAccount(
@@ -8121,7 +8195,12 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             pca.enableAccountStorageEvents();
 
             secondBrowserStorageInstance
-                .setAccount(accountEntity, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(
+                    accountEntity,
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    ApiId.acquireTokenSilent_authCode
+                )
                 .then(() => {
                     // Ensure account is present in the cache before setting it as active
                     secondBrowserStorageInstance.setActiveAccount(

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError.js";
-import { ApiId } from "../../src/utils/BrowserConstants.js";
+import { ApiId, apiIdToName } from "../../src/utils/BrowserConstants.js";
 import {
     TEST_CONFIG,
     TEST_TOKENS,
@@ -2832,6 +2832,46 @@ describe("BrowserCacheManager tests", () => {
                     expect(
                         browserLocalStorage.getAccount(key, RANDOM_TEST_GUID)
                     ).toBeNull();
+                });
+
+                it("getAccount adds accountCachedBy telemetry field", async () => {
+                    const perfClient = new StubPerformanceClient();
+                    const addFieldsSpy = jest.spyOn(perfClient, "addFields");
+                    const tempCache = new BrowserCacheManager(
+                        TEST_CONFIG.MSAL_CLIENT_ID,
+                        cacheConfig,
+                        browserCrypto,
+                        logger,
+                        perfClient,
+                        new EventHandler()
+                    );
+                    await tempCache.initialize(TEST_CONFIG.CORRELATION_ID);
+
+                    const account = new AccountEntity();
+                    Object.assign(account, TEST_ACCOUNT_ENTITY, {
+                        cachedByApiId: ApiId.hydrateCache,
+                    });
+                    const key = tempCache.generateAccountKey(
+                        AccountEntity.getAccountInfo(account)
+                    );
+                    await tempCache.setUserData(
+                        key,
+                        JSON.stringify(account),
+                        TEST_CONFIG.CORRELATION_ID,
+                        account.lastUpdatedAt || Date.now().toString(),
+                        false
+                    );
+
+                    const result = tempCache.getAccount(
+                        key,
+                        TEST_CONFIG.CORRELATION_ID
+                    );
+
+                    expect(result?.cachedByApiId).toBe(ApiId.hydrateCache);
+                    expect(addFieldsSpy).toHaveBeenCalledWith(
+                        { accountCachedBy: apiIdToName(ApiId.hydrateCache) },
+                        TEST_CONFIG.CORRELATION_ID
+                    );
                 });
 
                 it("getAccount returns AccountEntity", async () => {

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { BrowserAuthErrorMessage } from "../../src/error/BrowserAuthError.js";
+import { ApiId } from "../../src/utils/BrowserConstants.js";
 import {
     TEST_CONFIG,
     TEST_TOKENS,
@@ -267,7 +268,8 @@ describe("BrowserCacheManager tests", () => {
                         refreshToken: TEST_REFRESH_TOKEN_ENTITY,
                     },
                     TEST_CONFIG.CORRELATION_ID,
-                    true
+                    true,
+                    ApiId.acquireTokenPopup
                 );
 
                 // Setup some v0 cache entries
@@ -367,7 +369,8 @@ describe("BrowserCacheManager tests", () => {
                         refreshToken: TEST_REFRESH_TOKEN_ENTITY,
                     },
                     TEST_CONFIG.CORRELATION_ID,
-                    true
+                    true,
+                    ApiId.acquireTokenPopup
                 );
 
                 // Setup some v1 cache entries
@@ -689,7 +692,8 @@ describe("BrowserCacheManager tests", () => {
                     await browserCacheManager.setAccount(
                         currentAccount,
                         TEST_CONFIG.CORRELATION_ID,
-                        true
+                        true,
+                        ApiId.acquireTokenPopup
                     );
                     await browserCacheManager.setIdTokenCredential(
                         currentIdToken,
@@ -1256,7 +1260,8 @@ describe("BrowserCacheManager tests", () => {
                 await browserCacheManager.setAccount(
                     account,
                     TEST_CONFIG.CORRELATION_ID,
-                    true // KMSI = true, NO encryption
+                    true, // KMSI = true, NO encryption
+                    ApiId.acquireTokenPopup
                 );
 
                 const accountInfo = {
@@ -1281,7 +1286,8 @@ describe("BrowserCacheManager tests", () => {
                 await browserCacheManager.setAccount(
                     account,
                     TEST_CONFIG.CORRELATION_ID,
-                    false // KMSI = false, encryption for security
+                    false, // KMSI = false, encryption for security
+                    ApiId.acquireTokenPopup
                 );
 
                 const accountInfo = {
@@ -1297,6 +1303,33 @@ describe("BrowserCacheManager tests", () => {
 
                 const parsedValue = JSON.parse(rawValue!);
                 expect(isEncrypted(parsedValue)).toBe(true);
+            });
+
+            it("should set cachedByApiId on account", async () => {
+                const account = new AccountEntity();
+                Object.assign(account, TEST_ACCOUNT_ENTITY);
+
+                const apiId = ApiId.acquireTokenPopup;
+                await browserCacheManager.setAccount(
+                    account,
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    apiId
+                );
+
+                const accountInfo = {
+                    homeAccountId: account.homeAccountId,
+                    environment: account.environment,
+                    tenantId: account.realm,
+                    username: account.username,
+                    localAccountId: account.localAccountId,
+                };
+                const key = browserCacheManager.generateAccountKey(accountInfo);
+                const rawValue = window.localStorage.getItem(key);
+                expect(rawValue).toBeDefined();
+
+                const parsedValue = JSON.parse(rawValue!);
+                expect(parsedValue.cachedByApiId).toBe(apiId);
             });
 
             it("should retrieve idToken without decryption when KMSI is true", async () => {
@@ -2820,7 +2853,8 @@ describe("BrowserCacheManager tests", () => {
                     await browserLocalStorage.setAccount(
                         testAccount,
                         TEST_CONFIG.CORRELATION_ID,
-                        true
+                        true,
+                        ApiId.acquireTokenSilent_authCode
                     );
                     expect(
                         browserLocalStorage.getAccount(
@@ -2842,7 +2876,8 @@ describe("BrowserCacheManager tests", () => {
                     await browserSessionStorage.setAccount(
                         testAccount,
                         TEST_CONFIG.CORRELATION_ID,
-                        true
+                        true,
+                        ApiId.acquireTokenSilent_authCode
                     );
                     expect(
                         browserSessionStorage.getAccount(
@@ -4165,7 +4200,7 @@ describe("BrowserCacheManager tests", () => {
                                     {},
                                     "test-correlation-id",
                                     true,
-                                    undefined
+                                    ApiId.acquireTokenSilent_authCode
                                 )
                                 .then(() => {
                                     throw new Error(
@@ -4441,7 +4476,8 @@ describe("BrowserCacheManager tests", () => {
                     await browserLocalStorage.setAccount(
                         testAccount,
                         TEST_CONFIG.CORRELATION_ID,
-                        true
+                        true,
+                        ApiId.acquireTokenSilent_authCode
                     );
                     expect(
                         browserLocalStorage.getAccount(
@@ -4463,7 +4499,8 @@ describe("BrowserCacheManager tests", () => {
                     await browserSessionStorage.setAccount(
                         testAccount,
                         TEST_CONFIG.CORRELATION_ID,
-                        true
+                        true,
+                        ApiId.acquireTokenSilent_authCode
                     );
 
                     expect(

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -21,7 +21,10 @@ import {
     buildConfiguration,
     CacheOptions,
 } from "../../src/config/Configuration.js";
-import { BrowserCacheLocation } from "../../src/utils/BrowserConstants.js";
+import {
+    ApiId,
+    BrowserCacheLocation,
+} from "../../src/utils/BrowserConstants.js";
 import {
     ID_TOKEN_CLAIMS,
     RANDOM_TEST_GUID,
@@ -166,6 +169,40 @@ describe("TokenCache tests", () => {
                 expect.anything(),
                 false
             );
+        });
+
+        it("sets cachedByApiId when loading external tokens", async () => {
+            const request: SilentRequest = {
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                account: {
+                    homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                    environment: testEnvironment,
+                    tenantId: TEST_CONFIG.TENANT,
+                    username: "username",
+                    localAccountId: TEST_DATA_CLIENT_INFO.TEST_LOCAL_ACCOUNT_ID,
+                    loginHint: "login_hint",
+                },
+            };
+            const response: ExternalTokenResponse = {
+                id_token: testIdToken,
+                access_token: testAccessToken,
+                refresh_token: testRefreshToken,
+            };
+            const options: LoadTokenOptions = {};
+            const result = await tokenCache.loadExternalTokens(
+                request,
+                response,
+                options
+            );
+
+            const accountKey = browserStorage.generateAccountKey(
+                result.account!
+            );
+            const accountEntity = await browserStorage.getAccount(
+                accountKey,
+                RANDOM_TEST_GUID
+            );
+            expect(accountEntity?.cachedByApiId).toBe(ApiId.loadExternalTokens);
         });
 
         it("loads id token with request authority and client info provided in options", async () => {

--- a/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
@@ -15,6 +15,7 @@ import {
     RefreshTokenEntity,
     TimeUtils,
 } from "@azure/msal-common/browser";
+import { ApiId } from "../../../../src/utils/BrowserConstants.js";
 import {
     TestTokenResponse,
     TestAccountDetails,
@@ -406,7 +407,12 @@ async function saveTokensIntoCache(
     refreshTokenEntity?: RefreshTokenEntity
 ): Promise<void> {
     accountEntity
-        ? await cacheManager.setAccount(accountEntity, correlationId, true)
+        ? await cacheManager.setAccount(
+              accountEntity,
+              correlationId,
+              true,
+              ApiId.acquireTokenSilent_authCode
+          )
         : null;
     accessTokenEntity
         ? await cacheManager.setAccessTokenCredential(

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -2554,7 +2554,12 @@ describe("RedirectClient", () => {
                 }
             );
             browserStorage
-                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(
+                    testAccount,
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    ApiId.acquireTokenRedirect
+                )
                 .then(() =>
                     redirectClient.logout({ account: testAccountInfo })
                 );
@@ -2615,7 +2620,12 @@ describe("RedirectClient", () => {
                 }
             );
             browserStorage
-                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(
+                    testAccount,
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    ApiId.acquireTokenRedirect
+                )
                 .then(() =>
                     redirectClient.logout({
                         account: testAccountInfo,
@@ -2704,7 +2714,12 @@ describe("RedirectClient", () => {
             );
             browserStorage.setInteractionInProgress(true);
             browserStorage
-                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(
+                    testAccount,
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    ApiId.acquireTokenRedirect
+                )
                 .then(() =>
                     redirectClient
                         .logout({
@@ -2819,7 +2834,12 @@ describe("RedirectClient", () => {
             );
             browserStorage.setInteractionInProgress(true);
             browserStorage
-                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(
+                    testAccount,
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    ApiId.acquireTokenRedirect
+                )
                 .then(() =>
                     redirectClient
                         .logout({
@@ -2933,7 +2953,8 @@ describe("RedirectClient", () => {
             await browserStorage.setAccount(
                 testAccountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                ApiId.acquireTokenRedirect
             );
             await browserStorage.setIdTokenCredential(
                 testIdToken,

--- a/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
@@ -167,7 +167,8 @@ describe("SilentAuthCodeClient", () => {
                     cloud_instance_host_name: request.cloudInstanceHostName,
                 },
                 expect.anything(),
-                expect.anything()
+                ApiId.acquireTokenSilent_authCode,
+                false
             );
             expect(tokenResp).toEqual(testTokenResponse);
         });

--- a/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
@@ -23,6 +23,7 @@ import {
     AccountEntity,
     CredentialType,
 } from "@azure/msal-common";
+import { ApiId } from "../../src/utils/BrowserConstants.js";
 import * as BrowserCrypto from "../../src/crypto/BrowserCrypto.js";
 import {
     createBrowserAuthError,
@@ -149,7 +150,10 @@ describe("SilentRefreshClient", () => {
             const tokenResp = await silentRefreshClient.acquireToken(
                 tokenRequest
             );
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest);
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedTokenRequest,
+                ApiId.acquireTokenSilent_silentFlow
+            );
             expect(tokenResp).toEqual(testTokenResponse);
         });
 
@@ -205,7 +209,10 @@ describe("SilentRefreshClient", () => {
             const tokenResp = await silentRefreshClient.acquireToken(
                 tokenRequest
             );
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest);
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedTokenRequest,
+                ApiId.acquireTokenSilent_silentFlow
+            );
             expect(tokenResp).toEqual(testTokenResponse);
         });
 

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { InteractionHandler } from "../../src/interaction_handler/InteractionHandler.js";
+import { ApiId } from "../../src/utils/BrowserConstants.js";
 import {
     PkceCodes,
     NetworkRequestOptions,
@@ -327,12 +328,14 @@ describe("InteractionHandler.ts Unit Tests", () => {
                         responseMode: "fragment",
                         nonce: TEST_CONFIG.CORRELATION_ID,
                         state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                    }
+                    },
+                    ApiId.acquireTokenRedirect
                 );
 
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(acquireTokenSpy).toHaveBeenCalledWith(
                 testAuthCodeRequest,
+                ApiId.acquireTokenRedirect,
                 testCodeResponse
             );
             expect(acquireTokenSpy).not.toThrow();
@@ -407,7 +410,8 @@ describe("InteractionHandler.ts Unit Tests", () => {
                     responseMode: "fragment",
                     nonce: TEST_CONFIG.CORRELATION_ID,
                     state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                }
+                },
+                ApiId.acquireTokenPopup
             );
             expect(updateAuthoritySpy).toHaveBeenCalledWith(
                 testCodeResponse.cloud_instance_host_name,
@@ -416,6 +420,7 @@ describe("InteractionHandler.ts Unit Tests", () => {
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(acquireTokenSpy).toHaveBeenCalledWith(
                 testAuthCodeRequest,
+                ApiId.acquireTokenPopup,
                 testCodeResponse
             );
             expect(acquireTokenSpy).not.toThrow();
@@ -487,11 +492,13 @@ describe("InteractionHandler.ts Unit Tests", () => {
                     responseMode: "fragment",
                     nonce: TEST_CONFIG.CORRELATION_ID,
                     state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                }
+                },
+                ApiId.acquireTokenPopup
             );
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(acquireTokenSpy).toHaveBeenCalledWith(
                 testAuthCodeRequest,
+                ApiId.acquireTokenPopup,
                 testCodeResponse
             );
             expect(acquireTokenSpy).not.toThrow();

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -3502,6 +3502,7 @@ export type PerformanceEvent = {
     context?: string;
     cacheLocation?: string;
     cacheRetentionDays?: number;
+    accountCachedBy?: string;
     cacheRtCount?: number;
     cacheIdCount?: number;
     cacheAtCount?: number;
@@ -4823,8 +4824,8 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/telemetry/performance/PerformanceEvent.ts:815:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:815:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:815:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:889:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:889:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:889:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:890:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:890:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:890:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1081,13 +1081,13 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract generateCredentialKey(credential: CredentialEntity): string;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     getAccessToken(account: AccountInfo, request: BaseAuthRequest, tokenKeys?: TokenKeys, targetRealm?: string): AccessTokenEntity | null;
@@ -1115,13 +1115,13 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     getBaseAccountInfo(accountFilter: AccountFilter, correlationId: string): AccountInfo | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     getIdToken(account: AccountInfo, correlationId: string, tokenKeys?: TokenKeys, targetRealm?: string, performanceClient?: IPerformanceClient): IdTokenEntity | null;
@@ -1131,13 +1131,13 @@ export abstract class CacheManager implements ICacheManager {
     getIdTokensByFilter(filter: CredentialFilter, correlationId: string, tokenKeys?: TokenKeys): Map<string, IdTokenEntity>;
     abstract getKeys(): string[];
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     getRefreshToken(account: AccountInfo, familyRT: boolean, correlationId: string, tokenKeys?: TokenKeys, performanceClient?: IPerformanceClient): RefreshTokenEntity | null;
@@ -4677,48 +4677,48 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/authority/Authority.ts:818:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/Authority.ts:1009:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/AuthorityOptions.ts:26:5 - (ae-forgotten-export) The symbol "CloudInstanceDiscoveryResponse" needs to be exported by the entry point index.d.ts
-// src/cache/CacheManager.ts:340:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:341:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:612:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1533:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1535:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1548:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1550:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1569:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1571:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1579:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1581:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1596:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1598:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1611:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1613:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1645:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1647:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1660:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1662:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1672:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1674:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1684:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1686:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1696:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1698:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1716:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1717:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1739:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1741:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1759:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1761:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1779:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1781:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1791:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1793:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:342:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:343:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:620:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1543:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1544:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1558:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1559:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1579:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1580:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1589:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1590:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1606:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1607:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1621:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1622:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1655:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1656:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1670:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1671:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1682:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1683:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1694:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1695:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1706:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1707:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1724:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1725:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1749:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1750:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1769:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1770:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1789:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1790:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1801:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:1802:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1810:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/utils/CacheTypes.ts:94:53 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
 // src/cache/utils/CacheTypes.ts:94:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
-// src/client/AuthorizationCodeClient.ts:159:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:160:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:229:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:465:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:161:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:230:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:466:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:196:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:293:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:294:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -129,6 +129,8 @@ export class AccountEntity {
     // (undocumented)
     authorityType: string;
     // (undocumented)
+    cachedByApiId?: number;
+    // (undocumented)
     clientInfo?: string;
     // (undocumented)
     cloudGraphHostName?: string;
@@ -773,7 +775,7 @@ export class AuthorizationCodeClient extends BaseClient {
     constructor(configuration: ClientConfiguration, performanceClient?: IPerformanceClient);
     // Warning: (tsdoc-code-span-missing-delimiter) The code span is missing its closing backtick
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    acquireToken(request: CommonAuthorizationCodeRequest, authCodePayload?: AuthorizationCodePayload): Promise<AuthenticationResult>;
+    acquireToken(request: CommonAuthorizationCodeRequest, apiId: number, authCodePayload?: AuthorizationCodePayload): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     getLogoutUri(logoutRequest: CommonEndSessionRequest): string;
     // (undocumented)
@@ -1079,13 +1081,13 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract generateCredentialKey(credential: CredentialEntity): string;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     getAccessToken(account: AccountInfo, request: BaseAuthRequest, tokenKeys?: TokenKeys, targetRealm?: string): AccessTokenEntity | null;
@@ -1113,13 +1115,13 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     getBaseAccountInfo(accountFilter: AccountFilter, correlationId: string): AccountInfo | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     getIdToken(account: AccountInfo, correlationId: string, tokenKeys?: TokenKeys, targetRealm?: string, performanceClient?: IPerformanceClient): IdTokenEntity | null;
@@ -1129,13 +1131,13 @@ export abstract class CacheManager implements ICacheManager {
     getIdTokensByFilter(filter: CredentialFilter, correlationId: string, tokenKeys?: TokenKeys): Map<string, IdTokenEntity>;
     abstract getKeys(): string[];
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     getRefreshToken(account: AccountInfo, familyRT: boolean, correlationId: string, tokenKeys?: TokenKeys, performanceClient?: IPerformanceClient): RefreshTokenEntity | null;
@@ -1181,13 +1183,13 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    saveCacheRecord(cacheRecord: CacheRecord, correlationId: string, kmsi: boolean, storeInCache?: StoreInCache): Promise<void>;
+    saveCacheRecord(cacheRecord: CacheRecord, correlationId: string, kmsi: boolean, apiId: number, storeInCache?: StoreInCache): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract setAccessTokenCredential(accessToken: AccessTokenEntity, correlationId: string, kmsi: boolean): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    abstract setAccount(account: AccountEntity, correlationId: string, kmsi: boolean): Promise<void>;
+    abstract setAccount(account: AccountEntity, correlationId: string, kmsi: boolean, apiId: number): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract setAppMetadata(appMetadata: AppMetadataEntity, correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -3818,9 +3820,9 @@ export type RefreshTokenCache = Record<string, RefreshTokenEntity>;
 export class RefreshTokenClient extends BaseClient {
     constructor(configuration: ClientConfiguration, performanceClient?: IPerformanceClient);
     // (undocumented)
-    acquireToken(request: CommonRefreshTokenRequest): Promise<AuthenticationResult>;
+    acquireToken(request: CommonRefreshTokenRequest, apiId: number): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    acquireTokenByRefreshToken(request: CommonSilentFlowRequest): Promise<AuthenticationResult>;
+    acquireTokenByRefreshToken(request: CommonSilentFlowRequest, apiId: number): Promise<AuthenticationResult>;
 }
 
 // Warning: (ae-missing-release-tag) "RefreshTokenEntity" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3952,7 +3954,7 @@ export class ResponseHandler {
     static generateAuthenticationResult(cryptoObj: ICrypto, authority: Authority, cacheRecord: CacheRecord, fromTokenCache: boolean, request: BaseAuthRequest, idTokenClaims?: TokenClaims, requestState?: RequestStateObject, serverTokenResponse?: ServerAuthorizationTokenResponse, requestId?: string): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    handleServerTokenResponse(serverTokenResponse: ServerAuthorizationTokenResponse, authority: Authority, reqTimestamp: number, request: BaseAuthRequest, authCodePayload?: AuthorizationCodePayload, userAssertionHash?: string, handlingRefreshTokenResponse?: boolean, forceCacheRefreshTokenResponse?: boolean, serverRequestId?: string): Promise<AuthenticationResult>;
+    handleServerTokenResponse(serverTokenResponse: ServerAuthorizationTokenResponse, authority: Authority, reqTimestamp: number, request: BaseAuthRequest, apiId: number, authCodePayload?: AuthorizationCodePayload, userAssertionHash?: string, handlingRefreshTokenResponse?: boolean, forceCacheRefreshTokenResponse?: boolean, serverRequestId?: string): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     validateTokenResponse(serverResponse: ServerAuthorizationTokenResponse, refreshAccessToken?: boolean): void;
@@ -4675,61 +4677,61 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/authority/Authority.ts:818:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/Authority.ts:1009:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/AuthorityOptions.ts:26:5 - (ae-forgotten-export) The symbol "CloudInstanceDiscoveryResponse" needs to be exported by the entry point index.d.ts
-// src/cache/CacheManager.ts:339:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:340:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:610:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1533:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1534:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1548:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1549:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1569:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1570:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1579:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1580:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1596:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1597:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1611:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1612:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1645:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1646:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1660:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1661:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1672:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1673:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1684:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1685:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1696:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1697:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1714:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1715:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1739:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1740:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1759:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1760:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1779:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1780:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1791:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1792:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1800:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:341:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:612:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1533:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1535:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1548:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1550:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1569:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1571:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1579:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1581:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1596:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1598:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1611:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1613:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1645:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1647:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1660:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1662:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1672:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1674:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1684:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1686:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1696:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1698:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1716:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1717:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1739:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1741:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1759:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1761:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1779:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1781:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1791:5 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1793:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1802:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/utils/CacheTypes.ts:94:53 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
 // src/cache/utils/CacheTypes.ts:94:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
-// src/client/AuthorizationCodeClient.ts:157:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:158:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:227:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:463:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:193:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:289:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:290:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:341:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:159:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:160:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:229:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:465:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:196:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:293:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:294:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:345:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/SilentFlowClient.ts:173:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/ClientConfiguration.ts:51:5 - (ae-forgotten-export) The symbol "ClientCredentials" needs to be exported by the entry point index.d.ts
 // src/config/ClientConfiguration.ts:53:5 - (ae-forgotten-export) The symbol "TelemetryOptions" needs to be exported by the entry point index.d.ts
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/request/AuthenticationHeaderParser.ts:74:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:343:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:344:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:345:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:346:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:347:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceClient.ts:942:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceClient.ts:942:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
 // src/telemetry/performance/PerformanceClient.ts:954:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -92,6 +92,8 @@ export abstract class CacheManager implements ICacheManager {
      * set account entity in the platform cache
      * @param account
      * @param correlationId
+     * @param kmsi - Keep Me Signed In
+     * @param apiId - API identifier for telemetry tracking
      */
     abstract setAccount(
         account: AccountEntity,
@@ -544,6 +546,7 @@ export abstract class CacheManager implements ICacheManager {
      * @param cacheRecord {CacheRecord}
      * @param correlationId {?string} correlation id
      * @param kmsi - Keep Me Signed In
+     * @param apiId - API identifier for telemetry tracking
      * @param storeInCache {?StoreInCache}
      */
     async saveCacheRecord(

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -96,7 +96,8 @@ export abstract class CacheManager implements ICacheManager {
     abstract setAccount(
         account: AccountEntity,
         correlationId: string,
-        kmsi: boolean
+        kmsi: boolean,
+        apiId: number
     ): Promise<void>;
 
     /**
@@ -549,6 +550,7 @@ export abstract class CacheManager implements ICacheManager {
         cacheRecord: CacheRecord,
         correlationId: string,
         kmsi: boolean,
+        apiId: number,
         storeInCache?: StoreInCache
     ): Promise<void> {
         if (!cacheRecord) {
@@ -559,7 +561,12 @@ export abstract class CacheManager implements ICacheManager {
 
         try {
             if (!!cacheRecord.account) {
-                await this.setAccount(cacheRecord.account, correlationId, kmsi);
+                await this.setAccount(
+                    cacheRecord.account,
+                    correlationId,
+                    kmsi,
+                    apiId
+                );
             }
 
             if (!!cacheRecord.idToken && storeInCache?.idToken !== false) {

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -66,6 +66,7 @@ export class AccountEntity {
     tenantProfiles?: Array<TenantProfile>;
     lastUpdatedAt: string;
     dataBoundary?: DataBoundary;
+    cachedByApiId?: number;
 
     /**
      * Returns the AccountInfo interface for this account.

--- a/lib/msal-common/src/cache/interface/ICacheManager.ts
+++ b/lib/msal-common/src/cache/interface/ICacheManager.ts
@@ -32,7 +32,8 @@ export interface ICacheManager {
     setAccount(
         account: AccountEntity,
         correlationId: string,
-        kmsi: boolean
+        kmsi: boolean,
+        apiId: number
     ): Promise<void>;
 
     /**
@@ -195,6 +196,7 @@ export interface ICacheManager {
         cacheRecord: CacheRecord,
         correlationId: string,
         kmsi: boolean,
+        apiId: number,
         storeInCache?: StoreInCache
     ): Promise<void>;
 

--- a/lib/msal-common/src/cache/interface/ICacheManager.ts
+++ b/lib/msal-common/src/cache/interface/ICacheManager.ts
@@ -28,6 +28,7 @@ export interface ICacheManager {
      * @param account
      * @param correlationId
      * @param kmsi
+     * @param apiId - API identifier for telemetry tracking
      */
     setAccount(
         account: AccountEntity,

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -74,6 +74,7 @@ export class AuthorizationCodeClient extends BaseClient {
      */
     async acquireToken(
         request: CommonAuthorizationCodeRequest,
+        apiId: number,
         authCodePayload?: AuthorizationCodePayload
     ): Promise<AuthenticationResult> {
         this.performanceClient?.addQueueMeasurement(
@@ -123,6 +124,7 @@ export class AuthorizationCodeClient extends BaseClient {
             this.authority,
             reqTimestamp,
             request,
+            apiId,
             authCodePayload,
             undefined,
             undefined,

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -71,6 +71,7 @@ export class AuthorizationCodeClient extends BaseClient {
      * API to acquire a token in exchange of 'authorization_code` acquired by the user in the first leg of the
      * authorization_code_grant
      * @param request
+     * @param apiId - API identifier for telemetry tracking
      */
     async acquireToken(
         request: CommonAuthorizationCodeRequest,

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -65,7 +65,8 @@ export class RefreshTokenClient extends BaseClient {
         super(configuration, performanceClient);
     }
     public async acquireToken(
-        request: CommonRefreshTokenRequest
+        request: CommonRefreshTokenRequest,
+        apiId: number
     ): Promise<AuthenticationResult> {
         this.performanceClient?.addQueueMeasurement(
             PerformanceEvents.RefreshTokenClientAcquireToken,
@@ -104,6 +105,7 @@ export class RefreshTokenClient extends BaseClient {
             this.authority,
             reqTimestamp,
             request,
+            apiId,
             undefined,
             undefined,
             true,
@@ -117,7 +119,8 @@ export class RefreshTokenClient extends BaseClient {
      * @param request
      */
     public async acquireTokenByRefreshToken(
-        request: CommonSilentFlowRequest
+        request: CommonSilentFlowRequest,
+        apiId: number
     ): Promise<AuthenticationResult> {
         // Cannot renew token if no request object is given.
         if (!request) {
@@ -152,7 +155,7 @@ export class RefreshTokenClient extends BaseClient {
                     this.logger,
                     this.performanceClient,
                     request.correlationId
-                )(request, true);
+                )(request, true, apiId);
             } catch (e) {
                 const noFamilyRTInCache =
                     e instanceof InteractionRequiredAuthError &&
@@ -171,7 +174,7 @@ export class RefreshTokenClient extends BaseClient {
                         this.logger,
                         this.performanceClient,
                         request.correlationId
-                    )(request, false);
+                    )(request, false, apiId);
                     // throw in all other cases
                 } else {
                     throw e;
@@ -185,7 +188,7 @@ export class RefreshTokenClient extends BaseClient {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(request, false);
+        )(request, false, apiId);
     }
 
     /**
@@ -194,7 +197,8 @@ export class RefreshTokenClient extends BaseClient {
      */
     private async acquireTokenWithCachedRefreshToken(
         request: CommonSilentFlowRequest,
-        foci: boolean
+        foci: boolean,
+        apiId: number
     ) {
         this.performanceClient?.addQueueMeasurement(
             PerformanceEvents.RefreshTokenClientAcquireTokenWithCachedRefreshToken,
@@ -258,7 +262,7 @@ export class RefreshTokenClient extends BaseClient {
                 this.logger,
                 this.performanceClient,
                 request.correlationId
-            )(refreshTokenRequest);
+            )(refreshTokenRequest, apiId);
         } catch (e) {
             if (e instanceof InteractionRequiredAuthError) {
                 this.performanceClient?.addFields(

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -187,6 +187,7 @@ export class ResponseHandler {
         authority: Authority,
         reqTimestamp: number,
         request: BaseAuthRequest,
+        apiId: number,
         authCodePayload?: AuthorizationCodePayload,
         userAssertionHash?: string,
         handlingRefreshTokenResponse?: boolean,
@@ -310,6 +311,7 @@ export class ResponseHandler {
                 cacheRecord,
                 request.correlationId,
                 isKmsi(idTokenClaims || {}),
+                apiId,
                 request.storeInCache
             );
         } finally {

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -872,6 +872,7 @@ export type PerformanceEvent = {
     // Cache Data
     cacheLocation?: string;
     cacheRetentionDays?: number;
+    accountCachedBy?: string;
 
     // Number of tokens in the cache to be reported when cache quota is exceeded
     cacheRtCount?: number;

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -103,7 +103,8 @@ describe("CacheManager.ts test cases", () => {
             await mockCache.cacheManager.saveCacheRecord(
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             const mockCacheAccount = mockCache.cacheManager.getAccount(
                 accountKey
@@ -138,7 +139,8 @@ describe("CacheManager.ts test cases", () => {
             await mockCache.cacheManager.saveCacheRecord(
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             const mockCacheAT = mockCache.cacheManager.getAccessTokenCredential(
                 atKey
@@ -175,6 +177,7 @@ describe("CacheManager.ts test cases", () => {
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
                 true,
+                0,
                 {
                     accessToken: false,
                 }
@@ -207,7 +210,8 @@ describe("CacheManager.ts test cases", () => {
             await mockCache.cacheManager.saveCacheRecord(
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             const mockCacheAT = mockCache.cacheManager.getAccessTokenCredential(
                 atKey
@@ -241,6 +245,7 @@ describe("CacheManager.ts test cases", () => {
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
                 true,
+                0,
                 {
                     idToken: false,
                 }
@@ -321,6 +326,7 @@ describe("CacheManager.ts test cases", () => {
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
                 true,
+                0,
                 {
                     refreshToken: false,
                 }
@@ -826,7 +832,8 @@ describe("CacheManager.ts test cases", () => {
         await mockCache.cacheManager.saveCacheRecord(
             cacheRecord,
             TEST_CONFIG.CORRELATION_ID,
-            true
+            true,
+            0
         );
 
         const cacheAccount = mockCache.cacheManager.getAccount(
@@ -856,7 +863,8 @@ describe("CacheManager.ts test cases", () => {
         await mockCache.cacheManager.saveCacheRecord(
             cacheRecord,
             TEST_CONFIG.CORRELATION_ID,
-            true
+            true,
+            0
         );
 
         const cachedAccessToken =
@@ -889,7 +897,8 @@ describe("CacheManager.ts test cases", () => {
         await mockCache.cacheManager.saveCacheRecord(
             cacheRecord,
             TEST_CONFIG.CORRELATION_ID,
-            true
+            true,
+            0
         );
 
         const cachedAccessToken =

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -234,7 +234,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
                 state: testState,
@@ -355,7 +355,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
                 state: testState,
@@ -467,7 +467,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 authenticationScheme: AuthenticationScheme.BEARER,
             };
 
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
                 state: testState,
@@ -563,7 +563,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
 
             await expect(
-                client.acquireToken(authCodeRequest, {
+                client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                     state: testState,
@@ -660,7 +660,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
 
             await expect(
-                client.acquireToken(authCodeRequest, {
+                client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                     state: testState,
@@ -759,6 +759,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -944,6 +945,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -1073,7 +1075,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 authenticationScheme: AuthenticationScheme.BEARER,
             };
 
-            client.acquireToken(authorizationCodeRequest).catch((error) => {
+            client.acquireToken(authorizationCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1121,7 +1123,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(authorizationCodeRequest).catch((error) => {
+            client.acquireToken(authorizationCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1164,7 +1166,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(authCodeRequest).catch((error) => {
+            client.acquireToken(authCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1205,7 +1207,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 enableSpaAuthorizationCode: true,
             };
 
-            client.acquireToken(authCodeRequest).catch((error) => {
+            client.acquireToken(authCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1254,7 +1256,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(authCodeRequest).catch((error) => {
+            client.acquireToken(authCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1379,6 +1381,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -1568,6 +1571,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -1749,7 +1753,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
 
             expect(
-                client.acquireToken(authCodeRequest, {
+                client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                     state: testState,
@@ -1857,6 +1861,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -1964,6 +1969,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -2048,6 +2054,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -2112,6 +2119,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -2192,7 +2200,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 correlationId: RANDOM_TEST_GUID,
                 authenticationScheme: AuthenticationScheme.BEARER,
             };
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
             });
@@ -2273,7 +2281,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 correlationId: RANDOM_TEST_GUID,
                 authenticationScheme: AuthenticationScheme.BEARER,
             };
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
             });
@@ -2367,7 +2375,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 authenticationScheme: AuthenticationScheme.BEARER,
             };
             try {
-                await client.acquireToken(authCodeRequest, {
+                await client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                 });
@@ -2462,7 +2470,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 authenticationScheme: AuthenticationScheme.BEARER,
             };
             try {
-                await client.acquireToken(authCodeRequest, {
+                await client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                 });

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -101,7 +101,15 @@ export class MockStorageClass extends CacheManager {
         return null;
     }
 
-    async setAccount(value: AccountEntity): Promise<void> {
+    async setAccount(
+        value: AccountEntity,
+        _correlationId?: string,
+        _kmsi?: boolean,
+        apiId?: number
+    ): Promise<void> {
+        if (typeof apiId !== "undefined") {
+            value.cachedByApiId = apiId;
+        }
         const key = this.generateAccountKey(
             AccountEntity.getAccountInfo(value)
         );

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -184,7 +184,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((e) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((e) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -216,7 +216,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((e) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((e) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -246,7 +246,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -263,7 +263,7 @@ describe("RefreshTokenClient unit tests", () => {
                 <any>"executePostToTokenEndpoint"
             ).mockResolvedValue(AUTHENTICATION_RESULT);
 
-            await client.acquireToken(refreshTokenRequest);
+            await client.acquireToken(refreshTokenRequest, 0);
             expect(spy).toHaveBeenCalled();
         });
 
@@ -281,7 +281,7 @@ describe("RefreshTokenClient unit tests", () => {
             ).mockResolvedValue({ ...AUTHENTICATION_RESULT, headers: {} });
 
             let refreshTokenSize;
-            await client.acquireToken(refreshTokenRequest).then(() => {
+            await client.acquireToken(refreshTokenRequest, 0).then(() => {
                 expect(spy).toHaveBeenCalled();
                 for (let i = 0; i < spy.mock.calls.length; i++) {
                     const arg = spy.mock.calls[i][0];
@@ -312,7 +312,7 @@ describe("RefreshTokenClient unit tests", () => {
             });
 
             let refreshTokenSize;
-            await client.acquireToken(refreshTokenRequest).then(() => {
+            await client.acquireToken(refreshTokenRequest, 0).then(() => {
                 expect(spy).toHaveBeenCalled();
                 for (let i = 0; i < spy.mock.calls.length; i++) {
                     const arg = spy.mock.calls[i][0];
@@ -357,7 +357,8 @@ describe("RefreshTokenClient unit tests", () => {
             await config.storageInterface!.setAccount(
                 testAccountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             await config.storageInterface!.setRefreshTokenCredential(
                 testRefreshTokenEntity,
@@ -416,7 +417,7 @@ describe("RefreshTokenClient unit tests", () => {
                     TEST_CONFIG.TOKEN_TYPE_BEARER as AuthenticationScheme,
             };
 
-            client.acquireToken(refreshTokenRequest);
+            client.acquireToken(refreshTokenRequest, 0);
         });
 
         it("acquires a token", async () => {
@@ -443,7 +444,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest,
+                0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -579,7 +581,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -612,9 +614,10 @@ describe("RefreshTokenClient unit tests", () => {
                 "acquireToken"
             );
 
-            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            await client.acquireTokenByRefreshToken(silentFlowRequest, 0);
             expect(refreshTokenClientSpy).toHaveBeenCalledWith(
-                expectedRefreshRequest
+                expectedRefreshRequest,
+                0
             );
         });
 
@@ -645,10 +648,11 @@ describe("RefreshTokenClient unit tests", () => {
                 "acquireToken"
             );
 
-            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            await client.acquireTokenByRefreshToken(silentFlowRequest, 0);
             expect(refreshTokenClientSpy).toHaveBeenCalled();
             expect(refreshTokenClientSpy).toHaveBeenCalledWith(
-                expectedRefreshRequest
+                expectedRefreshRequest,
+                0
             );
         });
 
@@ -680,9 +684,10 @@ describe("RefreshTokenClient unit tests", () => {
                 "acquireToken"
             );
 
-            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            await client.acquireTokenByRefreshToken(silentFlowRequest, 0);
             expect(refreshTokenClientSpy).toHaveBeenCalledWith(
-                expectedRefreshRequest
+                expectedRefreshRequest,
+                0
             );
         });
 
@@ -709,7 +714,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest,
+                0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -831,7 +837,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest,
+                0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -949,7 +956,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest,
+                0
             );
 
             expect(authResult.requestId).toBeTruthy;
@@ -978,7 +986,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest,
+                0
             );
 
             expect(authResult.requestId).toBeFalsy;
@@ -1016,7 +1025,7 @@ describe("RefreshTokenClient unit tests", () => {
                 authenticationScheme:
                     TEST_CONFIG.TOKEN_TYPE_BEARER as AuthenticationScheme,
             };
-            await client.acquireToken(refreshTokenRequest);
+            await client.acquireToken(refreshTokenRequest, 0);
 
             expect(performanceClient.addFields).toHaveBeenCalledWith(
                 {
@@ -1061,7 +1070,7 @@ describe("RefreshTokenClient unit tests", () => {
                 authenticationScheme:
                     TEST_CONFIG.TOKEN_TYPE_BEARER as AuthenticationScheme,
             };
-            await client.acquireToken(refreshTokenRequest);
+            await client.acquireToken(refreshTokenRequest, 0);
 
             expect(performanceClient.addFields).toHaveBeenCalledWith(
                 {
@@ -1109,7 +1118,8 @@ describe("RefreshTokenClient unit tests", () => {
             await config.storageInterface!.setAccount(
                 testAccountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             await config.storageInterface!.setRefreshTokenCredential(
                 testRefreshTokenEntity,
@@ -1148,7 +1158,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest,
+                0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -1234,9 +1245,10 @@ describe("RefreshTokenClient unit tests", () => {
                 "acquireToken"
             );
 
-            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            await client.acquireTokenByRefreshToken(silentFlowRequest, 0);
             expect(refreshTokenClientSpy).toHaveBeenCalledWith(
-                expectedRefreshRequest
+                expectedRefreshRequest,
+                0
             );
         });
     });
@@ -1254,14 +1266,17 @@ describe("RefreshTokenClient unit tests", () => {
                 stubPerformanceClient
             );
             await expect(
-                client.acquireTokenByRefreshToken({
-                    scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
-                    // @ts-ignore
-                    account: null,
-                    authority: TEST_CONFIG.validAuthority,
-                    correlationId: TEST_CONFIG.CORRELATION_ID,
-                    forceRefresh: false,
-                })
+                client.acquireTokenByRefreshToken(
+                    {
+                        scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                        // @ts-ignore
+                        account: null,
+                        authority: TEST_CONFIG.validAuthority,
+                        correlationId: TEST_CONFIG.CORRELATION_ID,
+                        forceRefresh: false,
+                    },
+                    0
+                )
             ).rejects.toMatchObject(
                 createClientAuthError(
                     ClientAuthErrorCodes.noAccountInSilentRequest
@@ -1283,7 +1298,7 @@ describe("RefreshTokenClient unit tests", () => {
 
             await expect(
                 //@ts-ignore
-                client.acquireTokenByRefreshToken(null)
+                client.acquireTokenByRefreshToken(null, 0)
             ).rejects.toMatchObject(
                 createClientConfigurationError(
                     ClientConfigurationErrorCodes.tokenRequestEmpty
@@ -1292,7 +1307,7 @@ describe("RefreshTokenClient unit tests", () => {
 
             await expect(
                 //@ts-ignore
-                client.acquireTokenByRefreshToken(undefined)
+                client.acquireTokenByRefreshToken(undefined, 0)
             ).rejects.toMatchObject(
                 createClientConfigurationError(
                     ClientConfigurationErrorCodes.tokenRequestEmpty
@@ -1375,7 +1390,7 @@ describe("RefreshTokenClient unit tests", () => {
                 resEvents = events;
             });
             await expect(
-                client.acquireTokenByRefreshToken(tokenRequest)
+                client.acquireTokenByRefreshToken(tokenRequest, 0)
             ).rejects.toMatchObject(
                 createInteractionRequiredAuthError(
                     InteractionRequiredAuthErrorCodes.refreshTokenExpired
@@ -1411,7 +1426,7 @@ describe("RefreshTokenClient unit tests", () => {
                 stubPerformanceClient
             );
             await expect(
-                client.acquireTokenByRefreshToken(tokenRequest)
+                client.acquireTokenByRefreshToken(tokenRequest, 0)
             ).rejects.toMatchObject(
                 createInteractionRequiredAuthError(
                     InteractionRequiredAuthErrorCodes.refreshTokenExpired
@@ -1425,7 +1440,8 @@ describe("RefreshTokenClient unit tests", () => {
             await config.storageInterface!.setAccount(
                 testAccountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             const rtExpiresOn = TimeUtils.nowSeconds() + 60 * 60;
             const rtEntity = {
@@ -1490,7 +1506,7 @@ describe("RefreshTokenClient unit tests", () => {
             ).toBe(rtEntity);
 
             await expect(
-                client.acquireTokenByRefreshToken(silentFlowRequest)
+                client.acquireTokenByRefreshToken(silentFlowRequest, 0)
             ).rejects.toMatchObject(invalidGrantAuthError);
 
             expect(
@@ -1528,7 +1544,7 @@ describe("RefreshTokenClient unit tests", () => {
                 stubPerformanceClient
             );
             try {
-                await client.acquireToken(refreshTokenRequest);
+                await client.acquireToken(refreshTokenRequest, 0);
             } catch {}
             expect(createTokenRequestBodySpy).toHaveBeenCalledWith(
                 refreshTokenRequest
@@ -1557,7 +1573,7 @@ describe("RefreshTokenClient unit tests", () => {
                 stubPerformanceClient
             );
             try {
-                await client.acquireToken(refreshTokenRequest);
+                await client.acquireToken(refreshTokenRequest, 0);
             } catch {}
             expect(createTokenRequestBodySpy).toHaveBeenCalledWith(
                 refreshTokenRequest

--- a/lib/msal-common/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-common/test/config/ClientConfiguration.spec.ts
@@ -76,7 +76,8 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
             emptyConfig.storageInterface.setAccount(
                 MockCache.acc,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             )
         ).rejects.toEqual(
             createClientAuthError(ClientAuthErrorCodes.methodNotImplemented)
@@ -176,7 +177,12 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
                 },
             },
         });
-        await cacheStorageMock.setAccount(MockCache.acc);
+        await cacheStorageMock.setAccount(
+            MockCache.acc,
+            TEST_CONFIG.CORRELATION_ID,
+            true,
+            0
+        );
         expect(newConfig.cryptoInterface).not.toBeNull();
         expect(newConfig.storageInterface).not.toBeNull();
         expect(newConfig.networkInterface).not.toBeNull();

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -179,7 +179,8 @@ describe("ResponseHandler.ts", () => {
                         testResponse,
                         testAuthority,
                         timestamp,
-                        testRequest
+                        testRequest,
+                        0
                     );
                 expect(tokenResp).toBeUndefined();
             } catch (e) {
@@ -257,7 +258,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
         });
 
@@ -325,7 +327,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
         });
 
@@ -391,8 +394,44 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
+        });
+
+        it("sets cachedByApiId on cached account", async () => {
+            const testRequest: BaseAuthRequest = {
+                authority: testAuthority.canonicalAuthority,
+                correlationId: "CORRELATION_ID",
+                scopes: ["openid", "profile", "User.Read", "email"],
+            };
+            const testResponse: ServerAuthorizationTokenResponse = {
+                ...AUTHENTICATION_RESULT.body,
+            };
+
+            const responseHandler = new ResponseHandler(
+                "this-is-a-client-id",
+                testCacheManager,
+                cryptoInterface,
+                logger,
+                null,
+                null
+            );
+
+            const timestamp = TimeUtils.nowSeconds();
+            const apiId = 1234;
+            await responseHandler.handleServerTokenResponse(
+                testResponse,
+                testAuthority,
+                timestamp,
+                testRequest,
+                apiId
+            );
+
+            const accountKeys = testCacheManager.getAccountKeys();
+            expect(accountKeys.length).toBeGreaterThan(0);
+            const account = testCacheManager.getAccount(accountKeys[0]);
+            expect(account?.cachedByApiId).toBe(apiId);
         });
 
         it("includes spa_code in response as code", async () => {
@@ -422,7 +461,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
             expect(response.code).toEqual(testSpaCode);
         });
@@ -503,7 +543,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
         });
     });
@@ -533,7 +574,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
 
             expect(result.familyId).toBe("");
@@ -580,7 +622,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
 
             expect(result.tokenType).toBe(AuthenticationScheme.POP);
@@ -627,7 +670,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
 
             expect(result.tokenType).toBe(AuthenticationScheme.POP);
@@ -658,7 +702,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
+                testRequest,
+                0
             );
 
             expect(result.requestId).toBe("");
@@ -827,7 +872,8 @@ describe("ResponseHandler.ts", () => {
                     testResponse,
                     testAuthority,
                     timestamp,
-                    testRequest
+                    testRequest,
+                    0
                 );
                 throw Error("should throw cache error");
             } catch (e) {
@@ -873,7 +919,8 @@ describe("ResponseHandler.ts", () => {
                     testResponse,
                     testAuthority,
                     timestamp,
-                    testRequest
+                    testRequest,
+                    0
                 );
                 throw Error("should throw cache error");
             } catch (e) {
@@ -919,7 +966,8 @@ describe("ResponseHandler.ts", () => {
                     testResponse,
                     testAuthority,
                     timestamp,
-                    testRequest
+                    testRequest,
+                    0
                 );
                 throw Error("should throw cache error");
             } catch (e) {
@@ -962,7 +1010,8 @@ describe("ResponseHandler.ts", () => {
                     testResponse,
                     testAuthority,
                     timestamp,
-                    testRequest
+                    testRequest,
+                    0
                 );
                 throw Error("should throw cache error");
             } catch (e) {

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -200,6 +200,7 @@ export abstract class ClientApplication {
             );
             return await authorizationCodeClient.acquireToken(
                 validRequest,
+                ApiId.acquireTokenByCode,
                 authCodePayLoad
             );
         } catch (e) {
@@ -256,7 +257,10 @@ export abstract class ClientApplication {
                 "Refresh token client created",
                 validRequest.correlationId
             );
-            return await refreshTokenClient.acquireToken(validRequest);
+            return await refreshTokenClient.acquireToken(
+                validRequest,
+                ApiId.acquireTokenByRefreshToken
+            );
         } catch (e) {
             if (e instanceof AuthError) {
                 e.setCorrelationId(validRequest.correlationId);
@@ -326,7 +330,8 @@ export abstract class ClientApplication {
                         clientConfiguration
                     );
                     return refreshTokenClient.acquireTokenByRefreshToken(
-                        validRequest
+                        validRequest,
+                        ApiId.acquireTokenSilent
                     );
                 }
                 throw error;
@@ -364,7 +369,8 @@ export abstract class ClientApplication {
 
             try {
                 await refreshTokenClient.acquireTokenByRefreshToken(
-                    validRequest
+                    validRequest,
+                    ApiId.acquireTokenSilent
                 );
             } catch {
                 // do nothing, this is running in the background and no action is to be taken upon success or failure

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -40,6 +40,7 @@ import {
     ManagedIdentityConfiguration,
     ManagedIdentityNodeConfiguration,
 } from "../config/Configuration.js";
+import { ApiId } from "../utils/Constants.js";
 
 /**
  * OAuth2.0 client credential grant
@@ -328,7 +329,8 @@ export class ClientCredentialClient extends BaseClient {
             serverTokenResponse,
             this.authority,
             reqTimestamp,
-            request
+            request,
+            ApiId.acquireTokenByClientCredential
         );
 
         return tokenResponse;

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -25,6 +25,7 @@ import {
     createAuthError,
     createClientAuthError,
 } from "@azure/msal-common/node";
+import { ApiId } from "../utils/Constants.js";
 
 /**
  * OAuth2.0 Device code client
@@ -66,7 +67,8 @@ export class DeviceCodeClient extends BaseClient {
             response,
             this.authority,
             reqTimestamp,
-            request
+            request,
+            ApiId.acquireTokenByDeviceCode
         );
     }
 

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -25,6 +25,7 @@ import { ManagedIdentityRequestParameters } from "../../config/ManagedIdentityRe
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import { ManagedIdentityRequest } from "../../request/ManagedIdentityRequest.js";
 import {
+    ApiId,
     HttpMethod,
     ManagedIdentityIdType,
     ManagedIdentityQueryParameters,
@@ -312,7 +313,8 @@ export abstract class BaseManagedIdentitySource {
             serverTokenResponse,
             fakeAuthority,
             reqTimestamp,
-            managedIdentityRequest
+            managedIdentityRequest,
+            ApiId.acquireTokenWithManagedIdentity
         );
     }
 

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -35,6 +35,7 @@ import {
     UrlUtils,
 } from "@azure/msal-common/node";
 import { EncodingUtils } from "../utils/EncodingUtils.js";
+import { ApiId } from "../utils/Constants.js";
 
 /**
  * On-Behalf-Of client
@@ -306,6 +307,7 @@ export class OnBehalfOfClient extends BaseClient {
             this.authority,
             reqTimestamp,
             request,
+            ApiId.acquireTokenByOBO,
             undefined,
             userAssertionHash
         );

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -24,6 +24,7 @@ import {
     UrlUtils,
     getClientAssertion,
 } from "@azure/msal-common/node";
+import { ApiId } from "../utils/Constants.js";
 
 /**
  * Oauth2.0 Password grant client
@@ -67,7 +68,8 @@ export class UsernamePasswordClient extends BaseClient {
             response.body,
             this.authority,
             reqTimestamp,
-            request
+            request,
+            ApiId.acquireTokenByUsernamePassword
         );
 
         return tokenResponse;

--- a/lib/msal-node/src/utils/Constants.ts
+++ b/lib/msal-node/src/utils/Constants.ts
@@ -160,6 +160,8 @@ export const ApiId = {
     acquireTokenByUsernamePassword: 371,
     acquireTokenByDeviceCode: 671,
     acquireTokenByClientCredential: 771,
+    acquireTokenByOBO: 772,
+    acquireTokenWithManagedIdentity: 773,
     acquireTokenByCode: 871,
     acquireTokenByRefreshToken: 872,
 };


### PR DESCRIPTION
This pull request adds tracking of the `ApiId` when setting and retrieving accounts across the MSAL browser, node, and common packages. This change improves telemetry and debugging by associating account cache operations with the specific API calls that triggered them. The update includes passing the `ApiId` through several layers of account and token handling logic, and updating the public changelogs for relevant packages.

**Telemetry and API Tracking Improvements:**

* Added `ApiId` as a parameter to account and token cache operations, ensuring that every set/get account action is tracked with the originating API for better telemetry and diagnostics. (`BrowserCacheManager.ts`, `TokenCache.ts`, `InteractionHandler.ts`, `PlatformAuthInteractionClient.ts`, `SilentAuthCodeClient.ts`, `SilentRefreshClient.ts`, `CustomAuthInteractionClientBase.ts`, `SignInClient.ts`, `JitClient.ts`, `MfaClient.ts`, `CustomAuthSilentCacheClient.ts`, `Authorize.ts`) [[1]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2L1061-R1079) [[2]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2L2282-R2294) [[3]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2R2308-R2316) [[4]](diffhunk://#diff-5f7831e13b2c981db1cd1b03fed5d4c547c6e15d722bedf343e48d5c98d22f8fL194-R196) [[5]](diffhunk://#diff-5f7831e13b2c981db1cd1b03fed5d4c547c6e15d722bedf343e48d5c98d22f8fL234-R237) [[6]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8L942-R943) [[7]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fL1630-R1631) [[8]](diffhunk://#diff-244dfa122d07581eab88090f1afcda16eadd373c130463c14fa5d42598c4c2e7L744-R745) [[9]](diffhunk://#diff-244dfa122d07581eab88090f1afcda16eadd373c130463c14fa5d42598c4c2e7R821) [[10]](diffhunk://#diff-4463cecbdd32231efe5a8bc67925fb7bd906c5dc07c997596b1cd68d937d8c43R139) [[11]](diffhunk://#diff-2ae98a2162c2240ac97776505160467964916113e1f2813699ef3e1c9dfa5ee4L77-R83) [[12]](diffhunk://#diff-653018603cd6ea57661b967057d0def0a06bebd57fa1d98ca854a4bdedf4ddfeL100-R102) [[13]](diffhunk://#diff-653018603cd6ea57661b967057d0def0a06bebd57fa1d98ca854a4bdedf4ddfeL117-R120) [[14]](diffhunk://#diff-e2408a72cb1e61c210c62556f7ac2ba51339e6f18058eec56cc62e89441f2a15L157-R158) [[15]](diffhunk://#diff-9336756cabd0ff586b82f0661635ee833b68067712ea6ab300a101b15c15ba93L140-R141) [[16]](diffhunk://#diff-604a05d2c04229f01ff73d74a4576db80f37fb8fbf36c11be9835efcdc7712b4L92-R93) [[17]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL179-R180) [[18]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL223-R225) [[19]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL266-R269) [[20]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL282-R286) [[21]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL304-R309) [[22]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afL59-R61) [[23]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afL92-R94) [[24]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afR108) [[25]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afL155-R162) [[26]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165L441-R441)

* Updated the `BrowserCacheManager` to store the `cachedByApiId` property on account entities, and to log this information with each cache access for enhanced performance tracking. [[1]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2R1050-R1056) [[2]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2L1061-R1079)

**Changelog Updates:**

* Added patch changelog entries for `@azure/msal-browser`, `@azure/msal-common`, and `@azure/msal-node` to document the new API tracking feature. [[1]](diffhunk://#diff-9f2afeb40815eaa78c13b75d40d8b91a8b5fed7bec8674ac92b8b17d8cb1621dR1-R7) [[2]](diffhunk://#diff-727cdb89dd5cd630b13cd8e99161a17bd78db099f939ceffe6f1ed6ec0fe7ed9R1-R7) [[3]](diffhunk://#diff-07eee42033d047072a5cbde6ffb42b003a33752aee28035853d2e709956d04edR1-R7)

**Internal Refactoring:**

* Propagated the `ApiId` parameter through various authentication and cache management flows, including silent and interactive authentication, to ensure consistent tracking throughout the codebase. [[1]](diffhunk://#diff-653018603cd6ea57661b967057d0def0a06bebd57fa1d98ca854a4bdedf4ddfeL100-R102) [[2]](diffhunk://#diff-653018603cd6ea57661b967057d0def0a06bebd57fa1d98ca854a4bdedf4ddfeL117-R120) [[3]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL282-R286) [[4]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afL59-R61) [[5]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afR108)

These changes collectively enhance observability and traceability of account operations, making it easier to diagnose issues and analyze API usage patterns.