### PR TITLE
Add interrupted user to interaction required list

### DIFF
--- a/change/@azure-msal-common-0d6bd166-040d-4ff3-b891-2c14d4a63dfc.json
+++ b/change/@azure-msal-common-0d6bd166-040d-4ff3-b891-2c14d4a63dfc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add interrupted user to interaction required list #8323",
+  "packageName": "@azure/msal-common",
+  "email": "hemoral@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-0d6bd166-040d-4ff3-b891-2c14d4a63dfc.json
+++ b/change/@azure-msal-common-0d6bd166-040d-4ff3-b891-2c14d4a63dfc.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add interrupted user to interaction required list #8323",
+  "comment": "Add interrupted user to interaction required list [#8323](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8323)",
   "packageName": "@azure/msal-common",
   "email": "hemoral@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -885,9 +885,7 @@ export type AzureRegionConfiguration = {
     environmentRegion: string | undefined;
 };
 
-// Warning: (ae-missing-release-tag) "badToken" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const badToken = "bad_token";
 
 // Warning: (ae-missing-release-tag) "BaseAuthRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1945,9 +1943,7 @@ export type CommonUsernamePasswordRequest = BaseAuthRequest & {
     password: string;
 };
 
-// Warning: (ae-missing-release-tag) "consentRequired" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const consentRequired = "consent_required";
 
 // Warning: (ae-missing-release-tag) "Constants" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2618,9 +2614,7 @@ const INSTANCE_AWARE = "instance_aware";
 // @public (undocumented)
 function instrumentBrokerParams(parameters: Map<string, string>, correlationId?: string, performanceClient?: IPerformanceClient): void;
 
-// Warning: (ae-missing-release-tag) "interactionRequired" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const interactionRequired = "interaction_required";
 
 // Warning: (ae-missing-release-tag) "InteractionRequiredAuthError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2667,9 +2661,7 @@ export const InteractionRequiredAuthErrorMessage: {
     };
 };
 
-// Warning: (ae-missing-release-tag) "interruptedUser" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const interruptedUser = "interrupted_user";
 
 // Warning: (ae-missing-release-tag) "IntFields" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2995,9 +2987,7 @@ export type LoggerOptions = {
 // @public (undocumented)
 const LOGIN_HINT = "login_hint";
 
-// Warning: (ae-missing-release-tag) "loginRequired" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const loginRequired = "login_required";
 
 // Warning: (ae-missing-release-tag) "LogLevel" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3081,9 +3071,7 @@ const multipleMatchingTokens = "multiple_matching_tokens";
 // @public (undocumented)
 const NATIVE_BROKER = "nativebroker";
 
-// Warning: (ae-missing-release-tag) "nativeAccountUnavailable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const nativeAccountUnavailable = "native_account_unavailable";
 
 // Warning: (ae-missing-release-tag) "NativeRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3192,9 +3180,7 @@ const noNetworkConnectivity = "no_network_connectivity";
 // @public
 function normalizeUrlForComparison(url: string): string;
 
-// Warning: (ae-missing-release-tag) "noTokensFound" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const noTokensFound = "no_tokens_found";
 
 // Warning: (ae-missing-release-tag) "nowSeconds" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3848,9 +3834,7 @@ export type RefreshTokenEntity = CredentialEntity & {
     expiresOn?: string;
 };
 
-// Warning: (ae-missing-release-tag) "refreshTokenExpired" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const refreshTokenExpired = "refresh_token_expired";
 
 // Warning: (ae-missing-release-tag) "REQ_CNF" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4590,9 +4574,7 @@ const userCanceled = "user_canceled";
 // @public (undocumented)
 const userTimeoutReached = "user_timeout_reached";
 
-// Warning: (ae-missing-release-tag) "uxNotAllowed" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 const uxNotAllowed = "ux_not_allowed";
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2643,7 +2643,8 @@ declare namespace InteractionRequiredAuthErrorCodes {
         interactionRequired,
         consentRequired,
         loginRequired,
-        badToken
+        badToken,
+        interruptedUser
     }
 }
 export { InteractionRequiredAuthErrorCodes }
@@ -2665,6 +2666,11 @@ export const InteractionRequiredAuthErrorMessage: {
         desc: string;
     };
 };
+
+// Warning: (ae-missing-release-tag) "interruptedUser" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const interruptedUser = "interrupted_user";
 
 // Warning: (ae-missing-release-tag) "IntFields" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2659,6 +2659,10 @@ export const InteractionRequiredAuthErrorMessage: {
         code: string;
         desc: string;
     };
+    interrupted_user: {
+        code: string;
+        desc: string;
+    };
 };
 
 // @public

--- a/lib/msal-common/src/error/InteractionRequiredAuthError.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthError.ts
@@ -17,7 +17,7 @@ export const InteractionRequiredServerErrorMessage = [
     InteractionRequiredAuthErrorCodes.loginRequired,
     InteractionRequiredAuthErrorCodes.badToken,
     InteractionRequiredAuthErrorCodes.uxNotAllowed,
-    InteractionRequiredAuthErrorCodes.interruptedUser
+    InteractionRequiredAuthErrorCodes.interruptedUser,
 ];
 
 export const InteractionRequiredAuthSubErrorMessage = [
@@ -27,7 +27,7 @@ export const InteractionRequiredAuthSubErrorMessage = [
     "user_password_expired",
     "consent_required",
     "bad_token",
-    "interrupted_user"
+    "interrupted_user",
 ];
 
 const InteractionRequiredAuthErrorMessages = {
@@ -73,7 +73,7 @@ export const InteractionRequiredAuthErrorMessage = {
         desc: InteractionRequiredAuthErrorMessages[
             InteractionRequiredAuthErrorCodes.interruptedUser
         ],
-    }
+    },
 };
 
 /**

--- a/lib/msal-common/src/error/InteractionRequiredAuthError.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthError.ts
@@ -17,6 +17,7 @@ export const InteractionRequiredServerErrorMessage = [
     InteractionRequiredAuthErrorCodes.loginRequired,
     InteractionRequiredAuthErrorCodes.badToken,
     InteractionRequiredAuthErrorCodes.uxNotAllowed,
+    InteractionRequiredAuthErrorCodes.interruptedUser
 ];
 
 export const InteractionRequiredAuthSubErrorMessage = [
@@ -26,6 +27,7 @@ export const InteractionRequiredAuthSubErrorMessage = [
     "user_password_expired",
     "consent_required",
     "bad_token",
+    "interrupted_user"
 ];
 
 const InteractionRequiredAuthErrorMessages = {
@@ -39,6 +41,8 @@ const InteractionRequiredAuthErrorMessages = {
         "Identity provider returned bad_token due to an expired or invalid refresh token. Please invoke an interactive API to resolve.",
     [InteractionRequiredAuthErrorCodes.uxNotAllowed]:
         "`canShowUI` flag in Edge was set to false. User interaction required on web page. Please invoke an interactive API to resolve.",
+    [InteractionRequiredAuthErrorCodes.interruptedUser]:
+        "The user could not be authenticated due to an interrupted state. Please invoke an interactive API to resolve.",
 };
 
 /**

--- a/lib/msal-common/src/error/InteractionRequiredAuthError.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthError.ts
@@ -68,6 +68,12 @@ export const InteractionRequiredAuthErrorMessage = {
             InteractionRequiredAuthErrorCodes.badToken
         ],
     },
+    interrupted_user: {
+        code: InteractionRequiredAuthErrorCodes.interruptedUser,
+        desc: InteractionRequiredAuthErrorMessages[
+            InteractionRequiredAuthErrorCodes.interruptedUser
+        ],
+    }
 };
 
 /**

--- a/lib/msal-common/src/error/InteractionRequiredAuthErrorCodes.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthErrorCodes.ts
@@ -3,15 +3,49 @@
  * Licensed under the MIT License.
  */
 
-// Codes defined by MSAL
+/**
+ * MSAL-defined interaction required error code indicating no tokens are found in cache.
+ * @public
+ */
 export const noTokensFound = "no_tokens_found";
+/**
+ * MSAL-defined error code indicating a native account is unavailable on the platform.
+ * @public
+ */
 export const nativeAccountUnavailable = "native_account_unavailable";
+/**
+ * MSAL-defined error code indicating the refresh token has expired and user interaction is needed.
+ * @public
+ */
 export const refreshTokenExpired = "refresh_token_expired";
+/**
+ * MSAL-defined error code indicating UI/UX is not allowed (e.g., blocked by policy), requiring alternate interaction.
+ * @public
+ */
 export const uxNotAllowed = "ux_not_allowed";
 
-// Codes potentially returned by server
+/**
+ * Server-originated error code indicating interaction is required to complete the request.
+ * @public
+ */
 export const interactionRequired = "interaction_required";
+/**
+ * Server-originated error code indicating user consent is required.
+ * @public
+ */
 export const consentRequired = "consent_required";
+/**
+ * Server-originated error code indicating user login is required.
+ * @public
+ */
 export const loginRequired = "login_required";
+/**
+ * Server-originated error code indicating the token is invalid or corrupted.
+ * @public
+ */
 export const badToken = "bad_token";
+/**
+ * Server-originated error code indicating the user was interrupted and must reattempt the flow.
+ * @public
+ */
 export const interruptedUser = "interrupted_user";

--- a/lib/msal-common/src/error/InteractionRequiredAuthErrorCodes.ts
+++ b/lib/msal-common/src/error/InteractionRequiredAuthErrorCodes.ts
@@ -14,3 +14,4 @@ export const interactionRequired = "interaction_required";
 export const consentRequired = "consent_required";
 export const loginRequired = "login_required";
 export const badToken = "bad_token";
+export const interruptedUser = "interrupted_user";

--- a/lib/msal-common/test/error/InteractionRequiredAuthError.spec.ts
+++ b/lib/msal-common/test/error/InteractionRequiredAuthError.spec.ts
@@ -3,6 +3,8 @@ import {
     InteractionRequiredAuthSubErrorMessage,
     InteractionRequiredServerErrorMessage,
     isInteractionRequiredError,
+    createInteractionRequiredAuthError,
+    InteractionRequiredAuthErrorCodes,
 } from "../../src/error/InteractionRequiredAuthError";
 import { AuthError } from "../../src/error/AuthError";
 
@@ -93,6 +95,28 @@ describe("InteractionRequiredAuthError.ts Class Unit Tests", () => {
             expect(
                 isInteractionRequiredError("", "", "not_interaction_required")
             ).toBe(false);
+        });
+    });
+
+    describe("createInteractionRequiredAuthError()", () => {
+
+        it("produces non-empty messages for all mapped codes", () => {
+            const codes = [
+                InteractionRequiredAuthErrorCodes.noTokensFound,
+                InteractionRequiredAuthErrorCodes.nativeAccountUnavailable,
+                InteractionRequiredAuthErrorCodes.refreshTokenExpired,
+                InteractionRequiredAuthErrorCodes.badToken,
+                InteractionRequiredAuthErrorCodes.uxNotAllowed,
+                InteractionRequiredAuthErrorCodes.interruptedUser,
+            ];
+
+            codes.forEach((code) => {
+                const err = createInteractionRequiredAuthError(code);
+                expect(err instanceof InteractionRequiredAuthError).toBe(true);
+                expect(err.errorCode).toBe(code);
+                expect(typeof err.errorMessage).toBe("string");
+                expect(err.errorMessage.length).toBeGreaterThan(0);
+            });
         });
     });
 });

--- a/lib/msal-common/test/error/InteractionRequiredAuthError.spec.ts
+++ b/lib/msal-common/test/error/InteractionRequiredAuthError.spec.ts
@@ -99,7 +99,6 @@ describe("InteractionRequiredAuthError.ts Class Unit Tests", () => {
     });
 
     describe("createInteractionRequiredAuthError()", () => {
-
         it("produces non-empty messages for all mapped codes", () => {
             const codes = [
                 InteractionRequiredAuthErrorCodes.noTokensFound,


### PR DESCRIPTION
This pull request introduces a new error code, `interruptedUser`, to the MSAL Common library to better handle cases where user authentication is interrupted. The change ensures consistent support for this error code across the API, error messages, and error code enumerations.

**New error code integration:**

* Added `interruptedUser` to the `InteractionRequiredAuthErrorCodes` enum, allowing the codebase to recognize and handle this new error scenario. [[1]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117L2646-R2647) [[2]](diffhunk://#diff-9b9e373ecd25242838c370efe898168af89089ced090e293f571d816f02e8cf0R17)
* Added a corresponding error message for `interruptedUser` to `InteractionRequiredAuthErrorMessage` and included a warning about the missing release tag.
* Included `interruptedUser` in the `InteractionRequiredServerErrorMessage` and `InteractionRequiredAuthSubErrorMessage` arrays, ensuring it is recognized as a valid server and sub-error. [[1]](diffhunk://#diff-175e2da3fd2f20fd01bf24622c10e9a9a44b468507420611113b1917ea47f00bR20) [[2]](diffhunk://#diff-175e2da3fd2f20fd01bf24622c10e9a9a44b468507420611113b1917ea47f00bR30)
* Provided a descriptive error message for `interruptedUser` in `InteractionRequiredAuthErrorMessages`, guiding developers to invoke an interactive API to resolve the error.