### PR TITLE
Disallow major changes in v5

### DIFF
--- a/change/@azure-msal-angular-88568bb8-8c7f-4b83-89dc-d0c103ef2578.json
+++ b/change/@azure-msal-angular-88568bb8-8c7f-4b83-89dc-d0c103ef2578.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Disallow major changes #15525",
   "packageName": "@azure/msal-angular",
   "email": "shylasummers@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@azure-msal-angular-88568bb8-8c7f-4b83-89dc-d0c103ef2578.json
+++ b/change/@azure-msal-angular-88568bb8-8c7f-4b83-89dc-d0c103ef2578.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disallow major changes #15525",
+  "packageName": "@azure/msal-angular",
+  "email": "shylasummers@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-65758ec5-b9d0-4029-902f-266e2dd5e35b.json
+++ b/change/@azure-msal-browser-65758ec5-b9d0-4029-902f-266e2dd5e35b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disallow major changes #15525",
+  "packageName": "@azure/msal-browser",
+  "email": "shylasummers@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-65758ec5-b9d0-4029-902f-266e2dd5e35b.json
+++ b/change/@azure-msal-browser-65758ec5-b9d0-4029-902f-266e2dd5e35b.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Disallow major changes #15525",
   "packageName": "@azure/msal-browser",
   "email": "shylasummers@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@azure-msal-common-a7def96d-3305-451a-9d36-8fc33ef76c98.json
+++ b/change/@azure-msal-common-a7def96d-3305-451a-9d36-8fc33ef76c98.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Disallow major changes #15525",
   "packageName": "@azure/msal-common",
   "email": "shylasummers@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@azure-msal-common-a7def96d-3305-451a-9d36-8fc33ef76c98.json
+++ b/change/@azure-msal-common-a7def96d-3305-451a-9d36-8fc33ef76c98.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disallow major changes #15525",
+  "packageName": "@azure/msal-common",
+  "email": "shylasummers@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-extensions-8dcca3c4-b132-4704-b355-4607b306893b.json
+++ b/change/@azure-msal-node-extensions-8dcca3c4-b132-4704-b355-4607b306893b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disallow major changes #15525",
+  "packageName": "@azure/msal-node-extensions",
+  "email": "shylasummers@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-extensions-8dcca3c4-b132-4704-b355-4607b306893b.json
+++ b/change/@azure-msal-node-extensions-8dcca3c4-b132-4704-b355-4607b306893b.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Disallow major changes #15525",
   "packageName": "@azure/msal-node-extensions",
   "email": "shylasummers@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@azure-msal-node-f05b82a3-a9da-4cbf-a36c-5e78f69aac43.json
+++ b/change/@azure-msal-node-f05b82a3-a9da-4cbf-a36c-5e78f69aac43.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Disallow major changes #15525",
   "packageName": "@azure/msal-node",
   "email": "shylasummers@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@azure-msal-node-f05b82a3-a9da-4cbf-a36c-5e78f69aac43.json
+++ b/change/@azure-msal-node-f05b82a3-a9da-4cbf-a36c-5e78f69aac43.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disallow major changes #15525",
+  "packageName": "@azure/msal-node",
+  "email": "shylasummers@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-react-24e90074-18b8-4b78-b0aa-2a19428c2c53.json
+++ b/change/@azure-msal-react-24e90074-18b8-4b78-b0aa-2a19428c2c53.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Disallow major changes #15525",
   "packageName": "@azure/msal-react",
   "email": "shylasummers@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@azure-msal-react-24e90074-18b8-4b78-b0aa-2a19428c2c53.json
+++ b/change/@azure-msal-react-24e90074-18b8-4b78-b0aa-2a19428c2c53.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disallow major changes #15525",
+  "packageName": "@azure/msal-react",
+  "email": "shylasummers@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/extensions/msal-node-extensions/package.json
+++ b/extensions/msal-node-extensions/package.json
@@ -61,7 +61,9 @@
     "url": "https://www.microsoft.com"
   },
   "beachball": {
-    "disallowedChangeTypes": []
+    "disallowedChangeTypes": [
+      "major"
+    ]
   },
   "dependencies": {
     "@azure/msal-common": "16.0.1",

--- a/lib/msal-angular/package.json
+++ b/lib/msal-angular/package.json
@@ -33,7 +33,9 @@
   },
   "typings": "./dist/azure-msal-angular.d.ts",
   "beachball": {
-    "disallowedChangeTypes": []
+    "disallowedChangeTypes": [
+      "major"
+    ]
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.2.3",

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -63,7 +63,9 @@
     "node": ">=0.8.0"
   },
   "beachball": {
-    "disallowedChangeTypes": []
+    "disallowedChangeTypes": [
+      "major"
+    ]
   },
   "directories": {
     "test": "test"

--- a/lib/msal-common/package.json
+++ b/lib/msal-common/package.json
@@ -94,7 +94,9 @@
     "apiExtractor": "api-extractor run"
   },
   "beachball": {
-    "disallowedChangeTypes": []
+    "disallowedChangeTypes": [
+      "major"
+    ]
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -59,7 +59,9 @@
     "apiExtractor": "api-extractor run"
   },
   "beachball": {
-    "disallowedChangeTypes": []
+    "disallowedChangeTypes": [
+      "major"
+    ]
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.43.4",

--- a/lib/msal-react/package.json
+++ b/lib/msal-react/package.json
@@ -38,7 +38,9 @@
     "node": ">=20"
   },
   "beachball": {
-    "disallowedChangeTypes": []
+    "disallowedChangeTypes": [
+      "major"
+    ]
   },
   "scripts": {
     "build": "rollup -c --strictDeprecations --bundleConfigAsCjs",


### PR DESCRIPTION
Now that v5 is released, we don't need to make any more major changes to v5. This PR re-adds major changes to the `disallowedChangeTypes` list in `package.json`.