### PR TITLE
[v5] Add correlationId to POST authorize request query params

### DIFF
--- a/change/@azure-msal-browser-310d4c86-8ca9-4b5d-a814-f5d2bdcd7e9f.json
+++ b/change/@azure-msal-browser-310d4c86-8ca9-4b5d-a814-f5d2bdcd7e9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add correlationId to POST request query params [#8308](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8308)",
+  "packageName": "@azure/msal-browser",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-310d4c86-8ca9-4b5d-a814-f5d2bdcd7e9f.json
+++ b/change/@azure-msal-browser-310d4c86-8ca9-4b5d-a814-f5d2bdcd7e9f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add correlationId to POST request query params [#8308](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8308)",
+  "comment": "Add correlationId to POST authorize request query params [#8309](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8309)",
   "packageName": "@azure/msal-browser",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -214,6 +214,13 @@ export async function getEARForm(
         queryParams,
         request.extraQueryParameters || {}
     );
+
+    // Add correlationId to query params so gateway can propagate it to IDPs
+    RequestParameterBuilder.addCorrelationId(
+        queryParams,
+        request.correlationId
+    );
+
     const url = AuthorizeProtocol.getAuthorizeUrl(authority, queryParams);
 
     return createForm(frame, url, parameters);
@@ -259,6 +266,12 @@ export async function getCodeForm(
     RequestParameterBuilder.addExtraParameters(
         queryParams,
         request.extraQueryParameters || {}
+    );
+
+    // Add correlationId to query params so gateway can propagate it to IDPs
+    RequestParameterBuilder.addCorrelationId(
+        queryParams,
+        request.correlationId
     );
 
     const url = AuthorizeProtocol.getAuthorizeUrl(authority, queryParams);

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -193,6 +193,14 @@ describe("Authorize Protocol Tests", () => {
                     BrowserConstants.MSAL_SKU
                 );
                 checkInputProperties(AADServerParamKeys.X_CLIENT_VER, version);
+
+                // Verify correlationId is present in authorize URL query params
+                const actionUrl = new URL(form.action);
+                expect(
+                    actionUrl.searchParams.get(
+                        AADServerParamKeys.CLIENT_REQUEST_ID
+                    )
+                ).toEqual(validRequest.correlationId);
             });
         });
 
@@ -379,6 +387,84 @@ describe("Authorize Protocol Tests", () => {
                 );
                 expect(response).toEqual(getTestAuthenticationResult());
             });
+        });
+    });
+
+    describe("getCodeForm tests", () => {
+        const config = buildConfiguration(
+            { auth: { clientId: TEST_CONFIG.MSAL_CLIENT_ID } },
+            true
+        );
+        const logger = new Logger({});
+        const performanceClient = new StubPerformanceClient();
+        const authorityOptions: AuthorityOptions = {
+            protocolMode: ProtocolMode.AAD,
+            knownAuthorities: [],
+            cloudDiscoveryMetadata: "",
+            authorityMetadata: "",
+        };
+        const eventHandler = new EventHandler();
+        const cacheManager = new BrowserCacheManager(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            config.cache,
+            new CryptoOps(logger, performanceClient),
+            logger,
+            performanceClient,
+            eventHandler
+        );
+        let authority: Authority;
+        const validRequest: CommonAuthorizationUrlRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            scopes: ["openid", "profile"],
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            redirectUri: window.location.href,
+            state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
+            nonce: ID_TOKEN_CLAIMS.nonce,
+            responseMode: Constants.ResponseMode.FRAGMENT,
+            codeChallenge: "code-challenge",
+        };
+
+        beforeAll(async () => {
+            jest.useFakeTimers();
+            authority = await AuthorityFactory.createDiscoveredInstance(
+                TEST_CONFIG.validAuthority,
+                config.system.networkClient,
+                cacheManager,
+                authorityOptions,
+                logger,
+                TEST_CONFIG.CORRELATION_ID,
+                performanceClient
+            );
+        });
+
+        afterAll(() => {
+            jest.useRealTimers();
+        });
+
+        it("Adds correlationId to both post body and query params", async () => {
+            const form = await Authorize.getCodeForm(
+                document,
+                config,
+                authority,
+                validRequest,
+                logger,
+                performanceClient
+            );
+
+            // Post body check
+            const clientRequestIdInput = form.elements.namedItem(
+                AADServerParamKeys.CLIENT_REQUEST_ID
+            ) as HTMLInputElement;
+            expect(clientRequestIdInput).toBeTruthy();
+            expect(clientRequestIdInput.value).toEqual(
+                validRequest.correlationId
+            );
+
+            // Query param check
+            const actionUrl = new URL(form.action);
+            expect(
+                actionUrl.searchParams.get(AADServerParamKeys.CLIENT_REQUEST_ID)
+            ).toEqual(validRequest.correlationId);
         });
     });
 });


### PR DESCRIPTION
This pull request enhances the `@azure/msal-browser` library by ensuring that the `correlationId` is included in the query parameters of POST authorize requests. This change improves traceability and debugging by allowing the gateway to propagate the correlation ID to identity providers (IDPs). The update is validated with new and expanded unit tests.

Enhancements to correlation ID propagation:

* Updated `getEARForm` and `getCodeForm` in `Authorize.ts` to add `correlationId` to the query parameters, enabling the gateway to propagate it to IDPs. [[1]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165R217-R223) [[2]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165R271-R276)
* Added and extended unit tests in `Authorize.spec.ts` to verify that the `correlationId` is present in both the POST body and query parameters for authorize requests. [[1]](diffhunk://#diff-383f979b9a05a2d7fe02052138e8087f6ca2167e78d44dc4d41c391463d4da04R196-R203) [[2]](diffhunk://#diff-383f979b9a05a2d7fe02052138e8087f6ca2167e78d44dc4d41c391463d4da04R392-R469)

Release and documentation:

* Added a patch release entry in `@azure-msal-browser-310d4c86-8ca9-4b5d-a814-f5d2bdcd7e9f.json` documenting the change and referencing the relevant pull request.