### PR TITLE
[v5] Strict matching default for MSAL Interceptor

### DIFF
--- a/change/@azure-msal-angular-0e4576d0-f88b-40f7-9d46-acfeca4f1bad.json
+++ b/change/@azure-msal-angular-0e4576d0-f88b-40f7-9d46-acfeca4f1bad.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Make strictMatching default",
+  "comment": "Make strictMatching default [#8355](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8355)",
   "packageName": "@azure/msal-angular",
   "email": "joarroyo@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-angular-0e4576d0-f88b-40f7-9d46-acfeca4f1bad.json
+++ b/change/@azure-msal-angular-0e4576d0-f88b-40f7-9d46-acfeca4f1bad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make strictMatching default",
+  "packageName": "@azure/msal-angular",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-8da2a968-6ae2-4495-8ca6-e327ce3f5bd1.json
+++ b/change/@azure-msal-common-8da2a968-6ae2-4495-8ca6-e327ce3f5bd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove matchPattern from StringUtils",
+  "packageName": "@azure/msal-common",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-8da2a968-6ae2-4495-8ca6-e327ce3f5bd1.json
+++ b/change/@azure-msal-common-8da2a968-6ae2-4495-8ca6-e327ce3f5bd1.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Remove matchPattern from StringUtils",
+  "comment": "Remove matchPattern from StringUtils [#8355](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8355)",
   "packageName": "@azure/msal-common",
   "email": "joarroyo@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-angular/docs/msal-interceptor.md
+++ b/lib/msal-angular/docs/msal-interceptor.md
@@ -184,6 +184,8 @@ Strict matching is enabled by default. No additional configuration is required:
 
 If your patterns rely on the looser matching from v4, you can set `strictMatching: false` to retain the legacy behaviour temporarily:
 
+> **Note:** Legacy matching (`strictMatching: false`) is provided for backwards compatibility and may be removed in a future major version. We recommend updating your `protectedResourceMap` patterns to work with strict matching.
+
 ```javascript
 {
     interactionType: InteractionType.Redirect,

--- a/lib/msal-angular/docs/msal-interceptor.md
+++ b/lib/msal-angular/docs/msal-interceptor.md
@@ -147,6 +147,54 @@ Other things to note regarding the `protectedResourceMap`:
 * **Wildcards**: `protectedResourceMap` supports using `*` for wildcards. When using wildcards, if multiple matching entries are found in the `protectedResourceMap`, the first match found will be used (based on the order of the `protectedResourceMap`). 
 * **Relative paths**: If there are relative resource paths in your application, you may need to provide the relative path in the `protectedResourceMap`. This also applies to issues that may arise with ngx-translate. Be aware that the relative path in your `protectedResourceMap` may or may not need a leading slash depending on your app, and may need to try both.
 
+### Strict Matching (`strictMatching`)
+
+In msal-angular v5, URL component pattern matching for `protectedResourceMap` entries uses strict matching semantics by default. The `strictMatching` field on `MsalInterceptorConfiguration` controls this behaviour.
+
+#### What strict matching changes
+
+| Behaviour | Legacy (`strictMatching: false`) | Strict (default in v5) |
+|-----------|----------------------------------|------------------------|
+| Metacharacter escaping | `.` and other regex metacharacters are **not** escaped; they act as regex operators | All metacharacters (including `.`) are treated as **literals** |
+| Anchoring | Pattern may match anywhere within the string | Pattern must match the **full string** (`^…$`) |
+| Host wildcard (`*`) | `*` matches any character sequence, including `.` | `*` matches any character sequence that does **not** include `.` (wildcards stay within a single DNS label) |
+| Path/search/hash wildcard (`*`) | `*` matches any character sequence | `*` matches any character sequence (unchanged) |
+| `?` character | Passed through to the underlying regex | Treated as a **literal** `?` (URL query-string separator, not a wildcard) |
+
+With strict matching (the v5 default):
+- A pattern like `*.contoso.com` matches `app.contoso.com` but **not** `a.b.contoso.com` (wildcard cannot span dot separators).
+- A pattern like `https://graph.microsoft.com/v1.0/me` matches only that exact URL.
+
+#### Default behaviour in v5 (no configuration needed)
+
+Strict matching is enabled by default. No additional configuration is required:
+
+```javascript
+{
+    interactionType: InteractionType.Redirect,
+    protectedResourceMap: new Map([
+        ["https://*.contoso.com/api", ["contoso.scope"]],
+        ["https://graph.microsoft.com/v1.0/me", ["user.read"]]
+    ])
+    // strictMatching defaults to true in v5
+}
+```
+
+#### Opting out to legacy matching (`strictMatching: false`)
+
+If your patterns rely on the looser matching from v4, you can set `strictMatching: false` to retain the legacy behaviour temporarily:
+
+```javascript
+{
+    interactionType: InteractionType.Redirect,
+    protectedResourceMap: new Map([
+        ["https://*.contoso.com/api", ["contoso.scope"]],
+        ["https://graph.microsoft.com/v1.0/me", ["user.read"]]
+    ]),
+    strictMatching: false  // Use legacy matching for backwards compatibility
+}
+```
+
 ### Optional authRequest
 
 For more information on the optional `authRequest` that can be set in the `MsalInterceptorConfiguration`, please see our [multi-tenant doc here](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-angular/docs/multi-tenant.md#dynamic-auth-request).

--- a/lib/msal-angular/docs/v4-v5-upgrade-guide.md
+++ b/lib/msal-angular/docs/v4-v5-upgrade-guide.md
@@ -4,7 +4,13 @@ MSAL Angular v5 requires a minimum version of Angular 19 and is dropping support
 
 Please see the [MSAL Browser v4-v5 migration guide](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/v4-migration.md) for browser support and other key changes.
 
-## Changes in `@azure/msal-angular@5`
+## Breaking changes in `@azure/msal-angular@5`
+
+### Strict matching for `protectedResourceMap`
+
+In msal-angular v5, URL pattern matching for protectedResourceMap entries uses strict matching semantics by default. Strict matching treats pattern metacharacters as literals, anchors matches to the full URL component, and applies host wildcard rules that do not span dot separators. If your v4 configuration relied on looser matching behavior, update your protectedResourceMap patterns to align with strict matching, or set strictMatching to false to retain legacy behavior temporarily. See [MSAL Interceptor docs](./msal-interceptor.md) for more details.
+
+## Other changes in `@azure/msal-angular@5`
 
 ### `inject(TOKEN)` syntax
 

--- a/lib/msal-angular/docs/v4-v5-upgrade-guide.md
+++ b/lib/msal-angular/docs/v4-v5-upgrade-guide.md
@@ -8,7 +8,7 @@ Please see the [MSAL Browser v4-v5 migration guide](https://github.com/AzureAD/m
 
 ### Strict matching for `protectedResourceMap`
 
-In msal-angular v5, URL pattern matching for protectedResourceMap entries uses strict matching semantics by default. Strict matching treats pattern metacharacters as literals, anchors matches to the full URL component, and applies host wildcard rules that do not span dot separators. If your v4 configuration relied on looser matching behavior, update your protectedResourceMap patterns to align with strict matching, or set strictMatching to false to retain legacy behavior temporarily. See [MSAL Interceptor docs](./msal-interceptor.md) for more details.
+In msal-angular v5, URL pattern matching for protectedResourceMap entries uses strict matching semantics by default. Strict matching treats pattern metacharacters as literals, anchors matches to the full URL component, and applies host wildcard rules that do not span dot separators. If your v4 configuration relied on looser matching behavior, update your protectedResourceMap patterns to align with strict matching, or set strictMatching to false to retain legacy behavior temporarily. See [MSAL Interceptor docs](./msal-interceptor.md#strict-matching-strictmatching) for more details.
 
 ## Other changes in `@azure/msal-angular@5`
 

--- a/lib/msal-angular/src/msal.interceptor.config.ts
+++ b/lib/msal-angular/src/msal.interceptor.config.ts
@@ -31,6 +31,19 @@ export type MsalInterceptorConfiguration = {
         req: HttpRequest<unknown>,
         originalAuthRequest: MsalInterceptorAuthRequest
       ) => MsalInterceptorAuthRequest);
+  /**
+   * When `true` (the default in v5), enables stricter, more correct URL component pattern matching for
+   * `protectedResourceMap` entries. Strict matching uses anchored regex patterns and
+   * treats metacharacters (including `.`) as literals, so patterns match only their
+   * intended strings. Wildcards still apply, but host-component wildcards
+   * are constrained to a single DNS label.
+   * 
+   * Set to `false` to use the legacy matching behaviour from v4 for
+   * backwards compatibility.
+   *
+   * @default true
+   */
+  strictMatching?: boolean;
 };
 
 export type ProtectedResourceScopes = {

--- a/lib/msal-angular/src/msal.interceptor.config.ts
+++ b/lib/msal-angular/src/msal.interceptor.config.ts
@@ -37,7 +37,7 @@ export type MsalInterceptorConfiguration = {
    * treats metacharacters (including `.`) as literals, so patterns match only their
    * intended strings. Wildcards still apply, but host-component wildcards
    * are constrained to a single DNS label.
-   * 
+   *
    * Set to `false` to use the legacy matching behaviour from v4 for
    * backwards compatibility.
    *

--- a/lib/msal-angular/src/msal.interceptor.spec.ts
+++ b/lib/msal-angular/src/msal.interceptor.spec.ts
@@ -1354,6 +1354,48 @@ describe("matchPatternStrict unit tests", () => {
       expect(match("/v1.0/me", "/v1.0/other", "path")).toBe(false);
     });
   });
+
+  describe("edge cases", () => {
+    it("empty pattern matches empty input", () => {
+      expect(match("", "", "host")).toBe(true);
+    });
+
+    it("empty pattern does not match non-empty input", () => {
+      expect(match("", "something", "host")).toBe(false);
+    });
+
+    it("non-empty pattern does not match empty input", () => {
+      expect(match("example.com", "", "host")).toBe(false);
+    });
+
+    it("host wildcard-only pattern matches a label with no dots", () => {
+      expect(match("*", "anything", "host")).toBe(true);
+    });
+
+    it("host wildcard-only pattern does not match input containing a dot", () => {
+      expect(match("*", "a.b", "host")).toBe(false);
+    });
+
+    it("host pattern with port number matches correctly", () => {
+      expect(match("*.contoso.com:443", "app.contoso.com:443", "host")).toBe(
+        true
+      );
+    });
+
+    it("host pattern with port does not match different port", () => {
+      expect(match("*.contoso.com:443", "app.contoso.com:8080", "host")).toBe(
+        false
+      );
+    });
+
+    it("multiple wildcards in host pattern match multiple labels", () => {
+      expect(match("*.*.contoso.com", "a.b.contoso.com", "host")).toBe(true);
+    });
+
+    it("multiple wildcards in host do not match fewer labels than wildcards", () => {
+      expect(match("*.*.contoso.com", "a.contoso.com", "host")).toBe(false);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1522,6 +1564,55 @@ describe("msal.interceptor matchPattern (legacy)", () => {
       httpMock.verify();
       done();
     }, 200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchPattern direct unit tests (exercising the legacy private helper via cast)
+// ---------------------------------------------------------------------------
+// These tests mirror the matchPattern tests that were previously in
+// StringUtils.spec.ts (msal-common) and in the fix/strict-matching-option branch.
+// matchPattern was moved from StringUtils to MsalInterceptor as a private method.
+// ---------------------------------------------------------------------------
+describe("matchPattern unit tests (legacy)", () => {
+  let matchLegacy: (pattern: string, input: string) => boolean;
+
+  beforeEach(() => {
+    const emptyMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >();
+    initializeMsalStrict(emptyMap, false);
+    matchLegacy = (interceptor as any).matchPattern.bind(interceptor);
+  });
+
+  it("no wildcard", () => {
+    const matches = matchLegacy(
+      "https://myapplication.com/user/1",
+      "https://myapplication.com/user/1"
+    );
+    expect(matches).toBe(true);
+  });
+
+  it("single wildcard", () => {
+    const matches = matchLegacy(
+      "https://myapplication.com/user/*",
+      "https://myapplication.com/user/1"
+    );
+    expect(matches).toBe(true);
+  });
+
+  it("multiple wildcards", () => {
+    const matches = matchLegacy(
+      "https://*.myapplication.com/user/*",
+      "https://test.myapplication.com/user/1"
+    );
+    expect(matches).toBe(true);
+  });
+
+  it("backslash is escaped", () => {
+    const matches = matchLegacy("test\\*", "test\\api");
+    expect(matches).toBe(true);
   });
 });
 

--- a/lib/msal-angular/src/msal.interceptor.spec.ts
+++ b/lib/msal-angular/src/msal.interceptor.spec.ts
@@ -107,6 +107,8 @@ function MSALInterceptorFactory(): MsalInterceptorConfiguration {
       ["http://applicationF.com/profile/", ["customF.scope"]],
     ]),
     authRequest: testInterceptorConfig.authRequest,
+    // Legacy test suite: use legacy matching to preserve existing test coverage
+    strictMatching: false,
   };
 }
 
@@ -1171,5 +1173,501 @@ describe("MsalInterceptor", () => {
       httpMock.verify();
       done();
     }, 200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchPatternStrict / matchPattern helper tests
+// ---------------------------------------------------------------------------
+// These tests exercise the local matching helpers defined in MsalInterceptor.
+// They are invoked indirectly through the interceptor's URL-matching flow.
+// ---------------------------------------------------------------------------
+
+function MSALStrictInterceptorFactory(
+  resourceMap: Map<string, Array<string | ProtectedResourceScopes> | null>,
+  strict?: boolean
+): MsalInterceptorConfiguration {
+  return {
+    interactionType: InteractionType.Popup,
+    protectedResourceMap: resourceMap,
+    strictMatching: strict,
+  };
+}
+
+function initializeMsalStrict(
+  resourceMap: Map<string, Array<string | ProtectedResourceScopes> | null>,
+  strict?: boolean
+) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [
+      MsalModule.forRoot(
+        MSALInstanceFactory(),
+        null,
+        MSALStrictInterceptorFactory(resourceMap, strict)
+      ),
+    ],
+    providers: [
+      MsalInterceptor,
+      MsalService,
+      MsalBroadcastService,
+      {
+        provide: HTTP_INTERCEPTORS,
+        useClass: MsalInterceptor,
+        multi: true,
+      },
+      Location,
+      provideHttpClient(withInterceptorsFromDi()),
+      provideHttpClientTesting(),
+      provideRouter([]),
+    ],
+    teardown: { destroyAfterEach: false },
+  });
+
+  interceptor = TestBed.inject(MsalInterceptor);
+  httpMock = TestBed.inject(HttpTestingController);
+  httpClient = TestBed.inject(HttpClient);
+}
+
+// ---------------------------------------------------------------------------
+// matchPatternStrict direct unit tests (exercising the private helper via cast)
+// ---------------------------------------------------------------------------
+describe("matchPatternStrict unit tests", () => {
+  // Access the private method via cast for direct unit testing.
+  let match: (pattern: string, input: string, component: "protocol" | "host" | "path" | "search" | "hash") => boolean;
+
+  beforeEach(() => {
+    const emptyMap = new Map<string, Array<string | ProtectedResourceScopes> | null>();
+    initializeMsalStrict(emptyMap);
+    match = (interceptor as any).matchPatternStrict.bind(interceptor);
+  });
+
+  describe("host component - wildcard stays within a single DNS label", () => {
+    it("wildcard host pattern matches intended subdomain", () => {
+      expect(match("*.contoso.com", "app.contoso.com", "host")).toBe(true);
+    });
+
+    it("wildcard host pattern does not match when wildcard would span a dot boundary", () => {
+      expect(match("*.contoso.com", "othercontoso.com", "host")).toBe(false);
+    });
+
+    it("wildcard host pattern does not match multi-label wildcard expansion", () => {
+      expect(match("*.contoso.com", "a.b.contoso.com", "host")).toBe(false);
+    });
+
+    it("exact host pattern matches its intended host", () => {
+      expect(match("api.contoso.com", "api.contoso.com", "host")).toBe(true);
+    });
+
+    it("exact host pattern does not match a different host", () => {
+      expect(match("api.contoso.com", "other.contoso.com", "host")).toBe(false);
+    });
+  });
+
+  describe("dot metacharacter escaping", () => {
+    it("dot in pattern is treated as a literal dot", () => {
+      expect(match("example.com", "example.com", "host")).toBe(true);
+    });
+
+    it("dot in pattern does not match a non-dot character", () => {
+      expect(match("example.com", "exampleXcom", "host")).toBe(false);
+    });
+  });
+
+  describe("anchoring - full-string match required", () => {
+    it("pattern must match the full string, not just a substring", () => {
+      expect(match("/user/1", "/user/1/extra", "path")).toBe(false);
+    });
+
+    it("pattern must not match a prefix of the input", () => {
+      expect(match("contoso", "contoso.com", "host")).toBe(false);
+    });
+
+    it("pattern must not match a suffix of the input", () => {
+      expect(match("contoso.com", "api.contoso.com", "host")).toBe(false);
+    });
+  });
+
+  describe("path component - wildcard matches across slashes", () => {
+    it("path wildcard matches a single path segment", () => {
+      expect(match("/user/*", "/user/1", "path")).toBe(true);
+    });
+
+    it("path wildcard matches multiple path segments", () => {
+      expect(match("/user/*", "/user/1/2/3", "path")).toBe(true);
+    });
+
+    it("path wildcard does not match a completely different path", () => {
+      expect(match("/user/*", "/admin/1", "path")).toBe(false);
+    });
+  });
+
+  describe("question mark is a literal (URL query separator)", () => {
+    it("? in a pattern matches a literal ? in the input", () => {
+      expect(match("/items?page=1", "/items?page=1", "path")).toBe(true);
+    });
+
+    it("? in a pattern does not match a different character", () => {
+      expect(match("/items?page=1", "/itemsXpage=1", "path")).toBe(false);
+    });
+
+    it("pattern with ? does not match input missing the ? character", () => {
+      expect(match("/items?page=1", "/itemspage=1", "path")).toBe(false);
+    });
+  });
+
+  describe("host pattern only matches the host component", () => {
+    it("wildcard host pattern does not match a completely different hostname", () => {
+      expect(match("*.microsoft.com", "other.com", "host")).toBe(false);
+    });
+
+    it("wildcard host pattern does not match a host with no dot before the domain", () => {
+      expect(match("*.microsoft.com", "othermicrosoft.com", "host")).toBe(false);
+    });
+
+    it("wildcard host pattern matches only the correct host component", () => {
+      expect(match("*.microsoft.com", "login.microsoft.com", "host")).toBe(true);
+    });
+  });
+
+  describe("no component-specific semantics for path - defaults to permissive wildcard", () => {
+    it("* matches across any characters in path component", () => {
+      expect(match("/user/*", "/user/1", "path")).toBe(true);
+    });
+
+    it("exact match succeeds in path component", () => {
+      expect(match("/v1.0/me", "/v1.0/me", "path")).toBe(true);
+    });
+
+    it("non-match returns false in path component", () => {
+      expect(match("/v1.0/me", "/v1.0/other", "path")).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchPatternStrict integration tests (via interceptor matching flow)
+// ---------------------------------------------------------------------------
+describe("msal.interceptor matchPatternStrict", () => {
+  const hostwildcardMap = new Map<
+    string,
+    Array<string | ProtectedResourceScopes> | null
+  >([
+    ["https://*.contoso.com/api", ["contoso.scope"]],
+    ["https://exact.api.com/data", ["exact.scope"]],
+  ]);
+
+  describe("host wildcard matching", () => {
+    beforeEach(() => {
+      initializeMsalStrict(hostwildcardMap);
+    });
+
+    it("msal.interceptor matchPatternStrict: host wildcard matches a single-label subdomain", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "strict-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://app.contoso.com/api").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://app.contoso.com/api");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer strict-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+
+    it("msal.interceptor matchPatternStrict: host wildcard does not span dot separators", (done) => {
+      httpClient
+        .get("https://a.b.contoso.com/api")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne("https://a.b.contoso.com/api");
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
+
+    it("msal.interceptor matchPatternStrict: pattern is anchored (no substring matches)", (done) => {
+      httpClient
+        .get("https://exact.api.com/data/extra")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne("https://exact.api.com/data/extra");
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
+
+    it("msal.interceptor matchPatternStrict: treats regex metacharacters as literals", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "exact-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://exact.api.com/data").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://exact.api.com/data");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer exact-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+  });
+
+  describe("pathname matching", () => {
+    const pathMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >([["https://myapplication.com/user/*", ["customscope.read"]]]);
+
+    beforeEach(() => {
+      initializeMsalStrict(pathMap);
+    });
+
+    it("msal.interceptor matchPatternStrict: pathname wildcard matches expected segments", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "path-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://myapplication.com/user/1").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne(
+          "https://myapplication.com/user/1"
+        );
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer path-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+  });
+});
+
+describe("msal.interceptor matchPattern (legacy)", () => {
+  it("msal.interceptor matchPattern: legacy behavior is unchanged for existing patterns", (done) => {
+    const legacyMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >([
+      ["https://*.myapplication.com/*", ["mail.read"]],
+    ]);
+    initializeMsalStrict(legacyMap, false);
+
+    spyOn(
+      PublicClientApplication.prototype,
+      "acquireTokenSilent"
+    ).and.returnValue(
+      new Promise((resolve) => {
+        // @ts-ignore
+        resolve({ accessToken: "legacy-token" });
+      })
+    );
+    spyOn(
+      PublicClientApplication.prototype,
+      "getAllAccounts"
+    ).and.returnValue([sampleAccountInfo]);
+
+    httpClient.get("https://mail.myapplication.com/me").subscribe();
+    setTimeout(() => {
+      const request = httpMock.expectOne(
+        "https://mail.myapplication.com/me"
+      );
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toEqual(
+        "Bearer legacy-token"
+      );
+      httpMock.verify();
+      done();
+    }, 200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MsalInterceptor strict matching integration tests
+// ---------------------------------------------------------------------------
+describe("MsalInterceptor - strictMatching option", () => {
+  describe("MsalInterceptor: uses strict matching by default for protectedResourceMap entries", () => {
+    const defaultStrictMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >([
+      ["https://*.contoso.com/api", ["contoso.scope"]],
+      ["https://exact.api.com/data", ["exact.scope"]],
+    ]);
+
+    beforeEach(() => {
+      // No strictMatching field set — should default to strict (v5)
+      initializeMsalStrict(defaultStrictMap);
+    });
+
+    it("MsalInterceptor: attaches authorization header only when URL components match configured pattern", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "default-strict-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://app.contoso.com/api").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://app.contoso.com/api");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer default-strict-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+
+    it("MsalInterceptor: strict matching applies host label boundaries for wildcard hosts", (done) => {
+      httpClient
+        .get("https://a.b.contoso.com/api")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne("https://a.b.contoso.com/api");
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
+  });
+
+  describe("MsalInterceptor: strictMatching=false uses legacy matching behavior", () => {
+    const legacyMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >([
+      ["https://*.contoso.com/api", ["contoso.scope"]],
+    ]);
+
+    beforeEach(() => {
+      initializeMsalStrict(legacyMap, false);
+    });
+
+    it("MsalInterceptor: strictMatching=false uses legacy matching behavior", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "legacy-compat-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://app.contoso.com/api").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://app.contoso.com/api");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer legacy-compat-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
+  });
+
+  describe("strictMatching: true - host pattern does not match hostnames in the query string", () => {
+    const microsoftResourceMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >([["https://*.microsoft.com", ["microsoft.scope"]]]);
+
+    beforeEach(() => {
+      initializeMsalStrict(microsoftResourceMap);
+    });
+
+    it("does not attach authorization header when the matched hostname appears only in the query string", (done) => {
+      httpClient
+        .get("http://other.com?redirect=login.microsoft.com")
+        .subscribe((response) => expect(response).toBeTruthy());
+
+      const request = httpMock.expectOne(
+        "http://other.com?redirect=login.microsoft.com"
+      );
+      request.flush({ data: "test" });
+      expect(request.request.headers.get("Authorization")).toBeNull();
+      httpMock.verify();
+      done();
+    });
+
+    it("attaches authorization header for an actual microsoft.com subdomain request", (done) => {
+      spyOn(
+        PublicClientApplication.prototype,
+        "acquireTokenSilent"
+      ).and.returnValue(
+        new Promise((resolve) => {
+          // @ts-ignore
+          resolve({ accessToken: "ms-token" });
+        })
+      );
+      spyOn(
+        PublicClientApplication.prototype,
+        "getAllAccounts"
+      ).and.returnValue([sampleAccountInfo]);
+
+      httpClient.get("https://login.microsoft.com").subscribe();
+      setTimeout(() => {
+        const request = httpMock.expectOne("https://login.microsoft.com");
+        request.flush({ data: "test" });
+        expect(request.request.headers.get("Authorization")).toEqual(
+          "Bearer ms-token"
+        );
+        httpMock.verify();
+        done();
+      }, 200);
+    });
   });
 });

--- a/lib/msal-angular/src/msal.interceptor.spec.ts
+++ b/lib/msal-angular/src/msal.interceptor.spec.ts
@@ -1234,10 +1234,17 @@ function initializeMsalStrict(
 // ---------------------------------------------------------------------------
 describe("matchPatternStrict unit tests", () => {
   // Access the private method via cast for direct unit testing.
-  let match: (pattern: string, input: string, component: "protocol" | "host" | "path" | "search" | "hash") => boolean;
+  let match: (
+    pattern: string,
+    input: string,
+    component: "protocol" | "host" | "path" | "search" | "hash"
+  ) => boolean;
 
   beforeEach(() => {
-    const emptyMap = new Map<string, Array<string | ProtectedResourceScopes> | null>();
+    const emptyMap = new Map<
+      string,
+      Array<string | ProtectedResourceScopes> | null
+    >();
     initializeMsalStrict(emptyMap);
     match = (interceptor as any).matchPatternStrict.bind(interceptor);
   });
@@ -1322,11 +1329,15 @@ describe("matchPatternStrict unit tests", () => {
     });
 
     it("wildcard host pattern does not match a host with no dot before the domain", () => {
-      expect(match("*.microsoft.com", "othermicrosoft.com", "host")).toBe(false);
+      expect(match("*.microsoft.com", "othermicrosoft.com", "host")).toBe(
+        false
+      );
     });
 
     it("wildcard host pattern matches only the correct host component", () => {
-      expect(match("*.microsoft.com", "login.microsoft.com", "host")).toBe(true);
+      expect(match("*.microsoft.com", "login.microsoft.com", "host")).toBe(
+        true
+      );
     });
   });
 
@@ -1468,9 +1479,7 @@ describe("msal.interceptor matchPatternStrict", () => {
 
       httpClient.get("https://myapplication.com/user/1").subscribe();
       setTimeout(() => {
-        const request = httpMock.expectOne(
-          "https://myapplication.com/user/1"
-        );
+        const request = httpMock.expectOne("https://myapplication.com/user/1");
         request.flush({ data: "test" });
         expect(request.request.headers.get("Authorization")).toEqual(
           "Bearer path-token"
@@ -1487,9 +1496,7 @@ describe("msal.interceptor matchPattern (legacy)", () => {
     const legacyMap = new Map<
       string,
       Array<string | ProtectedResourceScopes> | null
-    >([
-      ["https://*.myapplication.com/*", ["mail.read"]],
-    ]);
+    >([["https://*.myapplication.com/*", ["mail.read"]]]);
     initializeMsalStrict(legacyMap, false);
 
     spyOn(
@@ -1501,16 +1508,13 @@ describe("msal.interceptor matchPattern (legacy)", () => {
         resolve({ accessToken: "legacy-token" });
       })
     );
-    spyOn(
-      PublicClientApplication.prototype,
-      "getAllAccounts"
-    ).and.returnValue([sampleAccountInfo]);
+    spyOn(PublicClientApplication.prototype, "getAllAccounts").and.returnValue([
+      sampleAccountInfo,
+    ]);
 
     httpClient.get("https://mail.myapplication.com/me").subscribe();
     setTimeout(() => {
-      const request = httpMock.expectOne(
-        "https://mail.myapplication.com/me"
-      );
+      const request = httpMock.expectOne("https://mail.myapplication.com/me");
       request.flush({ data: "test" });
       expect(request.request.headers.get("Authorization")).toEqual(
         "Bearer legacy-token"
@@ -1583,9 +1587,7 @@ describe("MsalInterceptor - strictMatching option", () => {
     const legacyMap = new Map<
       string,
       Array<string | ProtectedResourceScopes> | null
-    >([
-      ["https://*.contoso.com/api", ["contoso.scope"]],
-    ]);
+    >([["https://*.contoso.com/api", ["contoso.scope"]]]);
 
     beforeEach(() => {
       initializeMsalStrict(legacyMap, false);

--- a/lib/msal-angular/src/msal.interceptor.ts
+++ b/lib/msal-angular/src/msal.interceptor.ts
@@ -296,11 +296,36 @@ export class MsalInterceptor implements HttpInterceptor {
     // URL properties from https://developer.mozilla.org/en-US/docs/Web/API/URL
     const urlProperties = ["protocol", "host", "pathname", "search", "hash"];
 
+    const useStrictMatching = this.msalInterceptorConfig.strictMatching !== false;
+
     for (const property of urlProperties) {
       if (keyComponents[property]) {
         const decodedInput = decodeURIComponent(keyComponents[property]);
-        if (!this.matchPattern(decodedInput, endpointComponents[property])) {
-          return false;
+        if (useStrictMatching) {
+          /*
+           * Strict matching (v5 default): anchored patterns, metacharacters
+           * are treated as literals, host wildcards do not span dot separators.
+           */
+          const component =
+            property === "pathname"
+              ? "path"
+              : (property as "host" | "protocol" | "search" | "hash");
+          if (
+            !this.matchPatternStrict(
+              decodedInput,
+              endpointComponents[property],
+              component
+            )
+          ) {
+            return false;
+          }
+        } else {
+          // Legacy matching: preserved for backwards compatibility with v4.
+          if (
+            !this.matchPattern(decodedInput, endpointComponents[property])
+          ) {
+            return false;
+          }
         }
       }
     }
@@ -409,6 +434,48 @@ export class MsalInterceptor implements HttpInterceptor {
         .replace(/\?/g, "\\?")
     );
 
+    return regex.test(input);
+  }
+
+  /**
+   * Tests if a given string matches a given pattern using stricter, anchored
+   * matching semantics.
+   *
+   * Differences from `matchPattern` (legacy):
+   * - All regex metacharacters (including `.`) are treated as literals.
+   * - The generated regex is anchored with `^` and `$` (full-string match).
+   * - `*` wildcard behaviour depends on the URL component:
+   *   - `host`: `*` matches any characters that do NOT include `.`
+   *     (wildcards stay within a single DNS label).
+   *   - All other components: `*` matches any characters.
+   *
+   * @param pattern - The protectedResourceMap key pattern.
+   * @param input - The URL component value from the outgoing request.
+   * @param component - Which URL component is being matched.
+   * @returns `true` if the full input string matches the pattern.
+   */
+  private matchPatternStrict(
+    pattern: string,
+    input: string,
+    component: "protocol" | "host" | "path" | "search" | "hash"
+  ): boolean {
+    // Step 1: Escape all regex metacharacters so literals match literally.
+    let regexBody = pattern.replace(/[.+^${}()|[\]\\*?]/g, "\\$&");
+
+    // Step 2: Replace escaped wildcards with component-aware regex equivalents.
+    if (component === "host") {
+      regexBody = regexBody.replace(/\\\*/g, "[^.]*");
+    } else {
+      // Path, protocol, search, hash: `*` matches any characters.
+      regexBody = regexBody.replace(/\\\*/g, ".*");
+    }
+
+    // Treat `?` as a literal (URL query-string separator, not a wildcard).
+    regexBody = regexBody.replace(/\\\?/g, "\\?");
+
+    // Step 3: Anchor for full-string matching.
+    // eslint-disable-next-line security/detect-non-literal-regexp
+    const regex = new RegExp(`^${regexBody}$`);
     return regex.test(input);
   }
 }

--- a/lib/msal-angular/src/msal.interceptor.ts
+++ b/lib/msal-angular/src/msal.interceptor.ts
@@ -296,6 +296,18 @@ export class MsalInterceptor implements HttpInterceptor {
     // URL properties from https://developer.mozilla.org/en-US/docs/Web/API/URL
     const urlProperties = ["protocol", "host", "pathname", "search", "hash"];
 
+    // Maps URL property names to the component identifiers used by matchPatternStrict.
+    const componentMap: Record<
+      string,
+      "protocol" | "host" | "path" | "search" | "hash"
+    > = {
+      protocol: "protocol",
+      host: "host",
+      pathname: "path",
+      search: "search",
+      hash: "hash",
+    };
+
     const useStrictMatching =
       this.msalInterceptorConfig.strictMatching !== false;
 
@@ -307,10 +319,7 @@ export class MsalInterceptor implements HttpInterceptor {
            * Strict matching (v5 default): anchored patterns, metacharacters
            * are treated as literals, host wildcards do not span dot separators.
            */
-          const component =
-            property === "pathname"
-              ? "path"
-              : (property as "host" | "protocol" | "search" | "hash");
+          const component = componentMap[property];
           if (
             !this.matchPatternStrict(
               decodedInput,
@@ -441,11 +450,11 @@ export class MsalInterceptor implements HttpInterceptor {
    * matching semantics.
    *
    * Differences from `matchPattern` (legacy):
-   * - All regex metacharacters (including `.`) are treated as literals.
+   * - All regex metacharacters (including `.` and `?`) are treated as literals.
    * - The generated regex is anchored with `^` and `$` (full-string match).
    * - `*` wildcard behaviour depends on the URL component:
-   *   - `host`: `*` matches any characters that do NOT include `.`
-   *     (wildcards stay within a single DNS label).
+   *   - `host`: `*` maps to `[^.]*` — matches any characters that do NOT
+   *     include `.`, so wildcards stay within a single DNS label.
    *   - All other components: `*` matches any characters.
    *
    * @param pattern - The protectedResourceMap key pattern.
@@ -458,7 +467,7 @@ export class MsalInterceptor implements HttpInterceptor {
     input: string,
     component: "protocol" | "host" | "path" | "search" | "hash"
   ): boolean {
-    // Step 1: Escape all regex metacharacters so literals match literally.
+    // Step 1: Escape all regex metacharacters so literals (including . and ?) match literally.
     let regexBody = pattern.replace(/[.+^${}()|[\]\\*?]/g, "\\$&");
 
     // Step 2: Replace escaped wildcards with component-aware regex equivalents.
@@ -468,9 +477,6 @@ export class MsalInterceptor implements HttpInterceptor {
       // Path, protocol, search, hash: `*` matches any characters.
       regexBody = regexBody.replace(/\\\*/g, ".*");
     }
-
-    // Treat `?` as a literal (URL query-string separator, not a wildcard).
-    regexBody = regexBody.replace(/\\\?/g, "\\?");
 
     // Step 3: Anchor for full-string matching.
     // eslint-disable-next-line security/detect-non-literal-regexp

--- a/lib/msal-angular/src/msal.interceptor.ts
+++ b/lib/msal-angular/src/msal.interceptor.ts
@@ -296,7 +296,8 @@ export class MsalInterceptor implements HttpInterceptor {
     // URL properties from https://developer.mozilla.org/en-US/docs/Web/API/URL
     const urlProperties = ["protocol", "host", "pathname", "search", "hash"];
 
-    const useStrictMatching = this.msalInterceptorConfig.strictMatching !== false;
+    const useStrictMatching =
+      this.msalInterceptorConfig.strictMatching !== false;
 
     for (const property of urlProperties) {
       if (keyComponents[property]) {
@@ -321,9 +322,7 @@ export class MsalInterceptor implements HttpInterceptor {
           }
         } else {
           // Legacy matching: preserved for backwards compatibility with v4.
-          if (
-            !this.matchPattern(decodedInput, endpointComponents[property])
-          ) {
+          if (!this.matchPattern(decodedInput, endpointComponents[property])) {
             return false;
           }
         }

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -4282,9 +4282,6 @@ export class StringUtils {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static jsonParseHelper<T>(str: string): T | null;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    static matchPattern(pattern: string, input: string): boolean;
-    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static queryStringToObject<T>(query: string): T;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     static removeEmptyStringsFromArray(arr: Array<string>): Array<string>;

--- a/lib/msal-common/src/utils/StringUtils.ts
+++ b/lib/msal-common/src/utils/StringUtils.ts
@@ -83,24 +83,4 @@ export class StringUtils {
         }
     }
 
-    /**
-     * Tests if a given string matches a given pattern, with support for wildcards and queries.
-     * @param pattern Wildcard pattern to string match. Supports "*" for wildcards and "?" for queries
-     * @param input String to match against
-     */
-    static matchPattern(pattern: string, input: string): boolean {
-        /**
-         * Wildcard support: https://stackoverflow.com/a/3117248/4888559
-         * Queries: replaces "?" in string with escaped "\?" for regex test
-         */
-        // eslint-disable-next-line security/detect-non-literal-regexp
-        const regex: RegExp = new RegExp(
-            pattern
-                .replace(/\\/g, "\\\\")
-                .replace(/\*/g, "[^ ]*")
-                .replace(/\?/g, "\\?")
-        );
-
-        return regex.test(input);
-    }
 }

--- a/lib/msal-common/src/utils/StringUtils.ts
+++ b/lib/msal-common/src/utils/StringUtils.ts
@@ -82,5 +82,4 @@ export class StringUtils {
             return null;
         }
     }
-
 }

--- a/lib/msal-common/test/utils/StringUtils.spec.ts
+++ b/lib/msal-common/test/utils/StringUtils.spec.ts
@@ -91,5 +91,4 @@ describe("StringUtils.ts Class Unit Tests", () => {
             expect(parsedValEmptyString).toBeNull();
         });
     });
-
 });

--- a/lib/msal-common/test/utils/StringUtils.spec.ts
+++ b/lib/msal-common/test/utils/StringUtils.spec.ts
@@ -92,38 +92,4 @@ describe("StringUtils.ts Class Unit Tests", () => {
         });
     });
 
-    describe("matchPattern", () => {
-        it("no wildcard", () => {
-            const matches = StringUtils.matchPattern(
-                "https://myapplication.com/user/1",
-                "https://myapplication.com/user/1"
-            );
-
-            expect(matches).toBe(true);
-        });
-
-        it("single wildcard", () => {
-            const matches = StringUtils.matchPattern(
-                "https://myapplication.com/user/*",
-                "https://myapplication.com/user/1"
-            );
-
-            expect(matches).toBe(true);
-        });
-
-        it("multiple wildcards", () => {
-            const matches = StringUtils.matchPattern(
-                "https://*.myapplication.com/user/*",
-                "https://test.myapplication.com/user/1"
-            );
-
-            expect(matches).toBe(true);
-        });
-
-        it("backslash is escaped", () => {
-            const matches = StringUtils.matchPattern("test\\*", "test\\api");
-
-            expect(matches).toBe(true);
-        });
-    });
 });


### PR DESCRIPTION
This PR makes strictMatching the default for the MSAL Angular interceptor.