### PR TITLE
[v5] Add new authority metadata

### DIFF
--- a/change/@azure-msal-common-b6feb9cb-1882-4142-b4ae-e3aa14d331e1.json
+++ b/change/@azure-msal-common-b6feb9cb-1882-4142-b4ae-e3aa14d331e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[v5] Add new authority metadata [#8307](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8307)",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-b6feb9cb-1882-4142-b4ae-e3aa14d331e1.json
+++ b/change/@azure-msal-common-b6feb9cb-1882-4142-b4ae-e3aa14d331e1.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "[v5] Add new authority metadata [#8307](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8307)",
+  "comment": "[v5] Add new authority metadata [#8310](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8310)",
   "packageName": "@azure/msal-common",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-common/src/authority/AuthorityMetadata.ts
+++ b/lib/msal-common/src/authority/AuthorityMetadata.ts
@@ -90,6 +90,21 @@ export const rawMetdataJSON: RawMetadata = {
                 preferred_cache: "login-us.microsoftonline.com",
                 aliases: ["login-us.microsoftonline.com"],
             },
+            {
+                preferred_network: "login.sovcloud-identity.fr",
+                preferred_cache: "login.sovcloud-identity.fr",
+                aliases: ["login.sovcloud-identity.fr"],
+            },
+            {
+                preferred_network: "login.sovcloud-identity.de",
+                preferred_cache: "login.sovcloud-identity.de",
+                aliases: ["login.sovcloud-identity.de"],
+            },
+            {
+                preferred_network: "login.sovcloud-identity.sg",
+                preferred_cache: "login.sovcloud-identity.sg",
+                aliases: ["login.sovcloud-identity.sg"],
+            },
         ],
     },
 };

--- a/lib/msal-common/test/test_kit/StringConstants.ts
+++ b/lib/msal-common/test/test_kit/StringConstants.ts
@@ -297,6 +297,9 @@ export const CLOUD_HOSTS = {
     GermanyCloud: "login.microsoftonline.de",
     USGovAGCloud: "login.microsoftonline.us",
     USGovCloud: "login-us.microsoftonline.com",
+    SovCloudFR: "login.sovcloud-identity.fr",
+    SovCloudDE: "login.sovcloud-identity.de",
+    SovCloudSG: "login.sovcloud-identity.sg",
 };
 
 export const METADATA_ALIASES = {
@@ -310,6 +313,9 @@ export const METADATA_ALIASES = {
     GermanyCloud: ["login.microsoftonline.de"],
     USGovAGCloud: ["login.microsoftonline.us", "login.usgovcloudapi.net"],
     USGovCloud: ["login-us.microsoftonline.com"],
+    SovCloudFR: ["login.sovcloud-identity.fr"],
+    SovCloudDE: ["login.sovcloud-identity.de"],
+    SovCloudSG: ["login.sovcloud-identity.sg"],
 };
 
 export const PREFERRED_CACHE_ALIAS = "login.windows.net";


### PR DESCRIPTION
This pull request adds support for new SovCloud authority metadata in the `@azure/msal-common` package, enhancing authentication capabilities for France, Germany, and Singapore SovCloud environments. The changes primarily involve updating authority metadata and test constants to recognize these new hosts.

**Authority metadata updates:**

* Added new SovCloud authority entries for France (`login.sovcloud-identity.fr`), Germany (`login.sovcloud-identity.de`), and Singapore (`login.sovcloud-identity.sg`) to the `rawMetdataJSON` in `AuthorityMetadata.ts`.

**Test constants updates:**

* Added SovCloud host constants for France, Germany, and Singapore in `CLOUD_HOSTS` within `StringConstants.ts`.
* Updated `METADATA_ALIASES` in `StringConstants.ts` to include SovCloud aliases for France, Germany, and Singapore.

**Release notes:**

* Added a patch change file documenting the addition of new authority metadata for SovCloud environments.