### PR TITLE
[v4] Add support for client data telemetry with CLI_DATA parameter

### DIFF
--- a/change/@azure-msal-browser-ae790b79-88ea-45d8-929a-1373ad2b9f6c.json
+++ b/change/@azure-msal-browser-ae790b79-88ea-45d8-929a-1373ad2b9f6c.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add support for client data telemetry with CLI_DATA parameter #8378",
+  "comment": "Add support for client data telemetry with CLI_DATA parameter #8378 (https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8378)",
   "packageName": "@azure/msal-browser",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-ae790b79-88ea-45d8-929a-1373ad2b9f6c.json
+++ b/change/@azure-msal-browser-ae790b79-88ea-45d8-929a-1373ad2b9f6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for client data telemetry with CLI_DATA parameter #8378",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-17d28873-a06b-4a2d-b3c0-9a775064086b.json
+++ b/change/@azure-msal-common-17d28873-a06b-4a2d-b3c0-9a775064086b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add support for client data telemetry with CLI_DATA parameter #8378",
+  "comment": "Add support for client data telemetry with CLI_DATA parameter #8378 (https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8378)",
   "packageName": "@azure/msal-common",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-17d28873-a06b-4a2d-b3c0-9a775064086b.json
+++ b/change/@azure-msal-common-17d28873-a06b-4a2d-b3c0-9a775064086b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for client data telemetry with CLI_DATA parameter #8378",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -46,6 +46,84 @@ import { decryptEarResponse } from "../crypto/BrowserCrypto.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 
 /**
+ * Parsed representation of the clientdata response parameter from the /authorize endpoint.
+ *
+ * Format: urlencoded(account_type|error|sub_error|cloud_instance|caller_data_boundary)
+ */
+type ClientData = {
+    /** Account type: "m" for MSA, "e" for Entra */
+    accountType: string;
+    /** Error code string (e.g. "0x8004345C" for MSA) */
+    error: string;
+    /** Sub-error code string (e.g. "0x80043588" for MSA) */
+    subError: string;
+    /** Cloud instance hostname (e.g. "login.microsoftonline.com") */
+    cloudInstance: string;
+    /** Caller data boundary (e.g. "none" for MSA) */
+    callerDataBoundary: string;
+};
+
+const clientDataAccountTypeMapping = new Map([
+    ["e", "AAD"],
+    ["m", "MSA"],
+]);
+
+/**
+ * Parses the clientdata response parameter from the /authorize endpoint.
+ *
+ * The clientdata value is URL-encoded and pipe-delimited:
+ *   urlencoded(account_type | error | sub_error | cloud_instance | caller_data_boundary)
+ *
+ * @param clientdata - The raw clientdata string from the authorize response
+ * @returns Parsed ClientData object, or null if the input is empty/invalid
+ */
+export function parseClientData(clientdata?: string): ClientData | null {
+    if (!clientdata) {
+        return null;
+    }
+
+    try {
+        const decoded = decodeURIComponent(clientdata);
+        const parts = decoded.split("|");
+
+        if (parts.length < 5) {
+            return null;
+        }
+
+        return {
+            accountType: clientDataAccountTypeMapping.get(parts[0] || "") || "",
+            error: parts[1]?.trim() || "",
+            subError: parts[2]?.trim() || "",
+            cloudInstance: parts[3]?.trim() || "",
+            callerDataBoundary: parts[4]?.trim() || "",
+        };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Instruments account type, error, and suberror from clientdata
+ */
+function instrumentClientData(
+    response: AuthorizeResponse,
+    correlationId: string,
+    performanceClient: IPerformanceClient
+): void {
+    const parsed = parseClientData(response.clientdata);
+    if (parsed) {
+        performanceClient.addFields(
+            {
+                accountType: parsed.accountType,
+                serverErrorNo: parsed.error,
+                serverSubErrorNo: parsed.subError,
+            },
+            correlationId
+        );
+    }
+}
+
+/**
  * Returns map of parameters that are applicable to all calls to /authorize whether using PKCE or EAR
  * @param config
  * @param authority
@@ -412,6 +490,10 @@ export async function handleResponseCode(
         config.auth.clientId,
         request
     );
+
+    // Instrument clientdata telemetry fields from the authorize response
+    instrumentClientData(response, request.correlationId, performanceClient);
+
     if (response.accountId) {
         return invokeAsync(
             handleResponsePlatformBroker,
@@ -491,6 +573,9 @@ export async function handleResponseEAR(
         config.auth.clientId,
         request
     );
+
+    // Instrument clientdata telemetry fields from the authorize response
+    instrumentClientData(response, request.correlationId, performanceClient);
 
     // Validate state & check response for errors
     AuthorizeProtocol.validateAuthorizationResponse(response, request.state);

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -51,7 +51,7 @@ import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandle
  * Format: urlencoded(account_type|error|sub_error|cloud_instance|caller_data_boundary)
  */
 type ClientData = {
-    /** Account type: "m" for MSA, "e" for Entra */
+    /** Account type: MSA, AAD */
     accountType: string;
     /** Error code string (e.g. "0x8004345C" for MSA) */
     error: string;
@@ -91,7 +91,8 @@ export function parseClientData(clientdata?: string): ClientData | null {
         }
 
         return {
-            accountType: clientDataAccountTypeMapping.get(parts[0] || "") || "",
+            accountType:
+                clientDataAccountTypeMapping.get(parts[0]?.trim() || "") || "",
             error: parts[1]?.trim() || "",
             subError: parts[2]?.trim() || "",
             cloudInstance: parts[3]?.trim() || "",
@@ -111,16 +112,21 @@ function instrumentClientData(
     performanceClient: IPerformanceClient
 ): void {
     const parsed = parseClientData(response.clientdata);
-    if (parsed) {
+    parsed?.accountType &&
         performanceClient.addFields(
-            {
-                accountType: parsed.accountType,
-                serverErrorNo: parsed.error,
-                serverSubErrorNo: parsed.subError,
-            },
+            { accountType: parsed.accountType },
             correlationId
         );
-    }
+    parsed?.error &&
+        performanceClient.addFields(
+            { serverErrorNo: parsed.error },
+            correlationId
+        );
+    parsed?.subError &&
+        performanceClient.addFields(
+            { serverSubErrorNo: parsed.subError },
+            correlationId
+        );
 }
 
 /**

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -662,45 +662,6 @@ describe("Authorize Protocol Tests", () => {
             addFieldsSpy.mockRestore();
         });
 
-        it("endMeasurement overwrites accountType set by clientdata instrumentation", async () => {
-            /**
-             * instrumentClientData sets accountType via addFields (e.g. "MSA" from clientdata).
-             * PerformanceClient.endMeasurement later sets finalEvent.accountType = getAccountType(account),
-             * which overwrites the addFields value. This is by design: the token-response-derived
-             * account type is authoritative and should take precedence over the clientdata hint.
-             */
-            const addFieldsSpy = jest.spyOn(performanceClient, "addFields");
-            // clientdata: m|error|suberror|cloud|boundary → accountType set to "MSA"
-            const clientdata = "m%7Cerror%7Csuberror%7Ccloud%7Cboundary";
-            const response = {
-                ear_jwe: validEarJWE,
-                state: validRequest.state,
-                clientdata,
-            };
-
-            await Authorize.handleResponseEAR(
-                validRequest,
-                response,
-                ApiId.acquireTokenPopup,
-                config,
-                authority,
-                cacheManager,
-                cacheManager,
-                eventHandler,
-                logger,
-                performanceClient
-            );
-
-            // Verify instrumentClientData sets accountType (not a separate field name)
-            expect(addFieldsSpy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    accountType: "MSA",
-                }),
-                validRequest.correlationId
-            );
-            addFieldsSpy.mockRestore();
-        });
-
         it("handleResponseCode instruments clientdata telemetry before processing response", async () => {
             const addFieldsSpy = jest.spyOn(performanceClient, "addFields");
             // clientdata: e|AADSTS65001|consent_required|login.microsoftonline.com|none

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -565,7 +565,17 @@ describe("Authorize Protocol Tests", () => {
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
                     accountType: "MSA",
+                }),
+                validRequest.correlationId
+            );
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
                     serverErrorNo: "0x8004345C",
+                }),
+                validRequest.correlationId
+            );
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
                     serverSubErrorNo: "0x80047857",
                 }),
                 validRequest.correlationId
@@ -634,7 +644,17 @@ describe("Authorize Protocol Tests", () => {
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
                     accountType: "AAD",
+                }),
+                validRequest.correlationId
+            );
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
                     serverErrorNo: "AADSTS50076",
+                }),
+                validRequest.correlationId
+            );
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
                     serverSubErrorNo: "basic_action",
                 }),
                 validRequest.correlationId
@@ -716,7 +736,17 @@ describe("Authorize Protocol Tests", () => {
             expect(addFieldsSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
                     accountType: "AAD",
+                }),
+                validRequest.correlationId
+            );
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
                     serverErrorNo: "AADSTS65001",
+                }),
+                validRequest.correlationId
+            );
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
                     serverSubErrorNo: "consent_required",
                 }),
                 validRequest.correlationId

--- a/lib/msal-browser/test/protocol/Authorize.spec.ts
+++ b/lib/msal-browser/test/protocol/Authorize.spec.ts
@@ -194,6 +194,7 @@ describe("Authorize Protocol Tests", () => {
                     BrowserConstants.MSAL_SKU
                 );
                 checkInputProperties(AADServerParamKeys.X_CLIENT_VER, version);
+                checkInputProperties(AADServerParamKeys.CLI_DATA, "1");
 
                 // Verify correlationId is present in authorize URL query params
                 const actionUrl = new URL(form.action);
@@ -465,6 +466,262 @@ describe("Authorize Protocol Tests", () => {
             expect(
                 actionUrl.searchParams.get(AADServerParamKeys.CLIENT_REQUEST_ID)
             ).toEqual(validRequest.correlationId);
+        });
+
+        it("Includes clidata=1 in form post body", async () => {
+            const form = await Authorize.getCodeForm(
+                document,
+                config,
+                authority,
+                validRequest,
+                logger,
+                performanceClient
+            );
+
+            const cliDataInput = form.elements.namedItem(
+                AADServerParamKeys.CLI_DATA
+            ) as HTMLInputElement;
+            expect(cliDataInput).toBeTruthy();
+            expect(cliDataInput.value).toEqual("1");
+        });
+    });
+
+    describe("instrumentClientData Tests", () => {
+        const config = buildConfiguration(
+            { auth: { clientId: TEST_CONFIG.MSAL_CLIENT_ID } },
+            true
+        );
+        const logger = new Logger({});
+        const performanceClient = new StubPerformanceClient();
+        const authorityOptions: AuthorityOptions = {
+            protocolMode: ProtocolMode.EAR,
+            knownAuthorities: [],
+            cloudDiscoveryMetadata: "",
+            authorityMetadata: "",
+        };
+        const eventHandler = new EventHandler();
+        const cacheManager = new BrowserCacheManager(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            config.cache,
+            new CryptoOps(logger, performanceClient),
+            logger,
+            performanceClient,
+            eventHandler
+        );
+        let authority: Authority;
+        const validRequest: CommonAuthorizationUrlRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            scopes: ["openid", "profile"],
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            redirectUri: window.location.href,
+            state: TEST_STATE_VALUES.TEST_STATE_REDIRECT,
+            nonce: ID_TOKEN_CLAIMS.nonce,
+            responseMode: ResponseMode.FRAGMENT,
+            codeChallenge: "code-challenge",
+            earJwk: validEarJWK,
+        };
+
+        beforeAll(async () => {
+            jest.useFakeTimers();
+            authority = await AuthorityFactory.createDiscoveredInstance(
+                TEST_CONFIG.validAuthority,
+                config.system.networkClient,
+                cacheManager,
+                authorityOptions,
+                logger,
+                TEST_CONFIG.CORRELATION_ID,
+                performanceClient
+            );
+        });
+
+        afterAll(() => {
+            jest.useRealTimers();
+        });
+
+        it("handleResponseEAR instruments clientdata telemetry when clientdata is present", async () => {
+            const addFieldsSpy = jest.spyOn(performanceClient, "addFields");
+            // clientdata: m|0x8004345C|0x80047857|none|login.microsoftonline.com
+            const clientdata =
+                "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com";
+            const response = {
+                ear_jwe: validEarJWE,
+                state: validRequest.state,
+                clientdata,
+            };
+
+            await Authorize.handleResponseEAR(
+                validRequest,
+                response,
+                ApiId.acquireTokenPopup,
+                config,
+                authority,
+                cacheManager,
+                cacheManager,
+                eventHandler,
+                logger,
+                performanceClient
+            );
+
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    accountType: "MSA",
+                    serverErrorNo: "0x8004345C",
+                    serverSubErrorNo: "0x80047857",
+                }),
+                validRequest.correlationId
+            );
+            addFieldsSpy.mockRestore();
+        });
+
+        it("handleResponseEAR does not instrument clientdata when clientdata is absent", async () => {
+            const addFieldsSpy = jest.spyOn(performanceClient, "addFields");
+            addFieldsSpy.mockClear();
+            const response = {
+                ear_jwe: validEarJWE,
+                state: validRequest.state,
+            };
+
+            await Authorize.handleResponseEAR(
+                validRequest,
+                response,
+                ApiId.acquireTokenPopup,
+                config,
+                authority,
+                cacheManager,
+                cacheManager,
+                eventHandler,
+                logger,
+                performanceClient
+            );
+
+            // addFields may be called for other reasons, but NOT with clientData fields
+            const clientDataCalls = addFieldsSpy.mock.calls.filter(
+                (call: unknown[]) => {
+                    const fields = call[0] as
+                        | Record<string, unknown>
+                        | undefined;
+                    return fields && "serverErrorNo" in fields;
+                }
+            );
+            expect(clientDataCalls).toHaveLength(0);
+            addFieldsSpy.mockRestore();
+        });
+
+        it("handleResponseEAR instruments Entra (AAD) account type from clientdata", async () => {
+            const addFieldsSpy = jest.spyOn(performanceClient, "addFields");
+            // clientdata: e|AADSTS50076|basic_action|login.microsoftonline.com|none
+            const clientdata =
+                "e%7CAADSTS50076%7Cbasic_action%7Clogin.microsoftonline.com%7Cnone";
+            const response = {
+                ear_jwe: validEarJWE,
+                state: validRequest.state,
+                clientdata,
+            };
+
+            await Authorize.handleResponseEAR(
+                validRequest,
+                response,
+                ApiId.acquireTokenPopup,
+                config,
+                authority,
+                cacheManager,
+                cacheManager,
+                eventHandler,
+                logger,
+                performanceClient
+            );
+
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    accountType: "AAD",
+                    serverErrorNo: "AADSTS50076",
+                    serverSubErrorNo: "basic_action",
+                }),
+                validRequest.correlationId
+            );
+            addFieldsSpy.mockRestore();
+        });
+
+        it("endMeasurement overwrites accountType set by clientdata instrumentation", async () => {
+            /**
+             * instrumentClientData sets accountType via addFields (e.g. "MSA" from clientdata).
+             * PerformanceClient.endMeasurement later sets finalEvent.accountType = getAccountType(account),
+             * which overwrites the addFields value. This is by design: the token-response-derived
+             * account type is authoritative and should take precedence over the clientdata hint.
+             */
+            const addFieldsSpy = jest.spyOn(performanceClient, "addFields");
+            // clientdata: m|error|suberror|cloud|boundary → accountType set to "MSA"
+            const clientdata = "m%7Cerror%7Csuberror%7Ccloud%7Cboundary";
+            const response = {
+                ear_jwe: validEarJWE,
+                state: validRequest.state,
+                clientdata,
+            };
+
+            await Authorize.handleResponseEAR(
+                validRequest,
+                response,
+                ApiId.acquireTokenPopup,
+                config,
+                authority,
+                cacheManager,
+                cacheManager,
+                eventHandler,
+                logger,
+                performanceClient
+            );
+
+            // Verify instrumentClientData sets accountType (not a separate field name)
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    accountType: "MSA",
+                }),
+                validRequest.correlationId
+            );
+            addFieldsSpy.mockRestore();
+        });
+
+        it("handleResponseCode instruments clientdata telemetry before processing response", async () => {
+            const addFieldsSpy = jest.spyOn(performanceClient, "addFields");
+            // clientdata: e|AADSTS65001|consent_required|login.microsoftonline.com|none
+            const clientdata =
+                "e%7CAADSTS65001%7Cconsent_required%7Clogin.microsoftonline.com%7Cnone";
+            const response = {
+                // Use accountId so it hits the platformBroker path, which throws without a provider
+                accountId: "test-account-id",
+                state: validRequest.state,
+                clientdata,
+            };
+
+            try {
+                await Authorize.handleResponseCode(
+                    validRequest,
+                    response,
+                    "code-verifier",
+                    ApiId.acquireTokenPopup,
+                    config,
+                    {} as any, // authClient not needed — accountId path is taken
+                    cacheManager,
+                    cacheManager,
+                    eventHandler,
+                    logger,
+                    performanceClient
+                    // no platformAuthProvider → throws nativeConnectionNotEstablished
+                );
+            } catch {
+                // Expected: nativeConnectionNotEstablished
+            }
+
+            // instrumentClientData ran before the throw
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    accountType: "AAD",
+                    serverErrorNo: "AADSTS65001",
+                    serverSubErrorNo: "consent_required",
+                }),
+                validRequest.correlationId
+            );
+            addFieldsSpy.mockRestore();
         });
     });
 });

--- a/lib/msal-browser/test/protocol/ClientDataParser.spec.ts
+++ b/lib/msal-browser/test/protocol/ClientDataParser.spec.ts
@@ -1,130 +1,119 @@
 import { parseClientData } from "../../src/protocol/Authorize.js";
 
-describe("parseAuxClientData", () => {
-    describe("parseAuxClientData", () => {
-        it("returns null for undefined input", () => {
-            expect(parseClientData(undefined)).toBeNull();
-        });
+describe("parseClientData", () => {
+    it("returns null for undefined input", () => {
+        expect(parseClientData(undefined)).toBeNull();
+    });
 
-        it("returns null for empty string", () => {
-            expect(parseClientData("")).toBeNull();
-        });
+    it("returns null for empty string", () => {
+        expect(parseClientData("")).toBeNull();
+    });
 
-        it("returns null when fewer than 5 pipe-delimited parts", () => {
-            // Only 3 parts
-            expect(parseClientData("m%7C0x8004345C%7C0x80043588")).toBeNull();
-        });
+    it("returns null when fewer than 5 pipe-delimited parts", () => {
+        // Only 3 parts
+        expect(parseClientData("m%7C0x8004345C%7C0x80043588")).toBeNull();
+    });
 
-        it("returns null when only 4 pipe-delimited parts", () => {
-            expect(
-                parseClientData("m%7C0x8004345C%7C0x80043588%7Cnone")
-            ).toBeNull();
-        });
+    it("returns null when only 4 pipe-delimited parts", () => {
+        expect(
+            parseClientData("m%7C0x8004345C%7C0x80043588%7Cnone")
+        ).toBeNull();
+    });
 
-        it("parses a valid URL-encoded MSA clientdata payload", () => {
-            const encoded =
-                "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com";
-            const result = parseClientData(encoded);
+    it("parses a valid URL-encoded MSA clientdata payload", () => {
+        const encoded =
+            "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com";
+        const result = parseClientData(encoded);
 
-            expect(result).not.toBeNull();
-            expect(result!.accountType).toBe("MSA");
-            expect(result!.error).toBe("0x8004345C");
-            expect(result!.subError).toBe("0x80047857");
-            expect(result!.cloudInstance).toBe("none");
-            expect(result!.callerDataBoundary).toBe(
-                "login.microsoftonline.com"
-            );
-        });
+        expect(result).not.toBeNull();
+        expect(result!.accountType).toBe("MSA");
+        expect(result!.error).toBe("0x8004345C");
+        expect(result!.subError).toBe("0x80047857");
+        expect(result!.cloudInstance).toBe("none");
+        expect(result!.callerDataBoundary).toBe("login.microsoftonline.com");
+    });
 
-        it("parses a valid URL-encoded Entra (AAD) clientdata payload", () => {
-            const encoded =
-                "e%7CAADSTS50076%7Cbasic_action%7Clogin.microsoftonline.com%7Cnone";
-            const result = parseClientData(encoded);
+    it("parses a valid URL-encoded Entra (AAD) clientdata payload", () => {
+        const encoded =
+            "e%7CAADSTS50076%7Cbasic_action%7Clogin.microsoftonline.com%7Cnone";
+        const result = parseClientData(encoded);
 
-            expect(result).not.toBeNull();
-            expect(result!.accountType).toBe("AAD");
-            expect(result!.error).toBe("AADSTS50076");
-            expect(result!.subError).toBe("basic_action");
-            expect(result!.cloudInstance).toBe("login.microsoftonline.com");
-            expect(result!.callerDataBoundary).toBe("none");
-        });
+        expect(result).not.toBeNull();
+        expect(result!.accountType).toBe("AAD");
+        expect(result!.error).toBe("AADSTS50076");
+        expect(result!.subError).toBe("basic_action");
+        expect(result!.cloudInstance).toBe("login.microsoftonline.com");
+        expect(result!.callerDataBoundary).toBe("none");
+    });
 
-        it("parses a payload with no errors (empty error and suberror)", () => {
-            const encoded = "m%7C%7C%7Clogin.microsoftonline.com%7Cnone";
-            const result = parseClientData(encoded);
+    it("parses a payload with no errors (empty error and suberror)", () => {
+        const encoded = "m%7C%7C%7Clogin.microsoftonline.com%7Cnone";
+        const result = parseClientData(encoded);
 
-            expect(result).not.toBeNull();
-            expect(result!.accountType).toBe("MSA");
-            expect(result!.error).toBe("");
-            expect(result!.subError).toBe("");
-            expect(result!.cloudInstance).toBe("login.microsoftonline.com");
-            expect(result!.callerDataBoundary).toBe("none");
-        });
+        expect(result).not.toBeNull();
+        expect(result!.accountType).toBe("MSA");
+        expect(result!.error).toBe("");
+        expect(result!.subError).toBe("");
+        expect(result!.cloudInstance).toBe("login.microsoftonline.com");
+        expect(result!.callerDataBoundary).toBe("none");
+    });
 
-        it("parses a non-encoded (plain) pipe-delimited string", () => {
-            const plain =
-                "m|0x8004345C|0x80047857|none|login.microsoftonline.com";
-            const result = parseClientData(plain);
+    it("parses a non-encoded (plain) pipe-delimited string", () => {
+        const plain = "m|0x8004345C|0x80047857|none|login.microsoftonline.com";
+        const result = parseClientData(plain);
 
-            expect(result).not.toBeNull();
-            expect(result!.accountType).toBe("MSA");
-            expect(result!.error).toBe("0x8004345C");
-            expect(result!.subError).toBe("0x80047857");
-        });
+        expect(result).not.toBeNull();
+        expect(result!.accountType).toBe("MSA");
+        expect(result!.error).toBe("0x8004345C");
+        expect(result!.subError).toBe("0x80047857");
+    });
 
-        it("handles whitespace in pipe-delimited fields by trimming", () => {
-            const encoded =
-                "m%7C%200x8004345C%20%7C%200x80047857%20%7C%20none%20%7C%20login.microsoftonline.com%20";
-            const result = parseClientData(encoded);
+    it("handles whitespace in pipe-delimited fields by trimming", () => {
+        const encoded =
+            "m%7C%200x8004345C%20%7C%200x80047857%20%7C%20none%20%7C%20login.microsoftonline.com%20";
+        const result = parseClientData(encoded);
 
-            expect(result).not.toBeNull();
-            expect(result!.accountType).toBe("MSA");
-            expect(result!.error).toBe("0x8004345C");
-            expect(result!.subError).toBe("0x80047857");
-            expect(result!.cloudInstance).toBe("none");
-            expect(result!.callerDataBoundary).toBe(
-                "login.microsoftonline.com"
-            );
-        });
+        expect(result).not.toBeNull();
+        expect(result!.accountType).toBe("MSA");
+        expect(result!.error).toBe("0x8004345C");
+        expect(result!.subError).toBe("0x80047857");
+        expect(result!.cloudInstance).toBe("none");
+        expect(result!.callerDataBoundary).toBe("login.microsoftonline.com");
+    });
 
-        it("returns empty accountType for unknown account type code", () => {
-            const encoded =
-                "x%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com";
-            const result = parseClientData(encoded);
+    it("returns empty accountType for unknown account type code", () => {
+        const encoded =
+            "x%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com";
+        const result = parseClientData(encoded);
 
-            expect(result).not.toBeNull();
-            expect(result!.accountType).toBe("");
-        });
+        expect(result).not.toBeNull();
+        expect(result!.accountType).toBe("");
+    });
 
-        it("returns null for invalid URL encoding", () => {
-            const invalid = "%ZZ%7Cfoo%7Cbar%7Cbaz%7Cqux";
-            expect(parseClientData(invalid)).toBeNull();
-        });
+    it("returns null for invalid URL encoding", () => {
+        const invalid = "%ZZ%7Cfoo%7Cbar%7Cbaz%7Cqux";
+        expect(parseClientData(invalid)).toBeNull();
+    });
 
-        it("handles more than 5 pipe-delimited parts (ignores extras)", () => {
-            const encoded =
-                "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com%7Cextra_field";
-            const result = parseClientData(encoded);
+    it("handles more than 5 pipe-delimited parts (ignores extras)", () => {
+        const encoded =
+            "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com%7Cextra_field";
+        const result = parseClientData(encoded);
 
-            expect(result).not.toBeNull();
-            expect(result!.accountType).toBe("MSA");
-            expect(result!.error).toBe("0x8004345C");
-            expect(result!.subError).toBe("0x80047857");
-            expect(result!.cloudInstance).toBe("none");
-            expect(result!.callerDataBoundary).toBe(
-                "login.microsoftonline.com"
-            );
-        });
+        expect(result).not.toBeNull();
+        expect(result!.accountType).toBe("MSA");
+        expect(result!.error).toBe("0x8004345C");
+        expect(result!.subError).toBe("0x80047857");
+        expect(result!.cloudInstance).toBe("none");
+        expect(result!.callerDataBoundary).toBe("login.microsoftonline.com");
+    });
 
-        it("handles trailing whitespace from URL encoding (e.g., %20 at end)", () => {
-            const encoded =
-                "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com%20";
-            const result = parseClientData(encoded);
+    it("handles trailing whitespace from URL encoding (e.g., %20 at end)", () => {
+        const encoded =
+            "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com%20";
+        const result = parseClientData(encoded);
 
-            expect(result).not.toBeNull();
-            expect(result!.callerDataBoundary).toBe(
-                "login.microsoftonline.com"
-            );
-        });
+        expect(result).not.toBeNull();
+        expect(result!.callerDataBoundary).toBe("login.microsoftonline.com");
     });
 });

--- a/lib/msal-browser/test/protocol/ClientDataParser.spec.ts
+++ b/lib/msal-browser/test/protocol/ClientDataParser.spec.ts
@@ -1,0 +1,130 @@
+import { parseClientData } from "../../src/protocol/Authorize.js";
+
+describe("parseAuxClientData", () => {
+    describe("parseAuxClientData", () => {
+        it("returns null for undefined input", () => {
+            expect(parseClientData(undefined)).toBeNull();
+        });
+
+        it("returns null for empty string", () => {
+            expect(parseClientData("")).toBeNull();
+        });
+
+        it("returns null when fewer than 5 pipe-delimited parts", () => {
+            // Only 3 parts
+            expect(parseClientData("m%7C0x8004345C%7C0x80043588")).toBeNull();
+        });
+
+        it("returns null when only 4 pipe-delimited parts", () => {
+            expect(
+                parseClientData("m%7C0x8004345C%7C0x80043588%7Cnone")
+            ).toBeNull();
+        });
+
+        it("parses a valid URL-encoded MSA clientdata payload", () => {
+            const encoded =
+                "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com";
+            const result = parseClientData(encoded);
+
+            expect(result).not.toBeNull();
+            expect(result!.accountType).toBe("MSA");
+            expect(result!.error).toBe("0x8004345C");
+            expect(result!.subError).toBe("0x80047857");
+            expect(result!.cloudInstance).toBe("none");
+            expect(result!.callerDataBoundary).toBe(
+                "login.microsoftonline.com"
+            );
+        });
+
+        it("parses a valid URL-encoded Entra (AAD) clientdata payload", () => {
+            const encoded =
+                "e%7CAADSTS50076%7Cbasic_action%7Clogin.microsoftonline.com%7Cnone";
+            const result = parseClientData(encoded);
+
+            expect(result).not.toBeNull();
+            expect(result!.accountType).toBe("AAD");
+            expect(result!.error).toBe("AADSTS50076");
+            expect(result!.subError).toBe("basic_action");
+            expect(result!.cloudInstance).toBe("login.microsoftonline.com");
+            expect(result!.callerDataBoundary).toBe("none");
+        });
+
+        it("parses a payload with no errors (empty error and suberror)", () => {
+            const encoded = "m%7C%7C%7Clogin.microsoftonline.com%7Cnone";
+            const result = parseClientData(encoded);
+
+            expect(result).not.toBeNull();
+            expect(result!.accountType).toBe("MSA");
+            expect(result!.error).toBe("");
+            expect(result!.subError).toBe("");
+            expect(result!.cloudInstance).toBe("login.microsoftonline.com");
+            expect(result!.callerDataBoundary).toBe("none");
+        });
+
+        it("parses a non-encoded (plain) pipe-delimited string", () => {
+            const plain =
+                "m|0x8004345C|0x80047857|none|login.microsoftonline.com";
+            const result = parseClientData(plain);
+
+            expect(result).not.toBeNull();
+            expect(result!.accountType).toBe("MSA");
+            expect(result!.error).toBe("0x8004345C");
+            expect(result!.subError).toBe("0x80047857");
+        });
+
+        it("handles whitespace in pipe-delimited fields by trimming", () => {
+            const encoded =
+                "m%7C%200x8004345C%20%7C%200x80047857%20%7C%20none%20%7C%20login.microsoftonline.com%20";
+            const result = parseClientData(encoded);
+
+            expect(result).not.toBeNull();
+            expect(result!.accountType).toBe("MSA");
+            expect(result!.error).toBe("0x8004345C");
+            expect(result!.subError).toBe("0x80047857");
+            expect(result!.cloudInstance).toBe("none");
+            expect(result!.callerDataBoundary).toBe(
+                "login.microsoftonline.com"
+            );
+        });
+
+        it("returns empty accountType for unknown account type code", () => {
+            const encoded =
+                "x%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com";
+            const result = parseClientData(encoded);
+
+            expect(result).not.toBeNull();
+            expect(result!.accountType).toBe("");
+        });
+
+        it("returns null for invalid URL encoding", () => {
+            const invalid = "%ZZ%7Cfoo%7Cbar%7Cbaz%7Cqux";
+            expect(parseClientData(invalid)).toBeNull();
+        });
+
+        it("handles more than 5 pipe-delimited parts (ignores extras)", () => {
+            const encoded =
+                "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com%7Cextra_field";
+            const result = parseClientData(encoded);
+
+            expect(result).not.toBeNull();
+            expect(result!.accountType).toBe("MSA");
+            expect(result!.error).toBe("0x8004345C");
+            expect(result!.subError).toBe("0x80047857");
+            expect(result!.cloudInstance).toBe("none");
+            expect(result!.callerDataBoundary).toBe(
+                "login.microsoftonline.com"
+            );
+        });
+
+        it("handles trailing whitespace from URL encoding (e.g., %20 at end)", () => {
+            const encoded =
+                "m%7C0x8004345C%7C0x80047857%7Cnone%7Clogin.microsoftonline.com%20";
+            const result = parseClientData(encoded);
+
+            expect(result).not.toBeNull();
+            expect(result!.callerDataBoundary).toBe(
+                "login.microsoftonline.com"
+            );
+        });
+    });
+});

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -4760,12 +4760,12 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/response/ResponseHandler.ts:352:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:353:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:354:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:942:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:942:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:954:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:954:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:955:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceClient.ts:955:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceClient.ts:944:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:944:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:956:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:956:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:957:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceClient.ts:957:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:604:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:604:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:604:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -78,7 +78,8 @@ declare namespace AADServerParamKeys {
         BROKER_REDIRECT_URI,
         INSTANCE_AWARE,
         EAR_JWK,
-        EAR_JWE_CRYPTO
+        EAR_JWE_CRYPTO,
+        CLI_DATA
     }
 }
 export { AADServerParamKeys }
@@ -267,6 +268,11 @@ function addCcsUpn(parameters: Map<string, string>, loginHint: string): void;
 //
 // @public
 function addClaims(parameters: Map<string, string>, claims?: string, clientCapabilities?: Array<string>): void;
+
+// Warning: (ae-missing-release-tag) "addCliData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function addCliData(parameters: Map<string, string>): void;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "addClientAssertion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -831,6 +837,7 @@ export type AuthorizeResponse = {
     correlation_id?: string;
     claims?: string;
     accountId?: string;
+    clientdata?: string;
 };
 
 // Warning: (ae-missing-release-tag) "authTimeNotFound" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1339,6 +1346,11 @@ export type ClaimsRequestKeys = (typeof ClaimsRequestKeys)[keyof typeof ClaimsRe
 //
 // @public (undocumented)
 const claimsRequestParsingError = "claims_request_parsing_error";
+
+// Warning: (ae-missing-release-tag) "CLI_DATA" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const CLI_DATA = "clidata";
 
 // Warning: (ae-missing-release-tag) "CLIENT_ASSERTION" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3445,6 +3457,7 @@ export type PerformanceEvent = {
     errorCode?: string;
     subErrorCode?: string;
     serverErrorNo?: string;
+    serverSubErrorNo?: string;
     libraryName: string;
     libraryVersion: string;
     previousLibraryVersion?: string;
@@ -3903,6 +3916,7 @@ declare namespace RequestParameterBuilder {
         addRequestTokenUse,
         addGrantType,
         addClientInfo,
+        addCliData,
         addInstanceAware,
         addExtraQueryParameters,
         addClientCapabilitiesToClaims,
@@ -4749,12 +4763,12 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/response/ResponseHandler.ts:352:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:353:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/response/ResponseHandler.ts:354:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:942:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:942:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:954:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/telemetry/performance/PerformanceClient.ts:954:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-// src/telemetry/performance/PerformanceClient.ts:955:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceClient.ts:955:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceClient.ts:944:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:944:15 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:956:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/telemetry/performance/PerformanceClient.ts:956:27 - (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
+// src/telemetry/performance/PerformanceClient.ts:957:24 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceClient.ts:957:17 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:604:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:604:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:604:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
@@ -4798,53 +4812,53 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/telemetry/performance/PerformanceEvent.ts:704:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:704:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:704:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:716:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:716:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:716:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:723:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:723:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:723:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:735:23 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:735:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:735:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:750:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:750:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:750:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:757:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:757:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:757:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:765:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:765:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:765:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:771:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:771:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:771:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:778:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:778:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:778:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:813:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:813:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:813:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:819:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:819:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:819:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:826:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:826:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:826:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:834:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:834:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:834:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:843:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:843:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:843:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:851:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:851:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:851:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:858:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:858:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:858:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:934:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:934:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:934:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:721:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:721:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:721:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:728:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:728:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:728:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:740:23 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:740:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:740:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:755:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:755:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:755:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:762:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:762:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:762:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:770:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:770:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:770:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:776:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:776:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:776:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:783:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:783:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:783:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:818:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:818:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:818:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:824:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:824:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:824:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:831:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:831:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:831:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:839:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:839:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:839:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:848:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:848:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:848:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:856:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:856:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:856:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:863:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:863:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:863:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:939:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:939:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:939:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -78,7 +78,8 @@ declare namespace AADServerParamKeys {
         BROKER_REDIRECT_URI,
         INSTANCE_AWARE,
         EAR_JWK,
-        EAR_JWE_CRYPTO
+        EAR_JWE_CRYPTO,
+        CLI_DATA
     }
 }
 export { AADServerParamKeys }
@@ -267,6 +268,11 @@ function addCcsUpn(parameters: Map<string, string>, loginHint: string): void;
 //
 // @public
 function addClaims(parameters: Map<string, string>, claims?: string, clientCapabilities?: Array<string>): void;
+
+// Warning: (ae-missing-release-tag) "addCliData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function addCliData(parameters: Map<string, string>): void;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "addClientAssertion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -831,6 +837,7 @@ export type AuthorizeResponse = {
     correlation_id?: string;
     claims?: string;
     accountId?: string;
+    clientdata?: string;
 };
 
 // Warning: (ae-missing-release-tag) "authTimeNotFound" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1338,6 +1345,11 @@ export type ClaimsRequestKeys = (typeof ClaimsRequestKeys)[keyof typeof ClaimsRe
 //
 // @public (undocumented)
 const claimsRequestParsingError = "claims_request_parsing_error";
+
+// Warning: (ae-missing-release-tag) "CLI_DATA" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const CLI_DATA = "clidata";
 
 // Warning: (ae-missing-release-tag) "CLIENT_ASSERTION" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3443,6 +3455,7 @@ export type PerformanceEvent = {
     errorCode?: string;
     subErrorCode?: string;
     serverErrorNo?: string;
+    serverSubErrorNo?: string;
     libraryName: string;
     libraryVersion: string;
     previousLibraryVersion?: string;
@@ -3900,6 +3913,7 @@ declare namespace RequestParameterBuilder {
         addRequestTokenUse,
         addGrantType,
         addClientInfo,
+        addCliData,
         addInstanceAware,
         addExtraQueryParameters,
         addClientCapabilitiesToClaims,
@@ -4795,53 +4809,53 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/telemetry/performance/PerformanceEvent.ts:698:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:698:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:698:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:710:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:710:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:710:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:717:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:717:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:717:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:729:23 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:729:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:729:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:744:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:744:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:744:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:751:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:751:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:751:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:759:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:759:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:759:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:765:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:765:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:765:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:772:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:772:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:772:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:806:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:806:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:806:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:812:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:812:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:812:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:819:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:819:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:819:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:827:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:827:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:827:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:836:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:836:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:836:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:844:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:844:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:844:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:851:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:851:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:851:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:927:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:927:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:927:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:715:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:715:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:715:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:722:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:722:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:722:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:734:23 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:734:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:734:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:749:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:749:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:749:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:756:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:756:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:756:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:764:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:764:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:764:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:770:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:770:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:770:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:777:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:777:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:777:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:811:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:811:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:811:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:817:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:817:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:817:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:824:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:824:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:824:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:832:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:832:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:832:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:841:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:841:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:841:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:849:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:849:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:849:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:856:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:856:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:856:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:932:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:932:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:932:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/src/constants/AADServerParamKeys.ts
+++ b/lib/msal-common/src/constants/AADServerParamKeys.ts
@@ -61,3 +61,4 @@ export const BROKER_REDIRECT_URI = "brk_redirect_uri";
 export const INSTANCE_AWARE = "instance_aware";
 export const EAR_JWK = "ear_jwk";
 export const EAR_JWE_CRYPTO = "ear_jwe_crypto";
+export const CLI_DATA = "clidata";

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -75,6 +75,9 @@ export function getStandardAuthorizeRequestParameters(
     // add client_info=1
     RequestParameterBuilder.addClientInfo(parameters);
 
+    // add clidata=1
+    RequestParameterBuilder.addCliData(parameters);
+
     if (request.prompt) {
         RequestParameterBuilder.addPrompt(parameters, request.prompt);
         performanceClient?.addFields({ prompt: request.prompt }, correlationId);

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -458,6 +458,13 @@ export function addClientInfo(parameters: Map<string, string>): void {
     parameters.set(CLIENT_INFO, "1");
 }
 
+/**
+ * add clidata=1 to request to indicate client data support
+ */
+export function addCliData(parameters: Map<string, string>): void {
+    parameters.set(AADServerParamKeys.CLI_DATA, "1");
+}
+
 export function addInstanceAware(parameters: Map<string, string>): void {
     if (!parameters.has(AADServerParamKeys.INSTANCE_AWARE)) {
         parameters.set(AADServerParamKeys.INSTANCE_AWARE, "true");

--- a/lib/msal-common/src/response/AuthorizeResponse.ts
+++ b/lib/msal-common/src/response/AuthorizeResponse.ts
@@ -77,4 +77,9 @@ export type AuthorizeResponse = {
      * AccountId for the user, returned when platform broker is available to use
      */
     accountId?: string;
+    /**
+     * Client data returned by the server when clidata=1 is sent on the request.
+     * URL-encoded string in the format: account_type|error|sub_error|cloud_instance|caller_data_boundary
+     */
+    clientdata?: string;
 };

--- a/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceClient.ts
@@ -158,8 +158,10 @@ export function addError(
         event.errorCode = error.errorCode;
         event.subErrorCode = error.subError;
         if (
-            error instanceof ServerError ||
-            error instanceof InteractionRequiredAuthError
+            !event.serverErrorNo &&
+            (error instanceof ServerError ||
+                error instanceof InteractionRequiredAuthError) &&
+            error.errorNo
         ) {
             event.serverErrorNo = error.errorNo;
         }

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -705,6 +705,11 @@ export type PerformanceEvent = {
     serverErrorNo?: string;
 
     /**
+     * Server sub error number
+     */
+    serverSubErrorNo?: string;
+
+    /**
      * Name of the library used for the operation.
      *
      * @type {string}

--- a/lib/msal-common/test/protocol/Authorize.spec.ts
+++ b/lib/msal-common/test/protocol/Authorize.spec.ts
@@ -111,6 +111,9 @@ describe("Authorize Protocol Tests", () => {
                     )}`
                 )
             ).toBe(true);
+            expect(loginUrl.includes(`${AADServerParamKeys.CLI_DATA}=1`)).toBe(
+                true
+            );
         });
 
         it("Creates an authorization url passing in optional parameters", async () => {

--- a/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
+++ b/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
@@ -689,6 +689,86 @@ describe("PerformanceClient.spec.ts", () => {
                 error
             );
         });
+
+        it("does not set serverErrorNo from ServerError when serverErrorNo is already present", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+            const error = new ServerError(
+                "test-error-code",
+                undefined,
+                undefined,
+                "70011"
+            );
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                // serverSubErrorNo was already set via addFields (clientdata),
+                // so addError should NOT overwrite serverErrorNo
+                expect(event.serverErrorNo).toEqual("basic-server-error-code");
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.AcquireTokenSilent,
+                correlationId
+            );
+
+            // Simulate instrumentClientData having set serverSubErrorNo via addFields
+            mockPerfClient.addFields(
+                { serverErrorNo: "basic-server-error-code" },
+                correlationId
+            );
+
+            topLevelEvent.end(
+                {
+                    success: false,
+                },
+                error
+            );
+        });
+
+        it("does not set serverErrorNo from InteractionRequiredAuthError when serverErrorNo is already present", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+            const error = new InteractionRequiredAuthError(
+                "test-error-code",
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                "70011"
+            );
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                // serverSubErrorNo was already set via addFields (clientdata),
+                // so addError should NOT overwrite serverErrorNo
+                expect(event.serverErrorNo).toEqual("basic-server-error-code");
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.AcquireTokenSilent,
+                correlationId
+            );
+
+            // Simulate instrumentClientData having set serverSubErrorNo via addFields
+            mockPerfClient.addFields(
+                { serverErrorNo: "basic-server-error-code" },
+                correlationId
+            );
+
+            topLevelEvent.end(
+                {
+                    success: false,
+                },
+                error
+            );
+        });
     });
 
     describe("compactStackTrace", () => {

--- a/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
+++ b/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
@@ -1578,6 +1578,72 @@ describe("PerformanceClient.spec.ts", () => {
             topLevelEvent.end({ success: true }, undefined, unknownAccount);
         });
 
+        it("endMeasurement overwrites accountType previously set via addFields when account is provided", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+            // AAD account (tid is NOT the MSA tenant)
+            const aadAccount = {
+                homeAccountId: "test-home-account-id",
+                environment: "login.microsoftonline.com",
+                tenantId: "test-tenant-id",
+                username: "test@example.com",
+                localAccountId: "test-local-account-id",
+                idTokenClaims: {
+                    tid: "test-tenant-id",
+                },
+            };
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                // The account-derived type ("AAD") must overwrite the
+                // addFields value ("MSA") — account info is authoritative.
+                expect(event.accountType).toBe("AAD");
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.AcquireTokenSilent,
+                correlationId
+            );
+
+            // Simulate instrumentClientData setting accountType via addFields
+            mockPerfClient.addFields(
+                { accountType: "MSA" },
+                correlationId
+            );
+
+            // End with an AAD account — endMeasurement should overwrite accountType
+            topLevelEvent.end({ success: true }, undefined, aadAccount);
+        });
+
+        it("addFields accountType is preserved when endMeasurement is called without account", (done) => {
+            const mockPerfClient = new MockPerformanceClient();
+            const correlationId = "test-correlation-id";
+
+            mockPerfClient.addPerformanceCallback((events) => {
+                expect(events.length).toBe(1);
+                const event = events[0];
+                // No account passed to end(), so the addFields value should remain
+                expect(event.accountType).toBe("MSA");
+                done();
+            });
+
+            const topLevelEvent = mockPerfClient.startMeasurement(
+                PerformanceEvents.AcquireTokenSilent,
+                correlationId
+            );
+
+            // Simulate instrumentClientData setting accountType via addFields
+            mockPerfClient.addFields(
+                { accountType: "MSA" },
+                correlationId
+            );
+
+            // End without account — addFields value should be preserved
+            topLevelEvent.end({ success: true });
+        });
+
         it("handles account with empty dataBoundary properly", (done) => {
             const mockPerfClient = new MockPerformanceClient();
             const correlationId = "test-correlation-id";

--- a/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
+++ b/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
@@ -1608,10 +1608,7 @@ describe("PerformanceClient.spec.ts", () => {
             );
 
             // Simulate instrumentClientData setting accountType via addFields
-            mockPerfClient.addFields(
-                { accountType: "MSA" },
-                correlationId
-            );
+            mockPerfClient.addFields({ accountType: "MSA" }, correlationId);
 
             // End with an AAD account — endMeasurement should overwrite accountType
             topLevelEvent.end({ success: true }, undefined, aadAccount);
@@ -1635,10 +1632,7 @@ describe("PerformanceClient.spec.ts", () => {
             );
 
             // Simulate instrumentClientData setting accountType via addFields
-            mockPerfClient.addFields(
-                { accountType: "MSA" },
-                correlationId
-            );
+            mockPerfClient.addFields({ accountType: "MSA" }, correlationId);
 
             // End without account — addFields value should be preserved
             topLevelEvent.end({ success: true });


### PR DESCRIPTION
This pull request introduces a new mechanism for parsing and instrumenting the `clientdata` parameter returned from the `/authorize` endpoint, enhancing telemetry and error reporting for authentication flows. The main changes include the addition of a robust parser for the `clientdata` field, its integration into the telemetry pipeline, and comprehensive tests to ensure correct parsing and instrumentation. API review files and constants are also updated to reflect these changes.

**Clientdata Parsing and Instrumentation:**

- Added a new `parseClientData` function to extract structured information (account type, error, suberror, cloud instance, and caller data boundary) from the `clientdata` parameter, with robust handling for malformed or missing data. (`lib/msal-browser/src/protocol/Authorize.ts`, `lib/msal-browser/test/protocol/ClientDataParser.spec.ts`) [[1]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165R48-R125) [[2]](diffhunk://#diff-5d9629a97f66d7059e7e9ba3cc5efcd1a65407d6c346145d19d1a46854705876R1-R130)
- Introduced the `instrumentClientData` function, which processes the parsed `clientdata` and instruments telemetry fields (`accountType`, `serverErrorNo`, `serverSubErrorNo`) via the `performanceClient`. This function is now called in both `handleResponseCode` and `handleResponseEAR` flows to ensure telemetry is captured early. (`lib/msal-browser/src/protocol/Authorize.ts`) [[1]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165R493-R496) [[2]](diffhunk://#diff-a4a9623518687b3ceac75fec2a3748ba77e40fd2166581e3ff0c4149258c6165R577-R579)

**API and Telemetry Updates:**

- Updated API review files to add the `CLI_DATA` constant, the `addCliData` function, and the `clientdata` property to the `AuthorizeResponse` type, reflecting the new parameter and its usage. Also added `serverSubErrorNo` to the `PerformanceEvent` type. (`lib/msal-common/apiReview/msal-common.api.md`) [[1]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117L81-R82) [[2]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R272-R276) [[3]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R840) [[4]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R1349-R1353) [[5]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R3458) [[6]](diffhunk://#diff-09087b913ebbfa828e5f36b7476a400328e0a7131db84f622cc5f6994759a117R3909)

**Testing Enhancements:**

- Added a dedicated test suite for `parseClientData`, covering various edge cases, malformed input, and correct parsing for both MSA and Entra (AAD) account types. (`lib/msal-browser/test/protocol/ClientDataParser.spec.ts`)
- Expanded the `Authorize` protocol tests to verify that `clidata=1` is included in requests, and that telemetry fields are correctly instrumented from `clientdata` in both success and error scenarios. (`lib/msal-browser/test/protocol/Authorize.spec.ts`) [[1]](diffhunk://#diff-383f979b9a05a2d7fe02052138e8087f6ca2167e78d44dc4d41c391463d4da04R197) [[2]](diffhunk://#diff-383f979b9a05a2d7fe02052138e8087f6ca2167e78d44dc4d41c391463d4da04R470-R725)

These changes collectively improve error diagnostics, telemetry, and maintainability of the authentication flows by providing structured, early insight into server responses.