### PR TITLE
fix(msal-common): Fix tenant profile loss in cross-tenant scenarios

### DIFF
--- a/change/@azure-msal-browser-d7ed497b-3f33-42fd-b46f-ee236365da34.json
+++ b/change/@azure-msal-browser-d7ed497b-3f33-42fd-b46f-ee236365da34.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Thread performanceClient through buildAccountToCache callers for telemetry [#8471](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8471)",
+    "packageName": "@azure/msal-browser",
+    "email": "ruijungao@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-fd3934ae-e4c3-4b1f-b373-8fc245187599.json
+++ b/change/@azure-msal-common-fd3934ae-e4c3-4b1f-b373-8fc245187599.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Fix tenant profile loss in cross-tenant B2B scenarios by replacing broken startsWith cache key lookup with entity-level matching via getAccountsFilteredBy [#8471](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8471)",
+    "packageName": "@azure/msal-common",
+    "email": "ruijungao@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -5,44 +5,44 @@
 
 import {
     AccessTokenEntity,
-    ICrypto,
-    IdTokenEntity,
-    Logger,
-    ScopeSet,
+    AccountEntity,
+    AccountEntityUtils,
     Authority,
     AuthorityFactory,
     AuthorityOptions,
-    ExternalTokenResponse,
-    AccountEntity,
     AuthToken,
-    RefreshTokenEntity,
-    CacheRecord,
-    TokenClaims,
-    CacheHelpers,
     buildAccountToCache,
-    TimeUtils,
-    AccountEntityUtils,
     buildStaticAuthorityOptions,
+    CacheHelpers,
+    CacheRecord,
+    ExternalTokenResponse,
+    ICrypto,
+    IdTokenEntity,
     invokeAsync,
     IPerformanceClient,
+    Logger,
+    RefreshTokenEntity,
+    ScopeSet,
     StubPerformanceClient,
+    TimeUtils,
+    TokenClaims,
 } from "@azure/msal-common/browser";
 import { buildConfiguration, Configuration } from "../config/Configuration.js";
-import type { SilentRequest } from "../request/SilentRequest.js";
-import { BrowserCacheManager } from "./BrowserCacheManager.js";
-import {
-    createBrowserAuthError,
-    BrowserAuthErrorCodes,
-} from "../error/BrowserAuthError.js";
-import type { AuthenticationResult } from "../response/AuthenticationResult.js";
-import { base64Decode } from "../encode/Base64Decode.js";
 import * as BrowserCrypto from "../crypto/BrowserCrypto.js";
 import { CryptoOps } from "../crypto/CryptoOps.js";
+import { base64Decode } from "../encode/Base64Decode.js";
+import {
+    BrowserAuthErrorCodes,
+    createBrowserAuthError,
+} from "../error/BrowserAuthError.js";
 import { EventHandler } from "../event/EventHandler.js";
-import * as BrowserUtils from "../utils/BrowserUtils.js";
-import * as BrowserRootPerformanceEvents from "../telemetry/BrowserRootPerformanceEvents.js";
+import type { SilentRequest } from "../request/SilentRequest.js";
+import type { AuthenticationResult } from "../response/AuthenticationResult.js";
 import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
+import * as BrowserRootPerformanceEvents from "../telemetry/BrowserRootPerformanceEvents.js";
 import { ApiId } from "../utils/BrowserConstants.js";
+import * as BrowserUtils from "../utils/BrowserUtils.js";
+import { BrowserCacheManager } from "./BrowserCacheManager.js";
 
 export type LoadTokenOptions = {
     clientInfo?: string;
@@ -132,7 +132,8 @@ export async function loadExternalTokens(
             logger,
             cryptoOps,
             authority,
-            idTokenClaims
+            idTokenClaims,
+            performanceClient
         );
 
         const idToken = await invokeAsync(
@@ -231,7 +232,8 @@ async function loadAccount(
     logger: Logger,
     cryptoObj: ICrypto,
     authority: Authority,
-    idTokenClaims?: TokenClaims
+    idTokenClaims?: TokenClaims,
+    performanceClient?: IPerformanceClient
 ): Promise<AccountEntity> {
     logger.verbose("TokenCache - loading account", correlationId);
 
@@ -278,7 +280,8 @@ async function loadAccount(
         claimsTenantId,
         undefined, // authCodePayload
         undefined, // nativeAccountId
-        logger
+        logger,
+        performanceClient
     );
 
     await storage.setAccount(

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -4,80 +4,80 @@
  */
 
 import {
-    Logger,
-    ICrypto,
-    AuthToken,
+    AADServerParamKeys,
+    AccessTokenEntity,
     AccountEntity,
+    AccountEntityUtils,
+    AccountInfo,
+    AuthError,
+    AuthToken,
     AuthorityType,
-    ScopeSet,
-    TimeUtils,
-    UrlString,
-    PopTokenGenerator,
-    SignedHttpRequestParameters,
+    CacheHelpers,
+    ClientAuthErrorCodes,
+    CommonSilentFlowRequest,
+    Constants,
+    ICrypto,
     IPerformanceClient,
     IdTokenEntity,
-    AccessTokenEntity,
-    AuthError,
-    CommonSilentFlowRequest,
-    AccountInfo,
-    AADServerParamKeys,
+    InProgressPerformanceEvent,
+    Logger,
+    PerformanceEvents,
+    PopTokenGenerator,
+    ScopeSet,
+    ServerTelemetryManager,
+    SignedHttpRequestParameters,
+    TimeUtils,
     TokenClaims,
+    UrlString,
+    buildAccountToCache,
     createClientAuthError,
-    ClientAuthErrorCodes,
     invokeAsync,
     updateAccountTenantProfileData,
-    CacheHelpers,
-    buildAccountToCache,
-    InProgressPerformanceEvent,
-    ServerTelemetryManager,
-    AccountEntityUtils,
-    Constants,
-    PerformanceEvents,
 } from "@azure/msal-common/browser";
-import {
-    BaseInteractionClient,
-    getDiscoveredAuthority,
-    getRedirectUri,
-    initializeServerTelemetryManager,
-} from "./BaseInteractionClient.js";
-import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
-import { BrowserConfiguration } from "../config/Configuration.js";
-import { BrowserCacheManager } from "../cache/BrowserCacheManager.js";
-import { EventHandler } from "../event/EventHandler.js";
-import { PopupRequest } from "../request/PopupRequest.js";
-import { SilentRequest } from "../request/SilentRequest.js";
-import { SsoSilentRequest } from "../request/SsoSilentRequest.js";
-import {
-    ApiId,
-    TemporaryCacheKeys,
-    PlatformAuthConstants,
-    BrowserConstants,
-    CacheLookupPolicy,
-} from "../utils/BrowserConstants.js";
+import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 import { PlatformAuthRequest } from "../broker/nativeBroker/PlatformAuthRequest.js";
 import {
     MATS,
     PlatformAuthResponse,
 } from "../broker/nativeBroker/PlatformAuthResponse.js";
+import { BrowserCacheManager } from "../cache/BrowserCacheManager.js";
+import { BrowserConfiguration } from "../config/Configuration.js";
+import { base64Decode } from "../encode/Base64Decode.js";
+import {
+    BrowserAuthErrorCodes,
+    createBrowserAuthError,
+} from "../error/BrowserAuthError.js";
 import {
     NativeAuthError,
     NativeAuthErrorCodes,
     createNativeAuthError,
     isFatalNativeAuthError,
 } from "../error/NativeAuthError.js";
-import { RedirectRequest } from "../request/RedirectRequest.js";
-import { NavigationOptions } from "../navigation/NavigationOptions.js";
+import { EventHandler } from "../event/EventHandler.js";
 import { INavigationClient } from "../navigation/INavigationClient.js";
-import {
-    createBrowserAuthError,
-    BrowserAuthErrorCodes,
-} from "../error/BrowserAuthError.js";
-import { SilentCacheClient } from "./SilentCacheClient.js";
-import { AuthenticationResult } from "../response/AuthenticationResult.js";
-import { base64Decode } from "../encode/Base64Decode.js";
+import { NavigationOptions } from "../navigation/NavigationOptions.js";
 import { version } from "../packageMetadata.js";
-import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 import { HandleRedirectPromiseOptions } from "../request/HandleRedirectPromiseOptions.js";
+import { PopupRequest } from "../request/PopupRequest.js";
+import { RedirectRequest } from "../request/RedirectRequest.js";
+import { SilentRequest } from "../request/SilentRequest.js";
+import { SsoSilentRequest } from "../request/SsoSilentRequest.js";
+import { AuthenticationResult } from "../response/AuthenticationResult.js";
+import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
+import {
+    ApiId,
+    BrowserConstants,
+    CacheLookupPolicy,
+    PlatformAuthConstants,
+    TemporaryCacheKeys,
+} from "../utils/BrowserConstants.js";
+import {
+    BaseInteractionClient,
+    getDiscoveredAuthority,
+    getRedirectUri,
+    initializeServerTelemetryManager,
+} from "./BaseInteractionClient.js";
+import { SilentCacheClient } from "./SilentCacheClient.js";
 
 export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected apiId: ApiId;
@@ -545,7 +545,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             undefined, // environment
             idTokenClaims.tid,
             undefined, // auth code payload
-            response.account.id
+            response.account.id,
+            this.logger,
+            this.performanceClient
         );
 
         // Ensure expires_in is in number format

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1009,7 +1009,7 @@ const BROKER_REDIRECT_URI = "brk_redirect_uri";
 // Warning: (ae-missing-release-tag) "buildAccountToCache" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function buildAccountToCache(cacheStorage: CacheManager, authority: Authority, homeAccountId: string, base64Decode: (input: string) => string, correlationId: string, idTokenClaims?: TokenClaims, clientInfo?: string, environment?: string, claimsTenantId?: string | null, authCodePayload?: AuthorizationCodePayload, nativeAccountId?: string, logger?: Logger): AccountEntity;
+export function buildAccountToCache(cacheStorage: CacheManager, authority: Authority, homeAccountId: string, base64Decode: (input: string) => string, correlationId: string, idTokenClaims?: TokenClaims, clientInfo?: string, environment?: string, claimsTenantId?: string | null, authCodePayload?: AuthorizationCodePayload, nativeAccountId?: string, logger?: Logger, performanceClient?: IPerformanceClient): AccountEntity;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-incompatible-release-tags) The symbol "buildClientConfiguration" is marked as @public, but its signature references "ClientConfiguration" which is marked as @internal
@@ -3504,6 +3504,7 @@ export type PerformanceEvent = {
     cacheRetentionDays?: number;
     accountCachedBy?: string;
     acntLoggedOut?: boolean;
+    cacheMatchedAccounts?: number;
     cacheRtCount?: number;
     cacheIdCount?: number;
     cacheAtCount?: number;
@@ -4961,11 +4962,11 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/telemetry/performance/PerformanceEvent.ts:259:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:259:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:259:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:335:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:335:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:335:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:406:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:406:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:406:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:338:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:338:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:338:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:409:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:409:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:409:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -652,8 +652,20 @@ export function buildAccountToCache(
         { homeAccountId },
         correlationId
     );
-    const cachedAccount: AccountEntity | null =
-        matchingAccounts.length > 0 ? matchingAccounts[0] : null;
+
+    if (matchingAccounts.length > 1) {
+        /*
+         * Base accounts are expected to be unique for a given homeAccountId in normal cache usage.
+         * If multiple matches exist, ignore the cache hit rather than arbitrarily choosing one.
+         */
+        logger?.warning(
+            "Multiple base accounts matched homeAccountId. Ignoring cached account and creating a new base account.",
+            correlationId
+        );
+    }
+
+    const cachedAccount =
+        matchingAccounts.length === 1 ? matchingAccounts[0] : null;
 
     const baseAccount =
         cachedAccount ||

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -398,7 +398,8 @@ export class ResponseHandler {
                 claimsTenantId,
                 authCodePayload,
                 undefined, // nativeAccountId
-                this.logger
+                this.logger,
+                this.performanceClient
             );
         }
 
@@ -643,17 +644,22 @@ export function buildAccountToCache(
     claimsTenantId?: string | null,
     authCodePayload?: AuthorizationCodePayload,
     nativeAccountId?: string,
-    logger?: Logger
+    logger?: Logger,
+    performanceClient?: IPerformanceClient
 ): AccountEntity {
     logger?.verbose("setCachedAccount called", correlationId);
 
     // Check if base account is already cached
-    const matchingAccounts = cacheStorage.getAccountsFilteredBy(
+    const matchedAccounts = cacheStorage.getAccountsFilteredBy(
         { homeAccountId },
         correlationId
     );
+    performanceClient?.addFields(
+        { cacheMatchedAccounts: matchedAccounts.length },
+        correlationId
+    );
 
-    if (matchingAccounts.length > 1) {
+    if (matchedAccounts.length > 1) {
         /*
          * Base accounts are expected to be unique for a given homeAccountId in normal cache usage.
          * If multiple matches exist, ignore the cache hit rather than arbitrarily choosing one.

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -3,36 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { ServerAuthorizationTokenResponse } from "./ServerAuthorizationTokenResponse.js";
-import { ICrypto } from "../crypto/ICrypto.js";
 import {
-    ClientAuthErrorCodes,
-    createClientAuthError,
-} from "../error/ClientAuthError.js";
-import { Logger } from "../logger/Logger.js";
-import { ServerError } from "../error/ServerError.js";
-import { ScopeSet } from "../request/ScopeSet.js";
-import { AuthenticationResult } from "./AuthenticationResult.js";
-import { AccountEntity } from "../cache/entities/AccountEntity.js";
-import { Authority } from "../authority/Authority.js";
-import { IdTokenEntity } from "../cache/entities/IdTokenEntity.js";
-import { AccessTokenEntity } from "../cache/entities/AccessTokenEntity.js";
-import { RefreshTokenEntity } from "../cache/entities/RefreshTokenEntity.js";
-import {
-    InteractionRequiredAuthError,
-    isInteractionRequiredError,
-} from "../error/InteractionRequiredAuthError.js";
-import { CacheRecord } from "../cache/entities/CacheRecord.js";
-import { CacheManager } from "../cache/CacheManager.js";
-import * as ProtocolUtils from "../utils/ProtocolUtils.js";
-import * as Constants from "../utils/Constants.js";
-import { PopTokenGenerator } from "../crypto/PopTokenGenerator.js";
-import { AppMetadataEntity } from "../cache/entities/AppMetadataEntity.js";
-import { ICachePlugin } from "../cache/interface/ICachePlugin.js";
-import { TokenCacheContext } from "../cache/persistence/TokenCacheContext.js";
-import { ISerializableTokenCache } from "../cache/interface/ISerializableTokenCache.js";
-import { AuthorizationCodePayload } from "./AuthorizationCodePayload.js";
-import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
+    AccountInfo,
+    buildTenantProfile,
+    updateAccountTenantProfileData,
+} from "../account/AccountInfo.js";
 import {
     checkMaxAge,
     extractTokenClaims,
@@ -42,16 +17,41 @@ import {
     TokenClaims,
     getTenantIdFromIdTokenClaims,
 } from "../account/TokenClaims.js";
-import {
-    AccountInfo,
-    buildTenantProfile,
-    updateAccountTenantProfileData,
-} from "../account/AccountInfo.js";
-import * as CacheHelpers from "../cache/utils/CacheHelpers.js";
-import * as TimeUtils from "../utils/TimeUtils.js";
+import { Authority } from "../authority/Authority.js";
+import { CacheManager } from "../cache/CacheManager.js";
+import { AccessTokenEntity } from "../cache/entities/AccessTokenEntity.js";
+import { AccountEntity } from "../cache/entities/AccountEntity.js";
+import { AppMetadataEntity } from "../cache/entities/AppMetadataEntity.js";
+import { CacheRecord } from "../cache/entities/CacheRecord.js";
+import { IdTokenEntity } from "../cache/entities/IdTokenEntity.js";
+import { RefreshTokenEntity } from "../cache/entities/RefreshTokenEntity.js";
+import { ICachePlugin } from "../cache/interface/ICachePlugin.js";
+import { ISerializableTokenCache } from "../cache/interface/ISerializableTokenCache.js";
+import { TokenCacheContext } from "../cache/persistence/TokenCacheContext.js";
 import * as AccountEntityUtils from "../cache/utils/AccountEntityUtils.js";
+import * as CacheHelpers from "../cache/utils/CacheHelpers.js";
+import { ICrypto } from "../crypto/ICrypto.js";
+import { PopTokenGenerator } from "../crypto/PopTokenGenerator.js";
+import {
+    ClientAuthErrorCodes,
+    createClientAuthError,
+} from "../error/ClientAuthError.js";
+import {
+    InteractionRequiredAuthError,
+    isInteractionRequiredError,
+} from "../error/InteractionRequiredAuthError.js";
+import { ServerError } from "../error/ServerError.js";
+import { Logger } from "../logger/Logger.js";
+import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
+import { ScopeSet } from "../request/ScopeSet.js";
 import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
+import * as Constants from "../utils/Constants.js";
+import * as ProtocolUtils from "../utils/ProtocolUtils.js";
 import { RequestStateObject } from "../utils/StateTypes.js";
+import * as TimeUtils from "../utils/TimeUtils.js";
+import { AuthenticationResult } from "./AuthenticationResult.js";
+import { AuthorizationCodePayload } from "./AuthorizationCodePayload.js";
+import { ServerAuthorizationTokenResponse } from "./ServerAuthorizationTokenResponse.js";
 
 /**
  * Class that handles response parsing.
@@ -648,15 +648,12 @@ export function buildAccountToCache(
     logger?.verbose("setCachedAccount called", correlationId);
 
     // Check if base account is already cached
-    const accountKeys = cacheStorage.getAccountKeys();
-    const baseAccountKey = accountKeys.find((accountKey: string) => {
-        return accountKey.startsWith(homeAccountId);
-    });
-
-    let cachedAccount: AccountEntity | null = null;
-    if (baseAccountKey) {
-        cachedAccount = cacheStorage.getAccount(baseAccountKey, correlationId);
-    }
+    const matchingAccounts = cacheStorage.getAccountsFilteredBy(
+        { homeAccountId },
+        correlationId
+    );
+    const cachedAccount: AccountEntity | null =
+        matchingAccounts.length > 0 ? matchingAccounts[0] : null;
 
     const baseAccount =
         cachedAccount ||

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -312,6 +312,9 @@ export type PerformanceEvent = {
     accountCachedBy?: string;
     acntLoggedOut?: boolean;
 
+    // Number of cached accounts matched by homeAccountId in buildAccountToCache
+    cacheMatchedAccounts?: number;
+
     // Number of tokens in the cache to be reported when cache quota is exceeded
     cacheRtCount?: number;
     cacheIdCount?: number;
@@ -520,6 +523,7 @@ export const IntFields: ReadonlySet<string> = new Set([
     "currRefreshCount",
     "expiredCacheRemovedCount",
     "upgradedCacheCount",
+    "cacheMatchedAccounts",
     "networkRtt",
     "redirectBridgeTimeoutMs",
     "redirectBridgeMessageVersion",

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -1,5 +1,41 @@
+import { TestTimeUtils } from "msal-test-utils";
+import { AccountInfo } from "../../src/account/AccountInfo.js";
+import * as AuthToken from "../../src/account/AuthToken.js";
+import { TokenClaims } from "../../src/account/TokenClaims.js";
+import { Authority } from "../../src/authority/Authority.js";
+import { AuthorityOptions } from "../../src/authority/AuthorityOptions.js";
+import { ProtocolMode } from "../../src/authority/ProtocolMode.js";
+import { CacheManager } from "../../src/cache/CacheManager.js";
+import * as AccountEntityUtils from "../../src/cache/utils/AccountEntityUtils.js";
+import { ICrypto } from "../../src/crypto/ICrypto.js";
+import {
+    AuthError,
+    getDefaultErrorMessage,
+} from "../../src/error/AuthError.js";
+import { CacheError, CacheErrorCodes } from "../../src/error/CacheError.js";
+import { cacheQuotaExceeded } from "../../src/error/CacheErrorCodes.js";
+import {
+    ClientAuthError,
+    ClientAuthErrorCodes,
+} from "../../src/error/ClientAuthError.js";
+import { InteractionRequiredAuthError } from "../../src/error/InteractionRequiredAuthError.js";
+import { ServerError } from "../../src/error/ServerError.js";
+import { Logger, LogLevel } from "../../src/logger/Logger.js";
+import {
+    INetworkModule,
+    NetworkRequestOptions,
+} from "../../src/network/INetworkModule.js";
+import { BaseAuthRequest } from "../../src/request/BaseAuthRequest.js";
+import { AuthenticationResult } from "../../src/response/AuthenticationResult.js";
+import {
+    buildAccountToCache,
+    ResponseHandler,
+} from "../../src/response/ResponseHandler.js";
 import { ServerAuthorizationTokenResponse } from "../../src/response/ServerAuthorizationTokenResponse.js";
-import { ResponseHandler } from "../../src/response/ResponseHandler.js";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
+import { AuthenticationScheme } from "../../src/utils/Constants.js";
+import * as TimeUtils from "../../src/utils/TimeUtils.js";
+import { mockCrypto, MockStorageClass } from "../client/ClientTestUtils.js";
 import {
     AUTHENTICATION_RESULT,
     ID_TOKEN_CLAIMS,
@@ -11,39 +47,6 @@ import {
     TEST_TOKENS,
     TEST_URIS,
 } from "../test_kit/StringConstants.js";
-import { Authority } from "../../src/authority/Authority.js";
-import {
-    INetworkModule,
-    NetworkRequestOptions,
-} from "../../src/network/INetworkModule.js";
-import { ICrypto } from "../../src/crypto/ICrypto.js";
-import { mockCrypto, MockStorageClass } from "../client/ClientTestUtils.js";
-import { TokenClaims } from "../../src/account/TokenClaims.js";
-import { AccountInfo } from "../../src/account/AccountInfo.js";
-import { AuthenticationResult } from "../../src/response/AuthenticationResult.js";
-import { AuthenticationScheme } from "../../src/utils/Constants.js";
-import { AuthorityOptions } from "../../src/authority/AuthorityOptions.js";
-import { ProtocolMode } from "../../src/authority/ProtocolMode.js";
-import { Logger, LogLevel } from "../../src/logger/Logger.js";
-import * as AuthToken from "../../src/account/AuthToken.js";
-import { BaseAuthRequest } from "../../src/request/BaseAuthRequest.js";
-import * as TimeUtils from "../../src/utils/TimeUtils.js";
-import {
-    AuthError,
-    getDefaultErrorMessage,
-} from "../../src/error/AuthError.js";
-import {
-    ClientAuthError,
-    ClientAuthErrorCodes,
-} from "../../src/error/ClientAuthError.js";
-import { InteractionRequiredAuthError } from "../../src/error/InteractionRequiredAuthError.js";
-import { ServerError } from "../../src/error/ServerError.js";
-import { CacheError, CacheErrorCodes } from "../../src/error/CacheError.js";
-import { CacheManager } from "../../src/cache/CacheManager.js";
-import { cacheQuotaExceeded } from "../../src/error/CacheErrorCodes.js";
-import { TestTimeUtils } from "msal-test-utils";
-import * as AccountEntityUtils from "../../src/cache/utils/AccountEntityUtils.js";
-import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 
 const networkInterface: INetworkModule = {
     sendGetRequestAsync<T>(url: string, options?: NetworkRequestOptions): T {
@@ -1211,6 +1214,106 @@ describe("ResponseHandler.ts", () => {
                     getDefaultErrorMessage(CacheErrorCodes.cacheErrorUnknown)
                 );
             }
+        });
+    });
+
+    describe("buildAccountToCache", () => {
+        it("reuses cached account when cache keys have a prefix not starting with homeAccountId", () => {
+            const homeAccountId =
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID;
+            const homeTenantId = homeAccountId.split(".")[1];
+            const environment = "login.windows.net";
+
+            // Create an AccountEntity already in cache with a home tenant profile
+            const existingAccount = AccountEntityUtils.createAccountEntity(
+                {
+                    homeAccountId,
+                    idTokenClaims: {
+                        ...testIdTokenClaims,
+                        tid: homeTenantId,
+                    },
+                    environment,
+                },
+                testAuthority,
+                mockCrypto.base64Decode
+            );
+            existingAccount.tenantProfiles = [
+                {
+                    tenantId: homeTenantId,
+                    localAccountId: existingAccount.localAccountId,
+                    isHomeTenant: true,
+                    username: testIdTokenClaims.preferred_username || "",
+                },
+            ];
+
+            // Simulate a cache key with a prefix (like msal-browser's "msal.2|" prefix)
+            const prefixedKey = `msal.2|${homeAccountId}|${environment}|${homeTenantId}`;
+
+            // Override getAccountKeys and getAccount to use prefixed keys
+            jest.spyOn(testCacheManager, "getAccountKeys").mockReturnValue([
+                prefixedKey,
+            ]);
+            jest.spyOn(testCacheManager, "getAccount").mockImplementation(
+                (key: string) => {
+                    if (key === prefixedKey) {
+                        return existingAccount;
+                    }
+                    return null;
+                }
+            );
+
+            const guestTenantId = "guest-tenant-id";
+            const result = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                homeAccountId,
+                mockCrypto.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                {
+                    ...testIdTokenClaims,
+                    tid: guestTenantId,
+                },
+                undefined, // clientInfo
+                environment,
+                guestTenantId
+            );
+
+            // Should preserve the existing home tenant profile and add guest
+            expect(result.tenantProfiles).toHaveLength(2);
+            expect(
+                result.tenantProfiles?.find(
+                    (tp) => tp.tenantId === homeTenantId
+                )
+            ).toBeDefined();
+            expect(
+                result.tenantProfiles?.find(
+                    (tp) => tp.tenantId === guestTenantId
+                )
+            ).toBeDefined();
+        });
+
+        it("creates new account when no cached account matches homeAccountId", () => {
+            jest.spyOn(testCacheManager, "getAccountKeys").mockReturnValue([]);
+
+            const homeAccountId =
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID;
+            const tenantId = testIdTokenClaims.tid || "";
+
+            const result = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                homeAccountId,
+                mockCrypto.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                testIdTokenClaims,
+                undefined,
+                "login.windows.net",
+                tenantId
+            );
+
+            expect(result.homeAccountId).toEqual(homeAccountId);
+            expect(result.tenantProfiles).toHaveLength(1);
+            expect(result.tenantProfiles?.[0].tenantId).toEqual(tenantId);
         });
     });
 });


### PR DESCRIPTION
## Bug

Related PR: #6536 (multi-tenant account / cross-tenant token caching).

`buildAccountToCache` in `ResponseHandler.ts` uses `accountKey.startsWith(homeAccountId)` to look up an existing cached `AccountEntity`. However, `BrowserCacheManager` generates cache keys with a `msal.2|` prefix:

```
msal.2|{homeAccountId}|{environment}|{tenantId}
```

Since the key starts with `msal.2|`, not `homeAccountId`, `startsWith` **always returns false**. Every token operation creates a brand-new `AccountEntity`, overwriting the previous `tenantProfiles` array.

**Impact:** After `loginPopup(home)` + `acquireTokenSilent(guest)`, `getAllAccounts()[0].tenantProfiles` contains only the guest profile — the home profile is lost. 100% reproducible, no concurrency needed.

**Minimum Repro** is attached:

```js
import {
    CacheLookupPolicy,
    PublicClientApplication,
} from "@azure/msal-browser";
import { broadcastResponseToMainFrame } from "@azure/msal-browser/redirect-bridge";

// Popup callback handler (MSAL v5)
if (
    new URLSearchParams(location.hash.slice(1)).has("code") ||
    new URLSearchParams(location.search).has("code")
) {
    await broadcastResponseToMainFrame();
}

// Config
const CLIENT_ID = "bafa2dd2-166c-46ff-be35-9b50b0e9dbd3";
const HOME_TENANT = "kingdomwei.onmicrosoft.com";
const GUEST_TENANT = "kingdomshu.onmicrosoft.com";
const SCOPES = ["User.Read"];

const app = new PublicClientApplication({
    auth: {
        clientId: CLIENT_ID,
        authority: `https://login.microsoftonline.com/${HOME_TENANT}`,
        redirectUri: location.href.split("?")[0],
    },
    cache: { cacheLocation: "localStorage" },
});
await app.initialize();

// Step 1: Login home tenant
const { account } = await app.loginPopup({ scopes: SCOPES });
console.log("Login OK:", account.username, "tenant:", account.tenantId);
console.log(
    "tenantProfiles after login:",
    app.getAllAccounts()[0]?.tenantProfiles
);

// Step 2: Acquire guest tenant token
try {
    await app.acquireTokenSilent({
        account,
        scopes: SCOPES,
        authority: `https://login.microsoftonline.com/${GUEST_TENANT}`,
        cacheLookupPolicy: CacheLookupPolicy.RefreshToken,
    });
} catch {
    await app.acquireTokenPopup({
        account,
        scopes: SCOPES,
        authority: `https://login.microsoftonline.com/${GUEST_TENANT}`,
    });
}
console.log("Guest token acquired.");

// Step 3: Check — expect 2 profiles (home + guest), but home is lost
const profiles = app.getAllAccounts()[0]?.tenantProfiles;
console.log("tenantProfiles after guest token:", profiles);
console.log(
    "Expected: 2 profiles (home + guest). Actual:",
    profiles?.size,
    "— home profile",
    [...(profiles?.values() ?? [])].some((p) => p.isHomeTenant)
        ? "present"
        : "MISSING"
);
```

**Behavior Before Patching**:

<img width="712" height="238" alt="image" src="https://github.com/user-attachments/assets/7b9a4d25-d4fc-46f0-bbfd-7e5823d9e774" />

## Fix

Replace the key-based `startsWith` lookup with `getAccountsFilteredBy({ homeAccountId })`, which matches on the entity's `homeAccountId` property directly — independent of cache key format.

```diff
- const accountKeys = cacheStorage.getAccountKeys();
- const baseAccountKey = accountKeys.find((accountKey: string) => {
-     return accountKey.startsWith(homeAccountId);
- });
- let cachedAccount: AccountEntity | null = null;
- if (baseAccountKey) {
-     cachedAccount = cacheStorage.getAccount(baseAccountKey, correlationId);
- }
+ const matchingAccounts = cacheStorage.getAccountsFilteredBy(
+     { homeAccountId },
+     correlationId
+ );
+ const cachedAccount: AccountEntity | null =
+     matchingAccounts.length > 0 ? matchingAccounts[0] : null;
```

**Behavior After Patching**:

<img width="713" height="277" alt="image" src="https://github.com/user-attachments/assets/4057272b-e79f-4e51-8289-b301d58efd8d" />

## Tests

Added 2 tests to `ResponseHandler.spec.ts`:
- Verifies cached account is found and home tenant profile preserved when cache keys have a `msal.2|` prefix
- Verifies fallback to `createAccountEntity` when no match exists

All 949 msal-common tests pass.
