### PR TITLE
[v5] Validate NAA broker response account

### DIFF
--- a/change/@azure-msal-browser-7b68f1ac-e063-49ad-8b3d-55c149df18a7.json
+++ b/change/@azure-msal-browser-7b68f1ac-e063-49ad-8b3d-55c149df18a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Validate NAA broker response account",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-7b68f1ac-e063-49ad-8b3d-55c149df18a7.json
+++ b/change/@azure-msal-browser-7b68f1ac-e063-49ad-8b3d-55c149df18a7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Validate NAA broker response account",
+  "comment": "Validate NAA broker response account [#8286](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8286)",
   "packageName": "@azure/msal-browser",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -208,9 +208,7 @@ export class NestedAppAuthAdapter {
             effectiveIdTokenClaims?.preferred_username ||
             effectiveIdTokenClaims?.upn;
 
-        const email = effectiveIdTokenClaims?.emails
-            ? effectiveIdTokenClaims.emails[0]
-            : null;
+        const email = effectiveIdTokenClaims?.emails?.[0] || null;
 
         const username =
             fromAccount.username || preferredUsername || email || "";

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -27,6 +27,7 @@ import {
     AccessTokenEntity,
     TenantProfile,
     buildTenantProfile,
+    getTenantIdFromIdTokenClaims,
     TimeUtils,
     Constants,
 } from "@azure/msal-common/browser";
@@ -178,18 +179,41 @@ export class NestedAppAuthAdapter {
             effectiveIdTokenClaims?.sub ||
             "";
 
+        /*
+         * In B2C scenarios tid may not be present, use getTenantIdFromIdTokenClaims
+         * which handles tid, tfp (modern B2C), and acr (legacy B2C) claims
+         */
         const tenantId =
-            fromAccount.tenantId || effectiveIdTokenClaims?.tid || "";
+            fromAccount.tenantId ||
+            getTenantIdFromIdTokenClaims(effectiveIdTokenClaims) ||
+            "";
 
         const homeAccountId =
             fromAccount.homeAccountId || `${localAccountId}.${tenantId}`;
 
-        const username =
-            fromAccount.username ||
-            effectiveIdTokenClaims?.preferred_username ||
-            "";
+        // Validate environment - required field
+        const environment = fromAccount.environment;
+        if (!environment) {
+            throw createClientAuthError(
+                ClientAuthErrorCodes.invalidCacheEnvironment
+            );
+        }
 
-        const name = fromAccount.name || effectiveIdTokenClaims?.name;
+        /*
+         * In B2C scenarios the emails claim is used instead of preferred_username and it is an array.
+         * In most cases it will contain a single email. This field should not be relied upon if a custom
+         * policy is configured to return more than 1 email.
+         */
+        const preferredUsername =
+            effectiveIdTokenClaims?.preferred_username ||
+            effectiveIdTokenClaims?.upn;
+        const email = effectiveIdTokenClaims?.emails
+            ? effectiveIdTokenClaims.emails[0]
+            : null;
+        const username =
+            fromAccount.username || preferredUsername || email || "";
+
+        const name = fromAccount.name || effectiveIdTokenClaims?.name || "";
 
         const loginHint =
             fromAccount.loginHint || effectiveIdTokenClaims?.login_hint;
@@ -206,7 +230,7 @@ export class NestedAppAuthAdapter {
 
         const account: MsalAccountInfo = {
             homeAccountId,
-            environment: fromAccount.environment,
+            environment,
             tenantId,
             username,
             localAccountId,

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -207,9 +207,11 @@ export class NestedAppAuthAdapter {
         const preferredUsername =
             effectiveIdTokenClaims?.preferred_username ||
             effectiveIdTokenClaims?.upn;
+            
         const email = effectiveIdTokenClaims?.emails
             ? effectiveIdTokenClaims.emails[0]
             : null;
+
         const username =
             fromAccount.username || preferredUsername || email || "";
 

--- a/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
+++ b/lib/msal-browser/src/naa/mapping/NestedAppAuthAdapter.ts
@@ -207,7 +207,7 @@ export class NestedAppAuthAdapter {
         const preferredUsername =
             effectiveIdTokenClaims?.preferred_username ||
             effectiveIdTokenClaims?.upn;
-            
+
         const email = effectiveIdTokenClaims?.emails
             ? effectiveIdTokenClaims.emails[0]
             : null;

--- a/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
+++ b/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
@@ -19,6 +19,7 @@ import {
     AuthError,
     BrowserCacheLocation,
     CacheLookupPolicy,
+    ClientAuthError,
     ClientAuthErrorCodes,
     Configuration,
     IPublicClientApplication,
@@ -417,6 +418,75 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
                 mockBridge.getBridgeRequests().at(-1)!
             ) as any;
             expect(bridgeRequest.tokenParams?.forceRefresh).toBeUndefined();
+        });
+
+        describe("response validation", () => {
+            it("acquireTokenSilent derives account fields from idTokenClaims when bridge returns minimal account", async () => {
+                // Bridge returns minimal account with only required fields
+                const minimalAccountResponse = {
+                    token: {
+                        ...SILENT_TOKEN_RESPONSE.token,
+                    },
+                    account: {
+                        environment: "login.microsoftonline.com",
+                        username: "", // Empty - should be derived from claims
+                        // No homeAccountId, localAccountId, tenantId, name, etc.
+                    },
+                };
+                mockBridge.addAuthResultResponse(
+                    "GetToken",
+                    minimalAccountResponse
+                );
+
+                const testRequest = {
+                    scopes: [NAA_SCOPE],
+                    account: testAccount,
+                    correlationId: NAA_CORRELATION_ID,
+                    cacheLookupPolicy: CacheLookupPolicy.Skip,
+                };
+
+                const response = await pca.acquireTokenSilent(testRequest);
+
+                // Account fields should be derived from idTokenClaims in the token response
+                const expectedClaims = SILENT_TOKEN_RESPONSE.account
+                    .idTokenClaims as Record<string, unknown>;
+                expect(response.account).toBeDefined();
+                expect(response.account?.localAccountId).toBe(
+                    expectedClaims.oid
+                );
+                expect(response.account?.tenantId).toBe(expectedClaims.tid);
+                expect(response.account?.username).toBe(
+                    expectedClaims.preferred_username
+                );
+                expect(response.account?.name).toBe(expectedClaims.name);
+            });
+
+            it("acquireTokenSilent throws error when bridge returns empty environment", async () => {
+                const invalidAccountResponse = {
+                    token: {
+                        ...SILENT_TOKEN_RESPONSE.token,
+                    },
+                    account: {
+                        environment: "", // Empty - should throw
+                        username: "test@contoso.com",
+                    },
+                };
+                mockBridge.addAuthResultResponse(
+                    "GetToken",
+                    invalidAccountResponse
+                );
+
+                const testRequest = {
+                    scopes: [NAA_SCOPE],
+                    account: testAccount,
+                    correlationId: NAA_CORRELATION_ID,
+                    cacheLookupPolicy: CacheLookupPolicy.Skip,
+                };
+
+                await expect(() =>
+                    pca.acquireTokenSilent(testRequest)
+                ).rejects.toBeInstanceOf(ClientAuthError);
+            });
         });
 
         afterEach(() => {

--- a/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
+++ b/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
@@ -297,7 +297,11 @@ describe("NestedAppAuthAdapter tests", () => {
             describe("fallback to idTokenClaims", () => {
                 it.each([
                     ["oid", { oid: TEST_OID, tid: TEST_TID }, TEST_OID],
-                    ["sub (when oid missing)", { sub: TEST_SUB, tid: TEST_TID }, TEST_SUB],
+                    [
+                        "sub (when oid missing)",
+                        { sub: TEST_SUB, tid: TEST_TID },
+                        TEST_SUB,
+                    ],
                 ])(
                     "should derive localAccountId from %s claim",
                     (_desc, claims, expected) => {
@@ -325,12 +329,19 @@ describe("NestedAppAuthAdapter tests", () => {
                         TEST_ID_TOKEN,
                         createBaseClaims()
                     );
-                    expect(result.homeAccountId).toBe(`${TEST_OID}.${TEST_TID}`);
+                    expect(result.homeAccountId).toBe(
+                        `${TEST_OID}.${TEST_TID}`
+                    );
                 });
 
                 it.each([
                     ["name", { name: TEST_NAME }, "name", TEST_NAME],
-                    ["loginHint", { login_hint: TEST_LOGIN_HINT }, "loginHint", TEST_LOGIN_HINT],
+                    [
+                        "loginHint",
+                        { login_hint: TEST_LOGIN_HINT },
+                        "loginHint",
+                        TEST_LOGIN_HINT,
+                    ],
                 ])(
                     "should derive %s from idTokenClaims when not in account",
                     (_field, extraClaims, resultField, expected) => {
@@ -339,9 +350,9 @@ describe("NestedAppAuthAdapter tests", () => {
                             TEST_ID_TOKEN,
                             createBaseClaims(extraClaims)
                         );
-                        expect(
-                            result[resultField as keyof typeof result]
-                        ).toBe(expected);
+                        expect(result[resultField as keyof typeof result]).toBe(
+                            expected
+                        );
                     }
                 );
 
@@ -365,7 +376,9 @@ describe("NestedAppAuthAdapter tests", () => {
 
             describe("environment validation", () => {
                 it("should throw ClientAuthError with invalidCacheEnvironment code when environment is empty", () => {
-                    const naaAccount = createMinimalAccount({ environment: "" });
+                    const naaAccount = createMinimalAccount({
+                        environment: "",
+                    });
 
                     expect(() =>
                         nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount)
@@ -384,8 +397,16 @@ describe("NestedAppAuthAdapter tests", () => {
 
             describe("B2C scenarios", () => {
                 it.each([
-                    ["tfp (modern B2C)", { oid: TEST_OID, tfp: TEST_TFP }, TEST_TFP],
-                    ["acr (legacy B2C)", { oid: TEST_OID, acr: TEST_ACR }, TEST_ACR],
+                    [
+                        "tfp (modern B2C)",
+                        { oid: TEST_OID, tfp: TEST_TFP },
+                        TEST_TFP,
+                    ],
+                    [
+                        "acr (legacy B2C)",
+                        { oid: TEST_OID, acr: TEST_ACR },
+                        TEST_ACR,
+                    ],
                 ])(
                     "should derive tenantId from %s claim",
                     (_desc, claims, expected) => {
@@ -402,7 +423,12 @@ describe("NestedAppAuthAdapter tests", () => {
                     const result = nestedAppAuthAdapter.fromNaaAccountInfo(
                         createMinimalAccount(),
                         TEST_ID_TOKEN,
-                        { oid: TEST_OID, tid: TEST_TID, tfp: TEST_TFP, acr: TEST_ACR }
+                        {
+                            oid: TEST_OID,
+                            tid: TEST_TID,
+                            tfp: TEST_TFP,
+                            acr: TEST_ACR,
+                        }
                     );
                     expect(result.tenantId).toBe(TEST_TID);
                 });
@@ -411,7 +437,9 @@ describe("NestedAppAuthAdapter tests", () => {
                     const result = nestedAppAuthAdapter.fromNaaAccountInfo(
                         createMinimalAccount({ username: "" }),
                         TEST_ID_TOKEN,
-                        createBaseClaims({ emails: [TEST_EMAIL, "secondary@contoso.com"] })
+                        createBaseClaims({
+                            emails: [TEST_EMAIL, "secondary@contoso.com"],
+                        })
                     );
                     expect(result.username).toBe(TEST_EMAIL);
                 });
@@ -422,13 +450,21 @@ describe("NestedAppAuthAdapter tests", () => {
                     [
                         "account username over claims",
                         TEST_USERNAME,
-                        { preferred_username: TEST_PREFERRED_USERNAME, upn: TEST_UPN, emails: [TEST_EMAIL] },
+                        {
+                            preferred_username: TEST_PREFERRED_USERNAME,
+                            upn: TEST_UPN,
+                            emails: [TEST_EMAIL],
+                        },
                         TEST_USERNAME,
                     ],
                     [
                         "preferred_username when account username is empty",
                         "",
-                        { preferred_username: TEST_PREFERRED_USERNAME, upn: TEST_UPN, emails: [TEST_EMAIL] },
+                        {
+                            preferred_username: TEST_PREFERRED_USERNAME,
+                            upn: TEST_UPN,
+                            emails: [TEST_EMAIL],
+                        },
                         TEST_PREFERRED_USERNAME,
                     ],
                     [
@@ -464,24 +500,9 @@ describe("NestedAppAuthAdapter tests", () => {
 
             describe("empty field fallbacks", () => {
                 it.each([
-                    [
-                        "localAccountId",
-                        { tid: TEST_TID },
-                        "localAccountId",
-                        "",
-                    ],
-                    [
-                        "tenantId",
-                        { oid: TEST_OID },
-                        "tenantId",
-                        "",
-                    ],
-                    [
-                        "name",
-                        { oid: TEST_OID, tid: TEST_TID },
-                        "name",
-                        "",
-                    ],
+                    ["localAccountId", { tid: TEST_TID }, "localAccountId", ""],
+                    ["tenantId", { oid: TEST_OID }, "tenantId", ""],
+                    ["name", { oid: TEST_OID, tid: TEST_TID }, "name", ""],
                 ])(
                     "should return empty string for %s when not derivable",
                     (_field, claims, resultField, expected) => {

--- a/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
+++ b/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
@@ -225,6 +225,24 @@ describe("NestedAppAuthAdapter tests", () => {
         const TEST_LOGIN_HINT = "test-login-hint";
         const TEST_ID_TOKEN = "mock.id.token";
 
+        // Helper to create minimal account with just required fields
+        const createMinimalAccount = (
+            overrides: Partial<NaaAccountInfo> = {}
+        ): NaaAccountInfo => ({
+            environment: TEST_ENVIRONMENT,
+            username: TEST_USERNAME,
+            ...overrides,
+        });
+
+        // Helper to create base idTokenClaims
+        const createBaseClaims = (
+            overrides: Record<string, unknown> = {}
+        ): Record<string, unknown> => ({
+            oid: TEST_OID,
+            tid: TEST_TID,
+            ...overrides,
+        });
+
         describe("response validation", () => {
             describe("basic field mapping", () => {
                 it("should map all fields from NaaAccountInfo when provided", () => {
@@ -234,497 +252,259 @@ describe("NestedAppAuthAdapter tests", () => {
                         tenantId: TEST_TID,
                         username: TEST_USERNAME,
                         localAccountId: TEST_OID,
-                    name: TEST_NAME,
-                    loginHint: TEST_LOGIN_HINT,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN
-                );
-
-                expect(result.homeAccountId).toBe(`${TEST_OID}.${TEST_TID}`);
-                expect(result.environment).toBe(TEST_ENVIRONMENT);
-                expect(result.tenantId).toBe(TEST_TID);
-                expect(result.username).toBe(TEST_USERNAME);
-                expect(result.localAccountId).toBe(TEST_OID);
-                expect(result.name).toBe(TEST_NAME);
-                expect(result.loginHint).toBe(TEST_LOGIN_HINT);
-                expect(result.idToken).toBe(TEST_ID_TOKEN);
-            });
-
-            it("should create tenantProfile for the account", () => {
-                const naaAccount: NaaAccountInfo = {
-                    homeAccountId: `${TEST_OID}.${TEST_TID}`,
-                    environment: TEST_ENVIRONMENT,
-                    tenantId: TEST_TID,
-                    username: TEST_USERNAME,
-                    localAccountId: TEST_OID,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
-
-                expect(result.tenantProfiles).toBeDefined();
-                expect(result.tenantProfiles?.size).toBe(1);
-                expect(result.tenantProfiles?.has(TEST_TID)).toBe(true);
-                const tenantProfile = result.tenantProfiles?.get(TEST_TID);
-                expect(tenantProfile?.tenantId).toBe(TEST_TID);
-                expect(tenantProfile?.localAccountId).toBe(TEST_OID);
-            });
-        });
-
-        describe("fallback to idTokenClaims", () => {
-            it("should derive localAccountId from oid claim when not in account", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.localAccountId).toBe(TEST_OID);
-            });
-
-            it("should derive localAccountId from sub claim when oid not present", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    sub: TEST_SUB,
-                    tid: TEST_TID,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.localAccountId).toBe(TEST_SUB);
-            });
-
-            it("should derive tenantId from tid claim when not in account", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.tenantId).toBe(TEST_TID);
-            });
-
-            it("should compute homeAccountId from localAccountId and tenantId when not provided", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.homeAccountId).toBe(`${TEST_OID}.${TEST_TID}`);
-            });
-
-            it("should derive name from idTokenClaims when not in account", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    name: TEST_NAME,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.name).toBe(TEST_NAME);
-            });
-
-            it("should derive loginHint from idTokenClaims when not in account", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    login_hint: TEST_LOGIN_HINT,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.loginHint).toBe(TEST_LOGIN_HINT);
-            });
-
-            it("should use idTokenClaims from account when not passed as parameter", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                    idTokenClaims: {
-                        oid: TEST_OID,
-                        tid: TEST_TID,
                         name: TEST_NAME,
-                    },
-                };
+                        loginHint: TEST_LOGIN_HINT,
+                    };
 
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
-
-                expect(result.localAccountId).toBe(TEST_OID);
-                expect(result.tenantId).toBe(TEST_TID);
-                expect(result.name).toBe(TEST_NAME);
-            });
-        });
-
-        describe("environment validation", () => {
-            it("should throw ClientAuthError when environment is empty", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: "",
-                    username: TEST_USERNAME,
-                };
-
-                expect(() =>
-                    nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount)
-                ).toThrow(ClientAuthError);
-            });
-
-            it("should throw error with invalidCacheEnvironment code", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: "",
-                    username: TEST_USERNAME,
-                };
-
-                try {
-                    nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
-                    fail("Expected error to be thrown");
-                } catch (error) {
-                    expect(error).toBeInstanceOf(ClientAuthError);
-                    expect((error as ClientAuthError).errorCode).toBe(
-                        ClientAuthErrorCodes.invalidCacheEnvironment
+                    const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                        naaAccount,
+                        TEST_ID_TOKEN
                     );
-                }
+
+                    expect(result.homeAccountId).toBe(
+                        `${TEST_OID}.${TEST_TID}`
+                    );
+                    expect(result.environment).toBe(TEST_ENVIRONMENT);
+                    expect(result.tenantId).toBe(TEST_TID);
+                    expect(result.username).toBe(TEST_USERNAME);
+                    expect(result.localAccountId).toBe(TEST_OID);
+                    expect(result.name).toBe(TEST_NAME);
+                    expect(result.loginHint).toBe(TEST_LOGIN_HINT);
+                    expect(result.idToken).toBe(TEST_ID_TOKEN);
+                });
+
+                it("should create tenantProfile for the account", () => {
+                    const naaAccount: NaaAccountInfo = {
+                        homeAccountId: `${TEST_OID}.${TEST_TID}`,
+                        environment: TEST_ENVIRONMENT,
+                        tenantId: TEST_TID,
+                        username: TEST_USERNAME,
+                        localAccountId: TEST_OID,
+                    };
+
+                    const result =
+                        nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
+
+                    expect(result.tenantProfiles).toBeDefined();
+                    expect(result.tenantProfiles?.size).toBe(1);
+                    expect(result.tenantProfiles?.has(TEST_TID)).toBe(true);
+                    const tenantProfile = result.tenantProfiles?.get(TEST_TID);
+                    expect(tenantProfile?.tenantId).toBe(TEST_TID);
+                    expect(tenantProfile?.localAccountId).toBe(TEST_OID);
+                });
             });
-        });
 
-        describe("B2C scenarios", () => {
-            it("should derive tenantId from tfp claim (modern B2C)", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tfp: TEST_TFP, // Modern B2C policy claim
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
+            describe("fallback to idTokenClaims", () => {
+                it.each([
+                    ["oid", { oid: TEST_OID, tid: TEST_TID }, TEST_OID],
+                    ["sub (when oid missing)", { sub: TEST_SUB, tid: TEST_TID }, TEST_SUB],
+                ])(
+                    "should derive localAccountId from %s claim",
+                    (_desc, claims, expected) => {
+                        const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                            createMinimalAccount(),
+                            TEST_ID_TOKEN,
+                            claims
+                        );
+                        expect(result.localAccountId).toBe(expected);
+                    }
                 );
 
-                expect(result.tenantId).toBe(TEST_TFP);
-            });
+                it("should derive tenantId from tid claim when not in account", () => {
+                    const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                        createMinimalAccount(),
+                        TEST_ID_TOKEN,
+                        createBaseClaims()
+                    );
+                    expect(result.tenantId).toBe(TEST_TID);
+                });
 
-            it("should derive tenantId from acr claim (legacy B2C)", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
+                it("should compute homeAccountId from localAccountId and tenantId when not provided", () => {
+                    const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                        createMinimalAccount(),
+                        TEST_ID_TOKEN,
+                        createBaseClaims()
+                    );
+                    expect(result.homeAccountId).toBe(`${TEST_OID}.${TEST_TID}`);
+                });
 
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    acr: TEST_ACR, // Legacy B2C policy claim
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
+                it.each([
+                    ["name", { name: TEST_NAME }, "name", TEST_NAME],
+                    ["loginHint", { login_hint: TEST_LOGIN_HINT }, "loginHint", TEST_LOGIN_HINT],
+                ])(
+                    "should derive %s from idTokenClaims when not in account",
+                    (_field, extraClaims, resultField, expected) => {
+                        const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                            createMinimalAccount(),
+                            TEST_ID_TOKEN,
+                            createBaseClaims(extraClaims)
+                        );
+                        expect(
+                            result[resultField as keyof typeof result]
+                        ).toBe(expected);
+                    }
                 );
 
-                expect(result.tenantId).toBe(TEST_ACR);
+                it("should use idTokenClaims from account when not passed as parameter", () => {
+                    const naaAccount = createMinimalAccount({
+                        idTokenClaims: {
+                            oid: TEST_OID,
+                            tid: TEST_TID,
+                            name: TEST_NAME,
+                        },
+                    });
+
+                    const result =
+                        nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
+
+                    expect(result.localAccountId).toBe(TEST_OID);
+                    expect(result.tenantId).toBe(TEST_TID);
+                    expect(result.name).toBe(TEST_NAME);
+                });
             });
 
-            it("should prefer tid over tfp and acr", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
+            describe("environment validation", () => {
+                it("should throw ClientAuthError with invalidCacheEnvironment code when environment is empty", () => {
+                    const naaAccount = createMinimalAccount({ environment: "" });
 
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    tfp: TEST_TFP,
-                    acr: TEST_ACR,
-                };
+                    expect(() =>
+                        nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount)
+                    ).toThrow(ClientAuthError);
 
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
+                    try {
+                        nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
+                        fail("Expected error to be thrown");
+                    } catch (error) {
+                        expect((error as ClientAuthError).errorCode).toBe(
+                            ClientAuthErrorCodes.invalidCacheEnvironment
+                        );
+                    }
+                });
+            });
+
+            describe("B2C scenarios", () => {
+                it.each([
+                    ["tfp (modern B2C)", { oid: TEST_OID, tfp: TEST_TFP }, TEST_TFP],
+                    ["acr (legacy B2C)", { oid: TEST_OID, acr: TEST_ACR }, TEST_ACR],
+                ])(
+                    "should derive tenantId from %s claim",
+                    (_desc, claims, expected) => {
+                        const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                            createMinimalAccount(),
+                            TEST_ID_TOKEN,
+                            claims
+                        );
+                        expect(result.tenantId).toBe(expected);
+                    }
                 );
 
-                expect(result.tenantId).toBe(TEST_TID);
+                it("should prefer tid over tfp and acr", () => {
+                    const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                        createMinimalAccount(),
+                        TEST_ID_TOKEN,
+                        { oid: TEST_OID, tid: TEST_TID, tfp: TEST_TFP, acr: TEST_ACR }
+                    );
+                    expect(result.tenantId).toBe(TEST_TID);
+                });
+
+                it("should derive username from emails claim in B2C scenarios", () => {
+                    const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                        createMinimalAccount({ username: "" }),
+                        TEST_ID_TOKEN,
+                        createBaseClaims({ emails: [TEST_EMAIL, "secondary@contoso.com"] })
+                    );
+                    expect(result.username).toBe(TEST_EMAIL);
+                });
             });
 
-            it("should derive username from emails claim in B2C scenarios", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: "", // Empty username
-                };
+            describe("username fallback chain", () => {
+                it.each([
+                    [
+                        "account username over claims",
+                        TEST_USERNAME,
+                        { preferred_username: TEST_PREFERRED_USERNAME, upn: TEST_UPN, emails: [TEST_EMAIL] },
+                        TEST_USERNAME,
+                    ],
+                    [
+                        "preferred_username when account username is empty",
+                        "",
+                        { preferred_username: TEST_PREFERRED_USERNAME, upn: TEST_UPN, emails: [TEST_EMAIL] },
+                        TEST_PREFERRED_USERNAME,
+                    ],
+                    [
+                        "upn when preferred_username is not present",
+                        "",
+                        { upn: TEST_UPN, emails: [TEST_EMAIL] },
+                        TEST_UPN,
+                    ],
+                    [
+                        "emails[0] when preferred_username and upn are not present",
+                        "",
+                        { emails: [TEST_EMAIL] },
+                        TEST_EMAIL,
+                    ],
+                    [
+                        "empty string when no username sources are available",
+                        "",
+                        {},
+                        "",
+                    ],
+                ])(
+                    "should prefer %s",
+                    (_desc, accountUsername, extraClaims, expected) => {
+                        const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                            createMinimalAccount({ username: accountUsername }),
+                            TEST_ID_TOKEN,
+                            createBaseClaims(extraClaims)
+                        );
+                        expect(result.username).toBe(expected);
+                    }
+                );
+            });
 
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    emails: [TEST_EMAIL, "secondary@contoso.com"],
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
+            describe("empty field fallbacks", () => {
+                it.each([
+                    [
+                        "localAccountId",
+                        { tid: TEST_TID },
+                        "localAccountId",
+                        "",
+                    ],
+                    [
+                        "tenantId",
+                        { oid: TEST_OID },
+                        "tenantId",
+                        "",
+                    ],
+                    [
+                        "name",
+                        { oid: TEST_OID, tid: TEST_TID },
+                        "name",
+                        "",
+                    ],
+                ])(
+                    "should return empty string for %s when not derivable",
+                    (_field, claims, resultField, expected) => {
+                        const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                            createMinimalAccount(),
+                            TEST_ID_TOKEN,
+                            claims
+                        );
+                        expect(result[resultField as keyof typeof result]).toBe(
+                            expected
+                        );
+                    }
                 );
 
-                // Should use first email from array
-                expect(result.username).toBe(TEST_EMAIL);
+                it("should return undefined for loginHint when not derivable", () => {
+                    const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                        createMinimalAccount(),
+                        TEST_ID_TOKEN,
+                        createBaseClaims()
+                    );
+                    expect(result.loginHint).toBeUndefined();
+                });
             });
-        });
-
-        describe("username fallback chain", () => {
-            it("should prefer account username over claims", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    preferred_username: TEST_PREFERRED_USERNAME,
-                    upn: TEST_UPN,
-                    emails: [TEST_EMAIL],
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.username).toBe(TEST_USERNAME);
-            });
-
-            it("should fallback to preferred_username when account username is empty", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: "",
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    preferred_username: TEST_PREFERRED_USERNAME,
-                    upn: TEST_UPN,
-                    emails: [TEST_EMAIL],
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.username).toBe(TEST_PREFERRED_USERNAME);
-            });
-
-            it("should fallback to upn when preferred_username is not present", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: "",
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    upn: TEST_UPN,
-                    emails: [TEST_EMAIL],
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.username).toBe(TEST_UPN);
-            });
-
-            it("should fallback to emails[0] when preferred_username and upn are not present", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: "",
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    emails: [TEST_EMAIL],
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.username).toBe(TEST_EMAIL);
-            });
-
-            it("should return empty string when no username sources are available", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: "",
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.username).toBe("");
-            });
-        });
-
-        describe("empty field fallbacks", () => {
-            it("should return empty string for localAccountId when not derivable", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    tid: TEST_TID,
-                    // No oid or sub
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.localAccountId).toBe("");
-            });
-
-            it("should return empty string for tenantId when not derivable", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    // No tid, tfp, or acr
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.tenantId).toBe("");
-            });
-
-            it("should return empty string for name when not derivable", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    // No name
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.name).toBe("");
-            });
-
-            it("should return undefined for loginHint when not derivable", () => {
-                const naaAccount: NaaAccountInfo = {
-                    environment: TEST_ENVIRONMENT,
-                    username: TEST_USERNAME,
-                };
-
-                const idTokenClaims = {
-                    oid: TEST_OID,
-                    tid: TEST_TID,
-                    // No login_hint
-                };
-
-                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
-                    naaAccount,
-                    TEST_ID_TOKEN,
-                    idTokenClaims
-                );
-
-                expect(result.loginHint).toBeUndefined();
-            });
-        });
         });
     });
 });

--- a/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
+++ b/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
@@ -12,6 +12,7 @@ import {
     AuthenticationResult,
     Logger,
     ClientAuthErrorCodes,
+    AccountInfo as MsalAccountInfo,
 } from "@azure/msal-common";
 import { CryptoOps } from "../../src/crypto/CryptoOps.js";
 import { NestedAppAuthAdapter } from "../../src/naa/mapping/NestedAppAuthAdapter.js";
@@ -33,6 +34,7 @@ import {
     REDIRECT_REQUEST,
 } from "./BridgeProxyConstants.js";
 import { TokenRequest } from "../../src/naa/TokenRequest.js";
+import { AccountInfo as NaaAccountInfo } from "../../src/naa/AccountInfo.js";
 
 describe("NestedAppAuthAdapter tests", () => {
     let nestedAppAuthAdapter: NestedAppAuthAdapter;
@@ -205,6 +207,524 @@ describe("NestedAppAuthAdapter tests", () => {
             expect(error instanceof AuthError).toBe(true);
             expect(error.errorCode).toBe("unknown_error");
             expect(error.errorMessage).toBe("An unknown error occurred");
+        });
+    });
+
+    describe("fromNaaAccountInfo tests", () => {
+        const TEST_OID = "test-oid-12345";
+        const TEST_SUB = "test-sub-67890";
+        const TEST_TID = "test-tenant-id";
+        const TEST_TFP = "B2C_1_signupsignin"; // B2C modern policy
+        const TEST_ACR = "b2c_1_legacy"; // B2C legacy policy
+        const TEST_ENVIRONMENT = "login.microsoftonline.com";
+        const TEST_USERNAME = "testuser@contoso.com";
+        const TEST_PREFERRED_USERNAME = "preferred@contoso.com";
+        const TEST_UPN = "upn@contoso.com";
+        const TEST_EMAIL = "email@contoso.com";
+        const TEST_NAME = "Test User";
+        const TEST_LOGIN_HINT = "test-login-hint";
+        const TEST_ID_TOKEN = "mock.id.token";
+
+        describe("response validation", () => {
+            describe("basic field mapping", () => {
+                it("should map all fields from NaaAccountInfo when provided", () => {
+                    const naaAccount: NaaAccountInfo = {
+                        homeAccountId: `${TEST_OID}.${TEST_TID}`,
+                        environment: TEST_ENVIRONMENT,
+                        tenantId: TEST_TID,
+                        username: TEST_USERNAME,
+                        localAccountId: TEST_OID,
+                    name: TEST_NAME,
+                    loginHint: TEST_LOGIN_HINT,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN
+                );
+
+                expect(result.homeAccountId).toBe(`${TEST_OID}.${TEST_TID}`);
+                expect(result.environment).toBe(TEST_ENVIRONMENT);
+                expect(result.tenantId).toBe(TEST_TID);
+                expect(result.username).toBe(TEST_USERNAME);
+                expect(result.localAccountId).toBe(TEST_OID);
+                expect(result.name).toBe(TEST_NAME);
+                expect(result.loginHint).toBe(TEST_LOGIN_HINT);
+                expect(result.idToken).toBe(TEST_ID_TOKEN);
+            });
+
+            it("should create tenantProfile for the account", () => {
+                const naaAccount: NaaAccountInfo = {
+                    homeAccountId: `${TEST_OID}.${TEST_TID}`,
+                    environment: TEST_ENVIRONMENT,
+                    tenantId: TEST_TID,
+                    username: TEST_USERNAME,
+                    localAccountId: TEST_OID,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
+
+                expect(result.tenantProfiles).toBeDefined();
+                expect(result.tenantProfiles?.size).toBe(1);
+                expect(result.tenantProfiles?.has(TEST_TID)).toBe(true);
+                const tenantProfile = result.tenantProfiles?.get(TEST_TID);
+                expect(tenantProfile?.tenantId).toBe(TEST_TID);
+                expect(tenantProfile?.localAccountId).toBe(TEST_OID);
+            });
+        });
+
+        describe("fallback to idTokenClaims", () => {
+            it("should derive localAccountId from oid claim when not in account", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.localAccountId).toBe(TEST_OID);
+            });
+
+            it("should derive localAccountId from sub claim when oid not present", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    sub: TEST_SUB,
+                    tid: TEST_TID,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.localAccountId).toBe(TEST_SUB);
+            });
+
+            it("should derive tenantId from tid claim when not in account", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.tenantId).toBe(TEST_TID);
+            });
+
+            it("should compute homeAccountId from localAccountId and tenantId when not provided", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.homeAccountId).toBe(`${TEST_OID}.${TEST_TID}`);
+            });
+
+            it("should derive name from idTokenClaims when not in account", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    name: TEST_NAME,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.name).toBe(TEST_NAME);
+            });
+
+            it("should derive loginHint from idTokenClaims when not in account", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    login_hint: TEST_LOGIN_HINT,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.loginHint).toBe(TEST_LOGIN_HINT);
+            });
+
+            it("should use idTokenClaims from account when not passed as parameter", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                    idTokenClaims: {
+                        oid: TEST_OID,
+                        tid: TEST_TID,
+                        name: TEST_NAME,
+                    },
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
+
+                expect(result.localAccountId).toBe(TEST_OID);
+                expect(result.tenantId).toBe(TEST_TID);
+                expect(result.name).toBe(TEST_NAME);
+            });
+        });
+
+        describe("environment validation", () => {
+            it("should throw ClientAuthError when environment is empty", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: "",
+                    username: TEST_USERNAME,
+                };
+
+                expect(() =>
+                    nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount)
+                ).toThrow(ClientAuthError);
+            });
+
+            it("should throw error with invalidCacheEnvironment code", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: "",
+                    username: TEST_USERNAME,
+                };
+
+                try {
+                    nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
+                    fail("Expected error to be thrown");
+                } catch (error) {
+                    expect(error).toBeInstanceOf(ClientAuthError);
+                    expect((error as ClientAuthError).errorCode).toBe(
+                        ClientAuthErrorCodes.invalidCacheEnvironment
+                    );
+                }
+            });
+        });
+
+        describe("B2C scenarios", () => {
+            it("should derive tenantId from tfp claim (modern B2C)", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tfp: TEST_TFP, // Modern B2C policy claim
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.tenantId).toBe(TEST_TFP);
+            });
+
+            it("should derive tenantId from acr claim (legacy B2C)", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    acr: TEST_ACR, // Legacy B2C policy claim
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.tenantId).toBe(TEST_ACR);
+            });
+
+            it("should prefer tid over tfp and acr", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    tfp: TEST_TFP,
+                    acr: TEST_ACR,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.tenantId).toBe(TEST_TID);
+            });
+
+            it("should derive username from emails claim in B2C scenarios", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: "", // Empty username
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    emails: [TEST_EMAIL, "secondary@contoso.com"],
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                // Should use first email from array
+                expect(result.username).toBe(TEST_EMAIL);
+            });
+        });
+
+        describe("username fallback chain", () => {
+            it("should prefer account username over claims", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    preferred_username: TEST_PREFERRED_USERNAME,
+                    upn: TEST_UPN,
+                    emails: [TEST_EMAIL],
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.username).toBe(TEST_USERNAME);
+            });
+
+            it("should fallback to preferred_username when account username is empty", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: "",
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    preferred_username: TEST_PREFERRED_USERNAME,
+                    upn: TEST_UPN,
+                    emails: [TEST_EMAIL],
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.username).toBe(TEST_PREFERRED_USERNAME);
+            });
+
+            it("should fallback to upn when preferred_username is not present", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: "",
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    upn: TEST_UPN,
+                    emails: [TEST_EMAIL],
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.username).toBe(TEST_UPN);
+            });
+
+            it("should fallback to emails[0] when preferred_username and upn are not present", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: "",
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    emails: [TEST_EMAIL],
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.username).toBe(TEST_EMAIL);
+            });
+
+            it("should return empty string when no username sources are available", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: "",
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.username).toBe("");
+            });
+        });
+
+        describe("empty field fallbacks", () => {
+            it("should return empty string for localAccountId when not derivable", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    tid: TEST_TID,
+                    // No oid or sub
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.localAccountId).toBe("");
+            });
+
+            it("should return empty string for tenantId when not derivable", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    // No tid, tfp, or acr
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.tenantId).toBe("");
+            });
+
+            it("should return empty string for name when not derivable", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    // No name
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.name).toBe("");
+            });
+
+            it("should return undefined for loginHint when not derivable", () => {
+                const naaAccount: NaaAccountInfo = {
+                    environment: TEST_ENVIRONMENT,
+                    username: TEST_USERNAME,
+                };
+
+                const idTokenClaims = {
+                    oid: TEST_OID,
+                    tid: TEST_TID,
+                    // No login_hint
+                };
+
+                const result = nestedAppAuthAdapter.fromNaaAccountInfo(
+                    naaAccount,
+                    TEST_ID_TOKEN,
+                    idTokenClaims
+                );
+
+                expect(result.loginHint).toBeUndefined();
+            });
+        });
         });
     });
 });

--- a/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
+++ b/lib/msal-browser/test/naa/NestedAppAuthAdapter.spec.ts
@@ -380,10 +380,6 @@ describe("NestedAppAuthAdapter tests", () => {
                         environment: "",
                     });
 
-                    expect(() =>
-                        nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount)
-                    ).toThrow(ClientAuthError);
-
                     try {
                         nestedAppAuthAdapter.fromNaaAccountInfo(naaAccount);
                         fail("Expected error to be thrown");


### PR DESCRIPTION
This pull request enhances the logic for mapping account information from ID token claims, especially for Azure AD B2C scenarios, and adds comprehensive tests to validate these changes. The main improvements include more robust fallback mechanisms for key account fields, stricter environment validation, and better support for B2C-specific claims. Extensive unit tests have been added to ensure correct mapping and error handling.

### Account Mapping Improvements

* Enhanced the fallback logic in `NestedAppAuthAdapter.fromNaaAccountInfo` to derive `tenantId`, `localAccountId`, and `username` from multiple claims, including support for B2C-specific claims (`tid`, `tfp`, `acr`, `preferred_username`, `upn`, `emails`).
* Added strict validation for the `environment` field, throwing a `ClientAuthError` if it is missing or empty.

### B2C Scenario Support

* Integrated the `getTenantIdFromIdTokenClaims` utility to correctly handle `tid`, `tfp`, and `acr` claims for tenant identification in B2C flows.

### Test Coverage

* Added extensive unit tests in `NestedAppAuthAdapter.spec.ts` to verify field mapping, fallback logic, environment validation, and B2C claim handling.
* Added new tests in `NestedAppAuthController.spec.ts` to ensure correct field derivation from minimal account responses and proper error handling for invalid environments.

### Test Imports and Setup

* Updated test imports to include necessary types and utilities for new test cases, such as `MsalAccountInfo`, `NaaAccountInfo`, and error classes. [[1]](diffhunk://#diff-55abf3020a146fd079cdd4b9ffb51de460c15ead5bf5931a65afc76269ea50b1R15) [[2]](diffhunk://#diff-55abf3020a146fd079cdd4b9ffb51de460c15ead5bf5931a65afc76269ea50b1R37) [[3]](diffhunk://#diff-763bb9e9dfe004e7f109fcdaa38b118ebd9165a896138a91f281f87d509d21f0R22)