### PR TITLE
Improve compatibility with `React.StrictMode`

### DIFF
--- a/change/@azure-msal-react-4f039f9f-c1e0-4074-8610-ae97976618cf.json
+++ b/change/@azure-msal-react-4f039f9f-c1e0-4074-8610-ae97976618cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve compatability with `React.StrictMode` [#8383](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8383)",
+  "packageName": "@azure/msal-react",
+  "email": "herman.jensen@intility.no",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-react-4f039f9f-c1e0-4074-8610-ae97976618cf.json
+++ b/change/@azure-msal-react-4f039f9f-c1e0-4074-8610-ae97976618cf.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Improve compatability with `React.StrictMode` [#8383](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8383)",
+  "comment": "Improve compatibility with `React.StrictMode` [#8383](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8383)",
   "packageName": "@azure/msal-react",
   "email": "herman.jensen@intility.no",
   "dependentChangeType": "patch"

--- a/lib/msal-react/src/hooks/useMsalAuthentication.ts
+++ b/lib/msal-react/src/hooks/useMsalAuthentication.ts
@@ -60,6 +60,7 @@ export function useMsalAuthentication(
     // Used to prevent state updates after unmount
     const mounted = useRef(true);
     useEffect(() => {
+        mounted.current = true;
         return () => {
             mounted.current = false;
         };

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -1016,6 +1016,7 @@ describe("MsalAuthenticationTemplate tests", () => {
         ).not.toBeInTheDocument();
     });
 
+    test("Renders provided error component when rendered within React.StrictMode", async () => {
         const error = new AuthError("login_failed");
         jest.spyOn(pca, "loginPopup").mockImplementation(() => {
             return Promise.reject(error);

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -1016,7 +1016,6 @@ describe("MsalAuthenticationTemplate tests", () => {
         ).not.toBeInTheDocument();
     });
 
-    test("Renders provided error component in when rendered within React.StrictMode", async () => {
         const error = new AuthError("login_failed");
         jest.spyOn(pca, "loginPopup").mockImplementation(() => {
             return Promise.reject(error);

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -1016,6 +1016,39 @@ describe("MsalAuthenticationTemplate tests", () => {
         ).not.toBeInTheDocument();
     });
 
+    test("Renders provided error component in when rendered within React.StrictMode", async () => {
+        const error = new AuthError("login_failed");
+        jest.spyOn(pca, "loginPopup").mockImplementation(() => {
+            return Promise.reject(error);
+        });
+
+        const errorMessage = ({ error }: MsalAuthenticationResult) => {
+            if (error) {
+                return <p>Error Occurred: {error.errorCode}</p>;
+            }
+
+            return null;
+        };
+
+        render(
+            <React.StrictMode>
+                <MsalProvider instance={pca}>
+                    <p>This text will always display.</p>
+                    <MsalAuthenticationTemplate
+                        interactionType={InteractionType.Popup}
+                        errorComponent={errorMessage}
+                    >
+                        <span> A user is authenticated!</span>
+                    </MsalAuthenticationTemplate>
+                </MsalProvider>
+            </React.StrictMode>
+        );
+
+        expect(
+            await screen.findByText("Error Occurred: login_failed")
+        ).toBeInTheDocument();
+    });
+
     test("Throws invalid interaction type error", async () => {
         const error = new AuthError("login_failed");
         const loginPopupSpy = jest


### PR DESCRIPTION
Fixes #8381, which swallows errors with reacts `<StrictMode>` because the hook thinks it is unmounted.