### PR TITLE
[v5] Update windows container image

### DIFF
--- a/.pipelines/1p-build.yml
+++ b/.pipelines/1p-build.yml
@@ -10,7 +10,7 @@ parameters:
 variables:
     CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
     LinuxContainerImage: "mcr.microsoft.com/onebranch/cbl-mariner/build:2.0" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
-    WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2019/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+    WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
     DEBIAN_FRONTEND: noninteractive
     ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
         sourceBranchName: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
@@ -33,7 +33,9 @@ extends:
     parameters:
         globalSdl:
             policheck:
-                break: true
+        featureFlags:
+            WindowsHostVersion:
+                Version: 2022
         stages:
             - stage: build_and_test
               displayName: "MSAL JS Build and Test"

--- a/.pipelines/1p-build.yml
+++ b/.pipelines/1p-build.yml
@@ -33,6 +33,7 @@ extends:
     parameters:
         globalSdl:
             policheck:
+                break: true
         featureFlags:
             WindowsHostVersion:
                 Version: 2022

--- a/.pipelines/sdl.yml
+++ b/.pipelines/sdl.yml
@@ -1,6 +1,6 @@
 variables:
     CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
-    WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2019/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+    WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
     DEBIAN_FRONTEND: noninteractive
 resources:
     repositories:
@@ -19,6 +19,9 @@ extends:
         globalSdl:
             policheck:
                 break: true
+        featureFlags:
+            WindowsHostVersion:
+                Version: 2022
         stages:
             - stage: sdl
               displayName: "Run SDL Checks"


### PR DESCRIPTION
This pull request updates the pipeline configurations to use newer Windows container images and explicitly sets the Windows host version to 2022. These changes help ensure the build and SDL pipelines run on a more recent Windows environment, improving compatibility and support.

**Pipeline environment updates:**

* Updated `WindowsContainerImage` from `ltsc2019` to `ltsc2022` in both `.pipelines/1p-build.yml` and `.pipelines/sdl.yml` to ensure builds use the latest supported Windows base image. [[1]](diffhunk://#diff-f55c23abffd72028ef6e3ee5d844475081794fa8b0d2c1b5407f79abeaecc1faL13-R13) [[2]](diffhunk://#diff-788d73f9a678f9a34a5cd486c9c03ef6f1ab8d4737c63bd8cfd6f182c64703d7L3-R3)
* Added `featureFlags` to both pipeline files to explicitly set the `WindowsHostVersion` to 2022, ensuring the build agents use the correct Windows version. [[1]](diffhunk://#diff-f55c23abffd72028ef6e3ee5d844475081794fa8b0d2c1b5407f79abeaecc1faL36-R38) [[2]](diffhunk://#diff-788d73f9a678f9a34a5cd486c9c03ef6f1ab8d4737c63bd8cfd6f182c64703d7R22-R24)