### PR TITLE
Add correlation id to events

### DIFF
--- a/change/@azure-msal-browser-fa824f6f-99e2-465b-94f8-5b61f3237e39.json
+++ b/change/@azure-msal-browser-fa824f6f-99e2-465b-94f8-5b61f3237e39.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "Add correlationId to events",
+  "type": "minor",
+  "comment": "Add correlationId to events [#8288](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8288)",
   "packageName": "@azure/msal-browser",
   "email": "thomas.norling@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-fa824f6f-99e2-465b-94f8-5b61f3237e39.json
+++ b/change/@azure-msal-browser-fa824f6f-99e2-465b-94f8-5b61f3237e39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add correlationId to events",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-react-f09dca2e-bdde-4d68-8f75-7188726f626b.json
+++ b/change/@azure-msal-react-f09dca2e-bdde-4d68-8f75-7188726f626b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Test updates",
+  "packageName": "@azure/msal-react",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/lib/msal-angular/src/msal.broadcast.service.spec.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.spec.ts
@@ -202,10 +202,12 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.INITIALIZE_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.ACQUIRE_TOKEN_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
 
@@ -252,10 +254,12 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_END,
+      "test-correlation-id",
       InteractionType.Redirect
     );
 
@@ -296,6 +300,7 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.ACQUIRE_TOKEN_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
 
@@ -336,10 +341,12 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_END,
+      "test-correlation-id",
       InteractionType.Redirect
     );
 
@@ -364,10 +371,12 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.ACQUIRE_TOKEN_SUCCESS,
+      "test-correlation-id",
       InteractionType.Redirect
     );
   });
@@ -391,14 +400,17 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.ACQUIRE_TOKEN_SUCCESS,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_END,
+      "test-correlation-id",
       InteractionType.Redirect
     );
   });
@@ -422,14 +434,17 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.ACQUIRE_TOKEN_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_END,
+      "test-correlation-id",
       InteractionType.Redirect
     );
   });
@@ -455,6 +470,7 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.INITIALIZE_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
   });

--- a/lib/msal-angular/src/msal.broadcast.service.spec.ts
+++ b/lib/msal-angular/src/msal.broadcast.service.spec.ts
@@ -97,6 +97,7 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.ACQUIRE_TOKEN_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
 
@@ -143,10 +144,12 @@ describe("MsalBroadcastService", () => {
 
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_START,
+      "test-correlation-id",
       InteractionType.Redirect
     );
     eventHandler.emitEvent(
       EventType.HANDLE_REDIRECT_END,
+      "test-correlation-id",
       InteractionType.Redirect
     );
 

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -602,7 +602,7 @@ export class EventHandler {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    emitEvent(eventType: EventType, interactionType?: InteractionType, payload?: EventPayload, error?: EventError): void;
+    emitEvent(eventType: EventType, correlationId: string, interactionType?: InteractionType, payload?: EventPayload, error?: EventError): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     removeEventCallback(callbackId: string): void;
     subscribeCrossTab(): void;
@@ -617,6 +617,7 @@ export type EventMessage = {
     interactionType: InteractionType | null;
     payload: EventPayload;
     error: EventError;
+    correlationId: string;
     timestamp: number;
 };
 
@@ -1516,8 +1517,8 @@ export type WrapperSKU = (typeof WrapperSKU)[keyof typeof WrapperSKU];
 // src/cache/LocalStorage.ts:429:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/LocalStorage.ts:460:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/config/Configuration.ts:199:5 - (ae-forgotten-export) The symbol "InternalAuthOptions" needs to be exported by the entry point index.d.ts
-// src/event/EventHandler.ts:114:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/event/EventHandler.ts:141:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/event/EventHandler.ts:116:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/event/EventHandler.ts:143:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"
 // src/index.ts:8:4 - (tsdoc-undefined-tag) The TSDoc tag "@module" is not defined in this configuration
 // src/navigation/NavigationClient.ts:40:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1821,7 +1821,10 @@ export class BrowserCacheManager extends CacheManager {
             );
             this.browserStorage.removeItem(activeAccountKey);
         }
-        this.eventHandler.emitEvent(EventType.ACTIVE_ACCOUNT_CHANGED, correlationId);
+        this.eventHandler.emitEvent(
+            EventType.ACTIVE_ACCOUNT_CHANGED,
+            correlationId
+        );
     }
 
     /**

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -1821,7 +1821,7 @@ export class BrowserCacheManager extends CacheManager {
             );
             this.browserStorage.removeItem(activeAccountKey);
         }
-        this.eventHandler.emitEvent(EventType.ACTIVE_ACCOUNT_CHANGED);
+        this.eventHandler.emitEvent(EventType.ACTIVE_ACCOUNT_CHANGED, correlationId);
     }
 
     /**

--- a/lib/msal-browser/src/controllers/NestedAppAuthController.ts
+++ b/lib/msal-browser/src/controllers/NestedAppAuthController.ts
@@ -203,6 +203,7 @@ export class NestedAppAuthController implements IController {
 
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
+            correlationId,
             InteractionType.Popup,
             validRequest
         );
@@ -249,6 +250,7 @@ export class NestedAppAuthController implements IController {
 
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_SUCCESS,
+                correlationId,
                 InteractionType.Popup,
                 result
             );
@@ -275,6 +277,7 @@ export class NestedAppAuthController implements IController {
                     : this.nestedAppAuthAdapter.fromBridgeError(e);
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_FAILURE,
+                correlationId,
                 InteractionType.Popup,
                 null,
                 e as EventError
@@ -304,6 +307,7 @@ export class NestedAppAuthController implements IController {
         const correlationId = validRequest.correlationId || createNewGuid();
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
+            correlationId,
             InteractionType.Silent,
             validRequest
         );
@@ -313,6 +317,7 @@ export class NestedAppAuthController implements IController {
         if (result) {
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_SUCCESS,
+                correlationId,
                 InteractionType.Silent,
                 result
             );
@@ -366,6 +371,7 @@ export class NestedAppAuthController implements IController {
 
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_SUCCESS,
+                correlationId,
                 InteractionType.Silent,
                 result
             );
@@ -389,6 +395,7 @@ export class NestedAppAuthController implements IController {
                     : this.nestedAppAuthAdapter.fromBridgeError(e);
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_FAILURE,
+                correlationId,
                 InteractionType.Silent,
                 null,
                 e as EventError
@@ -459,6 +466,7 @@ export class NestedAppAuthController implements IController {
         if (result) {
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_SUCCESS,
+                correlationId,
                 InteractionType.Silent,
                 result
             );
@@ -483,6 +491,7 @@ export class NestedAppAuthController implements IController {
 
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_FAILURE,
+            correlationId,
             InteractionType.Silent,
             null
         );

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -305,8 +305,10 @@ export class StandardController implements IController {
                 correlationId
             );
             this.initialized = true;
-            this.eventHandler.emitEvent(EventType.INITIALIZE_END,
-                correlationId);
+            this.eventHandler.emitEvent(
+                EventType.INITIALIZE_END,
+                correlationId
+            );
             return;
         }
 
@@ -315,8 +317,7 @@ export class StandardController implements IController {
             BrowserRootPerformanceEvents.InitializeClientApplication,
             correlationId
         );
-        this.eventHandler.emitEvent(EventType.INITIALIZE_START,
-                correlationId);
+        this.eventHandler.emitEvent(EventType.INITIALIZE_START, correlationId);
 
         // Broker applications are initialized twice, so we avoid double-counting it
         this.logMultipleInstances(initMeasurement, correlationId);
@@ -450,10 +451,10 @@ export class StandardController implements IController {
                 const correlationId =
                     platformBrokerRequest?.correlationId || "";
                 this.eventHandler.emitEvent(
-                        EventType.HANDLE_REDIRECT_START,
-                            correlationId,
-                        InteractionType.Redirect
-                    );
+                    EventType.HANDLE_REDIRECT_START,
+                    correlationId,
+                    InteractionType.Redirect
+                );
                 rootMeasurement = this.performanceClient.startMeasurement(
                     BrowserRootPerformanceEvents.AcquireTokenRedirect,
                     correlationId
@@ -490,7 +491,7 @@ export class StandardController implements IController {
                 const correlationId = standardRequest.correlationId;
                 this.eventHandler.emitEvent(
                     EventType.HANDLE_REDIRECT_START,
-                        correlationId,
+                    correlationId,
                     InteractionType.Redirect
                 );
                 // Reset rootMeasurement now that we have correlationId
@@ -722,7 +723,7 @@ export class StandardController implements IController {
 
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_FAILURE,
-                        correlationId,
+                correlationId,
                 InteractionType.Redirect,
                 null,
                 e as EventError
@@ -775,7 +776,7 @@ export class StandardController implements IController {
         const loggedInAccounts = this.getAllAccounts();
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
-                        correlationId,
+            correlationId,
             InteractionType.Popup,
             request
         );
@@ -836,7 +837,7 @@ export class StandardController implements IController {
                     loggedInAccounts.length < this.getAllAccounts().length;
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_SUCCESS,
-                        correlationId,
+                    correlationId,
                     InteractionType.Popup,
                     result
                 );
@@ -863,7 +864,7 @@ export class StandardController implements IController {
             .catch((e: Error) => {
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_FAILURE,
-                        correlationId,
+                    correlationId,
                     InteractionType.Popup,
                     null,
                     e
@@ -951,7 +952,7 @@ export class StandardController implements IController {
         this.logger.verbose("ssoSilent called", correlationId);
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
-                        correlationId,
+            correlationId,
             InteractionType.Silent,
             validRequest
         );
@@ -986,7 +987,7 @@ export class StandardController implements IController {
                     loggedInAccounts.length < this.getAllAccounts().length;
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_SUCCESS,
-                        correlationId,
+                    correlationId,
                     InteractionType.Silent,
                     response
                 );
@@ -1013,7 +1014,7 @@ export class StandardController implements IController {
             .catch((e: Error) => {
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_FAILURE,
-                        correlationId,
+                    correlationId,
                     InteractionType.Silent,
                     null,
                     e
@@ -1057,7 +1058,7 @@ export class StandardController implements IController {
         preflightCheck(this.initialized, atbcMeasurement);
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
-                        correlationId,
+            correlationId,
             InteractionType.Silent,
             request
         );
@@ -1084,7 +1085,7 @@ export class StandardController implements IController {
                         .then((result: AuthenticationResult) => {
                             this.eventHandler.emitEvent(
                                 EventType.ACQUIRE_TOKEN_SUCCESS,
-                        correlationId,
+                                correlationId,
                                 InteractionType.Silent,
                                 result
                             );
@@ -1105,7 +1106,7 @@ export class StandardController implements IController {
                             this.hybridAuthCodeResponses.delete(hybridAuthCode);
                             this.eventHandler.emitEvent(
                                 EventType.ACQUIRE_TOKEN_FAILURE,
-                        correlationId,
+                                correlationId,
                                 InteractionType.Silent,
                                 null,
                                 error
@@ -1169,7 +1170,7 @@ export class StandardController implements IController {
         } catch (e) {
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_FAILURE,
-                        correlationId,
+                correlationId,
                 InteractionType.Silent,
                 null,
                 e as EventError
@@ -2008,7 +2009,7 @@ export class StandardController implements IController {
             this.trackPageVisibility(request.correlationId);
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
-                        request.correlationId,
+            request.correlationId,
             InteractionType.Silent,
             request
         );
@@ -2136,7 +2137,7 @@ export class StandardController implements IController {
             .then((response) => {
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_SUCCESS,
-                        request.correlationId,
+                    request.correlationId,
                     InteractionType.Silent,
                     response
                 );

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -305,29 +305,29 @@ export class StandardController implements IController {
                 correlationId
             );
             this.initialized = true;
-            this.eventHandler.emitEvent(EventType.INITIALIZE_END);
+            this.eventHandler.emitEvent(EventType.INITIALIZE_END,
+                correlationId);
             return;
         }
 
-        const initCorrelationId =
-            request?.correlationId || this.getRequestCorrelationId();
         const allowPlatformBroker = this.config.system.allowPlatformBroker;
         const initMeasurement = this.performanceClient.startMeasurement(
             BrowserRootPerformanceEvents.InitializeClientApplication,
-            initCorrelationId
+            correlationId
         );
-        this.eventHandler.emitEvent(EventType.INITIALIZE_START);
+        this.eventHandler.emitEvent(EventType.INITIALIZE_START,
+                correlationId);
 
         // Broker applications are initialized twice, so we avoid double-counting it
-        this.logMultipleInstances(initMeasurement, initCorrelationId);
+        this.logMultipleInstances(initMeasurement, correlationId);
 
         await invokeAsync(
             this.browserStorage.initialize.bind(this.browserStorage),
             BrowserPerformanceEvents.InitializeCache,
             this.logger,
             this.performanceClient,
-            initCorrelationId
-        )(initCorrelationId);
+            correlationId
+        )(correlationId);
 
         if (allowPlatformBroker) {
             try {
@@ -335,11 +335,11 @@ export class StandardController implements IController {
                 this.platformAuthProvider = await getPlatformAuthProvider(
                     this.logger,
                     this.performanceClient,
-                    initCorrelationId,
+                    correlationId,
                     this.config.system.nativeBrokerHandshakeTimeout
                 );
             } catch (e) {
-                this.logger.verbose(e as string, initCorrelationId);
+                this.logger.verbose(e as string, correlationId);
             }
         }
 
@@ -351,9 +351,9 @@ export class StandardController implements IController {
         }
 
         !this.config.system.navigatePopups &&
-            (await this.preGeneratePkceCodes(initCorrelationId));
+            (await this.preGeneratePkceCodes(correlationId));
         this.initialized = true;
-        this.eventHandler.emitEvent(EventType.INITIALIZE_END);
+        this.eventHandler.emitEvent(EventType.INITIALIZE_END, correlationId);
         initMeasurement.end({
             allowPlatformBroker: allowPlatformBroker,
             success: true,
@@ -444,16 +444,16 @@ export class StandardController implements IController {
 
         let rootMeasurement: InProgressPerformanceEvent;
 
-        this.eventHandler.emitEvent(
-            EventType.HANDLE_REDIRECT_START,
-            InteractionType.Redirect
-        );
-
         let redirectResponse: Promise<AuthenticationResult | null>;
         try {
             if (useNative && this.platformAuthProvider) {
                 const correlationId =
                     platformBrokerRequest?.correlationId || "";
+                this.eventHandler.emitEvent(
+                        EventType.HANDLE_REDIRECT_START,
+                            correlationId,
+                        InteractionType.Redirect
+                    );
                 rootMeasurement = this.performanceClient.startMeasurement(
                     BrowserRootPerformanceEvents.AcquireTokenRedirect,
                     correlationId
@@ -488,6 +488,11 @@ export class StandardController implements IController {
                 const [standardRequest, codeVerifier] =
                     this.browserStorage.getCachedRequest("");
                 const correlationId = standardRequest.correlationId;
+                this.eventHandler.emitEvent(
+                    EventType.HANDLE_REDIRECT_START,
+                        correlationId,
+                    InteractionType.Redirect
+                );
                 // Reset rootMeasurement now that we have correlationId
                 rootMeasurement = this.performanceClient.startMeasurement(
                     BrowserRootPerformanceEvents.AcquireTokenRedirect,
@@ -517,6 +522,7 @@ export class StandardController implements IController {
                     this.browserStorage.resetRequestCache(result.correlationId);
                     this.eventHandler.emitEvent(
                         EventType.ACQUIRE_TOKEN_SUCCESS,
+                        result.correlationId,
                         InteractionType.Redirect,
                         result
                     );
@@ -530,6 +536,7 @@ export class StandardController implements IController {
                     if (isLoggingIn) {
                         this.eventHandler.emitEvent(
                             EventType.LOGIN_SUCCESS,
+                            result.correlationId,
                             InteractionType.Redirect,
                             result.account
                         );
@@ -559,6 +566,7 @@ export class StandardController implements IController {
 
                 this.eventHandler.emitEvent(
                     EventType.HANDLE_REDIRECT_END,
+                    rootMeasurement.event.correlationId,
                     InteractionType.Redirect
                 );
 
@@ -571,12 +579,14 @@ export class StandardController implements IController {
                 const eventError = e as EventError;
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_FAILURE,
+                    rootMeasurement.event.correlationId,
                     InteractionType.Redirect,
                     null,
                     eventError
                 );
                 this.eventHandler.emitEvent(
                     EventType.HANDLE_REDIRECT_END,
+                    rootMeasurement.event.correlationId,
                     InteractionType.Redirect
                 );
 
@@ -640,6 +650,7 @@ export class StandardController implements IController {
 
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_START,
+                correlationId,
                 InteractionType.Redirect,
                 request
             );
@@ -711,6 +722,7 @@ export class StandardController implements IController {
 
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_FAILURE,
+                        correlationId,
                 InteractionType.Redirect,
                 null,
                 e as EventError
@@ -763,6 +775,7 @@ export class StandardController implements IController {
         const loggedInAccounts = this.getAllAccounts();
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
+                        correlationId,
             InteractionType.Popup,
             request
         );
@@ -823,12 +836,14 @@ export class StandardController implements IController {
                     loggedInAccounts.length < this.getAllAccounts().length;
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_SUCCESS,
+                        correlationId,
                     InteractionType.Popup,
                     result
                 );
                 if (isLoggingIn) {
                     this.eventHandler.emitEvent(
                         EventType.LOGIN_SUCCESS,
+                        correlationId,
                         InteractionType.Popup,
                         result.account
                     );
@@ -848,6 +863,7 @@ export class StandardController implements IController {
             .catch((e: Error) => {
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_FAILURE,
+                        correlationId,
                     InteractionType.Popup,
                     null,
                     e
@@ -935,6 +951,7 @@ export class StandardController implements IController {
         this.logger.verbose("ssoSilent called", correlationId);
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
+                        correlationId,
             InteractionType.Silent,
             validRequest
         );
@@ -969,12 +986,14 @@ export class StandardController implements IController {
                     loggedInAccounts.length < this.getAllAccounts().length;
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_SUCCESS,
+                        correlationId,
                     InteractionType.Silent,
                     response
                 );
                 if (isLoggingIn) {
                     this.eventHandler.emitEvent(
                         EventType.LOGIN_SUCCESS,
+                        correlationId,
                         InteractionType.Silent,
                         response.account
                     );
@@ -994,6 +1013,7 @@ export class StandardController implements IController {
             .catch((e: Error) => {
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_FAILURE,
+                        correlationId,
                     InteractionType.Silent,
                     null,
                     e
@@ -1037,6 +1057,7 @@ export class StandardController implements IController {
         preflightCheck(this.initialized, atbcMeasurement);
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
+                        correlationId,
             InteractionType.Silent,
             request
         );
@@ -1063,6 +1084,7 @@ export class StandardController implements IController {
                         .then((result: AuthenticationResult) => {
                             this.eventHandler.emitEvent(
                                 EventType.ACQUIRE_TOKEN_SUCCESS,
+                        correlationId,
                                 InteractionType.Silent,
                                 result
                             );
@@ -1083,6 +1105,7 @@ export class StandardController implements IController {
                             this.hybridAuthCodeResponses.delete(hybridAuthCode);
                             this.eventHandler.emitEvent(
                                 EventType.ACQUIRE_TOKEN_FAILURE,
+                        correlationId,
                                 InteractionType.Silent,
                                 null,
                                 error
@@ -1146,6 +1169,7 @@ export class StandardController implements IController {
         } catch (e) {
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_FAILURE,
+                        correlationId,
                 InteractionType.Silent,
                 null,
                 e as EventError
@@ -1984,6 +2008,7 @@ export class StandardController implements IController {
             this.trackPageVisibility(request.correlationId);
         this.eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
+                        request.correlationId,
             InteractionType.Silent,
             request
         );
@@ -2111,6 +2136,7 @@ export class StandardController implements IController {
             .then((response) => {
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_SUCCESS,
+                        request.correlationId,
                     InteractionType.Silent,
                     response
                 );
@@ -2129,6 +2155,7 @@ export class StandardController implements IController {
             .catch((tokenRenewalError: Error) => {
                 this.eventHandler.emitEvent(
                     EventType.ACQUIRE_TOKEN_FAILURE,
+                    request.correlationId,
                     InteractionType.Silent,
                     null,
                     tokenRenewalError
@@ -2214,6 +2241,7 @@ export class StandardController implements IController {
 
                     this.eventHandler.emitEvent(
                         EventType.ACQUIRE_TOKEN_NETWORK_START,
+                        silentRequest.correlationId,
                         InteractionType.Silent,
                         silentRequest
                     );

--- a/lib/msal-browser/src/event/EventHandler.ts
+++ b/lib/msal-browser/src/event/EventHandler.ts
@@ -86,6 +86,7 @@ export class EventHandler {
      */
     emitEvent(
         eventType: EventType,
+        correlationId: string,
         interactionType?: InteractionType,
         payload?: EventPayload,
         error?: EventError
@@ -95,6 +96,7 @@ export class EventHandler {
             interactionType: interactionType || null,
             payload: payload || null,
             error: error || null,
+            correlationId: correlationId,
             timestamp: Date.now(),
         };
 

--- a/lib/msal-browser/src/event/EventMessage.ts
+++ b/lib/msal-browser/src/event/EventMessage.ts
@@ -21,6 +21,7 @@ export type EventMessage = {
     interactionType: InteractionType | null;
     payload: EventPayload;
     error: EventError;
+    correlationId: string;
     timestamp: number;
 };
 

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -361,7 +361,7 @@ export class PopupClient extends StandardInteractionClient {
                 );
                 this.eventHandler.emitEvent(
                     EventType.POPUP_OPENED,
-                        correlationId,
+                    correlationId,
                     InteractionType.Popup,
                     { popupWindow },
                     null

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -361,6 +361,7 @@ export class PopupClient extends StandardInteractionClient {
                 );
                 this.eventHandler.emitEvent(
                     EventType.POPUP_OPENED,
+                        correlationId,
                     InteractionType.Popup,
                     { popupWindow },
                     null
@@ -684,6 +685,7 @@ export class PopupClient extends StandardInteractionClient {
         this.logger.verbose("logoutPopupAsync called", this.correlationId);
         this.eventHandler.emitEvent(
             EventType.LOGOUT_START,
+            this.correlationId,
             InteractionType.Popup,
             validRequest
         );
@@ -729,6 +731,7 @@ export class PopupClient extends StandardInteractionClient {
                 ) {
                     this.eventHandler.emitEvent(
                         EventType.LOGOUT_SUCCESS,
+                        validRequest.correlationId,
                         InteractionType.Popup,
                         validRequest
                     );
@@ -761,6 +764,7 @@ export class PopupClient extends StandardInteractionClient {
 
             this.eventHandler.emitEvent(
                 EventType.LOGOUT_SUCCESS,
+                validRequest.correlationId,
                 InteractionType.Popup,
                 validRequest
             );
@@ -769,6 +773,7 @@ export class PopupClient extends StandardInteractionClient {
             const popupWindow = this.openPopup(logoutUri, popupParams);
             this.eventHandler.emitEvent(
                 EventType.POPUP_OPENED,
+                validRequest.correlationId,
                 InteractionType.Popup,
                 { popupWindow },
                 null
@@ -822,12 +827,14 @@ export class PopupClient extends StandardInteractionClient {
             }
             this.eventHandler.emitEvent(
                 EventType.LOGOUT_FAILURE,
+                this.correlationId,
                 InteractionType.Popup,
                 null,
                 e as EventError
             );
             this.eventHandler.emitEvent(
                 EventType.LOGOUT_END,
+                this.correlationId,
                 InteractionType.Popup
             );
             throw e;
@@ -835,6 +842,7 @@ export class PopupClient extends StandardInteractionClient {
 
         this.eventHandler.emitEvent(
             EventType.LOGOUT_END,
+            this.correlationId,
             InteractionType.Popup
         );
     }

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -144,6 +144,7 @@ export class RedirectClient extends StandardInteractionClient {
                 this.browserStorage.resetRequestCache(this.correlationId);
                 this.eventHandler.emitEvent(
                     EventType.RESTORE_FROM_BFCACHE,
+                        this.correlationId,
                     InteractionType.Redirect
                 );
             }
@@ -819,6 +820,7 @@ export class RedirectClient extends StandardInteractionClient {
         try {
             this.eventHandler.emitEvent(
                 EventType.LOGOUT_START,
+                this.correlationId,
                 InteractionType.Redirect,
                 logoutRequest
             );
@@ -859,6 +861,7 @@ export class RedirectClient extends StandardInteractionClient {
                     if (validLogoutRequest.account?.homeAccountId) {
                         this.eventHandler.emitEvent(
                             EventType.LOGOUT_SUCCESS,
+                            this.correlationId,
                             InteractionType.Redirect,
                             validLogoutRequest
                         );
@@ -874,6 +877,7 @@ export class RedirectClient extends StandardInteractionClient {
             if (validLogoutRequest.account?.homeAccountId) {
                 this.eventHandler.emitEvent(
                     EventType.LOGOUT_SUCCESS,
+                    this.correlationId,
                     InteractionType.Redirect,
                     validLogoutRequest
                 );
@@ -929,12 +933,14 @@ export class RedirectClient extends StandardInteractionClient {
             }
             this.eventHandler.emitEvent(
                 EventType.LOGOUT_FAILURE,
+                this.correlationId,
                 InteractionType.Redirect,
                 null,
                 e as EventError
             );
             this.eventHandler.emitEvent(
                 EventType.LOGOUT_END,
+                this.correlationId,
                 InteractionType.Redirect
             );
             throw e;
@@ -942,6 +948,7 @@ export class RedirectClient extends StandardInteractionClient {
 
         this.eventHandler.emitEvent(
             EventType.LOGOUT_END,
+            this.correlationId,
             InteractionType.Redirect
         );
     }

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -144,7 +144,7 @@ export class RedirectClient extends StandardInteractionClient {
                 this.browserStorage.resetRequestCache(this.correlationId);
                 this.eventHandler.emitEvent(
                     EventType.RESTORE_FROM_BFCACHE,
-                        this.correlationId,
+                    this.correlationId,
                     InteractionType.Redirect
                 );
             }

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -3446,7 +3446,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 .mockResolvedValue(testTokenResponse);
 
             jest.spyOn(EventHandler.prototype, "emitEvent").mockImplementation(
-                (eventType, interactionType) => {
+                (eventType, _correlationId, interactionType) => {
                     if (
                         eventType === EventType.ACQUIRE_TOKEN_START &&
                         interactionType === InteractionType.Silent

--- a/lib/msal-browser/test/event/EventHandler.spec.ts
+++ b/lib/msal-browser/test/event/EventHandler.spec.ts
@@ -102,7 +102,10 @@ describe("Event API tests", () => {
         const eventHandler = new EventHandler(logger);
 
         eventHandler.addEventCallback(subscriber);
-        eventHandler.emitEvent(EventType.ACQUIRE_TOKEN_SUCCESS, "test-correlation-id");
+        eventHandler.emitEvent(
+            EventType.ACQUIRE_TOKEN_SUCCESS,
+            "test-correlation-id"
+        );
     });
 
     it("sets all expected fields on event", (done) => {

--- a/lib/msal-browser/test/event/EventHandler.spec.ts
+++ b/lib/msal-browser/test/event/EventHandler.spec.ts
@@ -35,6 +35,7 @@ describe("Event API tests", () => {
         eventHandler.addEventCallback(subscriber);
         eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_SUCCESS,
+            "test-correlation-id",
             InteractionType.Popup
         );
     });
@@ -52,11 +53,13 @@ describe("Event API tests", () => {
         const callbackId = eventHandler.addEventCallback(callbackSpy);
         eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_SUCCESS,
+            "test-correlation-id",
             InteractionType.Popup
         );
         eventHandler.removeEventCallback(callbackId || "");
         eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_SUCCESS,
+            "test-correlation-id",
             InteractionType.Popup
         );
         expect(callbackSpy).toHaveBeenCalledTimes(1);
@@ -81,6 +84,7 @@ describe("Event API tests", () => {
         eventHandler.addEventCallback(subscriber2);
         eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
+            "test-correlation-id",
             InteractionType.Redirect
         );
     });
@@ -98,7 +102,7 @@ describe("Event API tests", () => {
         const eventHandler = new EventHandler(logger);
 
         eventHandler.addEventCallback(subscriber);
-        eventHandler.emitEvent(EventType.ACQUIRE_TOKEN_SUCCESS);
+        eventHandler.emitEvent(EventType.ACQUIRE_TOKEN_SUCCESS, "test-correlation-id");
     });
 
     it("sets all expected fields on event", (done) => {
@@ -116,6 +120,7 @@ describe("Event API tests", () => {
         eventHandler.addEventCallback(subscriber);
         eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_SUCCESS,
+            "test-correlation-id",
             InteractionType.Silent,
             { scopes: ["user.read"] },
             null
@@ -143,6 +148,7 @@ describe("Event API tests", () => {
         ]);
         eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_START,
+            "test-correlation-id",
             InteractionType.Redirect
         );
         expect(callback1Events.length).toBe(1);
@@ -151,6 +157,7 @@ describe("Event API tests", () => {
 
         eventHandler.emitEvent(
             EventType.ACQUIRE_TOKEN_SUCCESS,
+            "test-correlation-id",
             InteractionType.Redirect
         );
         expect(callback1Events.length).toBe(1);

--- a/lib/msal-browser/test/event/EventMessage.spec.ts
+++ b/lib/msal-browser/test/event/EventMessage.spec.ts
@@ -3,8 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { InteractionStatus, InteractionType } from "../../src/utils/BrowserConstants.js";
-import { EventMessage, EventMessageUtils } from "../../src/event/EventMessage.js";
+import {
+    InteractionStatus,
+    InteractionType,
+} from "../../src/utils/BrowserConstants.js";
+import {
+    EventMessage,
+    EventMessageUtils,
+} from "../../src/event/EventMessage.js";
 import { EventType } from "../../src/event/EventType.js";
 
 describe("EventMessage.ts Unit Tests", () => {

--- a/lib/msal-browser/test/event/EventMessage.spec.ts
+++ b/lib/msal-browser/test/event/EventMessage.spec.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { InteractionStatus, InteractionType } from "../../src";
-import { EventMessage, EventMessageUtils } from "../../src/event/EventMessage";
-import { EventType } from "../../src/event/EventType";
+import { InteractionStatus, InteractionType } from "../../src/utils/BrowserConstants.js";
+import { EventMessage, EventMessageUtils } from "../../src/event/EventMessage.js";
+import { EventType } from "../../src/event/EventType.js";
 
 describe("EventMessage.ts Unit Tests", () => {
     describe("getInteractionStatusFromEvent()", () => {
@@ -15,6 +15,7 @@ describe("EventMessage.ts Unit Tests", () => {
             payload: null,
             error: null,
             timestamp: 0,
+            correlationId: "test-correlation-id",
         };
 
         it("returns status AcquireToken with event type ACQUIRE_TOKEN_START", () => {

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -1934,6 +1934,7 @@ describe("RedirectClient", () => {
                     bfCacheCallback({ persisted: true });
                     expect(eventSpy).toHaveBeenCalledWith(
                         EventType.RESTORE_FROM_BFCACHE,
+                        TEST_CONFIG.CORRELATION_ID,
                         InteractionType.Redirect
                     );
                     expect(browserStorage.isInteractionInProgress()).toBe(
@@ -2674,6 +2675,7 @@ describe("RedirectClient", () => {
                 expect(telemetrySpy).toHaveBeenCalledWith(testError);
                 expect(eventSpy).toHaveBeenCalledWith(
                     EventType.LOGOUT_FAILURE,
+                    TEST_CONFIG.CORRELATION_ID,
                     InteractionType.Redirect,
                     null,
                     testError

--- a/lib/msal-react/test/MsalProvider.spec.tsx
+++ b/lib/msal-react/test/MsalProvider.spec.tsx
@@ -17,8 +17,9 @@ import {
     InteractionStatus,
     PublicClientApplication,
 } from "@azure/msal-browser";
-import { testAccount, TEST_CONFIG } from "./TestConstants";
-import { IMsalContext, MsalConsumer, MsalProvider } from "../src/index";
+import { testAccount, TEST_CONFIG } from "./TestConstants.js";
+import { IMsalContext, MsalConsumer } from "../src/MsalContext.js";
+import { MsalProvider } from "../src/MsalProvider.js";
 
 describe("MsalProvider tests", () => {
     let pca: PublicClientApplication;
@@ -50,6 +51,7 @@ describe("MsalProvider tests", () => {
                 const eventStart: EventMessage = {
                     eventType: EventType.HANDLE_REDIRECT_START,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,
@@ -62,6 +64,7 @@ describe("MsalProvider tests", () => {
                 const eventEnd: EventMessage = {
                     eventType: EventType.HANDLE_REDIRECT_END,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,
@@ -116,6 +119,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.HANDLE_REDIRECT_START,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -133,6 +137,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.HANDLE_REDIRECT_END,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -204,6 +209,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.HANDLE_REDIRECT_START,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -221,6 +227,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.LOGIN_SUCCESS,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -260,6 +267,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.HANDLE_REDIRECT_START,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -276,6 +284,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_FAILURE,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -314,6 +323,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.HANDLE_REDIRECT_START,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -330,6 +340,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_START,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -348,6 +359,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.HANDLE_REDIRECT_END,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -366,7 +378,6 @@ describe("MsalProvider tests", () => {
 
         test("Login Success", async () => {
             const TestComponent = ({ accounts, inProgress }: IMsalContext) => {
-                console.log(accounts, inProgress);
                 if (
                     accounts.length === 1 &&
                     inProgress === InteractionStatus.None
@@ -395,6 +406,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_START,
                 interactionType: InteractionType.Popup,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -412,6 +424,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                 interactionType: InteractionType.Popup,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -427,6 +440,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.LOGIN_SUCCESS,
                 interactionType: InteractionType.Popup,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -474,6 +488,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.LOGOUT_START,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -491,6 +506,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.LOGOUT_END,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -538,6 +554,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_START,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -555,6 +572,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -610,6 +628,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_START,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -627,6 +646,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_FAILURE,
                 interactionType: InteractionType.Redirect,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -674,6 +694,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_START,
                 interactionType: InteractionType.Popup,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -691,6 +712,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                 interactionType: InteractionType.Popup,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -738,6 +760,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_START,
                 interactionType: InteractionType.Popup,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -755,6 +778,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_FAILURE,
                 interactionType: InteractionType.Popup,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -806,6 +830,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_START,
                 interactionType: InteractionType.Silent,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -827,6 +852,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                 interactionType: InteractionType.Silent,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -878,6 +904,7 @@ describe("MsalProvider tests", () => {
             let eventMessage: EventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_START,
                 interactionType: InteractionType.Silent,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -899,6 +926,7 @@ describe("MsalProvider tests", () => {
             eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_FAILURE,
                 interactionType: InteractionType.Silent,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,
@@ -940,6 +968,7 @@ describe("MsalProvider tests", () => {
             const eventMessage = {
                 eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                 interactionType: null,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
                 payload: null,
                 error: null,
                 timestamp: 10000,

--- a/lib/msal-react/test/TestConstants.ts
+++ b/lib/msal-react/test/TestConstants.ts
@@ -8,6 +8,7 @@ import { TestTimeUtils } from "msal-test-utils";
 
 export const TEST_CONFIG = {
     MSAL_CLIENT_ID: "0813e1d1-ad72-46a9-8665-399bba48c201",
+    CORRELATION_ID: "test-correlation-id",
 };
 
 export const TEST_DATA_CLIENT_INFO = {

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
     act,
     fireEvent,
@@ -12,14 +12,10 @@ import {
     waitFor,
 } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { testAccount, testResult, TEST_CONFIG } from "../TestConstants";
-import {
-    MsalProvider,
-    MsalAuthenticationTemplate,
-    MsalAuthenticationResult,
-    IMsalContext,
-    useMsal,
-} from "../../src/index";
+import { testAccount, testResult, TEST_CONFIG } from "../TestConstants.js";
+import { MsalProvider } from "../../src/MsalProvider.js";
+import { MsalAuthenticationTemplate } from "../../src/components/MsalAuthenticationTemplate.js";
+import { useMsal } from "../../src/hooks/useMsal.js";
 import {
     PublicClientApplication,
     Configuration,
@@ -32,7 +28,9 @@ import {
     AuthError,
     InteractionRequiredAuthError,
 } from "@azure/msal-browser";
-import { ReactAuthErrorMessage } from "../../src/error/ReactAuthError";
+import { ReactAuthErrorMessage } from "../../src/error/ReactAuthError.js";
+import { MsalAuthenticationResult } from "src/hooks/useMsalAuthentication.js";
+import { IMsalContext } from "src/MsalContext.js";
 
 describe("MsalAuthenticationTemplate tests", () => {
     let pca: PublicClientApplication;
@@ -69,6 +67,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventStart: EventMessage = {
                     eventType: EventType.HANDLE_REDIRECT_START,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,
@@ -81,6 +80,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventEnd: EventMessage = {
                     eventType: EventType.HANDLE_REDIRECT_END,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,
@@ -118,6 +118,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const acquireTokenEvent: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Popup,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testResult,
                     error: null,
                     timestamp: 10000,
@@ -129,6 +130,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const loginEvent: EventMessage = {
                     eventType: EventType.LOGIN_SUCCESS,
                     interactionType: InteractionType.Popup,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testAccount,
                     error: null,
                     timestamp: 10000,
@@ -170,6 +172,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testResult,
                     error: null,
                     timestamp: 10000,
@@ -211,6 +214,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Silent,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testResult,
                     error: null,
                     timestamp: 10000,
@@ -256,6 +260,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Popup,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testResult,
                     error: null,
                     timestamp: 10000,
@@ -302,6 +307,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testResult,
                     error: null,
                     timestamp: 10000,
@@ -347,6 +353,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Silent,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testResult,
                     error: null,
                     timestamp: 10000,
@@ -388,6 +395,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const startMessage: EventMessage = {
                     eventType: EventType.HANDLE_REDIRECT_START,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,
@@ -395,6 +403,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const failureMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_FAILURE,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: error,
                     timestamp: 10000,
@@ -402,6 +411,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const endMessage: EventMessage = {
                     eventType: EventType.HANDLE_REDIRECT_END,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,
@@ -795,6 +805,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                     const eventStart: EventMessage = {
                         eventType: EventType.HANDLE_REDIRECT_START,
                         interactionType: InteractionType.Redirect,
+                        correlationId: TEST_CONFIG.CORRELATION_ID,
                         payload: null,
                         error: null,
                         timestamp: 10000,
@@ -807,6 +818,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                     const eventEnd: EventMessage = {
                         eventType: EventType.HANDLE_REDIRECT_END,
                         interactionType: InteractionType.Redirect,
+                        correlationId: TEST_CONFIG.CORRELATION_ID,
                         payload: null,
                         error: null,
                         timestamp: 10000,
@@ -835,6 +847,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                         const eventMessage: EventMessage = {
                             eventType: EventType.ACQUIRE_TOKEN_START,
                             interactionType: InteractionType.Redirect,
+                            correlationId: TEST_CONFIG.CORRELATION_ID,
                             payload: null,
                             error: null,
                             timestamp: 10000,
@@ -881,6 +894,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testResult,
                     error: null,
                     timestamp: 10000,
@@ -957,6 +971,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_FAILURE,
                     interactionType: InteractionType.Popup,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: error,
                     timestamp: 10000,
@@ -1009,6 +1024,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_FAILURE,
                     interactionType: InteractionType.Popup,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: error,
                     timestamp: 10000,
@@ -1024,10 +1040,12 @@ describe("MsalAuthenticationTemplate tests", () => {
             const [errorCode, setErrorCode] = useState(
                 error && error.errorCode
             );
-            // @ts-ignore
-            login("invalid_type").catch((error) =>
-                setErrorCode(error.errorCode)
-            );
+            useEffect(() => {
+                // @ts-ignore
+                login("invalid_type").catch((error) =>
+                    setErrorCode(error.errorCode)
+                );
+            }, [login]);
 
             if (error) {
                 return <p>Error Occurred: {errorCode}</p>;
@@ -1071,6 +1089,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_FAILURE,
                     interactionType: InteractionType.Silent,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: error,
                     timestamp: 10000,
@@ -1090,6 +1109,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
                     interactionType: InteractionType.Popup,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: testResult,
                     error: null,
                     timestamp: 10000,
@@ -1160,6 +1180,7 @@ describe("MsalAuthenticationTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.ACQUIRE_TOKEN_START,
                     interactionType: InteractionType.Popup,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,

--- a/lib/msal-react/test/components/UnauthenticatedTemplate.spec.tsx
+++ b/lib/msal-react/test/components/UnauthenticatedTemplate.spec.tsx
@@ -6,8 +6,9 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { testAccount, TEST_CONFIG } from "../TestConstants";
-import { MsalProvider, UnauthenticatedTemplate } from "../../src/index";
+import { testAccount, TEST_CONFIG } from "../TestConstants.js";
+import { MsalProvider } from "../../src/MsalProvider.js";
+import { UnauthenticatedTemplate } from "../../src/components/UnauthenticatedTemplate.js";
 import {
     PublicClientApplication,
     IPublicClientApplication,
@@ -282,6 +283,7 @@ describe("UnauthenticatedTemplate tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.HANDLE_REDIRECT_START,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,

--- a/lib/msal-react/test/components/withMsal.spec.tsx
+++ b/lib/msal-react/test/components/withMsal.spec.tsx
@@ -10,8 +10,9 @@ import {
     InteractionType,
     PublicClientApplication,
 } from "@azure/msal-browser";
-import { TEST_CONFIG } from "../TestConstants";
-import { MsalProvider, withMsal } from "../../src/index";
+import { TEST_CONFIG } from "../TestConstants.js";
+import { MsalProvider } from "../../src/MsalProvider.js";
+import { withMsal } from "../../src/components/withMsal.js";
 
 describe("withMsal tests", () => {
     let pca: PublicClientApplication;
@@ -40,6 +41,7 @@ describe("withMsal tests", () => {
                 const eventMessage: EventMessage = {
                     eventType: EventType.HANDLE_REDIRECT_END,
                     interactionType: InteractionType.Redirect,
+                    correlationId: TEST_CONFIG.CORRELATION_ID,
                     payload: null,
                     error: null,
                     timestamp: 10000,


### PR DESCRIPTION
This pull request adds support for passing a `correlationId` to all MSAL event emissions, improving traceability across authentication flows. The change affects the main browser library, ensuring that events such as initialization, token acquisition, login, and redirect handling consistently include a correlation ID. This enhancement is reflected in both the implementation and corresponding unit tests.

### Event emission improvements

* Updated all calls to `eventHandler.emitEvent` in `BrowserCacheManager`, `StandardController`, and `NestedAppAuthController` to include a `correlationId` parameter, ensuring every event can be traced with a unique identifier. [[1]](diffhunk://#diff-9fe0cda3d1225c92740f98cfd73639c5db18bf24234c273756a855e5b48adae2L1824-R1824) [[2]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fL308-R342) [[3]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fL354-R356) [[4]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fL447-R456) [[5]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR491-R495) [[6]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR525) [[7]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR539) [[8]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR569) [[9]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR582-R589) [[10]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR653) [[11]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR725) [[12]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR778) [[13]](diffhunk://#diff-d8bde128bad64cb357b230e9a738968be4d62b4e3d7c78e889f3e38d4689f73fR839-R846) [[14]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R206) [[15]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R253) [[16]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R280) [[17]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R310) [[18]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R320) [[19]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R374) [[20]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R398) [[21]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R469) [[22]](diffhunk://#diff-7b9a3c980bbe784b514c142a68327c6e99af1de61b545e2e9e7bde79bdf4a8c8R494)

### Test coverage enhancements

* Updated unit tests in `msal.broadcast.service.spec.ts` to pass a test correlation ID to all event emissions, verifying the new parameter is correctly handled in various authentication scenarios. [[1]](diffhunk://#diff-a6ea20ae7f987e24236e894d19983943a4628e00607c6a2bbe15b4e76c75046cR205-R210) [[2]](diffhunk://#diff-a6ea20ae7f987e24236e894d19983943a4628e00607c6a2bbe15b4e76c75046cR257-R262) [[3]](diffhunk://#diff-a6ea20ae7f987e24236e894d19983943a4628e00607c6a2bbe15b4e76c75046cR303) [[4]](diffhunk://#diff-a6ea20ae7f987e24236e894d19983943a4628e00607c6a2bbe15b4e76c75046cR344-R349) [[5]](diffhunk://#diff-a6ea20ae7f987e24236e894d19983943a4628e00607c6a2bbe15b4e76c75046cR374-R379) [[6]](diffhunk://#diff-a6ea20ae7f987e24236e894d19983943a4628e00607c6a2bbe15b4e76c75046cR403-R413) [[7]](diffhunk://#diff-a6ea20ae7f987e24236e894d19983943a4628e00607c6a2bbe15b4e76c75046cR437-R447) [[8]](diffhunk://#diff-a6ea20ae7f987e24236e894d19983943a4628e00607c6a2bbe15b4e76c75046cR473)

### Package metadata

* Updated the `@azure/msal-browser` change file to document the addition of `correlationId` to events and mark the release as a patch update.