### PR TITLE
Add correlationId to POST request query params

### DIFF
--- a/change/@azure-msal-browser-9e057f03-1c0c-4592-8d24-032b325205f1.json
+++ b/change/@azure-msal-browser-9e057f03-1c0c-4592-8d24-032b325205f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add correlationId to POST request query params [#8308](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8308)",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -215,6 +215,15 @@ export async function getEARForm(
         queryParams,
         request.extraQueryParameters || {}
     );
+
+    // Add correlationId to query params so gateway can propagate it to IDPs
+    if (request.correlationId) {
+        RequestParameterBuilder.addCorrelationId(
+            queryParams,
+            request.correlationId
+        );
+    }
+
     const url = AuthorizeProtocol.getAuthorizeUrl(
         authority,
         queryParams,
@@ -258,10 +267,19 @@ export async function getCodeForm(
     );
 
     const queryParams = new Map<string, string>();
+
     RequestParameterBuilder.addExtraQueryParameters(
         queryParams,
         request.extraQueryParameters || {}
     );
+
+    // Add correlationId to query params so gateway can propagate it to IDPs
+    if (request.correlationId) {
+        RequestParameterBuilder.addCorrelationId(
+            queryParams,
+            request.correlationId
+        );
+    }
 
     const url = AuthorizeProtocol.getAuthorizeUrl(
         authority,

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -217,12 +217,10 @@ export async function getEARForm(
     );
 
     // Add correlationId to query params so gateway can propagate it to IDPs
-    if (request.correlationId) {
-        RequestParameterBuilder.addCorrelationId(
-            queryParams,
-            request.correlationId
-        );
-    }
+    RequestParameterBuilder.addCorrelationId(
+        queryParams,
+        request.correlationId
+    );
 
     const url = AuthorizeProtocol.getAuthorizeUrl(
         authority,
@@ -274,12 +272,10 @@ export async function getCodeForm(
     );
 
     // Add correlationId to query params so gateway can propagate it to IDPs
-    if (request.correlationId) {
-        RequestParameterBuilder.addCorrelationId(
-            queryParams,
-            request.correlationId
-        );
-    }
+    RequestParameterBuilder.addCorrelationId(
+        queryParams,
+        request.correlationId
+    );
 
     const url = AuthorizeProtocol.getAuthorizeUrl(
         authority,

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -194,6 +194,14 @@ describe("Authorize Protocol Tests", () => {
                     BrowserConstants.MSAL_SKU
                 );
                 checkInputProperties(AADServerParamKeys.X_CLIENT_VER, version);
+
+                // Verify correlationId is present in authorize URL query params
+                const actionUrl = new URL(form.action);
+                expect(
+                    actionUrl.searchParams.get(
+                        AADServerParamKeys.CLIENT_REQUEST_ID
+                    )
+                ).toEqual(validRequest.correlationId);
             });
         });
 
@@ -380,6 +388,83 @@ describe("Authorize Protocol Tests", () => {
                 );
                 expect(response).toEqual(getTestAuthenticationResult());
             });
+        });
+    });
+    describe("getCodeForm tests", () => {
+        const config = buildConfiguration(
+            { auth: { clientId: TEST_CONFIG.MSAL_CLIENT_ID } },
+            true
+        );
+        const logger = new Logger({});
+        const performanceClient = new StubPerformanceClient();
+        const authorityOptions: AuthorityOptions = {
+            protocolMode: ProtocolMode.EAR,
+            knownAuthorities: [],
+            cloudDiscoveryMetadata: "",
+            authorityMetadata: "",
+        };
+        const eventHandler = new EventHandler();
+        const cacheManager = new BrowserCacheManager(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            config.cache,
+            new CryptoOps(logger, performanceClient),
+            logger,
+            performanceClient,
+            eventHandler
+        );
+        let authority: Authority;
+        const validRequest: CommonAuthorizationUrlRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            scopes: ["openid", "profile"],
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            redirectUri: window.location.href,
+            state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
+            nonce: ID_TOKEN_CLAIMS.nonce,
+            responseMode: ResponseMode.FRAGMENT,
+            codeChallenge: "code-challenge",
+        };
+
+        beforeAll(async () => {
+            jest.useFakeTimers();
+            authority = await AuthorityFactory.createDiscoveredInstance(
+                TEST_CONFIG.validAuthority,
+                config.system.networkClient,
+                cacheManager,
+                authorityOptions,
+                logger,
+                TEST_CONFIG.CORRELATION_ID,
+                performanceClient
+            );
+        });
+
+        afterAll(() => {
+            jest.useRealTimers();
+        });
+
+        it("Adds correlationId to both post body and query params", async () => {
+            const form = await Authorize.getCodeForm(
+                document,
+                config,
+                authority,
+                validRequest,
+                logger,
+                performanceClient
+            );
+
+            // Post body check
+            const clientRequestIdInput = form.elements.namedItem(
+                AADServerParamKeys.CLIENT_REQUEST_ID
+            ) as HTMLInputElement;
+            expect(clientRequestIdInput).toBeTruthy();
+            expect(clientRequestIdInput.value).toEqual(
+                validRequest.correlationId
+            );
+
+            // Query param check
+            const actionUrl = new URL(form.action);
+            expect(
+                actionUrl.searchParams.get(AADServerParamKeys.CLIENT_REQUEST_ID)
+            ).toEqual(validRequest.correlationId);
         });
     });
 });

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -398,7 +398,7 @@ describe("Authorize Protocol Tests", () => {
         const logger = new Logger({});
         const performanceClient = new StubPerformanceClient();
         const authorityOptions: AuthorityOptions = {
-            protocolMode: ProtocolMode.EAR,
+            protocolMode: ProtocolMode.AAD,
             knownAuthorities: [],
             cloudDiscoveryMetadata: "",
             authorityMetadata: "",


### PR DESCRIPTION
This pull request adds support for propagating the `correlationId` in authorization requests to ensure traceability across services. The main changes involve updating the `getEARForm` and `getCodeForm` functions to include the `correlationId` in the query parameters, and adding tests to verify this behavior.

Enhancements to correlationId propagation:

* Updated `getEARForm` and `getCodeForm` in `Authorize.ts` to add the `correlationId` to the query parameters, allowing gateways to propagate it to identity providers. [[1]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165R218-R226) [[2]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165R270-R283)

Testing improvements:

* Added and updated tests in `Authorize.spec.ts` to verify that the `correlationId` is present in both the post body and query parameters of the authorization forms. [[1]](diffhunk://#diff-383f979b9a05a2d7fe02052138e8087f6ca2167e78d44dc4d41c391463d4da04R197-R204) [[2]](diffhunk://#diff-383f979b9a05a2d7fe02052138e8087f6ca2167e78d44dc4d41c391463d4da04R393-R469)