### PR TITLE
fix(msal-common): use proper 2-arg comparator in getAccountInfoFilteredBy sort

### DIFF
--- a/change/@azure-msal-common-b843b148-a865-4af5-adbe-be8d29b8f313.json
+++ b/change/@azure-msal-common-b843b148-a865-4af5-adbe-be8d29b8f313.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Fix unstable sort in getAccountInfoFilteredBy by replacing incorrect 1-arg comparator with proper 2-arg comparator [#8477](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8477)",
+    "packageName": "@azure/msal-common",
+    "email": "ruijungao@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -4,49 +4,49 @@
  */
 
 import {
-    AccountFilter,
-    CredentialFilter,
-    ValidCredentialType,
-    AppMetadataFilter,
-    AppMetadataCache,
-    TokenKeys,
-    TenantProfileFilter,
-} from "./utils/CacheTypes.js";
-import { CacheRecord } from "./entities/CacheRecord.js";
-import * as Constants from "../utils/Constants.js";
-import { CredentialEntity } from "./entities/CredentialEntity.js";
-import { ScopeSet } from "../request/ScopeSet.js";
-import { AccountEntity } from "./entities/AccountEntity.js";
-import { AccessTokenEntity } from "./entities/AccessTokenEntity.js";
-import { IdTokenEntity } from "./entities/IdTokenEntity.js";
-import { RefreshTokenEntity } from "./entities/RefreshTokenEntity.js";
-import { ICacheManager } from "./interface/ICacheManager.js";
-import {
-    createClientAuthError,
-    ClientAuthErrorCodes,
-} from "../error/ClientAuthError.js";
-import {
     AccountInfo,
     TenantProfile,
     updateAccountTenantProfileData,
 } from "../account/AccountInfo.js";
-import { AppMetadataEntity } from "./entities/AppMetadataEntity.js";
-import { ServerTelemetryEntity } from "./entities/ServerTelemetryEntity.js";
-import { ThrottlingEntity } from "./entities/ThrottlingEntity.js";
 import { extractTokenClaims } from "../account/AuthToken.js";
-import { ICrypto } from "../crypto/ICrypto.js";
-import { AuthorityMetadataEntity } from "./entities/AuthorityMetadataEntity.js";
-import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
-import { Logger } from "../logger/Logger.js";
-import { name, version } from "../packageMetadata.js";
-import { StoreInCache } from "../request/StoreInCache.js";
+import { TokenClaims } from "../account/TokenClaims.js";
 import { getAliasesFromStaticSources } from "../authority/AuthorityMetadata.js";
 import { StaticAuthorityOptions } from "../authority/AuthorityOptions.js";
-import { TokenClaims } from "../account/TokenClaims.js";
-import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
-import { createCacheError } from "../error/CacheError.js";
-import * as AccountEntityUtils from "./utils/AccountEntityUtils.js";
+import { ICrypto } from "../crypto/ICrypto.js";
 import { AuthError } from "../error/AuthError.js";
+import { createCacheError } from "../error/CacheError.js";
+import {
+    ClientAuthErrorCodes,
+    createClientAuthError,
+} from "../error/ClientAuthError.js";
+import { Logger } from "../logger/Logger.js";
+import { name, version } from "../packageMetadata.js";
+import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
+import { ScopeSet } from "../request/ScopeSet.js";
+import { StoreInCache } from "../request/StoreInCache.js";
+import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
+import * as Constants from "../utils/Constants.js";
+import { AccessTokenEntity } from "./entities/AccessTokenEntity.js";
+import { AccountEntity } from "./entities/AccountEntity.js";
+import { AppMetadataEntity } from "./entities/AppMetadataEntity.js";
+import { AuthorityMetadataEntity } from "./entities/AuthorityMetadataEntity.js";
+import { CacheRecord } from "./entities/CacheRecord.js";
+import { CredentialEntity } from "./entities/CredentialEntity.js";
+import { IdTokenEntity } from "./entities/IdTokenEntity.js";
+import { RefreshTokenEntity } from "./entities/RefreshTokenEntity.js";
+import { ServerTelemetryEntity } from "./entities/ServerTelemetryEntity.js";
+import { ThrottlingEntity } from "./entities/ThrottlingEntity.js";
+import { ICacheManager } from "./interface/ICacheManager.js";
+import * as AccountEntityUtils from "./utils/AccountEntityUtils.js";
+import {
+    AccountFilter,
+    AppMetadataCache,
+    AppMetadataFilter,
+    CredentialFilter,
+    TenantProfileFilter,
+    TokenKeys,
+    ValidCredentialType,
+} from "./utils/CacheTypes.js";
 
 /**
  * Interface class which implement cache storage functions used by MSAL to perform validity checks, and store tokens.
@@ -315,8 +315,10 @@ export abstract class CacheManager implements ICacheManager {
         const allAccounts = this.getAllAccounts(accountFilter, correlationId);
         if (allAccounts.length > 1) {
             // If one or more accounts are found, prioritize accounts that have an ID token
-            const sortedAccounts = allAccounts.sort((account) => {
-                return account.idTokenClaims ? -1 : 1;
+            const sortedAccounts = allAccounts.sort((a, b) => {
+                const aHasClaims = a.idTokenClaims ? 1 : 0;
+                const bHasClaims = b.idTokenClaims ? 1 : 0;
+                return bHasClaims - aHasClaims;
             });
             return sortedAccounts[0];
         } else if (allAccounts.length === 1) {

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -3,50 +3,50 @@
  * Licensed under the MIT License.
  */
 
-import {
-    AuthenticationScheme,
-    CredentialType,
-} from "../../src/utils/Constants.js";
-import { AccountEntity } from "../../src/cache/entities/AccountEntity.js";
-import { AccessTokenEntity } from "../../src/cache/entities/AccessTokenEntity.js";
-import { CacheRecord } from "../../src/cache/entities/CacheRecord.js";
-import { AccountFilter } from "../../src/cache/utils/CacheTypes.js";
-import {
-    TEST_CONFIG,
-    TEST_TOKENS,
-    ID_TOKEN_CLAIMS,
-    CACHE_MOCKS,
-    TEST_POP_VALUES,
-    TEST_SSH_VALUES,
-    TEST_CRYPTO_VALUES,
-    TEST_ACCOUNT_INFO,
-    TEST_TOKEN_LIFETIMES,
-    ID_TOKEN_ALT_CLAIMS,
-    GUEST_ID_TOKEN_CLAIMS,
-    RANDOM_TEST_GUID,
-} from "../test_kit/StringConstants.js";
-import { AccountInfo } from "../../src/account/AccountInfo.js";
-import { MockCache } from "./MockCache.js";
 import { buildAccountFromIdTokenClaims, buildIdToken } from "msal-test-utils";
-import {
-    generateAccountKey,
-    generateCredentialKey,
-    mockCrypto,
-} from "../client/ClientTestUtils.js";
-import { TestError } from "../test_kit/TestErrors.js";
+import { AccountInfo } from "../../src/account/AccountInfo.js";
+import * as authorityMetadata from "../../src/authority/AuthorityMetadata.js";
 import { CacheManager } from "../../src/cache/CacheManager.js";
-import { AuthorityMetadataEntity } from "../../src/cache/entities/AuthorityMetadataEntity.js";
+import { AccessTokenEntity } from "../../src/cache/entities/AccessTokenEntity.js";
+import { AccountEntity } from "../../src/cache/entities/AccountEntity.js";
 import { AppMetadataEntity } from "../../src/cache/entities/AppMetadataEntity.js";
-import { RefreshTokenEntity } from "../../src/cache/entities/RefreshTokenEntity.js";
+import { AuthorityMetadataEntity } from "../../src/cache/entities/AuthorityMetadataEntity.js";
+import { CacheRecord } from "../../src/cache/entities/CacheRecord.js";
 import { IdTokenEntity } from "../../src/cache/entities/IdTokenEntity.js";
+import { RefreshTokenEntity } from "../../src/cache/entities/RefreshTokenEntity.js";
 import * as AccountEntityUtils from "../../src/cache/utils/AccountEntityUtils.js";
+import { AccountFilter } from "../../src/cache/utils/CacheTypes.js";
 import {
     CacheHelpers,
     CommonSilentFlowRequest,
     ScopeSet,
 } from "../../src/index.js";
 import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
-import * as authorityMetadata from "../../src/authority/AuthorityMetadata.js";
+import {
+    AuthenticationScheme,
+    CredentialType,
+} from "../../src/utils/Constants.js";
+import {
+    generateAccountKey,
+    generateCredentialKey,
+    mockCrypto,
+} from "../client/ClientTestUtils.js";
+import {
+    CACHE_MOCKS,
+    GUEST_ID_TOKEN_CLAIMS,
+    ID_TOKEN_ALT_CLAIMS,
+    ID_TOKEN_CLAIMS,
+    RANDOM_TEST_GUID,
+    TEST_ACCOUNT_INFO,
+    TEST_CONFIG,
+    TEST_CRYPTO_VALUES,
+    TEST_POP_VALUES,
+    TEST_SSH_VALUES,
+    TEST_TOKEN_LIFETIMES,
+    TEST_TOKENS,
+} from "../test_kit/StringConstants.js";
+import { TestError } from "../test_kit/TestErrors.js";
+import { MockCache } from "./MockCache.js";
 
 describe("CacheManager.ts test cases", () => {
     const mockCache = new MockCache(CACHE_MOCKS.MOCK_CLIENT_ID, mockCrypto, {
@@ -765,6 +765,30 @@ describe("CacheManager.ts test cases", () => {
             expect(reversedResultAccount?.tenantId).toBe(
                 GUEST_ID_TOKEN_CLAIMS.tid
             );
+        });
+
+        it("returns first inserted account when multiple accounts have idTokenClaims", () => {
+            const filter = {
+                homeAccountId: multiTenantAccount.homeAccountId,
+            };
+
+            // Verify insertion order: home tenant first, guest tenant second
+            const allAccounts = mockCache.cacheManager.getAllAccounts(
+                filter,
+                RANDOM_TEST_GUID
+            );
+            expect(allAccounts).toHaveLength(2);
+            expect(allAccounts[0].tenantId).toBe(ID_TOKEN_CLAIMS.tid);
+            expect(allAccounts[1].tenantId).toBe(GUEST_ID_TOKEN_CLAIMS.tid);
+
+            // getAccountInfoFilteredBy should return the first (home) account
+            const resultAccount =
+                mockCache.cacheManager.getAccountInfoFilteredBy(
+                    filter,
+                    RANDOM_TEST_GUID
+                );
+            expect(resultAccount).not.toBeNull();
+            expect(resultAccount?.tenantId).toBe(ID_TOKEN_CLAIMS.tid);
         });
 
         it("returns account matching filter with isHomeTenant = true", () => {

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/auth.js
@@ -49,8 +49,10 @@ function handleResponse(resp) {
             if (currentAccounts.length === 0) {
                 return;
             } else if (currentAccounts.length > 1) {
-                activeAccount = currentAccounts.sort((account) => {
-                    return account.tenantId === account.homeAccountId.split(".")[1] ? -1 : 1; 
+                activeAccount = currentAccounts.sort((a, b) => {
+                    const aIsHome = a.tenantId === a.homeAccountId.split(".")[1] ? 1 : 0;
+                    const bIsHome = b.tenantId === b.homeAccountId.split(".")[1] ? 1 : 0;
+                    return bIsHome - aIsHome;
                 })[0];
             } else if (currentAccounts.length === 1) {
                 activeAccount = currentAccounts[0];


### PR DESCRIPTION
## Problem

`getAccountInfoFilteredBy()` and the e2e test sample use `Array.prototype.sort()` with a single-argument comparator, which is incorrect. `sort()` expects two arguments and a return value of negative/zero/positive. The 1-arg form never returns `0`, breaking stable sort guarantees.

**Impact:** After cross-tenant `acquireTokenSilent`, both home and guest tenant profiles have cached ID tokens. `getAccount({ homeAccountId })` may return the guest profile instead of the expected home profile.

## Fix

Replace 1-arg comparators with proper 2-arg comparators that return `0` for equal priority, preserving insertion order.

## Changes

| File | Change |
|------|--------|
| `lib/msal-common/src/cache/CacheManager.ts` | Fix sort comparator in `getAccountInfoFilteredBy` |
| `lib/msal-common/test/cache/CacheManager.spec.ts` | Add test verifying stable sort when both accounts have idTokenClaims |
| `samples/.../customizable-e2e-test/auth.js` | Fix same 1-arg sort pattern for home tenant priority |