### PR TITLE
Add CJS build for redirect-bridge subpath export

### DIFF
--- a/change/@azure-msal-browser-facf90c7-fc2b-419d-82e3-ddcd716c248b.json
+++ b/change/@azure-msal-browser-facf90c7-fc2b-419d-82e3-ddcd716c248b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add CJS build for redirect-bridge subpath export [#8541](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8541)",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -44,7 +44,7 @@
       },
       "require": {
         "types": "./lib/redirect-bridge/types/redirect_bridge/index.d.ts",
-        "default": "./lib/redirect-bridge/msal-redirect-bridge.js"
+        "default": "./lib/redirect-bridge/msal-redirect-bridge.cjs"
       }
     },
     ".": {

--- a/lib/msal-browser/rollup.config.js
+++ b/lib/msal-browser/rollup.config.js
@@ -236,6 +236,30 @@ export default [
         ],
     },
     {
+        // Redirect Bridge - CommonJS build
+        input: "src/redirect_bridge/index.ts",
+        output: {
+            dir: "lib/redirect-bridge",
+            format: "cjs",
+            banner: fileHeader,
+            sourcemap: true,
+            entryFileNames: "msal-redirect-bridge.cjs",
+            inlineDynamicImports: true,
+        },
+        plugins: [
+            nodeResolve({
+                browser: true,
+                resolveOnly: ["@azure/msal-common", "tslib"],
+            }),
+            typescript({
+                typescript: require("typescript"),
+                tsconfig: "tsconfig.redirect-bridge.build.json",
+                sourceMap: true,
+                compilerOptions: { outDir: "lib/redirect-bridge/types" },
+            }),
+        ],
+    },
+    {
         // Redirect Bridge - UMD build
         input: "src/redirect_bridge/index.ts",
         output: [


### PR DESCRIPTION
This pull request updates the build process for the `redirect-bridge` module in `msal-browser` to add a CommonJS (CJS) build output. The package configuration is also updated to reference this new CJS bundle as the default export.

**Build system updates:**

* Added a new Rollup build configuration in `rollup.config.js` to generate a CommonJS (`.cjs`) bundle for `redirect-bridge`, including source maps and type definitions.

**Package configuration updates:**

* Updated the `package.json` export map to point the `default` export to the new CommonJS bundle (`msal-redirect-bridge.cjs`) instead of the previous JavaScript file.