### PR TITLE
[v4] Add strict matching to MSAL Interceptor

### DIFF
--- a/change/@azure-msal-angular-88497ef7-99f0-403f-acd9-d522982fb7ab.json
+++ b/change/@azure-msal-angular-88497ef7-99f0-403f-acd9-d522982fb7ab.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add strict matching to interceptor",
+  "comment": "Add strict matching to interceptor [#8351](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8351)",
   "packageName": "@azure/msal-angular",
   "email": "joarroyo@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-angular-88497ef7-99f0-403f-acd9-d522982fb7ab.json
+++ b/change/@azure-msal-angular-88497ef7-99f0-403f-acd9-d522982fb7ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add strict matching to interceptor",
+  "packageName": "@azure/msal-angular",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-58cc31c3-ae7f-4ac5-bd11-c5aa7076f2c1.json
+++ b/change/@azure-msal-common-58cc31c3-ae7f-4ac5-bd11-c5aa7076f2c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add strict matching to StringUtils",
+  "packageName": "@azure/msal-common",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-58cc31c3-ae7f-4ac5-bd11-c5aa7076f2c1.json
+++ b/change/@azure-msal-common-58cc31c3-ae7f-4ac5-bd11-c5aa7076f2c1.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add strict matching to StringUtils",
+  "comment": "Add strict matching to StringUtils [#8351](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8351)",
   "packageName": "@azure/msal-common",
   "email": "joarroyo@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-angular/docs/msal-interceptor.md
+++ b/lib/msal-angular/docs/msal-interceptor.md
@@ -147,6 +147,43 @@ Other things to note regarding the `protectedResourceMap`:
 * **Wildcards**: `protectedResourceMap` supports using `*` for wildcards. When using wildcards, if multiple matching entries are found in the `protectedResourceMap`, the first match found will be used (based on the order of the `protectedResourceMap`). 
 * **Relative paths**: If there are relative resource paths in your application, you may need to provide the relative path in the `protectedResourceMap`. This also applies to issues that may arise with ngx-translate. Be aware that the relative path in your `protectedResourceMap` may or may not need a leading slash depending on your app, and may need to try both.
 
+### Strict Matching (`strictMatching`)
+
+The optional `strictMatching` boolean field on `MsalInterceptorConfiguration` enables stricter, more semantically correct URL component pattern matching for `protectedResourceMap` entries. It defaults to `false` for backwards compatibility with existing applications.
+
+#### What `strictMatching: true` changes
+
+| Behaviour | Legacy (default) | Strict (`strictMatching: true`) |
+|-----------|------------------|---------------------------------|
+| Metacharacter escaping | `.` and other regex metacharacters are **not** escaped; they act as regex operators | All metacharacters (including `.`) are treated as **literals** |
+| Anchoring | Pattern may match anywhere within the string | Pattern must match the **full string** (`^…$`) |
+| Host wildcard (`*`) | `*` matches any character sequence, including `.` | `*` matches any character sequence that does **not** include `.` (wildcards stay within a single DNS label) |
+| Path/search/hash wildcard (`*`) | `*` matches any character sequence | `*` matches any character sequence (unchanged) |
+| `?` character | Passed through to the underlying regex | Treated as a **literal** `?` (URL query-string separator, not a wildcard) |
+
+With `strictMatching: true`:
+- A pattern like `*.contoso.com` matches `app.contoso.com` but **not** `a.b.contoso.com` (wildcard cannot span dot separators).
+- A pattern like `https://graph.microsoft.com/v1.0/me` matches only that exact URL.
+
+#### Enabling strict matching
+
+```javascript
+{
+    interactionType: InteractionType.Redirect,
+    protectedResourceMap: new Map([
+        ["https://*.contoso.com/api", ["contoso.scope"]],
+        ["https://graph.microsoft.com/v1.0/me", ["user.read"]]
+    ]),
+    strictMatching: true  // Enable stricter, anchored pattern matching
+}
+```
+
+#### Compatibility and migration
+
+`strictMatching` is optional and defaults to `false` in the current release line so existing applications are unaffected. You can opt in incrementally by enabling it and reviewing your `protectedResourceMap` patterns for correctness.
+
+> **Forward-looking note:** In **msal-angular v5**, `strictMatching` will be `true` by default. We recommend reviewing and updating your `protectedResourceMap` patterns to be compatible with strict matching semantics before upgrading to v5.
+
 ### Optional authRequest
 
 For more information on the optional `authRequest` that can be set in the `MsalInterceptorConfiguration`, please see our [multi-tenant doc here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/multi-tenant.md#dynamic-auth-request).

--- a/lib/msal-angular/src/msal.interceptor.config.ts
+++ b/lib/msal-angular/src/msal.interceptor.config.ts
@@ -31,6 +31,23 @@ export type MsalInterceptorConfiguration = {
         req: HttpRequest<unknown>,
         originalAuthRequest: MsalInterceptorAuthRequest
       ) => MsalInterceptorAuthRequest);
+  /**
+   * When `true`, enables stricter, more correct URL component pattern matching for
+   * `protectedResourceMap` entries. Strict matching uses anchored regex patterns and
+   * treats metacharacters (including `.`) as literals, so patterns match only their
+   * intended strings. Wildcards still apply, but host-component wildcards
+   * are constrained to a single DNS label.
+   *
+   * When `false` or omitted (default), the legacy matching behaviour is preserved for
+   * backwards compatibility.
+   *
+   * **Forward-looking note:** In msal-angular v5, `strictMatching` will be `true` by
+   * default. Applications that rely on the legacy matching behaviour should migrate to
+   * strict matching patterns before upgrading to v5.
+   *
+   * @default false
+   */
+  strictMatching?: boolean;
 };
 
 export type ProtectedResourceScopes = {

--- a/lib/msal-angular/src/msal.interceptor.spec.ts
+++ b/lib/msal-angular/src/msal.interceptor.spec.ts
@@ -31,6 +31,7 @@ let httpClient: HttpClient;
 let testInteractionType: InteractionType;
 
 let testInterceptorConfig: Partial<MsalInterceptorConfiguration> = {};
+let testStrictMatching: boolean | undefined = undefined;
 
 const sampleAccountInfo: AccountInfo = {
   homeAccountId: "test",
@@ -101,6 +102,7 @@ function MSALInterceptorFactory(): MsalInterceptorConfiguration {
       ["http://applicationF.com/profile/", ["customF.scope"]],
     ]),
     authRequest: testInterceptorConfig.authRequest,
+    strictMatching: testStrictMatching,
   };
 }
 
@@ -136,6 +138,7 @@ describe("MsalInterceptor", () => {
   beforeEach(() => {
     testInteractionType = InteractionType.Popup;
     testInterceptorConfig = {};
+    testStrictMatching = undefined;
     initializeMsal();
   });
 
@@ -1164,5 +1167,359 @@ describe("MsalInterceptor", () => {
       httpMock.verify();
       done();
     }, 200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// strictMatching option tests
+// ---------------------------------------------------------------------------
+// These tests verify that when strictMatching: true is set in the interceptor
+// configuration, URL component pattern matching uses anchored, literal-correct
+// semantics. Legacy behaviour is exercised in the main describe block above.
+// ---------------------------------------------------------------------------
+
+function MSALStrictInterceptorFactory(
+  resourceMap: Map<string, Array<string | ProtectedResourceScopes> | null>
+): MsalInterceptorConfiguration {
+  return {
+    interactionType: InteractionType.Popup,
+    protectedResourceMap: resourceMap,
+    strictMatching: true,
+  };
+}
+
+function initializeMsalStrict(
+  resourceMap: Map<string, Array<string | ProtectedResourceScopes> | null>
+) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [
+      HttpClientTestingModule,
+      RouterTestingModule,
+      MsalModule.forRoot(
+        MSALInstanceFactory(),
+        null,
+        MSALStrictInterceptorFactory(resourceMap)
+      ),
+    ],
+    providers: [
+      MsalInterceptor,
+      MsalService,
+      MsalBroadcastService,
+      {
+        provide: HTTP_INTERCEPTORS,
+        useClass: MsalInterceptor,
+        multi: true,
+      },
+      Location,
+    ],
+    teardown: { destroyAfterEach: false },
+  });
+
+  interceptor = TestBed.inject(MsalInterceptor);
+  httpMock = TestBed.inject(HttpTestingController);
+  httpClient = TestBed.inject(HttpClient);
+}
+
+describe("MsalInterceptor - strictMatching option", () => {
+  describe("strictMatching: false (default) - legacy behaviour is unchanged", () => {
+    beforeEach(() => {
+      testInteractionType = InteractionType.Popup;
+      testInterceptorConfig = {};
+      testStrictMatching = false;
+      initializeMsal();
+    });
+
+    it("attaches authorization header for wildcard host pattern (legacy behaviour)", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "access-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://mail.myapplication.com/me").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://mail.myapplication.com/me");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer access-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+
+    it("attaches authorization header for exact match (legacy behaviour)", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "access-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://graph.microsoft.com/v1.0/me").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne(
+          "https://graph.microsoft.com/v1.0/me"
+        );
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer access-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+  });
+
+  describe("strictMatching: true - strict, anchored host pattern matching", () => {
+    const strictResourceMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >([
+      // Wildcard host pattern: intended to match only direct subdomains of contoso.com
+      ["https://*.contoso.com/api", ["contoso.scope"]],
+      // Exact host pattern for baseline check
+      ["https://exact.api.com/data", ["exact.scope"]],
+    ]);
+
+    beforeEach(() => {
+      initializeMsalStrict(strictResourceMap);
+    });
+
+    it("attaches authorization header when wildcard host matches an intended subdomain", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "strict-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://app.contoso.com/api").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://app.contoso.com/api");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer strict-token"
+        );
+        expect(
+          PublicClientApplication.prototype.acquireTokenSilent
+        ).toHaveBeenCalledWith(
+          jasmine.objectContaining({ scopes: ["contoso.scope"] })
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+
+    it("does not attach authorization header when wildcard host would need to span a dot boundary", (done) => {
+      httpClient
+        .get("https://othercontoso.com/api")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne("https://othercontoso.com/api");
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
+
+    it("attaches authorization header for a second intended subdomain", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "strict-token-2" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://mail.contoso.com/api").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://mail.contoso.com/api");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer strict-token-2"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+
+    it("does not attach authorization header when wildcard would need to span multiple dot boundaries", (done) => {
+      httpClient
+        .get("https://a.b.contoso.com/api")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne("https://a.b.contoso.com/api");
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
+
+    it("attaches authorization header for an exact host pattern match", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "exact-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://exact.api.com/data").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://exact.api.com/data");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer exact-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+
+    it("does not attach authorization header when path does not match exactly under strict mode", (done) => {
+      httpClient
+        .get("https://exact.api.com/data/extra")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne("https://exact.api.com/data/extra");
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
+  });
+
+  describe("strictMatching: true - host pattern does not match hostnames in the query string", () => {
+    const microsoftResourceMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >([["https://*.microsoft.com", ["microsoft.scope"]]]);
+
+    beforeEach(() => {
+      initializeMsalStrict(microsoftResourceMap);
+    });
+
+    it("does not attach authorization header when the matched hostname appears only in the query string", (done) => {
+      httpClient
+        .get("http://other.com?redirect=login.microsoft.com")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne(
+        "http://other.com?redirect=login.microsoft.com"
+      );
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
+
+    it("attaches authorization header for an actual microsoft.com subdomain request", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "ms-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://login.microsoft.com").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://login.microsoft.com");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer ms-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+  });
+
+  describe("strictMatching: true - scheme-less wildcard key (*.microsoft.com) does not match other.com?redirect=login.microsoft.com", () => {
+    /*
+     * When a protectedResourceMap key has no scheme (e.g. "*.microsoft.com"),
+     * getAbsoluteUrl() resolves it relative to the app's own origin, so
+     * the anchor element used internally produces:
+     *   href = "http://localhost:9876/*.microsoft.com"
+     *     → host:     "localhost:9876"              (app's own origin, NOT microsoft.com)
+     *     → pathname: "/*.microsoft.com"            (wildcard lands in PATH, not host)
+     *
+     * This contrasts with the full-scheme form (tested in the describe block above):
+     *   href = "https://*.microsoft.com"
+     *     → host:     "*.microsoft.com"             (wildcard lands in HOST as intended)
+     *     → pathname: "/"
+     *
+     * Both forms correctly reject "other.com?redirect=login.microsoft.com", but for
+     * different structural reasons:
+     *   - full-scheme:  host check fails  (pattern [^.]*\.microsoft\.com ≠ other.com)
+     *   - scheme-less:  host check fails  (literal localhost:9876 ≠ other.com)
+     *
+     * Prefer the full-scheme form (https://*.microsoft.com) so that the wildcard is
+     * compared against the host component as intended, not silently moved into the path.
+     */
+    const schemelessResourceMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >([["*.microsoft.com", ["scope.less"]]]);
+
+    beforeEach(() => {
+      initializeMsalStrict(schemelessResourceMap);
+    });
+
+    it("does not attach header for other.com?redirect=login.microsoft.com (host mismatch: scheme-less key resolves to app origin, not microsoft.com)", (done) => {
+      httpClient
+        .get("http://other.com?redirect=login.microsoft.com")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne(
+        "http://other.com?redirect=login.microsoft.com"
+      );
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
   });
 });

--- a/lib/msal-angular/src/msal.interceptor.ts
+++ b/lib/msal-angular/src/msal.interceptor.ts
@@ -293,10 +293,34 @@ export class MsalInterceptor implements HttpInterceptor {
     for (const property of urlProperties) {
       if (keyComponents[property]) {
         const decodedInput = decodeURIComponent(keyComponents[property]);
-        if (
-          !StringUtils.matchPattern(decodedInput, endpointComponents[property])
-        ) {
-          return false;
+        if (this.msalInterceptorConfig.strictMatching) {
+          /*
+           * Strict matching: anchored patterns, metacharacters are literals,
+           * host wildcards do not span dot separators.
+           */
+          const component =
+            property === "pathname"
+              ? "path"
+              : (property as "host" | "protocol" | "search" | "hash");
+          if (
+            !StringUtils.matchPatternStrict(
+              decodedInput,
+              endpointComponents[property],
+              { component }
+            )
+          ) {
+            return false;
+          }
+        } else {
+          // Legacy matching: preserved exactly for backwards compatibility.
+          if (
+            !StringUtils.matchPattern(
+              decodedInput,
+              endpointComponents[property]
+            )
+          ) {
+            return false;
+          }
         }
       }
     }

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -4236,6 +4236,9 @@ export class StringUtils {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static matchPattern(pattern: string, input: string): boolean;
+    static matchPatternStrict(pattern: string, input: string, options?: {
+        component?: "host" | "path" | "protocol" | "search" | "hash";
+    }): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static queryStringToObject<T>(query: string): T;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/utils/StringUtils.ts
+++ b/lib/msal-common/src/utils/StringUtils.ts
@@ -103,4 +103,52 @@ export class StringUtils {
 
         return regex.test(input);
     }
+
+    /**
+     * Tests if a given string matches a given pattern using stricter, anchored matching semantics.
+     *
+     * Differences from `matchPattern` (legacy):
+     * - All regex metacharacters (including `.`) in the pattern are treated as literals,
+     *   so `example.com` matches only `example.com` and not `exampleXcom`.
+     * - The generated regex is anchored with `^` and `$` so partial/substring matches
+     *   are not allowed.
+     * - `*` is the only supported wildcard. Its behaviour depends on the URL component:
+     *   - `host` component: `*` matches any sequence of characters that does NOT include
+     *     a dot (`.`), keeping wildcards within a single DNS label boundary.
+     *   - All other components: `*` matches any sequence of characters (including `/`).
+     *
+     * @param pattern - The `protectedResourceMap` key pattern to match against. `*` is a
+     *   multi-character wildcard; all other characters are treated as literals.
+     * @param input - The URL component value (e.g. host, pathname) extracted from the
+     *   outgoing request URL to test against the pattern.
+     * @param options - Optional. Provide `component` to enable component-aware wildcard
+     *   semantics. Accepted values: `"host"`, `"path"`, `"protocol"`, `"search"`,
+     *   `"hash"`. Defaults to path-style (permissive) matching when omitted.
+     * @returns `true` if the full input string matches the pattern; `false` otherwise.
+     */
+    static matchPatternStrict(
+        pattern: string,
+        input: string,
+        options?: {
+            component?: "host" | "path" | "protocol" | "search" | "hash";
+        }
+    ): boolean {
+        const component = options?.component;
+
+        // Step 1: Escape all regex special characters so literals are matched literally.
+        let regexBody = pattern.replace(/[.+^${}()|[\]\\*?]/g, "\\$&");
+
+        // Step 2: Replace the escaped '*' with its component-aware regex equivalent.
+        if (component === "host") {
+            regexBody = regexBody.replace(/\\\*/g, "[^.]*");
+        } else {
+            // PATH, PROTOCOL, SEARCH, HASH, or unspecified: '*' matches any characters.
+            regexBody = regexBody.replace(/\\\*/g, ".*");
+        }
+
+        // Step 3: Anchor for full-string matching.
+        // eslint-disable-next-line security/detect-non-literal-regexp
+        const regex = new RegExp(`^${regexBody}$`);
+        return regex.test(input);
+    }
 }

--- a/lib/msal-common/test/utils/StringUtils.spec.ts
+++ b/lib/msal-common/test/utils/StringUtils.spec.ts
@@ -126,4 +126,216 @@ describe("StringUtils.ts Class Unit Tests", () => {
             expect(matches).toBe(true);
         });
     });
+
+    describe("matchPatternStrict", () => {
+        describe("host component - wildcard stays within a single DNS label", () => {
+            it("wildcard host pattern matches intended subdomain", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "*.contoso.com",
+                        "app.contoso.com",
+                        { component: "host" }
+                    )
+                ).toBe(true);
+            });
+
+            it("wildcard host pattern does not match when wildcard would span a dot boundary", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "*.contoso.com",
+                        "othercontoso.com",
+                        { component: "host" }
+                    )
+                ).toBe(false);
+            });
+
+            it("wildcard host pattern does not match multi-label wildcard expansion", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "*.contoso.com",
+                        "a.b.contoso.com",
+                        { component: "host" }
+                    )
+                ).toBe(false);
+            });
+
+            it("exact host pattern matches its intended host", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "api.contoso.com",
+                        "api.contoso.com",
+                        { component: "host" }
+                    )
+                ).toBe(true);
+            });
+
+            it("exact host pattern does not match a different host", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "api.contoso.com",
+                        "other.contoso.com",
+                        { component: "host" }
+                    )
+                ).toBe(false);
+            });
+        });
+
+        describe("dot metacharacter escaping", () => {
+            it("dot in pattern is treated as a literal dot", () => {
+                expect(
+                    StringUtils.matchPatternStrict("example.com", "example.com")
+                ).toBe(true);
+            });
+
+            it("dot in pattern does not match a non-dot character", () => {
+                expect(
+                    StringUtils.matchPatternStrict("example.com", "exampleXcom")
+                ).toBe(false);
+            });
+        });
+
+        describe("anchoring - full-string match required", () => {
+            it("pattern must match the full string, not just a substring", () => {
+                expect(
+                    StringUtils.matchPatternStrict("/user/1", "/user/1/extra", {
+                        component: "path",
+                    })
+                ).toBe(false);
+            });
+
+            it("pattern must not match a prefix of the input", () => {
+                expect(
+                    StringUtils.matchPatternStrict("contoso", "contoso.com", {
+                        component: "host",
+                    })
+                ).toBe(false);
+            });
+
+            it("pattern must not match a suffix of the input", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "contoso.com",
+                        "api.contoso.com",
+                        { component: "host" }
+                    )
+                ).toBe(false);
+            });
+        });
+
+        describe("path component - wildcard matches across slashes", () => {
+            it("path wildcard matches a single path segment", () => {
+                expect(
+                    StringUtils.matchPatternStrict("/user/*", "/user/1", {
+                        component: "path",
+                    })
+                ).toBe(true);
+            });
+
+            it("path wildcard matches multiple path segments", () => {
+                expect(
+                    StringUtils.matchPatternStrict("/user/*", "/user/1/2/3", {
+                        component: "path",
+                    })
+                ).toBe(true);
+            });
+
+            it("path wildcard does not match a completely different path", () => {
+                expect(
+                    StringUtils.matchPatternStrict("/user/*", "/admin/1", {
+                        component: "path",
+                    })
+                ).toBe(false);
+            });
+        });
+
+        describe("question mark is a literal (URL query separator)", () => {
+            it("? in a pattern matches a literal ? in the input", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "/items?page=1",
+                        "/items?page=1"
+                    )
+                ).toBe(true);
+            });
+
+            it("? in a pattern does not match a different character", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "/items?page=1",
+                        "/itemsXpage=1"
+                    )
+                ).toBe(false);
+            });
+
+            it("pattern with ? does not match input missing the ? character", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "/items?page=1",
+                        "/itemspage=1"
+                    )
+                ).toBe(false);
+            });
+        });
+
+        describe("host pattern only matches the host component, not values in other components", () => {
+            it("wildcard host pattern does not match a hostname that appears only in the query string", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "*.microsoft.com",
+                        "other.com",
+                        { component: "host" }
+                    )
+                ).toBe(false);
+            });
+
+            it("wildcard host pattern does not match a host with no dot before the domain", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "*.microsoft.com",
+                        "othermicrosoft.com",
+                        { component: "host" }
+                    )
+                ).toBe(false);
+            });
+
+            it("wildcard host pattern matches only the correct host component", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "*.microsoft.com",
+                        "login.microsoft.com",
+                        { component: "host" }
+                    )
+                ).toBe(true);
+            });
+        });
+
+        describe("no options provided - defaults to permissive wildcard semantics", () => {
+            it("* matches across any characters when no component specified", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "https://myapplication.com/user/*",
+                        "https://myapplication.com/user/1"
+                    )
+                ).toBe(true);
+            });
+
+            it("exact match succeeds when no component specified", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "https://myapplication.com/v1.0/me",
+                        "https://myapplication.com/v1.0/me"
+                    )
+                ).toBe(true);
+            });
+
+            it("non-match returns false when no component specified", () => {
+                expect(
+                    StringUtils.matchPatternStrict(
+                        "https://myapplication.com/v1.0/me",
+                        "https://myapplication.com/v1.0/other"
+                    )
+                ).toBe(false);
+            });
+        });
+    });
 });


### PR DESCRIPTION
This PR adds strict matching to MSAL Common's StringUtils, to be used in the MSAL Angular interceptor.