### PR TITLE
Enable waitForBridgeLateResponse Telemetry

### DIFF
--- a/change/@azure-msal-browser-28a3f15c-a369-438e-9d46-bf5fb0e2b83c.json
+++ b/change/@azure-msal-browser-28a3f15c-a369-438e-9d46-bf5fb0e2b83c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enable waitForBridgeLateResponse Telemetry [#8509](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8509)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -388,7 +388,8 @@ declare namespace BrowserRootPerformanceEvents {
         SsoSilent,
         InitializeClientApplication,
         LocalStorageUpdated,
-        LoadExternalTokens
+        LoadExternalTokens,
+        WaitForBridgeLateResponse
     }
 }
 
@@ -1506,6 +1507,11 @@ const userCancelled = "user_cancelled";
 //
 // @public (undocumented)
 export const version = "5.6.3";
+
+// Warning: (ae-missing-release-tag) "WaitForBridgeLateResponse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const WaitForBridgeLateResponse = "waitForBridgeLateResponse";
 
 // Warning: (ae-incompatible-release-tags) The symbol "waitForBridgeResponse" is marked as @public, but its signature references "BrowserExperimentalOptions" which is marked as @internal
 // Warning: (ae-incompatible-release-tags) The symbol "waitForBridgeResponse" is marked as @public, but its signature references "BrowserExperimentalOptions" which is marked as @internal

--- a/lib/msal-browser/src/telemetry/BrowserRootPerformanceEvents.ts
+++ b/lib/msal-browser/src/telemetry/BrowserRootPerformanceEvents.ts
@@ -41,3 +41,5 @@ export const InitializeClientApplication = "initializeClientApplication";
 export const LocalStorageUpdated = "localStorageUpdated";
 // Load external tokens
 export const LoadExternalTokens = "loadExternalTokens";
+// Wait for late response from broker
+export const WaitForBridgeLateResponse = "waitForBridgeLateResponse";

--- a/lib/msal-browser/src/telemetry/BrowserRootPerformanceEvents.ts
+++ b/lib/msal-browser/src/telemetry/BrowserRootPerformanceEvents.ts
@@ -41,5 +41,5 @@ export const InitializeClientApplication = "initializeClientApplication";
 export const LocalStorageUpdated = "localStorageUpdated";
 // Load external tokens
 export const LoadExternalTokens = "loadExternalTokens";
-// Wait for late response from broker
+// Wait for late response from bridge after timeout has already occurred
 export const WaitForBridgeLateResponse = "waitForBridgeLateResponse";


### PR DESCRIPTION
This pull request introduces a new performance event, `WaitForBridgeLateResponse`, to the MSAL browser package. The event is added to the relevant enums and exports, and is now part of the public API, although it is missing a release tag. The changes are focused on improving telemetry and event tracking for brokered authentication scenarios.

New performance event addition:

* Added `WaitForBridgeLateResponse` to the `BrowserRootPerformanceEvents` enum in `msal-browser.api.md` and exported it in `BrowserRootPerformanceEvents.ts` for tracking late responses from the broker. [[1]](diffhunk://#diff-d8aa8313e46503e745028509a1ac18093831ea5baeafe63c63ea825727aa3580L391-R392) [[2]](diffhunk://#diff-cb11f501261b4dfc9a14834c3352073dc7500baaa5111cc21f552b2d600c5af2R44-R45)
* Declared `WaitForBridgeLateResponse` as a public (undocumented) constant in the API review file, with a warning about the missing release tag.