### PR TITLE
Unskip E2E tests

### DIFF
--- a/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
+++ b/samples/msal-browser-samples/VanillaJSTestApp2.0/app/customizable-e2e-test/test/localStorage.spec.ts
@@ -157,7 +157,7 @@ describe("LocalStorage Tests", function () {
             });
         });
 
-        it.skip("Logging in on one tab updates cache/UI in another tab", async () => {
+        it("Logging in on one tab updates cache/UI in another tab", async () => {
             const testName = "multi-tab";
             const screenshot = new Screenshot(
                 `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`

--- a/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
@@ -35,7 +35,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 // Load scenario configuration
 const config = require("../config/ADFS.json");
 
-describe.skip("Device Code ADFS 2019 Tests", () => {
+describe("Device Code ADFS 2019 Tests", () => {
     jest.setTimeout(45000);
     jest.retryTimes(RETRY_TIMES);
     let browser: puppeteer.Browser;

--- a/samples/msal-node-samples/silent-flow/test/silent-flow-adfs.spec.ts
+++ b/samples/msal-node-samples/silent-flow/test/silent-flow-adfs.spec.ts
@@ -40,7 +40,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 // Load scenario configuration
 const config = require("../config/ADFS.json");
 
-describe.skip("Silent Flow ADFS 2019 Tests", () => {
+describe("Silent Flow ADFS 2019 Tests", () => {
     jest.retryTimes(RETRY_TIMES);
     jest.setTimeout(ONE_SECOND_IN_MS * 45);
     let browser: puppeteer.Browser;


### PR DESCRIPTION
Now that the lab migration has been completed, we are able to unskip tests that were previously not working due to lab configuration issues. These tests are those in the silent flow ADFS, device code ADFS, and local storage (multi-tab) test suites.