### PR TITLE
Fix hash handling in broadcastResponseToMainFrame to prevent malformed URLs

### DIFF
--- a/change/@azure-msal-browser-3040e510-3bd9-458a-acc6-59e37d8846a6.json
+++ b/change/@azure-msal-browser-3040e510-3bd9-458a-acc6-59e37d8846a6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix hash handling in broadcastResponseToMainFrame to prevent malformed URLs #8460 (https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8460)",
+  "comment": "Fix hash handling in broadcastResponseToMainFrame to prevent malformed URLs [#8460](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8460)",
   "packageName": "@azure/msal-browser",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-3040e510-3bd9-458a-acc6-59e37d8846a6.json
+++ b/change/@azure-msal-browser-3040e510-3bd9-458a-acc6-59e37d8846a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix hash handling in broadcastResponseToMainFrame to prevent malformed URLs #8460 (https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8460)",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/docs/redirect-bridge.md
+++ b/lib/msal-browser/docs/redirect-bridge.md
@@ -118,6 +118,18 @@ const msalConfig = {
 For more information on running MSAL in iframes, see
 [Using MSAL in iframed apps](./iframe-usage.md).
 
+## Hash-Based Routing
+
+Applications that use hash-based routing (e.g. React Router's `HashRouter`, Angular `useHash: true`, Vue Router hash mode) have URLs like `https://example.com/#/dashboard`. When the redirect bridge navigates back to the originating page with the authentication response, it must avoid creating malformed URLs with two `#` fragments (e.g. `/#/dashboard#code=...`).
+
+MSAL handles this automatically:
+
+- **`response_mode=fragment`** (default): The redirect bridge strips the existing hash-based route from the origin URL before appending the auth response hash. The URL becomes `https://example.com/#code=...&state=...`. After `handleRedirectPromise` processes the response, it restores the original route hash (e.g. `/#/dashboard`) when `navigateToLoginRequestUrl` is enabled (the default).
+
+- **`response_mode=query`**: The redirect bridge inserts the auth response query parameters *before* the hash fragment, producing `https://example.com/?code=...&state=...#/dashboard`. The hash-based route is preserved throughout.
+
+No special configuration is needed — both response modes work correctly with hash-based routing and the redirect bridge.
+
 ## Angular
 
 1. **Create the redirect bridge component** (`src/app/redirect/redirect.component.ts`):

--- a/lib/msal-browser/src/redirect_bridge/index.ts
+++ b/lib/msal-browser/src/redirect_bridge/index.ts
@@ -96,19 +96,28 @@ export async function broadcastResponseToMainFrame(
         }
 
         /*
-         * Strip existing hash from the origin URL before appending the auth response hash
-         * to avoid creating a malformed URL with two # fragments (e.g. /#/route#code=xxx).
+         * Strip existing hash from the origin URL before appending the auth response
+         * to avoid creating a malformed URL with two # fragments (e.g. /#/route#code=xxx)
+         * or query params trapped inside the fragment (e.g. /#/route?state=xxx).
          * The original hash is restored later by RedirectClient.handleRedirectPromise.
          */
-        let baseUrl = navigateToUrl || BrowserUtils.getHomepage();
-        if (hasResponseInHash) {
-            const hashIndex = baseUrl.indexOf("#");
-            if (hashIndex > -1) {
-                baseUrl = baseUrl.substring(0, hashIndex);
-            }
+        const baseUrl = navigateToUrl || BrowserUtils.getHomepage();
+        const baseHashIndex = baseUrl.indexOf("#");
+        let homepage: string;
+        if (baseHashIndex > -1 && hasResponseInHash) {
+            // Hash response: strip origin hash to avoid double # fragments
+            homepage = `${baseUrl.substring(
+                0,
+                baseHashIndex
+            )}${fullUrlResponse}`;
+        } else if (baseHashIndex > -1 && hasResponseInQuery) {
+            // Query response: insert query params before the existing hash fragment
+            const preHash = baseUrl.substring(0, baseHashIndex);
+            const fragment = baseUrl.substring(baseHashIndex);
+            homepage = `${preHash}${fullUrlResponse}${fragment}`;
+        } else {
+            homepage = `${baseUrl}${fullUrlResponse}`;
         }
-
-        const homepage = `${baseUrl}${fullUrlResponse}`;
         await navClient.navigateInternal(homepage, navigationOptions);
 
         // Do NOT clear URL for redirect flow - we're navigating away anyway

--- a/lib/msal-browser/src/redirect_bridge/index.ts
+++ b/lib/msal-browser/src/redirect_bridge/index.ts
@@ -115,14 +115,23 @@ export async function broadcastResponseToMainFrame(
             const preHash = baseUrl.substring(0, baseHashIndex);
             const fragment = baseUrl.substring(baseHashIndex);
             // If the base URL already has query params, join with "&" instead of adding a second "?"
-            if (preHash.indexOf("?") !== -1 && fullUrlResponse.startsWith("?")) {
-                homepage = `${preHash}${fullUrlResponse.replace("?", "&")}${fragment}`;
+            if (
+                preHash.indexOf("?") !== -1 &&
+                fullUrlResponse.startsWith("?")
+            ) {
+                homepage = `${preHash}${fullUrlResponse.replace(
+                    "?",
+                    "&"
+                )}${fragment}`;
             } else {
                 homepage = `${preHash}${fullUrlResponse}${fragment}`;
             }
         } else {
             // No hash fragment: append auth response to the end of the base URL
-            if (baseUrl.indexOf("?") !== -1 && fullUrlResponse.startsWith("?")) {
+            if (
+                baseUrl.indexOf("?") !== -1 &&
+                fullUrlResponse.startsWith("?")
+            ) {
                 // Base URL already has query params; avoid creating a second "?"
                 homepage = `${baseUrl}${fullUrlResponse.replace("?", "&")}`;
             } else {

--- a/lib/msal-browser/src/redirect_bridge/index.ts
+++ b/lib/msal-browser/src/redirect_bridge/index.ts
@@ -96,10 +96,24 @@ export async function broadcastResponseToMainFrame(
         }
 
         /*
-         * Strip existing hash from the origin URL before appending the auth response
-         * to avoid creating a malformed URL with two # fragments (e.g. /#/route#code=xxx)
-         * or query params trapped inside the fragment (e.g. /#/route?state=xxx).
-         * The original hash is restored later by RedirectClient.handleRedirectPromise.
+         * For apps that use hash-based routing (e.g. "/#/route"), the redirect bridge
+         * must carefully reconstruct the URL so that the authentication response does
+         * not break client-side routing:
+         *
+         * - When the server returns the response in the fragment (response_mode=fragment),
+         *   the existing route fragment is stripped from the origin URL before appending
+         *   the auth response. This avoids malformed URLs with two "#" fragments
+         *   (e.g. "/#/route#code=..." or "/#/route#id_token=...").
+         *
+         * - When the server returns the response in the query string (response_mode=query),
+         *   the query parameters are inserted before the existing fragment so that the
+         *   hash-based route (e.g. "/#/route") is preserved and continues to work. This
+         *   configuration (responseMode: "query") is often recommended for hash-routed SPAs.
+         *
+         * The original route fragment (e.g. "/#/route") is restored later by
+         * RedirectClient.handleRedirectPromise when navigateToLoginRequestUrl is enabled,
+         * so the application is returned to the original hash-routed location after the
+         * authentication response is processed.
          */
         const baseUrl = navigateToUrl || BrowserUtils.getHomepage();
         const baseHashIndex = baseUrl.indexOf("#");

--- a/lib/msal-browser/src/redirect_bridge/index.ts
+++ b/lib/msal-browser/src/redirect_bridge/index.ts
@@ -95,9 +95,20 @@ export async function broadcastResponseToMainFrame(
             fullUrlResponse = urlQuery;
         }
 
-        const homepage = `${
-            navigateToUrl || BrowserUtils.getHomepage()
-        }${fullUrlResponse}`;
+        /*
+         * Strip existing hash from the origin URL before appending the auth response hash
+         * to avoid creating a malformed URL with two # fragments (e.g. /#/route#code=xxx).
+         * The original hash is restored later by RedirectClient.handleRedirectPromise.
+         */
+        let baseUrl = navigateToUrl || BrowserUtils.getHomepage();
+        if (hasResponseInHash) {
+            const hashIndex = baseUrl.indexOf("#");
+            if (hashIndex > -1) {
+                baseUrl = baseUrl.substring(0, hashIndex);
+            }
+        }
+
+        const homepage = `${baseUrl}${fullUrlResponse}`;
         await navClient.navigateInternal(homepage, navigationOptions);
 
         // Do NOT clear URL for redirect flow - we're navigating away anyway

--- a/lib/msal-browser/src/redirect_bridge/index.ts
+++ b/lib/msal-browser/src/redirect_bridge/index.ts
@@ -114,9 +114,20 @@ export async function broadcastResponseToMainFrame(
             // Query response: insert query params before the existing hash fragment
             const preHash = baseUrl.substring(0, baseHashIndex);
             const fragment = baseUrl.substring(baseHashIndex);
-            homepage = `${preHash}${fullUrlResponse}${fragment}`;
+            // If the base URL already has query params, join with "&" instead of adding a second "?"
+            if (preHash.indexOf("?") !== -1 && fullUrlResponse.startsWith("?")) {
+                homepage = `${preHash}${fullUrlResponse.replace("?", "&")}${fragment}`;
+            } else {
+                homepage = `${preHash}${fullUrlResponse}${fragment}`;
+            }
         } else {
-            homepage = `${baseUrl}${fullUrlResponse}`;
+            // No hash fragment: append auth response to the end of the base URL
+            if (baseUrl.indexOf("?") !== -1 && fullUrlResponse.startsWith("?")) {
+                // Base URL already has query params; avoid creating a second "?"
+                homepage = `${baseUrl}${fullUrlResponse.replace("?", "&")}`;
+            } else {
+                homepage = `${baseUrl}${fullUrlResponse}`;
+            }
         }
         await navClient.navigateInternal(homepage, navigationOptions);
 

--- a/lib/msal-browser/src/redirect_bridge/index.ts
+++ b/lib/msal-browser/src/redirect_bridge/index.ts
@@ -82,19 +82,6 @@ export async function broadcastResponseToMainFrame(
             // SessionStorage access may fail in some contexts, use default
         }
 
-        // Reconstruct full URL with auth response (preserve original format)
-        let fullUrlResponse = "";
-        if (hasResponseInHash && hasResponseInQuery) {
-            // Hybrid format
-            fullUrlResponse = `${urlQuery}${urlHash}`;
-        } else if (hasResponseInHash) {
-            // Hash only
-            fullUrlResponse = urlHash;
-        } else {
-            // Query only
-            fullUrlResponse = urlQuery;
-        }
-
         /*
          * For apps that use hash-based routing (e.g. "/#/route"), the redirect bridge
          * must carefully reconstruct the URL so that the authentication response does
@@ -102,56 +89,37 @@ export async function broadcastResponseToMainFrame(
          *
          * - When the server returns the response in the fragment (response_mode=fragment),
          *   the existing route fragment is stripped from the origin URL before appending
-         *   the auth response. This avoids malformed URLs with two "#" fragments
-         *   (e.g. "/#/route#code=..." or "/#/route#id_token=...").
+         *   the auth response hash. This avoids malformed URLs with two "#" fragments
+         *   (e.g. "/#/route#code=...").
          *
          * - When the server returns the response in the query string (response_mode=query),
-         *   the query parameters are inserted before the existing fragment so that the
-         *   hash-based route (e.g. "/#/route") is preserved and continues to work. This
-         *   configuration (responseMode: "query") is often recommended for hash-routed SPAs.
+         *   the query parameters are inserted before any existing hash fragment so that
+         *   the hash-based route is preserved (e.g. "/#/route").
          *
-         * The original route fragment (e.g. "/#/route") is restored later by
-         * RedirectClient.handleRedirectPromise when navigateToLoginRequestUrl is enabled,
-         * so the application is returned to the original hash-routed location after the
-         * authentication response is processed.
+         * The original route fragment is restored later by
+         * RedirectClient.handleRedirectPromise when navigateToLoginRequestUrl is enabled.
          */
         const baseUrl = navigateToUrl || BrowserUtils.getHomepage();
-        const baseHashIndex = baseUrl.indexOf("#");
-        let homepage: string;
-        if (baseHashIndex > -1 && hasResponseInHash) {
-            // Hash response: strip origin hash to avoid double # fragments
-            homepage = `${baseUrl.substring(
-                0,
-                baseHashIndex
-            )}${fullUrlResponse}`;
-        } else if (baseHashIndex > -1 && hasResponseInQuery) {
-            // Query response: insert query params before the existing hash fragment
-            const preHash = baseUrl.substring(0, baseHashIndex);
-            const fragment = baseUrl.substring(baseHashIndex);
-            // If the base URL already has query params, join with "&" instead of adding a second "?"
-            if (
-                preHash.indexOf("?") !== -1 &&
-                fullUrlResponse.startsWith("?")
-            ) {
-                homepage = `${preHash}${fullUrlResponse.replace(
-                    "?",
-                    "&"
-                )}${fragment}`;
-            } else {
-                homepage = `${preHash}${fullUrlResponse}${fragment}`;
-            }
-        } else {
-            // No hash fragment: append auth response to the end of the base URL
-            if (
-                baseUrl.indexOf("?") !== -1 &&
-                fullUrlResponse.startsWith("?")
-            ) {
-                // Base URL already has query params; avoid creating a second "?"
-                homepage = `${baseUrl}${fullUrlResponse.replace("?", "&")}`;
-            } else {
-                homepage = `${baseUrl}${fullUrlResponse}`;
-            }
+
+        // Decompose baseUrl into path (everything before #) and fragment (# and after)
+        const baseHashIdx = baseUrl.indexOf("#");
+        const basePath =
+            baseHashIdx > -1 ? baseUrl.substring(0, baseHashIdx) : baseUrl;
+        const baseFragment =
+            baseHashIdx > -1 ? baseUrl.substring(baseHashIdx) : "";
+
+        // Build query portion: if auth response has query params, append to basePath
+        let queryPart = "";
+        if (hasResponseInQuery) {
+            queryPart = basePath.includes("?")
+                ? urlQuery.replace("?", "&")
+                : urlQuery;
         }
+
+        // Build hash portion: auth response hash replaces the original, otherwise preserve it
+        const hashPart = hasResponseInHash ? urlHash : baseFragment;
+
+        const homepage = `${basePath}${queryPart}${hashPart}`;
         await navClient.navigateInternal(homepage, navigationOptions);
 
         // Do NOT clear URL for redirect flow - we're navigating away anyway

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -309,10 +309,9 @@ describe("broadcastResponseToMainFrame", () => {
             );
         });
 
-        it("strips existing hash from cached origin URL when no clientId in interaction status", async () => {
-            // Set interaction status WITHOUT a clientId so the code falls through
-            // to the getHomepage() fallback. But also cache an origin URL with a
-            // hash under a different key path to verify the fallback is exercised.
+        it("falls back to homepage when interaction status JSON is unparseable", async () => {
+            // Invalid JSON triggers the catch block, so navigateToUrl stays empty
+            // and getHomepage() is used as the fallback
             mockSessionStorage[`msal.interaction.status`] = "invalid-json";
 
             window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
@@ -325,6 +324,28 @@ describe("broadcastResponseToMainFrame", () => {
 
             // getHomepage() returns origin + "/" which has no hash,
             // so the result should simply be homepage + auth hash
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+            expect(callArgs).toContain(
+                TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT
+            );
+        });
+
+        it("falls back to homepage when interaction status has no clientId", async () => {
+            // Valid JSON but without clientId means cached origin URL is never looked up
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                type: "redirect",
+            });
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // No clientId means no cached origin URL, falls back to getHomepage()
             const hashCount = (callArgs.match(/#/g) || []).length;
             expect(hashCount).toBe(1);
             expect(callArgs).toContain(

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -278,6 +278,139 @@ describe("broadcastResponseToMainFrame", () => {
                 TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT
             );
         });
+
+        it("strips existing hash from cached origin URL when auth response is in hash", async () => {
+            const testClientId = "test-client-id-hash";
+            // Simulate a hash-routed SPA: the origin URL has a hash fragment
+            const cachedOriginUrl =
+                "https://localhost:3000/#/dashboard";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // Must NOT contain two # fragments (the bug produced /#/dashboard#code=...)
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+
+            // Should navigate to the base URL + auth response hash (without the original hash)
+            expect(callArgs).toBe(
+                `https://localhost:3000/${TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT}`
+            );
+        });
+
+        it("strips existing hash from homepage fallback when auth response is in hash", async () => {
+            // Simulate homepage having a hash (e.g. window.location.href = "https://localhost/#/app")
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+            // getHomepage() returns origin + "/" so this is implicitly tested through the
+            // regular fallback path—but let's also test with a cached URL that has a hash
+            // and no clientId lookup, falling back to getHomepage()
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // Homepage fallback should not produce double hashes
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+            expect(callArgs).toContain(
+                TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT
+            );
+        });
+
+        it("preserves origin URL hash when auth response is only in query string", async () => {
+            const testClientId = "test-client-id-query";
+            const cachedOriginUrl =
+                "https://localhost:3000/#/dashboard";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            // Auth response in query string only (response_mode=query)
+            window.location.search = `?state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}&code=test_code`;
+            window.location.hash = "";
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // When auth response is in query, the origin hash should be preserved
+            expect(callArgs).toContain("/#/dashboard");
+            expect(callArgs).toContain("?state=");
+        });
+
+        it("strips hash from origin URL with complex hash-based route", async () => {
+            const testClientId = "test-client-id-complex";
+            // Complex hash-based route with nested path and query params in hash
+            const cachedOriginUrl =
+                "https://myapp.com/#/settings/profile?tab=security";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // Must have exactly one # (from auth response)
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+
+            // Should be base URL + auth hash
+            expect(callArgs).toBe(
+                `https://myapp.com/${TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT}`
+            );
+        });
+
+        it("does not strip hash when origin URL has no hash", async () => {
+            const testClientId = "test-client-id-nohash";
+            const cachedOriginUrl = "https://localhost:3000/app/page";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            expect(callArgs).toBe(
+                `https://localhost:3000/app/page${TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT}`
+            );
+        });
     });
 
     describe("Hybrid response format (query + hash)", () => {

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -484,6 +484,70 @@ describe("broadcastResponseToMainFrame", () => {
                 TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT
             );
         });
+
+        it("handles hybrid auth response (query + hash both with state) for redirect flow", async () => {
+            const testClientId = "test-client-id-hybrid";
+            const cachedOriginUrl = "https://myapp.com/page#/dashboard";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            // Both query and hash contain state — true hybrid response
+            window.location.search = `?state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}&code=test_code`;
+            window.location.hash = `#state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}&session_state=session123`;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // Query part appended before hash, only one #, only one ?
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+            const questionCount = (callArgs.match(/\?/g) || []).length;
+            expect(questionCount).toBe(1);
+            // Query params come before hash
+            expect(callArgs.indexOf("?state=")).toBeLessThan(
+                callArgs.indexOf("#state=")
+            );
+        });
+
+        it("handles hybrid auth response with existing query params in origin URL (no double ?)", async () => {
+            const testClientId = "test-client-id-hybrid-q";
+            const cachedOriginUrl =
+                "https://myapp.com/page?ref=email#/dashboard";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            // Both query and hash contain state — true hybrid response
+            window.location.search = `?state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}&code=test_code`;
+            window.location.hash = `#state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}&session_state=session123`;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // Must not produce double "?" — existing query merged with "&"
+            const questionCount = (callArgs.match(/\?/g) || []).length;
+            expect(questionCount).toBe(1);
+            expect(callArgs).toContain("?ref=email&state=");
+
+            // Only one # from the auth response hash
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+        });
     });
 
     describe("Hybrid response format (query + hash)", () => {

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -281,7 +281,6 @@ describe("broadcastResponseToMainFrame", () => {
 
         it("strips existing hash from cached origin URL when auth response is in hash", async () => {
             const testClientId = "test-client-id-hash";
-            // Simulate a hash-routed SPA: the origin URL has a hash fragment
             const cachedOriginUrl = "https://localhost:3000/#/dashboard";
 
             mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
@@ -302,90 +301,13 @@ describe("broadcastResponseToMainFrame", () => {
             // Must NOT contain two # fragments (the bug produced /#/dashboard#code=...)
             const hashCount = (callArgs.match(/#/g) || []).length;
             expect(hashCount).toBe(1);
-
-            // Should navigate to the base URL + auth response hash (without the original hash)
             expect(callArgs).toBe(
                 `https://localhost:3000/${TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT}`
             );
         });
 
-        it("falls back to homepage when interaction status JSON is unparseable", async () => {
-            // Invalid JSON triggers the catch block, so navigateToUrl stays empty
-            // and getHomepage() is used as the fallback
-            mockSessionStorage[`msal.interaction.status`] = "invalid-json";
-
-            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
-
-            await broadcastResponseToMainFrame();
-
-            const callArgs = (
-                mockNavigationClient.navigateInternal as jest.Mock
-            ).mock.calls[0][0] as string;
-
-            // getHomepage() returns origin + "/" which has no hash,
-            // so the result should simply be homepage + auth hash
-            const hashCount = (callArgs.match(/#/g) || []).length;
-            expect(hashCount).toBe(1);
-            expect(callArgs).toContain(
-                TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT
-            );
-        });
-
-        it("falls back to homepage when interaction status has no clientId", async () => {
-            // Valid JSON but without clientId means cached origin URL is never looked up
-            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
-                type: "redirect",
-            });
-
-            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
-
-            await broadcastResponseToMainFrame();
-
-            const callArgs = (
-                mockNavigationClient.navigateInternal as jest.Mock
-            ).mock.calls[0][0] as string;
-
-            // No clientId means no cached origin URL, falls back to getHomepage()
-            const hashCount = (callArgs.match(/#/g) || []).length;
-            expect(hashCount).toBe(1);
-            expect(callArgs).toContain(
-                TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT
-            );
-        });
-
-        it("preserves origin URL hash when auth response is only in query string", async () => {
-            const testClientId = "test-client-id-query";
-            const cachedOriginUrl = "https://localhost:3000/#/dashboard";
-
-            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
-                clientId: testClientId,
-                type: "redirect",
-            });
-            mockSessionStorage[`msal.${testClientId}.request.origin`] =
-                cachedOriginUrl;
-
-            // Auth response in query string only (response_mode=query)
-            window.location.search = `?state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}&code=test_code`;
-            window.location.hash = "";
-
-            await broadcastResponseToMainFrame();
-
-            const callArgs = (
-                mockNavigationClient.navigateInternal as jest.Mock
-            ).mock.calls[0][0] as string;
-
-            // When auth response is in query, the origin hash should be preserved
-            // and query params must appear before the hash fragment
-            const stateIndex = callArgs.indexOf("?state=");
-            const hashIndex = callArgs.indexOf("#/dashboard");
-            expect(stateIndex).toBeGreaterThanOrEqual(0);
-            expect(hashIndex).toBeGreaterThanOrEqual(0);
-            expect(stateIndex).toBeLessThan(hashIndex);
-        });
-
         it("strips hash from origin URL with complex hash-based route", async () => {
             const testClientId = "test-client-id-complex";
-            // Complex hash-based route with nested path and query params in hash
             const cachedOriginUrl =
                 "https://myapp.com/#/settings/profile?tab=security";
 
@@ -404,13 +326,38 @@ describe("broadcastResponseToMainFrame", () => {
                 mockNavigationClient.navigateInternal as jest.Mock
             ).mock.calls[0][0] as string;
 
-            // Must have exactly one # (from auth response)
             const hashCount = (callArgs.match(/#/g) || []).length;
             expect(hashCount).toBe(1);
-
-            // Should be base URL + auth hash
             expect(callArgs).toBe(
                 `https://myapp.com/${TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT}`
+            );
+        });
+
+        it("strips hash from origin URL that has both query params and hash", async () => {
+            const testClientId = "test-client-id-qh";
+            const cachedOriginUrl =
+                "https://myapp.com/page?ref=email#/dashboard";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // Hash replaced, existing query preserved, no double #
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+            expect(callArgs).toBe(
+                `https://myapp.com/page?ref=email${TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT}`
             );
         });
 
@@ -435,6 +382,106 @@ describe("broadcastResponseToMainFrame", () => {
 
             expect(callArgs).toBe(
                 `https://localhost:3000/app/page${TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT}`
+            );
+        });
+
+        it("preserves origin URL hash when auth response is only in query string", async () => {
+            const testClientId = "test-client-id-query";
+            const cachedOriginUrl = "https://localhost:3000/#/dashboard";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.search = `?state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}&code=test_code`;
+            window.location.hash = "";
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // Query params must appear before the hash fragment
+            const stateIndex = callArgs.indexOf("?state=");
+            const hashIndex = callArgs.indexOf("#/dashboard");
+            expect(stateIndex).toBeGreaterThanOrEqual(0);
+            expect(hashIndex).toBeGreaterThanOrEqual(0);
+            expect(stateIndex).toBeLessThan(hashIndex);
+        });
+
+        it("merges query response with existing query params in origin URL (no double ?)", async () => {
+            const testClientId = "test-client-id-dblq";
+            const cachedOriginUrl =
+                "https://myapp.com/page?ref=email#/dashboard";
+
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                clientId: testClientId,
+                type: "redirect",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.search = `?state=${TEST_STATE_VALUES.TEST_STATE_REDIRECT}&code=test_code`;
+            window.location.hash = "";
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // Must not have double "?" — second query joined with "&"
+            const questionCount = (callArgs.match(/\?/g) || []).length;
+            expect(questionCount).toBe(1);
+
+            // Original query, auth query, and hash all present in correct order
+            expect(callArgs).toContain("?ref=email&state=");
+            expect(callArgs).toContain("#/dashboard");
+            expect(callArgs.indexOf("?ref=email")).toBeLessThan(
+                callArgs.indexOf("#/dashboard")
+            );
+        });
+
+        it("falls back to homepage when interaction status JSON is unparseable", async () => {
+            mockSessionStorage[`msal.interaction.status`] = "invalid-json";
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            // getHomepage() returns origin + "/" which has no hash
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+            expect(callArgs).toContain(
+                TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT
+            );
+        });
+
+        it("falls back to homepage when interaction status has no clientId", async () => {
+            mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
+                type: "redirect",
+            });
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            const callArgs = (
+                mockNavigationClient.navigateInternal as jest.Mock
+            ).mock.calls[0][0] as string;
+
+            const hashCount = (callArgs.match(/#/g) || []).length;
+            expect(hashCount).toBe(1);
+            expect(callArgs).toContain(
+                TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT
             );
         });
     });

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -351,8 +351,12 @@ describe("broadcastResponseToMainFrame", () => {
             ).mock.calls[0][0] as string;
 
             // When auth response is in query, the origin hash should be preserved
-            expect(callArgs).toContain("/#/dashboard");
-            expect(callArgs).toContain("?state=");
+            const stateIndex = callArgs.indexOf("?state=");
+            const hashIndex = callArgs.indexOf("/#/dashboard");
+            expect(stateIndex).toBeGreaterThanOrEqual(0);
+            expect(hashIndex).toBeGreaterThanOrEqual(0);
+            // Ensure the query parameters appear before the hash-based route
+            expect(stateIndex).toBeLessThan(hashIndex);
         });
 
         it("strips hash from origin URL with complex hash-based route", async () => {

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -282,8 +282,7 @@ describe("broadcastResponseToMainFrame", () => {
         it("strips existing hash from cached origin URL when auth response is in hash", async () => {
             const testClientId = "test-client-id-hash";
             // Simulate a hash-routed SPA: the origin URL has a hash fragment
-            const cachedOriginUrl =
-                "https://localhost:3000/#/dashboard";
+            const cachedOriginUrl = "https://localhost:3000/#/dashboard";
 
             mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
                 clientId: testClientId,
@@ -332,8 +331,7 @@ describe("broadcastResponseToMainFrame", () => {
 
         it("preserves origin URL hash when auth response is only in query string", async () => {
             const testClientId = "test-client-id-query";
-            const cachedOriginUrl =
-                "https://localhost:3000/#/dashboard";
+            const cachedOriginUrl = "https://localhost:3000/#/dashboard";
 
             mockSessionStorage[`msal.interaction.status`] = JSON.stringify({
                 clientId: testClientId,

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -309,19 +309,22 @@ describe("broadcastResponseToMainFrame", () => {
             );
         });
 
-        it("strips existing hash from homepage fallback when auth response is in hash", async () => {
-            // Simulate homepage having a hash (e.g. window.location.href = "https://localhost/#/app")
+        it("strips existing hash from cached origin URL when no clientId in interaction status", async () => {
+            // Set interaction status WITHOUT a clientId so the code falls through
+            // to the getHomepage() fallback. But also cache an origin URL with a
+            // hash under a different key path to verify the fallback is exercised.
+            mockSessionStorage[`msal.interaction.status`] = "invalid-json";
+
             window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
-            // getHomepage() returns origin + "/" so this is implicitly tested through the
-            // regular fallback path—but let's also test with a cached URL that has a hash
-            // and no clientId lookup, falling back to getHomepage()
+
             await broadcastResponseToMainFrame();
 
             const callArgs = (
                 mockNavigationClient.navigateInternal as jest.Mock
             ).mock.calls[0][0] as string;
 
-            // Homepage fallback should not produce double hashes
+            // getHomepage() returns origin + "/" which has no hash,
+            // so the result should simply be homepage + auth hash
             const hashCount = (callArgs.match(/#/g) || []).length;
             expect(hashCount).toBe(1);
             expect(callArgs).toContain(
@@ -351,11 +354,11 @@ describe("broadcastResponseToMainFrame", () => {
             ).mock.calls[0][0] as string;
 
             // When auth response is in query, the origin hash should be preserved
+            // and query params must appear before the hash fragment
             const stateIndex = callArgs.indexOf("?state=");
-            const hashIndex = callArgs.indexOf("/#/dashboard");
+            const hashIndex = callArgs.indexOf("#/dashboard");
             expect(stateIndex).toBeGreaterThanOrEqual(0);
             expect(hashIndex).toBeGreaterThanOrEqual(0);
-            // Ensure the query parameters appear before the hash-based route
             expect(stateIndex).toBeLessThan(hashIndex);
         });
 


### PR DESCRIPTION
This pull request addresses an issue with redirect navigation in hash-routed single-page applications (SPAs) by ensuring that authentication response hashes do not result in malformed URLs containing multiple `#` fragments. The main logic is updated to strip any existing hash from the origin URL before appending the authentication response hash, and comprehensive tests are added to cover various scenarios.

**Redirect URL handling improvements:**

* Updated `broadcastResponseToMainFrame` in `index.ts` to strip any existing hash fragment from the base URL before appending the authentication response hash, preventing URLs with multiple `#` fragments (e.g., `/#/route#code=...`). This ensures correct navigation in hash-routed SPAs and preserves the original hash when the response is only in the query string.

**Test coverage enhancements:**

* Added multiple tests to `broadcastResponseToMainFrame.spec.ts` to verify:
  - Existing hashes are stripped from cached origin URLs and homepage fallback URLs when the auth response is in the hash.
  - The original hash is preserved when the auth response is only in the query string.
  - Complex hash-based routes are handled correctly, ensuring only a single `#` is present.
  - URLs without a hash remain unchanged except for the appended auth response.