### PR TITLE
Enhance documentation hygiene guidelines for managing stale links in markdown files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,3 +42,4 @@ When reviewing pull requests, GitHub Copilot should provide comprehensive feedba
 1. Suggest adding test coverage (if not included) for new functions, properties, error and edge cases. Complex features should include E2E tests. 
 1. Suggest adding telemetry for any changes that may impact performance or reliability and for any areas that may be useful for debugging or monitoring.
 1. Changefiles should be included for all changes to the source code for core libraries (lib/) or extensions (extensions/) and should adhere to the guidelines specified in `.github/instructions/changefiles.instructions.md`
+1. Validate that all internal links in markdown files are correct. When files, directories, or samples are added, removed, renamed, or moved, scan all `.md` files for stale references (relative paths and GitHub URLs) and flag broken links. See `.github/instructions/doc_links.instructions.md` for the full link validation checklist.

--- a/.github/instructions/doc_links.instructions.md
+++ b/.github/instructions/doc_links.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: "**/*.md"
+description: "Use when editing, reviewing, or creating markdown files. Validates that internal links (relative paths and GitHub repository URLs) point to files, directories, and anchors that actually exist. Also applies when files or directories are deleted, renamed, or moved — scan markdown files for stale references."
+---
+
+# Documentation Link Integrity
+
+When editing markdown files or deleting/renaming/moving files and directories, verify that all internal links remain valid.
+
+## When to check
+
+- **Editing a `.md` file**: Validate all links within the file being edited
+- **Deleting or renaming a file or directory**: Search all `.md` files in the repo for references to the old path and update or remove them
+- **Adding a new sample or directory**: Ensure it is referenced from the relevant README(s)
+- **Reviewing a pull request**: Flag any links that point to paths not present in the PR's final file tree
+
+## What to validate
+
+### Relative links
+
+- `[text](./path/to/file.md)` — verify the target file exists at that relative path
+- `[text](../other-package/docs/file.md)` — verify cross-package references resolve correctly
+- `[text](./path/to/file.md#anchor)` — verify the anchor heading exists in the target file
+
+### GitHub repository URLs
+
+- Links containing `github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/` or `/blob/dev/` — verify the referenced path exists in the repo
+- Links to specific branches (`/tree/main/`, `/tree/dev/`) — confirm the path exists on that branch
+- Links to samples (e.g., `samples/msal-browser-samples/SomeSample`) — confirm the sample directory still exists
+
+### External links
+
+- Do not validate external URLs (e.g., Microsoft docs, npm, MDN) during code review — these require network access
+- If an external link is obviously outdated (e.g., references a removed Azure portal blade or a deprecated API version), flag it
+
+## Common broken link patterns
+
+| Scenario | What breaks | Fix |
+|----------|-------------|-----|
+| Sample directory removed | README links to `samples/.../RemovedSample` | Remove or replace the link |
+| File renamed | Links using the old filename | Update to new filename |
+| Directory restructured | Relative paths shift | Update all affected relative links |
+| Anchor heading changed | `#old-heading` no longer matches | Update to `#new-heading` |
+| Branch name changed | `/tree/old-branch/` URLs | Update to current branch |
+
+## How to scan
+
+1. Identify the paths being changed (added, removed, renamed)
+2. Search all `.md` files for references to those paths: look for both relative paths and full GitHub URLs
+3. For each stale reference, suggest the corrected link or flag for removal
+4. When removing a link to a deleted resource, check if there is a replacement (e.g., a successor sample) and link to that instead

--- a/.github/prompts/doc-audit.prompt.md
+++ b/.github/prompts/doc-audit.prompt.md
@@ -1,11 +1,11 @@
 ---
-description: "Audit documentation against recent code changes. Scans source diffs and identifies docs that are outdated, missing, or inconsistent."
+description: "Audit documentation against recent code changes. Scans source diffs and identifies docs that are outdated, missing, or inconsistent. Also validates that all internal links in markdown files point to valid targets."
 agent: "agent"
 ---
 
 # Documentation Audit
 
-Review all recent code changes and compare them against the existing documentation to identify gaps, inconsistencies, or missing updates.
+Review all recent code changes and compare them against the existing documentation to identify gaps, inconsistencies, broken links, or missing updates.
 
 ## Steps
 
@@ -17,6 +17,7 @@ Review all recent code changes and compare them against the existing documentati
    - New or changed configuration options
    - New browser/platform constraints or workarounds
    - Breaking changes or deprecations
+   - Deleted or renamed files, directories, or samples
 
 3. **Map changes to docs**: For each library with source changes, scan the corresponding `docs/` directory:
    - `lib/msal-browser/docs/` for msal-browser changes
@@ -32,10 +33,23 @@ Review all recent code changes and compare them against the existing documentati
    - Known limitations sections reflect current browser/platform constraints
    - Configuration docs list all current options with correct defaults
 
-5. **Report findings**: Produce a table of findings:
+5. **Validate links**: Scan all `.md` files in affected libraries for broken links:
+   - **Deleted/renamed files**: Search all `.md` files for relative paths and GitHub URLs referencing removed or renamed paths
+   - **Relative links**: Verify `[text](./path)` targets exist at the resolved path
+   - **GitHub URLs**: Verify links containing `github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/` or `/blob/dev/` reference paths that exist in the repo
+   - **Anchor links**: Verify `#heading-anchor` references match actual headings in the target file
+   - **Sample links**: Confirm links to `samples/` directories point to samples that still exist
+
+6. **Report findings**: Produce a table of findings:
 
    | Source Change | Affected Doc(s) | Status | Suggested Update |
    |---------------|-----------------|--------|------------------|
    | ... | ... | Missing / Outdated / OK | ... |
 
-6. **Suggest fixes**: For each gap, suggest the specific documentation update needed — including the file path, section, and proposed content.
+   And a separate table for link issues:
+
+   | File | Broken Link | Reason | Suggested Fix |
+   |------|-------------|--------|---------------|
+   | ... | ... | Target deleted / Renamed / Anchor missing | ... |
+
+7. **Suggest fixes**: For each gap, suggest the specific documentation update needed — including the file path, section, and proposed content.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,10 @@ Some samples located in the `samples/` directory contain a `test/` folder. End t
 
 ### Documentation Hygiene
 
-When deleting, renaming, or moving files and directories (especially samples), always scan all `.md` files for stale references. This includes:
+When a commit deletes, renames, or moves files and directories (especially samples), scan `.md` files for references **to the affected paths only** — do not audit unrelated links. Look for:
 
 - Relative links (`./path/to/file`)
 - GitHub URLs (`github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/...`)
-- Anchor references (`#heading-name`)
+- Anchor references (`#heading-name`) if headings were changed
 
-Update or remove broken links before merging. Use the `/doc-audit` prompt (`.github/prompts/doc-audit.prompt.md`) for a comprehensive check. Follow guidelines listed at  `.github/instructions/doc_links.instructions.md`.
+Update or remove stale links introduced or exposed by the current change before merging. For a full repo-wide audit, use the `/doc-audit` prompt (`.github/prompts/doc-audit.prompt.md`). Follow guidelines listed at `.github/instructions/doc_links.instructions.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,13 @@ Some samples located in the `samples/` directory contain a `test/` folder. End t
 
 1. **Always run `npm install` at repository root** to bootstrap the monorepo
 1. Repository uses npm workspaces - dependencies are shared and managed at root level
+
+### Documentation Hygiene
+
+When deleting, renaming, or moving files and directories (especially samples), always scan all `.md` files for stale references. This includes:
+
+- Relative links (`./path/to/file`)
+- GitHub URLs (`github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/...`)
+- Anchor references (`#heading-name`)
+
+Update or remove broken links before merging. Use the `/doc-audit` prompt (`.github/prompts/doc-audit.prompt.md`) for a comprehensive check. See `.github/instructions/doc_links.instructions.md` for full guidelines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,4 +49,4 @@ When deleting, renaming, or moving files and directories (especially samples), a
 - GitHub URLs (`github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/...`)
 - Anchor references (`#heading-name`)
 
-Update or remove broken links before merging. Use the `/doc-audit` prompt (`.github/prompts/doc-audit.prompt.md`) for a comprehensive check. See `.github/instructions/doc_links.instructions.md` for full guidelines.
+Update or remove broken links before merging. Use the `/doc-audit` prompt (`.github/prompts/doc-audit.prompt.md`) for a comprehensive check. Follow guidelines listed at  `.github/instructions/doc_links.instructions.md`.

--- a/lib/msal-browser/FAQ.md
+++ b/lib/msal-browser/FAQ.md
@@ -89,7 +89,7 @@ MSAL.js also supports the following environments:
 
 -   WebViews
 -   Office Add-ins (see the [sample](https://github.com/OfficeDev/PnP-OfficeAddins/tree/main/Samples/auth/Office-Add-in-Microsoft-Graph-React))
--   Chromium Extensions (see the [sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-browser-samples/ChromiumExtensionSample))
+-   Chromium Extensions
 -   Teams Applications (see the [sample](https://github.com/pnp/teams-dev-samples/tree/main/samples/tab-sso/src/nodejs))
 
 ### Known Issues with Certain Browsers

--- a/lib/msal-browser/README.md
+++ b/lib/msal-browser/README.md
@@ -107,7 +107,6 @@ We also provide samples for addin/plugin scenarios:
 
 -   [Office Addin-in using MSAL.js](https://github.com/OfficeDev/PnP-OfficeAddins/blob/main/Samples/auth/Office-Add-in-Microsoft-Graph-React/)
 -   [Teams Tab using MSAL.js](https://github.com/pnp/teams-dev-samples/tree/main/samples/tab-sso/src/nodejs)
--   [Chromium Extension using MSAL.js](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-browser-samples/ChromiumExtensionSample)
 
 ## Build and Test
 


### PR DESCRIPTION
Enhance documentation hygiene guidelines for managing stale links in markdown files
Remove a link to Chromium Extension that no longer exists