### PR TITLE
[v5] Restore CryptoProvider export

### DIFF
--- a/change/@azure-msal-node-2283d3d7-8924-4596-a52a-60ab1720cad5.json
+++ b/change/@azure-msal-node-2283d3d7-8924-4596-a52a-60ab1720cad5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "restore cryptoProvider export [#8276](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8276)",
+  "packageName": "@azure/msal-node",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -126,7 +126,6 @@ export class ClientAssertion {
     // @deprecated (undocumented)
     static fromCertificate(thumbprint: string, privateKey: string, publicCertificate?: string): ClientAssertion;
     static fromCertificateWithSha256Thumbprint(thumbprint: string, privateKey: string, publicCertificate?: string): ClientAssertion;
-    // Warning: (ae-forgotten-export) The symbol "CryptoProvider" needs to be exported by the entry point index.d.ts
     getJwt(cryptoProvider: CryptoProvider, issuer: string, jwtAudience: string): string;
     static parseCertificate(publicCertificate: string): Array<string>;
 }
@@ -166,6 +165,22 @@ export type Configuration = {
     system?: NodeSystemOptions;
     telemetry?: NodeTelemetryOptions;
 };
+
+// @public
+export class CryptoProvider implements ICrypto {
+    constructor();
+    base64Decode(input: string): string;
+    base64Encode(input: string): string;
+    base64UrlEncode(): string;
+    clearKeystore(): Promise<boolean>;
+    createNewGuid(): string;
+    encodeKid(): string;
+    generatePkceCodes(): Promise<PkceCodes>;
+    getPublicKeyThumbprint(): Promise<string>;
+    hashString(plainText: string): Promise<string>;
+    removeTokenBindingKey(): Promise<void>;
+    signJwt(): Promise<string>;
+}
 
 // @internal
 class Deserializer {

--- a/lib/msal-node/src/index.ts
+++ b/lib/msal-node/src/index.ts
@@ -75,6 +75,8 @@ const PromptValue = CommonConstants.PromptValue;
 const ResponseMode = CommonConstants.ResponseMode;
 export { PromptValue, ResponseMode };
 
+export { CryptoProvider } from "./crypto/CryptoProvider.js";
+
 // Common Object Formats
 export {
     AuthorizationCodePayload,


### PR DESCRIPTION
Restores export of `CryptoProvider` class which was removed in v5. Folks are using the `generatePkceCodes` function and we did not provide an alternative.