### PR TITLE
Bump beachball dependency to version 2.63.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "@microsoft/api-extractor": "^7.43.4",
                 "@octokit/graphql": "^4.6.0",
                 "@octokit/rest": "^18.2.1",
-                "beachball": "^2.22.4",
+                "beachball": "^2.63.1",
                 "dotenv": "^8.2.0",
                 "eslint": "^7.8.1",
                 "eslint-import-resolver-typescript": "^3.7.0",
@@ -314,6 +314,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -754,6 +755,7 @@
             "integrity": "sha512-vdMJX9E7wePN41T+6BYRQBA+XiR9a5DBhs20dqtv8YVireQktH6mxLZIg1pVxkL/gnao2gpl/lOvp0xmC7UN/Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.26.9",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -827,6 +829,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -1015,7 +1018,8 @@
             "version": "12.20.55",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
             "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "lib/msal-angular/node_modules/ajv": {
             "version": "8.18.0",
@@ -1141,6 +1145,7 @@
             "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-19.2.2.tgz",
             "integrity": "sha512-dFuwFsDJMBSd1YtmLLcX5bNNUCQUlRqgf34aXA+79PmkOP+0eF8GP2949wq3+jMjmFTNm80Oo8IUYiSLwklKCQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/wasm-node": "^4.24.0",
@@ -1227,6 +1232,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -1366,6 +1372,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -1380,6 +1387,7 @@
             "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -1524,6 +1532,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
             "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -2391,6 +2400,7 @@
             "integrity": "sha512-XGChk+26XZpcwzIQUVjgLxGVC//m5TaDrogseQNIGs2Chzv6KYbo91HftL69fTiM5udRYjg6IV7XEzDNF/GVUw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2454,6 +2464,7 @@
             "integrity": "sha512-/JYo8jJZ6BAgw3IVYJpinAfGb+RbaZubrElFvaq450BWxDPInv7Z99HKEQ3qEBRsBeIAQ/WrKXDxoJSjy7QMNQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2471,6 +2482,7 @@
             "integrity": "sha512-kWlqFW7ExvAqKv+X/6ZsWVW7YTmI1/3VUvADLC/6bkLTdKrHS8OtBHfsklXmHMNVbbFopTvoTeKkoqLGrW2lwg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2484,6 +2496,7 @@
             "integrity": "sha512-VZAzpxBoQgyy7AOlhxbAHxPQWo0nk8xsnrD36PLCZeTZA/5GNzO3lLVaX2N5BCUgpgiCBjNBKq9kVo6ZkAls9g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2520,6 +2533,7 @@
             "integrity": "sha512-bnQSmoJNI1LQxJnHnB01XQXqgOdgAtLAOsa24ZT6b2pWV3Vw0/7+V2dZsNZX/TJtejunvSgSDCEqgJhIQ5vBVg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2580,7 +2594,6 @@
             "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
             "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@jsdevtools/ono": "^7.1.3",
                 "@types/json-schema": "^7.0.15",
@@ -2598,7 +2611,6 @@
             "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
             "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -2607,15 +2619,13 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
             "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@apidevtools/swagger-parser": {
             "version": "10.1.1",
             "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
             "integrity": "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "11.7.2",
                 "@apidevtools/openapi-schemas": "^2.1.0",
@@ -2652,7 +2662,6 @@
             "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
             "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "dev": true,
-            "peer": true,
             "peerDependencies": {
                 "ajv": "^8.5.0"
             },
@@ -2678,7 +2687,6 @@
             "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-13.0.3.tgz",
             "integrity": "sha512-Vu011o3/bikQNwtjouwmUJud+Z6Brcjij2D0omPWClRGg8i5gBfOYSpDkFGkHbhGlaky4fgvfkxD0uHGq34uYA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -2697,7 +2705,6 @@
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -2710,7 +2717,6 @@
             "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.0.1.tgz",
             "integrity": "sha512-JbZtIqfEulsIA0rC3zM7jfF4KkOnye9aKcaO/jJqxJRm/gM6lAjEv7sL4njW8D+35l50P1f+UuH5OqN+UKJqNA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -2729,7 +2735,6 @@
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -2742,7 +2747,6 @@
             "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-17.2.1.tgz",
             "integrity": "sha512-J2jmTPv8ZraSHDTz9l2Bx8gNL3ktfDDWo2mxWfzarn64O9Fjhb+l85YWyubGy2xUdeGuZPKzvQLltGv8bSu8eQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -2761,7 +2765,6 @@
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -2774,7 +2777,6 @@
             "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-5.1.0.tgz",
             "integrity": "sha512-6BeOF2eQWNLq22ch7xP9RxYnPjtGev54OUCGggKOWoOvmesK7jUZbIyLk8JeXDT21PEl7iyYnxw78gxJ7zBxQw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -2793,7 +2795,6 @@
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -3117,6 +3118,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -7560,6 +7562,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -7608,15 +7611,13 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
             "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@feathersjs/hooks": {
             "version": "0.6.5",
             "resolved": "https://registry.npmjs.org/@feathersjs/hooks/-/hooks-0.6.5.tgz",
             "integrity": "sha512-WtcEoG/imdHRvC3vofGi/OcgH+cjHHhO0AfEeTlsnrKLjVKKBXV6aoIrB2nHZPpE7iW5sA7AZMR6bPD8ytxN+w==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -8417,6 +8418,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
             "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.1.2",
                 "@inquirer/confirm": "^5.1.6",
@@ -9228,8 +9230,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
             "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@jsonjoy.com/base64": {
             "version": "1.1.2",
@@ -9594,7 +9595,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/app-manifest/-/app-manifest-1.0.1.tgz",
             "integrity": "sha512-W4fw8JX/9CPATwNAi9dc25rCK/b3qSnoClVDzGfbYuy6ewY9FHgkwk/C1NzC8k/YwZAsKwMhHOvXUCt3u9ak3Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/fs-extra": "^11.0.1",
                 "@types/node-fetch": "^2.6.9",
@@ -9609,7 +9609,6 @@
             "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
             "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/jsonfile": "*",
                 "@types/node": "*"
@@ -9638,7 +9637,6 @@
             "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
             "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "dev": true,
-            "peer": true,
             "peerDependencies": {
                 "ajv": "^8.5.0"
             },
@@ -9653,7 +9651,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-contracts/-/dev-tunnels-contracts-1.1.9.tgz",
             "integrity": "sha512-OayhehwI+CnO0Wr53e29ZJZWGsNA5yVG7r54qmZSLc5HxA5Cozk4hP7EbYDCXkxh4NbQoT1dhTzC8bkRo+wWXw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "buffer": "^5.2.1",
                 "debug": "^4.1.1",
@@ -9665,7 +9662,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -9683,7 +9679,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-management/-/dev-tunnels-management-1.1.9.tgz",
             "integrity": "sha512-wGuFEzvRiWZmDxQMGKEjOKhEIVnLiG6vRUuM9Hwqxpe/kbiyA2WiUyEVpniNPaaw8gDHTf9zJHnPNNj0JiL5mA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@microsoft/dev-tunnels-contracts": ">1.1.8",
                 "axios": "^1.6.2",
@@ -9697,7 +9692,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -9715,7 +9709,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/m365-spec-parser/-/m365-spec-parser-0.2.8.tgz",
             "integrity": "sha512-G26jdZo6TQNEwpsY95p96RWLtuqzGhrqPFacKJgtODlWmYGj63InMvSdwTDNlZ610SdA9nZUqvULFWmDE/VNqg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@apidevtools/swagger-parser": "^10.1.1",
                 "@microsoft/app-manifest": "1.0.1",
@@ -9733,7 +9726,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
             "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -9774,6 +9766,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -9820,7 +9813,6 @@
             "integrity": "sha512-AowuJwrrUxeF9Bq/frxuy9YZjK/ECk3pi0UBXl3CQLZ4XNWfgWatiFi/UWpyHDLccFs+0Za3nNYATFvgsxEFwQ==",
             "dev": true,
             "hasInstallScript": true,
-            "peer": true,
             "dependencies": {
                 "@azure/arm-subscriptions": "^5.0.0",
                 "@azure/core-auth": "^1.4.0",
@@ -9863,7 +9855,6 @@
             "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.0.tgz",
             "integrity": "sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -9873,7 +9864,6 @@
             "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.2.tgz",
             "integrity": "sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/msal-common": "14.16.0",
                 "jsonwebtoken": "^9.0.0",
@@ -9888,7 +9878,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.5.2.tgz",
             "integrity": "sha512-CifrkgQjDkUkWexmgYYNyB5603HhTHI91vLFeQXh6qrTKiCMVASol01Rs1cv6LP/A2WccZSRlJKZhbaBIs/9ZA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -9905,7 +9894,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -9931,7 +9919,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.17.tgz",
             "integrity": "sha512-EqzhGryzmGpy2aJf6LxJVhndxYmFs+m8cxXzf8nejb1DE3sabf6mUgBcp4J0jAUEiAcYzqmkqRr7LPFh/WdnXA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -9946,7 +9933,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -9972,7 +9958,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.1.2.tgz",
             "integrity": "sha512-w3PMZH5rahrukn8/I7P9Ihil+twgLTUHDZtJlJyBbUKyPaOSSQjLZkb0PpncVhin1gCaMgOFXy6iNPgcZUoo2w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -9998,7 +9983,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-1.2.15.tgz",
             "integrity": "sha512-gQ77Ls09x5vKLVNMH9q/7xvYPT6sIs5f7URksw+a2iJZ0j48tVS6crLqm2ugG33tgXHIwiEqkytY60Zyh5GkJQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10014,7 +9998,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10040,7 +10023,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-1.1.16.tgz",
             "integrity": "sha512-TGLU9egcuo+s7PxphKUCnJnpCIVY32/EwPCLLuu+gTvYiD8hZgx8Z2niNQD36sa6xcfpdLY6xXDBiL/+g1r2XQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10056,7 +10038,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10082,7 +10063,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.16.tgz",
             "integrity": "sha512-Ou0LaSWvj1ni+egnyQ+NBtfM1885UwhRCMtsRt2bBO47DoC1dwtCa+ZUNgrxlnCHHF0IXsbQHYtIIjFGAavI4g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10097,7 +10077,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10123,7 +10102,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-1.1.16.tgz",
             "integrity": "sha512-aZYZVHLUXZ2gbBot+i+zOJrks1WaiI95lvZCn1sKfcw6MtSSlYC8uDX8sTzQvAsQ8epHoP84UNvAIT0KVGOGqw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10139,7 +10117,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10165,7 +10142,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-3.3.2.tgz",
             "integrity": "sha512-k52mOMRvTUejrqyF1h8Z07chC+sbaoaUYzzr1KrJXyj7yaX7Nrh0a9vktv8TuocRwIJOQMaj5oZEmkspEcJFYQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^1.5.2",
                 "@inquirer/confirm": "^2.0.17",
@@ -10186,7 +10162,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10212,7 +10187,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-1.2.16.tgz",
             "integrity": "sha512-pZ6TRg2qMwZAOZAV6TvghCtkr53dGnK29GMNQ3vMZXSNguvGqtOVc4j/h1T8kqGJFagjyfBZhUPGwNS55O5qPQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10227,7 +10201,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10253,7 +10226,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.3.3.tgz",
             "integrity": "sha512-RzlRISXWqIKEf83FDC9ZtJ3JvuK1l7aGpretf41BCWYrvla2wU8W8MTRNMiPrPJ+1SIqrRC1nZdZ60hD9hRXLg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10270,7 +10242,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10296,7 +10267,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
             "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "mute-stream": "^1.0.0"
             },
@@ -10309,7 +10279,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
             "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -10319,7 +10288,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
             "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
@@ -10335,7 +10303,6 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
             "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -10345,7 +10312,6 @@
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
             "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -10355,7 +10321,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/teamsfx-api/-/teamsfx-api-0.23.1.tgz",
             "integrity": "sha512-XmXX2dccOEU3lbYgOlijfwxmkXp6nO88JWx9P1al/1aMgbIeup2Y2H37Vmz2VwfIQC/i75FbbbbwqYjG2skQjQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/core-auth": "^1.4.0",
                 "@microsoft/teams-manifest": "0.1.5",
@@ -10371,7 +10336,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/teamsfx-core/-/teamsfx-core-2.0.9.tgz",
             "integrity": "sha512-6zA/vvpHViROP6eDbnjS8PtPyyB4eZGH/cgTiOHeiRHznT9Pkd3rqFvaIHPEDhv2g76llHEk2gTFSqL7QFovAQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@apidevtools/swagger-parser": "^10.1.0",
                 "@azure/arm-appservice": "^13.0.0",
@@ -10431,7 +10395,6 @@
             "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.0.tgz",
             "integrity": "sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -10441,7 +10404,6 @@
             "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.2.tgz",
             "integrity": "sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/msal-common": "14.16.0",
                 "jsonwebtoken": "^9.0.0",
@@ -10457,7 +10419,6 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -10474,7 +10435,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
             "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
@@ -10490,7 +10450,6 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -10502,8 +10461,7 @@
             "version": "0.1.14",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
             "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@microsoft/tsdoc": {
             "version": "0.16.0",
@@ -11069,6 +11027,7 @@
             "version": "5.17.1",
             "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.17.1.tgz",
             "integrity": "sha512-2B33kQf+GmPnrvXXweWAx+crbiUEsxCdCN979QDYnlH9ox4pd+0/IBriWLV+l6ORoBF60w39cWjFnJYGFdzXcw==",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@mui/core-downloads-tracker": "^5.17.1",
@@ -12106,6 +12065,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
             "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^2.4.4",
                 "@octokit/graphql": "^4.5.8",
@@ -12291,7 +12251,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12312,7 +12271,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12333,7 +12291,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12354,7 +12311,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12375,7 +12331,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12396,7 +12351,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12417,7 +12371,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12438,7 +12391,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12459,7 +12411,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12480,7 +12431,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12501,7 +12451,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12522,7 +12471,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12543,7 +12491,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12619,6 +12566,7 @@
             "version": "2.11.8",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -12628,7 +12576,6 @@
             "version": "2.10.5",
             "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
             "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
-            "peer": true,
             "dependencies": {
                 "debug": "^4.4.1",
                 "extract-zip": "^2.0.1",
@@ -12649,7 +12596,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -12667,7 +12613,6 @@
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
             "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
@@ -12681,7 +12626,6 @@
             "version": "3.1.7",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
             "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-            "peer": true,
             "dependencies": {
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
@@ -12714,6 +12658,7 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
             "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2",
                 "generic-pool": "3.9.0",
@@ -13595,6 +13540,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -14278,8 +14224,7 @@
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "peer": true
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.11",
@@ -14369,8 +14314,7 @@
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -14480,6 +14424,7 @@
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -14740,7 +14685,6 @@
             "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
             "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -14749,6 +14693,7 @@
             "version": "22.15.29",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
             "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -14795,14 +14740,11 @@
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
         },
         "node_modules/@types/parse-path": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.1.0.tgz",
-            "integrity": "sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==",
-            "deprecated": "This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
+            "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
             "dev": true,
-            "dependencies": {
-                "parse-path": "*"
-            }
+            "license": "MIT"
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.14",
@@ -14961,8 +14903,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
             "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/ws": {
             "version": "8.18.1",
@@ -14991,7 +14932,6 @@
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
             "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -15052,6 +14992,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -15866,6 +15807,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -15921,7 +15863,6 @@
             "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
             "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             }
@@ -16001,6 +15942,7 @@
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -16266,8 +16208,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
             "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -16406,7 +16347,6 @@
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
             "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -16415,7 +16355,6 @@
             "version": "0.13.4",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.1"
             },
@@ -16488,7 +16427,6 @@
             "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
             "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -16573,7 +16511,6 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
             "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -16585,7 +16522,6 @@
             "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
             "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.15.4",
                 "is-retry-allowed": "^2.2.0"
@@ -16598,8 +16534,7 @@
         "node_modules/b4a": {
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-            "peer": true
+            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg=="
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
@@ -16937,15 +16872,13 @@
             "version": "2.5.4",
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
             "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/bare-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
             "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "bare-events": "^2.5.4",
                 "bare-path": "^3.0.0",
@@ -16968,7 +16901,6 @@
             "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
             "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
             "optional": true,
-            "peer": true,
             "engines": {
                 "bare": ">=1.14.0"
             }
@@ -16978,7 +16910,6 @@
             "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
             "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "bare-os": "^3.0.1"
             }
@@ -16988,7 +16919,6 @@
             "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
             "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "streamx": "^2.21.0"
             },
@@ -17072,7 +17002,6 @@
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
             "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -17084,22 +17013,21 @@
             "dev": true
         },
         "node_modules/beachball": {
-            "version": "2.54.0",
-            "resolved": "https://registry.npmjs.org/beachball/-/beachball-2.54.0.tgz",
-            "integrity": "sha512-1c6guGSvI1MtMYWDQqzztvqRGoxR6I4GoePA3HlWQJav1NsK5kw1iGOUD9MKRbM+Tr3k1KwrwXIHisqXjYF98g==",
+            "version": "2.63.1",
+            "resolved": "https://registry.npmjs.org/beachball/-/beachball-2.63.1.tgz",
+            "integrity": "sha512-/tTHod4yKZA8jC193na7HhhW1zs4j6SzTnFppYq2Q1jqufLvUEaaHPPzee7QMxvzRDju9BH0urFzghvOdyPI6w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "cosmiconfig": "^8.3.6",
+                "cosmiconfig": "^9.0.0",
                 "execa": "^5.0.0",
-                "fs-extra": "^11.1.1",
-                "lodash": "^4.17.15",
                 "minimatch": "^3.0.4",
                 "p-graph": "^1.1.2",
                 "p-limit": "^3.0.2",
                 "prompts": "^2.4.2",
                 "semver": "^7.0.0",
                 "toposort": "^2.0.2",
-                "workspace-tools": "^0.38.2",
+                "workspace-tools": "^0.41.0",
                 "yargs-parser": "^21.0.0"
             },
             "bin": {
@@ -17107,46 +17035,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/beachball/node_modules/cosmiconfig": {
-            "version": "8.3.6",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-            "dev": true,
-            "dependencies": {
-                "import-fresh": "^3.3.0",
-                "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0",
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.9.5"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/beachball/node_modules/fs-extra": {
-            "version": "11.3.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/beasties": {
@@ -17405,6 +17293,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -17697,8 +17586,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
             "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -17751,7 +17639,6 @@
             "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
             "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "assertion-error": "^1.1.0",
                 "check-error": "^1.0.3",
@@ -17770,7 +17657,6 @@
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
             "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -17820,7 +17706,6 @@
             "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
             "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -17830,7 +17715,6 @@
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
             "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "get-func-name": "^2.0.2"
             },
@@ -17843,6 +17727,7 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
             "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "readdirp": "^4.0.1"
             },
@@ -17875,7 +17760,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
             "integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
-            "peer": true,
             "dependencies": {
                 "mitt": "^3.0.1",
                 "zod": "^3.24.1"
@@ -17970,7 +17854,6 @@
             "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
             "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "string-width": "^4.2.0"
             },
@@ -17985,15 +17868,13 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -18003,7 +17884,6 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -18258,7 +18138,6 @@
             "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
             "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "array-timsort": "^1.0.3",
                 "core-util-is": "^1.0.3",
@@ -18876,7 +18755,6 @@
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -18885,8 +18763,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/cryptr/-/cryptr-6.3.0.tgz",
             "integrity": "sha512-TA4byAuorT8qooU9H8YJhBwnqD151i1rcauHfJ3Divg6HmukHB2AYMp0hmjv2873J2alr4t15QqC7zAnWFrtfQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/css-loader": {
             "version": "6.11.0",
@@ -19065,7 +18942,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
             "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -19212,7 +19088,6 @@
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
             "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "type-detect": "^4.0.0"
             },
@@ -19350,7 +19225,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
             "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-            "peer": true,
             "dependencies": {
                 "ast-types": "^0.13.4",
                 "escodegen": "^2.1.0",
@@ -19435,7 +19309,6 @@
             "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
             "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "address": "^1.0.1",
                 "debug": "4"
@@ -19453,7 +19326,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -20534,6 +20406,7 @@
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -20639,7 +20512,6 @@
             "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "prr": "~1.0.1"
             },
@@ -20838,8 +20710,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
             "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/esbuild": {
             "version": "0.25.4",
@@ -20960,6 +20831,7 @@
             "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.3",
@@ -21815,6 +21687,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
             "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
@@ -21928,6 +21801,7 @@
             "version": "1.18.2",
             "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
             "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+            "peer": true,
             "dependencies": {
                 "cookie": "0.7.2",
                 "cookie-signature": "1.0.7",
@@ -22078,8 +21952,7 @@
         "node_modules/fast-fifo": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-            "peer": true
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -22124,8 +21997,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.0.6",
@@ -22953,7 +22825,6 @@
             "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
             "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -23117,7 +22988,6 @@
             "version": "6.0.4",
             "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
             "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
-            "peer": true,
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
@@ -23131,7 +23001,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -23252,6 +23121,7 @@
             "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
             "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-ssh": "^1.4.0",
                 "parse-url": "^9.2.0"
@@ -23262,6 +23132,7 @@
             "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
             "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "git-up": "^8.1.0"
             }
@@ -23511,7 +23382,6 @@
             "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
             "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -23660,6 +23530,7 @@
             "integrity": "sha512-ooiZW1Xy8rQ4oELQ++otI2T9DsKpV0M6c6cO6JGx4RTfav9poFFLlet9UMXHZnoM1yG0HWGlQLswBGX3RZmHtg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -24073,8 +23944,7 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
             "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
@@ -24247,7 +24117,6 @@
             "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "bin": {
                 "image-size": "bin/image-size.js"
             },
@@ -24621,8 +24490,7 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/is-bun-module": {
             "version": "2.0.0",
@@ -24942,7 +24810,6 @@
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
             "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -24982,6 +24849,7 @@
             "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
             "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "protocols": "^2.0.1"
             }
@@ -25306,7 +25174,8 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.0.1.tgz",
             "integrity": "sha512-w+JDABxQCkxbGGxg+a2hUVZyqUS2JKngvIyLGu/xiw2ZwgsoSB0iiecLQsQORSeaKQ6iGrCyWG86RfNDuoA7Lg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/jasmine-spec-reporter": {
             "version": "5.0.2",
@@ -25321,6 +25190,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -25622,6 +25492,7 @@
             "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
             "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -26166,6 +26037,7 @@
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -26188,8 +26060,7 @@
             "version": "3.7.7",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
             "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -26437,7 +26308,6 @@
             "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
             "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -26545,6 +26415,7 @@
             "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@colors/colors": "1.5.0",
                 "body-parser": "^1.19.0",
@@ -26974,7 +26845,6 @@
             "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
             "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.9"
             }
@@ -27011,6 +26881,7 @@
             "resolved": "https://registry.npmjs.org/less/-/less-4.2.2.tgz",
             "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
                 "parse-node-version": "^1.0.1",
@@ -27064,7 +26935,6 @@
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -27078,7 +26948,6 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -27609,7 +27478,6 @@
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
             "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "get-func-name": "^2.0.1"
             }
@@ -27676,7 +27544,6 @@
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -27880,7 +27747,6 @@
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
             "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "charenc": "0.0.2",
                 "crypt": "0.0.2",
@@ -28203,8 +28069,7 @@
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "peer": true
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
         },
         "node_modules/mkcert": {
             "version": "3.2.0",
@@ -28435,7 +28300,6 @@
             "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
             "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "mustache": "bin/mustache"
             }
@@ -28503,7 +28367,6 @@
             "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "sax": "^1.2.4"
@@ -28521,7 +28384,6 @@
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -28546,7 +28408,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-            "peer": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -28555,8 +28416,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-3.2.0.tgz",
             "integrity": "sha512-AINA32QbYO83L+3CBI6I5lH4LpBSlLwWteJ+uI25s4AQy6g/xz3RZuedmuNo91lLw2rY+AbPEPQdxd7mg1rXoQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/next": {
             "version": "15.5.12",
@@ -28722,7 +28582,6 @@
             "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
             "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "http2-client": "^1.2.5"
             },
@@ -29165,15 +29024,13 @@
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
             "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/node-readfiles": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
             "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "es6-promise": "^3.2.1"
             }
@@ -29957,7 +29814,6 @@
             "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
             "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-safe-stringify": "^2.0.7"
             }
@@ -29967,7 +29823,6 @@
             "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
             "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@exodus/schemasafe": "^1.0.0-rc.2",
                 "should": "^13.2.1",
@@ -29982,7 +29837,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -29992,7 +29846,6 @@
             "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
             "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "node-fetch-h2": "^2.3.0",
                 "oas-kit-common": "^1.0.8",
@@ -30012,7 +29865,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -30022,7 +29874,6 @@
             "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
             "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "url": "https://github.com/Mermade/oas-kit?sponsor=1"
             }
@@ -30032,7 +29883,6 @@
             "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
             "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "call-me-maybe": "^1.0.1",
                 "oas-kit-common": "^1.0.8",
@@ -30052,7 +29902,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -30433,6 +30282,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
             "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.33.1",
                 "@typescript-eslint/types": "8.33.1",
@@ -30642,6 +30492,7 @@
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -30764,6 +30615,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
             "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.18.0",
                 "@typescript-eslint/types": "7.18.0",
@@ -31037,6 +30889,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
             "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -31052,6 +30905,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -31108,7 +30962,6 @@
             "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.4.1.tgz",
             "integrity": "sha512-2eOdCCYJ5bhCe2p9KKETdg1UNshsKaT0lDU/jNopAg3t7zC1WxwvofTSO/+4Log5L4Re+wUdV8MqrQikZBa7+Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@xmldom/xmldom": "^0.8.5",
                 "commander": "^9.0.0",
@@ -31123,7 +30976,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
             "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
             }
@@ -31275,7 +31127,6 @@
             "resolved": "https://registry.npmjs.org/office-addin-project/-/office-addin-project-0.8.6.tgz",
             "integrity": "sha512-S93brHVDaMRZIIEibK12m6eTItoKqdy2Ep51qNhU7RaZTjH7n/C66AzdDai06UJb3I3AXfXHnKv/AJL2voGGWA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "adm-zip": "0.5.12",
                 "commander": "^6.2.1",
@@ -31295,7 +31146,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
             "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -31305,7 +31155,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -31320,7 +31169,6 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
-            "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -31330,7 +31178,6 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -31703,7 +31550,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
             "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-            "peer": true,
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
                 "agent-base": "^7.1.2",
@@ -31722,7 +31568,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -31739,7 +31584,6 @@
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -31753,7 +31597,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
             "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-            "peer": true,
             "dependencies": {
                 "degenerator": "^5.0.0",
                 "netmask": "^2.0.2"
@@ -32097,6 +31940,7 @@
             "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
             "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "protocols": "^2.0.0"
             }
@@ -32106,6 +31950,7 @@
             "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
             "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/parse-path": "^7.0.0",
                 "parse-path": "^7.0.0"
@@ -32269,7 +32114,6 @@
             "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
             "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -32453,6 +32297,7 @@
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
             "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -32518,6 +32363,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -32784,6 +32630,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
             "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -32821,7 +32668,6 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -32836,7 +32682,6 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -32848,8 +32693,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/proc-log": {
             "version": "2.0.1",
@@ -32950,7 +32794,6 @@
             "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
             "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "retry": "^0.12.0",
@@ -32961,14 +32804,14 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/protocols": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
             "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -32986,7 +32829,6 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
             "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -33005,7 +32847,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -33022,7 +32863,6 @@
             "version": "7.18.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
             "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -33031,7 +32871,6 @@
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -33051,8 +32890,7 @@
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/psl": {
             "version": "1.15.0",
@@ -33120,7 +32958,6 @@
             "version": "24.10.0",
             "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.10.0.tgz",
             "integrity": "sha512-xX0QJRc8t19iAwRDsAOR38Q/Zx/W6WVzJCEhKCAwp2XMsaWqfNtQ+rBfQW9PlF+Op24d7c8Zlgq9YNmbnA7hdQ==",
-            "peer": true,
             "dependencies": {
                 "@puppeteer/browsers": "2.10.5",
                 "chromium-bidi": "5.1.0",
@@ -33137,7 +32974,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -33154,7 +32990,6 @@
             "version": "8.18.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
             "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -33360,6 +33195,7 @@
             "version": "19.2.1",
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
             "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -33398,6 +33234,7 @@
             "version": "19.2.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
             "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -33834,7 +33671,6 @@
             "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
             "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "url": "https://github.com/Mermade/oas-kit?sponsor=1"
             }
@@ -34054,7 +33890,6 @@
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -34562,6 +34397,7 @@
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -34790,6 +34626,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -35194,7 +35031,6 @@
             "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
             "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "should-equal": "^2.0.0",
                 "should-format": "^3.0.3",
@@ -35208,7 +35044,6 @@
             "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
             "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "should-type": "^1.4.0"
             }
@@ -35218,7 +35053,6 @@
             "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
             "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "should-type": "^1.3.0",
                 "should-type-adaptors": "^1.0.1"
@@ -35228,15 +35062,13 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
             "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/should-type-adaptors": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
             "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "should-type": "^1.3.0",
                 "should-util": "^1.0.0"
@@ -35246,8 +35078,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
             "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/shx": {
             "version": "0.3.4",
@@ -35989,7 +35820,6 @@
             "version": "2.22.1",
             "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
             "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
-            "peer": true,
             "dependencies": {
                 "fast-fifo": "^1.3.2",
                 "text-decoder": "^1.1.0"
@@ -36424,7 +36254,6 @@
             "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
             "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "call-me-maybe": "^1.0.1",
                 "node-fetch": "^2.6.1",
@@ -36452,7 +36281,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -36774,7 +36602,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
             "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-            "peer": true,
             "dependencies": {
                 "b4a": "^1.6.4"
             }
@@ -37071,6 +36898,7 @@
             "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "bs-logger": "^0.2.6",
                 "fast-json-stable-stringify": "^2.1.0",
@@ -37173,6 +37001,7 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
             "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "arg": "^4.1.0",
                 "diff": "^4.0.1",
@@ -37229,7 +37058,8 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "peer": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -37694,15 +37524,13 @@
         "node_modules/typed-query-selector": {
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
-            "peer": true
+            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
         },
         "node_modules/typedi": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/typedi/-/typedi-0.10.0.tgz",
             "integrity": "sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/typedoc": {
             "version": "0.24.8",
@@ -37754,6 +37582,7 @@
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -37925,8 +37754,7 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/undici": {
             "version": "7.22.0",
@@ -38378,7 +38206,6 @@
             "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -38401,6 +38228,7 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -38875,7 +38703,6 @@
             "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
             "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0 || >=10.0.0"
             }
@@ -38982,6 +38809,7 @@
             "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -39199,6 +39027,7 @@
             "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
             "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
@@ -39643,10 +39472,11 @@
             "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
         },
         "node_modules/workspace-tools": {
-            "version": "0.38.4",
-            "resolved": "https://registry.npmjs.org/workspace-tools/-/workspace-tools-0.38.4.tgz",
-            "integrity": "sha512-wCei5WNlhHswuU5tPjTYy4yVd7jnavtRUNbqpiHAmWRPOJtkvUpBQZExrrgFs3h9jdx6Qf6inCDSwjqnXhf+vQ==",
+            "version": "0.41.0",
+            "resolved": "https://registry.npmjs.org/workspace-tools/-/workspace-tools-0.41.0.tgz",
+            "integrity": "sha512-iBB6LNqtJpfjTWnyjlgOwdJmf1wBTUsIr1V5phOBCJMywubpYAijDUqhgz7RfrTYdscA4vEFyhjiy4OSAGULcA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@yarnpkg/lockfile": "^1.1.0",
                 "fast-glob": "^3.3.1",
@@ -39859,7 +39689,8 @@
             "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
             "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ==",
             "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/xterm-addon-fit": {
             "version": "0.5.0",
@@ -39899,7 +39730,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
             "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -40100,6 +39930,7 @@
             "version": "3.25.75",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.75.tgz",
             "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -40117,7 +39948,8 @@
         "node_modules/zone.js": {
             "version": "0.15.1",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-            "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w=="
+            "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+            "peer": true
         },
         "regression-tests/msal-node/client-credential": {
             "version": "1.0.0",
@@ -40297,6 +40129,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.0.tgz",
             "integrity": "sha512-SzlLoMT/r5wKqPicx5okCAiN5UD5+VE7x/F1G6gSJCcnBfbK5PqHPUmDnMW4jw9Ode06KZDT7ntstn6fG+Ld8w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -40426,6 +40259,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -40500,6 +40334,7 @@
             "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.0.tgz",
             "integrity": "sha512-1P0TNL1F51NC7JAaXabaAHY7Y1zBloLSZXfml1POa4a116V+y/QZfPGsxM0LwD1qSSXhSb2LNl7duTtJAP39bA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parse5": "^8.0.0",
                 "tslib": "^2.3.0"
@@ -40551,6 +40386,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.0.tgz",
             "integrity": "sha512-6zJMPi0i/XDniEgv3/t2BjuDHiOG44lgIR5PYyxqGpgJ0kqB5hku/0TuentNEi1VnBYgthnfhjek7c+lakXmhw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -40567,6 +40403,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.0.tgz",
             "integrity": "sha512-0RPkma8UVNpse/VJcXT9w6SKzTMz4J/uMGj0l9enM1frg9xrx1fwi/lLmaVV9Nr9LfqPjQdxNFFlvaBB7g/2zg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -40580,6 +40417,7 @@
             "integrity": "sha512-gZd58p0/JjgdxMX3v+LjCB6e3dBIfNVr/YzXoh55TfffdBCUQY94hl1+DFQkJ72K5EX+1zbaz03dIm30kw1bGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -40612,6 +40450,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.0.tgz",
             "integrity": "sha512-VnTbmZq3g3Q+s3nCZ8VUDMLjMezOg/bqUxAJ/DrRWCrEcTP5JO3mrNPs3FHj+qlB0T+BQP7uQv6QTzPVKybwoA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -40637,6 +40476,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.0.tgz",
             "integrity": "sha512-NduUtPWLauH/FLayEDkLyaKAGqKzXbcfO7468LOWCXN3crhNVQyIWRQPOUcdpoJwDAGLpN85m3DhJhXNnA9c5w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "tslib": "^2.3.0"
@@ -40673,6 +40513,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.0.tgz",
             "integrity": "sha512-IUGukpvvT2B5Dl76qzk6rY7UIHUT9u4BhT2AwVz+5JqcX9KwQtYD17Gt7wj6bvIgCXKWG+CfN8Zd9DECOCYWjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -41170,6 +41011,7 @@
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -41553,6 +41395,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
             "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -41729,6 +41572,7 @@
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -42114,6 +41958,7 @@
             "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
@@ -42824,6 +42669,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -43060,6 +42906,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.0.tgz",
             "integrity": "sha512-SzlLoMT/r5wKqPicx5okCAiN5UD5+VE7x/F1G6gSJCcnBfbK5PqHPUmDnMW4jw9Ode06KZDT7ntstn6fG+Ld8w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43227,6 +43074,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.0.tgz",
             "integrity": "sha512-6zJMPi0i/XDniEgv3/t2BjuDHiOG44lgIR5PYyxqGpgJ0kqB5hku/0TuentNEi1VnBYgthnfhjek7c+lakXmhw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43243,6 +43091,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.0.tgz",
             "integrity": "sha512-0RPkma8UVNpse/VJcXT9w6SKzTMz4J/uMGj0l9enM1frg9xrx1fwi/lLmaVV9Nr9LfqPjQdxNFFlvaBB7g/2zg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43256,6 +43105,7 @@
             "integrity": "sha512-gZd58p0/JjgdxMX3v+LjCB6e3dBIfNVr/YzXoh55TfffdBCUQY94hl1+DFQkJ72K5EX+1zbaz03dIm30kw1bGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -43288,6 +43138,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.0.tgz",
             "integrity": "sha512-VnTbmZq3g3Q+s3nCZ8VUDMLjMezOg/bqUxAJ/DrRWCrEcTP5JO3mrNPs3FHj+qlB0T+BQP7uQv6QTzPVKybwoA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43313,6 +43164,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.0.tgz",
             "integrity": "sha512-NduUtPWLauH/FLayEDkLyaKAGqKzXbcfO7468LOWCXN3crhNVQyIWRQPOUcdpoJwDAGLpN85m3DhJhXNnA9c5w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "tslib": "^2.3.0"
@@ -43349,6 +43201,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.0.tgz",
             "integrity": "sha512-IUGukpvvT2B5Dl76qzk6rY7UIHUT9u4BhT2AwVz+5JqcX9KwQtYD17Gt7wj6bvIgCXKWG+CfN8Zd9DECOCYWjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43844,6 +43697,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -44403,6 +44257,7 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -44729,7 +44584,8 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.5.0.tgz",
             "integrity": "sha512-9PMzyvhtocxb3aXJVOPqBDswdgyAeSB81QnLop4npOpbqnheaTEwPc9ZloQeVswugPManznQBjD8kWDTjlnHuw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "samples/msal-angular-samples/angular-modules-sample/node_modules/json-parse-even-better-errors": {
             "version": "5.0.0",
@@ -44746,6 +44602,7 @@
             "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
             "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "jasmine-core": "^4.1.0"
             },
@@ -44772,6 +44629,7 @@
             "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
             "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
@@ -45470,6 +45328,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -45520,6 +45379,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -45776,6 +45636,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.0.tgz",
             "integrity": "sha512-SzlLoMT/r5wKqPicx5okCAiN5UD5+VE7x/F1G6gSJCcnBfbK5PqHPUmDnMW4jw9Ode06KZDT7ntstn6fG+Ld8w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -45943,6 +45804,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.0.tgz",
             "integrity": "sha512-6zJMPi0i/XDniEgv3/t2BjuDHiOG44lgIR5PYyxqGpgJ0kqB5hku/0TuentNEi1VnBYgthnfhjek7c+lakXmhw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -45959,6 +45821,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.0.tgz",
             "integrity": "sha512-0RPkma8UVNpse/VJcXT9w6SKzTMz4J/uMGj0l9enM1frg9xrx1fwi/lLmaVV9Nr9LfqPjQdxNFFlvaBB7g/2zg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -45972,6 +45835,7 @@
             "integrity": "sha512-gZd58p0/JjgdxMX3v+LjCB6e3dBIfNVr/YzXoh55TfffdBCUQY94hl1+DFQkJ72K5EX+1zbaz03dIm30kw1bGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -46004,6 +45868,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.0.tgz",
             "integrity": "sha512-VnTbmZq3g3Q+s3nCZ8VUDMLjMezOg/bqUxAJ/DrRWCrEcTP5JO3mrNPs3FHj+qlB0T+BQP7uQv6QTzPVKybwoA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -46029,6 +45894,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.0.tgz",
             "integrity": "sha512-NduUtPWLauH/FLayEDkLyaKAGqKzXbcfO7468LOWCXN3crhNVQyIWRQPOUcdpoJwDAGLpN85m3DhJhXNnA9c5w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "tslib": "^2.3.0"
@@ -46065,6 +45931,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.0.tgz",
             "integrity": "sha512-IUGukpvvT2B5Dl76qzk6rY7UIHUT9u4BhT2AwVz+5JqcX9KwQtYD17Gt7wj6bvIgCXKWG+CfN8Zd9DECOCYWjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -46562,6 +46429,7 @@
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -47144,6 +47012,7 @@
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -47520,6 +47389,7 @@
             "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
@@ -48238,6 +48108,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -48288,6 +48159,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -48492,6 +48364,7 @@
             "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -48672,6 +48545,7 @@
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -50425,6 +50299,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.110.tgz",
             "integrity": "sha512-WW2o4gTmREtSnqKty9nhqF/vA0GKd0V/rbC0OyjSk9Bz6bzlsXKT+i7WDdS/a0z74rfT2PO4dArVCSnapNLA5Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -50932,6 +50807,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.110.tgz",
             "integrity": "sha512-WW2o4gTmREtSnqKty9nhqF/vA0GKd0V/rbC0OyjSk9Bz6bzlsXKT+i7WDdS/a0z74rfT2PO4dArVCSnapNLA5Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -51537,6 +51413,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -51683,6 +51560,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.110.tgz",
             "integrity": "sha512-WW2o4gTmREtSnqKty9nhqF/vA0GKd0V/rbC0OyjSk9Bz6bzlsXKT+i7WDdS/a0z74rfT2PO4dArVCSnapNLA5Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@microsoft/api-extractor": "^7.43.4",
         "@octokit/graphql": "^4.6.0",
         "@octokit/rest": "^18.2.1",
-        "beachball": "^2.22.4",
+        "beachball": "^2.63.1",
         "dotenv": "^8.2.0",
         "eslint": "^7.8.1",
         "eslint-import-resolver-typescript": "^3.7.0",


### PR DESCRIPTION
This pull request updates the `beachball` dependency in the `package.json` file to a newer version. Previously pinned version in the package-lock did not contain a recent update that fixed local dev dependencies (private packages) from being marked as bumped in changelogs.

- Upgraded the `beachball` package from version `2.22.4` to `2.63.1` in `package.json`.