### PR TITLE
RT Expiry Telemetry

### DIFF
--- a/change/@azure-msal-common-7ffb9d9f-b183-4d11-acf5-75c86343872e.json
+++ b/change/@azure-msal-common-7ffb9d9f-b183-4d11-acf5-75c86343872e.json
@@ -1,6 +1,6 @@
 {
     "type": "patch",
-    "comment": "Add telemetry for RT expiration",
+    "comment": "Add telemetry for RT expiration [#8224](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8224)",
     "packageName": "@azure/msal-common",
     "email": "thomas.norling@microsoft.com",
     "dependentChangeType": "patch"

--- a/change/@azure-msal-common-7ffb9d9f-b183-4d11-acf5-75c86343872e.json
+++ b/change/@azure-msal-common-7ffb9d9f-b183-4d11-acf5-75c86343872e.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Add telemetry for RT expiration",
+    "packageName": "@azure/msal-common",
+    "email": "thomas.norling@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -3509,7 +3509,9 @@ export type PerformanceEvent = {
     embeddedClientId?: string;
     embeddedRedirectUri?: string;
     isAsyncPopup?: boolean;
-    rtExpiresOnMs?: number;
+    cacheRtExpiresOnSeconds?: number;
+    ntwkRtExpiresOnSeconds?: number;
+    rtOffsetSeconds?: number;
     sidFromClaims?: boolean;
     sidFromRequest?: boolean;
     loginHintFromRequest?: boolean;
@@ -4718,9 +4720,9 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/client/AuthorizationCodeClient.ts:227:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:463:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:193:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:289:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:290:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:341:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:285:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:286:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:337:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/SilentFlowClient.ts:173:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/ClientConfiguration.ts:51:5 - (ae-forgotten-export) The symbol "ClientCredentials" needs to be exported by the entry point index.d.ts
 // src/config/ClientConfiguration.ts:53:5 - (ae-forgotten-export) The symbol "TelemetryOptions" needs to be exported by the entry point index.d.ts

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -4718,14 +4718,14 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/cache/CacheManager.ts:1810:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/utils/CacheTypes.ts:94:53 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
 // src/cache/utils/CacheTypes.ts:94:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
-// src/client/AuthorizationCodeClient.ts:157:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:158:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:227:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:463:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:193:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:285:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:286:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:337:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:160:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:161:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:230:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:466:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:196:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:289:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:290:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:341:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/SilentFlowClient.ts:173:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/ClientConfiguration.ts:51:5 - (ae-forgotten-export) The symbol "ClientCredentials" needs to be exported by the entry point index.d.ts
 // src/config/ClientConfiguration.ts:53:5 - (ae-forgotten-export) The symbol "TelemetryOptions" needs to be exported by the entry point index.d.ts

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -222,23 +222,24 @@ export class RefreshTokenClient extends BaseClient {
             );
         }
 
-        if (
-            refreshToken.expiresOn &&
-            TimeUtils.isTokenExpired(
-                refreshToken.expiresOn,
+        if (refreshToken.expiresOn) {
+            const offset =
                 request.refreshTokenExpirationOffsetSeconds ||
-                    DEFAULT_REFRESH_TOKEN_EXPIRATION_OFFSET_SECONDS
-            )
-        ) {
+                DEFAULT_REFRESH_TOKEN_EXPIRATION_OFFSET_SECONDS;
             this.performanceClient?.addFields(
-                { rtExpiresOnMs: Number(refreshToken.expiresOn) },
+                {
+                    cacheRtExpiresOnSeconds: Number(refreshToken.expiresOn),
+                    rtOffsetSeconds: offset,
+                },
                 request.correlationId
             );
-            throw createInteractionRequiredAuthError(
-                InteractionRequiredAuthErrorCodes.refreshTokenExpired
-            );
+
+            if (TimeUtils.isTokenExpired(refreshToken.expiresOn, offset)) {
+                throw createInteractionRequiredAuthError(
+                    InteractionRequiredAuthErrorCodes.refreshTokenExpired
+                );
+            }
         }
-        // attach cached RT size to the current measurement
 
         const refreshTokenRequest: CommonRefreshTokenRequest = {
             ...request,
@@ -261,11 +262,6 @@ export class RefreshTokenClient extends BaseClient {
             )(refreshTokenRequest);
         } catch (e) {
             if (e instanceof InteractionRequiredAuthError) {
-                this.performanceClient?.addFields(
-                    { rtExpiresOnMs: Number(refreshToken.expiresOn) },
-                    request.correlationId
-                );
-
                 if (e.subError === InteractionRequiredAuthErrorCodes.badToken) {
                     // Remove bad refresh token from cache
                     this.logger.verbose(

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -456,6 +456,12 @@ export class ResponseHandler {
                           )
                         : serverTokenResponse.refresh_token_expires_in;
                 rtExpiresOn = reqTimestamp + rtExpiresIn;
+                this.performanceClient?.addFields(
+                    {
+                        ntwkRtExpiresOnSeconds: rtExpiresOn,
+                    },
+                    request.correlationId
+                );
             }
             cachedRefreshToken = CacheHelpers.createRefreshTokenEntity(
                 this.homeAccountIdentifier,

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -895,7 +895,9 @@ export type PerformanceEvent = {
 
     isAsyncPopup?: boolean;
 
-    rtExpiresOnMs?: number;
+    cacheRtExpiresOnSeconds?: number;
+    ntwkRtExpiresOnSeconds?: number;
+    rtOffsetSeconds?: number;
 
     sidFromClaims?: boolean;
     sidFromRequest?: boolean;

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -1383,7 +1383,9 @@ describe("RefreshTokenClient unit tests", () => {
             );
             rootMeasurement.end({ success: false });
             // @ts-ignore
-            expect(resEvents[0].rtExpiresOnMs).toEqual(rtExpiresOn);
+            expect(resEvents[0].cacheRtExpiresOnSeconds).toEqual(rtExpiresOn);
+            // @ts-ignore
+            expect(resEvents[0].rtOffsetSeconds).toEqual(300);
         });
 
         it("Throws error if cached RT expiration is within provided offset", async () => {
@@ -1502,7 +1504,9 @@ describe("RefreshTokenClient unit tests", () => {
 
             rootMeasurement.end({ success: false });
             // @ts-ignore
-            expect(resEvents[0].rtExpiresOnMs).toEqual(rtExpiresOn);
+            expect(resEvents[0].cacheRtExpiresOnSeconds).toEqual(rtExpiresOn);
+            // @ts-ignore
+            expect(resEvents[0].rtOffsetSeconds).toEqual(300);
         });
     });
     describe("Telemetry protocol mode tests", () => {

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -362,7 +362,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 reqTimestamp,
-                testRequest
+                testRequest,
+                0
             );
 
             expect(addFieldsSpy).toHaveBeenCalledWith(

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -329,6 +329,48 @@ describe("ResponseHandler.ts", () => {
             );
         });
 
+        it("adds rt expiry to performance fields when refresh_token_expires_in provided", async () => {
+            const testRequest: BaseAuthRequest = {
+                authority: testAuthority.canonicalAuthority,
+                correlationId: "CORRELATION_ID",
+                scopes: ["openid", "profile", "User.Read", "email"],
+            };
+            const refreshTokenExpiresIn = 600;
+            const testResponse: ServerAuthorizationTokenResponse = {
+                ...AUTHENTICATION_RESULT.body,
+                refresh_token_expires_in: refreshTokenExpiresIn,
+            };
+
+            const perfClient = new StubPerformanceClient();
+            const addFieldsSpy = jest.spyOn(perfClient, "addFields");
+
+            const responseHandler = new ResponseHandler(
+                "this-is-a-client-id",
+                testCacheManager,
+                cryptoInterface,
+                logger,
+                null,
+                null,
+                perfClient
+            );
+
+            const reqTimestamp = 1000;
+            await responseHandler.handleServerTokenResponse(
+                testResponse,
+                testAuthority,
+                reqTimestamp,
+                testRequest
+            );
+
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                {
+                    ntwkRtExpiresOnSeconds:
+                        reqTimestamp + refreshTokenExpiresIn,
+                },
+                testRequest.correlationId
+            );
+        });
+
         it("create CacheRecord with all token entities", (done) => {
             const testRequest: BaseAuthRequest = {
                 authority: testAuthority.canonicalAuthority,


### PR DESCRIPTION
This pull request adds telemetry for refresh token (RT) expiration to the `@azure/msal-common` package, improving observability around token lifetimes. It introduces new telemetry fields to track both cached and network-received RT expiration times, as well as the offset used for expiration checks. The changes also update related unit tests to verify the new telemetry fields.

**Telemetry enhancements:**

* Added new telemetry fields to `PerformanceEvent`: `cacheRtExpiresOnSeconds`, `ntwkRtExpiresOnSeconds`, and `rtOffsetSeconds`, replacing the previous `rtExpiresOnMs` field. These fields provide more granular tracking of refresh token expiration from both cache and network sources. [[1]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117L3512-R3514) [[2]](diffhunk://#diff-2f63a38227d7a354d8c67987de2d283da038557a987db95576a08fe16cc60354L898-R900)
* Updated `RefreshTokenClient` to log `cacheRtExpiresOnSeconds` and `rtOffsetSeconds` when checking cached RT expiration, and removed redundant telemetry on error. [[1]](diffhunk://#diff-3f3f7ffe90e832ac7ef7639d08bc689e87a3b455489a357fb72594c9427e54a6L225-R242) [[2]](diffhunk://#diff-3f3f7ffe90e832ac7ef7639d08bc689e87a3b455489a357fb72594c9427e54a6L264-L268)
* Updated `ResponseHandler` to log `ntwkRtExpiresOnSeconds` when a new RT expiration is received from the network.

**Testing improvements:**

* Updated and added unit tests in `RefreshTokenClient.spec.ts` and `ResponseHandler.spec.ts` to check for the new telemetry fields and ensure correct values are logged. [[1]](diffhunk://#diff-990aa777e0bbf234e09a8c471a3eaf1bb0ae0f6f5e409918b49ca30c0741cb8fL1386-R1388) [[2]](diffhunk://#diff-990aa777e0bbf234e09a8c471a3eaf1bb0ae0f6f5e409918b49ca30c0741cb8fL1505-R1509) [[3]](diffhunk://#diff-1f39f8f05f2db37ea3010dff4cbbbe19d594ebfd82f61814f26c044df720d047R332-R373)

**Changelog:**

* Added a changelog entry describing the new telemetry for RT expiration.

**API review and documentation:**

* Updated API review files and doc comment line numbers to reflect the new telemetry fields and code changes.