### PR TITLE
Add screenshot parameter to E2E test templates

### DIFF
--- a/.pipelines/1p-e2e.yml
+++ b/.pipelines/1p-e2e.yml
@@ -14,6 +14,10 @@ parameters:
       displayName: "NPM Install Timeout (Tests)"
       type: number
       default: 15
+    - name: "enableScreenshots"
+      displayName: "Enable E2E Screenshots"
+      type: boolean
+      default: false
 variables:
     CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
     LinuxContainerImage: "mcr.microsoft.com/onebranch/cbl-mariner/build:2.0" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
@@ -63,3 +67,4 @@ extends:
                             - "BrokerSingleFrameTestApp"
                         debug: ${{ parameters.debug }}
                         npmInstallTimeout: ${{ parameters.npmInstallTimeout }}
+                        enableScreenshots: ${{ parameters.enableScreenshots }}

--- a/.pipelines/1p-e2e.yml
+++ b/.pipelines/1p-e2e.yml
@@ -37,7 +37,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: dev
+          ref: e2e-test-screenshot-options
 
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/1p-e2e.yml
+++ b/.pipelines/1p-e2e.yml
@@ -37,7 +37,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: e2e-test-screenshot-options
+          ref: dev
 
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -152,4 +152,5 @@ extends:
                             - "angular-modules-sample"
                             - "angular-standalone-sample"
                         debug: ${{ parameters.debug }}
-                        npmInstallTimeout: ${{ parameters.npmInstallTimeout }}                        enableScreenshots: ${{ parameters.enableScreenshots }}
+                        npmInstallTimeout: ${{ parameters.npmInstallTimeout }}
+                        enableScreenshots: ${{ parameters.enableScreenshots }}

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -30,6 +30,10 @@ parameters:
       displayName: "NPM Install Timeout (Tests)"
       type: number
       default: 15
+    - name: "enableScreenshots"
+      displayName: "Enable E2E Screenshots"
+      type: boolean
+      default: false
 
 variables:
     CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
@@ -80,6 +84,7 @@ extends:
                             - "ExpressSample"
                         debug: ${{ parameters.debug }}
                         npmInstallTimeout: ${{ parameters.npmInstallTimeout }}
+                        enableScreenshots: ${{ parameters.enableScreenshots }}
                 - ${{ if eq(parameters.runNodeTests, true) }}:
                   - template: .pipelines/templates/e2e-tests.yml@1P
                     parameters:
@@ -102,6 +107,7 @@ extends:
                             # - "on-behalf-of"
                         debug: ${{ parameters.debug }}
                         npmInstallTimeout: ${{ parameters.npmInstallTimeout }}
+                        enableScreenshots: ${{ parameters.enableScreenshots }}
                 - ${{ if eq(parameters.runReactTests, true) }}:
                   - template: .pipelines/templates/e2e-tests.yml@1P
                     parameters:
@@ -119,12 +125,14 @@ extends:
                             - "b2c-sample"
                         debug: ${{ parameters.debug }}
                         npmInstallTimeout: ${{ parameters.npmInstallTimeout }}
+                        enableScreenshots: ${{ parameters.enableScreenshots }}
                   - template: .pipelines/templates/msal-react-react18-e2e.yml@self
                     parameters:
                         poolType: ${{ parameters.poolType }}
                         sourceBranch: ${{ variables.sourceBranch }}
                         debug: ${{ parameters.debug }}
                         npmInstallTimeout: ${{ parameters.npmInstallTimeout }}
+                        enableScreenshots: ${{ parameters.enableScreenshots }}
                         samples:
                             - "react-router-sample"
                             - "typescript-sample"
@@ -144,4 +152,4 @@ extends:
                             - "angular-modules-sample"
                             - "angular-standalone-sample"
                         debug: ${{ parameters.debug }}
-                        npmInstallTimeout: ${{ parameters.npmInstallTimeout }}
+                        npmInstallTimeout: ${{ parameters.npmInstallTimeout }}                        enableScreenshots: ${{ parameters.enableScreenshots }}

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -54,7 +54,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: dev
+          ref: e2e-test-screenshot-options
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
     parameters:

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -54,7 +54,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: e2e-test-screenshot-options
+          ref: dev
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
     parameters:

--- a/.pipelines/templates/msal-react-react18-e2e.yml
+++ b/.pipelines/templates/msal-react-react18-e2e.yml
@@ -13,6 +13,9 @@ parameters:
     - name: "debug"
       type: boolean
       default: false
+    - name: "enableScreenshots"
+      type: boolean
+      default: false
     - name: "samples"
       type: object
       default:
@@ -129,10 +132,11 @@ jobs:
                       pfxPath: "$(Build.SourcesDirectory)/LabCert.pfx"
                       pemPath: "$(Build.SourcesDirectory)/LabCert.pem"
 
-                - task: CmdLine@2
-                  displayName: "Create screenshot folder"
-                  inputs:
-                      script: mkdir -p ${{ replace(variables.samplePath, '/', '\') }}\test\screenshots\react18
+                - ${{ if eq(parameters.enableScreenshots, true) }}:
+                      - task: CmdLine@2
+                        displayName: "Create screenshot folder"
+                        inputs:
+                            script: mkdir -p ${{ replace(variables.samplePath, '/', '\') }}\test\screenshots\react18
 
                 - task: Npm@1
                   displayName: "Test ${{ sample }}"
@@ -149,6 +153,8 @@ jobs:
                       AZURE_TENANT_ID: $(AZURE_TENANT_ID)
                       JEST_JUNIT_OUTPUT_NAME: "${{ sample }}.xml"
                       SESSION_SECRET: $(EXPRESS_SESSION_SECRET)
+                      ${{ if eq(parameters.enableScreenshots, true) }}:
+                          ENABLE_E2E_SCREENSHOTS: "true"
 
                 - task: PublishTestResults@2
                   displayName: "Publish Test Results"
@@ -157,19 +163,20 @@ jobs:
                       testResultsFiles: "$(samplePath)/${{ sample }}.xml"
                       testRunTitle: "${{ sample }}-react18"
 
-                - task: CopyFiles@2
-                  condition: failed()
-                  inputs:
-                      SourceFolder: "${{ variables.samplePath }}/test/screenshots/react18"
-                      Contents: "**"
-                      TargetFolder: $(Build.ArtifactStagingDirectory)
+                - ${{ if eq(parameters.enableScreenshots, true) }}:
+                      - task: CopyFiles@2
+                        condition: failed()
+                        inputs:
+                            SourceFolder: "${{ variables.samplePath }}/test/screenshots/react18"
+                            Contents: "**"
+                            TargetFolder: $(Build.ArtifactStagingDirectory)
 
-                - task: PublishPipelineArtifact@1
-                  displayName: "Upload screenshots to artifacts"
-                  condition: succeededOrFailed()
-                  inputs:
-                      targetPath: $(Build.ArtifactStagingDirectory)
-                      artifact: "drop_e2e_test_validate_msal_react_r18_${{ replace(sample, '-', '_') }}"
-                      publishLocation: "pipeline"
+                      - task: PublishPipelineArtifact@1
+                        displayName: "Upload screenshots to artifacts"
+                        condition: succeededOrFailed()
+                        inputs:
+                            targetPath: $(Build.ArtifactStagingDirectory)
+                            artifact: "drop_e2e_test_validate_msal_react_r18_${{ replace(sample, '-', '_') }}"
+                            publishLocation: "pipeline"
 
                 - template: .pipelines/templates/remove-keyvault-secrets.yml@1P

--- a/.pipelines/templates/msal-react-react18-e2e.yml
+++ b/.pipelines/templates/msal-react-react18-e2e.yml
@@ -133,10 +133,12 @@ jobs:
                       pemPath: "$(Build.SourcesDirectory)/LabCert.pem"
 
                 - ${{ if eq(parameters.enableScreenshots, true) }}:
-                      - task: CmdLine@2
+                      - task: PowerShell@2
                         displayName: "Create screenshot folder"
                         inputs:
-                            script: mkdir -p ${{ replace(variables.samplePath, '/', '\') }}\test\screenshots\react18
+                            targetType: "inline"
+                            script: New-Item -ItemType Directory -Force -Path "${{ variables.samplePath }}/test/screenshots/react18"
+                            pwsh: true
 
                 - task: Npm@1
                   displayName: "Test ${{ sample }}"
@@ -173,7 +175,7 @@ jobs:
 
                       - task: PublishPipelineArtifact@1
                         displayName: "Upload screenshots to artifacts"
-                        condition: succeededOrFailed()
+                        condition: failed()
                         inputs:
                             targetPath: $(Build.ArtifactStagingDirectory)
                             artifact: "drop_e2e_test_validate_msal_react_r18_${{ replace(sample, '-', '_') }}"

--- a/.pipelines/templates/msal-react-react18-e2e.yml
+++ b/.pipelines/templates/msal-react-react18-e2e.yml
@@ -169,7 +169,7 @@ jobs:
                       - task: CopyFiles@2
                         condition: failed()
                         inputs:
-                            SourceFolder: "${{ variables.samplePath }}/test/screenshots/react18"
+                            SourceFolder: "$(samplePath)/test/screenshots/react18"
                             Contents: "**"
                             TargetFolder: $(Build.ArtifactStagingDirectory)
 

--- a/samples/e2eTestUtils/src/Constants.ts
+++ b/samples/e2eTestUtils/src/Constants.ts
@@ -99,6 +99,7 @@ export const SubmitButtonSelectors = {
     ACCEPTBUTTON: "#acceptButton, input[name='acceptButton']",
     REMOTE_CONNECT_SUBMIT: "#remoteConnectSubmit, input[name='remoteConnectSubmit']",
     SUBMITBUTTON: "#submitButton, input[name='submitButton']",
+    INPUT_SUBMIT: "input[type='submit']",
     SUBMIT: "button[type='submit']"
 }
 

--- a/samples/e2eTestUtils/src/ElectronPlaywrightTestUtils.ts
+++ b/samples/e2eTestUtils/src/ElectronPlaywrightTestUtils.ts
@@ -103,14 +103,21 @@ export async function clickSignIn(
 export class Screenshot {
     private folderName: string;
     private screenshotNum: number;
+    private enabled: boolean;
 
     constructor(foldername: string) {
         this.folderName = foldername;
         this.screenshotNum = 0;
-        createFolder(this.folderName);
+        this.enabled = process.env.ENABLE_E2E_SCREENSHOTS === "true";
+        if (this.enabled) {
+            createFolder(this.folderName);
+        }
     }
 
     async takeScreenshot(page: Page, screenshotName: string): Promise<void> {
+        if (!this.enabled) {
+            return;
+        }
         await page.screenshot({
             path: `${this.folderName}/${++this
                 .screenshotNum}_${screenshotName}.png`,

--- a/samples/e2eTestUtils/src/ElectronPlaywrightTestUtils.ts
+++ b/samples/e2eTestUtils/src/ElectronPlaywrightTestUtils.ts
@@ -108,7 +108,7 @@ export class Screenshot {
     constructor(foldername: string) {
         this.folderName = foldername;
         this.screenshotNum = 0;
-        this.enabled = process.env.ENABLE_E2E_SCREENSHOTS === "true";
+        this.enabled = process.env["ENABLE_E2E_SCREENSHOTS"] === "true";
         if (this.enabled) {
             createFolder(this.folderName);
         }

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -20,7 +20,7 @@ export class Screenshot {
     constructor(foldername: string) {
         this.folderName = foldername;
         this.screenshotNum = 0;
-        this.enabled = process.env.ENABLE_E2E_SCREENSHOTS === "true";
+        this.enabled = process.env["ENABLE_E2E_SCREENSHOTS"] === "true";
         if (this.enabled) {
             createFolder(this.folderName);
         }

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -15,14 +15,21 @@ const WAIT_FOR_NAVIGATION_CONFIG: WaitForOptions = {
 export class Screenshot {
     private folderName: string;
     private screenshotNum: number;
+    private enabled: boolean;
 
     constructor(foldername: string) {
         this.folderName = foldername;
         this.screenshotNum = 0;
-        createFolder(this.folderName);
+        this.enabled = process.env.ENABLE_E2E_SCREENSHOTS === "true";
+        if (this.enabled) {
+            createFolder(this.folderName);
+        }
     }
 
     async takeScreenshot(page: Page, screenshotName: string): Promise<void> {
+        if (!this.enabled) {
+            return;
+        }
         await page.screenshot({
             path: `${this.folderName}/${++this
                 .screenshotNum}_${screenshotName}.png`,

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -229,7 +229,7 @@ export async function fillPassword(page: Page, screenshot: Screenshot, password:
     try {
         await page.locator('span ::-p-text(Use your password)').setTimeout(1000).click().catch(() => {});
         await screenshot.takeScreenshot(page, "passwordPage");
-        await page.locator(`${Object.values(PasswordInputSelectors).join(", ")}`).setTimeout(2000).fill(password);
+        await page.locator(`${Object.values(PasswordInputSelectors).join(", ")}`).setTimeout(5000).fill(password);
         await screenshot.takeScreenshot(page, "loginPagePasswordFilled");
     } catch (e) {
         await screenshot.takeScreenshot(page, "failedToFillPassword").catch(() => {});
@@ -240,7 +240,7 @@ export async function fillPassword(page: Page, screenshot: Screenshot, password:
 export async function fillUsername(page: Page, screenshot: Screenshot, username: string): Promise<void> {
     try {
         await screenshot.takeScreenshot(page, "loginPage");
-        await page.locator(`${Object.values(UsernameSelectors).join(", ")}`).setTimeout(2000).fill(username);
+        await page.locator(`${Object.values(UsernameSelectors).join(", ")}`).setTimeout(5000).fill(username);
         await screenshot.takeScreenshot(page, "loginPageUsernameFilled");
     } catch (e) {
         await screenshot.takeScreenshot(page, "failedToFillUsername").catch(() => {});
@@ -250,8 +250,10 @@ export async function fillUsername(page: Page, screenshot: Screenshot, username:
 
 export async function clickSubmitButton(page: Page, screenshot: Screenshot): Promise<void> {
     try {
-        await page.locator(`${Object.values(SubmitButtonSelectors).join(", ")}`).setTimeout(2000).click();
-        await page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG).catch(() => {});
+        await Promise.all([
+            page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG).catch(() => {}),
+            page.locator(`${Object.values(SubmitButtonSelectors).join(", ")}`).setTimeout(5000).click(),
+        ]);
     } catch (e) {
         await screenshot.takeScreenshot(page, "errorClickingSubmit").catch(() => {});
         throw e;
@@ -428,13 +430,17 @@ export async function clickLoginRedirect(
     screenshot: Screenshot,
     page: Page
 ): Promise<void> {
+    await page.waitForSelector("#SignIn", { timeout: 5000 });
     // Home Page
     await screenshot.takeScreenshot(page, "samplePageInit");
     // Click Sign In
     await page.click("#SignIn");
     await screenshot.takeScreenshot(page, "signInClicked");
     // Click Sign In With Redirect
-    await page.click("#redirect");
+    await Promise.all([
+        page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG).catch(() => {}),
+        page.click("#redirect"),
+    ]);
 }
 
 export async function clickLogoutRedirect(

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
@@ -157,7 +157,8 @@ describe("AAD-Prod Tests", () => {
                     request: relativeRedirectUriRequest,
                 })
             );
-            page.reload();
+            await page.reload();
+            await pcaInitializedPoller(page, 5000);
 
             const testName = "redirectBaseCase";
             const screenshot = new Screenshot(
@@ -185,7 +186,8 @@ describe("AAD-Prod Tests", () => {
                     request: relativeRedirectUriRequest,
                 })
             );
-            page.reload();
+            await page.reload();
+            await pcaInitializedPoller(page, 5000);
 
             const testName = "redirectBaseCase";
             const screenshot = new Screenshot(

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
@@ -157,7 +157,8 @@ describe("AAD-Prod Tests", () => {
                     request: relativeRedirectUriRequest,
                 })
             );
-            page.reload();
+            await page.reload();
+            await pcaInitializedPoller(page, 5000);
 
             const testName = "redirectBaseCase";
             const screenshot = new Screenshot(
@@ -185,7 +186,8 @@ describe("AAD-Prod Tests", () => {
                     request: relativeRedirectUriRequest,
                 })
             );
-            page.reload();
+            await page.reload();
+            await pcaInitializedPoller(page, 5000);
 
             const testName = "redirectBaseCase";
             const screenshot = new Screenshot(


### PR DESCRIPTION
This pull request adds support for enabling and collecting screenshots during end-to-end (E2E) test runs in the pipelines, and improves the reliability and flexibility of E2E test utilities. The changes introduce a new pipeline parameter to toggle screenshot collection, update the test utilities to respect this toggle, and make several reliability improvements to test timing and navigation handling.

**Pipeline and E2E configuration enhancements:**

* Added a new `enableScreenshots` boolean parameter (default: false) to `.pipelines/1p-e2e.yml`, `.pipelines/3p-e2e.yml`, and `.pipelines/templates/msal-react-react18-e2e.yml`, allowing screenshots to be conditionally enabled for E2E test runs. The value is passed through to all relevant test templates. [[1]](diffhunk://#diff-57f294cb69b401945353876f033d790dc78de8d352c7dc6c49b1e1d4177a7a07R17-R20) [[2]](diffhunk://#diff-2ac63a1fdac4d0a041e1b992893ffc0785ad5fcfd2b58e9a68d5917abfa2bd04R33-R36) [[3]](diffhunk://#diff-778eb79c5fdd1676b8284396cc2ff9269aff9006258841cffbd6dbe964692b44R16-R18)
* Updated the E2E pipeline templates to create screenshot directories, set an `ENABLE_E2E_SCREENSHOTS` environment variable, and upload screenshots as pipeline artifacts only when `enableScreenshots` is true. This includes switching to PowerShell for cross-platform compatibility and ensuring artifacts are only published on test failures. [[1]](diffhunk://#diff-778eb79c5fdd1676b8284396cc2ff9269aff9006258841cffbd6dbe964692b44L132-R141) [[2]](diffhunk://#diff-778eb79c5fdd1676b8284396cc2ff9269aff9006258841cffbd6dbe964692b44R158-R159) [[3]](diffhunk://#diff-778eb79c5fdd1676b8284396cc2ff9269aff9006258841cffbd6dbe964692b44R168-R178)

**Test utility improvements:**

* Modified the `Screenshot` class in `samples/e2eTestUtils` to only take and save screenshots when the `ENABLE_E2E_SCREENSHOTS` environment variable is set to "true", preventing unnecessary file operations when screenshots are disabled. [[1]](diffhunk://#diff-9d4b2034e260c9d66bef51b7a42e8538aa4fd839950aacd745eedd8845e40d1aR106-R120) [[2]](diffhunk://#diff-14221c471a9eab1f39219d5771fbe75af04b79e9321248cf759bcf67fff611a5R18-R32)
* Increased timeout values for filling username and password fields from 2000ms to 5000ms, and improved the `clickSubmitButton` and `clickLoginRedirect` functions to better handle navigation and asynchronous actions, enhancing test reliability. [[1]](diffhunk://#diff-14221c471a9eab1f39219d5771fbe75af04b79e9321248cf759bcf67fff611a5L225-R232) [[2]](diffhunk://#diff-14221c471a9eab1f39219d5771fbe75af04b79e9321248cf759bcf67fff611a5L236-R243) [[3]](diffhunk://#diff-14221c471a9eab1f39219d5771fbe75af04b79e9321248cf759bcf67fff611a5L246-R256) [[4]](diffhunk://#diff-14221c471a9eab1f39219d5771fbe75af04b79e9321248cf759bcf67fff611a5R433-R443)

**Miscellaneous:**

* Added a new selector `INPUT_SUBMIT` to `SubmitButtonSelectors` in `Constants.ts` for improved element targeting.
* Updated E2E test specs to properly await page reloads and ensure the PCA is initialized before proceeding, reducing test flakiness. [[1]](diffhunk://#diff-b8f31f42cc08acb87454a148bb7f6af0eb3ce57140ddbe1ae3858f8f1a2aa86fL160-R161) [[2]](diffhunk://#diff-b8f31f42cc08acb87454a148bb7f6af0eb3ce57140ddbe1ae3858f8f1a2aa86fL188-R190) [[3]](diffhunk://#diff-773d2cd1522eaf73569f2cfcc5903c5f729679f1ea158ce1bf8c2115751cee71L160-R161) [[4]](diffhunk://#diff-773d2cd1522eaf73569f2cfcc5903c5f729679f1ea158ce1bf8c2115751cee71L188-R190)