### PR TITLE
Fix INetworkModule Typedocs

### DIFF
--- a/change/@azure-msal-common-7e9492d2-7df6-4eb9-8f6f-0914bfc787a1.json
+++ b/change/@azure-msal-common-7e9492d2-7df6-4eb9-8f6f-0914bfc787a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix INetworkModule Typedocs [#8277](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8277)",
+  "packageName": "@azure/msal-common",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2605,10 +2605,7 @@ export interface INativeBrokerPlugin {
 export interface INetworkModule {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     sendGetRequestAsync<T>(url: string, options?: NetworkRequestOptions, timeout?: number): Promise<NetworkResponse<T>>;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     sendPostRequestAsync<T>(url: string, options?: NetworkRequestOptions): Promise<NetworkResponse<T>>;
 }

--- a/lib/msal-common/src/network/INetworkModule.ts
+++ b/lib/msal-common/src/network/INetworkModule.ts
@@ -25,8 +25,8 @@ export interface INetworkModule {
     /**
      * Interface function for async network "GET" requests. Based on the Fetch standard: https://fetch.spec.whatwg.org/
      * @param url
-     * @param requestParams
-     * @param enableCaching
+     * @param options - Headers and/or body to include on the request
+     * @param timeout
      */
     sendGetRequestAsync<T>(
         url: string,
@@ -37,8 +37,7 @@ export interface INetworkModule {
     /**
      * Interface function for async network "POST" requests. Based on the Fetch standard: https://fetch.spec.whatwg.org/
      * @param url
-     * @param requestParams
-     * @param enableCaching
+     * @param options - Headers and/or body to include on the request
      */
     sendPostRequestAsync<T>(
         url: string,


### PR DESCRIPTION
This pull request makes minor improvements to the documentation of the `INetworkModule` interface, specifically updating the parameter descriptions for the `sendGetRequestAsync` and `sendPostRequestAsync` methods to better reflect their usage.

- Updated the `@param` documentation for the `options` parameter in both `sendGetRequestAsync` and `sendPostRequestAsync` methods to clarify that it includes headers and/or body, and added a `timeout` parameter description for `sendGetRequestAsync`. [[1]](diffhunk://#diff-b6be82612142b5a265b0b5320350ecabdd648662e0f20a21a1438227441759cbL28-R29) [[2]](diffhunk://#diff-b6be82612142b5a265b0b5320350ecabdd648662e0f20a21a1438227441759cbL40-R40)
- Cleaned up redundant warning comments in the API review file for `INetworkModule`.