### PR TITLE
[v4] Respect claims of the brokered application

### DIFF
--- a/change/@azure-msal-common-79a4d1d9-73c3-4be4-b159-2341a159485f.json
+++ b/change/@azure-msal-common-79a4d1d9-73c3-4be4-b159-2341a159485f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Update claims for brokering cases #[8409](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8409)",
+  "comment": "Update claims for brokering cases (#8409)",
   "packageName": "@azure/msal-common",
   "email": "sameera.gajjarapu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-79a4d1d9-73c3-4be4-b159-2341a159485f.json
+++ b/change/@azure-msal-common-79a4d1d9-73c3-4be4-b159-2341a159485f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update claims for brokering cases #[8409](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8409)",
+  "packageName": "@azure/msal-common",
+  "email": "sameera.gajjarapu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/docs/request-response-object.md
+++ b/lib/msal-browser/docs/request-response-object.md
@@ -14,3 +14,38 @@ The MSAL Browser library has a set of configuration options that can be used to 
 | `logoutRedirect` | [EndSessionRequest](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#endsessionrequest) | `void` |
 | `logoutPopup` | [EndSessionPopupRequest](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#endsessionpopuprequest) | `void` |
 | `ssoSilent` | [SsoSilentRequest](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#ssosilentrequest) | [AuthenticationResult](https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#authenticationresult) |
+
+## Request Parameters for Brokered Authentication
+
+### `skipBrokerClaims`
+
+When set to `true` on a request that also specifies an `embeddedClientId`, the `clientCapabilities` configured on the application (e.g. `["CP1", "CP2"]`) will be excluded from the `claims` parameter sent to the `/authorize` and `/token` endpoints. This is intended for brokered authentication flows where the embedded (child) application should not inherit the broker (parent) application's client capabilities.
+
+Both conditions must be met for capabilities to be excluded:
+
+- `skipBrokerClaims` is `true` on the request
+- `embeddedClientId` is set on the request (which results in the `brk_client_id` parameter being present)
+
+If only one condition is met, `clientCapabilities` are included as normal.
+
+#### Example
+
+```javascript
+const request = {
+    scopes: ["User.Read"],
+    embeddedClientId: "child-app-client-id",
+    skipBrokerClaims: true,
+};
+
+// clientCapabilities from config will NOT be sent in the claims parameter
+const response = await msalInstance.acquireTokenSilent(request);
+```
+
+#### Behavior Summary
+
+| `skipBrokerClaims` | `embeddedClientId` set | `clientCapabilities` included in claims |
+|--------------------|------------------------|-----------------------------------------|
+| `false` / not set  | Yes                    | Yes                                     |
+| `false` / not set  | No                     | Yes                                     |
+| `true`             | No                     | Yes                                     |
+| `true`             | Yes                    | **No**                                  |

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -915,6 +915,7 @@ export type BaseAuthRequest = {
     embeddedClientId?: string;
     httpMethod?: HttpMethod;
     authorizePostBodyParameters?: StringDict;
+    skipBrokerClaims?: boolean;
 };
 
 // Warning: (ae-internal-missing-underscore) The name "BaseClient" should be prefixed with an underscore because the declaration is marked as @internal
@@ -4732,7 +4733,7 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/client/AuthorizationCodeClient.ts:160:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:161:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:230:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:466:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:472:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:196:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:289:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:290:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -4733,7 +4733,7 @@ const X_MS_LIB_CAPABILITY = "x-ms-lib-capability";
 // src/client/AuthorizationCodeClient.ts:160:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:161:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:230:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:472:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:473:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:196:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:289:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:290:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -447,16 +447,13 @@ export class AuthorizationCodeClient extends BaseClient {
             this.performanceClient
         );
 
+        const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
+            ? undefined
+            : this.config.authOptions.clientCapabilities;
         if (
             !StringUtils.isEmptyObj(request.claims) ||
-            (this.config.authOptions.clientCapabilities &&
-                this.config.authOptions.clientCapabilities.length > 0)
+            (configClaims && configClaims.length > 0)
         ) {
-            const configClaims = parameters.has(
-                AADServerParamKeys.BROKER_CLIENT_ID
-            )
-                ? undefined
-                : this.config.authOptions.clientCapabilities;
             RequestParameterBuilder.addClaims(
                 parameters,
                 request.claims,

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -447,9 +447,12 @@ export class AuthorizationCodeClient extends BaseClient {
             this.performanceClient
         );
 
-        const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
-            ? undefined
-            : this.config.authOptions.clientCapabilities;
+        const configClaims =
+            request.skipBrokerClaims &&
+            parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
+                ? undefined
+                : this.config.authOptions.clientCapabilities;
+
         if (
             !StringUtils.isEmptyObj(request.claims) ||
             (configClaims && configClaims.length > 0)

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -447,6 +447,7 @@ export class AuthorizationCodeClient extends BaseClient {
             this.performanceClient
         );
 
+        // ignore config claims if skipBrokerClaims is set to true and this is a brokered authentication flow
         const configClaims =
             request.skipBrokerClaims &&
             parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -365,18 +365,6 @@ export class AuthorizationCodeClient extends BaseClient {
             }
         }
 
-        if (
-            !StringUtils.isEmptyObj(request.claims) ||
-            (this.config.authOptions.clientCapabilities &&
-                this.config.authOptions.clientCapabilities.length > 0)
-        ) {
-            RequestParameterBuilder.addClaims(
-                parameters,
-                request.claims,
-                this.config.authOptions.clientCapabilities
-            );
-        }
-
         let ccsCred: CcsCredential | undefined = undefined;
         if (request.clientInfo) {
             try {
@@ -458,6 +446,24 @@ export class AuthorizationCodeClient extends BaseClient {
             request.correlationId,
             this.performanceClient
         );
+
+        if (
+            !StringUtils.isEmptyObj(request.claims) ||
+            (this.config.authOptions.clientCapabilities &&
+                this.config.authOptions.clientCapabilities.length > 0)
+        ) {
+            const configClaims = parameters.has(
+                AADServerParamKeys.BROKER_CLIENT_ID
+            )
+                ? undefined
+                : this.config.authOptions.clientCapabilities;
+            RequestParameterBuilder.addClaims(
+                parameters,
+                request.claims,
+                configClaims
+            );
+        }
+
         return UrlUtils.mapToQueryString(parameters);
     }
 

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -509,16 +509,14 @@ export class RefreshTokenClient extends BaseClient {
             this.performanceClient
         );
 
+        const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
+            ? undefined
+            : this.config.authOptions.clientCapabilities;
+
         if (
             !StringUtils.isEmptyObj(request.claims) ||
-            (this.config.authOptions.clientCapabilities &&
-                this.config.authOptions.clientCapabilities.length > 0)
+            (configClaims && configClaims.length > 0)
         ) {
-            const configClaims = parameters.has(
-                AADServerParamKeys.BROKER_CLIENT_ID
-            )
-                ? undefined
-                : this.config.authOptions.clientCapabilities;
             RequestParameterBuilder.addClaims(
                 parameters,
                 request.claims,

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -509,6 +509,7 @@ export class RefreshTokenClient extends BaseClient {
             this.performanceClient
         );
 
+        // ignore config claims if skipBrokerClaims is set to true and this is a brokered authentication flow
         const configClaims =
             request.skipBrokerClaims &&
             parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -459,18 +459,6 @@ export class RefreshTokenClient extends BaseClient {
         }
 
         if (
-            !StringUtils.isEmptyObj(request.claims) ||
-            (this.config.authOptions.clientCapabilities &&
-                this.config.authOptions.clientCapabilities.length > 0)
-        ) {
-            RequestParameterBuilder.addClaims(
-                parameters,
-                request.claims,
-                this.config.authOptions.clientCapabilities
-            );
-        }
-
-        if (
             this.config.systemOptions.preventCorsPreflight &&
             request.ccsCredential
         ) {
@@ -520,6 +508,24 @@ export class RefreshTokenClient extends BaseClient {
             request.correlationId,
             this.performanceClient
         );
+
+        if (
+            !StringUtils.isEmptyObj(request.claims) ||
+            (this.config.authOptions.clientCapabilities &&
+                this.config.authOptions.clientCapabilities.length > 0)
+        ) {
+            const configClaims = parameters.has(
+                AADServerParamKeys.BROKER_CLIENT_ID
+            )
+                ? undefined
+                : this.config.authOptions.clientCapabilities;
+            RequestParameterBuilder.addClaims(
+                parameters,
+                request.claims,
+                configClaims
+            );
+        }
+
         return UrlUtils.mapToQueryString(parameters);
     }
 }

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -509,9 +509,11 @@ export class RefreshTokenClient extends BaseClient {
             this.performanceClient
         );
 
-        const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
-            ? undefined
-            : this.config.authOptions.clientCapabilities;
+        const configClaims =
+            request.skipBrokerClaims ||
+            parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
+                ? undefined
+                : this.config.authOptions.clientCapabilities;
 
         if (
             !StringUtils.isEmptyObj(request.claims) ||

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -510,7 +510,7 @@ export class RefreshTokenClient extends BaseClient {
         );
 
         const configClaims =
-            request.skipBrokerClaims ||
+            request.skipBrokerClaims &&
             parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
                 ? undefined
                 : this.config.authOptions.clientCapabilities;

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -231,6 +231,7 @@ export function getStandardAuthorizeRequestParameters(
         );
     }
 
+    // ignore config claims if skipBrokerClaims is set to true and this is a brokered authentication flow
     const configClaims =
         request.skipBrokerClaims &&
         parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
@@ -238,7 +239,6 @@ export function getStandardAuthorizeRequestParameters(
             : authOptions.clientCapabilities;
 
     if (request.claims || (configClaims && configClaims.length > 0)) {
-        // ignore config capabilities if claims are explicitly passed in the request for brokered auth flows
         RequestParameterBuilder.addClaims(
             parameters,
             request.claims,

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -236,7 +236,7 @@ export function getStandardAuthorizeRequestParameters(
         (authOptions.clientCapabilities &&
             authOptions.clientCapabilities.length > 0)
     ) {
-        // ignore config capabilities if claims are explicitly passed in the request for brokered auth flows
+        // For brokered auth flows (identified by BROKER_CLIENT_ID), config clientCapabilities are not applied
         const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
             ? undefined
             : authOptions.clientCapabilities;

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -231,15 +231,16 @@ export function getStandardAuthorizeRequestParameters(
         );
     }
 
-    if (
-        request.claims ||
-        (authOptions.clientCapabilities &&
-            authOptions.clientCapabilities.length > 0)
-    ) {
-        // For brokered auth flows (identified by BROKER_CLIENT_ID), config clientCapabilities are not applied
-        const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
-            ? undefined
-            : authOptions.clientCapabilities;
+    const shouldAddConfigCapabilities =
+        !parameters.has(AADServerParamKeys.BROKER_CLIENT_ID) &&
+        authOptions.clientCapabilities &&
+        authOptions.clientCapabilities.length > 0;
+
+    if (request.claims || shouldAddConfigCapabilities) {
+        // ignore config capabilities if claims are explicitly passed in the request for brokered auth flows
+        const configClaims = shouldAddConfigCapabilities
+            ? authOptions.clientCapabilities
+            : undefined;
         RequestParameterBuilder.addClaims(
             parameters,
             request.claims,

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -232,7 +232,7 @@ export function getStandardAuthorizeRequestParameters(
     }
 
     const configClaims =
-        request.skipBrokerClaims ||
+        request.skipBrokerClaims &&
         parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
             ? undefined
             : authOptions.clientCapabilities;

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -223,26 +223,27 @@ export function getStandardAuthorizeRequestParameters(
         RequestParameterBuilder.addState(parameters, request.state);
     }
 
+    if (request.embeddedClientId) {
+        RequestParameterBuilder.addBrokerParameters(
+            parameters,
+            authOptions.clientId,
+            authOptions.redirectUri
+        );
+    }
+
     if (
         request.claims ||
         (authOptions.clientCapabilities &&
             authOptions.clientCapabilities.length > 0)
     ) {
         // ignore config capabilities if claims are explicitly passed in the request for brokered auth flows
+        const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
+            ? undefined
+            : authOptions.clientCapabilities;
         RequestParameterBuilder.addClaims(
             parameters,
             request.claims,
-            request.embeddedClientId
-                ? undefined
-                : authOptions.clientCapabilities
-        );
-    }
-
-    if (request.embeddedClientId) {
-        RequestParameterBuilder.addBrokerParameters(
-            parameters,
-            authOptions.clientId,
-            authOptions.redirectUri
+            configClaims
         );
     }
 

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -231,9 +231,11 @@ export function getStandardAuthorizeRequestParameters(
         );
     }
 
-    const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
-        ? undefined
-        : authOptions.clientCapabilities;
+    const configClaims =
+        request.skipBrokerClaims ||
+        parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
+            ? undefined
+            : authOptions.clientCapabilities;
 
     if (request.claims || (configClaims && configClaims.length > 0)) {
         // ignore config capabilities if claims are explicitly passed in the request for brokered auth flows

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -228,10 +228,13 @@ export function getStandardAuthorizeRequestParameters(
         (authOptions.clientCapabilities &&
             authOptions.clientCapabilities.length > 0)
     ) {
+        // ignore config capabilities if claims are explicitly passed in the request for brokered auth flows
         RequestParameterBuilder.addClaims(
             parameters,
             request.claims,
-            authOptions.clientCapabilities
+            request.embeddedClientId
+                ? undefined
+                : authOptions.clientCapabilities
         );
     }
 

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -231,16 +231,12 @@ export function getStandardAuthorizeRequestParameters(
         );
     }
 
-    const shouldAddConfigCapabilities =
-        !parameters.has(AADServerParamKeys.BROKER_CLIENT_ID) &&
-        authOptions.clientCapabilities &&
-        authOptions.clientCapabilities.length > 0;
+    const configClaims = parameters.has(AADServerParamKeys.BROKER_CLIENT_ID)
+        ? undefined
+        : authOptions.clientCapabilities;
 
-    if (request.claims || shouldAddConfigCapabilities) {
+    if (request.claims || (configClaims && configClaims.length > 0)) {
         // ignore config capabilities if claims are explicitly passed in the request for brokered auth flows
-        const configClaims = shouldAddConfigCapabilities
-            ? authOptions.clientCapabilities
-            : undefined;
         RequestParameterBuilder.addClaims(
             parameters,
             request.claims,

--- a/lib/msal-common/src/request/BaseAuthRequest.ts
+++ b/lib/msal-common/src/request/BaseAuthRequest.ts
@@ -33,7 +33,7 @@ import { ShrOptions } from "../crypto/SignedHttpRequest.js";
  * - embeddedClientId        - Embedded client id. When specified, broker client id (brk_client_id) and redirect uri (brk_redirect_uri) params are set with values from the config, overriding the corresponding extra parameters, if present.
  * - httpMethod              - HTTP method to use for the /authorize request. Defaults to GET, but can be set to POST if the request requires body parameters
  * - authorizePostBodyParameters - String to string map of custom parameters added to the body of the /authorize call when httpMethod is set to POST
- * - skipBrokerClaims         - When true, clientCapabilities from configuration will be excluded from claims. Used in brokered authentication flows.
+ * - skipBrokerClaims         - When true and a brokered flow is used (for example, when broker params or an embeddedClientId are present), clientCapabilities from configuration will be excluded from claims; ignored for non-brokered flows.
  */
 export type BaseAuthRequest = {
     authority: string;

--- a/lib/msal-common/src/request/BaseAuthRequest.ts
+++ b/lib/msal-common/src/request/BaseAuthRequest.ts
@@ -33,6 +33,7 @@ import { ShrOptions } from "../crypto/SignedHttpRequest.js";
  * - embeddedClientId        - Embedded client id. When specified, broker client id (brk_client_id) and redirect uri (brk_redirect_uri) params are set with values from the config, overriding the corresponding extra parameters, if present.
  * - httpMethod              - HTTP method to use for the /authorize request. Defaults to GET, but can be set to POST if the request requires body parameters
  * - authorizePostBodyParameters - String to string map of custom parameters added to the body of the /authorize call when httpMethod is set to POST
+ * - skipBrokerClaims         - When true, clientCapabilities from configuration will be excluded from claims. Used in brokered authentication flows.
  */
 export type BaseAuthRequest = {
     authority: string;
@@ -58,4 +59,5 @@ export type BaseAuthRequest = {
     embeddedClientId?: string;
     httpMethod?: HttpMethod;
     authorizePostBodyParameters?: StringDict;
+    skipBrokerClaims?: boolean;
 };

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -2667,5 +2667,147 @@ describe("AuthorizationCodeClient unit tests", () => {
                 `brk_redirect_uri=${encodeURIComponent("https://localhost")}`
             );
         });
+
+        it("includes clientCapabilities from config when BROKER_CLIENT_ID is present but skipBrokerClaims is not set", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            // Add clientCapabilities to the config
+            config.authOptions.clientCapabilities = ["CP1", "CP2"];
+            const client = new AuthorizationCodeClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    embeddedClientId: "child_client_id_1",
+                    claims: JSON.stringify({ userinfo: { given_name: null } }),
+                });
+
+            // Verify embeddedClientId is used as client_id and brk_client_id (BROKER_CLIENT_ID) is present
+            expect(queryString).toContain(`client_id=child_client_id_1`);
+            expect(queryString).toContain(
+                `brk_client_id=${config.authOptions.clientId}`
+            );
+
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            // because skipBrokerClaims is not set, BROKER_CLIENT_ID alone does not skip capabilities
+            const claimsMatch = queryString.match(/claims=([^&]+)/);
+            expect(claimsMatch).not.toBeNull();
+            const parsedClaims = JSON.parse(
+                decodeURIComponent(claimsMatch![1])
+            );
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
+        });
+
+        it("includes clientCapabilities from config when BROKER_CLIENT_ID is NOT present", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            // Add clientCapabilities to the config
+            config.authOptions.clientCapabilities = ["CP1", "CP2"];
+            const client = new AuthorizationCodeClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    claims: JSON.stringify({ userinfo: { given_name: null } }),
+                });
+
+            // Verify standard client_id is used (from config)
+            expect(queryString).toContain(
+                `client_id=${config.authOptions.clientId}`
+            );
+            // Verify brk_client_id (BROKER_CLIENT_ID) is NOT present
+            expect(queryString).not.toContain(`brk_client_id=`);
+
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            const claimsMatch = queryString.match(/claims=([^&]+)/);
+            expect(claimsMatch).not.toBeNull();
+            const parsedClaims = JSON.parse(
+                decodeURIComponent(claimsMatch![1])
+            );
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
+        });
+
+        it("includes clientCapabilities from config when skipBrokerClaims is true but BROKER_CLIENT_ID is NOT present", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            // Add clientCapabilities to the config
+            config.authOptions.clientCapabilities = ["CP1", "CP2"];
+            const client = new AuthorizationCodeClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    claims: JSON.stringify({ userinfo: { given_name: null } }),
+                    skipBrokerClaims: true,
+                });
+
+            // Verify standard client_id is used (from config)
+            expect(queryString).toContain(
+                `client_id=${config.authOptions.clientId}`
+            );
+            // Verify brk_client_id is NOT present (not a brokered flow)
+            expect(queryString).not.toContain(`brk_client_id=`);
+
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            // because BROKER_CLIENT_ID is not present, skipBrokerClaims alone does not skip capabilities
+            const claimsMatch = queryString.match(/claims=([^&]+)/);
+            expect(claimsMatch).not.toBeNull();
+            const parsedClaims = JSON.parse(
+                decodeURIComponent(claimsMatch![1])
+            );
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
+        });
+
+        it("ignores clientCapabilities from config when both skipBrokerClaims is true and BROKER_CLIENT_ID is present", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            // Add clientCapabilities to the config
+            config.authOptions.clientCapabilities = ["CP1", "CP2"];
+            const client = new AuthorizationCodeClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    embeddedClientId: "child_client_id_1",
+                    claims: JSON.stringify({ userinfo: { given_name: null } }),
+                    skipBrokerClaims: true,
+                });
+
+            // Verify embeddedClientId is used as client_id and brk_client_id (BROKER_CLIENT_ID) is present
+            expect(queryString).toContain(`client_id=child_client_id_1`);
+            expect(queryString).toContain(
+                `brk_client_id=${config.authOptions.clientId}`
+            );
+
+            // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            // because both skipBrokerClaims is true AND BROKER_CLIENT_ID is present
+            const claimsMatch = queryString.match(/claims=([^&]+)/);
+            expect(claimsMatch).not.toBeNull();
+            const parsedClaims = JSON.parse(
+                decodeURIComponent(claimsMatch![1])
+            );
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc).toBeUndefined();
+        });
     });
 });

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -1644,7 +1644,7 @@ describe("RefreshTokenClient unit tests", () => {
             );
         });
 
-        it("ignores clientCapabilities from config when BROKER_CLIENT_ID is present", async () => {
+        it("includes clientCapabilities from config when BROKER_CLIENT_ID is present but skipBrokerClaims is not set", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
             // Add clientCapabilities to the config
@@ -1666,14 +1666,18 @@ describe("RefreshTokenClient unit tests", () => {
                 `brk_client_id=${config.authOptions.clientId}`
             );
 
-            // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            // because skipBrokerClaims is not set, BROKER_CLIENT_ID alone does not skip capabilities
             const claimsMatch = queryString.match(/claims=([^&]+)/);
             expect(claimsMatch).not.toBeNull();
             const parsedClaims = JSON.parse(
                 decodeURIComponent(claimsMatch![1])
             );
             expect(parsedClaims.userinfo).toBeDefined();
-            expect(parsedClaims.access_token?.xms_cc).toBeUndefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
         });
 
         it("includes clientCapabilities from config when BROKER_CLIENT_ID is NOT present", async () => {
@@ -1711,7 +1715,7 @@ describe("RefreshTokenClient unit tests", () => {
             ]);
         });
 
-        it("ignores clientCapabilities from config when skipBrokerClaims is true on request", async () => {
+        it("includes clientCapabilities from config when skipBrokerClaims is true but BROKER_CLIENT_ID is NOT present", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();
             // Add clientCapabilities to the config
@@ -1734,7 +1738,45 @@ describe("RefreshTokenClient unit tests", () => {
             // Verify brk_client_id is NOT present (not a brokered flow)
             expect(queryString).not.toContain(`brk_client_id=`);
 
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            // because BROKER_CLIENT_ID is not present, skipBrokerClaims alone does not skip capabilities
+            const claimsMatch = queryString.match(/claims=([^&]+)/);
+            expect(claimsMatch).not.toBeNull();
+            const parsedClaims = JSON.parse(
+                decodeURIComponent(claimsMatch![1])
+            );
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
+        });
+
+        it("ignores clientCapabilities from config when both skipBrokerClaims is true and BROKER_CLIENT_ID is present", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            // Add clientCapabilities to the config
+            config.authOptions.clientCapabilities = ["CP1", "CP2"];
+            const client = new RefreshTokenClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    embeddedClientId: "child_client_id_1",
+                    claims: JSON.stringify({ userinfo: { given_name: null } }),
+                    skipBrokerClaims: true,
+                });
+
+            // Verify embeddedClientId is used as client_id and brk_client_id (BROKER_CLIENT_ID) is present
+            expect(queryString).toContain(`client_id=child_client_id_1`);
+            expect(queryString).toContain(
+                `brk_client_id=${config.authOptions.clientId}`
+            );
+
             // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            // because both skipBrokerClaims is true AND BROKER_CLIENT_ID is present
             const claimsMatch = queryString.match(/claims=([^&]+)/);
             expect(claimsMatch).not.toBeNull();
             const parsedClaims = JSON.parse(

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -1643,5 +1643,70 @@ describe("RefreshTokenClient unit tests", () => {
                 `brk_redirect_uri=${encodeURIComponent("https://localhost")}`
             );
         });
+
+        it("ignores clientCapabilities from config when BROKER_CLIENT_ID is present", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            // Add clientCapabilities to the config
+            config.authOptions.clientCapabilities = ["CP1", "CP2"];
+            const client = new RefreshTokenClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    embeddedClientId: "child_client_id_1",
+                    claims: JSON.stringify({ userinfo: { given_name: null } }),
+                });
+
+            // Verify embeddedClientId is used as client_id and brk_client_id (BROKER_CLIENT_ID) is present
+            expect(queryString).toContain(`client_id=child_client_id_1`);
+            expect(queryString).toContain(`brk_client_id=`);
+
+            // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            const claimsMatch = queryString.match(/claims=([^&]+)/);
+            expect(claimsMatch).not.toBeNull();
+            const parsedClaims = JSON.parse(
+                decodeURIComponent(claimsMatch![1])
+            );
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc).toBeUndefined();
+        });
+
+        it("includes clientCapabilities from config when BROKER_CLIENT_ID is NOT present", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            // Add clientCapabilities to the config
+            config.authOptions.clientCapabilities = ["CP1", "CP2"];
+            const client = new RefreshTokenClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    claims: JSON.stringify({ userinfo: { given_name: null } }),
+                });
+
+            // Verify standard client_id is used (from config)
+            expect(queryString).toContain(
+                `client_id=${config.authOptions.clientId}`
+            );
+            // Verify brk_client_id (BROKER_CLIENT_ID) is NOT present
+            expect(queryString).not.toContain(`brk_client_id=`);
+
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            const claimsMatch = queryString.match(/claims=([^&]+)/);
+            expect(claimsMatch).not.toBeNull();
+            const parsedClaims = JSON.parse(
+                decodeURIComponent(claimsMatch![1])
+            );
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
+        });
     });
 });

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -1662,7 +1662,9 @@ describe("RefreshTokenClient unit tests", () => {
 
             // Verify embeddedClientId is used as client_id and brk_client_id (BROKER_CLIENT_ID) is present
             expect(queryString).toContain(`client_id=child_client_id_1`);
-            expect(queryString).toContain(`brk_client_id=`);
+            expect(queryString).toContain(
+                `brk_client_id=${config.authOptions.clientId}`
+            );
 
             // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
             const claimsMatch = queryString.match(/claims=([^&]+)/);

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -1710,5 +1710,38 @@ describe("RefreshTokenClient unit tests", () => {
                 "CP2",
             ]);
         });
+
+        it("ignores clientCapabilities from config when skipBrokerClaims is true on request", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            // Add clientCapabilities to the config
+            config.authOptions.clientCapabilities = ["CP1", "CP2"];
+            const client = new RefreshTokenClient(config);
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    claims: JSON.stringify({ userinfo: { given_name: null } }),
+                    skipBrokerClaims: true,
+                });
+
+            // Verify standard client_id is used (from config)
+            expect(queryString).toContain(
+                `client_id=${config.authOptions.clientId}`
+            );
+            // Verify brk_client_id is NOT present (not a brokered flow)
+            expect(queryString).not.toContain(`brk_client_id=`);
+
+            // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            const claimsMatch = queryString.match(/claims=([^&]+)/);
+            expect(claimsMatch).not.toBeNull();
+            const parsedClaims = JSON.parse(
+                decodeURIComponent(claimsMatch![1])
+            );
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc).toBeUndefined();
+        });
     });
 });

--- a/lib/msal-common/test/protocol/Authorize.spec.ts
+++ b/lib/msal-common/test/protocol/Authorize.spec.ts
@@ -1398,6 +1398,78 @@ describe("Authorize Protocol Tests", () => {
                 `brk_redirect_uri=${encodeURIComponent("https://localhost")}`
             );
         });
+
+        it("ignores clientCapabilities from config when embeddedClientId is provided", async () => {
+            const authOptionsWithCapabilities: AuthOptions = {
+                ...authOptions,
+                clientCapabilities: ["CP1", "CP2"],
+            };
+
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: ResponseMode.FRAGMENT,
+                redirectUri: "localhost",
+                embeddedClientId: "child_client_id_1",
+                claims: JSON.stringify({ userinfo: { given_name: null } }),
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptionsWithCapabilities,
+                    request,
+                    new Logger({})
+                );
+            const queryString = UrlUtils.mapToQueryString(params);
+
+            // Verify embeddedClientId is used as client_id
+            expect(queryString).toContain(`client_id=child_client_id_1`);
+
+            // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            const claimsParam = params.get(AADServerParamKeys.CLAIMS);
+            expect(claimsParam).toBeDefined();
+            const parsedClaims = JSON.parse(claimsParam!);
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc).toBeUndefined();
+        });
+
+        it("includes clientCapabilities from config when embeddedClientId is NOT provided", async () => {
+            const authOptionsWithCapabilities: AuthOptions = {
+                ...authOptions,
+                clientCapabilities: ["CP1", "CP2"],
+            };
+
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: ResponseMode.FRAGMENT,
+                redirectUri: "localhost",
+                claims: JSON.stringify({ userinfo: { given_name: null } }),
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptionsWithCapabilities,
+                    request,
+                    new Logger({})
+                );
+
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            const claimsParam = params.get(AADServerParamKeys.CLAIMS);
+            expect(claimsParam).toBeDefined();
+            const parsedClaims = JSON.parse(claimsParam!);
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
+        });
     });
 
     describe("getAuthorizationCodePayload", () => {

--- a/lib/msal-common/test/protocol/Authorize.spec.ts
+++ b/lib/msal-common/test/protocol/Authorize.spec.ts
@@ -1471,6 +1471,39 @@ describe("Authorize Protocol Tests", () => {
                 "CP2",
             ]);
         });
+
+        it("ignores clientCapabilities from config when skipBrokerClaims is true on request", async () => {
+            const authOptionsWithCapabilities: AuthOptions = {
+                ...authOptions,
+                clientCapabilities: ["CP1", "CP2"],
+            };
+
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: ResponseMode.FRAGMENT,
+                redirectUri: "localhost",
+                claims: JSON.stringify({ userinfo: { given_name: null } }),
+                skipBrokerClaims: true,
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptionsWithCapabilities,
+                    request,
+                    new Logger({})
+                );
+
+            // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            const claimsParam = params.get(AADServerParamKeys.CLAIMS);
+            expect(claimsParam).toBeDefined();
+            const parsedClaims = JSON.parse(claimsParam!);
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc).toBeUndefined();
+        });
     });
 
     describe("getAuthorizationCodePayload", () => {

--- a/lib/msal-common/test/protocol/Authorize.spec.ts
+++ b/lib/msal-common/test/protocol/Authorize.spec.ts
@@ -1399,7 +1399,7 @@ describe("Authorize Protocol Tests", () => {
             );
         });
 
-        it("ignores clientCapabilities from config when BROKER_CLIENT_ID is present", async () => {
+        it("includes clientCapabilities from config when BROKER_CLIENT_ID is present but skipBrokerClaims is not set", async () => {
             const authOptionsWithCapabilities: AuthOptions = {
                 ...authOptions,
                 clientCapabilities: ["CP1", "CP2"],
@@ -1429,12 +1429,16 @@ describe("Authorize Protocol Tests", () => {
             expect(queryString).toContain(`client_id=child_client_id_1`);
             expect(params.has(AADServerParamKeys.BROKER_CLIENT_ID)).toBe(true);
 
-            // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            // because skipBrokerClaims is not set, BROKER_CLIENT_ID alone does not skip capabilities
             const claimsParam = params.get(AADServerParamKeys.CLAIMS);
             expect(claimsParam).toBeDefined();
             const parsedClaims = JSON.parse(claimsParam!);
             expect(parsedClaims.userinfo).toBeDefined();
-            expect(parsedClaims.access_token?.xms_cc).toBeUndefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
         });
 
         it("includes clientCapabilities from config when BROKER_CLIENT_ID is NOT present", async () => {
@@ -1472,7 +1476,7 @@ describe("Authorize Protocol Tests", () => {
             ]);
         });
 
-        it("ignores clientCapabilities from config when skipBrokerClaims is true on request", async () => {
+        it("includes clientCapabilities from config when skipBrokerClaims is true but BROKER_CLIENT_ID is NOT present", async () => {
             const authOptionsWithCapabilities: AuthOptions = {
                 ...authOptions,
                 clientCapabilities: ["CP1", "CP2"],
@@ -1497,7 +1501,51 @@ describe("Authorize Protocol Tests", () => {
                     new Logger({})
                 );
 
+            // Verify claims are present and DO include access_token.xms_cc (clientCapabilities)
+            // because BROKER_CLIENT_ID is not present, skipBrokerClaims alone does not skip capabilities
+            const claimsParam = params.get(AADServerParamKeys.CLAIMS);
+            expect(claimsParam).toBeDefined();
+            const parsedClaims = JSON.parse(claimsParam!);
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.access_token?.xms_cc?.values).toEqual([
+                "CP1",
+                "CP2",
+            ]);
+        });
+
+        it("ignores clientCapabilities from config when both skipBrokerClaims is true and BROKER_CLIENT_ID is present", async () => {
+            const authOptionsWithCapabilities: AuthOptions = {
+                ...authOptions,
+                clientCapabilities: ["CP1", "CP2"],
+            };
+
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: ResponseMode.FRAGMENT,
+                redirectUri: "localhost",
+                embeddedClientId: "child_client_id_1",
+                claims: JSON.stringify({ userinfo: { given_name: null } }),
+                skipBrokerClaims: true,
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptionsWithCapabilities,
+                    request,
+                    new Logger({})
+                );
+            const queryString = UrlUtils.mapToQueryString(params);
+
+            // Verify embeddedClientId is used as client_id and brk_client_id is present
+            expect(queryString).toContain(`client_id=child_client_id_1`);
+            expect(params.has(AADServerParamKeys.BROKER_CLIENT_ID)).toBe(true);
+
             // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
+            // because both skipBrokerClaims is true AND BROKER_CLIENT_ID is present
             const claimsParam = params.get(AADServerParamKeys.CLAIMS);
             expect(claimsParam).toBeDefined();
             const parsedClaims = JSON.parse(claimsParam!);

--- a/lib/msal-common/test/protocol/Authorize.spec.ts
+++ b/lib/msal-common/test/protocol/Authorize.spec.ts
@@ -1399,7 +1399,7 @@ describe("Authorize Protocol Tests", () => {
             );
         });
 
-        it("ignores clientCapabilities from config when embeddedClientId is provided", async () => {
+        it("ignores clientCapabilities from config when BROKER_CLIENT_ID is present", async () => {
             const authOptionsWithCapabilities: AuthOptions = {
                 ...authOptions,
                 clientCapabilities: ["CP1", "CP2"],
@@ -1425,8 +1425,9 @@ describe("Authorize Protocol Tests", () => {
                 );
             const queryString = UrlUtils.mapToQueryString(params);
 
-            // Verify embeddedClientId is used as client_id
+            // Verify embeddedClientId is used as client_id and brk_client_id is present
             expect(queryString).toContain(`client_id=child_client_id_1`);
+            expect(params.has(AADServerParamKeys.BROKER_CLIENT_ID)).toBe(true);
 
             // Verify claims are present but do NOT include access_token.xms_cc (clientCapabilities)
             const claimsParam = params.get(AADServerParamKeys.CLAIMS);
@@ -1436,7 +1437,7 @@ describe("Authorize Protocol Tests", () => {
             expect(parsedClaims.access_token?.xms_cc).toBeUndefined();
         });
 
-        it("includes clientCapabilities from config when embeddedClientId is NOT provided", async () => {
+        it("includes clientCapabilities from config when BROKER_CLIENT_ID is NOT present", async () => {
             const authOptionsWithCapabilities: AuthOptions = {
                 ...authOptions,
                 clientCapabilities: ["CP1", "CP2"],


### PR DESCRIPTION
This PR ensures the embedded application's claims are the only ones sent up to the token request when brokered.

Please note: Does not cover native use cases (which will follow up with another PR). 