### PR TITLE
Attach cached ssoCapable to ssoSilent and acquireTokenSilent telemetry

### DIFF
--- a/change/@azure-msal-browser-be83df9e-7f2e-4edc-b700-b9cc18a2a618.json
+++ b/change/@azure-msal-browser-be83df9e-7f2e-4edc-b700-b9cc18a2a618.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Attach cached ssoCapable value to ssoSilent and acquireTokenSilent telemetry. Refactor verifySsoCapability to accept request instead of account.",
+    "packageName": "@azure/msal-browser",
+    "email": "sameera.gajjarapu@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-16f0de3a-f4d8-4b8b-8614-83d3661ade3b.json
+++ b/change/@azure-msal-common-16f0de3a-f4d8-4b8b-8614-83d3661ade3b.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Add ssoCapable field to PerformanceEvent type for SSO capability telemetry.",
+    "packageName": "@azure/msal-common",
+    "email": "sameera.gajjarapu@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -94,6 +94,7 @@ import {
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
 import { collectInstanceStats } from "../utils/MsalFrameStatsUtils.js";
 import { HandleRedirectPromiseOptions } from "../request/HandleRedirectPromiseOptions.js";
+import { CommonAuthorizationUrlRequest } from "@azure/msal-common";
 
 function preflightCheck(
     initialized: boolean,
@@ -472,6 +473,7 @@ export class StandardController implements IController {
         let rootMeasurement: InProgressPerformanceEvent;
 
         let redirectResponse: Promise<AuthenticationResult | null>;
+        let cachedRedirectRequest: SsoSilentRequest | undefined;
         try {
             if (useNative && this.platformAuthProvider) {
                 const correlationId =
@@ -517,6 +519,7 @@ export class StandardController implements IController {
             } else {
                 const [standardRequest, codeVerifier] =
                     this.browserStorage.getCachedRequest("");
+                cachedRedirectRequest = standardRequest;
                 const correlationId = standardRequest.correlationId;
                 this.eventHandler.emitEvent(
                     EventType.HANDLE_REDIRECT_START,
@@ -585,7 +588,7 @@ export class StandardController implements IController {
 
                     // Fire-and-forget SSO capability verification in background
                     this.verifySsoCapability(
-                        result.account,
+                        cachedRedirectRequest,
                         InteractionType.Redirect
                     );
                 } else {
@@ -913,7 +916,7 @@ export class StandardController implements IController {
                 );
 
                 // SSO capability verification in background
-                this.verifySsoCapability(result.account, InteractionType.Popup);
+                this.verifySsoCapability(request, InteractionType.Popup);
 
                 return result;
             })
@@ -992,17 +995,43 @@ export class StandardController implements IController {
     }
 
     /**
+     * Reads the cached ssoCapable value from localStorage.
+     * @returns The cached ssoCapable boolean value, or undefined if not cached or expired.
+     */
+    private getCachedSsoCapable(): boolean | undefined {
+        try {
+            const cachedValue = window.localStorage.getItem(
+                CacheKeys.SSO_CAPABLE
+            );
+            if (cachedValue) {
+                const parsed = JSON.parse(cachedValue);
+                if (
+                    parsed &&
+                    typeof parsed.ssoCapable === "boolean" &&
+                    parsed.expiresOn &&
+                    Date.now() < parsed.expiresOn
+                ) {
+                    return parsed.ssoCapable;
+                }
+            }
+        } catch {
+            // If parsing fails, return undefined
+        }
+        return undefined;
+    }
+
+    /**
      * SSO capability verification in the background.
      * This method makes an iframe request to /authorize to verify SSO capability without calling /token.
      * This method does not block the caller and tracks telemetry for success/failure.
      * This method only executes if verifySSO is set to true in the auth configuration.
      * The result is cached in localStorage with a 24-hour TTL; the SSO verification call
      * is only attempted when the cached value is absent or expired.
-     * @param account - The account to use for the SSO verification
+     * @param request - The original request used for the authentication flow
      * @param interactionType - The interactionType of the AT operation for logging purposes
      */
     private verifySsoCapability(
-        account: AccountInfo,
+        request: SsoSilentRequest | undefined,
         interactionType: InteractionType
     ): void {
         // Check if SSO capability verification is enabled
@@ -1013,24 +1042,13 @@ export class StandardController implements IController {
         // Check TTL: derive ssoCapable state from localStorage and skip if not expired
         const ssoCacheKey = CacheKeys.SSO_CAPABLE;
         const SSO_CAPABLE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-        try {
-            const cachedValue = window.localStorage.getItem(ssoCacheKey);
-            if (cachedValue) {
-                const parsed = JSON.parse(cachedValue);
-                if (
-                    parsed &&
-                    parsed.expiresOn &&
-                    Date.now() < parsed.expiresOn
-                ) {
-                    this.logger.verbose(
-                        `SSO capability verification skipped - cached value has not expired (interactionType: '${interactionType}')`,
-                        ""
-                    );
-                    return;
-                }
-            }
-        } catch {
-            // If parsing fails, proceed with the SSO verification
+        const cachedSsoCapable = this.getCachedSsoCapable();
+        if (cachedSsoCapable !== undefined) {
+            this.logger.verbose(
+                `SSO capability verification skipped - cached value has not expired (interactionType: '${interactionType}')`,
+                ""
+            );
+            return;
         }
 
         const correlationId = createNewGuid();
@@ -1053,7 +1071,7 @@ export class StandardController implements IController {
          */
         setTimeout(() => {
             const ssoVerificationRequest: SsoSilentRequest = {
-                account: account,
+                ...request,
                 correlationId: correlationId,
             };
 
@@ -1086,8 +1104,7 @@ export class StandardController implements IController {
                             fromCache: false,
                             success: result,
                         },
-                        undefined,
-                        account
+                        undefined
                     );
                 })
                 .catch((error: Error) => {
@@ -1109,8 +1126,7 @@ export class StandardController implements IController {
                             fromCache: false,
                             success: false,
                         },
-                        error,
-                        account
+                        error
                     );
                 });
         }, 0);
@@ -1147,6 +1163,7 @@ export class StandardController implements IController {
         );
         this.ssoSilentMeasurement?.add({
             scenarioId: request.scenarioId,
+            ssoCapable: this.getCachedSsoCapable(),
         });
         preflightCheck(
             this.initialized,
@@ -2115,6 +2132,7 @@ export class StandardController implements IController {
         atsMeasurement.add({
             cacheLookupPolicy: request.cacheLookupPolicy,
             scenarioId: request.scenarioId,
+            ssoCapable: this.getCachedSsoCapable(),
         });
 
         preflightCheck(this.initialized, atsMeasurement, this.config, request);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -4125,6 +4125,360 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentClientSpy).toHaveBeenCalledTimes(1);
             expect(ssoSilentFired).toBe(true);
         });
+
+        it("includes cached ssoCapable=true in telemetry when cached value exists", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            // Set cached ssoCapable value
+            const cacheEntry = JSON.stringify({
+                ssoCapable: true,
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBe(true);
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("includes cached ssoCapable=false in telemetry when cached value is false", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            // Set cached ssoCapable value to false
+            const cacheEntry = JSON.stringify({
+                ssoCapable: false,
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBe(false);
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when no cached value exists", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            // Ensure no cached value
+            window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached value has expired", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            // Set expired cached value
+            const cacheEntry = JSON.stringify({
+                ssoCapable: true,
+                expiresOn: Date.now() - 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached value is malformed JSON", (done) => {
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: BASIC_TEST_ACCOUNT_INFO.localAccountId,
+                tenantId: BASIC_TEST_ACCOUNT_INFO.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: BASIC_TEST_ACCOUNT_INFO,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            window.localStorage.setItem(
+                CacheKeys.SSO_CAPABLE,
+                "not-valid-json"
+            );
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached entry is missing ssoCapable field", (done) => {
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: BASIC_TEST_ACCOUNT_INFO.localAccountId,
+                tenantId: BASIC_TEST_ACCOUNT_INFO.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: BASIC_TEST_ACCOUNT_INFO,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            const cacheEntry = JSON.stringify({
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached entry is missing expiresOn field", (done) => {
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: BASIC_TEST_ACCOUNT_INFO.localAccountId,
+                tenantId: BASIC_TEST_ACCOUNT_INFO.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: BASIC_TEST_ACCOUNT_INFO,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            const cacheEntry = JSON.stringify({
+                ssoCapable: true,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached ssoCapable is non-boolean", (done) => {
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: BASIC_TEST_ACCOUNT_INFO.localAccountId,
+                tenantId: BASIC_TEST_ACCOUNT_INFO.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: BASIC_TEST_ACCOUNT_INFO,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            const cacheEntry = JSON.stringify({
+                ssoCapable: "true",
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("includes ssoCapable in telemetry on ssoSilent failure", (done) => {
+            const cacheEntry = JSON.stringify({
+                ssoCapable: true,
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentIframeClient.prototype,
+                "acquireToken"
+            ).mockRejectedValue(new AuthError("abc", "error message", "defg"));
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(false);
+                expect(events[0].ssoCapable).toBe(true);
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.ssoSilent({
+                scopes: ["openid"],
+                correlationId: RANDOM_TEST_GUID,
+            }).catch(() => {});
+        });
     });
 
     describe("acquireTokenByCode", () => {
@@ -6647,6 +7001,393 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentCacheSpy).toHaveBeenCalledTimes(1);
             expect(silentRefreshSpy).toHaveBeenCalledTimes(0);
             expect(silentIframeSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("includes cached ssoCapable=true in telemetry when cached value exists", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: true,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+                state: "test-state",
+            };
+
+            // Set cached ssoCapable value
+            const cacheEntry = JSON.stringify({
+                ssoCapable: true,
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBe(true);
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("includes cached ssoCapable=false in telemetry when cached value is false", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: true,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+                state: "test-state",
+            };
+
+            // Set cached ssoCapable value to false
+            const cacheEntry = JSON.stringify({
+                ssoCapable: false,
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBe(false);
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when no cached value exists", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: true,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+                state: "test-state",
+            };
+
+            // Ensure no cached value
+            window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached value has expired", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: true,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+                state: "test-state",
+            };
+
+            // Set expired cached value
+            const cacheEntry = JSON.stringify({
+                ssoCapable: true,
+                expiresOn: Date.now() - 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached value is malformed JSON", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: true,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+                state: "test-state",
+            };
+
+            window.localStorage.setItem(
+                CacheKeys.SSO_CAPABLE,
+                "not-valid-json"
+            );
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached entry is missing ssoCapable field", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: true,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+                state: "test-state",
+            };
+
+            const cacheEntry = JSON.stringify({
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached entry is missing expiresOn field", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: true,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+                state: "test-state",
+            };
+
+            const cacheEntry = JSON.stringify({
+                ssoCapable: true,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("does not include ssoCapable in telemetry when cached ssoCapable is non-boolean", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+            const testTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testAccount.localAccountId,
+                tenantId: testAccount.tenantId,
+                scopes: TEST_CONFIG.DEFAULT_SCOPES,
+                idToken: "test-idToken",
+                idTokenClaims: {},
+                accessToken: "test-accessToken",
+                fromCache: true,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(3600),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+                state: "test-state",
+            };
+
+            const cacheEntry = JSON.stringify({
+                ssoCapable: "true",
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockResolvedValue(testTokenResponse);
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(true);
+                expect(events[0].ssoCapable).toBeUndefined();
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+            });
+        });
+
+        it("includes ssoCapable in telemetry on acquireTokenSilent failure", (done) => {
+            const testAccount = BASIC_TEST_ACCOUNT_INFO;
+
+            const cacheEntry = JSON.stringify({
+                ssoCapable: true,
+                expiresOn: Date.now() + 24 * 60 * 60 * 1000,
+            });
+            window.localStorage.setItem(CacheKeys.SSO_CAPABLE, cacheEntry);
+
+            jest.spyOn(
+                SilentCacheClient.prototype,
+                "acquireToken"
+            ).mockRejectedValue(new AuthError("abc", "error message", "defg"));
+
+            const callbackId = pca.addPerformanceCallback((events) => {
+                expect(events[0].success).toBe(false);
+                expect(events[0].ssoCapable).toBe(true);
+                pca.removePerformanceCallback(callbackId);
+                window.localStorage.removeItem(CacheKeys.SSO_CAPABLE);
+                done();
+            });
+
+            pca.acquireTokenSilent({
+                scopes: ["openid"],
+                account: testAccount,
+                state: "test-state",
+                correlationId: RANDOM_TEST_GUID,
+                cacheLookupPolicy: CacheLookupPolicy.AccessToken,
+            }).catch(() => {});
         });
     });
 

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -3546,6 +3546,7 @@ export type PerformanceEvent = {
     silentRefreshReason?: string;
     deduped?: boolean;
     kmsi?: boolean;
+    ssoCapable?: boolean;
     isBackground?: boolean;
     preMigrateAcntCount?: number;
     preMigrateATCount?: number;

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -430,6 +430,11 @@ export type PerformanceEvent = {
     kmsi?: boolean;
 
     /**
+     * Cached SSO capability status from the most recent SSO verification
+     */
+    ssoCapable?: boolean;
+
+    /**
      * Whether this event was executed in the background
      */
     isBackground?: boolean;


### PR DESCRIPTION
- Add getCachedSsoCapable() helper to read cached SSO capability from localStorage
- Attach ssoCapable field to ssoSilent and acquireTokenSilent performance measurements
- Refactor verifySsoCapability to accept request instead of account
- Add ssoCapable field to PerformanceEvent type in msal-common
- Add unit tests for ssoCapable telemetry in ssoSilent and acquireTokenSilent
- Update API review for msal-common