### PR TITLE
[v5] Store apiId in cache

### DIFF
--- a/change/@azure-msal-browser-18df263d-9e30-471c-b734-08fafec3b69f.json
+++ b/change/@azure-msal-browser-18df263d-9e30-471c-b734-08fafec3b69f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Store apiId in cache to track which API cached account information [#8236](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8236)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-b8dd0e4c-ab69-41fb-a43b-932214ac6311.json
+++ b/change/@azure-msal-common-b8dd0e4c-ab69-41fb-a43b-932214ac6311.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add cachedByApiId field to AccountEntity for telemetry tracking [#8236](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8236)",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-12bc6d47-f612-484e-ae0d-604d668dbf9b.json
+++ b/change/@azure-msal-node-12bc6d47-f612-484e-ae0d-604d668dbf9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Store apiId in cache to track which API cached account information [#8236](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8236)",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -99,6 +99,8 @@ export const ApiId: {
     readonly acquireTokenSilent_silentFlow: 61;
     readonly logout: 961;
     readonly logoutPopup: 962;
+    readonly hydrateCache: 963;
+    readonly loadExternalTokens: 964;
 };
 
 // @public (undocumented)

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -49,6 +49,8 @@ import {
     InMemoryCacheKeys,
     INTERACTION_TYPE,
     TemporaryCacheKeys,
+    ApiId,
+    apiIdToName,
 } from "../utils/BrowserConstants.js";
 import * as CacheKeys from "./CacheKeys.js";
 import { LocalStorage } from "./LocalStorage.js";
@@ -1050,10 +1052,19 @@ export class BrowserCacheManager extends CacheManager {
             return null;
         }
 
-        return CacheManager.toObject<AccountEntity>(
+        const account = CacheManager.toObject<AccountEntity>(
             {} as AccountEntity,
             parsedAccount
         );
+
+        this.performanceClient.addFields(
+            {
+                accountCachedBy: apiIdToName(account.cachedByApiId),
+            },
+            correlationId
+        );
+
+        return account;
     }
 
     /**
@@ -1063,7 +1074,8 @@ export class BrowserCacheManager extends CacheManager {
     async setAccount(
         account: AccountEntity,
         correlationId: string,
-        kmsi: boolean
+        kmsi: boolean,
+        apiId: number
     ): Promise<void> {
         this.logger.trace(
             "BrowserCacheManager.setAccount called",
@@ -1074,6 +1086,7 @@ export class BrowserCacheManager extends CacheManager {
         );
         const timestamp = Date.now().toString();
         account.lastUpdatedAt = timestamp;
+        account.cachedByApiId = apiId;
         await this.setUserData(
             key,
             JSON.stringify(account),
@@ -2318,7 +2331,8 @@ export class BrowserCacheManager extends CacheManager {
             result.correlationId,
             AuthToken.isKmsi(
                 AuthToken.extractTokenClaims(result.idToken, base64Decode)
-            )
+            ),
+            ApiId.hydrateCache
         );
     }
 
@@ -2332,6 +2346,7 @@ export class BrowserCacheManager extends CacheManager {
         cacheRecord: CacheRecord,
         correlationId: string,
         kmsi: boolean,
+        apiId: number,
         storeInCache?: StoreInCache
     ): Promise<void> {
         try {
@@ -2339,6 +2354,7 @@ export class BrowserCacheManager extends CacheManager {
                 cacheRecord,
                 correlationId,
                 kmsi,
+                apiId,
                 storeInCache
             );
         } catch (e) {

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -41,6 +41,7 @@ import { EventHandler } from "../event/EventHandler.js";
 import * as BrowserUtils from "../utils/BrowserUtils.js";
 import * as BrowserRootPerformanceEvents from "../telemetry/BrowserRootPerformanceEvents.js";
 import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
+import { ApiId } from "../utils/BrowserConstants.js";
 
 export type LoadTokenOptions = {
     clientInfo?: string;
@@ -240,7 +241,8 @@ async function loadAccount(
         await storage.setAccount(
             accountEntity,
             correlationId,
-            AuthToken.isKmsi(idTokenClaims || {})
+            AuthToken.isKmsi(idTokenClaims || {}),
+            ApiId.loadExternalTokens
         );
         return accountEntity;
     } else if (!authority || (!clientInfo && !idTokenClaims)) {
@@ -280,7 +282,8 @@ async function loadAccount(
     await storage.setAccount(
         cachedAccount,
         correlationId,
-        AuthToken.isKmsi(idTokenClaims || {})
+        AuthToken.isKmsi(idTokenClaims || {}),
+        ApiId.loadExternalTokens
     );
     return cachedAccount;
 }

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -35,6 +35,7 @@ import {
     InteractionType,
     DEFAULT_REQUEST,
     CacheLookupPolicy,
+    ApiId,
 } from "../utils/BrowserConstants.js";
 import { IController } from "./IController.js";
 import { NestedAppOperatingContext } from "../operatingcontext/NestedAppOperatingContext.js";
@@ -837,7 +838,7 @@ export class NestedAppAuthController implements IController {
             accountEntity,
             result.correlationId,
             AuthToken.isKmsi(result.idTokenClaims),
-            0
+            ApiId.hydrateCache
         );
         return this.browserStorage.hydrateCache(result, request);
     }

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -836,7 +836,8 @@ export class NestedAppAuthController implements IController {
         await this.browserStorage.setAccount(
             accountEntity,
             result.correlationId,
-            AuthToken.isKmsi(result.idTokenClaims)
+            AuthToken.isKmsi(result.idTokenClaims),
+            0
         );
         return this.browserStorage.hydrateCache(result, request);
     }

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1438,7 +1438,8 @@ export class StandardController implements IController {
         await this.browserStorage.setAccount(
             accountEntity,
             result.correlationId,
-            AuthToken.isKmsi(result.idTokenClaims)
+            AuthToken.isKmsi(result.idTokenClaims),
+            ApiId.hydrateCache
         );
 
         if (result.fromPlatformBroker) {

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts
@@ -99,7 +99,8 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
     protected async handleTokenResponse(
         tokenResponse: SignInTokenResponse,
         requestScopes: string[],
-        correlationId: string
+        correlationId: string,
+        apiId: number
     ): Promise<AuthenticationResult> {
         this.logger.verbose("Processing token response.", correlationId);
 
@@ -116,7 +117,8 @@ export abstract class CustomAuthInteractionClientBase extends StandardInteractio
                     correlationId:
                         tokenResponse.correlation_id ?? correlationId,
                     scopes: requestScopes,
-                }
+                },
+                apiId
             );
 
         return result as AuthenticationResult;

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/jit/JitClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/jit/JitClient.ts
@@ -172,7 +172,8 @@ export class JitClient extends CustomAuthInteractionClientBase {
             scopes,
             tokenResponse.correlation_id ||
                 continueResponse.correlation_id ||
-                correlationId
+                correlationId,
+            apiId
         );
 
         return createJitCompletedResult({

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/mfa/MfaClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/mfa/MfaClient.ts
@@ -154,7 +154,8 @@ export class MfaClient extends CustomAuthInteractionClientBase {
         const result = await this.handleTokenResponse(
             tokenResponse,
             scopes,
-            tokenResponse.correlation_id || correlationId
+            tokenResponse.correlation_id || correlationId,
+            apiId
         );
 
         return createMfaCompletedResult({

--- a/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
@@ -98,7 +98,8 @@ export class CustomAuthSilentCacheClient extends CustomAuthInteractionClientBase
 
                 const refreshTokenResult =
                     await refreshTokenClient.acquireTokenByRefreshToken(
-                        silentRequest
+                        silentRequest,
+                        PublicApiId.ACCOUNT_GET_ACCESS_TOKEN
                     );
 
                 this.logger.verbose(

--- a/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts
@@ -198,7 +198,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
                 ),
             scopes,
             correlationId,
-            telemetryManager
+            telemetryManager,
+            apiId
         );
     }
 
@@ -249,7 +250,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
                 ),
             scopes,
             correlationId,
-            telemetryManager
+            telemetryManager,
+            apiId
         );
     }
 
@@ -299,7 +301,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
                 ),
             scopes,
             correlationId,
-            telemetryManager
+            telemetryManager,
+            apiId
         );
     }
 
@@ -315,7 +318,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
         tokenEndpointCaller: () => Promise<SignInTokenResponse>,
         scopes: string[],
         correlationId: string,
-        telemetryManager: ServerTelemetryManager
+        telemetryManager: ServerTelemetryManager,
+        apiId: number
     ): Promise<
         | SignInCompletedResult
         | SignInJitRequiredResult
@@ -337,7 +341,8 @@ export class SignInClient extends CustomAuthInteractionClientBase {
             const authResult = await this.handleTokenResponse(
                 tokenResponse,
                 scopes,
-                tokenResponse.correlation_id || correlationId
+                tokenResponse.correlation_id || correlationId,
+                apiId
             );
 
             return createSignInCompleteResult({

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -765,7 +765,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         await this.browserStorage.setAccount(
             accountEntity,
             this.correlationId,
-            kmsi
+            kmsi,
+            this.apiId
         );
         // Remove any existing cached tokens for this account in browser storage
         this.browserStorage.removeAccountContext(
@@ -841,6 +842,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             nativeCacheRecord,
             this.correlationId,
             AuthToken.isKmsi(idTokenClaims),
+            this.apiId,
             request.storeInCache
         );
     }

--- a/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
@@ -161,6 +161,7 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
                     cloud_instance_host_name: request.cloudInstanceHostName,
                 },
                 silentRequest,
+                this.apiId,
                 false
             );
         } catch (e) {

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -86,11 +86,13 @@ export class SilentRefreshClient extends StandardInteractionClient {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(silentRequest).catch((e: AuthError) => {
-            (e as AuthError).setCorrelationId(this.correlationId);
-            serverTelemetryManager.cacheFailedRequest(e);
-            throw e;
-        }) as Promise<AuthenticationResult>;
+        )(silentRequest, ApiId.acquireTokenSilent_silentFlow).catch(
+            (e: AuthError) => {
+                (e as AuthError).setCorrelationId(this.correlationId);
+                serverTelemetryManager.cacheFailedRequest(e);
+                throw e;
+            }
+        ) as Promise<AuthenticationResult>;
     }
 
     /**

--- a/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
@@ -18,6 +18,7 @@ import {
     AuthorizeProtocol,
     CommonAuthorizationUrlRequest,
 } from "@azure/msal-common/browser";
+import { ApiId } from "../utils/BrowserConstants.js";
 import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
 import { BrowserCacheManager } from "../cache/BrowserCacheManager.js";
 import {
@@ -56,7 +57,8 @@ export class InteractionHandler {
      */
     async handleCodeResponse(
         response: AuthorizeResponse,
-        request: CommonAuthorizationUrlRequest
+        request: CommonAuthorizationUrlRequest,
+        apiId: ApiId
     ): Promise<AuthenticationResult> {
         let authCodeResponse;
         try {
@@ -84,7 +86,7 @@ export class InteractionHandler {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(authCodeResponse, request);
+        )(authCodeResponse, request, apiId);
     }
 
     /**
@@ -97,6 +99,7 @@ export class InteractionHandler {
     async handleCodeResponseFromServer(
         authCodeResponse: AuthorizationCodePayload,
         request: CommonAuthorizationUrlRequest,
+        apiId: ApiId,
         validateNonce: boolean = true
     ): Promise<AuthenticationResult> {
         this.logger.trace(
@@ -132,7 +135,11 @@ export class InteractionHandler {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(this.authCodeRequest, authCodeResponse)) as AuthenticationResult;
+        )(
+            this.authCodeRequest,
+            apiId,
+            authCodeResponse
+        )) as AuthenticationResult;
         return tokenResponse;
     }
 

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -434,7 +434,7 @@ export async function handleResponseCode(
         logger,
         performanceClient,
         request.correlationId
-    )(response, request);
+    )(response, request, apiId);
 
     return result;
 }
@@ -552,6 +552,7 @@ export async function handleResponseEAR(
         authority,
         TimeUtils.nowSeconds(),
         request,
+        apiId,
         additionalData,
         undefined,
         undefined,

--- a/lib/msal-browser/src/utils/BrowserConstants.ts
+++ b/lib/msal-browser/src/utils/BrowserConstants.ts
@@ -111,6 +111,7 @@ export type InMemoryCacheKeys =
  * Before adding a new code you must claim it in the MSAL Telemetry tracker as these number spaces are shared across all MSALs
  * 0-99 Silent Flow
  * 800-899 Auth Code Flow
+ * 900-999 Misc
  */
 export const ApiId = {
     acquireTokenRedirect: 861,
@@ -122,8 +123,34 @@ export const ApiId = {
     acquireTokenSilent_silentFlow: 61,
     logout: 961,
     logoutPopup: 962,
+    hydrateCache: 963,
+    loadExternalTokens: 964,
 } as const;
 export type ApiId = (typeof ApiId)[keyof typeof ApiId];
+
+/**
+ * API Names for Telemetry purposes.
+ */
+export const ApiName = {
+    861: "acquireTokenRedirect",
+    862: "acquireTokenPopup",
+    863: "ssoSilent",
+    864: "acquireTokenSilent_authCode",
+    865: "handleRedirectPromise",
+    866: "acquireTokenByCode",
+    61: "acquireTokenSilent_silentFlow",
+    961: "logout",
+    962: "logoutPopup",
+    963: "hydrateCache",
+    964: "loadExternalTokens",
+} as const satisfies Record<ApiId, string>;
+
+export const apiIdToName = (id: number | undefined): string => {
+    if (typeof id === "number" && id in ApiName) {
+        return ApiName[id as ApiId];
+    }
+    return "unknown";
+};
 
 /*
  * Interaction type of the API - used for state and telemetry

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -4526,7 +4526,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 silentRequest3,
             ]);
 
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest, 61);
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedTokenRequest,
+                ApiId.acquireTokenSilent_silentFlow
+            );
             expect(atsSpy).toHaveBeenCalledTimes(1);
             expect(silentATStub).toHaveBeenCalledTimes(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -4526,7 +4526,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 silentRequest3,
             ]);
 
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest);
+            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest, 61);
             expect(atsSpy).toHaveBeenCalledTimes(1);
             expect(silentATStub).toHaveBeenCalledTimes(1);
             expect(parallelResponse[0]).toEqual(testTokenResponse);
@@ -4731,15 +4731,29 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 sshCertSilentRequest3,
             ]);
 
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest2);
-            expect(silentATStub).toHaveBeenCalledWith(expectedPopTokenRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(expectedPopTokenRequest2);
             expect(silentATStub).toHaveBeenCalledWith(
-                expectedSshCertificateRequest1
+                expectedTokenRequest1,
+                61
             );
             expect(silentATStub).toHaveBeenCalledWith(
-                expectedSshCertificateRequest2
+                expectedTokenRequest2,
+                61
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedPopTokenRequest1,
+                61
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedPopTokenRequest2,
+                61
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedSshCertificateRequest1,
+                61
+            );
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedSshCertificateRequest2,
+                61
             );
             expect(silentATStub).toHaveBeenCalledTimes(6);
         });
@@ -4826,8 +4840,8 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             const silentRequest3 = pca.acquireTokenSilent(tokenRequest2);
             await Promise.all([silentRequest1, silentRequest2, silentRequest3]);
 
-            expect(silentATStub).toHaveBeenCalledWith(tokenRequest1);
-            expect(silentATStub).toHaveBeenCalledWith(tokenRequest2);
+            expect(silentATStub).toHaveBeenCalledWith(tokenRequest1, 61);
+            expect(silentATStub).toHaveBeenCalledWith(tokenRequest2, 61);
             expect(silentATStub).toHaveBeenCalledTimes(2);
         });
 
@@ -6993,7 +7007,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             ]);
 
             secondBrowserStorageInstance
-                .setAccount(accountEntity, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(accountEntity, TEST_CONFIG.CORRELATION_ID, true, 0)
                 .then(async () => {
                     // Create a second PCA instance to simulate another tab
                     const pca2 = new PublicClientApplication({
@@ -7031,7 +7045,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             ]);
 
             secondBrowserStorageInstance
-                .setAccount(accountEntity, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(accountEntity, TEST_CONFIG.CORRELATION_ID, true, 0)
                 .then(() => {
                     // Ensure account is present in the cache before setting it as active
                     secondBrowserStorageInstance.setActiveAccount(

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -41,6 +41,8 @@ import {
     CredentialEntity,
 } from "@azure/msal-common/browser";
 import {
+    ApiId,
+    apiIdToName,
     BrowserCacheLocation,
     INTERACTION_TYPE,
     TemporaryCacheKeys,
@@ -257,7 +259,8 @@ describe("BrowserCacheManager tests", () => {
                         refreshToken: TEST_REFRESH_TOKEN_ENTITY,
                     },
                     TEST_CONFIG.CORRELATION_ID,
-                    true
+                    true,
+                    0
                 );
 
                 // Setup some v0 cache entries
@@ -357,7 +360,8 @@ describe("BrowserCacheManager tests", () => {
                         refreshToken: TEST_REFRESH_TOKEN_ENTITY,
                     },
                     TEST_CONFIG.CORRELATION_ID,
-                    true
+                    true,
+                    0
                 );
 
                 // Setup some v1 cache entries
@@ -680,7 +684,8 @@ describe("BrowserCacheManager tests", () => {
                     await browserCacheManager.setAccount(
                         currentAccount,
                         TEST_CONFIG.CORRELATION_ID,
-                        true
+                        true,
+                        0
                     );
                     await browserCacheManager.setIdTokenCredential(
                         currentIdToken,
@@ -1246,7 +1251,8 @@ describe("BrowserCacheManager tests", () => {
                 await browserCacheManager.setAccount(
                     account,
                     TEST_CONFIG.CORRELATION_ID,
-                    true // KMSI = true, NO encryption
+                    true, // KMSI = true, NO encryption
+                    0
                 );
 
                 const accountInfo = {
@@ -1264,13 +1270,40 @@ describe("BrowserCacheManager tests", () => {
                 expect(isEncrypted(parsedValue)).toBe(false);
             });
 
+            it("should set cachedByApiId on account", async () => {
+                const account = { ...TEST_ACCOUNT_ENTITY };
+
+                const apiId = ApiId.acquireTokenPopup;
+                await browserCacheManager.setAccount(
+                    account,
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    apiId
+                );
+
+                const accountInfo = {
+                    homeAccountId: account.homeAccountId,
+                    environment: account.environment,
+                    tenantId: account.realm,
+                    username: account.username,
+                    localAccountId: account.localAccountId,
+                };
+                const key = browserCacheManager.generateAccountKey(accountInfo);
+                const rawValue = window.localStorage.getItem(key);
+                expect(rawValue).toBeDefined();
+
+                const parsedValue = JSON.parse(rawValue!);
+                expect(parsedValue.cachedByApiId).toBe(apiId);
+            });
+
             it("should encrypt account when KMSI is false", async () => {
                 const account = { ...TEST_ACCOUNT_ENTITY };
 
                 await browserCacheManager.setAccount(
                     account,
                     TEST_CONFIG.CORRELATION_ID,
-                    false // KMSI = false, encryption for security
+                    false, // KMSI = false, encryption for security
+                    0
                 );
 
                 const accountInfo = {
@@ -2794,6 +2827,46 @@ describe("BrowserCacheManager tests", () => {
                     ).toBeNull();
                 });
 
+                it("getAccount adds accountCachedBy telemetry field", async () => {
+                    const perfClient = new StubPerformanceClient();
+                    const addFieldsSpy = jest.spyOn(perfClient, "addFields");
+                    const tempCache = new BrowserCacheManager(
+                        TEST_CONFIG.MSAL_CLIENT_ID,
+                        cacheConfig,
+                        browserCrypto,
+                        logger,
+                        perfClient,
+                        new EventHandler()
+                    );
+                    await tempCache.initialize(TEST_CONFIG.CORRELATION_ID);
+
+                    const account = {
+                        ...TEST_ACCOUNT_ENTITY,
+                        cachedByApiId: ApiId.hydrateCache,
+                    };
+                    const key = tempCache.generateAccountKey(
+                        AccountEntityUtils.getAccountInfo(account)
+                    );
+                    await tempCache.setUserData(
+                        key,
+                        JSON.stringify(account),
+                        TEST_CONFIG.CORRELATION_ID,
+                        account.lastUpdatedAt || Date.now().toString(),
+                        false
+                    );
+
+                    const result = tempCache.getAccount(
+                        key,
+                        TEST_CONFIG.CORRELATION_ID
+                    );
+
+                    expect(result?.cachedByApiId).toBe(ApiId.hydrateCache);
+                    expect(addFieldsSpy).toHaveBeenCalledWith(
+                        { accountCachedBy: apiIdToName(ApiId.hydrateCache) },
+                        TEST_CONFIG.CORRELATION_ID
+                    );
+                });
+
                 it("getAccount returns AccountEntity", async () => {
                     const testAccount = AccountEntityUtils.createAccountEntity(
                         {
@@ -2813,7 +2886,8 @@ describe("BrowserCacheManager tests", () => {
                     await browserLocalStorage.setAccount(
                         testAccount,
                         TEST_CONFIG.CORRELATION_ID,
-                        true
+                        true,
+                        0
                     );
                     expect(
                         browserLocalStorage.getAccount(
@@ -2827,7 +2901,8 @@ describe("BrowserCacheManager tests", () => {
                     await browserSessionStorage.setAccount(
                         testAccount,
                         TEST_CONFIG.CORRELATION_ID,
-                        true
+                        true,
+                        0
                     );
 
                     expect(
@@ -4020,6 +4095,7 @@ describe("BrowserCacheManager tests", () => {
                                     {},
                                     "test-correlation-id",
                                     true,
+                                    0,
                                     undefined
                                 )
                                 .then(() => {

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -26,7 +26,10 @@ import {
     buildConfiguration,
     CacheOptions,
 } from "../../src/config/Configuration.js";
-import { BrowserCacheLocation } from "../../src/utils/BrowserConstants.js";
+import {
+    ApiId,
+    BrowserCacheLocation,
+} from "../../src/utils/BrowserConstants.js";
 import {
     ID_TOKEN_CLAIMS,
     RANDOM_TEST_GUID,
@@ -175,6 +178,41 @@ describe("TokenCache tests", () => {
                 expect.anything(),
                 false
             );
+        });
+
+        it("sets cachedByApiId when loading external tokens", async () => {
+            const request: SilentRequest = {
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                account: {
+                    homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                    environment: testEnvironment,
+                    tenantId: TEST_CONFIG.TENANT,
+                    username: "username",
+                    localAccountId: TEST_DATA_CLIENT_INFO.TEST_LOCAL_ACCOUNT_ID,
+                    loginHint: "login_hint",
+                },
+            };
+            const response: ExternalTokenResponse = {
+                id_token: testIdToken,
+                access_token: testAccessToken,
+                refresh_token: testRefreshToken,
+            };
+            const options: LoadTokenOptions = {};
+            const result = await loadExternalTokens(
+                configuration,
+                request,
+                response,
+                options
+            );
+
+            const accountKey = browserStorage.generateAccountKey(
+                result.account!
+            );
+            const accountEntity = await browserStorage.getAccount(
+                accountKey,
+                RANDOM_TEST_GUID
+            );
+            expect(accountEntity?.cachedByApiId).toBe(ApiId.loadExternalTokens);
         });
 
         it("loads id token with request authority and client info provided in options", async () => {

--- a/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
@@ -410,7 +410,7 @@ async function saveTokensIntoCache(
     refreshTokenEntity?: RefreshTokenEntity
 ): Promise<void> {
     accountEntity
-        ? await cacheManager.setAccount(accountEntity, correlationId, true)
+        ? await cacheManager.setAccount(accountEntity, correlationId, true, 0)
         : null;
     accessTokenEntity
         ? await cacheManager.setAccessTokenCredential(

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -2583,7 +2583,7 @@ describe("RedirectClient", () => {
                 }
             );
             browserStorage
-                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true, 0)
                 .then(() =>
                     redirectClient.logout({ account: testAccountInfo })
                 );
@@ -2645,7 +2645,7 @@ describe("RedirectClient", () => {
                 }
             );
             browserStorage
-                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true)
+                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true, 0)
                 .then(() =>
                     redirectClient.logout({
                         account: testAccountInfo,
@@ -2736,7 +2736,8 @@ describe("RedirectClient", () => {
             await browserStorage.setAccount(
                 testAccountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             await browserStorage.setIdTokenCredential(
                 testIdToken,
@@ -2931,7 +2932,12 @@ describe("RedirectClient", () => {
 
                 browserStorage2.setInteractionInProgress(true);
                 browserStorage2
-                    .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true)
+                    .setAccount(
+                        testAccount,
+                        TEST_CONFIG.CORRELATION_ID,
+                        true,
+                        0
+                    )
                     .then(() =>
                         redirectClient2
                             .logout({
@@ -3044,7 +3050,12 @@ describe("RedirectClient", () => {
 
                 browserStorage3.setInteractionInProgress(true);
                 browserStorage3
-                    .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true)
+                    .setAccount(
+                        testAccount,
+                        TEST_CONFIG.CORRELATION_ID,
+                        true,
+                        0
+                    )
                     .then(() =>
                         redirectClient3
                             .logout({

--- a/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
@@ -167,7 +167,7 @@ describe("SilentAuthCodeClient", () => {
                     cloud_instance_host_name: request.cloudInstanceHostName,
                 },
                 expect.anything(),
-                864,
+                ApiId.acquireTokenSilent_authCode,
                 false
             );
             expect(tokenResp).toEqual(testTokenResponse);

--- a/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
@@ -167,7 +167,8 @@ describe("SilentAuthCodeClient", () => {
                     cloud_instance_host_name: request.cloudInstanceHostName,
                 },
                 expect.anything(),
-                expect.anything()
+                864,
+                false
             );
             expect(tokenResp).toEqual(testTokenResponse);
         });

--- a/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
@@ -30,6 +30,7 @@ import { SilentRefreshClient } from "../../src/interaction_client/SilentRefreshC
 import { BrowserCacheManager } from "../../src/cache/BrowserCacheManager.js";
 import { FetchClient } from "../../src/network/FetchClient.js";
 import { TestTimeUtils } from "msal-test-utils";
+import { ApiId } from "../../src/utils/BrowserConstants.js";
 
 const testIdTokenClaims: TokenClaims = {
     ver: "2.0",
@@ -147,7 +148,10 @@ describe("SilentRefreshClient", () => {
             const tokenResp = await silentRefreshClient.acquireToken(
                 tokenRequest
             );
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest, 61);
+            expect(silentATStub).toHaveBeenCalledWith(
+                expectedTokenRequest,
+                ApiId.acquireTokenSilent_silentFlow
+            );
             expect(tokenResp).toEqual(testTokenResponse);
         });
 

--- a/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
@@ -147,7 +147,7 @@ describe("SilentRefreshClient", () => {
             const tokenResp = await silentRefreshClient.acquireToken(
                 tokenRequest
             );
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest);
+            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest, 61);
             expect(tokenResp).toEqual(testTokenResponse);
         });
 
@@ -203,7 +203,7 @@ describe("SilentRefreshClient", () => {
             const tokenResp = await silentRefreshClient.acquireToken(
                 tokenRequest
             );
-            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest);
+            expect(silentATStub).toHaveBeenCalledWith(expectedTokenRequest, 61);
             expect(tokenResp).toEqual(testTokenResponse);
         });
 

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -326,7 +326,7 @@ describe("InteractionHandler.ts Unit Tests", () => {
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(acquireTokenSpy).toHaveBeenCalledWith(
                 testAuthCodeRequest,
-                862,
+                ApiId.acquireTokenPopup,
                 testCodeResponse
             );
             expect(acquireTokenSpy).not.toThrow();

--- a/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/InteractionHandler.spec.ts
@@ -29,6 +29,7 @@ import {
     Configuration,
     buildConfiguration,
 } from "../../src/config/Configuration.js";
+import { ApiId } from "../../src/utils/BrowserConstants.js";
 import {
     TEST_CONFIG,
     TEST_URIS,
@@ -318,12 +319,14 @@ describe("InteractionHandler.ts Unit Tests", () => {
                         responseMode: "fragment",
                         nonce: TEST_CONFIG.CORRELATION_ID,
                         state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                    }
+                    },
+                    ApiId.acquireTokenPopup
                 );
 
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(acquireTokenSpy).toHaveBeenCalledWith(
                 testAuthCodeRequest,
+                862,
                 testCodeResponse
             );
             expect(acquireTokenSpy).not.toThrow();
@@ -397,11 +400,13 @@ describe("InteractionHandler.ts Unit Tests", () => {
                     responseMode: "fragment",
                     nonce: TEST_CONFIG.CORRELATION_ID,
                     state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
-                }
+                },
+                ApiId.acquireTokenRedirect
             );
             expect(tokenResponse).toEqual(testTokenResponse);
             expect(acquireTokenSpy).toHaveBeenCalledWith(
                 testAuthCodeRequest,
+                ApiId.acquireTokenRedirect,
                 testCodeResponse
             );
             expect(acquireTokenSpy).not.toThrow();

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -148,6 +148,7 @@ export type AccountEntity = {
     tenantProfiles?: Array<TenantProfile>;
     lastUpdatedAt: string;
     dataBoundary?: DataBoundary;
+    cachedByApiId?: number;
 };
 
 declare namespace AccountEntityUtils {
@@ -804,7 +805,7 @@ export class AuthorizationCodeClient {
     constructor(configuration: ClientConfiguration, performanceClient: IPerformanceClient);
     // Warning: (tsdoc-code-span-missing-delimiter) The code span is missing its closing backtick
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    acquireToken(request: CommonAuthorizationCodeRequest, authCodePayload?: AuthorizationCodePayload): Promise<AuthenticationResult>;
+    acquireToken(request: CommonAuthorizationCodeRequest, apiId: number, authCodePayload?: AuthorizationCodePayload): Promise<AuthenticationResult>;
     // (undocumented)
     authority: Authority;
     // (undocumented)
@@ -1223,13 +1224,13 @@ export abstract class CacheManager implements ICacheManager {
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    saveCacheRecord(cacheRecord: CacheRecord, correlationId: string, kmsi: boolean, storeInCache?: StoreInCache): Promise<void>;
+    saveCacheRecord(cacheRecord: CacheRecord, correlationId: string, kmsi: boolean, apiId: number, storeInCache?: StoreInCache): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract setAccessTokenCredential(accessToken: AccessTokenEntity, correlationId: string, kmsi: boolean): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    abstract setAccount(account: AccountEntity, correlationId: string, kmsi: boolean): Promise<void>;
+    abstract setAccount(account: AccountEntity, correlationId: string, kmsi: boolean, apiId: number): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     abstract setAppMetadata(appMetadata: AppMetadataEntity, correlationId: string): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -3469,6 +3470,7 @@ export type PerformanceEvent = {
     context?: string;
     cacheLocation?: string;
     cacheRetentionDays?: number;
+    accountCachedBy?: string;
     cacheRtCount?: number;
     cacheIdCount?: number;
     cacheAtCount?: number;
@@ -3690,9 +3692,9 @@ export type RefreshTokenCache = Record<string, RefreshTokenEntity>;
 export class RefreshTokenClient {
     constructor(configuration: ClientConfiguration, performanceClient: IPerformanceClient);
     // (undocumented)
-    acquireToken(request: CommonRefreshTokenRequest): Promise<AuthenticationResult>;
+    acquireToken(request: CommonRefreshTokenRequest, apiId: number): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    acquireTokenByRefreshToken(request: CommonSilentFlowRequest): Promise<AuthenticationResult>;
+    acquireTokenByRefreshToken(request: CommonSilentFlowRequest, apiId: number): Promise<AuthenticationResult>;
     // (undocumented)
     authority: Authority;
     // (undocumented)
@@ -3918,7 +3920,7 @@ export class ResponseHandler {
     static generateAuthenticationResult(cryptoObj: ICrypto, authority: Authority, cacheRecord: CacheRecord, fromTokenCache: boolean, request: BaseAuthRequest, performanceClient: IPerformanceClient, idTokenClaims?: TokenClaims, requestState?: RequestStateObject, serverTokenResponse?: ServerAuthorizationTokenResponse, requestId?: string): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    handleServerTokenResponse(serverTokenResponse: ServerAuthorizationTokenResponse, authority: Authority, reqTimestamp: number, request: BaseAuthRequest, authCodePayload?: AuthorizationCodePayload, userAssertionHash?: string, handlingRefreshTokenResponse?: boolean, forceCacheRefreshTokenResponse?: boolean, serverRequestId?: string): Promise<AuthenticationResult>;
+    handleServerTokenResponse(serverTokenResponse: ServerAuthorizationTokenResponse, authority: Authority, reqTimestamp: number, request: BaseAuthRequest, apiId: number, authCodePayload?: AuthorizationCodePayload, userAssertionHash?: string, handlingRefreshTokenResponse?: boolean, forceCacheRefreshTokenResponse?: boolean, serverRequestId?: string): Promise<AuthenticationResult>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -4740,53 +4742,53 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/authority/Authority.ts:802:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/Authority.ts:1000:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/authority/AuthorityOptions.ts:25:5 - (ae-forgotten-export) The symbol "CloudInstanceDiscoveryResponse" needs to be exported by the entry point index.d.ts
-// src/cache/CacheManager.ts:340:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/CacheManager.ts:341:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:613:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1577:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1578:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1592:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1593:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1613:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1614:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1623:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1624:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1640:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1641:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1655:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1656:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1694:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1695:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1709:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1710:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1721:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1722:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1733:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1734:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1745:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1746:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1763:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1764:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1788:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1789:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1808:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1809:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1828:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1829:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1840:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1841:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/cache/CacheManager.ts:1849:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:342:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:620:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1584:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1585:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1599:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1600:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1620:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1621:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1630:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1631:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1647:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1648:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1662:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1663:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1701:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1702:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1716:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1717:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1728:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1729:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1740:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1741:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1752:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1753:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1770:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1771:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1795:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1796:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1815:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1816:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1835:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1836:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1847:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1848:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/cache/CacheManager.ts:1856:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/entities/AccountEntity.ts:49:5 - (ae-forgotten-export) The symbol "DataBoundary" needs to be exported by the entry point index.d.ts
 // src/cache/utils/CacheTypes.ts:93:53 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
 // src/cache/utils/CacheTypes.ts:93:43 - (tsdoc-malformed-html-name) Invalid HTML element: An HTML name must be an ASCII letter followed by zero or more letters, digits, or hyphens
-// src/client/AuthorizationCodeClient.ts:221:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:222:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:299:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:533:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:241:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:328:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:329:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/RefreshTokenClient.ts:386:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:223:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:224:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:301:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:535:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:244:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:332:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:333:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/RefreshTokenClient.ts:390:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/SilentFlowClient.ts:225:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/ClientConfiguration.ts:51:5 - (ae-forgotten-export) The symbol "ClientCredentials" needs to be exported by the entry point index.d.ts
 // src/config/ClientConfiguration.ts:53:5 - (ae-forgotten-export) The symbol "TelemetryOptions" needs to be exported by the entry point index.d.ts
@@ -4796,9 +4798,9 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/request/AuthenticationHeaderParser.ts:74:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:346:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/response/ResponseHandler.ts:347:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:348:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:349:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/response/ResponseHandler.ts:350:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceClient.ts:673:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/telemetry/performance/PerformanceClient.ts:673:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
 // src/telemetry/performance/PerformanceClient.ts:685:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -4881,8 +4883,8 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/telemetry/performance/PerformanceEvent.ts:234:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:234:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:234:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:308:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:308:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:308:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:309:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:309:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:309:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -91,7 +91,8 @@ export abstract class CacheManager implements ICacheManager {
     abstract setAccount(
         account: AccountEntity,
         correlationId: string,
-        kmsi: boolean
+        kmsi: boolean,
+        apiId: number
     ): Promise<void>;
 
     /**
@@ -549,6 +550,7 @@ export abstract class CacheManager implements ICacheManager {
         cacheRecord: CacheRecord,
         correlationId: string,
         kmsi: boolean,
+        apiId: number,
         storeInCache?: StoreInCache
     ): Promise<void> {
         if (!cacheRecord) {
@@ -559,7 +561,12 @@ export abstract class CacheManager implements ICacheManager {
 
         try {
             if (!!cacheRecord.account) {
-                await this.setAccount(cacheRecord.account, correlationId, kmsi);
+                await this.setAccount(
+                    cacheRecord.account,
+                    correlationId,
+                    kmsi,
+                    apiId
+                );
             }
 
             if (!!cacheRecord.idToken && storeInCache?.idToken !== false) {

--- a/lib/msal-common/src/cache/entities/AccountEntity.ts
+++ b/lib/msal-common/src/cache/entities/AccountEntity.ts
@@ -47,4 +47,6 @@ export type AccountEntity = {
     /** Timestamp when the entry was last updated */
     lastUpdatedAt: string;
     dataBoundary?: DataBoundary;
+    /** API identifier for telemetry to indicate which API cached this account */
+    cachedByApiId?: number;
 };

--- a/lib/msal-common/src/cache/interface/ICacheManager.ts
+++ b/lib/msal-common/src/cache/interface/ICacheManager.ts
@@ -32,7 +32,8 @@ export interface ICacheManager {
     setAccount(
         account: AccountEntity,
         correlationId: string,
-        kmsi: boolean
+        kmsi: boolean,
+        apiId: number
     ): Promise<void>;
 
     /**
@@ -224,6 +225,7 @@ export interface ICacheManager {
         cacheRecord: CacheRecord,
         correlationId: string,
         kmsi: boolean,
+        apiId: number,
         storeInCache?: StoreInCache
     ): Promise<void>;
 

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -128,6 +128,7 @@ export class AuthorizationCodeClient {
      */
     async acquireToken(
         request: CommonAuthorizationCodeRequest,
+        apiId: number,
         authCodePayload?: AuthorizationCodePayload
     ): Promise<AuthenticationResult> {
         if (!request.code) {
@@ -187,6 +188,7 @@ export class AuthorizationCodeClient {
             this.authority,
             reqTimestamp,
             request,
+            apiId,
             authCodePayload,
             undefined,
             undefined,

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -118,7 +118,8 @@ export class RefreshTokenClient {
         this.performanceClient = performanceClient;
     }
     public async acquireToken(
-        request: CommonRefreshTokenRequest
+        request: CommonRefreshTokenRequest,
+        apiId: number
     ): Promise<AuthenticationResult> {
         const reqTimestamp = TimeUtils.nowSeconds();
         const response = await invokeAsync(
@@ -157,6 +158,7 @@ export class RefreshTokenClient {
             this.authority,
             reqTimestamp,
             request,
+            apiId,
             undefined,
             undefined,
             true,
@@ -170,7 +172,8 @@ export class RefreshTokenClient {
      * @param request
      */
     public async acquireTokenByRefreshToken(
-        request: CommonSilentFlowRequest
+        request: CommonSilentFlowRequest,
+        apiId: number
     ): Promise<AuthenticationResult> {
         // Cannot renew token if no request object is given.
         if (!request) {
@@ -200,7 +203,7 @@ export class RefreshTokenClient {
                     this.logger,
                     this.performanceClient,
                     request.correlationId
-                )(request, true);
+                )(request, true, apiId);
             } catch (e) {
                 const noFamilyRTInCache =
                     e instanceof InteractionRequiredAuthError &&
@@ -219,7 +222,7 @@ export class RefreshTokenClient {
                         this.logger,
                         this.performanceClient,
                         request.correlationId
-                    )(request, false);
+                    )(request, false, apiId);
                     // throw in all other cases
                 } else {
                     throw e;
@@ -233,7 +236,7 @@ export class RefreshTokenClient {
             this.logger,
             this.performanceClient,
             request.correlationId
-        )(request, false);
+        )(request, false, apiId);
     }
 
     /**
@@ -242,7 +245,8 @@ export class RefreshTokenClient {
      */
     private async acquireTokenWithCachedRefreshToken(
         request: CommonSilentFlowRequest,
-        foci: boolean
+        foci: boolean,
+        apiId: number
     ) {
         // fetches family RT or application RT based on FOCI value
         const refreshToken = invoke(
@@ -296,7 +300,7 @@ export class RefreshTokenClient {
                 this.logger,
                 this.performanceClient,
                 request.correlationId
-            )(refreshTokenRequest);
+            )(refreshTokenRequest, apiId);
         } catch (e) {
             if (e instanceof InteractionRequiredAuthError) {
                 this.performanceClient?.addFields(

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -189,6 +189,7 @@ export class ResponseHandler {
         authority: Authority,
         reqTimestamp: number,
         request: BaseAuthRequest,
+        apiId: number,
         authCodePayload?: AuthorizationCodePayload,
         userAssertionHash?: string,
         handlingRefreshTokenResponse?: boolean,
@@ -311,6 +312,7 @@ export class ResponseHandler {
                 cacheRecord,
                 request.correlationId,
                 isKmsi(idTokenClaims || {}),
+                apiId,
                 request.storeInCache
             );
         } finally {

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -291,6 +291,7 @@ export type PerformanceEvent = {
     // Cache Data
     cacheLocation?: string;
     cacheRetentionDays?: number;
+    accountCachedBy?: string;
 
     // Number of tokens in the cache to be reported when cache quota is exceeded
     cacheRtCount?: number;

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -105,7 +105,8 @@ describe("CacheManager.ts test cases", () => {
             await mockCache.cacheManager.saveCacheRecord(
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             const mockCacheAccount = mockCache.cacheManager.getAccount(
                 accountKey
@@ -140,7 +141,8 @@ describe("CacheManager.ts test cases", () => {
             await mockCache.cacheManager.saveCacheRecord(
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             const mockCacheAT = mockCache.cacheManager.getAccessTokenCredential(
                 atKey
@@ -177,6 +179,7 @@ describe("CacheManager.ts test cases", () => {
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
                 true,
+                0,
                 {
                     accessToken: false,
                 }
@@ -209,7 +212,8 @@ describe("CacheManager.ts test cases", () => {
             await mockCache.cacheManager.saveCacheRecord(
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             const mockCacheAT = mockCache.cacheManager.getAccessTokenCredential(
                 atKey
@@ -243,6 +247,7 @@ describe("CacheManager.ts test cases", () => {
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
                 true,
+                0,
                 {
                     idToken: false,
                 }
@@ -317,6 +322,7 @@ describe("CacheManager.ts test cases", () => {
                 cacheRecord,
                 TEST_CONFIG.CORRELATION_ID,
                 true,
+                0,
                 {
                     refreshToken: false,
                 }
@@ -813,7 +819,8 @@ describe("CacheManager.ts test cases", () => {
         await mockCache.cacheManager.saveCacheRecord(
             cacheRecord,
             TEST_CONFIG.CORRELATION_ID,
-            true
+            true,
+            0
         );
 
         const cacheAccount = mockCache.cacheManager.getAccount(
@@ -843,7 +850,8 @@ describe("CacheManager.ts test cases", () => {
         await mockCache.cacheManager.saveCacheRecord(
             cacheRecord,
             TEST_CONFIG.CORRELATION_ID,
-            true
+            true,
+            0
         );
 
         const cachedAccessToken =
@@ -876,7 +884,8 @@ describe("CacheManager.ts test cases", () => {
         await mockCache.cacheManager.saveCacheRecord(
             cacheRecord,
             TEST_CONFIG.CORRELATION_ID,
-            true
+            true,
+            0
         );
 
         const cachedAccessToken =

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -242,7 +242,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
                 state: testState,
@@ -362,7 +362,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
                 state: testState,
@@ -473,7 +473,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 authenticationScheme: Constants.AuthenticationScheme.BEARER,
             };
 
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
                 state: testState,
@@ -572,7 +572,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
 
             await expect(
-                client.acquireToken(authCodeRequest, {
+                client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                     state: testState,
@@ -672,7 +672,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
 
             await expect(
-                client.acquireToken(authCodeRequest, {
+                client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                     state: testState,
@@ -774,6 +774,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -962,6 +963,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -1094,7 +1096,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 authenticationScheme: Constants.AuthenticationScheme.BEARER,
             };
 
-            client.acquireToken(authorizationCodeRequest).catch((error) => {
+            client.acquireToken(authorizationCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1145,7 +1147,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(authorizationCodeRequest).catch((error) => {
+            client.acquireToken(authorizationCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1191,7 +1193,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(authCodeRequest).catch((error) => {
+            client.acquireToken(authCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1254,7 +1256,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(authCodeRequest).catch((error) => {
+            client.acquireToken(authCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1317,7 +1319,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(authCodeRequest).catch((error) => {
+            client.acquireToken(authCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1361,7 +1363,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 enableSpaAuthorizationCode: true,
             };
 
-            client.acquireToken(authCodeRequest).catch((error) => {
+            client.acquireToken(authCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1410,7 +1412,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(authCodeRequest).catch((error) => {
+            client.acquireToken(authCodeRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -1538,6 +1540,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -1730,6 +1733,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -1914,7 +1918,7 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
 
             expect(
-                client.acquireToken(authCodeRequest, {
+                client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                     state: testState,
@@ -2025,6 +2029,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -2135,6 +2140,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -2222,6 +2228,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -2289,6 +2296,7 @@ describe("AuthorizationCodeClient unit tests", () => {
 
             const authenticationResult = await client.acquireToken(
                 authCodeRequest,
+                0,
                 {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
@@ -2354,7 +2362,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 correlationId: RANDOM_TEST_GUID,
                 authenticationScheme: Constants.AuthenticationScheme.BEARER,
             };
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
             });
@@ -2421,7 +2429,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 correlationId: RANDOM_TEST_GUID,
                 authenticationScheme: Constants.AuthenticationScheme.BEARER,
             };
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
             });
@@ -2491,7 +2499,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 correlationId: RANDOM_TEST_GUID,
                 authenticationScheme: Constants.AuthenticationScheme.BEARER,
             };
-            await client.acquireToken(authCodeRequest, {
+            await client.acquireToken(authCodeRequest, 0, {
                 code: authCodeRequest.code,
                 nonce: idTokenClaims.nonce,
                 cloud_instance_host_name: "login.windows.net",
@@ -2587,7 +2595,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 authenticationScheme: Constants.AuthenticationScheme.BEARER,
             };
             try {
-                await client.acquireToken(authCodeRequest, {
+                await client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                 });
@@ -2681,7 +2689,7 @@ describe("AuthorizationCodeClient unit tests", () => {
                 authenticationScheme: Constants.AuthenticationScheme.BEARER,
             };
             try {
-                await client.acquireToken(authCodeRequest, {
+                await client.acquireToken(authCodeRequest, 0, {
                     code: authCodeRequest.code,
                     nonce: idTokenClaims.nonce,
                 });

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -107,9 +107,7 @@ export class MockStorageClass extends CacheManager {
         _kmsi?: boolean,
         apiId?: number
     ): Promise<void> {
-        if (typeof apiId !== "undefined") {
-            value.cachedByApiId = apiId;
-        }
+        value.cachedByApiId = apiId;
         const key = generateAccountKey(
             AccountEntityUtils.getAccountInfo(value)
         );

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -101,7 +101,15 @@ export class MockStorageClass extends CacheManager {
         return null;
     }
 
-    async setAccount(value: AccountEntity): Promise<void> {
+    async setAccount(
+        value: AccountEntity,
+        _correlationId?: string,
+        _kmsi?: boolean,
+        apiId?: number
+    ): Promise<void> {
+        if (typeof apiId !== "undefined") {
+            value.cachedByApiId = apiId;
+        }
         const key = generateAccountKey(
             AccountEntityUtils.getAccountInfo(value)
         );

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -540,7 +540,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest, 0
+                refreshTokenRequest,
+                0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -940,7 +941,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest, 0
+                refreshTokenRequest,
+                0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -1062,7 +1064,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest, 0
+                refreshTokenRequest,
+                0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -1180,7 +1183,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest, 0
+                refreshTokenRequest,
+                0
             );
 
             expect(authResult.requestId).toBeTruthy;
@@ -1209,7 +1213,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest, 0
+                refreshTokenRequest,
+                0
             );
 
             expect(authResult.requestId).toBeFalsy;
@@ -1358,7 +1363,8 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest, 0
+                refreshTokenRequest,
+                0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -1465,14 +1471,17 @@ describe("RefreshTokenClient unit tests", () => {
                 stubPerformanceClient
             );
             await expect(
-                client.acquireTokenByRefreshToken({
-                    scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
-                    // @ts-ignore
-                    account: null,
-                    authority: TEST_CONFIG.validAuthority,
-                    correlationId: TEST_CONFIG.CORRELATION_ID,
-                    forceRefresh: false,
-                }, 0)
+                client.acquireTokenByRefreshToken(
+                    {
+                        scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                        // @ts-ignore
+                        account: null,
+                        authority: TEST_CONFIG.validAuthority,
+                        correlationId: TEST_CONFIG.CORRELATION_ID,
+                        forceRefresh: false,
+                    },
+                    0
+                )
             ).rejects.toMatchObject(
                 createClientAuthError(
                     ClientAuthErrorCodes.noAccountInSilentRequest

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -180,7 +180,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((e) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((e) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -212,7 +212,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((e) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((e) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -245,7 +245,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -295,7 +295,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -343,7 +343,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -360,7 +360,7 @@ describe("RefreshTokenClient unit tests", () => {
                 "executePostToTokenEndpoint"
             ).mockResolvedValue(AUTHENTICATION_RESULT);
 
-            await client.acquireToken(refreshTokenRequest);
+            await client.acquireToken(refreshTokenRequest, 0);
             expect(spy).toHaveBeenCalled();
         });
 
@@ -378,7 +378,7 @@ describe("RefreshTokenClient unit tests", () => {
             ).mockResolvedValue({ ...AUTHENTICATION_RESULT, headers: {} });
 
             let refreshTokenSize;
-            await client.acquireToken(refreshTokenRequest).then(() => {
+            await client.acquireToken(refreshTokenRequest, 0).then(() => {
                 expect(spy).toHaveBeenCalled();
                 for (let i = 0; i < spy.mock.calls.length; i++) {
                     const arg = spy.mock.calls[i][0];
@@ -409,7 +409,7 @@ describe("RefreshTokenClient unit tests", () => {
             });
 
             let refreshTokenSize;
-            await client.acquireToken(refreshTokenRequest).then(() => {
+            await client.acquireToken(refreshTokenRequest, 0).then(() => {
                 expect(spy).toHaveBeenCalled();
                 for (let i = 0; i < spy.mock.calls.length; i++) {
                     const arg = spy.mock.calls[i][0];
@@ -454,7 +454,8 @@ describe("RefreshTokenClient unit tests", () => {
             await config.storageInterface!.setAccount(
                 testAccountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             await config.storageInterface!.setRefreshTokenCredential(
                 testRefreshTokenEntity,
@@ -512,7 +513,7 @@ describe("RefreshTokenClient unit tests", () => {
                     TEST_CONFIG.TOKEN_TYPE_BEARER as Constants.AuthenticationScheme,
             };
 
-            client.acquireToken(refreshTokenRequest);
+            client.acquireToken(refreshTokenRequest, 0);
         });
 
         it("acquires a token", async () => {
@@ -539,7 +540,7 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest, 0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -675,7 +676,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -708,7 +709,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -758,7 +759,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -806,7 +807,7 @@ describe("RefreshTokenClient unit tests", () => {
                 },
             };
 
-            client.acquireToken(refreshTokenRequest).catch((error) => {
+            client.acquireToken(refreshTokenRequest, 0).catch((error) => {
                 // Catch errors thrown after the function call this test is testing
             });
         });
@@ -839,9 +840,10 @@ describe("RefreshTokenClient unit tests", () => {
                 "acquireToken"
             );
 
-            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            await client.acquireTokenByRefreshToken(silentFlowRequest, 0);
             expect(refreshTokenClientSpy).toHaveBeenCalledWith(
-                expectedRefreshRequest
+                expectedRefreshRequest,
+                0
             );
         });
 
@@ -872,10 +874,11 @@ describe("RefreshTokenClient unit tests", () => {
                 "acquireToken"
             );
 
-            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            await client.acquireTokenByRefreshToken(silentFlowRequest, 0);
             expect(refreshTokenClientSpy).toHaveBeenCalled();
             expect(refreshTokenClientSpy).toHaveBeenCalledWith(
-                expectedRefreshRequest
+                expectedRefreshRequest,
+                0
             );
         });
 
@@ -907,9 +910,10 @@ describe("RefreshTokenClient unit tests", () => {
                 "acquireToken"
             );
 
-            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            await client.acquireTokenByRefreshToken(silentFlowRequest, 0);
             expect(refreshTokenClientSpy).toHaveBeenCalledWith(
-                expectedRefreshRequest
+                expectedRefreshRequest,
+                0
             );
         });
 
@@ -936,7 +940,7 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest, 0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -1058,7 +1062,7 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest, 0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -1176,7 +1180,7 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest, 0
             );
 
             expect(authResult.requestId).toBeTruthy;
@@ -1205,7 +1209,7 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest, 0
             );
 
             expect(authResult.requestId).toBeFalsy;
@@ -1232,7 +1236,7 @@ describe("RefreshTokenClient unit tests", () => {
                 authenticationScheme:
                     TEST_CONFIG.TOKEN_TYPE_BEARER as Constants.AuthenticationScheme,
             };
-            await client.acquireToken(refreshTokenRequest);
+            await client.acquireToken(refreshTokenRequest, 0);
 
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 {
@@ -1266,7 +1270,7 @@ describe("RefreshTokenClient unit tests", () => {
                 authenticationScheme:
                     TEST_CONFIG.TOKEN_TYPE_BEARER as Constants.AuthenticationScheme,
             };
-            await client.acquireToken(refreshTokenRequest);
+            await client.acquireToken(refreshTokenRequest, 0);
 
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 {
@@ -1314,7 +1318,8 @@ describe("RefreshTokenClient unit tests", () => {
             await config.storageInterface!.setAccount(
                 testAccountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             await config.storageInterface!.setRefreshTokenCredential(
                 testRefreshTokenEntity,
@@ -1353,7 +1358,7 @@ describe("RefreshTokenClient unit tests", () => {
             };
 
             const authResult: AuthenticationResult = await client.acquireToken(
-                refreshTokenRequest
+                refreshTokenRequest, 0
             );
             const expectedScopes = [
                 Constants.OPENID_SCOPE,
@@ -1439,9 +1444,10 @@ describe("RefreshTokenClient unit tests", () => {
                 "acquireToken"
             );
 
-            await client.acquireTokenByRefreshToken(silentFlowRequest);
+            await client.acquireTokenByRefreshToken(silentFlowRequest, 0);
             expect(refreshTokenClientSpy).toHaveBeenCalledWith(
-                expectedRefreshRequest
+                expectedRefreshRequest,
+                0
             );
         });
     });
@@ -1466,7 +1472,7 @@ describe("RefreshTokenClient unit tests", () => {
                     authority: TEST_CONFIG.validAuthority,
                     correlationId: TEST_CONFIG.CORRELATION_ID,
                     forceRefresh: false,
-                })
+                }, 0)
             ).rejects.toMatchObject(
                 createClientAuthError(
                     ClientAuthErrorCodes.noAccountInSilentRequest
@@ -1488,7 +1494,7 @@ describe("RefreshTokenClient unit tests", () => {
 
             await expect(
                 //@ts-ignore
-                client.acquireTokenByRefreshToken(null)
+                client.acquireTokenByRefreshToken(null, 0)
             ).rejects.toMatchObject(
                 createClientConfigurationError(
                     ClientConfigurationErrorCodes.tokenRequestEmpty
@@ -1497,7 +1503,7 @@ describe("RefreshTokenClient unit tests", () => {
 
             await expect(
                 //@ts-ignore
-                client.acquireTokenByRefreshToken(undefined)
+                client.acquireTokenByRefreshToken(undefined, 0)
             ).rejects.toMatchObject(
                 createClientConfigurationError(
                     ClientConfigurationErrorCodes.tokenRequestEmpty
@@ -1582,7 +1588,7 @@ describe("RefreshTokenClient unit tests", () => {
                 resEvents = events;
             });
             await expect(
-                client.acquireTokenByRefreshToken(tokenRequest)
+                client.acquireTokenByRefreshToken(tokenRequest, 0)
             ).rejects.toMatchObject(
                 createInteractionRequiredAuthError(
                     InteractionRequiredAuthErrorCodes.refreshTokenExpired
@@ -1618,7 +1624,7 @@ describe("RefreshTokenClient unit tests", () => {
                 stubPerformanceClient
             );
             await expect(
-                client.acquireTokenByRefreshToken(tokenRequest)
+                client.acquireTokenByRefreshToken(tokenRequest, 0)
             ).rejects.toMatchObject(
                 createInteractionRequiredAuthError(
                     InteractionRequiredAuthErrorCodes.refreshTokenExpired
@@ -1632,7 +1638,8 @@ describe("RefreshTokenClient unit tests", () => {
             await config.storageInterface!.setAccount(
                 testAccountEntity,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             );
             const rtExpiresOn = TimeUtils.nowSeconds() + 60 * 60;
             const rtEntity = {
@@ -1697,7 +1704,7 @@ describe("RefreshTokenClient unit tests", () => {
             ).toBe(rtEntity);
 
             await expect(
-                client.acquireTokenByRefreshToken(silentFlowRequest)
+                client.acquireTokenByRefreshToken(silentFlowRequest, 0)
             ).rejects.toMatchObject(invalidGrantAuthError);
 
             expect(
@@ -1735,7 +1742,7 @@ describe("RefreshTokenClient unit tests", () => {
                 stubPerformanceClient
             );
             try {
-                await client.acquireToken(refreshTokenRequest);
+                await client.acquireToken(refreshTokenRequest, 0);
             } catch {}
             expect(createTokenRequestBodySpy).toHaveBeenCalledWith(
                 refreshTokenRequest
@@ -1764,7 +1771,7 @@ describe("RefreshTokenClient unit tests", () => {
                 stubPerformanceClient
             );
             try {
-                await client.acquireToken(refreshTokenRequest);
+                await client.acquireToken(refreshTokenRequest, 0);
             } catch {}
             expect(createTokenRequestBodySpy).toHaveBeenCalledWith(
                 refreshTokenRequest

--- a/lib/msal-common/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-common/test/config/ClientConfiguration.spec.ts
@@ -76,7 +76,8 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
             emptyConfig.storageInterface.setAccount(
                 MockCache.acc,
                 TEST_CONFIG.CORRELATION_ID,
-                true
+                true,
+                0
             )
         ).rejects.toEqual(
             createClientAuthError(ClientAuthErrorCodes.methodNotImplemented)

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -436,7 +436,8 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 reqTimestamp,
-                testRequest
+                testRequest,
+                0
             );
 
             expect(addFieldsSpy).toHaveBeenCalledWith(

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -183,8 +183,9 @@ describe("ResponseHandler.ts", () => {
                         testResponse,
                         testAuthority,
                         timestamp,
-                        testRequest
-                    , 0);
+                        testRequest,
+                        0
+                    );
                 expect(tokenResp).toBeUndefined();
             } catch (e) {
                 if (e instanceof AuthError) {
@@ -262,8 +263,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
         });
 
         it("does not create RefreshTokenEntity if refresh_token not in response", (done) => {
@@ -331,8 +333,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
         });
 
         it("create CacheRecord with all token entities", (done) => {
@@ -398,8 +401,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
         });
 
         it("adds rt expiry to performance fields when refresh_token_expires_in provided", async () => {
@@ -472,8 +476,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
             expect(response.code).toEqual(testSpaCode);
         });
 
@@ -555,8 +560,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
         });
     });
 
@@ -586,8 +592,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
 
             expect(result.familyId).toBe("");
         });
@@ -634,8 +641,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
 
             expect(result.tokenType).toBe(AuthenticationScheme.POP);
             expect(result.accessToken).toBe(TEST_TOKENS.POP_TOKEN);
@@ -682,8 +690,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
 
             expect(result.tokenType).toBe(AuthenticationScheme.POP);
             expect(result.accessToken).toBe(testResponse.access_token);
@@ -714,8 +723,9 @@ describe("ResponseHandler.ts", () => {
                 testResponse,
                 testAuthority,
                 timestamp,
-                testRequest
-            , 0);
+                testRequest,
+                0
+            );
 
             expect(result.requestId).toBe("");
         });
@@ -900,8 +910,9 @@ describe("ResponseHandler.ts", () => {
                     testResponse,
                     testAuthority,
                     timestamp,
-                    testRequest
-                , 0);
+                    testRequest,
+                    0
+                );
                 throw Error("should throw cache error");
             } catch (e) {
                 expect(e).toBeInstanceOf(CacheError);
@@ -947,8 +958,9 @@ describe("ResponseHandler.ts", () => {
                     testResponse,
                     testAuthority,
                     timestamp,
-                    testRequest
-                , 0);
+                    testRequest,
+                    0
+                );
                 throw Error("should throw cache error");
             } catch (e) {
                 expect(e).toBeInstanceOf(CacheError);
@@ -994,8 +1006,9 @@ describe("ResponseHandler.ts", () => {
                     testResponse,
                     testAuthority,
                     timestamp,
-                    testRequest
-                , 0);
+                    testRequest,
+                    0
+                );
                 throw Error("should throw cache error");
             } catch (e) {
                 expect(e).toBeInstanceOf(CacheError);
@@ -1038,8 +1051,9 @@ describe("ResponseHandler.ts", () => {
                     testResponse,
                     testAuthority,
                     timestamp,
-                    testRequest
-                , 0);
+                    testRequest,
+                    0
+                );
                 throw Error("should throw cache error");
             } catch (e) {
                 expect(e).toBeInstanceOf(CacheError);

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -184,7 +184,7 @@ describe("ResponseHandler.ts", () => {
                         testAuthority,
                         timestamp,
                         testRequest
-                    );
+                    , 0);
                 expect(tokenResp).toBeUndefined();
             } catch (e) {
                 if (e instanceof AuthError) {
@@ -263,7 +263,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
         });
 
         it("does not create RefreshTokenEntity if refresh_token not in response", (done) => {
@@ -332,7 +332,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
         });
 
         it("create CacheRecord with all token entities", (done) => {
@@ -399,7 +399,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
         });
 
         it("includes spa_code in response as code", async () => {
@@ -431,7 +431,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
             expect(response.code).toEqual(testSpaCode);
         });
 
@@ -514,7 +514,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
         });
     });
 
@@ -545,7 +545,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
 
             expect(result.familyId).toBe("");
         });
@@ -593,7 +593,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
 
             expect(result.tokenType).toBe(AuthenticationScheme.POP);
             expect(result.accessToken).toBe(TEST_TOKENS.POP_TOKEN);
@@ -641,7 +641,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
 
             expect(result.tokenType).toBe(AuthenticationScheme.POP);
             expect(result.accessToken).toBe(testResponse.access_token);
@@ -673,7 +673,7 @@ describe("ResponseHandler.ts", () => {
                 testAuthority,
                 timestamp,
                 testRequest
-            );
+            , 0);
 
             expect(result.requestId).toBe("");
         });
@@ -859,7 +859,7 @@ describe("ResponseHandler.ts", () => {
                     testAuthority,
                     timestamp,
                     testRequest
-                );
+                , 0);
                 throw Error("should throw cache error");
             } catch (e) {
                 expect(e).toBeInstanceOf(CacheError);
@@ -906,7 +906,7 @@ describe("ResponseHandler.ts", () => {
                     testAuthority,
                     timestamp,
                     testRequest
-                );
+                , 0);
                 throw Error("should throw cache error");
             } catch (e) {
                 expect(e).toBeInstanceOf(CacheError);
@@ -953,7 +953,7 @@ describe("ResponseHandler.ts", () => {
                     testAuthority,
                     timestamp,
                     testRequest
-                );
+                , 0);
                 throw Error("should throw cache error");
             } catch (e) {
                 expect(e).toBeInstanceOf(CacheError);
@@ -997,7 +997,7 @@ describe("ResponseHandler.ts", () => {
                     testAuthority,
                     timestamp,
                     testRequest
-                );
+                , 0);
                 throw Error("should throw cache error");
             } catch (e) {
                 expect(e).toBeInstanceOf(CacheError);

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 import { AccessTokenCache } from '@azure/msal-common/node';
 import { AccessTokenEntity } from '@azure/msal-common/node';
 import { AccountCache } from '@azure/msal-common/node';

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { AccessTokenCache } from '@azure/msal-common/node';
 import { AccessTokenEntity } from '@azure/msal-common/node';
 import { AccountCache } from '@azure/msal-common/node';

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -203,6 +203,7 @@ export abstract class ClientApplication {
             );
             return await authorizationCodeClient.acquireToken(
                 validRequest,
+                ApiId.acquireTokenByCode,
                 authCodePayLoad
             );
         } catch (e) {
@@ -260,7 +261,10 @@ export abstract class ClientApplication {
                 "Refresh token client created",
                 validRequest.correlationId
             );
-            return await refreshTokenClient.acquireToken(validRequest);
+            return await refreshTokenClient.acquireToken(
+                validRequest,
+                ApiId.acquireTokenByRefreshToken
+            );
         } catch (e) {
             if (e instanceof AuthError) {
                 e.setCorrelationId(validRequest.correlationId);
@@ -334,7 +338,8 @@ export abstract class ClientApplication {
                         new StubPerformanceClient()
                     );
                     return refreshTokenClient.acquireTokenByRefreshToken(
-                        validRequest
+                        validRequest,
+                        ApiId.acquireTokenSilent
                     );
                 }
                 throw error;
@@ -374,7 +379,8 @@ export abstract class ClientApplication {
 
             try {
                 await refreshTokenClient.acquireTokenByRefreshToken(
-                    validRequest
+                    validRequest,
+                    ApiId.acquireTokenSilent
                 );
             } catch {
                 // do nothing, this is running in the background and no action is to be taken upon success or failure

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -29,6 +29,7 @@ import {
     getClientAssertion,
     UrlUtils,
 } from "@azure/msal-common/node";
+import { ApiId } from "../utils/Constants.js";
 import {
     ManagedIdentityConfiguration,
     ManagedIdentityNodeConfiguration,
@@ -335,7 +336,8 @@ export class ClientCredentialClient extends BaseClient {
             serverTokenResponse,
             this.authority,
             reqTimestamp,
-            request
+            request,
+            ApiId.acquireTokenByClientCredential
         );
 
         return tokenResponse;

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -21,6 +21,7 @@ import {
     createClientAuthError,
     Constants,
 } from "@azure/msal-common/node";
+import { ApiId } from "../utils/Constants.js";
 import { CommonDeviceCodeRequest } from "../request/CommonDeviceCodeRequest.js";
 import * as NodeClientAuthErrorCodes from "../error/ClientAuthErrorCodes.js";
 import { BaseClient } from "./BaseClient.js";
@@ -66,7 +67,8 @@ export class DeviceCodeClient extends BaseClient {
             response,
             this.authority,
             reqTimestamp,
-            request
+            request,
+            ApiId.acquireTokenByDeviceCode
         );
     }
 

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -20,12 +20,12 @@ import {
     Constants,
     StubPerformanceClient,
 } from "@azure/msal-common/node";
-import { ApiId } from "../../utils/Constants.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import { ManagedIdentityRequestParameters } from "../../config/ManagedIdentityRequestParameters.js";
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
 import { ManagedIdentityRequest } from "../../request/ManagedIdentityRequest.js";
 import {
+    ApiId,
     HttpMethod,
     ManagedIdentityIdType,
     ManagedIdentityQueryParameters,

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -20,6 +20,7 @@ import {
     Constants,
     StubPerformanceClient,
 } from "@azure/msal-common/node";
+import { ApiId } from "../../utils/Constants.js";
 import { ManagedIdentityId } from "../../config/ManagedIdentityId.js";
 import { ManagedIdentityRequestParameters } from "../../config/ManagedIdentityRequestParameters.js";
 import { CryptoProvider } from "../../crypto/CryptoProvider.js";
@@ -317,7 +318,8 @@ export abstract class BaseManagedIdentitySource {
             serverTokenResponse,
             fakeAuthority,
             reqTimestamp,
-            managedIdentityRequest
+            managedIdentityRequest,
+            ApiId.acquireTokenWithManagedIdentity
         );
     }
 

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -28,6 +28,7 @@ import {
     getClientAssertion,
     UrlUtils,
 } from "@azure/msal-common/node";
+import { ApiId } from "../utils/Constants.js";
 import { EncodingUtils } from "../utils/EncodingUtils.js";
 import { CommonOnBehalfOfRequest } from "../request/CommonOnBehalfOfRequest.js";
 import { BaseClient } from "./BaseClient.js";
@@ -309,6 +310,7 @@ export class OnBehalfOfClient extends BaseClient {
             this.authority,
             reqTimestamp,
             request,
+            ApiId.acquireTokenByOBO,
             undefined,
             userAssertionHash
         );

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -21,6 +21,7 @@ import {
     UrlUtils,
     getClientAssertion,
 } from "@azure/msal-common/node";
+import { ApiId } from "../utils/Constants.js";
 import { CommonUsernamePasswordRequest } from "../request/CommonUsernamePasswordRequest.js";
 import { BaseClient } from "./BaseClient.js";
 
@@ -73,7 +74,8 @@ export class UsernamePasswordClient extends BaseClient {
             response.body,
             this.authority,
             reqTimestamp,
-            request
+            request,
+            ApiId.acquireTokenByUsernamePassword
         );
 
         return tokenResponse;

--- a/lib/msal-node/src/utils/Constants.ts
+++ b/lib/msal-node/src/utils/Constants.ts
@@ -151,6 +151,8 @@ export const ApiId = {
     acquireTokenByUsernamePassword: 371,
     acquireTokenByDeviceCode: 671,
     acquireTokenByClientCredential: 771,
+    acquireTokenByOBO: 772,
+    acquireTokenWithManagedIdentity: 773,
     acquireTokenByCode: 871,
     acquireTokenByRefreshToken: 872,
 };


### PR DESCRIPTION
This pull request enhances telemetry and auditing capabilities in the MSAL browser library by tracking which API is responsible for caching account information. The main changes involve updating the account caching logic to include an `apiId` field, propagating this information throughout the authentication flow, and updating relevant method signatures and calls to support this new parameter.

**Account caching and telemetry improvements:**

* Added `cachedByApiId` to `AccountEntity` and updated `setAccount` and related methods to accept and store an `apiId` parameter, allowing the library to track which API cached each account. (`lib/msal-browser/src/cache/BrowserCacheManager.ts`, `lib/msal-browser/src/cache/TokenCache.ts`, `lib/msal-browser/apiReview/msal-browser.api.md`, [[1]](diffhunk://#diff-d8aa8313e46503e745028509a1ac18093831ea5baeafe63c63ea825727aa3580R102-R103) [[2]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2L1053-R1067) [[3]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2L1066-R1078) [[4]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2R1089) [[5]](diffhunk://#diff-5f7831e13b2c981db1cd1b03fed5d4c547c6e15d722bedf343e48d5c98d22f8fR44) [[6]](diffhunk://#diff-5f7831e13b2c981db1cd1b03fed5d4c547c6e15d722bedf343e48d5c98d22f8fL243-R245) [[7]](diffhunk://#diff-5f7831e13b2c981db1cd1b03fed5d4c547c6e15d722bedf343e48d5c98d22f8fL283-R286)
* Updated all authentication and token handling flows to pass the appropriate `apiId` when caching account data, ensuring consistent telemetry across the codebase. (`lib/msal-browser/src/controllers/NestedAppAuthController.ts`, `lib/msal-browser/src/controllers/StandardController.ts`, `lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts`, `lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts`, `lib/msal-browser/src/interaction_client/SilentRefreshClient.ts`, [[1]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8L839-R840) [[2]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fL1441-R1442) [[3]](diffhunk://#diff-244dfa122d07581eab88090f1afcda16eadd373c130463c14fa5d42598c4c2e7L768-R769) [[4]](diffhunk://#diff-244dfa122d07581eab88090f1afcda16eadd373c130463c14fa5d42598c4c2e7R845) [[5]](diffhunk://#diff-4463cecbdd32231efe5a8bc67925fb7bd906c5dc07c997596b1cd68d937d8c43R164) [[6]](diffhunk://#diff-2ae98a2162c2240ac97776505160467964916113e1f2813699ef3e1c9dfa5ee4L89-R95)
* Extended the `ApiId` enum and related utilities to include new identifiers for cache hydration and loading external tokens, and updated the documentation accordingly. (`lib/msal-browser/src/utils/BrowserConstants.ts`, `lib/msal-browser/apiReview/msal-browser.api.md`, [[1]](diffhunk://#diff-d8aa8313e46503e745028509a1ac18093831ea5baeafe63c63ea825727aa3580R102-R103) [[2]](diffhunk://#diff-640656ae00bc3d19c859b7dc0f26479e8982a0e651a915120a4710c17611d808R114)

**API and method signature updates:**

* Modified method signatures in authentication handlers and interaction clients to accept and propagate the `apiId` parameter, ensuring the correct API context is available throughout the authentication process. (`lib/msal-browser/src/interaction_handler/InteractionHandler.ts`, `lib/msal-browser/src/custom_auth/core/interaction_client/CustomAuthInteractionClientBase.ts`, `lib/msal-browser/src/custom_auth/core/interaction_client/jit/JitClient.ts`, `lib/msal-browser/src/custom_auth/core/interaction_client/mfa/MfaClient.ts`, `lib/msal-browser/src/custom_auth/sign_in/interaction_client/SignInClient.ts`, [[1]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afR21) [[2]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afL59-R61) [[3]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afL87-R89) [[4]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afR102) [[5]](diffhunk://#diff-c59334568c321055c0e09ccc0cce7e60f4d12ad94d7a8130ef047a7188a984afL135-R142) [[6]](diffhunk://#diff-653018603cd6ea57661b967057d0def0a06bebd57fa1d98ca854a4bdedf4ddfeL102-R103) [[7]](diffhunk://#diff-653018603cd6ea57661b967057d0def0a06bebd57fa1d98ca854a4bdedf4ddfeL119-R121) [[8]](diffhunk://#diff-e2408a72cb1e61c210c62556f7ac2ba51339e6f18058eec56cc62e89441f2a15L175-R176) [[9]](diffhunk://#diff-9336756cabd0ff586b82f0661635ee833b68067712ea6ab300a101b15c15ba93L157-R158) [[10]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL201-R202) [[11]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL252-R254) [[12]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL302-R305) [[13]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL318-R322) [[14]](diffhunk://#diff-d55836b67b933c0308b5d45a8e2a612cd224ea2d2a25027c1c3b0558b4a1503cL340-R345)

**Protocol and flow propagation:**

* Updated protocol handling functions to pass `apiId` through the authentication code and external account flows, ensuring that the API context is maintained throughout the entire process. (`lib/msal-browser/src/protocol/Authorize.ts`, [[1]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165L437-R437) [[2]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165R555)

These changes improve the observability and maintainability of the library by enabling more granular tracking of account caching operations, which can help with debugging, analytics, and future feature development.