### PR TITLE
[v5] Add options to handleRedirectObservable

### DIFF
--- a/change/@azure-msal-angular-23c898e6-fb30-4ca5-bede-d03551e5ad30.json
+++ b/change/@azure-msal-angular-23c898e6-fb30-4ca5-bede-d03551e5ad30.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add handleRedirectObservable options [#8278](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/8278)",
+  "packageName": "@azure/msal-angular",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-angular/docs/redirects.md
+++ b/lib/msal-angular/docs/redirects.md
@@ -190,6 +190,35 @@ Apps using standalone components will be unable to handle redirects with `MsalRe
 - Accessing or performing any action related to user accounts should not be done until `handleRedirectObservable()` is complete, as it may not be fully populated until then. Additionally, if interactive APIs are called while `handleRedirectObservable()` is in progress, it will result in an `interaction_in_progress` error. See our document on [events](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/events.md#the-inprogress-observable) for more information on checking for interactions, and our document on [errors](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/errors.md) for details about the `interaction_in_progress` error. 
 - See our [MSAL Angular Modules Sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/samples/msal-angular-samples/angular-modules-sample/src/app/app.component.ts) for examples of this approach.
 
+### `handleRedirectObservable` options
+
+`handleRedirectObservable` accepts an optional `HandleRedirectPromiseOptions` object with the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `hash` | `string` | Optional hash to process instead of the current URL hash. |
+| `navigateToLoginRequestUrl` | `boolean` | Whether to navigate to the original request URL after processing the redirect. Defaults to `true`. Set to `false` if you want to handle navigation yourself. |
+
+Example usage:
+
+```js
+// Basic usage - processes redirect and navigates to original URL
+this.authService.handleRedirectObservable().subscribe();
+
+// Disable automatic navigation after redirect
+this.authService.handleRedirectObservable({ navigateToLoginRequestUrl: false }).subscribe({
+  next: (result: AuthenticationResult) => {
+    if (result) {
+      // Handle navigation yourself
+      this.router.navigate(['/home']);
+    }
+  }
+});
+
+// Process a specific hash
+this.authService.handleRedirectObservable({ hash: '#code=...' }).subscribe();
+```
+
 Example of home.component.ts file:
 ```js
 import { Component, OnInit } from '@angular/core';

--- a/lib/msal-angular/docs/v4-v5-upgrade-guide.md
+++ b/lib/msal-angular/docs/v4-v5-upgrade-guide.md
@@ -10,6 +10,27 @@ Please see the [MSAL Browser v4-v5 migration guide](https://github.com/AzureAD/m
 
 `MSAL_INSTANCE`, `MSAL_GUARD_CONFIG`, `MSAL_INTERCEPTOR_CONFIG`, and `MSAL_BROADCAST_CONFIG` now resolve to types instead of strings in order to support `inject(TOKEN)` syntax. This change may cause TypeScript errors in applications without explicit typing.
 
+### `handleRedirectObservable()` options
+
+`handleRedirectObservable()` now accepts an optional `HandleRedirectPromiseOptions` object, which includes the `navigateToLoginRequestUrl` option that was moved from the configuration in `@azure/msal-browser@5`. See the [redirects documentation](./redirects.md#handleredirectobservable-options) for more details.
+
+```typescript
+// Before (msal-browser v4 configuration)
+const msalConfig = {
+  auth: {
+    clientId: 'your-client-id',
+    navigateToLoginRequestUrl: false // This option has moved
+  }
+};
+
+// After (msal-angular v5)
+this.authService.handleRedirectObservable({ 
+  navigateToLoginRequestUrl: false 
+}).subscribe();
+```
+
+Note: Passing a hash string directly to `handleRedirectObservable(hash)` is now deprecated. Use the options object instead: `handleRedirectObservable({ hash: "#..." })`.
+
 ### `logout()`
 
 `logout()` has been removed. Please use `logoutRedirect()` or `logoutPopup()` instead.

--- a/lib/msal-angular/src/IMsalService.ts
+++ b/lib/msal-angular/src/IMsalService.ts
@@ -12,6 +12,7 @@ import {
   SsoSilentRequest,
   EndSessionRequest,
   EndSessionPopupRequest,
+  HandleRedirectPromiseOptions,
 } from "@azure/msal-browser";
 import { Observable } from "rxjs";
 
@@ -22,7 +23,13 @@ export interface IMsalService {
   acquireTokenSilent(
     silentRequest: SilentRequest
   ): Observable<AuthenticationResult>;
-  handleRedirectObservable(): Observable<AuthenticationResult | null>;
+  /**
+   * @deprecated Pass options object instead of hash string. Use handleRedirectObservable({ hash: "#..." }) instead.
+   */
+  handleRedirectObservable(hash: string): Observable<AuthenticationResult | null>;
+  handleRedirectObservable(
+    options?: HandleRedirectPromiseOptions
+  ): Observable<AuthenticationResult | null>;
   loginPopup(request?: PopupRequest): Observable<AuthenticationResult>;
   loginRedirect(request?: RedirectRequest): Observable<void>;
   logoutRedirect(logoutRequest?: EndSessionRequest): Observable<void>;

--- a/lib/msal-angular/src/IMsalService.ts
+++ b/lib/msal-angular/src/IMsalService.ts
@@ -26,7 +26,9 @@ export interface IMsalService {
   /**
    * @deprecated Pass options object instead of hash string. Use handleRedirectObservable({ hash: "#..." }) instead.
    */
-  handleRedirectObservable(hash: string): Observable<AuthenticationResult | null>;
+  handleRedirectObservable(
+    hash: string
+  ): Observable<AuthenticationResult | null>;
   handleRedirectObservable(
     options?: HandleRedirectPromiseOptions
   ): Observable<AuthenticationResult | null>;

--- a/lib/msal-angular/src/msal.service.spec.ts
+++ b/lib/msal-angular/src/msal.service.spec.ts
@@ -417,7 +417,7 @@ describe("MsalService", () => {
       });
     });
 
-    it("called with hash", (done) => {
+    it("called with hash string (legacy)", (done) => {
       const sampleAccessToken = {
         accessToken: "123abc",
       };
@@ -441,6 +441,60 @@ describe("MsalService", () => {
           expect(
             PublicClientApplication.prototype.handleRedirectPromise
           ).toHaveBeenCalledWith({ hash: hash });
+          done();
+        });
+    });
+
+    it("called with hash in options object", (done) => {
+      const sampleAccessToken = {
+        accessToken: "123abc",
+      };
+
+      const hash = "#/test";
+
+      spyOn(
+        PublicClientApplication.prototype,
+        "handleRedirectPromise"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          //@ts-ignore
+          resolve(sampleAccessToken);
+        })
+      );
+
+      authService
+        .handleRedirectObservable({ hash })
+        .subscribe((response: AuthenticationResult) => {
+          expect(response.accessToken).toBe(sampleAccessToken.accessToken);
+          expect(
+            PublicClientApplication.prototype.handleRedirectPromise
+          ).toHaveBeenCalledWith({ hash: hash });
+          done();
+        });
+    });
+
+    it("called with navigateToLoginRequestUrl", (done) => {
+      const sampleAccessToken = {
+        accessToken: "123abc",
+      };
+
+      spyOn(
+        PublicClientApplication.prototype,
+        "handleRedirectPromise"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          //@ts-ignore
+          resolve(sampleAccessToken);
+        })
+      );
+
+      authService
+        .handleRedirectObservable({ navigateToLoginRequestUrl: false })
+        .subscribe((response: AuthenticationResult) => {
+          expect(response.accessToken).toBe(sampleAccessToken.accessToken);
+          expect(
+            PublicClientApplication.prototype.handleRedirectPromise
+          ).toHaveBeenCalledWith({ navigateToLoginRequestUrl: false });
           done();
         });
     });

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -80,15 +80,17 @@ export class MsalService implements IMsalService {
         ? { hash: hashOrOptions }
         : hashOrOptions || {};
 
+    // Only include hash in the final options if there's a value
+    const hash = options.hash || this.redirectHash;
+    const finalOptions: HandleRedirectPromiseOptions = {
+      ...options,
+      ...(hash ? { hash } : {}),
+    };
+
     return from(
       this.instance
         .initialize()
-        .then(() =>
-          this.instance.handleRedirectPromise({
-            ...options,
-            hash: options.hash || this.redirectHash,
-          })
-        )
+        .then(() => this.instance.handleRedirectPromise(finalOptions))
         .finally(() => {
           // update inProgress state to none
           this.injector.get(MsalBroadcastService).resetInProgressEvent();

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -16,6 +16,7 @@ import {
   SsoSilentRequest,
   Logger,
   WrapperSKU,
+  HandleRedirectPromiseOptions,
 } from "@azure/msal-browser";
 import { Observable, from } from "rxjs";
 import { IMsalService } from "./IMsalService";
@@ -54,13 +55,29 @@ export class MsalService implements IMsalService {
   ): Observable<AuthenticationResult> {
     return from(this.instance.acquireTokenSilent(silentRequest));
   }
-  handleRedirectObservable(hash?: string): Observable<AuthenticationResult> {
+  /**
+   * @deprecated Pass options object instead of hash string. Use handleRedirectObservable({ hash: "#..." }) instead.
+   */
+  handleRedirectObservable(hash: string): Observable<AuthenticationResult>;
+  handleRedirectObservable(
+    options?: HandleRedirectPromiseOptions
+  ): Observable<AuthenticationResult>;
+  handleRedirectObservable(
+    hashOrOptions?: string | HandleRedirectPromiseOptions
+  ): Observable<AuthenticationResult> {
+    // Support both legacy string parameter (hash) and new options object
+    const options: HandleRedirectPromiseOptions =
+      typeof hashOrOptions === "string"
+        ? { hash: hashOrOptions }
+        : hashOrOptions || {};
+
     return from(
       this.instance
         .initialize()
         .then(() =>
           this.instance.handleRedirectPromise({
-            hash: hash || this.redirectHash,
+            ...options,
+            hash: options.hash || this.redirectHash,
           })
         )
         .finally(() => {

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -58,13 +58,15 @@ export class MsalService implements IMsalService {
   /**
    * @deprecated Pass options object instead of hash string. Use handleRedirectObservable({ hash: "#..." }) instead.
    */
-  handleRedirectObservable(hash: string): Observable<AuthenticationResult | null>;
-  /**  
-   * Handles the redirect response from authentication. Call this on every page load after a redirect-based login.  
-   * If no options are provided, the service will attempt to use the cached redirect hash captured during construction.  
-   *  
-   * @param options - Optional configuration for redirect handling, such as an explicit hash value to process.  
-   * @returns Observable that emits the AuthenticationResult when a redirect is successfully handled.  
+  handleRedirectObservable(
+    hash: string
+  ): Observable<AuthenticationResult | null>;
+  /**
+   * Handles the redirect response from authentication. Call this on every page load after a redirect-based login.
+   * If no options are provided, the service will attempt to use the cached redirect hash captured during construction.
+   *
+   * @param options - Optional configuration for redirect handling, such as an explicit hash value to process.
+   * @returns Observable that emits the AuthenticationResult when a redirect is successfully handled.
    */
   handleRedirectObservable(
     options?: HandleRedirectPromiseOptions

--- a/lib/msal-angular/src/msal.service.ts
+++ b/lib/msal-angular/src/msal.service.ts
@@ -58,13 +58,20 @@ export class MsalService implements IMsalService {
   /**
    * @deprecated Pass options object instead of hash string. Use handleRedirectObservable({ hash: "#..." }) instead.
    */
-  handleRedirectObservable(hash: string): Observable<AuthenticationResult>;
+  handleRedirectObservable(hash: string): Observable<AuthenticationResult | null>;
+  /**  
+   * Handles the redirect response from authentication. Call this on every page load after a redirect-based login.  
+   * If no options are provided, the service will attempt to use the cached redirect hash captured during construction.  
+   *  
+   * @param options - Optional configuration for redirect handling, such as an explicit hash value to process.  
+   * @returns Observable that emits the AuthenticationResult when a redirect is successfully handled.  
+   */
   handleRedirectObservable(
     options?: HandleRedirectPromiseOptions
-  ): Observable<AuthenticationResult>;
+  ): Observable<AuthenticationResult | null>;
   handleRedirectObservable(
     hashOrOptions?: string | HandleRedirectPromiseOptions
-  ): Observable<AuthenticationResult> {
+  ): Observable<AuthenticationResult | null> {
     // Support both legacy string parameter (hash) and new options object
     const options: HandleRedirectPromiseOptions =
       typeof hashOrOptions === "string"


### PR DESCRIPTION
This pull request updates the MSAL Angular library to enhance the `handleRedirectObservable` method, introducing support for an options object and deprecating the legacy hash string parameter. The documentation and tests are updated to reflect these changes, improving flexibility and aligning with recent MSAL Browser updates.

**API Enhancements:**

* The `handleRedirectObservable` method now accepts an optional `HandleRedirectPromiseOptions` object, allowing developers to specify properties like `hash` and `navigateToLoginRequestUrl` directly, rather than relying on configuration or legacy parameters. [[1]](diffhunk://#diff-83acb29430d043f25d217f4c19c2be0a1ce8965c6d98cf1302bec1b76482bc5aL25-R32) [[2]](diffhunk://#diff-9a5e0e1de8a95af0b95f81f165ef43b68c526f11be6c85ac27ea9056679a9b84L57-R80)
* The legacy usage of passing a hash string directly to `handleRedirectObservable(hash)` is now deprecated, with a deprecation notice added to the interface and documentation. [[1]](diffhunk://#diff-83acb29430d043f25d217f4c19c2be0a1ce8965c6d98cf1302bec1b76482bc5aL25-R32) [[2]](diffhunk://#diff-9a5e0e1de8a95af0b95f81f165ef43b68c526f11be6c85ac27ea9056679a9b84L57-R80)

**Documentation Updates:**

* The redirects documentation (`redirects.md`) and the v4-v5 upgrade guide are updated to describe the new options object, provide usage examples, and note the deprecation of the old hash parameter. [[1]](diffhunk://#diff-d2e4604b2d12ea6d23761ff646caddad69808b7b909fc5e583f79a83df7582d8R193-R221) [[2]](diffhunk://#diff-e45d12630756e91f4ed319a2b8f7cff5ebb99bc03efcfe55a1cd3849192388c8R13-R33)

**Type and Import Changes:**

* The `HandleRedirectPromiseOptions` type is imported from `@azure/msal-browser` and used throughout the service and interface definitions to support the new method signature. [[1]](diffhunk://#diff-83acb29430d043f25d217f4c19c2be0a1ce8965c6d98cf1302bec1b76482bc5aR15) [[2]](diffhunk://#diff-9a5e0e1de8a95af0b95f81f165ef43b68c526f11be6c85ac27ea9056679a9b84R19)

**Test Improvements:**

* New unit tests are added to verify support for the options object, including scenarios for specifying `hash` and `navigateToLoginRequestUrl`. Existing tests are updated to clarify legacy usage. [[1]](diffhunk://#diff-958413452524c452c6d24b44b912aed877645762c8ef4e3364d783a764782cccL420-R420) [[2]](diffhunk://#diff-958413452524c452c6d24b44b912aed877645762c8ef4e3364d783a764782cccR447-R500)