### PR TITLE
Add new authority metadata

### DIFF
--- a/change/@azure-msal-common-39f0cf0c-b0c3-42a2-987d-146de92784db.json
+++ b/change/@azure-msal-common-39f0cf0c-b0c3-42a2-987d-146de92784db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add new authority metadata [#8306](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8306)",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/authority/AuthorityMetadata.ts
+++ b/lib/msal-common/src/authority/AuthorityMetadata.ts
@@ -53,25 +53,25 @@ export const rawMetdataJSON: RawMetadata = {
         },
         "login.sovcloud-identity.fr": {
             token_endpoint:
-                "https://login.sovcloud-identity.fr/common/oauth2/v2.0/token",
+                "https://login.sovcloud-identity.fr/{tenantid}/oauth2/v2.0/token",
             jwks_uri:
-                "https://login.sovcloud-identity.fr/common/discovery/v2.0/keys",
+                "https://login.sovcloud-identity.fr/{tenantid}/discovery/v2.0/keys",
             issuer: "https://login.sovcloud-identity.fr/{tenantid}/v2.0",
             authorization_endpoint:
-                "https://login.sovcloud-identity.fr/common/oauth2/v2.0/authorize",
+                "https://login.sovcloud-identity.fr/{tenantid}/oauth2/v2.0/authorize",
             end_session_endpoint:
-                "https://login.sovcloud-identity.fr/common/oauth2/v2.0/logout",
+                "https://login.sovcloud-identity.fr/{tenantid}/oauth2/v2.0/logout",
         },
         "login.sovcloud-identity.de": {
             token_endpoint:
-                "https://login.sovcloud-identity.de/common/oauth2/v2.0/token",
+                "https://login.sovcloud-identity.de/{tenantid}/oauth2/v2.0/token",
             jwks_uri:
-                "https://login.sovcloud-identity.de/common/discovery/v2.0/keys",
+                "https://login.sovcloud-identity.de/{tenantid}/discovery/v2.0/keys",
             issuer: "https://login.sovcloud-identity.de/{tenantid}/v2.0",
             authorization_endpoint:
-                "https://login.sovcloud-identity.de/common/oauth2/v2.0/authorize",
+                "https://login.sovcloud-identity.de/{tenantid}/oauth2/v2.0/authorize",
             end_session_endpoint:
-                "https://login.sovcloud-identity.de/common/oauth2/v2.0/logout",
+                "https://login.sovcloud-identity.de/{tenantid}/oauth2/v2.0/logout",
         },
         "login.sovcloud-identity.sg": {
             token_endpoint:

--- a/lib/msal-common/src/authority/AuthorityMetadata.ts
+++ b/lib/msal-common/src/authority/AuthorityMetadata.ts
@@ -51,6 +51,39 @@ export const rawMetdataJSON: RawMetadata = {
             end_session_endpoint:
                 "https://login.microsoftonline.us/{tenantid}/oauth2/v2.0/logout",
         },
+        "login.sovcloud-identity.fr": {
+            token_endpoint:
+                "https://login.sovcloud-identity.fr/common/oauth2/v2.0/token",
+            jwks_uri:
+                "https://login.sovcloud-identity.fr/common/discovery/v2.0/keys",
+            issuer: "https://login.sovcloud-identity.fr/{tenantid}/v2.0",
+            authorization_endpoint:
+                "https://login.sovcloud-identity.fr/common/oauth2/v2.0/authorize",
+            end_session_endpoint:
+                "https://login.sovcloud-identity.fr/common/oauth2/v2.0/logout",
+        },
+        "login.sovcloud-identity.de": {
+            token_endpoint:
+                "https://login.sovcloud-identity.de/common/oauth2/v2.0/token",
+            jwks_uri:
+                "https://login.sovcloud-identity.de/common/discovery/v2.0/keys",
+            issuer: "https://login.sovcloud-identity.de/{tenantid}/v2.0",
+            authorization_endpoint:
+                "https://login.sovcloud-identity.de/common/oauth2/v2.0/authorize",
+            end_session_endpoint:
+                "https://login.sovcloud-identity.de/common/oauth2/v2.0/logout",
+        },
+        "login.sovcloud-identity.sg": {
+            token_endpoint:
+                "https://login.sovcloud-identity.sg/common/oauth2/v2.0/token",
+            jwks_uri:
+                "https://login.sovcloud-identity.sg/common/discovery/v2.0/keys",
+            issuer: "https://login.sovcloud-identity.sg/{tenantid}/v2.0",
+            authorization_endpoint:
+                "https://login.sovcloud-identity.sg/common/oauth2/v2.0/authorize",
+            end_session_endpoint:
+                "https://login.sovcloud-identity.sg/common/oauth2/v2.0/logout",
+        },
     },
     instanceDiscoveryMetadata: {
         tenant_discovery_endpoint:
@@ -91,6 +124,21 @@ export const rawMetdataJSON: RawMetadata = {
                 preferred_network: "login-us.microsoftonline.com",
                 preferred_cache: "login-us.microsoftonline.com",
                 aliases: ["login-us.microsoftonline.com"],
+            },
+            {
+                preferred_network: "login.sovcloud-identity.fr",
+                preferred_cache: "login.sovcloud-identity.fr",
+                aliases: ["login.sovcloud-identity.fr"],
+            },
+            {
+                preferred_network: "login.sovcloud-identity.de",
+                preferred_cache: "login.sovcloud-identity.de",
+                aliases: ["login.sovcloud-identity.de"],
+            },
+            {
+                preferred_network: "login.sovcloud-identity.sg",
+                preferred_cache: "login.sovcloud-identity.sg",
+                aliases: ["login.sovcloud-identity.sg"],
             },
         ],
     },

--- a/lib/msal-common/test/test_kit/StringConstants.ts
+++ b/lib/msal-common/test/test_kit/StringConstants.ts
@@ -294,6 +294,9 @@ export const CLOUD_HOSTS = {
     GermanyCloud: "login.microsoftonline.de",
     USGovAGCloud: "login.microsoftonline.us",
     USGovCloud: "login-us.microsoftonline.com",
+    SovCloudFR: "login.sovcloud-identity.fr",
+    SovCloudDE: "login.sovcloud-identity.de",
+    SovCloudSG: "login.sovcloud-identity.sg",
 };
 
 export const METADATA_ALIASES = {
@@ -307,6 +310,9 @@ export const METADATA_ALIASES = {
     GermanyCloud: ["login.microsoftonline.de"],
     USGovAGCloud: ["login.microsoftonline.us", "login.usgovcloudapi.net"],
     USGovCloud: ["login-us.microsoftonline.com"],
+    SovCloudFR: ["login.sovcloud-identity.fr"],
+    SovCloudDE: ["login.sovcloud-identity.de"],
+    SovCloudSG: ["login.sovcloud-identity.sg"],
 };
 
 export const PREFERRED_CACHE_ALIAS = "login.windows.net";


### PR DESCRIPTION
This pull request adds support for new SovCloud identity authorities in the `@azure/msal-common` package. The main changes involve updating authority metadata, test constants, and aliases to recognize and handle the new SovCloud endpoints.

Authority metadata updates:

* Added metadata for three new SovCloud authorities (`login.sovcloud-identity.fr`, `login.sovcloud-identity.de`, `login.sovcloud-identity.sg`) in `AuthorityMetadata.ts`, including their token, authorization, issuer, and logout endpoints.
* Added these SovCloud authorities to the `trustedHostList` with their preferred network, cache, and aliases in `AuthorityMetadata.ts`.

Test constants and aliases updates:

* Added SovCloud host constants (`SovCloudFR`, `SovCloudDE`, `SovCloudSG`) to `StringConstants.ts` for testing purposes.
* Updated `METADATA_ALIASES` in `StringConstants.ts` to include the new SovCloud authorities.

Documentation:

* Added a change file documenting the patch and referencing the relevant pull request.