### PR TITLE
Fix customizable e2e redirect navigation flake

### DIFF
--- a/samples/e2eTestUtils/src/Constants.ts
+++ b/samples/e2eTestUtils/src/Constants.ts
@@ -99,6 +99,7 @@ export const SubmitButtonSelectors = {
     ACCEPTBUTTON: "#acceptButton, input[name='acceptButton']",
     REMOTE_CONNECT_SUBMIT: "#remoteConnectSubmit, input[name='remoteConnectSubmit']",
     SUBMITBUTTON: "#submitButton, input[name='submitButton']",
+    INPUT_SUBMIT: "input[type='submit']",
     SUBMIT: "button[type='submit']"
 }
 

--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -229,7 +229,7 @@ export async function fillPassword(page: Page, screenshot: Screenshot, password:
     try {
         await page.locator('span ::-p-text(Use your password)').setTimeout(1000).click().catch(() => {});
         await screenshot.takeScreenshot(page, "passwordPage");
-        await page.locator(`${Object.values(PasswordInputSelectors).join(", ")}`).setTimeout(2000).fill(password);
+        await page.locator(`${Object.values(PasswordInputSelectors).join(", ")}`).setTimeout(5000).fill(password);
         await screenshot.takeScreenshot(page, "loginPagePasswordFilled");
     } catch (e) {
         await screenshot.takeScreenshot(page, "failedToFillPassword").catch(() => {});
@@ -240,7 +240,7 @@ export async function fillPassword(page: Page, screenshot: Screenshot, password:
 export async function fillUsername(page: Page, screenshot: Screenshot, username: string): Promise<void> {
     try {
         await screenshot.takeScreenshot(page, "loginPage");
-        await page.locator(`${Object.values(UsernameSelectors).join(", ")}`).setTimeout(2000).fill(username);
+        await page.locator(`${Object.values(UsernameSelectors).join(", ")}`).setTimeout(5000).fill(username);
         await screenshot.takeScreenshot(page, "loginPageUsernameFilled");
     } catch (e) {
         await screenshot.takeScreenshot(page, "failedToFillUsername").catch(() => {});
@@ -250,8 +250,10 @@ export async function fillUsername(page: Page, screenshot: Screenshot, username:
 
 export async function clickSubmitButton(page: Page, screenshot: Screenshot): Promise<void> {
     try {
-        await page.locator(`${Object.values(SubmitButtonSelectors).join(", ")}`).setTimeout(2000).click();
-        await page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG).catch(() => {});
+        await Promise.all([
+            page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG).catch(() => {}),
+            page.locator(`${Object.values(SubmitButtonSelectors).join(", ")}`).setTimeout(5000).click(),
+        ]);
     } catch (e) {
         await screenshot.takeScreenshot(page, "errorClickingSubmit").catch(() => {});
         throw e;
@@ -428,13 +430,17 @@ export async function clickLoginRedirect(
     screenshot: Screenshot,
     page: Page
 ): Promise<void> {
+    await page.waitForSelector("#SignIn", { timeout: 5000 });
     // Home Page
     await screenshot.takeScreenshot(page, "samplePageInit");
     // Click Sign In
     await page.click("#SignIn");
     await screenshot.takeScreenshot(page, "signInClicked");
     // Click Sign In With Redirect
-    await page.click("#redirect");
+    await Promise.all([
+        page.waitForNavigation(WAIT_FOR_NAVIGATION_CONFIG).catch(() => {}),
+        page.click("#redirect"),
+    ]);
 }
 
 export async function clickLogoutRedirect(

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
@@ -157,7 +157,8 @@ describe("AAD-Prod Tests", () => {
                     request: relativeRedirectUriRequest,
                 })
             );
-            page.reload();
+            await page.reload();
+            await pcaInitializedPoller(page, 5000);
 
             const testName = "redirectBaseCase";
             const screenshot = new Screenshot(
@@ -185,7 +186,8 @@ describe("AAD-Prod Tests", () => {
                     request: relativeRedirectUriRequest,
                 })
             );
-            page.reload();
+            await page.reload();
+            await pcaInitializedPoller(page, 5000);
 
             const testName = "redirectBaseCase";
             const screenshot = new Screenshot(

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
@@ -157,7 +157,8 @@ describe("AAD-Prod Tests", () => {
                     request: relativeRedirectUriRequest,
                 })
             );
-            page.reload();
+            await page.reload();
+            await pcaInitializedPoller(page, 5000);
 
             const testName = "redirectBaseCase";
             const screenshot = new Screenshot(
@@ -185,7 +186,8 @@ describe("AAD-Prod Tests", () => {
                     request: relativeRedirectUriRequest,
                 })
             );
-            page.reload();
+            await page.reload();
+            await pcaInitializedPoller(page, 5000);
 
             const testName = "redirectBaseCase";
             const screenshot = new Screenshot(


### PR DESCRIPTION
This pull request improves the reliability and robustness of end-to-end (E2E) tests by increasing timeouts, synchronizing navigation and click events, and ensuring the test environment is ready before proceeding. These changes help reduce test flakiness and improve consistency across different authentication flows.

**E2E test reliability improvements:**

* Increased the timeout for filling username and password fields from 2 seconds to 5 seconds in `fillUsername` and `fillPassword` to accommodate slower page loads. [[1]](diffhunk://#diff-14221c471a9eab1f39219d5771fbe75af04b79e9321248cf759bcf67fff611a5L232-R232) [[2]](diffhunk://#diff-14221c471a9eab1f39219d5771fbe75af04b79e9321248cf759bcf67fff611a5L243-R243)
* Updated `clickSubmitButton` to wait for navigation and the button click simultaneously, and increased the timeout for the submit button locator to 5 seconds.
* Added a new selector `INPUT_SUBMIT` to `SubmitButtonSelectors` to improve the robustness of submit button detection.

**Authentication flow synchronization:**

* In `clickLoginRedirect`, added a wait for the `#SignIn` selector before proceeding and changed the redirect button click to wait for navigation in parallel, reducing the chance of race conditions.

**Test initialization improvements:**

* After reloading the page in both `browserAAD.spec.ts` and `browserAADTenanted.spec.ts`, added a call to `pcaInitializedPoller` to ensure the authentication client is initialized before continuing the test. [[1]](diffhunk://#diff-b8f31f42cc08acb87454a148bb7f6af0eb3ce57140ddbe1ae3858f8f1a2aa86fL160-R161) [[2]](diffhunk://#diff-b8f31f42cc08acb87454a148bb7f6af0eb3ce57140ddbe1ae3858f8f1a2aa86fL188-R190) [[3]](diffhunk://#diff-773d2cd1522eaf73569f2cfcc5903c5f729679f1ea158ce1bf8c2115751cee71L160-R161) [[4]](diffhunk://#diff-773d2cd1522eaf73569f2cfcc5903c5f729679f1ea158ce1bf8c2115751cee71L188-R190)