### PR TITLE
docs: add E2E local test run instructions to samples/AGENTS.md

### DIFF
--- a/samples/AGENTS.md
+++ b/samples/AGENTS.md
@@ -14,3 +14,50 @@ Each sample has its own `README` file that provides detailed information about w
 - Never use deprecated functions, parameters or dependencies. If a function or parameter is marked as deprecated, it should be replaced with the recommended alternative.
 - Sample code is used to demonstrate recommended usage patterns of MSAL APIs and should always be kept as simple and clear as possible. Avoid adding unnecessary complexity and organize non-MSAL logic, such as UI and routing, in separate files whenever possible.
 - Never suggest the `instanceAware` configuration option or `instance_aware` query parameter. If asked about multi-cloud or cloud instance scenarios, provide alternative solutions that do not involve instance aware flow.
+
+## Running E2E Tests Locally
+
+### Prerequisites — `.env` file and lab certificate
+
+E2E tests authenticate against Microsoft lab infrastructure using credentials stored in a `.env` file. `LabClient.ts` (in `e2eTestUtils/src/`) resolves the file path in this order:
+
+1. `<repo-root>/../.env` (i.e., `msal-javascript-1p/` root when running inside the 1P monorepo)
+2. `<repo-root>/.env` (3P repo root)
+
+The `.env` must contain:
+
+```
+AZURE_CLIENT_ID=...
+AZURE_CLIENT_CERTIFICATE_PATH=...
+AZURE_TENANT_ID=...
+SESSION_SECRET=...
+```
+
+If the file is missing, generate it by running `gen_env.ps1` (Windows) or `gen_env.sh` (bash) from either the 1P root (`C:\src\msal-javascript-1p\`) or the 3P repo root. These scripts require `az` CLI access to the `msidlabs` KeyVault and will produce the `.env`, `LabCert.pem`, and `LabCert.pfx` files.
+
+### Running E2E tests for VanillaJSTestApp2.0
+
+Jest automatically starts the sample server before tests run (via `jestSetup.js` using `__STARTCMD__` from each sample's `jest.config.cjs`) — no need to start it manually.
+
+**Run all E2E tests:**
+
+```bash
+cd samples/msal-browser-samples/VanillaJSTestApp2.0
+npm run test:e2e
+```
+
+**Run a specific sample's tests** (replace `customizable-e2e-test` with any folder name under `app/`):
+
+```bash
+npm run test:e2e -- --sample=customizable-e2e-test
+```
+
+**Run a specific test file:**
+
+```bash
+npm run test:e2e -- --sample=customizable-e2e-test --testPathPattern=browserAADMultiTenant
+```
+
+### Before committing
+
+Always run `npm run format:fix` from the relevant library directory (e.g., `lib/msal-browser`, `lib/msal-common`) before committing source or test changes. The formatting check runs in CI and will block merging if not satisfied.


### PR DESCRIPTION
## Summary

Adds a new **Running E2E Tests Locally** section to \samples/AGENTS.md\ so AI agents (and developers) have clear, self-contained instructions for running E2E tests without needing to dig through individual sample READMEs or setup scripts.

### What's documented

- How to generate the \.env\ file and lab certificate (\gen_env.ps1\ / \gen_env.sh\) and where the file is resolved from
- Running all E2E tests for VanillaJSTestApp2.0 (\
pm run test:e2e\)
- Running a specific sample's tests (\--sample\ flag)
- Running a specific test file (\--testPathPattern\ flag)
- \
pm run format:fix\ requirement before committing

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>