### PR TITLE
fix(msal-common): Fix tenant profile loss in cross-tenant scenarios

### DIFF
--- a/change/@azure-msal-browser-d7ed497b-3f33-42fd-b46f-ee236365da34.json
+++ b/change/@azure-msal-browser-d7ed497b-3f33-42fd-b46f-ee236365da34.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Thread performanceClient through buildAccountToCache callers for telemetry [#8471](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8471)",
+    "packageName": "@azure/msal-browser",
+    "email": "ruijungao@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-fd3934ae-e4c3-4b1f-b373-8fc245187599.json
+++ b/change/@azure-msal-common-fd3934ae-e4c3-4b1f-b373-8fc245187599.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Fix tenant profile loss in cross-tenant B2B scenarios by replacing broken startsWith cache key lookup with entity-level matching via getAccountsFilteredBy [#8471](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8471)",
+    "packageName": "@azure/msal-common",
+    "email": "ruijungao@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -5,44 +5,44 @@
 
 import {
     AccessTokenEntity,
-    ICrypto,
-    IdTokenEntity,
-    Logger,
-    ScopeSet,
+    AccountEntity,
+    AccountEntityUtils,
     Authority,
     AuthorityFactory,
     AuthorityOptions,
-    ExternalTokenResponse,
-    AccountEntity,
     AuthToken,
-    RefreshTokenEntity,
-    CacheRecord,
-    TokenClaims,
-    CacheHelpers,
     buildAccountToCache,
-    TimeUtils,
-    AccountEntityUtils,
     buildStaticAuthorityOptions,
+    CacheHelpers,
+    CacheRecord,
+    ExternalTokenResponse,
+    ICrypto,
+    IdTokenEntity,
     invokeAsync,
     IPerformanceClient,
+    Logger,
+    RefreshTokenEntity,
+    ScopeSet,
     StubPerformanceClient,
+    TimeUtils,
+    TokenClaims,
 } from "@azure/msal-common/browser";
 import { buildConfiguration, Configuration } from "../config/Configuration.js";
-import type { SilentRequest } from "../request/SilentRequest.js";
-import { BrowserCacheManager } from "./BrowserCacheManager.js";
-import {
-    createBrowserAuthError,
-    BrowserAuthErrorCodes,
-} from "../error/BrowserAuthError.js";
-import type { AuthenticationResult } from "../response/AuthenticationResult.js";
-import { base64Decode } from "../encode/Base64Decode.js";
 import * as BrowserCrypto from "../crypto/BrowserCrypto.js";
 import { CryptoOps } from "../crypto/CryptoOps.js";
+import { base64Decode } from "../encode/Base64Decode.js";
+import {
+    BrowserAuthErrorCodes,
+    createBrowserAuthError,
+} from "../error/BrowserAuthError.js";
 import { EventHandler } from "../event/EventHandler.js";
-import * as BrowserUtils from "../utils/BrowserUtils.js";
-import * as BrowserRootPerformanceEvents from "../telemetry/BrowserRootPerformanceEvents.js";
+import type { SilentRequest } from "../request/SilentRequest.js";
+import type { AuthenticationResult } from "../response/AuthenticationResult.js";
 import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
+import * as BrowserRootPerformanceEvents from "../telemetry/BrowserRootPerformanceEvents.js";
 import { ApiId } from "../utils/BrowserConstants.js";
+import * as BrowserUtils from "../utils/BrowserUtils.js";
+import { BrowserCacheManager } from "./BrowserCacheManager.js";
 
 export type LoadTokenOptions = {
     clientInfo?: string;
@@ -132,7 +132,8 @@ export async function loadExternalTokens(
             logger,
             cryptoOps,
             authority,
-            idTokenClaims
+            idTokenClaims,
+            performanceClient
         );
 
         const idToken = await invokeAsync(
@@ -231,7 +232,8 @@ async function loadAccount(
     logger: Logger,
     cryptoObj: ICrypto,
     authority: Authority,
-    idTokenClaims?: TokenClaims
+    idTokenClaims?: TokenClaims,
+    performanceClient?: IPerformanceClient
 ): Promise<AccountEntity> {
     logger.verbose("TokenCache - loading account", correlationId);
 
@@ -278,7 +280,8 @@ async function loadAccount(
         claimsTenantId,
         undefined, // authCodePayload
         undefined, // nativeAccountId
-        logger
+        logger,
+        performanceClient
     );
 
     await storage.setAccount(

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -4,80 +4,80 @@
  */
 
 import {
-    Logger,
-    ICrypto,
-    AuthToken,
+    AADServerParamKeys,
+    AccessTokenEntity,
     AccountEntity,
+    AccountEntityUtils,
+    AccountInfo,
+    AuthError,
+    AuthToken,
     AuthorityType,
-    ScopeSet,
-    TimeUtils,
-    UrlString,
-    PopTokenGenerator,
-    SignedHttpRequestParameters,
+    CacheHelpers,
+    ClientAuthErrorCodes,
+    CommonSilentFlowRequest,
+    Constants,
+    ICrypto,
     IPerformanceClient,
     IdTokenEntity,
-    AccessTokenEntity,
-    AuthError,
-    CommonSilentFlowRequest,
-    AccountInfo,
-    AADServerParamKeys,
+    InProgressPerformanceEvent,
+    Logger,
+    PerformanceEvents,
+    PopTokenGenerator,
+    ScopeSet,
+    ServerTelemetryManager,
+    SignedHttpRequestParameters,
+    TimeUtils,
     TokenClaims,
+    UrlString,
+    buildAccountToCache,
     createClientAuthError,
-    ClientAuthErrorCodes,
     invokeAsync,
     updateAccountTenantProfileData,
-    CacheHelpers,
-    buildAccountToCache,
-    InProgressPerformanceEvent,
-    ServerTelemetryManager,
-    AccountEntityUtils,
-    Constants,
-    PerformanceEvents,
 } from "@azure/msal-common/browser";
-import {
-    BaseInteractionClient,
-    getDiscoveredAuthority,
-    getRedirectUri,
-    initializeServerTelemetryManager,
-} from "./BaseInteractionClient.js";
-import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
-import { BrowserConfiguration } from "../config/Configuration.js";
-import { BrowserCacheManager } from "../cache/BrowserCacheManager.js";
-import { EventHandler } from "../event/EventHandler.js";
-import { PopupRequest } from "../request/PopupRequest.js";
-import { SilentRequest } from "../request/SilentRequest.js";
-import { SsoSilentRequest } from "../request/SsoSilentRequest.js";
-import {
-    ApiId,
-    TemporaryCacheKeys,
-    PlatformAuthConstants,
-    BrowserConstants,
-    CacheLookupPolicy,
-} from "../utils/BrowserConstants.js";
+import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 import { PlatformAuthRequest } from "../broker/nativeBroker/PlatformAuthRequest.js";
 import {
     MATS,
     PlatformAuthResponse,
 } from "../broker/nativeBroker/PlatformAuthResponse.js";
+import { BrowserCacheManager } from "../cache/BrowserCacheManager.js";
+import { BrowserConfiguration } from "../config/Configuration.js";
+import { base64Decode } from "../encode/Base64Decode.js";
+import {
+    BrowserAuthErrorCodes,
+    createBrowserAuthError,
+} from "../error/BrowserAuthError.js";
 import {
     NativeAuthError,
     NativeAuthErrorCodes,
     createNativeAuthError,
     isFatalNativeAuthError,
 } from "../error/NativeAuthError.js";
-import { RedirectRequest } from "../request/RedirectRequest.js";
-import { NavigationOptions } from "../navigation/NavigationOptions.js";
+import { EventHandler } from "../event/EventHandler.js";
 import { INavigationClient } from "../navigation/INavigationClient.js";
-import {
-    createBrowserAuthError,
-    BrowserAuthErrorCodes,
-} from "../error/BrowserAuthError.js";
-import { SilentCacheClient } from "./SilentCacheClient.js";
-import { AuthenticationResult } from "../response/AuthenticationResult.js";
-import { base64Decode } from "../encode/Base64Decode.js";
+import { NavigationOptions } from "../navigation/NavigationOptions.js";
 import { version } from "../packageMetadata.js";
-import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 import { HandleRedirectPromiseOptions } from "../request/HandleRedirectPromiseOptions.js";
+import { PopupRequest } from "../request/PopupRequest.js";
+import { RedirectRequest } from "../request/RedirectRequest.js";
+import { SilentRequest } from "../request/SilentRequest.js";
+import { SsoSilentRequest } from "../request/SsoSilentRequest.js";
+import { AuthenticationResult } from "../response/AuthenticationResult.js";
+import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
+import {
+    ApiId,
+    BrowserConstants,
+    CacheLookupPolicy,
+    PlatformAuthConstants,
+    TemporaryCacheKeys,
+} from "../utils/BrowserConstants.js";
+import {
+    BaseInteractionClient,
+    getDiscoveredAuthority,
+    getRedirectUri,
+    initializeServerTelemetryManager,
+} from "./BaseInteractionClient.js";
+import { SilentCacheClient } from "./SilentCacheClient.js";
 
 export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected apiId: ApiId;
@@ -545,7 +545,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             undefined, // environment
             idTokenClaims.tid,
             undefined, // auth code payload
-            response.account.id
+            response.account.id,
+            this.logger,
+            this.performanceClient
         );
 
         // Ensure expires_in is in number format

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -542,7 +542,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             this.correlationId,
             idTokenClaims,
             response.client_info,
-            undefined, // environment
+            authority.getPreferredCache(), // environment
             idTokenClaims.tid,
             undefined, // auth code payload
             response.account.id,

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1009,7 +1009,7 @@ const BROKER_REDIRECT_URI = "brk_redirect_uri";
 // Warning: (ae-missing-release-tag) "buildAccountToCache" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function buildAccountToCache(cacheStorage: CacheManager, authority: Authority, homeAccountId: string, base64Decode: (input: string) => string, correlationId: string, idTokenClaims?: TokenClaims, clientInfo?: string, environment?: string, claimsTenantId?: string | null, authCodePayload?: AuthorizationCodePayload, nativeAccountId?: string, logger?: Logger): AccountEntity;
+export function buildAccountToCache(cacheStorage: CacheManager, authority: Authority, homeAccountId: string, base64Decode: (input: string) => string, correlationId: string, idTokenClaims?: TokenClaims, clientInfo?: string, environment?: string, claimsTenantId?: string | null, authCodePayload?: AuthorizationCodePayload, nativeAccountId?: string, logger?: Logger, performanceClient?: IPerformanceClient): AccountEntity;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-incompatible-release-tags) The symbol "buildClientConfiguration" is marked as @public, but its signature references "ClientConfiguration" which is marked as @internal
@@ -3504,6 +3504,7 @@ export type PerformanceEvent = {
     cacheRetentionDays?: number;
     accountCachedBy?: string;
     acntLoggedOut?: boolean;
+    cacheMatchedAccounts?: number;
     cacheRtCount?: number;
     cacheIdCount?: number;
     cacheAtCount?: number;
@@ -4961,11 +4962,11 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/telemetry/performance/PerformanceEvent.ts:259:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:259:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:259:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:335:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:335:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:335:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:406:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:406:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:406:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:338:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:338:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:338:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:409:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:409:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:409:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -4963,11 +4963,11 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/telemetry/performance/PerformanceEvent.ts:260:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // src/telemetry/performance/PerformanceEvent.ts:260:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // src/telemetry/performance/PerformanceEvent.ts:260:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:336:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:336:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:336:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
-// src/telemetry/performance/PerformanceEvent.ts:407:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// src/telemetry/performance/PerformanceEvent.ts:407:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
-// src/telemetry/performance/PerformanceEvent.ts:407:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:339:21 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:339:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:339:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
+// src/telemetry/performance/PerformanceEvent.ts:410:22 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// src/telemetry/performance/PerformanceEvent.ts:410:14 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// src/telemetry/performance/PerformanceEvent.ts:410:8 - (tsdoc-undefined-tag) The TSDoc tag "@type" is not defined in this configuration
 
 ```

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -654,8 +654,7 @@ export function buildAccountToCache(
      * the user's home identity) and environment (identifies the cloud) — the two
      * tenant-agnostic properties that uniquely locate a base AccountEntity.
      */
-    const accountEnvironment =
-        environment || authority.getPreferredCache();
+    const accountEnvironment = environment || authority.getPreferredCache();
     const matchedAccounts = cacheStorage.getAccountsFilteredBy(
         { homeAccountId, environment: accountEnvironment },
         correlationId

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -652,8 +652,20 @@ export function buildAccountToCache(
         { homeAccountId },
         correlationId
     );
-    const cachedAccount: AccountEntity | null =
-        matchingAccounts.length > 0 ? matchingAccounts[0] : null;
+
+    if (matchingAccounts.length > 1) {
+        /*
+         * Base accounts are expected to be unique for a given homeAccountId in normal cache usage.
+         * If multiple matches exist, ignore the cache hit rather than arbitrarily choosing one.
+         */
+        logger?.warning(
+            "Multiple base accounts matched homeAccountId. Ignoring cached account and creating a new base account.",
+            correlationId
+        );
+    }
+
+    const cachedAccount =
+        matchingAccounts.length === 1 ? matchingAccounts[0] : null;
 
     const baseAccount =
         cachedAccount ||

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -398,7 +398,8 @@ export class ResponseHandler {
                 claimsTenantId,
                 authCodePayload,
                 undefined, // nativeAccountId
-                this.logger
+                this.logger,
+                this.performanceClient
             );
         }
 
@@ -643,17 +644,22 @@ export function buildAccountToCache(
     claimsTenantId?: string | null,
     authCodePayload?: AuthorizationCodePayload,
     nativeAccountId?: string,
-    logger?: Logger
+    logger?: Logger,
+    performanceClient?: IPerformanceClient
 ): AccountEntity {
     logger?.verbose("setCachedAccount called", correlationId);
 
     // Check if base account is already cached
-    const matchingAccounts = cacheStorage.getAccountsFilteredBy(
+    const matchedAccounts = cacheStorage.getAccountsFilteredBy(
         { homeAccountId },
         correlationId
     );
+    performanceClient?.addFields(
+        { cacheMatchedAccounts: matchedAccounts.length },
+        correlationId
+    );
 
-    if (matchingAccounts.length > 1) {
+    if (matchedAccounts.length > 1) {
         /*
          * Base accounts are expected to be unique for a given homeAccountId in normal cache usage.
          * If multiple matches exist, ignore the cache hit rather than arbitrarily choosing one.

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -3,36 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { ServerAuthorizationTokenResponse } from "./ServerAuthorizationTokenResponse.js";
-import { ICrypto } from "../crypto/ICrypto.js";
 import {
-    ClientAuthErrorCodes,
-    createClientAuthError,
-} from "../error/ClientAuthError.js";
-import { Logger } from "../logger/Logger.js";
-import { ServerError } from "../error/ServerError.js";
-import { ScopeSet } from "../request/ScopeSet.js";
-import { AuthenticationResult } from "./AuthenticationResult.js";
-import { AccountEntity } from "../cache/entities/AccountEntity.js";
-import { Authority } from "../authority/Authority.js";
-import { IdTokenEntity } from "../cache/entities/IdTokenEntity.js";
-import { AccessTokenEntity } from "../cache/entities/AccessTokenEntity.js";
-import { RefreshTokenEntity } from "../cache/entities/RefreshTokenEntity.js";
-import {
-    InteractionRequiredAuthError,
-    isInteractionRequiredError,
-} from "../error/InteractionRequiredAuthError.js";
-import { CacheRecord } from "../cache/entities/CacheRecord.js";
-import { CacheManager } from "../cache/CacheManager.js";
-import * as ProtocolUtils from "../utils/ProtocolUtils.js";
-import * as Constants from "../utils/Constants.js";
-import { PopTokenGenerator } from "../crypto/PopTokenGenerator.js";
-import { AppMetadataEntity } from "../cache/entities/AppMetadataEntity.js";
-import { ICachePlugin } from "../cache/interface/ICachePlugin.js";
-import { TokenCacheContext } from "../cache/persistence/TokenCacheContext.js";
-import { ISerializableTokenCache } from "../cache/interface/ISerializableTokenCache.js";
-import { AuthorizationCodePayload } from "./AuthorizationCodePayload.js";
-import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
+    AccountInfo,
+    buildTenantProfile,
+    updateAccountTenantProfileData,
+} from "../account/AccountInfo.js";
 import {
     checkMaxAge,
     extractTokenClaims,
@@ -42,16 +17,41 @@ import {
     TokenClaims,
     getTenantIdFromIdTokenClaims,
 } from "../account/TokenClaims.js";
-import {
-    AccountInfo,
-    buildTenantProfile,
-    updateAccountTenantProfileData,
-} from "../account/AccountInfo.js";
-import * as CacheHelpers from "../cache/utils/CacheHelpers.js";
-import * as TimeUtils from "../utils/TimeUtils.js";
+import { Authority } from "../authority/Authority.js";
+import { CacheManager } from "../cache/CacheManager.js";
+import { AccessTokenEntity } from "../cache/entities/AccessTokenEntity.js";
+import { AccountEntity } from "../cache/entities/AccountEntity.js";
+import { AppMetadataEntity } from "../cache/entities/AppMetadataEntity.js";
+import { CacheRecord } from "../cache/entities/CacheRecord.js";
+import { IdTokenEntity } from "../cache/entities/IdTokenEntity.js";
+import { RefreshTokenEntity } from "../cache/entities/RefreshTokenEntity.js";
+import { ICachePlugin } from "../cache/interface/ICachePlugin.js";
+import { ISerializableTokenCache } from "../cache/interface/ISerializableTokenCache.js";
+import { TokenCacheContext } from "../cache/persistence/TokenCacheContext.js";
 import * as AccountEntityUtils from "../cache/utils/AccountEntityUtils.js";
+import * as CacheHelpers from "../cache/utils/CacheHelpers.js";
+import { ICrypto } from "../crypto/ICrypto.js";
+import { PopTokenGenerator } from "../crypto/PopTokenGenerator.js";
+import {
+    ClientAuthErrorCodes,
+    createClientAuthError,
+} from "../error/ClientAuthError.js";
+import {
+    InteractionRequiredAuthError,
+    isInteractionRequiredError,
+} from "../error/InteractionRequiredAuthError.js";
+import { ServerError } from "../error/ServerError.js";
+import { Logger } from "../logger/Logger.js";
+import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
+import { ScopeSet } from "../request/ScopeSet.js";
 import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
+import * as Constants from "../utils/Constants.js";
+import * as ProtocolUtils from "../utils/ProtocolUtils.js";
 import { RequestStateObject } from "../utils/StateTypes.js";
+import * as TimeUtils from "../utils/TimeUtils.js";
+import { AuthenticationResult } from "./AuthenticationResult.js";
+import { AuthorizationCodePayload } from "./AuthorizationCodePayload.js";
+import { ServerAuthorizationTokenResponse } from "./ServerAuthorizationTokenResponse.js";
 
 /**
  * Class that handles response parsing.
@@ -648,15 +648,12 @@ export function buildAccountToCache(
     logger?.verbose("setCachedAccount called", correlationId);
 
     // Check if base account is already cached
-    const accountKeys = cacheStorage.getAccountKeys();
-    const baseAccountKey = accountKeys.find((accountKey: string) => {
-        return accountKey.startsWith(homeAccountId);
-    });
-
-    let cachedAccount: AccountEntity | null = null;
-    if (baseAccountKey) {
-        cachedAccount = cacheStorage.getAccount(baseAccountKey, correlationId);
-    }
+    const matchingAccounts = cacheStorage.getAccountsFilteredBy(
+        { homeAccountId },
+        correlationId
+    );
+    const cachedAccount: AccountEntity | null =
+        matchingAccounts.length > 0 ? matchingAccounts[0] : null;
 
     const baseAccount =
         cachedAccount ||

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -649,9 +649,15 @@ export function buildAccountToCache(
 ): AccountEntity {
     logger?.verbose("setCachedAccount called", correlationId);
 
-    // Check if base account is already cached
+    /*
+     * Check if base account is already cached. Filter by homeAccountId (identifies
+     * the user's home identity) and environment (identifies the cloud) — the two
+     * tenant-agnostic properties that uniquely locate a base AccountEntity.
+     */
+    const accountEnvironment =
+        environment || authority.getPreferredCache();
     const matchedAccounts = cacheStorage.getAccountsFilteredBy(
-        { homeAccountId },
+        { homeAccountId, environment: accountEnvironment },
         correlationId
     );
     performanceClient?.addFields(

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -312,6 +312,9 @@ export type PerformanceEvent = {
     accountCachedBy?: string;
     acntLoggedOut?: boolean;
 
+    // Number of cached accounts matched by homeAccountId in buildAccountToCache
+    cacheMatchedAccounts?: number;
+
     // Number of tokens in the cache to be reported when cache quota is exceeded
     cacheRtCount?: number;
     cacheIdCount?: number;
@@ -520,6 +523,7 @@ export const IntFields: ReadonlySet<string> = new Set([
     "currRefreshCount",
     "expiredCacheRemovedCount",
     "upgradedCacheCount",
+    "cacheMatchedAccounts",
     "networkRtt",
     "redirectBridgeTimeoutMs",
     "redirectBridgeMessageVersion",

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -1,5 +1,41 @@
+import { TestTimeUtils } from "msal-test-utils";
+import { AccountInfo } from "../../src/account/AccountInfo.js";
+import * as AuthToken from "../../src/account/AuthToken.js";
+import { TokenClaims } from "../../src/account/TokenClaims.js";
+import { Authority } from "../../src/authority/Authority.js";
+import { AuthorityOptions } from "../../src/authority/AuthorityOptions.js";
+import { ProtocolMode } from "../../src/authority/ProtocolMode.js";
+import { CacheManager } from "../../src/cache/CacheManager.js";
+import * as AccountEntityUtils from "../../src/cache/utils/AccountEntityUtils.js";
+import { ICrypto } from "../../src/crypto/ICrypto.js";
+import {
+    AuthError,
+    getDefaultErrorMessage,
+} from "../../src/error/AuthError.js";
+import { CacheError, CacheErrorCodes } from "../../src/error/CacheError.js";
+import { cacheQuotaExceeded } from "../../src/error/CacheErrorCodes.js";
+import {
+    ClientAuthError,
+    ClientAuthErrorCodes,
+} from "../../src/error/ClientAuthError.js";
+import { InteractionRequiredAuthError } from "../../src/error/InteractionRequiredAuthError.js";
+import { ServerError } from "../../src/error/ServerError.js";
+import { Logger, LogLevel } from "../../src/logger/Logger.js";
+import {
+    INetworkModule,
+    NetworkRequestOptions,
+} from "../../src/network/INetworkModule.js";
+import { BaseAuthRequest } from "../../src/request/BaseAuthRequest.js";
+import { AuthenticationResult } from "../../src/response/AuthenticationResult.js";
+import {
+    buildAccountToCache,
+    ResponseHandler,
+} from "../../src/response/ResponseHandler.js";
 import { ServerAuthorizationTokenResponse } from "../../src/response/ServerAuthorizationTokenResponse.js";
-import { ResponseHandler } from "../../src/response/ResponseHandler.js";
+import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
+import { AuthenticationScheme } from "../../src/utils/Constants.js";
+import * as TimeUtils from "../../src/utils/TimeUtils.js";
+import { mockCrypto, MockStorageClass } from "../client/ClientTestUtils.js";
 import {
     AUTHENTICATION_RESULT,
     ID_TOKEN_CLAIMS,
@@ -11,39 +47,6 @@ import {
     TEST_TOKENS,
     TEST_URIS,
 } from "../test_kit/StringConstants.js";
-import { Authority } from "../../src/authority/Authority.js";
-import {
-    INetworkModule,
-    NetworkRequestOptions,
-} from "../../src/network/INetworkModule.js";
-import { ICrypto } from "../../src/crypto/ICrypto.js";
-import { mockCrypto, MockStorageClass } from "../client/ClientTestUtils.js";
-import { TokenClaims } from "../../src/account/TokenClaims.js";
-import { AccountInfo } from "../../src/account/AccountInfo.js";
-import { AuthenticationResult } from "../../src/response/AuthenticationResult.js";
-import { AuthenticationScheme } from "../../src/utils/Constants.js";
-import { AuthorityOptions } from "../../src/authority/AuthorityOptions.js";
-import { ProtocolMode } from "../../src/authority/ProtocolMode.js";
-import { Logger, LogLevel } from "../../src/logger/Logger.js";
-import * as AuthToken from "../../src/account/AuthToken.js";
-import { BaseAuthRequest } from "../../src/request/BaseAuthRequest.js";
-import * as TimeUtils from "../../src/utils/TimeUtils.js";
-import {
-    AuthError,
-    getDefaultErrorMessage,
-} from "../../src/error/AuthError.js";
-import {
-    ClientAuthError,
-    ClientAuthErrorCodes,
-} from "../../src/error/ClientAuthError.js";
-import { InteractionRequiredAuthError } from "../../src/error/InteractionRequiredAuthError.js";
-import { ServerError } from "../../src/error/ServerError.js";
-import { CacheError, CacheErrorCodes } from "../../src/error/CacheError.js";
-import { CacheManager } from "../../src/cache/CacheManager.js";
-import { cacheQuotaExceeded } from "../../src/error/CacheErrorCodes.js";
-import { TestTimeUtils } from "msal-test-utils";
-import * as AccountEntityUtils from "../../src/cache/utils/AccountEntityUtils.js";
-import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 
 const networkInterface: INetworkModule = {
     sendGetRequestAsync<T>(url: string, options?: NetworkRequestOptions): T {
@@ -1211,6 +1214,106 @@ describe("ResponseHandler.ts", () => {
                     getDefaultErrorMessage(CacheErrorCodes.cacheErrorUnknown)
                 );
             }
+        });
+    });
+
+    describe("buildAccountToCache", () => {
+        it("reuses cached account when cache keys have a prefix not starting with homeAccountId", () => {
+            const homeAccountId =
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID;
+            const homeTenantId = homeAccountId.split(".")[1];
+            const environment = "login.windows.net";
+
+            // Create an AccountEntity already in cache with a home tenant profile
+            const existingAccount = AccountEntityUtils.createAccountEntity(
+                {
+                    homeAccountId,
+                    idTokenClaims: {
+                        ...testIdTokenClaims,
+                        tid: homeTenantId,
+                    },
+                    environment,
+                },
+                testAuthority,
+                mockCrypto.base64Decode
+            );
+            existingAccount.tenantProfiles = [
+                {
+                    tenantId: homeTenantId,
+                    localAccountId: existingAccount.localAccountId,
+                    isHomeTenant: true,
+                    username: testIdTokenClaims.preferred_username || "",
+                },
+            ];
+
+            // Simulate a cache key with a prefix (like msal-browser's "msal.2|" prefix)
+            const prefixedKey = `msal.2|${homeAccountId}|${environment}|${homeTenantId}`;
+
+            // Override getAccountKeys and getAccount to use prefixed keys
+            jest.spyOn(testCacheManager, "getAccountKeys").mockReturnValue([
+                prefixedKey,
+            ]);
+            jest.spyOn(testCacheManager, "getAccount").mockImplementation(
+                (key: string) => {
+                    if (key === prefixedKey) {
+                        return existingAccount;
+                    }
+                    return null;
+                }
+            );
+
+            const guestTenantId = "guest-tenant-id";
+            const result = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                homeAccountId,
+                mockCrypto.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                {
+                    ...testIdTokenClaims,
+                    tid: guestTenantId,
+                },
+                undefined, // clientInfo
+                environment,
+                guestTenantId
+            );
+
+            // Should preserve the existing home tenant profile and add guest
+            expect(result.tenantProfiles).toHaveLength(2);
+            expect(
+                result.tenantProfiles?.find(
+                    (tp) => tp.tenantId === homeTenantId
+                )
+            ).toBeDefined();
+            expect(
+                result.tenantProfiles?.find(
+                    (tp) => tp.tenantId === guestTenantId
+                )
+            ).toBeDefined();
+        });
+
+        it("creates new account when no cached account matches homeAccountId", () => {
+            jest.spyOn(testCacheManager, "getAccountKeys").mockReturnValue([]);
+
+            const homeAccountId =
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID;
+            const tenantId = testIdTokenClaims.tid || "";
+
+            const result = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                homeAccountId,
+                mockCrypto.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                testIdTokenClaims,
+                undefined,
+                "login.windows.net",
+                tenantId
+            );
+
+            expect(result.homeAccountId).toEqual(homeAccountId);
+            expect(result.tenantProfiles).toHaveLength(1);
+            expect(result.tenantProfiles?.[0].tenantId).toEqual(tenantId);
         });
     });
 });

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -118,7 +118,8 @@ const testCacheManager = new MockStorageClass(
     TEST_CONFIG.MSAL_CLIENT_ID,
     cryptoInterface,
     logger,
-    new StubPerformanceClient()
+    new StubPerformanceClient(),
+    { canonicalAuthority: TEST_CONFIG.validAuthority }
 );
 
 const testAuthority = new Authority(
@@ -1314,6 +1315,186 @@ describe("ResponseHandler.ts", () => {
             expect(result.homeAccountId).toEqual(homeAccountId);
             expect(result.tenantProfiles).toHaveLength(1);
             expect(result.tenantProfiles?.[0].tenantId).toEqual(tenantId);
+        });
+
+        it("does not add duplicate tenant profile if tenant already exists in cache", () => {
+            const homeAccountId =
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID;
+            const tenantId = testIdTokenClaims.tid || "";
+            const environment = "login.windows.net";
+
+            const existingAccount = AccountEntityUtils.createAccountEntity(
+                {
+                    homeAccountId,
+                    idTokenClaims: {
+                        ...testIdTokenClaims,
+                        tid: tenantId,
+                    },
+                    environment,
+                },
+                testAuthority,
+                mockCrypto.base64Decode
+            );
+            existingAccount.tenantProfiles = [
+                {
+                    tenantId,
+                    localAccountId: existingAccount.localAccountId,
+                    isHomeTenant: true,
+                    username: testIdTokenClaims.preferred_username || "",
+                },
+            ];
+
+            jest.spyOn(
+                testCacheManager,
+                "getAccountsFilteredBy"
+            ).mockReturnValue([existingAccount]);
+
+            const result = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                homeAccountId,
+                mockCrypto.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                testIdTokenClaims,
+                undefined,
+                environment,
+                tenantId
+            );
+
+            expect(result.tenantProfiles).toHaveLength(1);
+            expect(result.tenantProfiles?.[0].tenantId).toEqual(tenantId);
+        });
+
+        it("falls back to new account and logs warning when multiple accounts match homeAccountId", () => {
+            const homeAccountId =
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID;
+            const environment = "login.windows.net";
+
+            const account1 = AccountEntityUtils.createAccountEntity(
+                {
+                    homeAccountId,
+                    idTokenClaims: testIdTokenClaims,
+                    environment,
+                },
+                testAuthority,
+                mockCrypto.base64Decode
+            );
+            const account2 = AccountEntityUtils.createAccountEntity(
+                {
+                    homeAccountId,
+                    idTokenClaims: testIdTokenClaims,
+                    environment,
+                },
+                testAuthority,
+                mockCrypto.base64Decode
+            );
+
+            jest.spyOn(
+                testCacheManager,
+                "getAccountsFilteredBy"
+            ).mockReturnValue([account1, account2]);
+
+            const warningSpy = jest.spyOn(Logger.prototype, "warning");
+
+            const tenantId = testIdTokenClaims.tid || "";
+            const result = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                homeAccountId,
+                mockCrypto.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                testIdTokenClaims,
+                undefined,
+                environment,
+                tenantId,
+                undefined,
+                undefined,
+                logger
+            );
+
+            expect(result.tenantProfiles).toHaveLength(1);
+            expect(warningSpy).toHaveBeenCalledWith(
+                expect.stringContaining("Multiple base accounts"),
+                expect.any(String)
+            );
+        });
+
+        it("uses account matching authority environment when multiple environments present in cache", () => {
+            const homeAccountId =
+                TEST_DATA_CLIENT_INFO.TEST_ENCODED_HOME_ACCOUNT_ID;
+
+            const accountWindows = AccountEntityUtils.createAccountEntity(
+                {
+                    homeAccountId,
+                    idTokenClaims: testIdTokenClaims,
+                    environment: "login.windows.net",
+                },
+                testAuthority,
+                mockCrypto.base64Decode
+            );
+            accountWindows.tenantProfiles = [
+                {
+                    tenantId: testIdTokenClaims.tid || "",
+                    localAccountId: accountWindows.localAccountId,
+                    isHomeTenant: true,
+                    username: testIdTokenClaims.preferred_username || "",
+                },
+            ];
+
+            const accountOther = AccountEntityUtils.createAccountEntity(
+                {
+                    homeAccountId,
+                    idTokenClaims: testIdTokenClaims,
+                    environment: "login.other-cloud.example",
+                },
+                testAuthority,
+                mockCrypto.base64Decode
+            );
+
+            const keyWindows = `${homeAccountId}-login.windows.net-${testIdTokenClaims.tid}`;
+            const keyOther = `${homeAccountId}-login.other-cloud.example-${testIdTokenClaims.tid}`;
+
+            jest.spyOn(testCacheManager, "getAccountKeys").mockReturnValue([
+                keyWindows,
+                keyOther,
+            ]);
+            jest.spyOn(testCacheManager, "getAccount").mockImplementation(
+                (key: string) => {
+                    if (key === keyWindows) return accountWindows;
+                    if (key === keyOther) return accountOther;
+                    return null;
+                }
+            );
+
+            const guestTenantId = "guest-tenant-id";
+            const result = buildAccountToCache(
+                testCacheManager,
+                testAuthority,
+                homeAccountId,
+                mockCrypto.base64Decode,
+                TEST_CONFIG.CORRELATION_ID,
+                {
+                    ...testIdTokenClaims,
+                    tid: guestTenantId,
+                },
+                undefined,
+                undefined, // no explicit environment; uses getPreferredCache() = "login.microsoftonline.com"
+                guestTenantId
+            );
+
+            // accountWindows should be matched via alias; accountOther should not match
+            expect(result.environment).toEqual("login.windows.net");
+            expect(result.tenantProfiles).toHaveLength(2);
+            expect(
+                result.tenantProfiles?.find(
+                    (tp) => tp.tenantId === testIdTokenClaims.tid
+                )
+            ).toBeDefined();
+            expect(
+                result.tenantProfiles?.find(
+                    (tp) => tp.tenantId === guestTenantId
+                )
+            ).toBeDefined();
         });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -314,6 +314,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -754,6 +755,7 @@
             "integrity": "sha512-vdMJX9E7wePN41T+6BYRQBA+XiR9a5DBhs20dqtv8YVireQktH6mxLZIg1pVxkL/gnao2gpl/lOvp0xmC7UN/Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.26.9",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -827,6 +829,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -1015,7 +1018,8 @@
             "version": "12.20.55",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
             "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "lib/msal-angular/node_modules/ajv": {
             "version": "8.18.0",
@@ -1141,6 +1145,7 @@
             "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-19.2.2.tgz",
             "integrity": "sha512-dFuwFsDJMBSd1YtmLLcX5bNNUCQUlRqgf34aXA+79PmkOP+0eF8GP2949wq3+jMjmFTNm80Oo8IUYiSLwklKCQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/wasm-node": "^4.24.0",
@@ -1227,6 +1232,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -1366,6 +1372,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -1380,6 +1387,7 @@
             "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -1524,6 +1532,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
             "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -2391,6 +2400,7 @@
             "integrity": "sha512-XGChk+26XZpcwzIQUVjgLxGVC//m5TaDrogseQNIGs2Chzv6KYbo91HftL69fTiM5udRYjg6IV7XEzDNF/GVUw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2454,6 +2464,7 @@
             "integrity": "sha512-/JYo8jJZ6BAgw3IVYJpinAfGb+RbaZubrElFvaq450BWxDPInv7Z99HKEQ3qEBRsBeIAQ/WrKXDxoJSjy7QMNQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2471,6 +2482,7 @@
             "integrity": "sha512-kWlqFW7ExvAqKv+X/6ZsWVW7YTmI1/3VUvADLC/6bkLTdKrHS8OtBHfsklXmHMNVbbFopTvoTeKkoqLGrW2lwg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2484,6 +2496,7 @@
             "integrity": "sha512-VZAzpxBoQgyy7AOlhxbAHxPQWo0nk8xsnrD36PLCZeTZA/5GNzO3lLVaX2N5BCUgpgiCBjNBKq9kVo6ZkAls9g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2520,6 +2533,7 @@
             "integrity": "sha512-bnQSmoJNI1LQxJnHnB01XQXqgOdgAtLAOsa24ZT6b2pWV3Vw0/7+V2dZsNZX/TJtejunvSgSDCEqgJhIQ5vBVg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2580,7 +2594,6 @@
             "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
             "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@jsdevtools/ono": "^7.1.3",
                 "@types/json-schema": "^7.0.15",
@@ -2598,7 +2611,6 @@
             "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
             "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -2607,15 +2619,13 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
             "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@apidevtools/swagger-parser": {
             "version": "10.1.1",
             "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
             "integrity": "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "11.7.2",
                 "@apidevtools/openapi-schemas": "^2.1.0",
@@ -2652,7 +2662,6 @@
             "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
             "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "dev": true,
-            "peer": true,
             "peerDependencies": {
                 "ajv": "^8.5.0"
             },
@@ -2678,7 +2687,6 @@
             "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-13.0.3.tgz",
             "integrity": "sha512-Vu011o3/bikQNwtjouwmUJud+Z6Brcjij2D0omPWClRGg8i5gBfOYSpDkFGkHbhGlaky4fgvfkxD0uHGq34uYA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -2697,7 +2705,6 @@
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -2710,7 +2717,6 @@
             "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-5.0.1.tgz",
             "integrity": "sha512-JbZtIqfEulsIA0rC3zM7jfF4KkOnye9aKcaO/jJqxJRm/gM6lAjEv7sL4njW8D+35l50P1f+UuH5OqN+UKJqNA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -2729,7 +2735,6 @@
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -2742,7 +2747,6 @@
             "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-17.2.1.tgz",
             "integrity": "sha512-J2jmTPv8ZraSHDTz9l2Bx8gNL3ktfDDWo2mxWfzarn64O9Fjhb+l85YWyubGy2xUdeGuZPKzvQLltGv8bSu8eQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -2761,7 +2765,6 @@
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -2774,7 +2777,6 @@
             "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-5.1.0.tgz",
             "integrity": "sha512-6BeOF2eQWNLq22ch7xP9RxYnPjtGev54OUCGggKOWoOvmesK7jUZbIyLk8JeXDT21PEl7iyYnxw78gxJ7zBxQw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -2793,7 +2795,6 @@
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -3117,6 +3118,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -7560,6 +7562,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -7608,15 +7611,13 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
             "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@feathersjs/hooks": {
             "version": "0.6.5",
             "resolved": "https://registry.npmjs.org/@feathersjs/hooks/-/hooks-0.6.5.tgz",
             "integrity": "sha512-WtcEoG/imdHRvC3vofGi/OcgH+cjHHhO0AfEeTlsnrKLjVKKBXV6aoIrB2nHZPpE7iW5sA7AZMR6bPD8ytxN+w==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -8417,6 +8418,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
             "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.1.2",
                 "@inquirer/confirm": "^5.1.6",
@@ -9228,8 +9230,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
             "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@jsonjoy.com/base64": {
             "version": "1.1.2",
@@ -9608,7 +9609,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/app-manifest/-/app-manifest-1.0.1.tgz",
             "integrity": "sha512-W4fw8JX/9CPATwNAi9dc25rCK/b3qSnoClVDzGfbYuy6ewY9FHgkwk/C1NzC8k/YwZAsKwMhHOvXUCt3u9ak3Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/fs-extra": "^11.0.1",
                 "@types/node-fetch": "^2.6.9",
@@ -9623,7 +9623,6 @@
             "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
             "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/jsonfile": "*",
                 "@types/node": "*"
@@ -9652,7 +9651,6 @@
             "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
             "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "dev": true,
-            "peer": true,
             "peerDependencies": {
                 "ajv": "^8.5.0"
             },
@@ -9667,7 +9665,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-contracts/-/dev-tunnels-contracts-1.1.9.tgz",
             "integrity": "sha512-OayhehwI+CnO0Wr53e29ZJZWGsNA5yVG7r54qmZSLc5HxA5Cozk4hP7EbYDCXkxh4NbQoT1dhTzC8bkRo+wWXw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "buffer": "^5.2.1",
                 "debug": "^4.1.1",
@@ -9679,7 +9676,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -9697,7 +9693,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-management/-/dev-tunnels-management-1.1.9.tgz",
             "integrity": "sha512-wGuFEzvRiWZmDxQMGKEjOKhEIVnLiG6vRUuM9Hwqxpe/kbiyA2WiUyEVpniNPaaw8gDHTf9zJHnPNNj0JiL5mA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@microsoft/dev-tunnels-contracts": ">1.1.8",
                 "axios": "^1.6.2",
@@ -9711,7 +9706,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -9729,7 +9723,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/m365-spec-parser/-/m365-spec-parser-0.2.8.tgz",
             "integrity": "sha512-G26jdZo6TQNEwpsY95p96RWLtuqzGhrqPFacKJgtODlWmYGj63InMvSdwTDNlZ610SdA9nZUqvULFWmDE/VNqg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@apidevtools/swagger-parser": "^10.1.1",
                 "@microsoft/app-manifest": "1.0.1",
@@ -9747,7 +9740,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
             "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -9788,6 +9780,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -9834,7 +9827,6 @@
             "integrity": "sha512-AowuJwrrUxeF9Bq/frxuy9YZjK/ECk3pi0UBXl3CQLZ4XNWfgWatiFi/UWpyHDLccFs+0Za3nNYATFvgsxEFwQ==",
             "dev": true,
             "hasInstallScript": true,
-            "peer": true,
             "dependencies": {
                 "@azure/arm-subscriptions": "^5.0.0",
                 "@azure/core-auth": "^1.4.0",
@@ -9877,7 +9869,6 @@
             "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.0.tgz",
             "integrity": "sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -9887,7 +9878,6 @@
             "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.2.tgz",
             "integrity": "sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/msal-common": "14.16.0",
                 "jsonwebtoken": "^9.0.0",
@@ -9902,7 +9892,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.5.2.tgz",
             "integrity": "sha512-CifrkgQjDkUkWexmgYYNyB5603HhTHI91vLFeQXh6qrTKiCMVASol01Rs1cv6LP/A2WccZSRlJKZhbaBIs/9ZA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -9919,7 +9908,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -9945,7 +9933,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.17.tgz",
             "integrity": "sha512-EqzhGryzmGpy2aJf6LxJVhndxYmFs+m8cxXzf8nejb1DE3sabf6mUgBcp4J0jAUEiAcYzqmkqRr7LPFh/WdnXA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -9960,7 +9947,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -9986,7 +9972,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.1.2.tgz",
             "integrity": "sha512-w3PMZH5rahrukn8/I7P9Ihil+twgLTUHDZtJlJyBbUKyPaOSSQjLZkb0PpncVhin1gCaMgOFXy6iNPgcZUoo2w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10012,7 +9997,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-1.2.15.tgz",
             "integrity": "sha512-gQ77Ls09x5vKLVNMH9q/7xvYPT6sIs5f7URksw+a2iJZ0j48tVS6crLqm2ugG33tgXHIwiEqkytY60Zyh5GkJQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10028,7 +10012,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10054,7 +10037,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-1.1.16.tgz",
             "integrity": "sha512-TGLU9egcuo+s7PxphKUCnJnpCIVY32/EwPCLLuu+gTvYiD8hZgx8Z2niNQD36sa6xcfpdLY6xXDBiL/+g1r2XQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10070,7 +10052,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10096,7 +10077,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.16.tgz",
             "integrity": "sha512-Ou0LaSWvj1ni+egnyQ+NBtfM1885UwhRCMtsRt2bBO47DoC1dwtCa+ZUNgrxlnCHHF0IXsbQHYtIIjFGAavI4g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10111,7 +10091,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10137,7 +10116,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-1.1.16.tgz",
             "integrity": "sha512-aZYZVHLUXZ2gbBot+i+zOJrks1WaiI95lvZCn1sKfcw6MtSSlYC8uDX8sTzQvAsQ8epHoP84UNvAIT0KVGOGqw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10153,7 +10131,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10179,7 +10156,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-3.3.2.tgz",
             "integrity": "sha512-k52mOMRvTUejrqyF1h8Z07chC+sbaoaUYzzr1KrJXyj7yaX7Nrh0a9vktv8TuocRwIJOQMaj5oZEmkspEcJFYQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^1.5.2",
                 "@inquirer/confirm": "^2.0.17",
@@ -10200,7 +10176,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10226,7 +10201,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-1.2.16.tgz",
             "integrity": "sha512-pZ6TRg2qMwZAOZAV6TvghCtkr53dGnK29GMNQ3vMZXSNguvGqtOVc4j/h1T8kqGJFagjyfBZhUPGwNS55O5qPQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10241,7 +10215,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10267,7 +10240,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.3.3.tgz",
             "integrity": "sha512-RzlRISXWqIKEf83FDC9ZtJ3JvuK1l7aGpretf41BCWYrvla2wU8W8MTRNMiPrPJ+1SIqrRC1nZdZ60hD9hRXLg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^6.0.0",
                 "@inquirer/type": "^1.1.6",
@@ -10284,7 +10256,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
             "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@inquirer/type": "^1.1.6",
                 "@types/mute-stream": "^0.0.4",
@@ -10310,7 +10281,6 @@
             "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
             "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "mute-stream": "^1.0.0"
             },
@@ -10323,7 +10293,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
             "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -10333,7 +10302,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
             "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
@@ -10349,7 +10317,6 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
             "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -10359,7 +10326,6 @@
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
             "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -10369,7 +10335,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/teamsfx-api/-/teamsfx-api-0.23.1.tgz",
             "integrity": "sha512-XmXX2dccOEU3lbYgOlijfwxmkXp6nO88JWx9P1al/1aMgbIeup2Y2H37Vmz2VwfIQC/i75FbbbbwqYjG2skQjQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/core-auth": "^1.4.0",
                 "@microsoft/teams-manifest": "0.1.5",
@@ -10385,7 +10350,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/teamsfx-core/-/teamsfx-core-2.0.9.tgz",
             "integrity": "sha512-6zA/vvpHViROP6eDbnjS8PtPyyB4eZGH/cgTiOHeiRHznT9Pkd3rqFvaIHPEDhv2g76llHEk2gTFSqL7QFovAQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@apidevtools/swagger-parser": "^10.1.0",
                 "@azure/arm-appservice": "^13.0.0",
@@ -10445,7 +10409,6 @@
             "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.0.tgz",
             "integrity": "sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -10455,7 +10418,6 @@
             "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.2.tgz",
             "integrity": "sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@azure/msal-common": "14.16.0",
                 "jsonwebtoken": "^9.0.0",
@@ -10471,7 +10433,6 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -10488,7 +10449,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
             "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
@@ -10504,7 +10464,6 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -10516,8 +10475,7 @@
             "version": "0.1.14",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
             "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@microsoft/tsdoc": {
             "version": "0.16.0",
@@ -11083,6 +11041,7 @@
             "version": "5.17.1",
             "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.17.1.tgz",
             "integrity": "sha512-2B33kQf+GmPnrvXXweWAx+crbiUEsxCdCN979QDYnlH9ox4pd+0/IBriWLV+l6ORoBF60w39cWjFnJYGFdzXcw==",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@mui/core-downloads-tracker": "^5.17.1",
@@ -12120,6 +12079,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
             "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^2.4.4",
                 "@octokit/graphql": "^4.5.8",
@@ -12261,6 +12221,7 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
             "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "dependencies": {
@@ -12299,11 +12260,11 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12319,11 +12280,11 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12339,11 +12300,11 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12359,11 +12320,11 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12379,11 +12340,11 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12399,11 +12360,11 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12419,11 +12380,11 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12439,11 +12400,11 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12459,11 +12420,11 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12479,11 +12440,11 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12499,11 +12460,11 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12519,11 +12480,11 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12539,11 +12500,11 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -12556,6 +12517,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "dev": true,
             "optional": true,
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
@@ -12568,6 +12530,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
             "optional": true
         },
         "node_modules/@pkgjs/parseargs": {
@@ -12617,6 +12580,7 @@
             "version": "2.11.8",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -12626,7 +12590,6 @@
             "version": "2.10.5",
             "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
             "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
-            "peer": true,
             "dependencies": {
                 "debug": "^4.4.1",
                 "extract-zip": "^2.0.1",
@@ -12647,7 +12610,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -12665,7 +12627,6 @@
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
             "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
@@ -12679,7 +12640,6 @@
             "version": "3.1.7",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
             "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-            "peer": true,
             "dependencies": {
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
@@ -12712,6 +12672,7 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
             "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2",
                 "generic-pool": "3.9.0",
@@ -13593,6 +13554,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -14276,8 +14238,7 @@
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "peer": true
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.11",
@@ -14367,8 +14328,7 @@
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -14478,6 +14438,7 @@
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -14738,7 +14699,6 @@
             "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
             "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -14747,6 +14707,7 @@
             "version": "22.15.29",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
             "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -14883,8 +14844,7 @@
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
             "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/@types/semver": {
             "version": "7.7.0",
@@ -14964,8 +14924,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
             "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/ws": {
             "version": "8.18.1",
@@ -14994,7 +14953,6 @@
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
             "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -15055,6 +15013,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -15869,6 +15828,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -15924,7 +15884,6 @@
             "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
             "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             }
@@ -16004,6 +15963,7 @@
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -16269,8 +16229,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
             "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -16409,7 +16368,6 @@
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
             "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -16418,7 +16376,6 @@
             "version": "0.13.4",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.1"
             },
@@ -16491,7 +16448,6 @@
             "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
             "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -16576,7 +16532,6 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
             "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -16588,7 +16543,6 @@
             "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
             "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.15.4",
                 "is-retry-allowed": "^2.2.0"
@@ -16601,8 +16555,7 @@
         "node_modules/b4a": {
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-            "peer": true
+            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg=="
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
@@ -16940,15 +16893,13 @@
             "version": "2.5.4",
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
             "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/bare-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
             "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "bare-events": "^2.5.4",
                 "bare-path": "^3.0.0",
@@ -16971,7 +16922,6 @@
             "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
             "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
             "optional": true,
-            "peer": true,
             "engines": {
                 "bare": ">=1.14.0"
             }
@@ -16981,7 +16931,6 @@
             "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
             "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "bare-os": "^3.0.1"
             }
@@ -16991,7 +16940,6 @@
             "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
             "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "streamx": "^2.21.0"
             },
@@ -17075,7 +17023,6 @@
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
             "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -17367,6 +17314,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -17659,8 +17607,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
             "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -17713,7 +17660,6 @@
             "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
             "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "assertion-error": "^1.1.0",
                 "check-error": "^1.0.3",
@@ -17732,7 +17678,6 @@
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
             "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -17782,7 +17727,6 @@
             "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
             "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -17792,7 +17736,6 @@
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
             "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "get-func-name": "^2.0.2"
             },
@@ -17805,6 +17748,7 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
             "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "readdirp": "^4.0.1"
             },
@@ -17837,7 +17781,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
             "integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
-            "peer": true,
             "dependencies": {
                 "mitt": "^3.0.1",
                 "zod": "^3.24.1"
@@ -17932,7 +17875,6 @@
             "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
             "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "string-width": "^4.2.0"
             },
@@ -17947,15 +17889,13 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -17965,7 +17905,6 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -18220,7 +18159,6 @@
             "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
             "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "array-timsort": "^1.0.3",
                 "core-util-is": "^1.0.3",
@@ -18838,7 +18776,6 @@
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -18847,8 +18784,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/cryptr/-/cryptr-6.3.0.tgz",
             "integrity": "sha512-TA4byAuorT8qooU9H8YJhBwnqD151i1rcauHfJ3Divg6HmukHB2AYMp0hmjv2873J2alr4t15QqC7zAnWFrtfQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/css-loader": {
             "version": "6.11.0",
@@ -19037,7 +18973,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
             "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -19184,7 +19119,6 @@
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
             "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "type-detect": "^4.0.0"
             },
@@ -19322,7 +19256,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
             "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-            "peer": true,
             "dependencies": {
                 "ast-types": "^0.13.4",
                 "escodegen": "^2.1.0",
@@ -19407,7 +19340,6 @@
             "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
             "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "address": "^1.0.1",
                 "debug": "4"
@@ -19425,7 +19357,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -20506,6 +20437,7 @@
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -20611,7 +20543,6 @@
             "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "prr": "~1.0.1"
             },
@@ -20810,8 +20741,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
             "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/esbuild": {
             "version": "0.25.4",
@@ -20932,6 +20862,7 @@
             "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.3",
@@ -21787,6 +21718,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
             "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
@@ -21900,6 +21832,7 @@
             "version": "1.18.2",
             "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
             "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+            "peer": true,
             "dependencies": {
                 "cookie": "0.7.2",
                 "cookie-signature": "1.0.7",
@@ -22050,8 +21983,7 @@
         "node_modules/fast-fifo": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-            "peer": true
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -22096,8 +22028,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.0.6",
@@ -22925,7 +22856,6 @@
             "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
             "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -23089,7 +23019,6 @@
             "version": "6.0.4",
             "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
             "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
-            "peer": true,
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
@@ -23103,7 +23032,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -23485,7 +23413,6 @@
             "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
             "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -23634,6 +23561,7 @@
             "integrity": "sha512-ooiZW1Xy8rQ4oELQ++otI2T9DsKpV0M6c6cO6JGx4RTfav9poFFLlet9UMXHZnoM1yG0HWGlQLswBGX3RZmHtg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -24047,8 +23975,7 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
             "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
@@ -24227,7 +24154,6 @@
             "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "bin": {
                 "image-size": "bin/image-size.js"
             },
@@ -24601,8 +24527,7 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/is-bun-module": {
             "version": "2.0.0",
@@ -24690,7 +24615,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -24752,7 +24677,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -24928,7 +24853,6 @@
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
             "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -25293,7 +25217,8 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.0.1.tgz",
             "integrity": "sha512-w+JDABxQCkxbGGxg+a2hUVZyqUS2JKngvIyLGu/xiw2ZwgsoSB0iiecLQsQORSeaKQ6iGrCyWG86RfNDuoA7Lg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/jasmine-spec-reporter": {
             "version": "5.0.2",
@@ -25308,6 +25233,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -25609,6 +25535,7 @@
             "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
             "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -26153,6 +26080,7 @@
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -26175,8 +26103,7 @@
             "version": "3.7.7",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
             "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -26424,7 +26351,6 @@
             "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
             "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -26622,6 +26548,7 @@
             "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@colors/colors": "1.5.0",
                 "body-parser": "^1.19.0",
@@ -27051,7 +26978,6 @@
             "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
             "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.9"
             }
@@ -27088,6 +27014,7 @@
             "resolved": "https://registry.npmjs.org/less/-/less-4.2.2.tgz",
             "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
                 "parse-node-version": "^1.0.1",
@@ -27141,7 +27068,6 @@
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -27155,7 +27081,6 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -27686,7 +27611,6 @@
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
             "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "get-func-name": "^2.0.1"
             }
@@ -27753,7 +27677,6 @@
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -27957,7 +27880,6 @@
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
             "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "charenc": "0.0.2",
                 "crypt": "0.0.2",
@@ -28280,8 +28202,7 @@
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "peer": true
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
         },
         "node_modules/mkcert": {
             "version": "3.2.0",
@@ -28512,7 +28433,6 @@
             "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
             "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "mustache": "bin/mustache"
             }
@@ -28580,7 +28500,6 @@
             "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "sax": "^1.2.4"
@@ -28598,7 +28517,6 @@
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -28623,7 +28541,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-            "peer": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -28632,8 +28549,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-3.2.0.tgz",
             "integrity": "sha512-AINA32QbYO83L+3CBI6I5lH4LpBSlLwWteJ+uI25s4AQy6g/xz3RZuedmuNo91lLw2rY+AbPEPQdxd7mg1rXoQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/next": {
             "version": "15.5.12",
@@ -28799,7 +28715,6 @@
             "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
             "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "http2-client": "^1.2.5"
             },
@@ -29242,15 +29157,13 @@
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
             "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/node-readfiles": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
             "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "es6-promise": "^3.2.1"
             }
@@ -30034,7 +29947,6 @@
             "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
             "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-safe-stringify": "^2.0.7"
             }
@@ -30044,7 +29956,6 @@
             "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
             "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@exodus/schemasafe": "^1.0.0-rc.2",
                 "should": "^13.2.1",
@@ -30059,7 +29970,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -30069,7 +29979,6 @@
             "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
             "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "node-fetch-h2": "^2.3.0",
                 "oas-kit-common": "^1.0.8",
@@ -30089,7 +29998,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -30099,7 +30007,6 @@
             "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
             "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "url": "https://github.com/Mermade/oas-kit?sponsor=1"
             }
@@ -30109,7 +30016,6 @@
             "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
             "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "call-me-maybe": "^1.0.1",
                 "oas-kit-common": "^1.0.8",
@@ -30129,7 +30035,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -30510,6 +30415,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
             "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.33.1",
                 "@typescript-eslint/types": "8.33.1",
@@ -30719,6 +30625,7 @@
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -30841,6 +30748,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
             "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.18.0",
                 "@typescript-eslint/types": "7.18.0",
@@ -31114,6 +31022,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
             "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -31129,6 +31038,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -31185,7 +31095,6 @@
             "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.4.1.tgz",
             "integrity": "sha512-2eOdCCYJ5bhCe2p9KKETdg1UNshsKaT0lDU/jNopAg3t7zC1WxwvofTSO/+4Log5L4Re+wUdV8MqrQikZBa7+Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@xmldom/xmldom": "^0.8.5",
                 "commander": "^9.0.0",
@@ -31200,7 +31109,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
             "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
             }
@@ -31352,7 +31260,6 @@
             "resolved": "https://registry.npmjs.org/office-addin-project/-/office-addin-project-0.8.6.tgz",
             "integrity": "sha512-S93brHVDaMRZIIEibK12m6eTItoKqdy2Ep51qNhU7RaZTjH7n/C66AzdDai06UJb3I3AXfXHnKv/AJL2voGGWA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "adm-zip": "0.5.12",
                 "commander": "^6.2.1",
@@ -31372,7 +31279,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
             "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -31382,7 +31288,6 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -31397,7 +31302,6 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
-            "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -31407,7 +31311,6 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -31780,7 +31683,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
             "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-            "peer": true,
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
                 "agent-base": "^7.1.2",
@@ -31799,7 +31701,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -31816,7 +31717,6 @@
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -31830,7 +31730,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
             "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-            "peer": true,
             "dependencies": {
                 "degenerator": "^5.0.0",
                 "netmask": "^2.0.2"
@@ -32348,7 +32247,6 @@
             "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
             "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -32532,6 +32430,7 @@
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
             "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -32543,6 +32442,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -32602,6 +32502,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -32868,6 +32769,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
             "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -32905,7 +32807,6 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -32920,7 +32821,6 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -32932,8 +32832,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/proc-log": {
             "version": "2.0.1",
@@ -33034,7 +32933,6 @@
             "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
             "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "retry": "^0.12.0",
@@ -33045,8 +32943,7 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/protocols": {
             "version": "2.0.2",
@@ -33071,7 +32968,6 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
             "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -33090,7 +32986,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -33107,7 +33002,6 @@
             "version": "7.18.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
             "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -33116,7 +33010,6 @@
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -33136,8 +33029,7 @@
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/psl": {
             "version": "1.15.0",
@@ -33205,7 +33097,6 @@
             "version": "24.10.0",
             "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.10.0.tgz",
             "integrity": "sha512-xX0QJRc8t19iAwRDsAOR38Q/Zx/W6WVzJCEhKCAwp2XMsaWqfNtQ+rBfQW9PlF+Op24d7c8Zlgq9YNmbnA7hdQ==",
-            "peer": true,
             "dependencies": {
                 "@puppeteer/browsers": "2.10.5",
                 "chromium-bidi": "5.1.0",
@@ -33222,7 +33113,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -33239,7 +33129,6 @@
             "version": "8.18.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
             "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -33445,6 +33334,7 @@
             "version": "19.2.1",
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
             "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -33483,6 +33373,7 @@
             "version": "19.2.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
             "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -33931,7 +33822,6 @@
             "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
             "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
             "dev": true,
-            "peer": true,
             "funding": {
                 "url": "https://github.com/Mermade/oas-kit?sponsor=1"
             }
@@ -34151,7 +34041,6 @@
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -34659,6 +34548,7 @@
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -34887,6 +34777,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -35291,7 +35182,6 @@
             "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
             "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "should-equal": "^2.0.0",
                 "should-format": "^3.0.3",
@@ -35305,7 +35195,6 @@
             "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
             "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "should-type": "^1.4.0"
             }
@@ -35315,7 +35204,6 @@
             "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
             "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "should-type": "^1.3.0",
                 "should-type-adaptors": "^1.0.1"
@@ -35325,15 +35213,13 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
             "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/should-type-adaptors": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
             "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "should-type": "^1.3.0",
                 "should-util": "^1.0.0"
@@ -35343,8 +35229,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
             "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/shx": {
             "version": "0.3.4",
@@ -36086,7 +35971,6 @@
             "version": "2.22.1",
             "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
             "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
-            "peer": true,
             "dependencies": {
                 "fast-fifo": "^1.3.2",
                 "text-decoder": "^1.1.0"
@@ -36521,7 +36405,6 @@
             "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
             "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "call-me-maybe": "^1.0.1",
                 "node-fetch": "^2.6.1",
@@ -36549,7 +36432,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -36871,7 +36753,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
             "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-            "peer": true,
             "dependencies": {
                 "b4a": "^1.6.4"
             }
@@ -37174,6 +37055,7 @@
             "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "bs-logger": "^0.2.6",
                 "fast-json-stable-stringify": "^2.1.0",
@@ -37276,6 +37158,7 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
             "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "arg": "^4.1.0",
                 "diff": "^4.0.1",
@@ -37332,7 +37215,8 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "peer": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -37797,15 +37681,13 @@
         "node_modules/typed-query-selector": {
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
-            "peer": true
+            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
         },
         "node_modules/typedi": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/typedi/-/typedi-0.10.0.tgz",
             "integrity": "sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/typedoc": {
             "version": "0.24.8",
@@ -37857,6 +37739,7 @@
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -38028,8 +37911,7 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
             "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/undici": {
             "version": "7.22.0",
@@ -38481,7 +38363,6 @@
             "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -38504,6 +38385,7 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -38978,7 +38860,6 @@
             "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
             "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0 || >=10.0.0"
             }
@@ -39085,6 +38966,7 @@
             "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -39302,6 +39184,7 @@
             "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
             "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
@@ -39963,7 +39846,8 @@
             "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
             "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ==",
             "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/xterm-addon-fit": {
             "version": "0.5.0",
@@ -40003,7 +39887,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
             "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -40204,6 +40087,7 @@
             "version": "3.25.75",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.75.tgz",
             "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -40221,7 +40105,8 @@
         "node_modules/zone.js": {
             "version": "0.15.1",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-            "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w=="
+            "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+            "peer": true
         },
         "regression-tests/msal-node/client-credential": {
             "version": "1.0.0",
@@ -40401,6 +40286,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.0.tgz",
             "integrity": "sha512-SzlLoMT/r5wKqPicx5okCAiN5UD5+VE7x/F1G6gSJCcnBfbK5PqHPUmDnMW4jw9Ode06KZDT7ntstn6fG+Ld8w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -40530,6 +40416,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -40604,6 +40491,7 @@
             "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.0.tgz",
             "integrity": "sha512-1P0TNL1F51NC7JAaXabaAHY7Y1zBloLSZXfml1POa4a116V+y/QZfPGsxM0LwD1qSSXhSb2LNl7duTtJAP39bA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parse5": "^8.0.0",
                 "tslib": "^2.3.0"
@@ -40655,6 +40543,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.0.tgz",
             "integrity": "sha512-6zJMPi0i/XDniEgv3/t2BjuDHiOG44lgIR5PYyxqGpgJ0kqB5hku/0TuentNEi1VnBYgthnfhjek7c+lakXmhw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -40671,6 +40560,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.0.tgz",
             "integrity": "sha512-0RPkma8UVNpse/VJcXT9w6SKzTMz4J/uMGj0l9enM1frg9xrx1fwi/lLmaVV9Nr9LfqPjQdxNFFlvaBB7g/2zg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -40684,6 +40574,7 @@
             "integrity": "sha512-gZd58p0/JjgdxMX3v+LjCB6e3dBIfNVr/YzXoh55TfffdBCUQY94hl1+DFQkJ72K5EX+1zbaz03dIm30kw1bGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -40716,6 +40607,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.0.tgz",
             "integrity": "sha512-VnTbmZq3g3Q+s3nCZ8VUDMLjMezOg/bqUxAJ/DrRWCrEcTP5JO3mrNPs3FHj+qlB0T+BQP7uQv6QTzPVKybwoA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -40741,6 +40633,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.0.tgz",
             "integrity": "sha512-NduUtPWLauH/FLayEDkLyaKAGqKzXbcfO7468LOWCXN3crhNVQyIWRQPOUcdpoJwDAGLpN85m3DhJhXNnA9c5w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "tslib": "^2.3.0"
@@ -40777,6 +40670,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.0.tgz",
             "integrity": "sha512-IUGukpvvT2B5Dl76qzk6rY7UIHUT9u4BhT2AwVz+5JqcX9KwQtYD17Gt7wj6bvIgCXKWG+CfN8Zd9DECOCYWjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -41274,6 +41168,7 @@
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -41657,6 +41552,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
             "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -41833,6 +41729,7 @@
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -42218,6 +42115,7 @@
             "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
@@ -42928,6 +42826,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -43164,6 +43063,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.0.tgz",
             "integrity": "sha512-SzlLoMT/r5wKqPicx5okCAiN5UD5+VE7x/F1G6gSJCcnBfbK5PqHPUmDnMW4jw9Ode06KZDT7ntstn6fG+Ld8w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43331,6 +43231,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.0.tgz",
             "integrity": "sha512-6zJMPi0i/XDniEgv3/t2BjuDHiOG44lgIR5PYyxqGpgJ0kqB5hku/0TuentNEi1VnBYgthnfhjek7c+lakXmhw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43347,6 +43248,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.0.tgz",
             "integrity": "sha512-0RPkma8UVNpse/VJcXT9w6SKzTMz4J/uMGj0l9enM1frg9xrx1fwi/lLmaVV9Nr9LfqPjQdxNFFlvaBB7g/2zg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43360,6 +43262,7 @@
             "integrity": "sha512-gZd58p0/JjgdxMX3v+LjCB6e3dBIfNVr/YzXoh55TfffdBCUQY94hl1+DFQkJ72K5EX+1zbaz03dIm30kw1bGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -43392,6 +43295,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.0.tgz",
             "integrity": "sha512-VnTbmZq3g3Q+s3nCZ8VUDMLjMezOg/bqUxAJ/DrRWCrEcTP5JO3mrNPs3FHj+qlB0T+BQP7uQv6QTzPVKybwoA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43417,6 +43321,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.0.tgz",
             "integrity": "sha512-NduUtPWLauH/FLayEDkLyaKAGqKzXbcfO7468LOWCXN3crhNVQyIWRQPOUcdpoJwDAGLpN85m3DhJhXNnA9c5w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "tslib": "^2.3.0"
@@ -43453,6 +43358,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.0.tgz",
             "integrity": "sha512-IUGukpvvT2B5Dl76qzk6rY7UIHUT9u4BhT2AwVz+5JqcX9KwQtYD17Gt7wj6bvIgCXKWG+CfN8Zd9DECOCYWjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -43948,6 +43854,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -44507,6 +44414,7 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -44833,7 +44741,8 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.5.0.tgz",
             "integrity": "sha512-9PMzyvhtocxb3aXJVOPqBDswdgyAeSB81QnLop4npOpbqnheaTEwPc9ZloQeVswugPManznQBjD8kWDTjlnHuw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "samples/msal-angular-samples/angular-modules-sample/node_modules/json-parse-even-better-errors": {
             "version": "5.0.0",
@@ -44850,6 +44759,7 @@
             "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
             "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "jasmine-core": "^4.1.0"
             },
@@ -44876,6 +44786,7 @@
             "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
             "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
@@ -45574,6 +45485,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -45624,6 +45536,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -45880,6 +45793,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.0.tgz",
             "integrity": "sha512-SzlLoMT/r5wKqPicx5okCAiN5UD5+VE7x/F1G6gSJCcnBfbK5PqHPUmDnMW4jw9Ode06KZDT7ntstn6fG+Ld8w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -46047,6 +45961,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.0.tgz",
             "integrity": "sha512-6zJMPi0i/XDniEgv3/t2BjuDHiOG44lgIR5PYyxqGpgJ0kqB5hku/0TuentNEi1VnBYgthnfhjek7c+lakXmhw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -46063,6 +45978,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.0.tgz",
             "integrity": "sha512-0RPkma8UVNpse/VJcXT9w6SKzTMz4J/uMGj0l9enM1frg9xrx1fwi/lLmaVV9Nr9LfqPjQdxNFFlvaBB7g/2zg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -46076,6 +45992,7 @@
             "integrity": "sha512-gZd58p0/JjgdxMX3v+LjCB6e3dBIfNVr/YzXoh55TfffdBCUQY94hl1+DFQkJ72K5EX+1zbaz03dIm30kw1bGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -46108,6 +46025,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.0.tgz",
             "integrity": "sha512-VnTbmZq3g3Q+s3nCZ8VUDMLjMezOg/bqUxAJ/DrRWCrEcTP5JO3mrNPs3FHj+qlB0T+BQP7uQv6QTzPVKybwoA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -46133,6 +46051,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.0.tgz",
             "integrity": "sha512-NduUtPWLauH/FLayEDkLyaKAGqKzXbcfO7468LOWCXN3crhNVQyIWRQPOUcdpoJwDAGLpN85m3DhJhXNnA9c5w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "tslib": "^2.3.0"
@@ -46169,6 +46088,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.0.tgz",
             "integrity": "sha512-IUGukpvvT2B5Dl76qzk6rY7UIHUT9u4BhT2AwVz+5JqcX9KwQtYD17Gt7wj6bvIgCXKWG+CfN8Zd9DECOCYWjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -46666,6 +46586,7 @@
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -47248,6 +47169,7 @@
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -47624,6 +47546,7 @@
             "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
@@ -48342,6 +48265,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -48392,6 +48316,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -48596,6 +48521,7 @@
             "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -48776,6 +48702,7 @@
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -50529,6 +50456,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.110.tgz",
             "integrity": "sha512-WW2o4gTmREtSnqKty9nhqF/vA0GKd0V/rbC0OyjSk9Bz6bzlsXKT+i7WDdS/a0z74rfT2PO4dArVCSnapNLA5Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -51036,6 +50964,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.110.tgz",
             "integrity": "sha512-WW2o4gTmREtSnqKty9nhqF/vA0GKd0V/rbC0OyjSk9Bz6bzlsXKT+i7WDdS/a0z74rfT2PO4dArVCSnapNLA5Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -51641,6 +51570,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -51787,6 +51717,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.110.tgz",
             "integrity": "sha512-WW2o4gTmREtSnqKty9nhqF/vA0GKd0V/rbC0OyjSk9Bz6bzlsXKT+i7WDdS/a0z74rfT2PO4dArVCSnapNLA5Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -52226,6 +52157,7 @@
             "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
             "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.4.4",
                 "@material-ui/styles": "^4.11.5",
@@ -52382,19 +52314,6 @@
                 "react-dom": "^16.8.0 || ^17.0.0"
             }
         },
-        "samples/msal-react-samples/react16-sample/node_modules/@types/react": {
-            "version": "17.0.91",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
-            "integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/prop-types": "*",
-                "@types/scheduler": "^0.16",
-                "csstype": "^3.2.2"
-            }
-        },
         "samples/msal-react-samples/react16-sample/node_modules/clsx": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
@@ -52409,6 +52328,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
             "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -52423,6 +52343,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
             "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -52478,6 +52399,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
             "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -52539,6 +52461,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/auth.js
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/auth.js
@@ -9,6 +9,7 @@ async function initializeMsal() {
         return response.json();
     }).then((authConfig) => {
         myMSALObj = new msal.PublicClientApplication(authConfig.msalConfig);
+        window.msalApp = myMSALObj;
         requestConfig = authConfig.request;
         tenantConfig = authConfig.tenants;
         myMSALObj.initialize().then(() => {
@@ -64,12 +65,16 @@ function handleResponse(resp) {
 }
 
 async function signIn(signInType) {
-    if (signInType === "popup") {
-        return myMSALObj.loginPopup(requestConfig).then(handleResponse).catch(function (error) {
+    const request = { ...requestConfig };
+    if ((signInType === "popupGuest" || signInType === "redirectGuest") && tenantConfig?.guest) {
+        request.authority = tenantConfig.guest.authority;
+    }
+    if (signInType === "popup" || signInType === "popupGuest") {
+        return myMSALObj.loginPopup(request).then(handleResponse).catch(function (error) {
             console.log(error);
         });
-    } else if (signInType === "redirect") {
-        return myMSALObj.loginRedirect(requestConfig)
+    } else if (signInType === "redirect" || signInType === "redirectGuest") {
+        return myMSALObj.loginRedirect(request);
     }
 }
 
@@ -111,38 +116,30 @@ async function getTokenRedirect(method = "GET") {
     }
 }
 
-async function getTokenSilently() {
-    const request = requestConfig;
+async function getTokenSilently(tenantKey) {
+    const request = { ...requestConfig };
     const currentAcc = myMSALObj.getActiveAccount();
-    if (currentAcc) {
-        request.account = currentAcc;
-        response = await myMSALObj.acquireTokenSilent(request).then(handleResponse).catch(error => {
-            console.error(error);
-        });
-    }
-}
+    if (!currentAcc) return;
 
-async function getGuestTokenSilently() {
-    const request = requestConfig;
-    if (tenantConfig?.guest) {
-        const currentAcc = myMSALObj.getActiveAccount();
-        const guestAccount = myMSALObj.getAccount({ homeAccountId: currentAcc?.homeAccountId, tenantId: tenantConfig.guest.tenantId } );
-        if (guestAccount) {
-            response = await myMSALObj.acquireTokenSilent({ ...request, account: guestAccount }).then(handleResponse).catch(error => {
-                console.error(error);
-            });
+    const tenantCfg = tenantKey ? tenantConfig?.[tenantKey] : null;
+    if (tenantKey && !tenantCfg) {
+        console.error(`Sample Configuration Error: No "${tenantKey}" tenant in MSAL Config`);
+        return;
+    }
+    if (tenantCfg) {
+        const tenantAccount = myMSALObj.getAccount({ homeAccountId: currentAcc.homeAccountId, tenantId: tenantCfg.tenantId });
+        if (tenantAccount) {
+            request.account = tenantAccount;
         } else {
-            const currentAcc = myMSALObj.getActiveAccount();
-            response = await myMSALObj.acquireTokenSilent({
-                 ...request,
-                 account: currentAcc,
-                 authority: tenantConfig.guest.authority,
-                 cacheLookupPolicy: msal.CacheLookupPolicy.RefreshToken
-            }).then(handleResponse).catch(error => {
-                console.error(error);
-            });
+            request.account = currentAcc;
+            request.authority = tenantCfg.authority;
+            request.cacheLookupPolicy = msal.CacheLookupPolicy.RefreshToken;
         }
     } else {
-        console.error("Sample Configuration Error: No guest tenant in MSAL Config");
+        request.account = currentAcc;
     }
+
+    response = await myMSALObj.acquireTokenSilent(request).then(handleResponse).catch(error => {
+        console.error(error);
+    });
 }

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/index.html
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/index.html
@@ -25,6 +25,8 @@
       <div class="dropdown-menu">
         <button class="dropdown-item" id="popup" onclick="signIn(this.id)">Sign in using Popup</button>
         <button class="dropdown-item" id="redirect" onclick="signIn(this.id)">Sign in using Redirect</button>
+        <button class="dropdown-item" id="popupGuest" onclick="signIn(this.id)">Sign in with Guest Tenant (Popup)</button>
+        <button class="dropdown-item" id="redirectGuest" onclick="signIn(this.id)">Sign in with Guest Tenant (Redirect)</button>
       </div>
     </div>
   </nav>
@@ -58,7 +60,11 @@
             <br>
             <br>
             <button class="btn btn-primary" id="acquireGuestToken"
-            onclick="getGuestTokenSilently()">acquireGuestToken</button>
+            onclick="getTokenSilently('guest')">acquireGuestToken</button>
+            <br>
+            <br>
+            <button class="btn btn-primary" id="acquireHomeToken"
+            onclick="getTokenSilently('home')">acquireHomeToken</button>
         </div>
       </div>
     </div>

--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADMultiTenant.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/browserAADMultiTenant.spec.ts
@@ -303,6 +303,73 @@ describe("AAD-Prod Tests", () => {
             });
         });
 
+        it("tenantProfiles accumulate across home and guest tenant authentication", async () => {
+            testName = "tenantProfilesAccumulate";
+            screenshot = new Screenshot(
+                `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
+            );
+
+            // The previous test already acquired the guest token via RT; both home and guest
+            // tokens are now in cache. Just inspect the resulting account state.
+            await screenshot.takeScreenshot(page, "tenantProfilesAccumulate-checkState");
+
+            // Evaluate getAllAccounts() inside the page to avoid cache encryption concerns.
+            // Use forEach instead of spread to avoid tslib helpers that are unavailable
+            // in the puppeteer browser execution context.
+            const accountData = await page.evaluate(() => {
+                return (window as any).msalApp.getAllAccounts().map((a: any) => {
+                    const keys: string[] = [];
+                    if (a.tenantProfiles) {
+                        a.tenantProfiles.forEach((_: any, k: string) => { keys.push(k); });
+                    }
+                    return {
+                        homeAccountId: a.homeAccountId,
+                        tenantId: a.tenantId,
+                        tenantProfilesSize: a.tenantProfiles ? a.tenantProfiles.size : 0,
+                        tenantProfileKeys: keys,
+                    };
+                });
+            });
+
+            // Should have 2 AccountInfo objects - one per tenant
+            expect(accountData).toHaveLength(2);
+
+            // Both should share the same homeAccountId
+            expect(accountData[0].homeAccountId).toEqual(accountData[1].homeAccountId);
+
+            // Each AccountInfo should carry both tenant profiles
+            for (const account of accountData) {
+                expect(account.tenantProfilesSize).toEqual(2);
+                expect(account.tenantProfileKeys).toContain(aadTenants.home.tenantId);
+                expect(account.tenantProfileKeys).toContain(aadTenants.guest.tenantId);
+            }
+        });
+
+        it("getActiveAccount returns non-null after cross-tenant token acquisition", async () => {
+            testName = "getActiveAccountAfterCrossTenant";
+            screenshot = new Screenshot(
+                `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
+            );
+
+            const activeAccountData = await page.evaluate(() => {
+                const account = (window as any).msalApp.getActiveAccount();
+                if (!account) return null;
+                return {
+                    homeAccountId: account.homeAccountId,
+                    tenantId: account.tenantId,
+                    username: account.username,
+                };
+            });
+
+            await screenshot.takeScreenshot(page, "getActiveAccount-result");
+
+            expect(activeAccountData).not.toBeNull();
+            expect(activeAccountData!.homeAccountId).toBeTruthy();
+            // The last token acquired before this test was the guest tenant token (via RT),
+            // so handleResponse set the active account to the guest-tenant AccountInfo.
+            expect(activeAccountData!.tenantId).toEqual(aadTenants.guest.tenantId);
+        });
+
         it("acquireTokenSilent from cache (guest tenant token)", async () => {
             testName = "acquireTokenSilentCacheGuest";
             screenshot = new Screenshot(
@@ -331,6 +398,108 @@ describe("AAD-Prod Tests", () => {
                 scopes: aadTokenRequest.scopes,
                 numberOfTenants: 2,
             });
+        });
+    });
+
+    describe("acquireToken Tests (guest-first direction)", () => {
+        let testName: string;
+        let screenshot: Screenshot;
+
+        beforeAll(async () => {
+            context = await browser.createBrowserContext();
+            page = await context.newPage();
+            page.setDefaultTimeout(ONE_SECOND_IN_MS * 5);
+            BrowserCache = new BrowserCacheUtils(
+                page,
+                aadMsalConfig.cache.cacheLocation
+            );
+            await page.goto(sampleHomeUrl);
+
+            testName = "acquireTokenGuestFirstBaseCase";
+            screenshot = new Screenshot(
+                `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
+            );
+
+            // Log in with guest tenant authority first — establishes AccountEntity
+            // with guest profile, giving us the reverse of the normal home-first flow.
+            await screenshot.takeScreenshot(page, "samplePageInit");
+            await page.click("#SignIn");
+            await screenshot.takeScreenshot(page, "signInClicked");
+            const newPopupWindowPromise = new Promise<puppeteer.Page | null>(resolve =>
+                page.once("popup", resolve)
+            );
+            await page.click("#popupGuest");
+            const popupPage = await newPopupWindowPromise;
+            const popupWindowClosed = new Promise<void>(resolve =>
+                popupPage!.once("close", resolve)
+            );
+            await enterCredentials(popupPage!, screenshot, username, accountPwd);
+            await waitForReturnToApp(screenshot, page, popupPage!, popupWindowClosed);
+        });
+
+        beforeEach(async () => {
+            await page.reload();
+            await page.waitForSelector("#WelcomeMessage");
+            await pcaInitializedPoller(page, 5000);
+        });
+
+        afterAll(async () => {
+            await page.evaluate(() =>
+                Object.assign({}, window.sessionStorage.clear())
+            );
+            await page.evaluate(() =>
+                Object.assign({}, window.localStorage.clear())
+            );
+            await page.close();
+        });
+
+        it("acquireTokenSilent via RefreshToken (home tenant token, after guest login)", async () => {
+            testName = "acquireTokenSilentRTHomeAfterGuestLogin";
+            screenshot = new Screenshot(
+                `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
+            );
+
+            // No home AccountInfo exists yet after guest-only login, so getHomeTokenSilently
+            // takes the RT path with explicit home authority, calling setCachedAccount
+            // and merging the home profile into the AccountEntity.
+            await page.click("#acquireHomeToken");
+            await page.waitForSelector("#scopes-acquired");
+            await screenshot.takeScreenshot(page, "guestFirst-gotHomeToken");
+
+            await BrowserCache.verifyTokenStore({
+                scopes: aadTokenRequest.scopes,
+                numberOfTenants: 2,
+            });
+        });
+
+        it("tenantProfiles accumulate when guest login precedes silent home token acquisition", async () => {
+            testName = "tenantProfilesGuestLoginFirst";
+            screenshot = new Screenshot(
+                `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
+            );
+
+            const accountData = await page.evaluate(() => {
+                const accounts = (window as any).msalApp.getAllAccounts();
+                return accounts.map((a: any) => {
+                    const keys: string[] = [];
+                    if (a.tenantProfiles) {
+                        a.tenantProfiles.forEach((_: any, k: string) => { keys.push(k); });
+                    }
+                    return {
+                        tenantProfilesSize: a.tenantProfiles ? a.tenantProfiles.size : 0,
+                        tenantProfileKeys: keys,
+                    };
+                });
+            });
+
+            await screenshot.takeScreenshot(page, "guestFirst-tenantProfiles");
+
+            expect(accountData).toHaveLength(2);
+            for (const account of accountData) {
+                expect(account.tenantProfilesSize).toEqual(2);
+                expect(account.tenantProfileKeys).toContain(aadTenants.home.tenantId);
+                expect(account.tenantProfileKeys).toContain(aadTenants.guest.tenantId);
+            }
         });
     });
 });


### PR DESCRIPTION
PR author: @rickygao

## Bug

Related PR: #6536 (multi-tenant account / cross-tenant token caching).

`buildAccountToCache` in `ResponseHandler.ts` uses `accountKey.startsWith(homeAccountId)` to look up an existing cached `AccountEntity`. However, `BrowserCacheManager` generates cache keys with a `msal.2|` prefix:

```
msal.2|{homeAccountId}|{environment}|{tenantId}
```

Since the key starts with `msal.2|`, not `homeAccountId`, `startsWith` **always returns false**. Every token operation creates a brand-new `AccountEntity`, overwriting the previous `tenantProfiles` array.

**Impact:** After `loginPopup(home)` + `acquireTokenSilent(guest)`, `getAllAccounts()[0].tenantProfiles` contains only the guest profile — the home profile is lost. 100% reproducible, no concurrency needed.

**Minimum Repro** is attached:

```js
import {
    CacheLookupPolicy,
    PublicClientApplication,
} from "@azure/msal-browser";
import { broadcastResponseToMainFrame } from "@azure/msal-browser/redirect-bridge";

// Popup callback handler (MSAL v5)
if (
    new URLSearchParams(location.hash.slice(1)).has("code") ||
    new URLSearchParams(location.search).has("code")
) {
    await broadcastResponseToMainFrame();
}

// Config
const CLIENT_ID = "bafa2dd2-166c-46ff-be35-9b50b0e9dbd3";
const HOME_TENANT = "kingdomwei.onmicrosoft.com";
const GUEST_TENANT = "kingdomshu.onmicrosoft.com";
const SCOPES = ["User.Read"];

const app = new PublicClientApplication({
    auth: {
        clientId: CLIENT_ID,
        authority: `https://login.microsoftonline.com/${HOME_TENANT}`,
        redirectUri: location.href.split("?")[0],
    },
    cache: { cacheLocation: "localStorage" },
});
await app.initialize();

// Step 1: Login home tenant
const { account } = await app.loginPopup({ scopes: SCOPES });
console.log("Login OK:", account.username, "tenant:", account.tenantId);
console.log(
    "tenantProfiles after login:",
    app.getAllAccounts()[0]?.tenantProfiles
);

// Step 2: Acquire guest tenant token
try {
    await app.acquireTokenSilent({
        account,
        scopes: SCOPES,
        authority: `https://login.microsoftonline.com/${GUEST_TENANT}`,
        cacheLookupPolicy: CacheLookupPolicy.RefreshToken,
    });
} catch {
    await app.acquireTokenPopup({
        account,
        scopes: SCOPES,
        authority: `https://login.microsoftonline.com/${GUEST_TENANT}`,
    });
}
console.log("Guest token acquired.");

// Step 3: Check — expect 2 profiles (home + guest), but home is lost
const profiles = app.getAllAccounts()[0]?.tenantProfiles;
console.log("tenantProfiles after guest token:", profiles);
console.log(
    "Expected: 2 profiles (home + guest). Actual:",
    profiles?.size,
    "— home profile",
    [...(profiles?.values() ?? [])].some((p) => p.isHomeTenant)
        ? "present"
        : "MISSING"
);
```

**Behavior Before Patching**:

<img width="712" height="238" alt="image" src="https://github.com/user-attachments/assets/7b9a4d25-d4fc-46f0-bbfd-7e5823d9e774" />

## Fix

Replace the key-based `startsWith` lookup with `getAccountsFilteredBy({ homeAccountId })`, which matches on the entity's `homeAccountId` property directly — independent of cache key format.

```diff
- const accountKeys = cacheStorage.getAccountKeys();
- const baseAccountKey = accountKeys.find((accountKey: string) => {
-     return accountKey.startsWith(homeAccountId);
- });
- let cachedAccount: AccountEntity | null = null;
- if (baseAccountKey) {
-     cachedAccount = cacheStorage.getAccount(baseAccountKey, correlationId);
- }
+ const matchingAccounts = cacheStorage.getAccountsFilteredBy(
+     { homeAccountId },
+     correlationId
+ );
+ const cachedAccount: AccountEntity | null =
+     matchingAccounts.length > 0 ? matchingAccounts[0] : null;
```

**Behavior After Patching**:

<img width="713" height="277" alt="image" src="https://github.com/user-attachments/assets/4057272b-e79f-4e51-8289-b301d58efd8d" />

## Tests

Added 2 tests to `ResponseHandler.spec.ts`:
- Verifies cached account is found and home tenant profile preserved when cache keys have a `msal.2|` prefix
- Verifies fallback to `createAccountEntity` when no match exists

All 949 msal-common tests pass.
