### PR TITLE
[v4] Add missing client capabilities in platform broker flows

### DIFF
--- a/change/@azure-msal-browser-1b2a76c3-c15b-44f4-a998-f3bb6137b81f.json
+++ b/change/@azure-msal-browser-1b2a76c3-c15b-44f4-a998-f3bb6137b81f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing client capabilities in platform broker flows",
+  "packageName": "@azure/msal-browser",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-1b2a76c3-c15b-44f4-a998-f3bb6137b81f.json
+++ b/change/@azure-msal-browser-1b2a76c3-c15b-44f4-a998-f3bb6137b81f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add missing client capabilities in platform broker flows",
+  "comment": "Add missing client capabilities in platform broker flows [#8429](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8429)",
   "packageName": "@azure/msal-browser",
   "email": "lalimasharda@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-de3bae34-3a4a-4fb4-80c6-5e686d9a8bf5.json
+++ b/change/@azure-msal-browser-de3bae34-3a4a-4fb4-80c6-5e686d9a8bf5.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add missing client capabilities in platform broker flows [#8428](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8428)",
-  "packageName": "@azure/msal-browser",
-  "email": "lalimasharda@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@azure-msal-browser-de3bae34-3a4a-4fb4-80c6-5e686d9a8bf5.json
+++ b/change/@azure-msal-browser-de3bae34-3a4a-4fb4-80c6-5e686d9a8bf5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing client capabilities in platform broker flows [#8428](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8428)",
+  "packageName": "@azure/msal-browser",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -922,12 +922,17 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         const scopeSet = new ScopeSet(scopes || []);
         scopeSet.appendScopes(OIDC_DEFAULT_SCOPES);
 
+        // ignore config claims if skipBrokerClaims is set to true and this is a brokered authentication flow
+        const configClaims =
+            request.skipBrokerClaims && !!request.embeddedClientId
+                ? undefined
+                : this.config.auth.clientCapabilities;
+
         const mergedClaims =
-            this.config.auth.clientCapabilities &&
-            this.config.auth.clientCapabilities.length
+            configClaims && configClaims.length
                 ? RequestParameterBuilder.addClientCapabilitiesToClaims(
                       claims,
-                      this.config.auth.clientCapabilities
+                      configClaims
                   )
                 : claims;
 

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -35,6 +35,7 @@ import {
     buildAccountToCache,
     InProgressPerformanceEvent,
     ServerTelemetryManager,
+    RequestParameterBuilder,
 } from "@azure/msal-common/browser";
 import { BaseInteractionClient } from "./BaseInteractionClient.js";
 import { BrowserConfiguration } from "../config/Configuration.js";
@@ -73,7 +74,6 @@ import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import { base64Decode } from "../encode/Base64Decode.js";
 import { version } from "../packageMetadata.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
-import { RequestParameterBuilder } from "@azure/msal-common";
 
 export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected apiId: ApiId;

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -73,7 +73,6 @@ import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import { base64Decode } from "../encode/Base64Decode.js";
 import { version } from "../packageMetadata.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
-import { HandleRedirectPromiseOptions } from "../request/HandleRedirectPromiseOptions.js";
 import { RequestParameterBuilder } from "@azure/msal-common";
 
 export class PlatformAuthInteractionClient extends BaseInteractionClient {

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -73,6 +73,8 @@ import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import { base64Decode } from "../encode/Base64Decode.js";
 import { version } from "../packageMetadata.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
+import { HandleRedirectPromiseOptions } from "../request/HandleRedirectPromiseOptions.js";
+import { RequestParameterBuilder } from "@azure/msal-common";
 
 export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected apiId: ApiId;
@@ -917,12 +919,22 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         const canonicalAuthority = await this.getCanonicalAuthority(request);
 
         // scopes are expected to be received by the native broker as "scope" and will be added to the request below. Other properties that should be dropped from the request to the native broker can be included in the object destructuring here.
-        const { scopes, ...remainingProperties } = request;
+        const { scopes, claims, ...remainingProperties } = request;
         const scopeSet = new ScopeSet(scopes || []);
         scopeSet.appendScopes(OIDC_DEFAULT_SCOPES);
 
+        const mergedClaims =
+            this.config.auth.clientCapabilities &&
+            this.config.auth.clientCapabilities.length
+                ? RequestParameterBuilder.addClientCapabilitiesToClaims(
+                      claims,
+                      this.config.auth.clientCapabilities
+                  )
+                : claims;
+
         const validatedRequest: PlatformAuthRequest = {
             ...remainingProperties,
+            claims: mergedClaims,
             accountId: this.accountId,
             clientId: this.config.auth.clientId,
             authority: canonicalAuthority.urlString,

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1852,6 +1852,220 @@ describe("PlatformAuthInteractionClient Tests", () => {
             const parsedClaims = JSON.parse(nativeRequest.claims || "");
             expect(parsedClaims.access_token).toBeUndefined();
         });
+
+        it("excludes broker's client capabilities when skipBrokerClaims=true and embeddedClientId is present", async () => {
+            const pcaWithClientCapabilities = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    clientCapabilities: ["CP1", "CP2", "CP3"],
+                },
+            });
+            await pcaWithClientCapabilities.initialize();
+            const platformAuthClientWithCapabilities =
+                new PlatformAuthInteractionClient(
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.config,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.browserStorage,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.browserCrypto,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.logger,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.eventHandler,
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.navigationClient,
+                    ApiId.acquireTokenPopup,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.performanceClient,
+                    platformAuthDOMHandler,
+                    "nativeAccountId",
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.nativeInternalStorage,
+                    "correlationId"
+                );
+
+            const existingClaims = JSON.stringify({
+                userinfo: {
+                    given_name: { essential: true },
+                },
+            });
+
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthClientWithCapabilities.initializeNativeRequest(
+                    {
+                        scopes: ["User.Read"],
+                        claims: existingClaims,
+                        skipBrokerClaims: true,
+                        embeddedClientId: "embedded-client-id",
+                    }
+                );
+
+            expect(nativeRequest.claims).toEqual(existingClaims);
+            const parsedClaims = JSON.parse(nativeRequest.claims || "");
+            // Verify existing claims are preserved
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.userinfo.given_name).toEqual({
+                essential: true,
+            });
+            // Verify broker's client capabilities are NOT added
+            expect(parsedClaims.access_token).toBeUndefined();
+        });
+
+        it("includes broker's client capabilities when skipBrokerClaims=true but embeddedClientId is not present", async () => {
+            const pcaWithClientCapabilities = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    clientCapabilities: ["CP1", "CP2", "CP3"],
+                },
+            });
+            await pcaWithClientCapabilities.initialize();
+            const platformAuthClientWithCapabilities =
+                new PlatformAuthInteractionClient(
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.config,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.browserStorage,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.browserCrypto,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.logger,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.eventHandler,
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.navigationClient,
+                    ApiId.acquireTokenPopup,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.performanceClient,
+                    platformAuthDOMHandler,
+                    "nativeAccountId",
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.nativeInternalStorage,
+                    "correlationId"
+                );
+
+            const existingClaims = JSON.stringify({
+                userinfo: {
+                    given_name: { essential: true },
+                },
+            });
+
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthClientWithCapabilities.initializeNativeRequest(
+                    {
+                        scopes: ["User.Read"],
+                        claims: existingClaims,
+                        skipBrokerClaims: true,
+                        // embeddedClientId is not provided
+                    }
+                );
+
+            expect(nativeRequest.claims).toBeDefined();
+            const parsedClaims = JSON.parse(nativeRequest.claims || "");
+
+            // Verify existing claims are preserved
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.userinfo.given_name).toEqual({
+                essential: true,
+            });
+
+            // Verify client capabilities are added (since embeddedClientId is not present)
+            expect(parsedClaims.access_token).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc.values).toEqual([
+                "CP1",
+                "CP2",
+                "CP3",
+            ]);
+        });
+
+        it("includes broker's client capabilities when skipBrokerClaims is false regardless of embeddedClientId", async () => {
+            const pcaWithClientCapabilities = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    clientCapabilities: ["CP1", "CP2", "CP3"],
+                },
+            });
+            await pcaWithClientCapabilities.initialize();
+            const platformAuthClientWithCapabilities =
+                new PlatformAuthInteractionClient(
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.config,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.browserStorage,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.browserCrypto,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.logger,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.eventHandler,
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.navigationClient,
+                    ApiId.acquireTokenPopup,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.performanceClient,
+                    platformAuthDOMHandler,
+                    "nativeAccountId",
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.nativeInternalStorage,
+                    "correlationId"
+                );
+
+            const existingClaims = JSON.stringify({
+                userinfo: {
+                    given_name: { essential: true },
+                },
+            });
+
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthClientWithCapabilities.initializeNativeRequest(
+                    {
+                        scopes: ["User.Read"],
+                        claims: existingClaims,
+                        skipBrokerClaims: false,
+                        embeddedClientId: "embedded-client-id",
+                    }
+                );
+
+            expect(nativeRequest.claims).toBeDefined();
+            const parsedClaims = JSON.parse(nativeRequest.claims || "");
+
+            // Verify existing claims are preserved
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.userinfo.given_name).toEqual({
+                essential: true,
+            });
+
+            // Verify client capabilities are added (since skipBrokerClaims is false)
+            expect(parsedClaims.access_token).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc.values).toEqual([
+                "CP1",
+                "CP2",
+                "CP3",
+            ]);
+        });
     });
 
     describe("Performance Event Validation", () => {

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1568,273 +1568,6 @@ describe("PlatformAuthInteractionClient Tests", () => {
             );
             expect(nativeRequest.redirectUri).toEqual("localhost");
         });
-    });
-
-    describe("Performance Event Validation", () => {
-        let performanceSpy: jest.SpyInstance;
-        let startMeasurementSpy: jest.SpyInstance;
-
-        beforeEach(() => {
-            // Create mock measurement with spies
-            const mockMeasurement = {
-                add: jest.fn(),
-                end: jest.fn(),
-                increment: jest.fn(),
-                discard: jest.fn(),
-            };
-
-            // Spy on performance client methods
-            startMeasurementSpy = jest
-                .spyOn(perfClient, "startMeasurement")
-                .mockReturnValue(mockMeasurement as any);
-            performanceSpy = jest.spyOn(perfClient, "addFields");
-        });
-
-        afterEach(() => {
-            performanceSpy.mockRestore();
-            startMeasurementSpy.mockRestore();
-        });
-
-        it("emits isNativeBroker=true for acquireToken success", async () => {
-            jest.spyOn(
-                PlatformAuthExtensionHandler.prototype,
-                "sendMessage"
-            ).mockImplementation((): Promise<PlatformAuthResponse> => {
-                return Promise.resolve(MOCK_WAM_RESPONSE);
-            });
-
-            // Mock successful token acquisition from cache first
-            const mockAuthResult = {
-                accessToken: "mock_access_token",
-                idToken: "mock_id_token",
-                account: {
-                    homeAccountId: "test-home-account-id",
-                    environment: "login.microsoftonline.com",
-                    nativeAccountId: "test-native-account-id",
-                    tenantId: "test-tenant-id",
-                    username: "test@example.com",
-                    localAccountId: "test-local-account-id",
-                    name: "Test User",
-                    idTokenClaims: {},
-                },
-                scopes: ["User.Read"],
-                expiresOn: new Date(Date.now() + 3600000),
-                tenantId: "test-tenant-id",
-                uniqueId: "test-unique-id",
-                tokenType: "Bearer" as const,
-                correlationId: RANDOM_TEST_GUID,
-                extExpiresOn: new Date(Date.now() + 7200000),
-                state: "",
-                fromCache: false,
-            };
-
-            // Mock the acquireTokensFromCache method to simulate a cache miss (rejects first), then WAM success (resolves)
-            jest.spyOn(
-                platformAuthInteractionClient as any,
-                "acquireTokensFromCache"
-            )
-                // First call rejects (simulates cache miss), second call resolves (simulates WAM success)
-                .mockRejectedValueOnce(new Error("No cached tokens"))
-                .mockResolvedValue(mockAuthResult);
-
-            await platformAuthInteractionClient.acquireToken({
-                scopes: ["User.Read"],
-                account: mockAuthResult.account,
-                correlationId: RANDOM_TEST_GUID,
-            });
-
-            // Get the latest mock measurement object
-            const mockMeasurement =
-                startMeasurementSpy.mock.results[
-                    startMeasurementSpy.mock.results.length - 1
-                ].value;
-
-            // Verify isNativeBroker is set during successful completion
-            expect(mockMeasurement.end).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    success: true,
-                    isNativeBroker: true,
-                })
-            );
-
-            // Verify the measurement was started with correct correlation ID
-            expect(startMeasurementSpy).toHaveBeenCalledWith(
-                expect.any(String),
-                RANDOM_TEST_GUID
-            );
-        });
-
-        it("should emit isNativeBroker=true for handleRedirectPromise", async () => {
-            // @ts-ignore
-            pca.browserStorage.setInteractionInProgress(true);
-            // @ts-ignore
-            pca.browserStorage.setTemporaryCache(
-                "request.native",
-                JSON.stringify({
-                    scopes: ["User.Read"],
-                    correlationId: RANDOM_TEST_GUID,
-                }),
-                true
-            );
-
-            jest.spyOn(
-                PlatformAuthExtensionHandler.prototype,
-                "sendMessage"
-            ).mockImplementation((): Promise<PlatformAuthResponse> => {
-                return Promise.resolve(MOCK_WAM_RESPONSE);
-            });
-
-            // Mock the protected handleNativeResponse method
-            jest.spyOn(
-                platformAuthInteractionClient as any,
-                "handleNativeResponse"
-            ).mockResolvedValue({
-                accessToken: "mock_access_token",
-                idToken: "mock_id_token",
-                account: null,
-                scopes: ["User.Read"],
-                expiresOn: new Date(Date.now() + 3600000),
-                tenantId: "mock_tenant_id",
-                uniqueId: "mock_unique_id",
-                tokenType: "Bearer",
-                correlationId: RANDOM_TEST_GUID,
-            });
-
-            jest.spyOn(
-                platformAuthInteractionClient as any,
-                "initializeServerTelemetryManager"
-            ).mockReturnValue({
-                clearNativeBrokerErrorCode: jest.fn(),
-            });
-
-            // Spy on performanceClient.addFields since handleRedirectPromise uses it directly
-            const addFieldsSpy = jest.spyOn(perfClient, "addFields");
-
-            await platformAuthInteractionClient.handleRedirectPromise(
-                perfClient,
-                RANDOM_TEST_GUID
-            );
-
-            // Verify that addFields was called with isNativeBroker: true
-            expect(addFieldsSpy).toHaveBeenCalledWith(
-                { isNativeBroker: true },
-                RANDOM_TEST_GUID
-            );
-        });
-
-        it("should use synchronized correlationId in performance measurements", async () => {
-            const customCorrelationId = "custom-correlation-123";
-
-            platformAuthInteractionClient = new PlatformAuthInteractionClient(
-                // @ts-ignore
-                pca.config,
-                // @ts-ignore
-                pca.browserStorage,
-                // @ts-ignore
-                pca.browserCrypto,
-                pca.getLogger(),
-                // @ts-ignore
-                pca.eventHandler,
-                // @ts-ignore
-                pca.navigationClient,
-                ApiId.acquireTokenRedirect,
-                perfClient,
-                wamProvider,
-                "nativeAccountId",
-                // @ts-ignore
-                pca.nativeInternalStorage,
-                customCorrelationId
-            );
-
-            jest.spyOn(
-                PlatformAuthExtensionHandler.prototype,
-                "sendMessage"
-            ).mockImplementation((): Promise<PlatformAuthResponse> => {
-                return Promise.resolve(MOCK_WAM_RESPONSE);
-            });
-
-            await platformAuthInteractionClient.acquireToken({
-                scopes: ["User.Read"],
-                correlationId: customCorrelationId,
-            });
-
-            // Should use the synchronized correlationId, which should be the customCorrelationId
-            // since synchronizeCorrelationId should update this.correlationId
-            expect(startMeasurementSpy).toHaveBeenCalledWith(
-                expect.any(String),
-                customCorrelationId
-            );
-        });
-
-        it("should emit success=false and errorCode for failed acquireToken", async () => {
-            // Mock sendMessage to succeed but handleNativeResponse to fail
-            jest.spyOn(
-                PlatformAuthExtensionHandler.prototype,
-                "sendMessage"
-            ).mockImplementation((): Promise<PlatformAuthResponse> => {
-                return Promise.resolve(MOCK_WAM_RESPONSE);
-            });
-
-            // Mock handleNativeResponse to throw an error
-            const authError = new AuthError("test_error", "Test error message");
-            jest.spyOn(
-                platformAuthInteractionClient as any,
-                "handleNativeResponse"
-            ).mockRejectedValue(authError);
-
-            try {
-                await platformAuthInteractionClient.acquireToken({
-                    scopes: ["User.Read"],
-                });
-            } catch (error) {
-                // Expected to throw
-            }
-
-            // Get the mock measurement object that was returned
-            const mockMeasurement = startMeasurementSpy.mock.results[0].value;
-
-            // Check that measurement.end was called with success: false and errorCode
-            expect(mockMeasurement.end).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    success: false,
-                    errorCode: "test_error",
-                })
-            );
-        });
-
-        it("should emit success=false and errorCode when sendMessage fails", async () => {
-            // Test that measurement.end is now called when sendMessage fails (bug fix)
-            const nativeError = createNativeAuthError(
-                "ContentError",
-                "problem getting response from extension"
-            );
-
-            jest.spyOn(
-                PlatformAuthExtensionHandler.prototype,
-                "sendMessage"
-            ).mockImplementation((): Promise<PlatformAuthResponse> => {
-                return Promise.reject(nativeError);
-            });
-
-            try {
-                await platformAuthInteractionClient.acquireToken({
-                    scopes: ["User.Read"],
-                });
-            } catch (error) {
-                // Expected to throw
-                expect(error).toBe(nativeError);
-            }
-
-            // Get the mock measurement object that was returned
-            const mockMeasurement = startMeasurementSpy.mock.results[0].value;
-
-            // After the fix, measurement.end should now be called when sendMessage fails
-            expect(mockMeasurement.end).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    success: false,
-                })
-            );
-        });
 
         it("merges client capabilities with empty claims", async () => {
             const pcaWithClientCapabilities = new PublicClientApplication({
@@ -2118,6 +1851,273 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(nativeRequest.claims).toEqual(existingClaims);
             const parsedClaims = JSON.parse(nativeRequest.claims || "");
             expect(parsedClaims.access_token).toBeUndefined();
+        });
+    });
+
+    describe("Performance Event Validation", () => {
+        let performanceSpy: jest.SpyInstance;
+        let startMeasurementSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            // Create mock measurement with spies
+            const mockMeasurement = {
+                add: jest.fn(),
+                end: jest.fn(),
+                increment: jest.fn(),
+                discard: jest.fn(),
+            };
+
+            // Spy on performance client methods
+            startMeasurementSpy = jest
+                .spyOn(perfClient, "startMeasurement")
+                .mockReturnValue(mockMeasurement as any);
+            performanceSpy = jest.spyOn(perfClient, "addFields");
+        });
+
+        afterEach(() => {
+            performanceSpy.mockRestore();
+            startMeasurementSpy.mockRestore();
+        });
+
+        it("emits isNativeBroker=true for acquireToken success", async () => {
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            // Mock successful token acquisition from cache first
+            const mockAuthResult = {
+                accessToken: "mock_access_token",
+                idToken: "mock_id_token",
+                account: {
+                    homeAccountId: "test-home-account-id",
+                    environment: "login.microsoftonline.com",
+                    nativeAccountId: "test-native-account-id",
+                    tenantId: "test-tenant-id",
+                    username: "test@example.com",
+                    localAccountId: "test-local-account-id",
+                    name: "Test User",
+                    idTokenClaims: {},
+                },
+                scopes: ["User.Read"],
+                expiresOn: new Date(Date.now() + 3600000),
+                tenantId: "test-tenant-id",
+                uniqueId: "test-unique-id",
+                tokenType: "Bearer" as const,
+                correlationId: RANDOM_TEST_GUID,
+                extExpiresOn: new Date(Date.now() + 7200000),
+                state: "",
+                fromCache: false,
+            };
+
+            // Mock the acquireTokensFromCache method to simulate a cache miss (rejects first), then WAM success (resolves)
+            jest.spyOn(
+                platformAuthInteractionClient as any,
+                "acquireTokensFromCache"
+            )
+                // First call rejects (simulates cache miss), second call resolves (simulates WAM success)
+                .mockRejectedValueOnce(new Error("No cached tokens"))
+                .mockResolvedValue(mockAuthResult);
+
+            await platformAuthInteractionClient.acquireToken({
+                scopes: ["User.Read"],
+                account: mockAuthResult.account,
+                correlationId: RANDOM_TEST_GUID,
+            });
+
+            // Get the latest mock measurement object
+            const mockMeasurement =
+                startMeasurementSpy.mock.results[
+                    startMeasurementSpy.mock.results.length - 1
+                ].value;
+
+            // Verify isNativeBroker is set during successful completion
+            expect(mockMeasurement.end).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    success: true,
+                    isNativeBroker: true,
+                })
+            );
+
+            // Verify the measurement was started with correct correlation ID
+            expect(startMeasurementSpy).toHaveBeenCalledWith(
+                expect.any(String),
+                RANDOM_TEST_GUID
+            );
+        });
+
+        it("should emit isNativeBroker=true for handleRedirectPromise", async () => {
+            // @ts-ignore
+            pca.browserStorage.setInteractionInProgress(true);
+            // @ts-ignore
+            pca.browserStorage.setTemporaryCache(
+                "request.native",
+                JSON.stringify({
+                    scopes: ["User.Read"],
+                    correlationId: RANDOM_TEST_GUID,
+                }),
+                true
+            );
+
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            // Mock the protected handleNativeResponse method
+            jest.spyOn(
+                platformAuthInteractionClient as any,
+                "handleNativeResponse"
+            ).mockResolvedValue({
+                accessToken: "mock_access_token",
+                idToken: "mock_id_token",
+                account: null,
+                scopes: ["User.Read"],
+                expiresOn: new Date(Date.now() + 3600000),
+                tenantId: "mock_tenant_id",
+                uniqueId: "mock_unique_id",
+                tokenType: "Bearer",
+                correlationId: RANDOM_TEST_GUID,
+            });
+
+            jest.spyOn(
+                platformAuthInteractionClient as any,
+                "initializeServerTelemetryManager"
+            ).mockReturnValue({
+                clearNativeBrokerErrorCode: jest.fn(),
+            });
+
+            // Spy on performanceClient.addFields since handleRedirectPromise uses it directly
+            const addFieldsSpy = jest.spyOn(perfClient, "addFields");
+
+            await platformAuthInteractionClient.handleRedirectPromise(
+                perfClient,
+                RANDOM_TEST_GUID
+            );
+
+            // Verify that addFields was called with isNativeBroker: true
+            expect(addFieldsSpy).toHaveBeenCalledWith(
+                { isNativeBroker: true },
+                RANDOM_TEST_GUID
+            );
+        });
+
+        it("should use synchronized correlationId in performance measurements", async () => {
+            const customCorrelationId = "custom-correlation-123";
+
+            platformAuthInteractionClient = new PlatformAuthInteractionClient(
+                // @ts-ignore
+                pca.config,
+                // @ts-ignore
+                pca.browserStorage,
+                // @ts-ignore
+                pca.browserCrypto,
+                pca.getLogger(),
+                // @ts-ignore
+                pca.eventHandler,
+                // @ts-ignore
+                pca.navigationClient,
+                ApiId.acquireTokenRedirect,
+                perfClient,
+                wamProvider,
+                "nativeAccountId",
+                // @ts-ignore
+                pca.nativeInternalStorage,
+                customCorrelationId
+            );
+
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            await platformAuthInteractionClient.acquireToken({
+                scopes: ["User.Read"],
+                correlationId: customCorrelationId,
+            });
+
+            // Should use the synchronized correlationId, which should be the customCorrelationId
+            // since synchronizeCorrelationId should update this.correlationId
+            expect(startMeasurementSpy).toHaveBeenCalledWith(
+                expect.any(String),
+                customCorrelationId
+            );
+        });
+
+        it("should emit success=false and errorCode for failed acquireToken", async () => {
+            // Mock sendMessage to succeed but handleNativeResponse to fail
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+
+            // Mock handleNativeResponse to throw an error
+            const authError = new AuthError("test_error", "Test error message");
+            jest.spyOn(
+                platformAuthInteractionClient as any,
+                "handleNativeResponse"
+            ).mockRejectedValue(authError);
+
+            try {
+                await platformAuthInteractionClient.acquireToken({
+                    scopes: ["User.Read"],
+                });
+            } catch (error) {
+                // Expected to throw
+            }
+
+            // Get the mock measurement object that was returned
+            const mockMeasurement = startMeasurementSpy.mock.results[0].value;
+
+            // Check that measurement.end was called with success: false and errorCode
+            expect(mockMeasurement.end).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    success: false,
+                    errorCode: "test_error",
+                })
+            );
+        });
+
+        it("should emit success=false and errorCode when sendMessage fails", async () => {
+            // Test that measurement.end is now called when sendMessage fails (bug fix)
+            const nativeError = createNativeAuthError(
+                "ContentError",
+                "problem getting response from extension"
+            );
+
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.reject(nativeError);
+            });
+
+            try {
+                await platformAuthInteractionClient.acquireToken({
+                    scopes: ["User.Read"],
+                });
+            } catch (error) {
+                // Expected to throw
+                expect(error).toBe(nativeError);
+            }
+
+            // Get the mock measurement object that was returned
+            const mockMeasurement = startMeasurementSpy.mock.results[0].value;
+
+            // After the fix, measurement.end should now be called when sendMessage fails
+            expect(mockMeasurement.end).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    success: false,
+                })
+            );
         });
     });
 });

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1835,5 +1835,289 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 })
             );
         });
+
+        it("merges client capabilities with empty claims", async () => {
+            const pcaWithClientCapabilities = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    clientCapabilities: ["CP1", "CP2", "CP3"],
+                },
+            });
+            await pcaWithClientCapabilities.initialize();
+            const platformAuthClientWithCapabilities =
+                new PlatformAuthInteractionClient(
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.config,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.browserStorage,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.browserCrypto,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.logger,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.eventHandler,
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.navigationClient,
+                    ApiId.acquireTokenSilent_silentFlow,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.performanceClient,
+                    wamProvider,
+                    "nativeAccountId",
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.nativeInternalStorage,
+                    "correlationId"
+                );
+
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthClientWithCapabilities.initializeNativeRequest(
+                    {
+                        scopes: ["User.Read"],
+                    }
+                );
+
+            expect(nativeRequest.claims).toBeDefined();
+            const parsedClaims = JSON.parse(nativeRequest.claims || "");
+            expect(parsedClaims.access_token).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc.values).toEqual([
+                "CP1",
+                "CP2",
+                "CP3",
+            ]);
+        });
+
+        it("merges client capabilities with existing claims", async () => {
+            const pcaWithClientCapabilities = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    clientCapabilities: ["CP1", "CP2", "CP3"],
+                },
+            });
+            await pcaWithClientCapabilities.initialize();
+            const platformAuthClientWithCapabilities =
+                new PlatformAuthInteractionClient(
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.config,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.browserStorage,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.browserCrypto,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.logger,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.eventHandler,
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.navigationClient,
+                    ApiId.acquireTokenPopup,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.performanceClient,
+                    platformAuthDOMHandler,
+                    "nativeAccountId",
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.nativeInternalStorage,
+                    "correlationId"
+                );
+
+            const existingClaims = JSON.stringify({
+                userinfo: {
+                    given_name: { essential: true },
+                },
+            });
+
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthClientWithCapabilities.initializeNativeRequest(
+                    {
+                        scopes: ["User.Read"],
+                        claims: existingClaims,
+                    }
+                );
+
+            expect(nativeRequest.claims).toBeDefined();
+            const parsedClaims = JSON.parse(nativeRequest.claims || "");
+
+            // Verify existing claims are preserved
+            expect(parsedClaims.userinfo).toBeDefined();
+            expect(parsedClaims.userinfo.given_name).toEqual({
+                essential: true,
+            });
+
+            // Verify client capabilities are added
+            expect(parsedClaims.access_token).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc.values).toEqual([
+                "CP1",
+                "CP2",
+                "CP3",
+            ]);
+        });
+
+        it("merges client capabilities with existing access_token claims", async () => {
+            const pcaWithClientCapabilities = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    clientCapabilities: ["CP1", "CP2", "CP3"],
+                },
+            });
+            await pcaWithClientCapabilities.initialize();
+            const platformAuthClientWithCapabilities =
+                new PlatformAuthInteractionClient(
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.config,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.browserStorage,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.browserCrypto,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.logger,
+                    // @ts-ignore
+                    (pcaWithClientCapabilities as any).controller.eventHandler,
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.navigationClient,
+                    ApiId.acquireTokenRedirect,
+                    // @ts-ignore
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.performanceClient,
+                    wamProvider,
+                    "nativeAccountId",
+                    (
+                        pcaWithClientCapabilities as any
+                    ).controller.nativeInternalStorage,
+                    "correlationId"
+                );
+
+            const existingClaims = JSON.stringify({
+                access_token: {
+                    custom_claim: "custom_value",
+                },
+            });
+
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthClientWithCapabilities.initializeNativeRequest(
+                    {
+                        scopes: ["User.Read"],
+                        claims: existingClaims,
+                    }
+                );
+
+            expect(nativeRequest.claims).toBeDefined();
+            const parsedClaims = JSON.parse(nativeRequest.claims || "");
+
+            // Verify existing access_token claims are preserved
+            expect(parsedClaims.access_token.custom_claim).toEqual(
+                "custom_value"
+            );
+
+            // Verify client capabilities are added
+            expect(parsedClaims.access_token.xms_cc).toBeDefined();
+            expect(parsedClaims.access_token.xms_cc.values).toEqual([
+                "CP1",
+                "CP2",
+                "CP3",
+            ]);
+        });
+
+        it("does not modify claims when no client capabilities are configured", async () => {
+            const existingClaims = JSON.stringify({
+                userinfo: {
+                    given_name: { essential: true },
+                },
+            });
+
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthInteractionClient.initializeNativeRequest({
+                    scopes: ["User.Read"],
+                    claims: existingClaims,
+                });
+
+            expect(nativeRequest.claims).toEqual(existingClaims);
+            const parsedClaims = JSON.parse(nativeRequest.claims || "");
+            expect(parsedClaims.access_token).toBeUndefined();
+        });
+
+        it("returns undefined claims when no claims or client capabilities are provided", async () => {
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthInteractionClient.initializeNativeRequest({
+                    scopes: ["User.Read"],
+                });
+
+            expect(nativeRequest.claims).toBe("{}");
+        });
+
+        it("does not add xms_cc when client capabilities array is empty", async () => {
+            const pcaWithEmptyCapabilities = new PublicClientApplication({
+                auth: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    clientCapabilities: [],
+                },
+            });
+            await pcaWithEmptyCapabilities.initialize();
+            const platformAuthClientWithEmptyCapabilities =
+                new PlatformAuthInteractionClient(
+                    // @ts-ignore
+                    (pcaWithEmptyCapabilities as any).controller.config,
+                    // @ts-ignore
+                    (pcaWithEmptyCapabilities as any).controller.browserStorage,
+                    // @ts-ignore
+                    (pcaWithEmptyCapabilities as any).controller.browserCrypto,
+                    // @ts-ignore
+                    (pcaWithEmptyCapabilities as any).controller.logger,
+                    // @ts-ignore
+                    (pcaWithEmptyCapabilities as any).controller.eventHandler,
+                    (
+                        pcaWithEmptyCapabilities as any
+                    ).controller.navigationClient,
+                    ApiId.acquireTokenRedirect,
+                    // @ts-ignore
+                    (
+                        pcaWithEmptyCapabilities as any
+                    ).controller.performanceClient,
+                    wamProvider,
+                    "nativeAccountId",
+                    (
+                        pcaWithEmptyCapabilities as any
+                    ).controller.nativeInternalStorage,
+                    "correlationId"
+                );
+
+            const existingClaims = JSON.stringify({
+                userinfo: {
+                    given_name: { essential: true },
+                },
+            });
+
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthClientWithEmptyCapabilities.initializeNativeRequest(
+                    {
+                        scopes: ["User.Read"],
+                        claims: existingClaims,
+                    }
+                );
+
+            expect(nativeRequest.claims).toEqual(existingClaims);
+            const parsedClaims = JSON.parse(nativeRequest.claims || "");
+            expect(parsedClaims.access_token).toBeUndefined();
+        });
     });
 });

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -2061,7 +2061,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
                     scopes: ["User.Read"],
                 });
 
-            expect(nativeRequest.claims).toBe("{}");
+            expect(nativeRequest.claims).toBeUndefined();
         });
 
         it("does not add xms_cc when client capabilities array is empty", async () => {


### PR DESCRIPTION
This pull request enhances the `PlatformAuthInteractionClient` in `@azure/msal-browser` to ensure that client capabilities are correctly merged into the claims for platform broker authentication flows. It also adds comprehensive tests to validate this merging logic under various scenarios.

Enhancements to client capabilities handling:

* Updated `PlatformAuthInteractionClient` to merge configured `clientCapabilities` into the `claims` property when initializing native requests, ensuring that capabilities are included in the request payload for platform broker flows.

Testing improvements:

* Added extensive tests to `PlatformAuthInteractionClient.spec.ts` to verify that client capabilities are merged with empty claims, existing claims, existing `access_token` claims, and that claims are not modified when no client capabilities are configured or the array is empty. These tests ensure robust coverage of the new merging logic.
