### PR TITLE
Remove hidden iframe after receiving response from the redirect bridge

### DIFF
--- a/change/@azure-msal-browser-efef7fa6-07a7-4de1-a11f-10e33d8cb818.json
+++ b/change/@azure-msal-browser-efef7fa6-07a7-4de1-a11f-10e33d8cb818.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove hidden iframe after receiving response from the redirect bridge #8459 (https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8459)",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-efef7fa6-07a7-4de1-a11f-10e33d8cb818.json
+++ b/change/@azure-msal-browser-efef7fa6-07a7-4de1-a11f-10e33d8cb818.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Remove hidden iframe after receiving response from the redirect bridge #8459 (https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8459)",
+  "comment": "Remove hidden iframe after receiving response from the redirect bridge [#8459](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8459)",
   "packageName": "@azure/msal-browser",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -38,6 +38,7 @@ import {
     initiateCodeRequest,
     initiateCodeFlowWithPost,
     initiateEarRequest,
+    removeHiddenIframe,
 } from "../interaction_handler/SilentHandler.js";
 import { SsoSilentRequest } from "../request/SsoSilentRequest.js";
 import { AuthenticationResult } from "../response/AuthenticationResult.js";
@@ -276,7 +277,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             earJwk: earJwk,
             codeChallenge: pkceCodes.challenge,
         };
-        await invokeAsync(
+        const iframe = await invokeAsync(
             initiateEarRequest,
             BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
             this.logger,
@@ -291,19 +292,30 @@ export class SilentIframeClient extends StandardInteractionClient {
         );
 
         const responseType = this.config.auth.OIDCOptions.responseMode;
-        const responseString = await invokeAsync(
-            BrowserUtils.waitForBridgeResponse,
-            BrowserPerformanceEvents.SilentHandlerMonitorIframeForHash,
-            this.logger,
-            this.performanceClient,
-            correlationId
-        )(
-            this.config.system.iframeBridgeTimeout,
-            this.logger,
-            this.browserCrypto,
-            request,
-            this.performanceClient
-        );
+        let responseString: string;
+        try {
+            responseString = await invokeAsync(
+                BrowserUtils.waitForBridgeResponse,
+                BrowserPerformanceEvents.SilentHandlerMonitorIframeForHash,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(
+                this.config.system.iframeBridgeTimeout,
+                this.logger,
+                this.browserCrypto,
+                request,
+                this.performanceClient
+            );
+        } finally {
+            invoke(
+                removeHiddenIframe,
+                BrowserPerformanceEvents.RemoveHiddenIframe,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(iframe);
+        }
 
         const serverParams = invoke(
             ResponseHandler.deserializeResponse,
@@ -415,8 +427,9 @@ export class SilentIframeClient extends StandardInteractionClient {
             codeChallenge: pkceCodes.challenge,
         };
 
+        let iframe: HTMLIFrameElement;
         if (request.httpMethod === Constants.HttpMethod.POST) {
-            await invokeAsync(
+            iframe = await invokeAsync(
                 initiateCodeFlowWithPost,
                 BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
                 this.logger,
@@ -446,7 +459,7 @@ export class SilentIframeClient extends StandardInteractionClient {
             );
 
             // Get the frame handle for the silent request
-            await invokeAsync(
+            iframe = await invokeAsync(
                 initiateCodeRequest,
                 BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
                 this.logger,
@@ -457,19 +470,30 @@ export class SilentIframeClient extends StandardInteractionClient {
 
         const responseType = this.config.auth.OIDCOptions.responseMode;
         // Wait for response from the redirect bridge.
-        const responseString = await invokeAsync(
-            BrowserUtils.waitForBridgeResponse,
-            BrowserPerformanceEvents.SilentHandlerMonitorIframeForHash,
-            this.logger,
-            this.performanceClient,
-            correlationId
-        )(
-            this.config.system.iframeBridgeTimeout,
-            this.logger,
-            this.browserCrypto,
-            request,
-            this.performanceClient
-        );
+        let responseString: string;
+        try {
+            responseString = await invokeAsync(
+                BrowserUtils.waitForBridgeResponse,
+                BrowserPerformanceEvents.SilentHandlerMonitorIframeForHash,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(
+                this.config.system.iframeBridgeTimeout,
+                this.logger,
+                this.browserCrypto,
+                request,
+                this.performanceClient
+            );
+        } finally {
+            invoke(
+                removeHiddenIframe,
+                BrowserPerformanceEvents.RemoveHiddenIframe,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(iframe);
+        }
 
         const serverParams = invoke(
             ResponseHandler.deserializeResponse,

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -486,15 +486,13 @@ export class SilentIframeClient extends StandardInteractionClient {
                 this.performanceClient
             );
         } finally {
-            if (iframe) {
-                invoke(
-                    removeHiddenIframe,
-                    BrowserPerformanceEvents.RemoveHiddenIframe,
-                    this.logger,
-                    this.performanceClient,
-                    correlationId
-                )(iframe);
-            }
+            invoke(
+                removeHiddenIframe,
+                BrowserPerformanceEvents.RemoveHiddenIframe,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(iframe);
         }
 
         const serverParams = invoke(

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -486,13 +486,15 @@ export class SilentIframeClient extends StandardInteractionClient {
                 this.performanceClient
             );
         } finally {
-            invoke(
-                removeHiddenIframe,
-                BrowserPerformanceEvents.RemoveHiddenIframe,
-                this.logger,
-                this.performanceClient,
-                correlationId
-            )(iframe);
+            if (iframe) {
+                invoke(
+                    removeHiddenIframe,
+                    BrowserPerformanceEvents.RemoveHiddenIframe,
+                    this.logger,
+                    this.performanceClient,
+                    correlationId
+                )(iframe);
+            }
         }
 
         const serverParams = invoke(

--- a/lib/msal-browser/src/interaction_handler/SilentHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/SilentHandler.ts
@@ -130,7 +130,7 @@ function createHiddenIframe(): HTMLIFrameElement {
 
 /**
  * @hidden
- * Removes a hidden iframe from the DOM.
+ * Removes a hidden iframe from `document.body` if it is a direct child.
  * @param iframe - The iframe element to remove.
  */
 export function removeHiddenIframe(iframe: HTMLIFrameElement): void {

--- a/lib/msal-browser/src/interaction_handler/SilentHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/SilentHandler.ts
@@ -127,3 +127,14 @@ function createHiddenIframe(): HTMLIFrameElement {
 
     return authFrame;
 }
+
+/**
+ * @hidden
+ * Removes a hidden iframe from the DOM.
+ * @param iframe - The iframe element to remove.
+ */
+export function removeHiddenIframe(iframe: HTMLIFrameElement): void {
+    if (document.body === iframe.parentNode) {
+        document.body.removeChild(iframe);
+    }
+}

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -1284,6 +1284,69 @@ describe("SilentIframeClient", () => {
                 expect(initiateCodeRequestSpy).toHaveBeenCalled();
                 expect(tokenResp).toEqual(testTokenResponse);
             });
+
+            it("removes hidden iframe after successful token acquisition", async () => {
+                const iframe = document.createElement("iframe");
+                document.body.appendChild(iframe);
+                jest.spyOn(AuthorizeProtocol, "getAuthCodeRequestUrl")
+                    .mockResolvedValue(testNavUrl);
+                jest.spyOn(SilentHandler, "initiateCodeRequest")
+                    .mockResolvedValue(iframe);
+                const removeIframeSpy = jest.spyOn(SilentHandler, "removeHiddenIframe");
+
+                await silentIframeClient.acquireToken({
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    loginHint: "testLoginHint",
+                    account: testAccount,
+                });
+
+                expect(removeIframeSpy).toHaveBeenCalledWith(iframe);
+                expect(document.body.contains(iframe)).toBe(false);
+            });
+
+            it("removes hidden iframe even when waitForBridgeResponse rejects", async () => {
+                const iframe = document.createElement("iframe");
+                document.body.appendChild(iframe);
+                jest.spyOn(AuthorizeProtocol, "getAuthCodeRequestUrl")
+                    .mockResolvedValue(testNavUrl);
+                jest.spyOn(SilentHandler, "initiateCodeRequest")
+                    .mockResolvedValue(iframe);
+                jest.restoreAllMocks();
+                jest.spyOn(ProtocolUtils, "setRequestState").mockReturnValue(
+                    TEST_STATE_VALUES.TEST_STATE_SILENT
+                );
+                jest.spyOn(PkceGenerator, "generatePkceCodes").mockResolvedValue({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER,
+                });
+                jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                    RANDOM_TEST_GUID
+                );
+                jest.spyOn(AuthorizeProtocol, "getAuthCodeRequestUrl")
+                    .mockResolvedValue(testNavUrl);
+                jest.spyOn(SilentHandler, "initiateCodeRequest")
+                    .mockResolvedValue(iframe);
+                jest.spyOn(BrowserUtils, "waitForBridgeResponse").mockRejectedValue(
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.timedOut,
+                        "redirect_bridge_timeout"
+                    )
+                );
+                const removeIframeSpy = jest.spyOn(SilentHandler, "removeHiddenIframe");
+
+                await expect(
+                    silentIframeClient.acquireToken({
+                        redirectUri: TEST_URIS.TEST_REDIR_URI,
+                        loginHint: "testLoginHint",
+                        account: testAccount,
+                    })
+                ).rejects.toMatchObject({
+                    errorCode: BrowserAuthErrorCodes.timedOut,
+                });
+
+                expect(removeIframeSpy).toHaveBeenCalledWith(iframe);
+                expect(document.body.contains(iframe)).toBe(false);
+            });
         });
 
         describe("storeInCache tests", () => {

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -1288,11 +1288,18 @@ describe("SilentIframeClient", () => {
             it("removes hidden iframe after successful token acquisition", async () => {
                 const iframe = document.createElement("iframe");
                 document.body.appendChild(iframe);
-                jest.spyOn(AuthorizeProtocol, "getAuthCodeRequestUrl")
-                    .mockResolvedValue(testNavUrl);
-                jest.spyOn(SilentHandler, "initiateCodeRequest")
-                    .mockResolvedValue(iframe);
-                const removeIframeSpy = jest.spyOn(SilentHandler, "removeHiddenIframe");
+                jest.spyOn(
+                    AuthorizeProtocol,
+                    "getAuthCodeRequestUrl"
+                ).mockResolvedValue(testNavUrl);
+                jest.spyOn(
+                    SilentHandler,
+                    "initiateCodeRequest"
+                ).mockResolvedValue(iframe);
+                const removeIframeSpy = jest.spyOn(
+                    SilentHandler,
+                    "removeHiddenIframe"
+                );
 
                 await silentIframeClient.acquireToken({
                     redirectUri: TEST_URIS.TEST_REDIR_URI,
@@ -1307,32 +1314,49 @@ describe("SilentIframeClient", () => {
             it("removes hidden iframe even when waitForBridgeResponse rejects", async () => {
                 const iframe = document.createElement("iframe");
                 document.body.appendChild(iframe);
-                jest.spyOn(AuthorizeProtocol, "getAuthCodeRequestUrl")
-                    .mockResolvedValue(testNavUrl);
-                jest.spyOn(SilentHandler, "initiateCodeRequest")
-                    .mockResolvedValue(iframe);
+                jest.spyOn(
+                    AuthorizeProtocol,
+                    "getAuthCodeRequestUrl"
+                ).mockResolvedValue(testNavUrl);
+                jest.spyOn(
+                    SilentHandler,
+                    "initiateCodeRequest"
+                ).mockResolvedValue(iframe);
                 jest.restoreAllMocks();
                 jest.spyOn(ProtocolUtils, "setRequestState").mockReturnValue(
                     TEST_STATE_VALUES.TEST_STATE_SILENT
                 );
-                jest.spyOn(PkceGenerator, "generatePkceCodes").mockResolvedValue({
+                jest.spyOn(
+                    PkceGenerator,
+                    "generatePkceCodes"
+                ).mockResolvedValue({
                     challenge: TEST_CONFIG.TEST_CHALLENGE,
                     verifier: TEST_CONFIG.TEST_VERIFIER,
                 });
                 jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
                     RANDOM_TEST_GUID
                 );
-                jest.spyOn(AuthorizeProtocol, "getAuthCodeRequestUrl")
-                    .mockResolvedValue(testNavUrl);
-                jest.spyOn(SilentHandler, "initiateCodeRequest")
-                    .mockResolvedValue(iframe);
-                jest.spyOn(BrowserUtils, "waitForBridgeResponse").mockRejectedValue(
+                jest.spyOn(
+                    AuthorizeProtocol,
+                    "getAuthCodeRequestUrl"
+                ).mockResolvedValue(testNavUrl);
+                jest.spyOn(
+                    SilentHandler,
+                    "initiateCodeRequest"
+                ).mockResolvedValue(iframe);
+                jest.spyOn(
+                    BrowserUtils,
+                    "waitForBridgeResponse"
+                ).mockRejectedValue(
                     createBrowserAuthError(
                         BrowserAuthErrorCodes.timedOut,
                         "redirect_bridge_timeout"
                     )
                 );
-                const removeIframeSpy = jest.spyOn(SilentHandler, "removeHiddenIframe");
+                const removeIframeSpy = jest.spyOn(
+                    SilentHandler,
+                    "removeHiddenIframe"
+                );
 
                 await expect(
                     silentIframeClient.acquireToken({

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -1314,15 +1314,6 @@ describe("SilentIframeClient", () => {
             it("removes hidden iframe even when waitForBridgeResponse rejects", async () => {
                 const iframe = document.createElement("iframe");
                 document.body.appendChild(iframe);
-                jest.spyOn(
-                    AuthorizeProtocol,
-                    "getAuthCodeRequestUrl"
-                ).mockResolvedValue(testNavUrl);
-                jest.spyOn(
-                    SilentHandler,
-                    "initiateCodeRequest"
-                ).mockResolvedValue(iframe);
-                jest.restoreAllMocks();
                 jest.spyOn(ProtocolUtils, "setRequestState").mockReturnValue(
                     TEST_STATE_VALUES.TEST_STATE_SILENT
                 );

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -274,4 +274,34 @@ describe("SilentHandler.ts Unit Tests", () => {
             expect(response2).toEqual("code=code2&state=state2");
         });
     });
+
+    describe("removeHiddenIframe", () => {
+        it("removes iframe from the DOM", () => {
+            const iframe = document.createElement("iframe");
+            document.body.appendChild(iframe);
+            expect(document.body.contains(iframe)).toBe(true);
+
+            SilentHandler.removeHiddenIframe(iframe);
+            expect(document.body.contains(iframe)).toBe(false);
+        });
+
+        it("does nothing when iframe is not in the DOM", () => {
+            const iframe = document.createElement("iframe");
+            expect(() =>
+                SilentHandler.removeHiddenIframe(iframe)
+            ).not.toThrow();
+        });
+
+        it("does nothing when iframe has a different parent", () => {
+            const container = document.createElement("div");
+            document.body.appendChild(container);
+            const iframe = document.createElement("iframe");
+            container.appendChild(iframe);
+
+            SilentHandler.removeHiddenIframe(iframe);
+            expect(container.contains(iframe)).toBe(true);
+
+            document.body.removeChild(container);
+        });
+    });
 });


### PR DESCRIPTION
This pull request improves the reliability and cleanliness of the silent authentication flow by ensuring that hidden iframes created for silent token acquisition are always removed from the DOM, regardless of whether the operation succeeds or fails. It introduces a new utility function for removing iframes, integrates it into the main authentication logic, and adds comprehensive tests to verify this behavior.

**Silent iframe cleanup improvements:**

* Added a new `removeHiddenIframe` function in `SilentHandler.ts` to safely remove hidden iframes from the DOM after silent authentication attempts.
* Updated `SilentIframeClient.ts` to always remove the hidden iframe in a `finally` block after waiting for the authentication response, ensuring cleanup on both success and error cases. [[1]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faR41) [[2]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faL279-R280) [[3]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faL294-R297) [[4]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faR310-R318) [[5]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faR430-R432) [[6]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faL449-R462) [[7]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faL460-R475) [[8]](diffhunk://#diff-379febb046eaaa641bafb36c0a72f4c585eda5881b889dd8942919112539e5faR488-R496)

**Testing and validation:**

* Added new tests in `SilentIframeClient.spec.ts` to verify that the hidden iframe is removed after both successful and failed token acquisition attempts.
* Added unit tests for the `removeHiddenIframe` function in `SilentHandler.spec.ts` to ensure correct behavior in various DOM scenarios.