### PR TITLE
Update windows server version to 2022 in pipeline definitions

### DIFF
--- a/.pipelines/1p-build.yml
+++ b/.pipelines/1p-build.yml
@@ -34,8 +34,9 @@ extends:
         globalSdl:
             policheck:
                 break: true
-        WindowsHostVersion: 
-            Version: 2022
+        featureFlags:
+            WindowsHostVersion: 
+                Version: 2022
         stages:
             - stage: build_and_test
               displayName: "MSAL JS Build and Test"

--- a/.pipelines/1p-build.yml
+++ b/.pipelines/1p-build.yml
@@ -10,7 +10,7 @@ parameters:
 variables:
     CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
     LinuxContainerImage: "mcr.microsoft.com/onebranch/cbl-mariner/build:2.0" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
-    WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2019/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+    WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
     DEBIAN_FRONTEND: noninteractive
     ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
         sourceBranchName: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
@@ -34,6 +34,8 @@ extends:
         globalSdl:
             policheck:
                 break: true
+        WindowsHostVersion: 
+            Version: 2022
         stages:
             - stage: build_and_test
               displayName: "MSAL JS Build and Test"

--- a/.pipelines/sdl.yml
+++ b/.pipelines/sdl.yml
@@ -19,8 +19,9 @@ extends:
         globalSdl:
             policheck:
                 break: true
-        WindowsHostVersion: 
-            Version: 2022
+        featureFlags:
+            WindowsHostVersion: 
+                Version: 2022
         stages:
             - stage: sdl
               displayName: "Run SDL Checks"

--- a/.pipelines/sdl.yml
+++ b/.pipelines/sdl.yml
@@ -1,6 +1,6 @@
 variables:
     CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-    WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2019/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+    WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
     DEBIAN_FRONTEND: noninteractive
 resources:
     repositories:
@@ -19,6 +19,8 @@ extends:
         globalSdl:
             policheck:
                 break: true
+        WindowsHostVersion: 
+            Version: 2022
         stages:
             - stage: sdl
               displayName: "Run SDL Checks"


### PR DESCRIPTION
This pull request updates the pipeline configuration to use Windows Server 2022 images for build and SDL (Security Development Lifecycle) processes, replacing the previous Windows Server 2019 images. Additionally, it explicitly sets the Windows host version to 2022 in both pipelines for consistency.

**Pipeline environment updates:**

* Updated the `WindowsContainerImage` variable in both `.pipelines/1p-build.yml` and `.pipelines/sdl.yml` to use the Windows Server 2022 image (`ltsc2022`) instead of Windows Server 2019 (`ltsc2019`). [[1]](diffhunk://#diff-f55c23abffd72028ef6e3ee5d844475081794fa8b0d2c1b5407f79abeaecc1faL13-R13) [[2]](diffhunk://#diff-788d73f9a678f9a34a5cd486c9c03ef6f1ab8d4737c63bd8cfd6f182c64703d7L3-R3)
* Explicitly set `WindowsHostVersion: Version: 2022` in both `.pipelines/1p-build.yml` and `.pipelines/sdl.yml` to ensure the pipelines run on Windows Server 2022 hosts. [[1]](diffhunk://#diff-f55c23abffd72028ef6e3ee5d844475081794fa8b0d2c1b5407f79abeaecc1faR37-R38) [[2]](diffhunk://#diff-788d73f9a678f9a34a5cd486c9c03ef6f1ab8d4737c63bd8cfd6f182c64703d7R22-R23)