### PR TITLE
Nest dynamic telemetry events

### DIFF
--- a/change/@azure-msal-common-adfe5127-b014-4bb3-a5c9-e227babd1432.json
+++ b/change/@azure-msal-common-adfe5127-b014-4bb3-a5c9-e227babd1432.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Nest dynamic telemetry events",
+  "comment": "Nest dynamic telemetry events #8357",
   "packageName": "@azure/msal-common",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-adfe5127-b014-4bb3-a5c9-e227babd1432.json
+++ b/change/@azure-msal-common-adfe5127-b014-4bb3-a5c9-e227babd1432.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Nest dynamic telemetry events",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-adfe5127-b014-4bb3-a5c9-e227babd1432.json
+++ b/change/@azure-msal-common-adfe5127-b014-4bb3-a5c9-e227babd1432.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Nest dynamic telemetry events #8357",
+  "comment": "Nest dynamic telemetry events [#8357](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8357)",
   "packageName": "@azure/msal-common",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -786,9 +786,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(event.correlationId).toBeDefined();
                 expect(event.success).toBeTruthy();
                 expect(
-                    event["handleRedirectPromiseDurationMs"]
+                    event.ext?.["handleRedirectPromiseDurationMs"]
                 ).toBeGreaterThanOrEqual(0);
-                expect(event["handleRedirectPromiseCallCount"]).toEqual(1);
+                expect(event.ext?.["handleRedirectPromiseCallCount"]).toEqual(1);
                 expect(event.success).toBeTruthy();
                 expect(event.accountType).toEqual(undefined);
                 pca.removePerformanceCallback(callbackId);
@@ -941,10 +941,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     expect(event.correlationId).toBeDefined();
                     expect(event.success).toBeTruthy();
                     expect(
-                        event["handleNativeRedirectPromiseDurationMs"]
+                        event.ext?.["handleNativeRedirectPromiseDurationMs"]
                     ).toBeGreaterThanOrEqual(0);
                     expect(
-                        event["handleNativeRedirectPromiseCallCount"]
+                        event.ext?.["handleNativeRedirectPromiseCallCount"]
                     ).toEqual(1);
                     expect(event.success).toBeTruthy();
                     expect(event.accountType).toEqual("MSA");

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -788,7 +788,9 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 expect(
                     event.ext?.["handleRedirectPromiseDurationMs"]
                 ).toBeGreaterThanOrEqual(0);
-                expect(event.ext?.["handleRedirectPromiseCallCount"]).toEqual(1);
+                expect(event.ext?.["handleRedirectPromiseCallCount"]).toEqual(
+                    1
+                );
                 expect(event.success).toBeTruthy();
                 expect(event.accountType).toEqual(undefined);
                 pca.removePerformanceCallback(callbackId);

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2108,11 +2108,6 @@ const DOMAIN_HINT = "domain_hint";
 // @public (undocumented)
 const DSTS = "dstsv2";
 
-// Warning: (ae-missing-release-tag) "DYNAMIC_FIELD_PREFIX" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
-export const DYNAMIC_FIELD_PREFIX = "dynamic.";
-
 // Warning: (ae-missing-release-tag) "EAR_JWE_CRYPTO" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -3493,7 +3488,7 @@ export type PerformanceEvent = {
     dataBoundary?: DataBoundary;
     logs?: string;
     silentRefreshReason?: string;
-    dynamic?: Record<string, string | number>;
+    ext?: Record<string, string | number>;
 };
 
 declare namespace PerformanceEvents {

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -3475,6 +3475,7 @@ export type PerformanceEvent = {
     extRtExpiresOnSeconds?: number;
     rtOffsetSeconds?: number;
     sidFromClaim?: boolean;
+    sidFromClaims?: boolean;
     sidFromRequest?: boolean;
     loginHintFromRequest?: boolean;
     loginHintFromUpn?: boolean;
@@ -4822,12 +4823,12 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/response/ResponseHandler.ts:355:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:356:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:357:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:724:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:724:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:738:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:738:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:739:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceClient.ts:739:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceClient.ts:723:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:723:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:737:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:737:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:738:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceClient.ts:738:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:37:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:37:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:37:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
@@ -4907,13 +4908,8 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/telemetry/performance/PerformanceEvent.ts:310:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:310:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:310:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:376:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:376:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:376:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:451:46 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
-// src/telemetry/performance/PerformanceEvent.ts:451:47 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:451:22 - (tsdoc-html-tag-missing-greater-than) The HTML tag has invalid syntax: Expecting an attribute or ">" or "/>"
-// src/telemetry/performance/PerformanceEvent.ts:451:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:451:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:378:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:378:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:378:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -4822,12 +4822,12 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/response/ResponseHandler.ts:355:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:356:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:357:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:726:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:726:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:740:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:740:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:741:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceClient.ts:741:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceClient.ts:724:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:724:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:738:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:738:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:739:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceClient.ts:739:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:37:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:37:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:37:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -3474,7 +3474,7 @@ export type PerformanceEvent = {
     ntwkRtExpiresOnSeconds?: number;
     extRtExpiresOnSeconds?: number;
     rtOffsetSeconds?: number;
-    sidFromClaims?: boolean;
+    sidFromClaim?: boolean;
     sidFromRequest?: boolean;
     loginHintFromRequest?: boolean;
     loginHintFromUpn?: boolean;
@@ -3487,7 +3487,40 @@ export type PerformanceEvent = {
     navigateCallbackResult?: boolean;
     dataBoundary?: DataBoundary;
     logs?: string;
+    cloudDiscoverySource?: string;
+    authorityEndpointSource?: string;
+    accountsRemoved?: number;
+    accessTokensRemoved?: number;
+    removeTokenBindingKeyFailure?: number;
     silentRefreshReason?: string;
+    deduped?: boolean;
+    kmsi?: boolean;
+    isBackground?: boolean;
+    preMigrateAcntCount?: number;
+    preMigrateATCount?: number;
+    preMigrateITCount?: number;
+    preMigrateRTCount?: number;
+    postMigrateAcntCount?: number;
+    postMigrateATCount?: number;
+    postMigrateITCount?: number;
+    postMigrateRTCount?: number;
+    oldAcntCount?: number;
+    oldATCount?: number;
+    oldITCount?: number;
+    oldRTCount?: number;
+    skipATMigrateCount?: number;
+    skipITMigrateCount?: number;
+    skipRTMigrateCount?: number;
+    migratedATCount?: number;
+    migratedITCount?: number;
+    migratedRTCount?: number;
+    expiredCacheRemovedCount?: number;
+    expiredAcntRemovedCount?: number;
+    invalidCacheCount?: number;
+    unencryptedCacheCount?: number;
+    encryptedCacheCount?: number;
+    encryptedCacheExpiredCount?: number;
+    encryptedCacheCorruptionCount?: number;
     ext?: Record<string, string | number>;
 };
 
@@ -4874,13 +4907,13 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/telemetry/performance/PerformanceEvent.ts:310:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:310:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:310:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:351:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:351:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:351:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:362:46 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
-// src/telemetry/performance/PerformanceEvent.ts:362:47 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:362:22 - (tsdoc-html-tag-missing-greater-than) The HTML tag has invalid syntax: Expecting an attribute or ">" or "/>"
-// src/telemetry/performance/PerformanceEvent.ts:362:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:362:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:376:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:376:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:376:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:451:46 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+// src/telemetry/performance/PerformanceEvent.ts:451:47 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:451:22 - (tsdoc-html-tag-missing-greater-than) The HTML tag has invalid syntax: Expecting an attribute or ">" or "/>"
+// src/telemetry/performance/PerformanceEvent.ts:451:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:451:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2108,6 +2108,11 @@ const DOMAIN_HINT = "domain_hint";
 // @public (undocumented)
 const DSTS = "dstsv2";
 
+// Warning: (ae-missing-release-tag) "DYNAMIC_FIELD_PREFIX" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const DYNAMIC_FIELD_PREFIX = "dynamic.";
+
 // Warning: (ae-missing-release-tag) "EAR_JWE_CRYPTO" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -3488,6 +3493,7 @@ export type PerformanceEvent = {
     dataBoundary?: DataBoundary;
     logs?: string;
     silentRefreshReason?: string;
+    dynamic?: Record<string, string | number>;
 };
 
 declare namespace PerformanceEvents {
@@ -4788,12 +4794,12 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/response/ResponseHandler.ts:355:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:356:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:357:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:673:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:673:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:685:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:685:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:686:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceClient.ts:686:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceClient.ts:726:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:726:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:740:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:740:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:741:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceClient.ts:741:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:37:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:37:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:37:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
@@ -4876,5 +4882,10 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/telemetry/performance/PerformanceEvent.ts:351:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:351:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:351:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:362:46 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+// src/telemetry/performance/PerformanceEvent.ts:362:47 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:362:22 - (tsdoc-html-tag-missing-greater-than) The HTML tag has invalid syntax: Expecting an attribute or ">" or "/>"
+// src/telemetry/performance/PerformanceEvent.ts:362:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:362:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -149,7 +149,7 @@ export function getStandardAuthorizeRequestParameters(
                 );
                 RequestParameterBuilder.addSid(parameters, accountSid);
                 performanceClient?.addFields(
-                    { sidFromClaims: true },
+                    { sidFromClaim: true },
                     correlationId
                 );
                 try {

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -149,7 +149,7 @@ export function getStandardAuthorizeRequestParameters(
                 );
                 RequestParameterBuilder.addSid(parameters, accountSid);
                 performanceClient?.addFields(
-                    { sidFromClaim: true },
+                    { sidFromClaims: true },
                     correlationId
                 );
                 try {

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -582,9 +582,7 @@ export abstract class PerformanceClient implements IPerformanceClient {
                 if (counter.startsWith(EXT_FIELD_PREFIX)) {
                     event.ext = event.ext || {};
                     // Route to ext sub-object
-                    const dynamicKey = counter.slice(
-                        EXT_FIELD_PREFIX.length
-                    );
+                    const dynamicKey = counter.slice(EXT_FIELD_PREFIX.length);
                     const currentValue = event.ext[dynamicKey];
                     if (currentValue === undefined) {
                         event.ext[dynamicKey] = 0;

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -11,6 +11,7 @@ import {
     PerformanceCallbackFunction,
 } from "./IPerformanceClient.js";
 import {
+    EXT_FIELD_PREFIX,
     IntFields,
     PerformanceEvent,
     PerformanceEventContext,
@@ -453,9 +454,16 @@ export abstract class PerformanceClient implements IPerformanceClient {
             addError(error, this.logger, rootEvent);
         }
 
-        // Add sub-measurement attribute to root event.
+        // Add sub-measurement attribute to root event's ext field.
         if (!isRoot) {
-            rootEvent[event.name + "DurationMs"] = Math.floor(event.durationMs);
+            rootEvent.ext =
+                {
+                    ...rootEvent.ext,
+                    ...event.ext,
+                } || {};
+            rootEvent.ext[event.name + "DurationMs"] = Math.floor(
+                event.durationMs
+            );
             return { ...rootEvent };
         }
 
@@ -521,10 +529,36 @@ export abstract class PerformanceClient implements IPerformanceClient {
     ): void {
         const event = this.eventsByCorrelationId.get(correlationId);
         if (event) {
-            this.eventsByCorrelationId.set(correlationId, {
+            const staticFields: { [key: string]: {} | undefined } = {};
+            const dynamicFields: Record<string, string | number> = {};
+
+            for (const key in fields) {
+                if (key.startsWith(EXT_FIELD_PREFIX)) {
+                    const dynamicKey = key.slice(EXT_FIELD_PREFIX.length);
+                    const value = fields[key];
+                    if (
+                        typeof value === "string" ||
+                        typeof value === "number"
+                    ) {
+                        dynamicFields[dynamicKey] = value;
+                    }
+                } else {
+                    staticFields[key] = fields[key];
+                }
+            }
+
+            const updatedEvent: PerformanceEvent = {
                 ...event,
-                ...fields,
-            });
+                ...staticFields,
+            };
+            if (Object.keys(dynamicFields).length) {
+                updatedEvent.ext = {
+                    ...updatedEvent.ext,
+                    ...dynamicFields,
+                };
+            }
+
+            this.eventsByCorrelationId.set(correlationId, updatedEvent);
         } else {
             this.logger.trace(
                 "PerformanceClient: Event not found for",
@@ -545,12 +579,31 @@ export abstract class PerformanceClient implements IPerformanceClient {
         const event = this.eventsByCorrelationId.get(correlationId);
         if (event) {
             for (const counter in fields) {
-                if (!event.hasOwnProperty(counter)) {
-                    event[counter] = 0;
-                } else if (isNaN(Number(event[counter]))) {
-                    return;
+                if (counter.startsWith(EXT_FIELD_PREFIX)) {
+                    event.ext = event.ext || {};
+                    // Route to ext sub-object
+                    const dynamicKey = counter.slice(
+                        EXT_FIELD_PREFIX.length
+                    );
+                    const currentValue = event.ext[dynamicKey];
+                    if (currentValue === undefined) {
+                        event.ext[dynamicKey] = 0;
+                    } else if (isNaN(Number(currentValue))) {
+                        return;
+                    }
+                    event.ext[dynamicKey] =
+                        (Number(event.ext[dynamicKey]) || 0) +
+                        (fields[counter] ?? 0);
+                } else {
+                    /* eslint-disable custom-msal/no-dynamic-telemetry-fields -- internal dispatching of static fields by name */
+                    if (!event.hasOwnProperty(counter)) {
+                        event[counter] = 0;
+                    } else if (isNaN(Number(event[counter]))) {
+                        return;
+                    }
+                    event[counter] += fields[counter];
+                    /* eslint-enable custom-msal/no-dynamic-telemetry-fields */
                 }
-                event[counter] += fields[counter];
             }
         } else {
             this.logger.trace(
@@ -674,9 +727,11 @@ export abstract class PerformanceClient implements IPerformanceClient {
      */
     private truncateIntegralFields(event: PerformanceEvent): void {
         this.intFields.forEach((key) => {
+            /* eslint-disable custom-msal/no-dynamic-telemetry-fields -- internal truncation of known integer fields */
             if (key in event && typeof event[key] === "number") {
                 event[key] = Math.floor(event[key]);
             }
+            /* eslint-enable custom-msal/no-dynamic-telemetry-fields */
         });
     }
 

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -456,11 +456,10 @@ export abstract class PerformanceClient implements IPerformanceClient {
 
         // Add sub-measurement attribute to root event's ext field.
         if (!isRoot) {
-            rootEvent.ext =
-                {
-                    ...rootEvent.ext,
-                    ...event.ext,
-                } || {};
+            rootEvent.ext = {
+                ...rootEvent.ext,
+                ...event.ext,
+            };
             rootEvent.ext[event.name + "DurationMs"] = Math.floor(
                 event.durationMs
             );

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -345,12 +345,101 @@ export type PerformanceEvent = {
     logs?: string;
 
     /**
+     * Source of cloud discovery metadata (config, cache, network, hardcoded_values)
+     */
+    cloudDiscoverySource?: string;
+
+    /**
+     * Source of authority endpoint metadata (config, cache, network, hardcoded_values)
+     */
+    authorityEndpointSource?: string;
+
+    /**
+     * Number of accounts removed during cache cleanup
+     */
+    accountsRemoved?: number;
+
+    /**
+     * Number of access tokens removed during cache cleanup
+     */
+    accessTokensRemoved?: number;
+
+    /**
+     * Number of failures when removing token binding keys
+     */
+    removeTokenBindingKeyFailure?: number;
+
+    /**
      * Reason for silent refresh fallback to iframe
      * Format: errorCode or errorCode|subError
      *
      * @type {?string}
      */
     silentRefreshReason?: string;
+
+    /**
+     * Whether this request was deduped with another in-flight request
+     */
+    deduped?: boolean;
+
+    /**
+     * Whether the user has "Keep Me Signed In" enabled
+     */
+    kmsi?: boolean;
+
+    /**
+     * Whether this event was executed in the background
+     */
+    isBackground?: boolean;
+
+    /**
+     * Cache migration telemetry — pre-migration counts
+     */
+    preMigrateAcntCount?: number;
+    preMigrateATCount?: number;
+    preMigrateITCount?: number;
+    preMigrateRTCount?: number;
+
+    /**
+     * Cache migration telemetry — post-migration counts
+     */
+    postMigrateAcntCount?: number;
+    postMigrateATCount?: number;
+    postMigrateITCount?: number;
+    postMigrateRTCount?: number;
+
+    /**
+     * Cache migration telemetry — old schema counts
+     */
+    oldAcntCount?: number;
+    oldATCount?: number;
+    oldITCount?: number;
+    oldRTCount?: number;
+
+    /**
+     * Cache migration telemetry — skipped and migrated counts
+     */
+    skipATMigrateCount?: number;
+    skipITMigrateCount?: number;
+    skipRTMigrateCount?: number;
+    migratedATCount?: number;
+    migratedITCount?: number;
+    migratedRTCount?: number;
+
+    /**
+     * Cache telemetry — expired, invalid, and removed counts
+     */
+    expiredCacheRemovedCount?: number;
+    expiredAcntRemovedCount?: number;
+    invalidCacheCount?: number;
+
+    /**
+     * Encrypted cache telemetry
+     */
+    unencryptedCacheCount?: number;
+    encryptedCacheCount?: number;
+    encryptedCacheExpiredCount?: number;
+    encryptedCacheCorruptionCount?: number;
 
     /**
      * Container for dynamically-named telemetry fields.

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -321,7 +321,7 @@ export type PerformanceEvent = {
     extRtExpiresOnSeconds?: number;
     rtOffsetSeconds?: number;
 
-    sidFromClaims?: boolean;
+    sidFromClaim?: boolean;
     sidFromRequest?: boolean;
     loginHintFromRequest?: boolean;
     loginHintFromUpn?: boolean;

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -322,6 +322,8 @@ export type PerformanceEvent = {
     rtOffsetSeconds?: number;
 
     sidFromClaim?: boolean;
+    // Backward-compatible alias for sidFromClaim
+    sidFromClaims?: boolean;
     sidFromRequest?: boolean;
     loginHintFromRequest?: boolean;
     loginHintFromUpn?: boolean;

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -448,7 +448,8 @@ export type PerformanceEvent = {
      * Use the "ext." prefix when calling addFields/incrementFields to automatically
      * route fields to this sub-object.
      *
-     * @type {?Record<string, string | number>}
+     * @remarks
+     * This property is typed as `Record<string, string | number>`.
      */
     ext?: Record<string, string | number>;
 };

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -351,6 +351,17 @@ export type PerformanceEvent = {
      * @type {?string}
      */
     silentRefreshReason?: string;
+
+    /**
+     * Container for dynamically-named telemetry fields.
+     * Fields whose names are constructed at runtime (e.g., "[eventName]CallCount")
+     * should be stored here instead of being set as top-level properties.
+     * Use the "ext." prefix when calling addFields/incrementFields to automatically
+     * route fields to this sub-object.
+     *
+     * @type {?Record<string, string | number>}
+     */
+    ext?: Record<string, string | number>;
 };
 
 export type PerformanceEventContext = {
@@ -364,6 +375,13 @@ export type PerformanceEventStackedContext = PerformanceEventContext & {
     name?: string;
     childErr?: string;
 };
+
+/**
+ * Prefix used to mark telemetry field names as dynamic.
+ * Fields with this prefix in addFields/incrementFields calls will be routed
+ * to the PerformanceEvent.ext sub-object.
+ */
+export const EXT_FIELD_PREFIX = "ext.";
 
 export const IntFields: ReadonlySet<string> = new Set([
     "accessTokenSize",

--- a/lib/msal-common/src/utils/FunctionWrappers.ts
+++ b/lib/msal-common/src/utils/FunctionWrappers.ts
@@ -33,8 +33,10 @@ export const invoke = <T extends Array<any>, U>(
         );
         if (correlationId) {
             // Track number of times this API is called in a single request
-            const eventCount = eventName + "CallCount";
-            telemetryClient.incrementFields({ [eventCount]: 1 }, correlationId);
+            telemetryClient.incrementFields(
+                { [`ext.${eventName}CallCount`]: 1 },
+                correlationId
+            );
         }
         try {
             const result = callback(...args);
@@ -89,8 +91,10 @@ export const invokeAsync = <T extends Array<any>, U>(
         );
         if (correlationId) {
             // Track number of times this API is called in a single request
-            const eventCount = eventName + "CallCount";
-            telemetryClient.incrementFields({ [eventCount]: 1 }, correlationId);
+            telemetryClient.incrementFields(
+                { [`ext.${eventName}CallCount`]: 1 },
+                correlationId
+            );
         }
         return callback(...args)
             .then((response) => {

--- a/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
+++ b/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
@@ -126,7 +126,7 @@ describe("PerformanceClient.spec.ts", () => {
                 sampleApplicationTelemetry.appVersion
             );
             expect(
-                events[0][
+                events[0].ext?.[
                     "refreshTokenClientAcquireTokenWithCachedRefreshTokenDurationMs"
                 ]
             ).toBe(Math.floor(samplePerfDuration));
@@ -212,12 +212,14 @@ describe("PerformanceClient.spec.ts", () => {
             expect(events.length).toEqual(1);
             const event = events[0];
             expect(
-                event[
+                event.ext?.[
                     "refreshTokenClientAcquireTokenWithCachedRefreshTokenDurationMs"
                 ]
             ).toBe(Math.floor(samplePerfDuration));
             expect(
-                event["refreshTokenClientCreateTokenRequestBodyDurationMs"]
+                event.ext?.[
+                    "refreshTokenClientCreateTokenRequestBodyDurationMs"
+                ]
             ).toBe(Math.floor(samplePerfDuration));
             expect(event.incompleteSubsCount).toEqual(0);
             done();
@@ -353,13 +355,15 @@ describe("PerformanceClient.spec.ts", () => {
             expect(events.length).toEqual(1);
             const event = events[0];
             expect(
-                event["refreshTokenClientAcquireTokenDurationMs"]
+                event.ext?.["refreshTokenClientAcquireTokenDurationMs"]
             ).toBeUndefined();
             expect(
-                event["refreshTokenClientExecutePostToTokenEndpointDurationMs"]
+                event.ext?.[
+                    "refreshTokenClientExecutePostToTokenEndpointDurationMs"
+                ]
             ).toBe(Math.floor(samplePerfDuration));
             expect(
-                event["silentCacheClientAcquireTokenDurationMs"]
+                event.ext?.["silentCacheClientAcquireTokenDurationMs"]
             ).toBeUndefined();
             expect(event.incompleteSubsCount).toEqual(2);
             done();
@@ -403,7 +407,7 @@ describe("PerformanceClient.spec.ts", () => {
             expect(events.length).toBe(1);
             const event = events[0];
             expect(
-                events[0][
+                events[0].ext?.[
                     "refreshTokenClientExecutePostToTokenEndpointDurationMs"
                 ]
             ).toBe(Math.floor(durationMs));
@@ -451,9 +455,9 @@ describe("PerformanceClient.spec.ts", () => {
             expect(events.length).toBe(1);
             expect(events[0].eventId).toBe(event1Id);
             expect(events[0].success).toBeFalsy();
-            expect(events[0]["refreshTokenClientAcquireTokenDurationMs"]).toBe(
-                Math.floor(samplePerfDuration)
-            );
+            expect(
+                events[0].ext?.["refreshTokenClientAcquireTokenDurationMs"]
+            ).toBe(Math.floor(samplePerfDuration));
 
             done();
         });
@@ -1488,6 +1492,133 @@ describe("PerformanceClient.spec.ts", () => {
                 correlationId
             );
             topLevelEvent.end({ success: true }, undefined, testAccount);
+        });
+    });
+
+    describe("Dynamic fields", () => {
+        it("routes dynamic-prefixed fields in incrementFields to event.ext", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                expect(event.ext).toBeDefined();
+                expect(event.ext?.["someApiCallCount"]).toBe(3);
+                // Static fields should NOT be in dynamic
+                expect(event.visibilityChangeCount).toBe(1);
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.RefreshTokenClientAcquireToken,
+                correlationId
+            );
+            topLevelEvent.increment({
+                ["ext.someApiCallCount"]: 2,
+            });
+            topLevelEvent.increment({
+                ["ext.someApiCallCount"]: 1,
+            });
+            topLevelEvent.increment({ visibilityChangeCount: 1 });
+            topLevelEvent.end({ success: true });
+        });
+
+        it("routes dynamic-prefixed fields in addFields to event.ext", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                expect(event.ext).toBeDefined();
+                expect(event.ext?.["customLabel"]).toBe("myValue");
+                // Static fields should be at the top level
+                expect(event.extensionId).toBe("test-ext");
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.RefreshTokenClientAcquireToken,
+                correlationId
+            );
+            topLevelEvent.add({
+                ["ext.customLabel"]: "myValue",
+                extensionId: "test-ext",
+            });
+            topLevelEvent.end({ success: true });
+        });
+
+        it("stores sub-measurement durationMs in event.ext", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                expect(event.ext).toBeDefined();
+                expect(
+                    event.ext?.[
+                        "refreshTokenClientAcquireTokenWithCachedRefreshTokenDurationMs"
+                    ]
+                ).toBe(Math.floor(samplePerfDuration));
+                // Top-level durationMs should still work
+                expect(event.durationMs).toBeDefined();
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.RefreshTokenClientAcquireToken,
+                correlationId
+            );
+
+            const subMeasurement = mockPerfClient.startMeasurement(
+                PerformanceEvents.RefreshTokenClientAcquireTokenWithCachedRefreshToken,
+                correlationId
+            );
+            subMeasurement.end({ success: true });
+
+            topLevelEvent.end({ success: true });
+        });
+
+        it("merges dynamic fields from multiple addFields calls", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                expect(event.ext?.["fieldA"]).toBe("valueA");
+                expect(event.ext?.["fieldB"]).toBe(42);
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.RefreshTokenClientAcquireToken,
+                correlationId
+            );
+            topLevelEvent.add({ ["ext.fieldA"]: "valueA" });
+            topLevelEvent.add({ ["ext.fieldB"]: 42 });
+            topLevelEvent.end({ success: true });
+        });
+
+        it("does not create ext object when no dynamic fields are set", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                expect(event.ext).toBeUndefined();
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.RefreshTokenClientAcquireToken,
+                correlationId
+            );
+            topLevelEvent.add({ extensionId: "test" });
+            topLevelEvent.end({ success: true });
         });
     });
 });

--- a/shared-configs/eslint-config-msal/index.js
+++ b/shared-configs/eslint-config-msal/index.js
@@ -85,6 +85,7 @@ module.exports = {
                 "ignoreModules": ["msal-node", "msal-node-extensions"]
             }
         ],
+        "custom-msal/no-dynamic-telemetry-fields": 2,
         "eol-last": 2,
         "eqeqeq": 2,
         "header/header": [

--- a/shared-configs/eslint-plugin-custom-msal/index.js
+++ b/shared-configs/eslint-plugin-custom-msal/index.js
@@ -2,13 +2,15 @@ const noClassMethodsInConstructorRule = require("./rules/no-class-methods-in-con
 const errorDescriptionIsDefined = require("./rules/error-description-is-defined");
 const noStringConcatenationInLogging = require("./rules/no-string-concatenation-in-logging");
 const quoteLoggingVariables = require("./rules/quote-logging-variables");
+const noDynamicTelemetryFields = require("./rules/no-dynamic-telemetry-fields");
 
 const plugin = {
     rules: {
         "no-class-methods-in-constructor": noClassMethodsInConstructorRule,
         "error-description-is-defined": errorDescriptionIsDefined,
         "no-string-concatenation-in-logging": noStringConcatenationInLogging,
-        "quote-logging-variables": quoteLoggingVariables
+        "quote-logging-variables": quoteLoggingVariables,
+        "no-dynamic-telemetry-fields": noDynamicTelemetryFields
     }
 }
 

--- a/shared-configs/eslint-plugin-custom-msal/rules/no-dynamic-telemetry-fields.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/no-dynamic-telemetry-fields.js
@@ -259,13 +259,23 @@ module.exports = {
                                 },
                             });
                         }
-                    } else if (allowedStaticFields.size > 0) {
-                        // Static key — validate against known PerformanceEvent fields
+                    } else {
+                        // Non-computed key (Identifier or string Literal)
                         const keyName =
                             prop.key.type === "Identifier"
                                 ? prop.key.name
                                 : prop.key.value;
+                        // String-literal keys starting with "ext." are valid
+                        // dynamic prefixes (addFields routes them at runtime)
                         if (
+                            typeof keyName === "string" &&
+                            keyName.startsWith("ext.")
+                        ) {
+                            continue;
+                        }
+                        // Otherwise validate against known PerformanceEvent fields
+                        if (
+                            allowedStaticFields.size > 0 &&
                             keyName &&
                             !allowedStaticFields.has(keyName)
                         ) {
@@ -283,24 +293,35 @@ module.exports = {
             },
 
             // Check direct indexed assignment on event objects: rootEvent[computedKey] = value
+            // Only rootEvent.ext[key] = value is allowed; rootEvent[key] = value
+            // is always reported because it bypasses the ext routing in addFields/incrementFields.
             AssignmentExpression(node) {
                 if (node.left.type !== "MemberExpression") return;
                 if (!node.left.computed) return;
 
                 const object = node.left.object;
+
+                // Allow: eventObj.ext[key] = value
+                if (
+                    object.type === "MemberExpression" &&
+                    !object.computed &&
+                    object.property.type === "Identifier" &&
+                    object.property.name === "ext"
+                ) {
+                    return;
+                }
+
                 const objectName = getObjectName(object);
 
                 if (
                     objectName &&
                     isPerformanceEventVariable(objectName)
                 ) {
-                    if (!isDynamicPrefix(node.left.property)) {
-                        context.report({
-                            node: node.left,
-                            messageId: "noDynamicAssignment",
-                            data: { object: objectName },
-                        });
-                    }
+                    context.report({
+                        node: node.left,
+                        messageId: "noDynamicAssignment",
+                        data: { object: objectName },
+                    });
                 }
             },
         };

--- a/shared-configs/eslint-plugin-custom-msal/rules/no-dynamic-telemetry-fields.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/no-dynamic-telemetry-fields.js
@@ -7,14 +7,69 @@
  * @fileoverview ESLint rule to disallow dynamic (computed) telemetry field names
  * that are not defined in PerformanceEvent. Dynamic fields must use the "ext." prefix
  * so they are automatically routed to the PerformanceEvent.ext sub-object.
+ * Additionally validates that static (non-computed) field names match known
+ * PerformanceEvent properties to catch typos and invalid field names.
  */
+
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Default path to the 3P PerformanceEvent type definition,
+ * resolved relative to this rule file's location in the repo.
+ */
+const DEFAULT_PERFORMANCE_EVENT_PATH = path.resolve(
+    __dirname,
+    "../../../lib/msal-common/src/telemetry/performance/PerformanceEvent.ts"
+);
+
+/** Cache for extracted field names keyed by resolved file path */
+const fieldNameCache = new Map();
+
+/**
+ * Extract property names from `type PerformanceEvent = { ... }` blocks in a
+ * TypeScript file. Handles both plain type definitions and intersection types
+ * (e.g., `type PerformanceEvent = Event & { ... }`). Only fields inside
+ * braces belonging to PerformanceEvent are collected.
+ * @param {string} filePath - Absolute path to the TypeScript file
+ * @returns {Set<string>} Set of extracted property names
+ */
+function extractFieldNames(filePath) {
+    const resolved = path.resolve(filePath);
+    if (fieldNameCache.has(resolved)) {
+        return fieldNameCache.get(resolved);
+    }
+
+    const fieldNames = new Set();
+    try {
+        const content = fs.readFileSync(resolved, "utf8");
+        // Match every `type PerformanceEvent = ...` block and extract fields
+        // from all `{ ... }` bodies within it (handles intersection types).
+        const typeBlockRegex =
+            /\btype\s+PerformanceEvent\b[^=]*=\s*([\s\S]*?)\n\};/g;
+        let blockMatch;
+        while ((blockMatch = typeBlockRegex.exec(content)) !== null) {
+            const body = blockMatch[1];
+            const fieldRegex = /^\s+(\w+)\??\s*:/gm;
+            let fieldMatch;
+            while ((fieldMatch = fieldRegex.exec(body)) !== null) {
+                fieldNames.add(fieldMatch[1]);
+            }
+        }
+    } catch {
+        // File not found or not readable — skip silently
+    }
+
+    fieldNameCache.set(resolved, fieldNames);
+    return fieldNames;
+}
 
 module.exports = {
     meta: {
         type: "problem",
         docs: {
             description:
-                "Disallow dynamic (computed) telemetry field names not defined in PerformanceEvent. Dynamic fields must use the 'ext.' prefix.",
+                "Disallow dynamic (computed) telemetry field names not defined in PerformanceEvent. Dynamic fields must use the 'ext.' prefix. Also validates static field names against known PerformanceEvent properties.",
             category: "Best Practices",
             recommended: true,
         },
@@ -38,6 +93,20 @@ module.exports = {
                             "Regex pattern to match variable names that hold PerformanceEvent objects",
                         default: "[Ee]vent",
                     },
+                    allowedFieldFiles: {
+                        type: "array",
+                        items: { type: "string" },
+                        description:
+                            "Additional TypeScript type definition files to extract allowed field names from. Paths are resolved relative to CWD.",
+                        default: [],
+                    },
+                    additionalAllowedFields: {
+                        type: "array",
+                        items: { type: "string" },
+                        description:
+                            "Explicit field names to allow in addition to those extracted from type files.",
+                        default: [],
+                    },
                 },
                 additionalProperties: false,
             },
@@ -47,6 +116,8 @@ module.exports = {
                 "Dynamic telemetry field name '{{name}}' is not allowed in '{{method}}()'. Use the 'ext.' prefix for computed field names (e.g., `ext.${fieldName}`) or use a static field name defined in PerformanceEvent.",
             noDynamicAssignment:
                 "Dynamic property assignment on performance event object '{{object}}' is not allowed. Use the 'ext' sub-object for computed field names (e.g., {{object}}.ext[fieldName]).",
+            unknownStaticField:
+                "Unknown telemetry field '{{name}}' in '{{method}}()'. Use a field defined in PerformanceEvent or the 'ext.' prefix for dynamic fields.",
         },
     },
 
@@ -61,7 +132,33 @@ module.exports = {
         const eventVarPattern = new RegExp(
             options.performanceEventVariablePattern || "[Ee]vent"
         );
+        const additionalAllowedFields = options.additionalAllowedFields || [];
+        const allowedFieldFiles = options.allowedFieldFiles || [];
         const sourceCode = context.getSourceCode();
+
+        // Build the set of allowed static field names
+        const allowedStaticFields = new Set(additionalAllowedFields);
+
+        // Always try to load the default 3P PerformanceEvent type
+        for (const name of extractFieldNames(DEFAULT_PERFORMANCE_EVENT_PATH)) {
+            allowedStaticFields.add(name);
+        }
+
+        // Load additional type definition files (resolved from CWD)
+        if (allowedFieldFiles.length > 0) {
+            const cwd =
+                typeof context.getCwd === "function"
+                    ? context.getCwd()
+                    : process.cwd();
+            for (const filePath of allowedFieldFiles) {
+                const resolved = path.isAbsolute(filePath)
+                    ? filePath
+                    : path.resolve(cwd, filePath);
+                for (const name of extractFieldNames(resolved)) {
+                    allowedStaticFields.add(name);
+                }
+            }
+        }
 
         /**
          * Checks if a computed key expression starts with "ext."
@@ -158,6 +255,25 @@ module.exports = {
                                 messageId: "noDynamicFields",
                                 data: {
                                     name: getComputedKeyText(prop.key),
+                                    method: methodName,
+                                },
+                            });
+                        }
+                    } else if (allowedStaticFields.size > 0) {
+                        // Static key — validate against known PerformanceEvent fields
+                        const keyName =
+                            prop.key.type === "Identifier"
+                                ? prop.key.name
+                                : prop.key.value;
+                        if (
+                            keyName &&
+                            !allowedStaticFields.has(keyName)
+                        ) {
+                            context.report({
+                                node: prop.key,
+                                messageId: "unknownStaticField",
+                                data: {
+                                    name: keyName,
                                     method: methodName,
                                 },
                             });

--- a/shared-configs/eslint-plugin-custom-msal/rules/no-dynamic-telemetry-fields.js
+++ b/shared-configs/eslint-plugin-custom-msal/rules/no-dynamic-telemetry-fields.js
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @fileoverview ESLint rule to disallow dynamic (computed) telemetry field names
+ * that are not defined in PerformanceEvent. Dynamic fields must use the "ext." prefix
+ * so they are automatically routed to the PerformanceEvent.ext sub-object.
+ */
+
+module.exports = {
+    meta: {
+        type: "problem",
+        docs: {
+            description:
+                "Disallow dynamic (computed) telemetry field names not defined in PerformanceEvent. Dynamic fields must use the 'ext.' prefix.",
+            category: "Best Practices",
+            recommended: true,
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    telemetryMethods: {
+                        type: "array",
+                        items: { type: "string" },
+                        default: [
+                            "addFields",
+                            "incrementFields",
+                            "add",
+                            "increment",
+                        ],
+                    },
+                    performanceEventVariablePattern: {
+                        type: "string",
+                        description:
+                            "Regex pattern to match variable names that hold PerformanceEvent objects",
+                        default: "[Ee]vent",
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        messages: {
+            noDynamicFields:
+                "Dynamic telemetry field name '{{name}}' is not allowed in '{{method}}()'. Use the 'ext.' prefix for computed field names (e.g., `ext.${fieldName}`) or use a static field name defined in PerformanceEvent.",
+            noDynamicAssignment:
+                "Dynamic property assignment on performance event object '{{object}}' is not allowed. Use the 'ext' sub-object for computed field names (e.g., {{object}}.ext[fieldName]).",
+        },
+    },
+
+    create(context) {
+        const options = context.options[0] || {};
+        const telemetryMethods = options.telemetryMethods || [
+            "addFields",
+            "incrementFields",
+            "add",
+            "increment",
+        ];
+        const eventVarPattern = new RegExp(
+            options.performanceEventVariablePattern || "[Ee]vent"
+        );
+        const sourceCode = context.getSourceCode();
+
+        /**
+         * Checks if a computed key expression starts with "ext."
+         * Handles template literals, string concatenation, and plain string literals.
+         */
+        function isDynamicPrefix(node) {
+            if (node.type === "TemplateLiteral") {
+                // Template literal: check if first quasi starts with "ext."
+                return (
+                    node.quasis.length > 0 &&
+                    node.quasis[0].value.raw.startsWith("ext.")
+                );
+            }
+            if (node.type === "BinaryExpression" && node.operator === "+") {
+                // String concatenation: check leftmost part recursively
+                return isDynamicPrefix(node.left);
+            }
+            if (node.type === "Literal" && typeof node.value === "string") {
+                return node.value.startsWith("ext.");
+            }
+            return false;
+        }
+
+        /**
+         * Extract a readable name from the computed key for the error message
+         */
+        function getComputedKeyText(node) {
+            return sourceCode.getText(node);
+        }
+
+        /**
+         * Check if a node is a call to one of the telemetry methods
+         */
+        function isTelemetryMethodCall(node) {
+            if (node.type !== "CallExpression") return false;
+            if (node.callee.type === "MemberExpression") {
+                const property = node.callee.property;
+                const methodName = property.name || property.value;
+                return telemetryMethods.includes(methodName);
+            }
+            return false;
+        }
+
+        /**
+         * Get method name from a call expression
+         */
+        function getMethodName(node) {
+            if (node.callee.type === "MemberExpression") {
+                return node.callee.property.name || node.callee.property.value;
+            }
+            return "unknown";
+        }
+
+        /**
+         * Check if a variable name looks like a PerformanceEvent object
+         */
+        function isPerformanceEventVariable(name) {
+            return eventVarPattern.test(name);
+        }
+
+        /**
+         * Extract the object name from a member expression for error reporting
+         */
+        function getObjectName(node) {
+            if (node.type === "Identifier") {
+                return node.name;
+            }
+            if (
+                node.type === "MemberExpression" &&
+                node.property.type === "Identifier"
+            ) {
+                return node.property.name;
+            }
+            return sourceCode.getText(node);
+        }
+
+        return {
+            // Check telemetry method calls: addFields({ [computed]: val }), incrementFields, add, increment
+            CallExpression(node) {
+                if (!isTelemetryMethodCall(node)) return;
+
+                const firstArg = node.arguments[0];
+                if (!firstArg || firstArg.type !== "ObjectExpression") return;
+
+                const methodName = getMethodName(node);
+
+                for (const prop of firstArg.properties) {
+                    if (prop.type === "SpreadElement") continue;
+                    if (prop.computed) {
+                        // Computed property key — only allow if starts with "ext."
+                        if (!isDynamicPrefix(prop.key)) {
+                            context.report({
+                                node: prop.key,
+                                messageId: "noDynamicFields",
+                                data: {
+                                    name: getComputedKeyText(prop.key),
+                                    method: methodName,
+                                },
+                            });
+                        }
+                    }
+                }
+            },
+
+            // Check direct indexed assignment on event objects: rootEvent[computedKey] = value
+            AssignmentExpression(node) {
+                if (node.left.type !== "MemberExpression") return;
+                if (!node.left.computed) return;
+
+                const object = node.left.object;
+                const objectName = getObjectName(object);
+
+                if (
+                    objectName &&
+                    isPerformanceEventVariable(objectName)
+                ) {
+                    if (!isDynamicPrefix(node.left.property)) {
+                        context.report({
+                            node: node.left,
+                            messageId: "noDynamicAssignment",
+                            data: { object: objectName },
+                        });
+                    }
+                }
+            },
+        };
+    },
+};

--- a/shared-configs/eslint-plugin-custom-msal/test/no-dynamic-telemetry-fields.test.js
+++ b/shared-configs/eslint-plugin-custom-msal/test/no-dynamic-telemetry-fields.test.js
@@ -1,0 +1,129 @@
+const { RuleTester } = require("eslint");
+const noDynamicTelemetryFields = require("../rules/no-dynamic-telemetry-fields");
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+});
+
+ruleTester.run("no-dynamic-telemetry-fields", noDynamicTelemetryFields, {
+    valid: [
+        // Static literal keys in telemetry calls are allowed
+        {
+            code: `telemetryClient.incrementFields({ visibilityChangeCount: 1 }, correlationId);`,
+        },
+        {
+            code: `telemetryClient.addFields({ fromCache: true }, correlationId);`,
+        },
+        {
+            code: `inProgressEvent.add({ errorCode: "invalid_grant" });`,
+        },
+        {
+            code: `inProgressEvent.increment({ multiMatchedAT: 1 });`,
+        },
+        // Computed keys with "ext." prefix are allowed
+        {
+            code: "telemetryClient.incrementFields({ [`ext.${eventName}CallCount`]: 1 }, correlationId);",
+        },
+        {
+            code: 'telemetryClient.addFields({ ["ext." + eventName + "Duration"]: 500 }, correlationId);',
+        },
+        {
+            code: 'telemetryClient.incrementFields({ ["ext.someField"]: 1 }, correlationId);',
+        },
+        // Non-telemetry method calls with computed keys are allowed
+        {
+            code: `someObject.someMethod({ [dynamicKey]: 1 });`,
+        },
+        {
+            code: `map.set({ [key]: value });`,
+        },
+        // Direct assignment on non-event variables is allowed
+        {
+            code: `someObject[dynamicKey] = 5;`,
+        },
+        {
+            code: `config[settingName] = true;`,
+        },
+        // Direct assignment on event variables using "ext" sub-object is allowed (static property)
+        {
+            code: `rootEvent.ext = {};`,
+        },
+        // Spread elements in telemetry calls are fine
+        {
+            code: `telemetryClient.addFields({ ...otherFields }, correlationId);`,
+        },
+    ],
+    invalid: [
+        // Computed keys without "ext." prefix in telemetry calls
+        {
+            code: `const eventCount = eventName + "CallCount"; telemetryClient.incrementFields({ [eventCount]: 1 }, correlationId);`,
+            errors: [
+                {
+                    messageId: "noDynamicFields",
+                },
+            ],
+        },
+        {
+            code: 'telemetryClient.incrementFields({ [eventName + "CallCount"]: 1 }, correlationId);',
+            errors: [
+                {
+                    messageId: "noDynamicFields",
+                },
+            ],
+        },
+        {
+            code: "telemetryClient.addFields({ [`${eventName}DurationMs`]: 50 }, correlationId);",
+            errors: [
+                {
+                    messageId: "noDynamicFields",
+                },
+            ],
+        },
+        {
+            code: `inProgressEvent.increment({ [fieldName]: 1 });`,
+            errors: [
+                {
+                    messageId: "noDynamicFields",
+                },
+            ],
+        },
+        {
+            code: `inProgressEvent.add({ [name + "Size"]: 100 });`,
+            errors: [
+                {
+                    messageId: "noDynamicFields",
+                },
+            ],
+        },
+        // Direct indexed assignment on event-like variables
+        {
+            code: `rootEvent[event.name + "DurationMs"] = Math.floor(event.durationMs);`,
+            errors: [
+                {
+                    messageId: "noDynamicAssignment",
+                },
+            ],
+        },
+        {
+            code: `perfEvent[dynamicKey] = value;`,
+            errors: [
+                {
+                    messageId: "noDynamicAssignment",
+                },
+            ],
+        },
+        {
+            code: `finalEvent[name + "Count"] = 5;`,
+            errors: [
+                {
+                    messageId: "noDynamicAssignment",
+                },
+            ],
+        },
+    ],
+});
+
+console.log("All no-dynamic-telemetry-fields tests passed!");

--- a/shared-configs/eslint-plugin-custom-msal/test/no-dynamic-telemetry-fields.test.js
+++ b/shared-configs/eslint-plugin-custom-msal/test/no-dynamic-telemetry-fields.test.js
@@ -10,7 +10,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("no-dynamic-telemetry-fields", noDynamicTelemetryFields, {
     valid: [
-        // Static literal keys in telemetry calls are allowed
+        // Static literal keys that ARE valid PerformanceEvent fields
         {
             code: `telemetryClient.incrementFields({ visibilityChangeCount: 1 }, correlationId);`,
         },
@@ -22,6 +22,12 @@ ruleTester.run("no-dynamic-telemetry-fields", noDynamicTelemetryFields, {
         },
         {
             code: `inProgressEvent.increment({ multiMatchedAT: 1 });`,
+        },
+        {
+            code: `telemetryClient.addFields({ correlationId: "abc-123" }, id);`,
+        },
+        {
+            code: `telemetryClient.addFields({ durationMs: 500, success: true }, id);`,
         },
         // Computed keys with "ext." prefix are allowed
         {
@@ -40,6 +46,10 @@ ruleTester.run("no-dynamic-telemetry-fields", noDynamicTelemetryFields, {
         {
             code: `map.set({ [key]: value });`,
         },
+        // Non-telemetry method calls with any static keys are allowed (no validation)
+        {
+            code: `someObject.someMethod({ totallyFakeField: 1 });`,
+        },
         // Direct assignment on non-event variables is allowed
         {
             code: `someObject[dynamicKey] = 5;`,
@@ -54,6 +64,15 @@ ruleTester.run("no-dynamic-telemetry-fields", noDynamicTelemetryFields, {
         // Spread elements in telemetry calls are fine
         {
             code: `telemetryClient.addFields({ ...otherFields }, correlationId);`,
+        },
+        // Fields from additionalAllowedFields option are allowed
+        {
+            code: `telemetryClient.addFields({ customOnePField: "value" }, id);`,
+            options: [{ additionalAllowedFields: ["customOnePField"] }],
+        },
+        // Multiple valid fields in one call
+        {
+            code: `telemetryClient.addFields({ correlationId: "abc", httpStatus: 200, success: true }, id);`,
         },
     ],
     invalid: [
@@ -120,6 +139,54 @@ ruleTester.run("no-dynamic-telemetry-fields", noDynamicTelemetryFields, {
             errors: [
                 {
                     messageId: "noDynamicAssignment",
+                },
+            ],
+        },
+        // Static keys that are NOT valid PerformanceEvent fields (typos, made-up names)
+        {
+            code: `telemetryClient.addFields({ correlationIdd: "value" }, id);`,
+            errors: [
+                {
+                    messageId: "unknownStaticField",
+                    data: { name: "correlationIdd", method: "addFields" },
+                },
+            ],
+        },
+        {
+            code: `inProgressEvent.add({ fakeField: 123 });`,
+            errors: [
+                {
+                    messageId: "unknownStaticField",
+                    data: { name: "fakeField", method: "add" },
+                },
+            ],
+        },
+        {
+            code: `telemetryClient.incrementFields({ durrationMs: 1 }, id);`,
+            errors: [
+                {
+                    messageId: "unknownStaticField",
+                    data: { name: "durrationMs", method: "incrementFields" },
+                },
+            ],
+        },
+        // Mix of valid and invalid static keys — only the invalid one is reported
+        {
+            code: `telemetryClient.addFields({ correlationId: "abc", notARealField: true }, id);`,
+            errors: [
+                {
+                    messageId: "unknownStaticField",
+                    data: { name: "notARealField", method: "addFields" },
+                },
+            ],
+        },
+        // String literal key that is not a valid field
+        {
+            code: `telemetryClient.addFields({ "badFieldName": 42 }, id);`,
+            errors: [
+                {
+                    messageId: "unknownStaticField",
+                    data: { name: "badFieldName", method: "addFields" },
                 },
             ],
         },

--- a/shared-configs/eslint-plugin-custom-msal/test/no-dynamic-telemetry-fields.test.js
+++ b/shared-configs/eslint-plugin-custom-msal/test/no-dynamic-telemetry-fields.test.js
@@ -61,6 +61,20 @@ ruleTester.run("no-dynamic-telemetry-fields", noDynamicTelemetryFields, {
         {
             code: `rootEvent.ext = {};`,
         },
+        // Direct computed assignment on event.ext[key] is allowed
+        {
+            code: `rootEvent.ext[fieldName] = 42;`,
+        },
+        {
+            code: `perfEvent.ext["someKey"] = "value";`,
+        },
+        // Non-computed string-literal keys starting with "ext." are allowed (routed at runtime)
+        {
+            code: `telemetryClient.addFields({ "ext.customField": 500 }, correlationId);`,
+        },
+        {
+            code: `inProgressEvent.add({ "ext.myCounter": 1 });`,
+        },
         // Spread elements in telemetry calls are fine
         {
             code: `telemetryClient.addFields({ ...otherFields }, correlationId);`,
@@ -136,6 +150,24 @@ ruleTester.run("no-dynamic-telemetry-fields", noDynamicTelemetryFields, {
         },
         {
             code: `finalEvent[name + "Count"] = 5;`,
+            errors: [
+                {
+                    messageId: "noDynamicAssignment",
+                },
+            ],
+        },
+        // Computed assignment with ext. prefix on event object itself is still invalid
+        // (should use event.ext[key] instead)
+        {
+            code: `perfEvent["ext.someKey"] = 1;`,
+            errors: [
+                {
+                    messageId: "noDynamicAssignment",
+                },
+            ],
+        },
+        {
+            code: "rootEvent[`ext.${name}`] = value;",
             errors: [
                 {
                     messageId: "noDynamicAssignment",


### PR DESCRIPTION
This pull request introduces a mechanism for handling dynamic telemetry fields in performance events, allowing for more flexible and scalable telemetry data collection. The main change is the addition of an `ext` sub-object to the `PerformanceEvent` type, which stores fields whose names are constructed at runtime. The pull request also updates relevant methods and tests to support this new structure, and adds a lint rule to enforce correct usage.

Dynamic telemetry fields support:

* Added an `ext` property to the `PerformanceEvent` type to store dynamically-named fields, such as call counts and sub-measurement durations. These fields are routed to `ext` using the `"ext."` prefix when calling `addFields` or `incrementFields`. (`lib/msal-common/src/telemetry/performance/PerformanceEvent.ts`, [lib/msal-common/src/telemetry/performance/PerformanceEvent.tsR354-R364](diffhunk://#diff-2f63a38227d7a354d8c67987de2d283da038557a987db95576a08fe16cc60354R354-R364))
* Introduced the `EXT_FIELD_PREFIX` constant and updated `PerformanceClient` methods (`addFields`, `incrementFields`) to automatically route fields with this prefix to the `ext` sub-object, ensuring separation between static and dynamic fields. (`lib/msal-common/src/telemetry/performance/PerformanceEvent.ts`, [[1]](diffhunk://#diff-2f63a38227d7a354d8c67987de2d283da038557a987db95576a08fe16cc60354R379-R385); `lib/msal-common/src/telemetry/performance/PerformanceClient.ts`, [[2]](diffhunk://#diff-5c2e3cc078d85a3fa0eb4b4596ecee70cc03689d6ac7ab96c69b8628fd8e055fL524-R561) [[3]](diffhunk://#diff-5c2e3cc078d85a3fa0eb4b4596ecee70cc03689d6ac7ab96c69b8628fd8e055fR582-R606) [[4]](diffhunk://#diff-5c2e3cc078d85a3fa0eb4b4596ecee70cc03689d6ac7ab96c69b8628fd8e055fL456-R466)

Code and test updates for dynamic fields:

* Updated function wrappers to increment API call counts using the dynamic field mechanism, storing them in `ext` instead of as top-level properties. (`lib/msal-common/src/utils/FunctionWrappers.ts`, [[1]](diffhunk://#diff-71662df5e90583aee6710b2dbac9fe829522000bf6b03e1ab1bed5f5a6f64932L36-R39) [[2]](diffhunk://#diff-71662df5e90583aee6710b2dbac9fe829522000bf6b03e1ab1bed5f5a6f64932L92-R97)
* Refactored tests to assert dynamic fields are correctly stored in `event.ext`, and added new tests to verify merging, routing, and absence of the `ext` object when not used. (`lib/msal-common/test/telemetry/PerformanceClient.spec.ts`, [[1]](diffhunk://#diff-a1c469f9aa50bb3cf9652bb95ab570e63f3445cc854ec1c098e7e7b45f824bd0L129-R129) [[2]](diffhunk://#diff-a1c469f9aa50bb3cf9652bb95ab570e63f3445cc854ec1c098e7e7b45f824bd0L215-R222) [[3]](diffhunk://#diff-a1c469f9aa50bb3cf9652bb95ab570e63f3445cc854ec1c098e7e7b45f824bd0L356-R366) [[4]](diffhunk://#diff-a1c469f9aa50bb3cf9652bb95ab570e63f3445cc854ec1c098e7e7b45f824bd0L406-R410) [[5]](diffhunk://#diff-a1c469f9aa50bb3cf9652bb95ab570e63f3445cc854ec1c098e7e7b45f824bd0L454-R460) [[6]](diffhunk://#diff-a1c469f9aa50bb3cf9652bb95ab570e63f3445cc854ec1c098e7e7b45f824bd0R1497-R1623)

Linting and documentation:

* Added a custom ESLint rule to enforce no dynamic telemetry fields at the top level, ensuring dynamic fields are always routed to `ext`. (`shared-configs/eslint-config-msal/index.js`, [shared-configs/eslint-config-msal/index.jsR88](diffhunk://#diff-2b30170ea2355b0ba1b936931fa57a0703830fa262c9ac8e5a64904d58245478R88))
* Updated API review and documentation comments to reflect the new structure and dynamic field handling. (`lib/msal-common/apiReview/msal-common.api.md`, [[1]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R3491) [[2]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117L4794-R4800) [[3]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R4883-R4887)

These changes provide a scalable foundation for telemetry data collection, making it easier to add new dynamic fields without bloating the top-level event structure.