### PR TITLE
Implement redirect bridge for logout flows and update postLogoutRedirectUri in samples

### DIFF
--- a/change/@azure-msal-browser-1995cfb9-b579-49b1-9210-e36c755bc53c.json
+++ b/change/@azure-msal-browser-1995cfb9-b579-49b1-9210-e36c755bc53c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement redirect bridge for logout flows and update postLogoutRedirectUri in samples (#8489)[https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8489]",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-1995cfb9-b579-49b1-9210-e36c755bc53c.json
+++ b/change/@azure-msal-browser-1995cfb9-b579-49b1-9210-e36c755bc53c.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Implement redirect bridge for logout flows and update postLogoutRedirectUri in samples (#8489)[https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8489]",
+  "comment": "Implement redirect bridge for logout flows and update postLogoutRedirectUri in samples [#8489](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8489)",
   "packageName": "@azure/msal-browser",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/docs/redirect-bridge.md
+++ b/lib/msal-browser/docs/redirect-bridge.md
@@ -39,6 +39,38 @@ This guide provides framework-specific instructions for setting up the redirect 
 > redirect bridge with your application or serve it from your own
 > infrastructure.
 
+## Logout and the Redirect Bridge
+
+### `logoutPopup()` — redirect bridge is **required**
+
+When using `logoutPopup()`, the `postLogoutRedirectUri` **must** point to a page that implements the redirect bridge (calls `broadcastResponseToMainFrame()`). After ESTS completes the sign-out, it redirects the popup to the `postLogoutRedirectUri`. The redirect bridge on that page broadcasts the response back to the main window and closes the popup. Without the bridge, the popup will remain open after logout because COOP headers prevent the main window from closing it directly.
+
+The simplest configuration is to set `postLogoutRedirectUri` to the same value as `redirectUri`:
+
+```javascript
+const msalConfig = {
+    auth: {
+        clientId: "{your-client-id}",
+        redirectUri: "/redirect",
+        postLogoutRedirectUri: "/redirect", // Must host the redirect bridge
+    },
+};
+```
+
+> [!IMPORTANT]
+> If your `postLogoutRedirectUri` differs from your `redirectUri`, you must
+> ensure both pages implement the redirect bridge **and** both URIs are
+> registered in your [Entra ID app registration](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app#add-a-redirect-uri)
+> as redirect URIs.
+>
+> **Note:** MSA (personal Microsoft accounts) requires the redirect URI to be
+> registered with the "logout" type to allow redirecting back after logout.
+> Check your app registration if you support MSA accounts.
+
+### `logoutRedirect()` — redirect bridge is **optional**
+
+For `logoutRedirect()`, hosting the redirect bridge on the `postLogoutRedirectUri` page is optional. The redirect flow navigates the entire browser window, so there is no popup to close. If the redirect bridge is present on the `postLogoutRedirectUri` page, it will navigate the user back to the origin page. If not, ESTS will redirect the user directly to the `postLogoutRedirectUri` page and the user stays there.
+
 ## Cross-Origin Iframe Limitation
 
 The redirect bridge relies on the [BroadcastChannel API](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) to send the authentication response from the popup back to the main application window. Starting with **Chromium 115+** (Chrome, Edge, and other Chromium-based browsers), [third-party storage partitioning](https://developers.google.com/privacy-sandbox/cookies/storage-partitioning) is enforced, which means `BroadcastChannel` is **partitioned by top-level site**, not just by origin. Other browsers are expected to adopt similar partitioning in the future.

--- a/lib/msal-browser/docs/redirect-bridge.md
+++ b/lib/msal-browser/docs/redirect-bridge.md
@@ -63,9 +63,12 @@ const msalConfig = {
 > registered in your [Entra ID app registration](https://learn.microsoft.com/azure/active-directory/develop/quickstart-register-app#add-a-redirect-uri)
 > as redirect URIs.
 >
-> **Note:** MSA (personal Microsoft accounts) requires the redirect URI to be
-> registered with the "logout" type to allow redirecting back after logout.
-> Check your app registration if you support MSA accounts.
+> **Note:** For applications that support personal Microsoft accounts (MSA),
+> the `postLogoutRedirectUri` **must** be registered as a redirect URI in your
+> app registration. If it is not registered, MSA will not redirect back after
+> sign-out and the user will see a generic "close this tab" page instead. See
+> [Send a sign-out request](https://learn.microsoft.com/entra/identity-platform/v2-protocols-oidc#send-a-sign-out-request)
+> for details.
 
 ### `logoutRedirect()` — redirect bridge is **optional**
 

--- a/lib/msal-browser/docs/v4-migration.md
+++ b/lib/msal-browser/docs/v4-migration.md
@@ -325,10 +325,12 @@ MSAL Browser v5 introduces built-in support for Cross-Origin-Opener-Policy (COOP
 
 When COOP headers are present on the authentication service response (e.g., `Cross-Origin-Opener-Policy: same-origin`), traditional popup and silent iframe authentication flows will fail because the authentication window cannot communicate back to the main application window. MSAL v5 solves this by introducing a redirect bridge pattern.
 
-**All authentication flows** (`acquireTokenSilent()`, `ssoSilent()`, `loginPopup()`, and `loginRedirect()`) now use the redirect bridge. The redirect bridge handles the authentication response differently based on the flow:
+**All authentication flows** (`acquireTokenSilent()`, `ssoSilent()`, `loginPopup()`, `loginRedirect()`, and `logoutPopup()`) now use the redirect bridge. The redirect bridge handles the authentication response differently based on the flow:
 
 - **Popup and silent flows**: The redirect bridge broadcasts the authentication response to the main application window using the BroadcastChannel API
 - **Redirect flow**: The redirect bridge caches the authentication response in `sessionStorage` and navigates back to your application's page that initiated the redirect. On the destination page, `handleRedirectPromise` picks up the cached response automatically. This avoids appending auth parameters to the URL, which would otherwise cause issues for single-page applications that use hash-based routing (e.g., `/#/dashboard`). If `sessionStorage` is unavailable (quota exceeded, restricted storage), the bridge still navigates to your application but `handleRedirectPromise` will return `null` and your app should handle re-authentication.
+- **`logoutPopup()`**: The redirect bridge broadcasts the logout completion back to the main window and closes the popup. For this to work, `postLogoutRedirectUri` must point to a page that implements the redirect bridge. The simplest approach is to set `postLogoutRedirectUri` to the same value as `redirectUri`. See the [Redirect Bridge — Logout section](./redirect-bridge.md#logout-and-the-redirect-bridge) for details.
+- **`logoutRedirect()`**: The redirect bridge is optional. If present on the `postLogoutRedirectUri` page, it will navigate the user back to the origin page. Otherwise, the user stays on the `postLogoutRedirectUri` page after logout.
 
 #### How It Works
 

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -18,6 +18,7 @@ import {
     invoke,
     PkceCodes,
     CommonAuthorizationUrlRequest,
+    ProtocolUtils,
 } from "@azure/msal-common/browser";
 import {
     initializeAuthorizationRequest,
@@ -761,6 +762,15 @@ export class PopupClient extends StandardInteractionClient {
                     return;
                 }
             }
+
+            // Redirect bridge requires "state" param to work properly
+            validRequest.state = ProtocolUtils.setRequestState(
+                this.browserCrypto,
+                validRequest.state || "",
+                {
+                    interactionType: InteractionType.Popup,
+                }
+            );
 
             // Create logout string and navigate user window to logout.
             const logoutUri: string = authClient.getLogoutUri(validRequest);

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -19,6 +19,7 @@ import {
     UrlUtils,
     InProgressPerformanceEvent,
     CommonAuthorizationUrlRequest,
+    ProtocolUtils,
 } from "@azure/msal-common/browser";
 import {
     initializeAuthorizationRequest,
@@ -869,6 +870,15 @@ export class RedirectClient extends StandardInteractionClient {
                     }
                 }
             }
+
+            // Redirect bridge requires "state" param to work properly
+            validLogoutRequest.state = ProtocolUtils.setRequestState(
+                this.browserCrypto,
+                validLogoutRequest.state || "",
+                {
+                    interactionType: InteractionType.Redirect,
+                }
+            );
 
             // Create logout string and navigate user window to logout.
             const logoutUri: string =

--- a/lib/msal-browser/src/redirect_bridge/index.ts
+++ b/lib/msal-browser/src/redirect_bridge/index.ts
@@ -7,6 +7,7 @@ import { parseAuthResponseFromUrl } from "../utils/BrowserUtils.js";
 import * as BrowserUtils from "../utils/BrowserUtils.js";
 import {
     ApiId,
+    INTERACTION_TYPE,
     InteractionType,
     TemporaryCacheKeys,
 } from "../utils/BrowserConstants.js";
@@ -59,14 +60,10 @@ export async function broadcastResponseToMainFrame(
 
     if (meta["interactionType"] === InteractionType.Redirect) {
         const navClient = navigationClient || new NavigationClient();
-        const navigationOptions: NavigationOptions = {
-            apiId: ApiId.handleRedirectPromise,
-            noHistory: true,
-            timeout: DEFAULT_REDIRECT_TIMEOUT_MS,
-        };
 
         let navigateToUrl = "";
         let clientId = "";
+        let interactionType = "";
         const interactionKey = `${PREFIX}.${TemporaryCacheKeys.INTERACTION_STATUS_KEY}`;
         /*
          * Retrieve the clientId and original navigation URL from
@@ -78,6 +75,7 @@ export async function broadcastResponseToMainFrame(
                 window.sessionStorage.getItem(interactionKey);
             const interactionStatus = JSON.parse(rawInteractionStatus || "");
             clientId = interactionStatus.clientId || "";
+            interactionType = interactionStatus.type;
 
             if (clientId) {
                 const originKey = `${PREFIX}.${clientId}.${TemporaryCacheKeys.ORIGIN_URI}`;
@@ -86,6 +84,15 @@ export async function broadcastResponseToMainFrame(
         } catch {
             // sessionStorage access or JSON.parse failed
         }
+
+        const navigationOptions: NavigationOptions = {
+            apiId:
+                interactionType === INTERACTION_TYPE.SIGNOUT
+                    ? ApiId.logout
+                    : ApiId.handleRedirectPromise,
+            noHistory: true,
+            timeout: DEFAULT_REDIRECT_TIMEOUT_MS,
+        };
 
         /*
          * Cache the auth response payload in sessionStorage under the URL_HASH

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -7214,6 +7214,10 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                         return Promise.resolve(true);
                     }
                 );
+                jest.spyOn(
+                    BrowserUtils,
+                    "waitForBridgeResponse"
+                ).mockRejectedValue(new Error("test"));
                 const popupWindow = { ...window };
                 jest.spyOn(PopupClient.prototype, "openPopup").mockReturnValue(
                     popupWindow

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -1064,6 +1064,21 @@ describe("PopupClient", () => {
             expect(popupSpy.mock.calls[0]).toHaveLength(2);
         });
 
+        it("calls getLogoutUri with a truthy state for redirect bridge support", async () => {
+            const logoutUriSpy = jest
+                .spyOn(AuthorizationCodeClient.prototype, "getLogoutUri")
+                .mockReturnValue(TEST_URIS.TEST_END_SESSION_ENDPOINT);
+
+            jest.spyOn(PopupClient.prototype, "openSizedPopup").mockReturnValue(
+                null
+            );
+
+            await popupClient.logout().catch(() => {});
+
+            expect(logoutUriSpy).toHaveBeenCalledTimes(1);
+            expect(logoutUriSpy.mock.calls[0][0].state).toBeTruthy();
+        });
+
         it("opens popups when making network request if configured", async () => {
             let pca = new PublicClientApplication({
                 auth: {

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -1043,6 +1043,9 @@ describe("PopupClient", () => {
             };
             // @ts-ignore
             jest.spyOn(window, "open").mockReturnValue(popupWindow);
+            jest.spyOn(BrowserUtils, "waitForBridgeResponse").mockRejectedValue(
+                new Error("test")
+            );
         });
 
         afterEach(() => {

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -2330,8 +2330,13 @@ describe("RedirectClient", () => {
                     options: NavigationOptions
                 ): Promise<boolean> => {
                     expect(logoutUriSpy).toHaveBeenCalledWith(
-                        validatedLogoutRequest
+                        expect.objectContaining({
+                            correlationId: RANDOM_TEST_GUID,
+                            postLogoutRedirectUri: TEST_URIS.TEST_REDIR_URI,
+                        })
                     );
+                    // State is now always set for logout flows
+                    expect(logoutUriSpy.mock.calls[0][0].state).toBeTruthy();
                     expect(urlNavigate).toEqual(testLogoutUrl);
                     expect(options.noHistory).toBeFalsy();
                     done();
@@ -2339,10 +2344,6 @@ describe("RedirectClient", () => {
                 }
             );
             redirectClient.logout();
-            const validatedLogoutRequest: CommonEndSessionRequest = {
-                correlationId: RANDOM_TEST_GUID,
-                postLogoutRedirectUri: TEST_URIS.TEST_REDIR_URI,
-            };
         });
 
         it("includes postLogoutRedirectUri if one is passed", (done) => {

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -394,6 +394,76 @@ describe("broadcastResponseToMainFrame", () => {
         });
     });
 
+    describe("Success cases - Signout redirect flow", () => {
+        it("uses ApiId.logout when interaction type is signout", async () => {
+            const testClientId = "test-client-signout";
+            const cachedOriginUrl = "https://localhost:8081/signed-out";
+
+            mockSessionStorage["msal.interaction.status"] = JSON.stringify({
+                clientId: testClientId,
+                type: "signout",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            // Should navigate with ApiId.logout (961) for signout flow
+            expect(mockNavigationClient.navigateInternal).toHaveBeenCalledWith(
+                cachedOriginUrl,
+                expect.objectContaining({
+                    apiId: 961, // ApiId.logout
+                    noHistory: true,
+                })
+            );
+        });
+
+        it("uses ApiId.handleRedirectPromise when interaction type is signin", async () => {
+            const testClientId = "test-client-signin";
+            const cachedOriginUrl = "https://localhost:8081/home";
+
+            mockSessionStorage["msal.interaction.status"] = JSON.stringify({
+                clientId: testClientId,
+                type: "signin",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            // Should navigate with ApiId.handleRedirectPromise (865) for signin flow
+            expect(mockNavigationClient.navigateInternal).toHaveBeenCalledWith(
+                cachedOriginUrl,
+                expect.objectContaining({
+                    apiId: 865, // ApiId.handleRedirectPromise
+                    noHistory: true,
+                })
+            );
+        });
+
+        it("broadcasts and closes popup window for signout popup flow", async () => {
+            mockSessionStorage["msal.interaction.status"] = JSON.stringify({
+                clientId: "test-client",
+                type: "signout",
+            });
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_POPUP;
+
+            await broadcastResponseToMainFrame();
+
+            // Popup signout should broadcast + close, same as popup signin
+            expect(mockHistoryReplaceState).toHaveBeenCalled();
+            expect(window.close).toHaveBeenCalled();
+            expect(
+                mockNavigationClient.navigateInternal
+            ).not.toHaveBeenCalled();
+        });
+    });
+
     describe("Hybrid response format (query + hash)", () => {
         it("handles query string only response", async () => {
             window.location.search = `?state=${TEST_STATE_VALUES.TEST_STATE_POPUP}&code=test_code`;

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -11,7 +11,7 @@ import {
     TEST_STATE_VALUES,
     RANDOM_TEST_GUID,
 } from "../utils/StringConstants.js";
-import { TemporaryCacheKeys } from "../../src/utils/BrowserConstants.js";
+import { ApiId, TemporaryCacheKeys } from "../../src/utils/BrowserConstants.js";
 
 jest.mock("../../src/navigation/NavigationClient.js");
 
@@ -410,11 +410,11 @@ describe("broadcastResponseToMainFrame", () => {
 
             await broadcastResponseToMainFrame();
 
-            // Should navigate with ApiId.logout (961) for signout flow
+            // Should navigate with ApiId.logout for signout flow
             expect(mockNavigationClient.navigateInternal).toHaveBeenCalledWith(
                 cachedOriginUrl,
                 expect.objectContaining({
-                    apiId: 961, // ApiId.logout
+                    apiId: ApiId.logout,
                     noHistory: true,
                 })
             );
@@ -435,11 +435,11 @@ describe("broadcastResponseToMainFrame", () => {
 
             await broadcastResponseToMainFrame();
 
-            // Should navigate with ApiId.handleRedirectPromise (865) for signin flow
+            // Should navigate with ApiId.handleRedirectPromise for signin flow
             expect(mockNavigationClient.navigateInternal).toHaveBeenCalledWith(
                 cachedOriginUrl,
                 expect.objectContaining({
-                    apiId: 865, // ApiId.handleRedirectPromise
+                    apiId: ApiId.handleRedirectPromise,
                     noHistory: true,
                 })
             );

--- a/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
+++ b/lib/msal-browser/test/redirect_bridge/broadcastResponseToMainFrame.spec.ts
@@ -392,6 +392,31 @@ describe("broadcastResponseToMainFrame", () => {
             );
             expect(urlHashCalls).toHaveLength(0);
         });
+
+        it("uses ApiId.handleRedirectPromise when interaction type is signin", async () => {
+            const testClientId = "test-client-signin";
+            const cachedOriginUrl = "https://localhost:8081/home";
+
+            mockSessionStorage["msal.interaction.status"] = JSON.stringify({
+                clientId: testClientId,
+                type: "signin",
+            });
+            mockSessionStorage[`msal.${testClientId}.request.origin`] =
+                cachedOriginUrl;
+
+            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
+
+            await broadcastResponseToMainFrame();
+
+            // Should navigate with ApiId.handleRedirectPromise for signin flow
+            expect(mockNavigationClient.navigateInternal).toHaveBeenCalledWith(
+                cachedOriginUrl,
+                expect.objectContaining({
+                    apiId: ApiId.handleRedirectPromise,
+                    noHistory: true,
+                })
+            );
+        });
     });
 
     describe("Success cases - Signout redirect flow", () => {
@@ -415,31 +440,6 @@ describe("broadcastResponseToMainFrame", () => {
                 cachedOriginUrl,
                 expect.objectContaining({
                     apiId: ApiId.logout,
-                    noHistory: true,
-                })
-            );
-        });
-
-        it("uses ApiId.handleRedirectPromise when interaction type is signin", async () => {
-            const testClientId = "test-client-signin";
-            const cachedOriginUrl = "https://localhost:8081/home";
-
-            mockSessionStorage["msal.interaction.status"] = JSON.stringify({
-                clientId: testClientId,
-                type: "signin",
-            });
-            mockSessionStorage[`msal.${testClientId}.request.origin`] =
-                cachedOriginUrl;
-
-            window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
-
-            await broadcastResponseToMainFrame();
-
-            // Should navigate with ApiId.handleRedirectPromise for signin flow
-            expect(mockNavigationClient.navigateInternal).toHaveBeenCalledWith(
-                cachedOriginUrl,
-                expect.objectContaining({
-                    apiId: ApiId.handleRedirectPromise,
                     noHistory: true,
                 })
             );

--- a/samples/msal-angular-samples/angular-modules-sample/src/app/app.module.ts
+++ b/samples/msal-angular-samples/angular-modules-sample/src/app/app.module.ts
@@ -46,7 +46,7 @@ export function MSALInstanceFactory(): IPublicClientApplication {
       clientId: environment.msalConfig.auth.clientId,
       authority: environment.msalConfig.auth.authority,
       redirectUri: '/redirect',
-      postLogoutRedirectUri: '/',
+      postLogoutRedirectUri: '/redirect',
     },
     cache: {
       cacheLocation: BrowserCacheLocation.SessionStorage,

--- a/samples/msal-angular-samples/angular-standalone-sample/src/app/app.config.ts
+++ b/samples/msal-angular-samples/angular-standalone-sample/src/app/app.config.ts
@@ -47,7 +47,7 @@ export function MSALInstanceFactory(): IPublicClientApplication {
       clientId: environment.msalConfig.auth.clientId,
       authority: environment.msalConfig.auth.authority,
       redirectUri: '/redirect',
-      postLogoutRedirectUri: '/',
+      postLogoutRedirectUri: '/redirect',
     },
     cache: {
       cacheLocation: BrowserCacheLocation.SessionStorage,

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/authConfigs/aadAuthConfig.json
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/authConfigs/aadAuthConfig.json
@@ -4,7 +4,7 @@
             "clientId": "0845a021-afdf-4126-abdd-099c5e6948e1",
             "authority": "https://login.microsoftonline.com/common",
             "redirectUri": "/redirect",
-            "postLogoutRedirectUri": "/"
+            "postLogoutRedirectUri": "/redirect"
         },
         "cache": {
             "cacheLocation": "sessionStorage"

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/authConfigs/aadMultiTenantAuthConfig.json
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/authConfigs/aadMultiTenantAuthConfig.json
@@ -3,7 +3,8 @@
         "auth": {
             "clientId": "0845a021-afdf-4126-abdd-099c5e6948e1",
             "authority": "https://login.microsoftonline.com/c7cef333-42af-492c-afb0-21f74a661133",
-            "redirectUri": "/redirect"
+            "redirectUri": "/redirect",
+            "postLogoutRedirectUri": "/redirect"
         },
         "cache": {
             "cacheLocation": "sessionStorage"

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/authConfigs/aadTenantedAuthConfig.json
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/authConfigs/aadTenantedAuthConfig.json
@@ -3,7 +3,8 @@
         "auth": {
             "clientId": "0845a021-afdf-4126-abdd-099c5e6948e1",
             "authority": "https://login.microsoftonline.com/c7cef333-42af-492c-afb0-21f74a661133",
-            "redirectUri": "/redirect"
+            "redirectUri": "/redirect",
+            "postLogoutRedirectUri": "/redirect"
         },
         "cache": {
             "cacheLocation": "sessionStorage"

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAAD.spec.ts
@@ -337,6 +337,10 @@ describe("AAD-Prod Tests", () => {
             expect(tokenStore.idTokens.length).toEqual(0);
             expect(tokenStore.accessTokens.length).toEqual(0);
             expect(tokenStore.refreshTokens.length).toEqual(0);
+
+            // Verify the popup window is closed after logout completes
+            await popupWindowClosed;
+            expect(popupWindow.isClosed()).toBeTruthy();
         });
     });
 

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADMultiTenant.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADMultiTenant.spec.ts
@@ -155,6 +155,10 @@ describe("AAD-Prod Tests", () => {
             expect(tokenStore.idTokens.length).toEqual(0);
             expect(tokenStore.accessTokens.length).toEqual(0);
             expect(tokenStore.refreshTokens.length).toEqual(0);
+
+            // Verify the popup window is closed after logout completes
+            await popupWindowClosed;
+            expect(popupWindow.isClosed()).toBeTruthy();
         });
     });
 

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADTenanted.spec.ts
@@ -341,6 +341,10 @@ describe("AAD-Prod Tests", () => {
             expect(tokenStore.idTokens.length).toEqual(0);
             expect(tokenStore.accessTokens.length).toEqual(0);
             expect(tokenStore.refreshTokens.length).toEqual(0);
+
+            // Verify the popup window is closed after logout completes
+            await popupWindowClosed;
+            expect(popupWindow.isClosed()).toBeTruthy();
         });
     });
 

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/testConfig.json
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/testConfig.json
@@ -4,7 +4,7 @@
             "clientId": "0845a021-afdf-4126-abdd-099c5e6948e1",
             "authority": "https://login.microsoftonline.com/common",
             "redirectUri": "/redirect",
-            "postLogoutRedirectUri":"/redirect"
+            "postLogoutRedirectUri": "/redirect"
         },
         "cache": {
             "cacheLocation": "memoryStorage"

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/testConfig.json
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/testConfig.json
@@ -3,7 +3,8 @@
         "auth": {
             "clientId": "0845a021-afdf-4126-abdd-099c5e6948e1",
             "authority": "https://login.microsoftonline.com/common",
-            "redirectUri": "/redirect"
+            "redirectUri": "/redirect",
+            "postLogoutRedirectUri":"/redirect"
         },
         "cache": {
             "cacheLocation": "memoryStorage"

--- a/samples/msal-react-samples/b2c-sample/src/authConfig.js
+++ b/samples/msal-react-samples/b2c-sample/src/authConfig.js
@@ -39,7 +39,7 @@ export const msalConfig = {
         authority: b2cPolicies.authorities.signUpSignIn.authority,
         knownAuthorities: [b2cPolicies.authorityDomain],
         redirectUri: "/redirect",
-        postLogoutRedirectUri: "/",
+        postLogoutRedirectUri: "/redirect",
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/nextjs-sample/src/authConfig.js
+++ b/samples/msal-react-samples/nextjs-sample/src/authConfig.js
@@ -4,7 +4,7 @@ export const msalConfig = {
         clientId: "0845a021-afdf-4126-abdd-099c5e6948e1",
         authority: "https://login.microsoftonline.com/common",
         redirectUri: "/redirect",
-        postLogoutRedirectUri: "/"
+        postLogoutRedirectUri: "/redirect"
     },
     system: {
         allowPlatformBroker: false, // Disables WAM Broker

--- a/samples/msal-react-samples/react-router-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react-router-sample/src/authConfig.js
@@ -17,7 +17,7 @@ export const msalConfig = {
         clientId: import.meta.env.VITE_CLIENT_ID,
         authority: import.meta.env.VITE_AUTHORITY,
         redirectUri: import.meta.env.VITE_REDIRECT_URI,
-        postLogoutRedirectUri: "/redirect",
+        postLogoutRedirectUri: import.meta.env.VITE_REDIRECT_URI,
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/react-router-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react-router-sample/src/authConfig.js
@@ -17,7 +17,7 @@ export const msalConfig = {
         clientId: import.meta.env.VITE_CLIENT_ID,
         authority: import.meta.env.VITE_AUTHORITY,
         redirectUri: import.meta.env.VITE_REDIRECT_URI,
-        postLogoutRedirectUri: "/",
+        postLogoutRedirectUri: "/redirect",
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/react16-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react16-sample/src/authConfig.js
@@ -6,7 +6,7 @@ export const msalConfig = {
         clientId: import.meta.env.VITE_CLIENT_ID,
         authority: import.meta.env.VITE_AUTHORITY,
         redirectUri: import.meta.env.VITE_REDIRECT_URI,
-        postLogoutRedirectUri: "/",
+        postLogoutRedirectUri: "/redirect",
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/react16-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react16-sample/src/authConfig.js
@@ -6,7 +6,7 @@ export const msalConfig = {
         clientId: import.meta.env.VITE_CLIENT_ID,
         authority: import.meta.env.VITE_AUTHORITY,
         redirectUri: import.meta.env.VITE_REDIRECT_URI,
-        postLogoutRedirectUri: "/redirect",
+        postLogoutRedirectUri: import.meta.env.VITE_REDIRECT_URI,
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/react17-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react17-sample/src/authConfig.js
@@ -6,7 +6,7 @@ export const msalConfig = {
         clientId: import.meta.env.VITE_CLIENT_ID,
         authority: import.meta.env.VITE_AUTHORITY,
         redirectUri: import.meta.env.VITE_REDIRECT_URI,
-        postLogoutRedirectUri: "/",
+        postLogoutRedirectUri: "/redirect",
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/react17-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react17-sample/src/authConfig.js
@@ -6,7 +6,7 @@ export const msalConfig = {
         clientId: import.meta.env.VITE_CLIENT_ID,
         authority: import.meta.env.VITE_AUTHORITY,
         redirectUri: import.meta.env.VITE_REDIRECT_URI,
-        postLogoutRedirectUri: "/redirect",
+        postLogoutRedirectUri: import.meta.env.VITE_REDIRECT_URI,
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/react18-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react18-sample/src/authConfig.js
@@ -6,7 +6,7 @@ export const msalConfig = {
         clientId: import.meta.env.VITE_CLIENT_ID,
         authority: import.meta.env.VITE_AUTHORITY,
         redirectUri: import.meta.env.VITE_REDIRECT_URI,
-        postLogoutRedirectUri: "/",
+        postLogoutRedirectUri: "/redirect",
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/react18-sample/src/authConfig.js
+++ b/samples/msal-react-samples/react18-sample/src/authConfig.js
@@ -6,7 +6,7 @@ export const msalConfig = {
         clientId: import.meta.env.VITE_CLIENT_ID,
         authority: import.meta.env.VITE_AUTHORITY,
         redirectUri: import.meta.env.VITE_REDIRECT_URI,
-        postLogoutRedirectUri: "/redirect",
+        postLogoutRedirectUri: import.meta.env.VITE_REDIRECT_URI,
         onRedirectNavigate: () => !BrowserUtils.isInIframe()
     },
     cache: {

--- a/samples/msal-react-samples/typescript-sample/src/authConfig.ts
+++ b/samples/msal-react-samples/typescript-sample/src/authConfig.ts
@@ -6,7 +6,7 @@ export const msalConfig: Configuration = {
         clientId: "0845a021-afdf-4126-abdd-099c5e6948e1",
         authority: "https://login.microsoftonline.com/common",
         redirectUri: "/redirect",
-        postLogoutRedirectUri: "/",
+        postLogoutRedirectUri: "/redirect",
     },
     system: {
         allowPlatformBroker: false, // Disables WAM Broker


### PR DESCRIPTION
This pull request improves the reliability and documentation of logout flows in MSAL Browser, especially when using popup and redirect methods with the redirect bridge. The main focus is ensuring that the redirect bridge works seamlessly for logout operations, that state parameters are always set for logout requests, and that documentation and samples reflect these requirements. Several new tests verify these behaviors.

**Enhancements to Logout Flows and Redirect Bridge:**

- Always sets the `state` parameter for logout requests in both `PopupClient` and `RedirectClient`, ensuring the redirect bridge functions correctly for logout operations. [[1]](diffhunk://#diff-3f43afd5556603a80064728bd701519ec2e22979f09ae6095b7fdea0507ad593R766-R774) [[2]](diffhunk://#diff-06ec3818a1cb128320c6ece84eed04190a54c03a09a455ca2d5c6947e29d5de1R874-R882)
- Updates the redirect bridge logic to use the correct `ApiId` for logout and signin flows, improving navigation accuracy after logout and sign-in. [[1]](diffhunk://#diff-32779cae0c41a7eaae4e816c284cefd873f5a1f6f28a9cca9e35f0f493d09f21R78) [[2]](diffhunk://#diff-32779cae0c41a7eaae4e816c284cefd873f5a1f6f28a9cca9e35f0f493d09f21R88-R96)
- Adds detailed documentation on how to configure `postLogoutRedirectUri` for popup and redirect logout flows, clarifying when the redirect bridge is required or optional. [[1]](diffhunk://#diff-6d999c2e1c399cb4aa0b131309af32623667e532ec30a0663f6db12320c064a5R42-R73) [[2]](diffhunk://#diff-7dd2f98fce0f4755bb8c50644c2a04c9c9d90d1ad11b13f46d2844ccd39df73fL328-R333)

**Sample and Configuration Updates:**

- Updates sample app configurations to set `postLogoutRedirectUri` to `/redirect`, matching the recommended setup for the redirect bridge. [[1]](diffhunk://#diff-582cec082560572f320bb72a87de6f9a8eca619fabb12715cc26e3327b6e58a4L49-R49) [[2]](diffhunk://#diff-15af7d8ba0266a55edbdcda7788a2c2afa61fd5b8cd59d5be517e44b49c339dbL50-R50) [[3]](diffhunk://#diff-aca718f7f5c35ee760ff6147f1a28a0696e1dd2af3ee7eb7f47fb3fe6d6fc624L6-R7) [[4]](diffhunk://#diff-1e445e6eaa2dcde2f98cdaa9a17e4fef1babdc7e6f5e5c58c957f865bd811b02L6-R7) [[5]](diffhunk://#diff-4f8fe6bdcdd72d4507053f5a0460663a5645c7e209f9d8d48ec0ebc0008bb0ebL6-R7)

**Testing Improvements:**

- Adds and updates tests to verify that the popup window is closed after logout completes and that the correct `ApiId` is used in navigation, ensuring correct logout bridge behavior. [[1]](diffhunk://#diff-b8f31f42cc08acb87454a148bb7f6af0eb3ce57140ddbe1ae3858f8f1a2aa86fR340-R343) [[2]](diffhunk://#diff-def430faf0812ded78f2722c5f59ce556f019104e7ef1dddc2b0cb1a04f7c587R158-R161) [[3]](diffhunk://#diff-773d2cd1522eaf73569f2cfcc5903c5f729679f1ea158ce1bf8c2115751cee71R344-R347) [[4]](diffhunk://#diff-aa927472dd709cb33e15a14c6838b03bc7ee96fc2c64cead5aebdbbbdb932317R397-R466) [[5]](diffhunk://#diff-6892d11e0bf0f9de499d836141fe1b0e7fe40f2b7d1d28e57830a083ba0080a4L2333-L2345)
- Mocks failures in bridge response handling in unit tests for better error coverage. [[1]](diffhunk://#diff-f936803be34376b4fc36745b78ec5110b6e3b420d907b033fa6924453d2815d5R7040-R7043) [[2]](diffhunk://#diff-0e4f86d8a16dd8be09b5f3b33d82dafe4c4325e3fd92b994120b0290beb0c2d6R1046-R1048)

**Codebase Maintenance:**

- Imports `ProtocolUtils` where needed to support state parameter handling. [[1]](diffhunk://#diff-3f43afd5556603a80064728bd701519ec2e22979f09ae6095b7fdea0507ad593R21) [[2]](diffhunk://#diff-06ec3818a1cb128320c6ece84eed04190a54c03a09a455ca2d5c6947e29d5de1R22)
- Minor code cleanup and consistency improvements in redirect bridge logic. [[1]](diffhunk://#diff-32779cae0c41a7eaae4e816c284cefd873f5a1f6f28a9cca9e35f0f493d09f21R10) [[2]](diffhunk://#diff-32779cae0c41a7eaae4e816c284cefd873f5a1f6f28a9cca9e35f0f493d09f21L62-R66)

These changes ensure a more robust and predictable logout experience for applications using MSAL Browser with COOP headers and the redirect bridge.