### PR TITLE
Update cache schema to fix upgrade bug between v4 and v5

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,10 +36,11 @@ Some samples located in the `samples/` directory contain a `test/` folder. End t
 
 ## Pull Request Review Guidelines
 
-When reviewing pull requests, GitHub Copilot should provide comprehensive feedback focusing on four key areas:
+When reviewing pull requests, GitHub Copilot should provide comprehensive feedback focusing on these key areas:
 
 1. Suggest documentation updates for new public methods, properties and APIs, changes to existing APIs, new error scenarios or codes, performance considerations, breaking changes, and usage examples. See `.github/instructions/doc_review.instructions.md` for the full documentation review checklist.
 1. Suggest adding test coverage (if not included) for new functions, properties, error and edge cases. Complex features should include E2E tests. 
 1. Suggest adding telemetry for any changes that may impact performance or reliability and for any areas that may be useful for debugging or monitoring.
 1. Changefiles should be included for all changes to the source code for core libraries (lib/) or extensions (extensions/) and should adhere to the guidelines specified in `.github/instructions/changefiles.instructions.md`
 1. Validate that all internal links in markdown files are correct. When files, directories, or samples are added, removed, renamed, or moved, scan all `.md` files for stale references (relative paths and GitHub URLs) and flag broken links. See `.github/instructions/doc_links.instructions.md` for the full link validation checklist.
+1. Review persisted cache changes for schema compatibility. If a PR changes cache keys or the persisted value shape in an incompatible way, require an explicit schema version bump plus migration, upgrade coverage, and downgrade coverage.

--- a/change/@azure-msal-browser-53530304-f5df-4fae-b704-8ddc589aa3a7.json
+++ b/change/@azure-msal-browser-53530304-f5df-4fae-b704-8ddc589aa3a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update cache schema version to fix bug when upgrading from v4 to v5",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-53530304-f5df-4fae-b704-8ddc589aa3a7.json
+++ b/change/@azure-msal-browser-53530304-f5df-4fae-b704-8ddc589aa3a7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Update cache schema version to fix bug when upgrading from v4 to v5",
+  "comment": "Update cache schema version to fix bug when upgrading from v4 to v5 [#8545](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8545)",
   "packageName": "@azure/msal-browser",
   "email": "thomas.norling@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-browser/AGENTS.md
+++ b/lib/msal-browser/AGENTS.md
@@ -37,3 +37,11 @@ Add performance measurements for:
 - **Add relevant fields** like operation counts, cache hit/miss, and custom error details or additional error context not automatically captured by invoke/invokeAsync
 - **Use existing PerformanceEvents** when possible rather than creating new ones
 - **Add telemetry for new operations** following the guidelines above
+
+## Cache Schema Compatibility
+
+When working on persisted cache behavior, explicitly evaluate whether the change is compatible with existing cache entries.
+
+- If a cache change is incompatible, increment the relevant cache schema version and update migration logic and tests.
+- Incompatible changes include any changes to the cache key, removing properties from the JSON value, changing property types, or introducing properties that code now requires or assumes exist.
+- Add or update upgrade and downgrade coverage whenever cache schema behavior changes.

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -563,7 +563,9 @@ export class BrowserCacheManager extends CacheManager {
                     { migratedITCount: 1 },
                     correlationId
                 );
-                currentCredentialKeys.idToken.push(newIdTokenKey);
+                if (!currentCredentialKeys.idToken.includes(newIdTokenKey)) {
+                    currentCredentialKeys.idToken.push(newIdTokenKey);
+                }
             }
         }
 
@@ -2006,10 +2008,8 @@ export class BrowserCacheManager extends CacheManager {
     }
 
     /**
-     * Cache Key: msal.<schema_version>-<home_account_id>-<environment>-<credential_type>-<client_id or familyId>-<realm>-<scopes>-<claims hash>-<scheme>
-     * IdToken Example: uid.utid-login.microsoftonline.com-idtoken-app_client_id-contoso.com
-     * AccessToken Example: uid.utid-login.microsoftonline.com-accesstoken-app_client_id-contoso.com-scope1 scope2--pop
-     * RefreshToken Example: uid.utid-login.microsoftonline.com-refreshtoken-1-contoso.com
+     * Generate Credential Key. All changes to the key REQUIRE a schema version update.
+     * Cache Key: msal.<schema_version>|<home_account_id>|<environment>|<credential_type>|<client_id or familyId>|<realm>|<scopes>|<scheme>
      * @param credentialEntity
      * @returns
      */

--- a/lib/msal-browser/src/cache/CacheKeys.ts
+++ b/lib/msal-browser/src/cache/CacheKeys.ts
@@ -6,8 +6,8 @@
 export const PREFIX = "msal";
 const BROWSER_PREFIX = "browser";
 export const CACHE_KEY_SEPARATOR = "|";
-export const CREDENTIAL_SCHEMA_VERSION = 2;
-export const ACCOUNT_SCHEMA_VERSION = 2;
+export const CREDENTIAL_SCHEMA_VERSION = 3;
+export const ACCOUNT_SCHEMA_VERSION = 3;
 
 export const LOG_LEVEL_CACHE_KEY = `${PREFIX}.${BROWSER_PREFIX}.log.level`;
 export const LOG_PII_CACHE_KEY = `${PREFIX}.${BROWSER_PREFIX}.log.pii`;

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -449,7 +449,7 @@ describe("BrowserCacheManager tests", () => {
                 );
             });
 
-            it("should migrate schema 2 credential keys into schema 3 without deleting schema 2 keys", async () => {
+            it("should migrate v2 tokens to current schema in localStorage", async () => {
                 await browserCacheManager.initialize(
                     TEST_CONFIG.CORRELATION_ID
                 );

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -501,15 +501,31 @@ describe("BrowserCacheManager tests", () => {
                     lastUpdatedAt: timestamp,
                 };
 
-                const compactIdTokenKey = `msal.2|${schema2IdToken.homeAccountId}|${schema2IdToken.environment}|${schema2IdToken.credentialType}|${schema2IdToken.clientId}|${schema2IdToken.realm}||`.toLowerCase();
-                const legacyIdTokenKey = `msal.2|${schema2IdToken.homeAccountId}|${schema2IdToken.environment}|${schema2IdToken.credentialType}|${schema2IdToken.clientId}|${schema2IdToken.realm}|||`.toLowerCase();
-                const compactAccessTokenKey = `msal.2|${schema2AccessToken.homeAccountId}|${schema2AccessToken.environment}|${schema2AccessToken.credentialType}|${schema2AccessToken.clientId}|${schema2AccessToken.realm}|${schema2AccessToken.target}|`.toLowerCase();
-                const legacyAccessTokenKey = `msal.2|${schema2AccessToken.homeAccountId}|${schema2AccessToken.environment}|${schema2AccessToken.credentialType}|${schema2AccessToken.clientId}|${schema2AccessToken.realm}|${schema2AccessToken.target}||`.toLowerCase();
+                const compactIdTokenKey =
+                    `msal.2|${schema2IdToken.homeAccountId}|${schema2IdToken.environment}|${schema2IdToken.credentialType}|${schema2IdToken.clientId}|${schema2IdToken.realm}||`.toLowerCase();
+                const legacyIdTokenKey =
+                    `msal.2|${schema2IdToken.homeAccountId}|${schema2IdToken.environment}|${schema2IdToken.credentialType}|${schema2IdToken.clientId}|${schema2IdToken.realm}|||`.toLowerCase();
+                const compactAccessTokenKey =
+                    `msal.2|${schema2AccessToken.homeAccountId}|${schema2AccessToken.environment}|${schema2AccessToken.credentialType}|${schema2AccessToken.clientId}|${schema2AccessToken.realm}|${schema2AccessToken.target}|`.toLowerCase();
+                const legacyAccessTokenKey =
+                    `msal.2|${schema2AccessToken.homeAccountId}|${schema2AccessToken.environment}|${schema2AccessToken.credentialType}|${schema2AccessToken.clientId}|${schema2AccessToken.realm}|${schema2AccessToken.target}||`.toLowerCase();
                 const schema2RefreshTokenFamilyId =
                     schema2RefreshToken.familyId ||
                     schema2RefreshToken.clientId;
-                const compactRefreshTokenKey = `msal.2|${schema2RefreshToken.homeAccountId}|${schema2RefreshToken.environment}|${schema2RefreshToken.credentialType}|${schema2RefreshTokenFamilyId}|${schema2RefreshToken.realm || ""}||`.toLowerCase();
-                const legacyRefreshTokenKey = `msal.2|${schema2RefreshToken.homeAccountId}|${schema2RefreshToken.environment}|${schema2RefreshToken.credentialType}|${schema2RefreshTokenFamilyId}|${schema2RefreshToken.realm || ""}|||`.toLowerCase();
+                const compactRefreshTokenKey = `msal.2|${
+                    schema2RefreshToken.homeAccountId
+                }|${schema2RefreshToken.environment}|${
+                    schema2RefreshToken.credentialType
+                }|${schema2RefreshTokenFamilyId}|${
+                    schema2RefreshToken.realm || ""
+                }||`.toLowerCase();
+                const legacyRefreshTokenKey = `msal.2|${
+                    schema2RefreshToken.homeAccountId
+                }|${schema2RefreshToken.environment}|${
+                    schema2RefreshToken.credentialType
+                }|${schema2RefreshTokenFamilyId}|${
+                    schema2RefreshToken.realm || ""
+                }|||`.toLowerCase();
 
                 window.localStorage.setItem(
                     compactIdTokenKey,
@@ -629,9 +645,9 @@ describe("BrowserCacheManager tests", () => {
                 expect(window.localStorage.getItem(legacyAccessTokenKey)).toBe(
                     JSON.stringify(schema2AccessToken)
                 );
-                expect(window.localStorage.getItem(compactRefreshTokenKey)).toBe(
-                    JSON.stringify(schema2RefreshToken)
-                );
+                expect(
+                    window.localStorage.getItem(compactRefreshTokenKey)
+                ).toBe(JSON.stringify(schema2RefreshToken));
                 expect(window.localStorage.getItem(legacyRefreshTokenKey)).toBe(
                     JSON.stringify(schema2RefreshToken)
                 );

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -247,7 +247,7 @@ describe("BrowserCacheManager tests", () => {
         });
 
         describe("migrateExistingCache", () => {
-            it("should migrate v0 tokens to v2 in localStorage", async () => {
+            it("should migrate v0 tokens to current schema in localStorage", async () => {
                 await browserCacheManager.initialize(
                     TEST_CONFIG.CORRELATION_ID
                 );
@@ -348,7 +348,7 @@ describe("BrowserCacheManager tests", () => {
                 );
             });
 
-            it("should migrate v1 tokens to v2 in localStorage", async () => {
+            it("should migrate v1 tokens to current schema in localStorage", async () => {
                 await browserCacheManager.initialize(
                     TEST_CONFIG.CORRELATION_ID
                 );
@@ -447,6 +447,202 @@ describe("BrowserCacheManager tests", () => {
                     },
                     TEST_CONFIG.CORRELATION_ID
                 );
+            });
+
+            it("should migrate schema 2 credential keys into schema 3 without deleting schema 2 keys", async () => {
+                await browserCacheManager.initialize(
+                    TEST_CONFIG.CORRELATION_ID
+                );
+
+                // Setup some current cache entries
+                await browserCacheManager.saveCacheRecord(
+                    {
+                        account: TEST_ACCOUNT_ENTITY,
+                        accessToken: TEST_ACCESS_TOKEN_ENTITY,
+                        idToken: TEST_ID_TOKEN_ENTITY,
+                        refreshToken: TEST_REFRESH_TOKEN_ENTITY,
+                    },
+                    TEST_CONFIG.CORRELATION_ID,
+                    true,
+                    0
+                );
+
+                // Setup some schema 2 cache entries
+                const schema2Account = {
+                    ...TEST_ACCOUNT_ENTITY,
+                    homeAccountId: "schema2-cleanup.uid.utid",
+                    lastUpdatedAt: (Date.now() - 1000).toString(),
+                };
+                const schema2AccountKey =
+                    `msal.2|${schema2Account.homeAccountId}|${schema2Account.environment}|utid`.toLowerCase();
+                window.localStorage.setItem(
+                    CacheKeys.getAccountKeysCacheKey(2),
+                    JSON.stringify([schema2AccountKey])
+                );
+                window.localStorage.setItem(
+                    schema2AccountKey,
+                    JSON.stringify(schema2Account)
+                );
+
+                const timestamp = (Date.now() - 1000).toString();
+                const schema2IdToken = {
+                    ...TEST_ID_TOKEN_ENTITY,
+                    homeAccountId: schema2Account.homeAccountId,
+                    lastUpdatedAt: timestamp,
+                };
+                const schema2AccessToken = {
+                    ...TEST_ACCESS_TOKEN_ENTITY,
+                    homeAccountId: schema2Account.homeAccountId,
+                    lastUpdatedAt: timestamp,
+                };
+                const schema2RefreshToken = {
+                    ...TEST_REFRESH_TOKEN_ENTITY,
+                    homeAccountId: schema2Account.homeAccountId,
+                    lastUpdatedAt: timestamp,
+                };
+
+                const compactIdTokenKey = `msal.2|${schema2IdToken.homeAccountId}|${schema2IdToken.environment}|${schema2IdToken.credentialType}|${schema2IdToken.clientId}|${schema2IdToken.realm}||`.toLowerCase();
+                const legacyIdTokenKey = `msal.2|${schema2IdToken.homeAccountId}|${schema2IdToken.environment}|${schema2IdToken.credentialType}|${schema2IdToken.clientId}|${schema2IdToken.realm}|||`.toLowerCase();
+                const compactAccessTokenKey = `msal.2|${schema2AccessToken.homeAccountId}|${schema2AccessToken.environment}|${schema2AccessToken.credentialType}|${schema2AccessToken.clientId}|${schema2AccessToken.realm}|${schema2AccessToken.target}|`.toLowerCase();
+                const legacyAccessTokenKey = `msal.2|${schema2AccessToken.homeAccountId}|${schema2AccessToken.environment}|${schema2AccessToken.credentialType}|${schema2AccessToken.clientId}|${schema2AccessToken.realm}|${schema2AccessToken.target}||`.toLowerCase();
+                const schema2RefreshTokenFamilyId =
+                    schema2RefreshToken.familyId ||
+                    schema2RefreshToken.clientId;
+                const compactRefreshTokenKey = `msal.2|${schema2RefreshToken.homeAccountId}|${schema2RefreshToken.environment}|${schema2RefreshToken.credentialType}|${schema2RefreshTokenFamilyId}|${schema2RefreshToken.realm || ""}||`.toLowerCase();
+                const legacyRefreshTokenKey = `msal.2|${schema2RefreshToken.homeAccountId}|${schema2RefreshToken.environment}|${schema2RefreshToken.credentialType}|${schema2RefreshTokenFamilyId}|${schema2RefreshToken.realm || ""}|||`.toLowerCase();
+
+                window.localStorage.setItem(
+                    compactIdTokenKey,
+                    JSON.stringify(schema2IdToken)
+                );
+                window.localStorage.setItem(
+                    legacyIdTokenKey,
+                    JSON.stringify(schema2IdToken)
+                );
+                window.localStorage.setItem(
+                    compactAccessTokenKey,
+                    JSON.stringify(schema2AccessToken)
+                );
+                window.localStorage.setItem(
+                    legacyAccessTokenKey,
+                    JSON.stringify(schema2AccessToken)
+                );
+                window.localStorage.setItem(
+                    compactRefreshTokenKey,
+                    JSON.stringify(schema2RefreshToken)
+                );
+                window.localStorage.setItem(
+                    legacyRefreshTokenKey,
+                    JSON.stringify(schema2RefreshToken)
+                );
+                window.localStorage.setItem(
+                    CacheKeys.getTokenKeysCacheKey(
+                        TEST_CONFIG.MSAL_CLIENT_ID,
+                        2
+                    ),
+                    JSON.stringify({
+                        idToken: [compactIdTokenKey, legacyIdTokenKey],
+                        accessToken: [
+                            compactAccessTokenKey,
+                            legacyAccessTokenKey,
+                        ],
+                        refreshToken: [
+                            compactRefreshTokenKey,
+                            legacyRefreshTokenKey,
+                        ],
+                    })
+                );
+
+                const addFieldsSpy = jest.spyOn(performanceClient, "addFields");
+
+                await browserCacheManager.migrateExistingCache(
+                    TEST_CONFIG.CORRELATION_ID
+                );
+
+                expect(addFieldsSpy).toHaveBeenCalledWith(
+                    {
+                        preMigrateATCount: 1,
+                        preMigrateAcntCount: 1,
+                        preMigrateITCount: 1,
+                        preMigrateRTCount: 1,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                );
+
+                expect(addFieldsSpy).toHaveBeenCalledWith(
+                    {
+                        postMigrateATCount: 2,
+                        postMigrateAcntCount: 2,
+                        postMigrateITCount: 2,
+                        postMigrateRTCount: 2,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                );
+
+                const currentTokenKeys = browserCacheManager.getTokenKeys();
+                expect(currentTokenKeys.idToken).toEqual([
+                    browserCacheManager.generateCredentialKey(
+                        TEST_ID_TOKEN_ENTITY
+                    ),
+                    browserCacheManager.generateCredentialKey(schema2IdToken),
+                ]);
+                expect(currentTokenKeys.accessToken).toEqual([
+                    browserCacheManager.generateCredentialKey(
+                        TEST_ACCESS_TOKEN_ENTITY
+                    ),
+                    browserCacheManager.generateCredentialKey(
+                        schema2AccessToken
+                    ),
+                ]);
+                expect(currentTokenKeys.refreshToken).toEqual([
+                    browserCacheManager.generateCredentialKey(
+                        TEST_REFRESH_TOKEN_ENTITY
+                    ),
+                    browserCacheManager.generateCredentialKey(
+                        schema2RefreshToken
+                    ),
+                ]);
+
+                const schema2TokenKeys = browserCacheManager.getTokenKeys(2);
+                expect(schema2TokenKeys.idToken).toEqual([
+                    compactIdTokenKey,
+                    legacyIdTokenKey,
+                ]);
+                expect(schema2TokenKeys.accessToken).toEqual([
+                    compactAccessTokenKey,
+                    legacyAccessTokenKey,
+                ]);
+                expect(schema2TokenKeys.refreshToken).toEqual([
+                    compactRefreshTokenKey,
+                    legacyRefreshTokenKey,
+                ]);
+
+                expect(window.localStorage.getItem(compactIdTokenKey)).toBe(
+                    JSON.stringify(schema2IdToken)
+                );
+                expect(window.localStorage.getItem(legacyIdTokenKey)).toBe(
+                    JSON.stringify(schema2IdToken)
+                );
+                expect(window.localStorage.getItem(compactAccessTokenKey)).toBe(
+                    JSON.stringify(schema2AccessToken)
+                );
+                expect(window.localStorage.getItem(legacyAccessTokenKey)).toBe(
+                    JSON.stringify(schema2AccessToken)
+                );
+                expect(window.localStorage.getItem(compactRefreshTokenKey)).toBe(
+                    JSON.stringify(schema2RefreshToken)
+                );
+                expect(window.localStorage.getItem(legacyRefreshTokenKey)).toBe(
+                    JSON.stringify(schema2RefreshToken)
+                );
+                expect(
+                    window.localStorage.getItem(
+                        CacheKeys.getTokenKeysCacheKey(
+                            TEST_CONFIG.MSAL_CLIENT_ID,
+                            2
+                        )
+                    )
+                ).not.toBeNull();
             });
 
             describe("getKMSIValues", () => {

--- a/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
+++ b/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
@@ -83,7 +83,7 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
             },
         };
 
-        createNestablePublicClientApplication(config).then((result) => {
+        await createNestablePublicClientApplication(config).then((result) => {
             pca = result;
         });
 

--- a/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
+++ b/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
@@ -83,9 +83,7 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
             },
         };
 
-        await createNestablePublicClientApplication(config).then((result) => {
-            pca = result;
-        });
+        pca = await createNestablePublicClientApplication(config);
 
         windowSpy = jest.spyOn(global, "window", "get");
 

--- a/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
+++ b/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
@@ -159,7 +159,7 @@ export class BrowserCacheUtils {
 
     async getAccountFromCache(): Promise<Array<string> | null> {
         const storage = await this.getWindowStorage();
-        const accountKeys = storage["msal.2.account.keys"];
+        const accountKeys = storage["msal.3.account.keys"];
 
         return JSON.parse(accountKeys);
     }

--- a/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
+++ b/samples/e2eTestUtils/src/BrowserCacheTestUtils.ts
@@ -161,7 +161,7 @@ export class BrowserCacheUtils {
         const storage = await this.getWindowStorage();
         const accountKeys = storage["msal.3.account.keys"];
 
-        return JSON.parse(accountKeys);
+        return accountKeys ? (JSON.parse(accountKeys) as Array<string>) : null;
     }
 
     async getTelemetryCacheEntry(

--- a/samples/msal-browser-samples/ExpressSample/test/test-helpers.ts
+++ b/samples/msal-browser-samples/ExpressSample/test/test-helpers.ts
@@ -2,6 +2,7 @@ import * as puppeteer from "puppeteer";
 import {
     Screenshot,
     enterCredentials,
+    BrowserCacheUtils,
 } from "e2e-test-utils";
 
 /**
@@ -35,6 +36,74 @@ export async function verifyCacheWasUsed(page: puppeteer.Page, screenshot: Scree
 
     // Verify no authentication network requests were made (indicating cached tokens were used)
     expect(networkRequests.length).toBe(0);
+}
+
+/**
+ * Force refresh tokens after an upgrade and verify the cache does not contain more token entries than before.
+ * @param page
+ * @param screenshot
+ * @param browserCache
+ */
+export async function forceRefreshAndVerifyTokenCountsDoNotIncrease(
+    page: puppeteer.Page,
+    screenshot: Screenshot,
+    browserCache: BrowserCacheUtils
+) {
+    const tokenKeysBefore = await browserCache.getTokens();
+
+    await page.locator('a[href="/playground"]').click();
+    await page.locator("button#applyConfig").waitHandle();
+    await screenshot.takeScreenshot(page, "Playground loaded");
+
+    await page.locator("button#applyConfig").click();
+    await page.waitForFunction(() => {
+        const responseContent = document.getElementById("responseContent");
+        return !!responseContent?.textContent?.includes(
+            'MSAL instance created and initialized'
+        );
+    });
+
+    await page.evaluate(() => {
+        const requestElement = document.getElementById(
+            "tokenRequest"
+        ) as HTMLTextAreaElement | null;
+
+        if (!requestElement) {
+            throw new Error("Token request textarea not found");
+        }
+
+        const request = requestElement.value
+            ? JSON.parse(requestElement.value)
+            : {};
+        request.forceRefresh = true;
+        requestElement.value = JSON.stringify(request, null, 2);
+    });
+    await screenshot.takeScreenshot(page, "Force refresh configured");
+
+    await page.locator("button#btnAcquireTokenSilent").click();
+    await page.waitForFunction(() => {
+        const responseContent = document.getElementById("responseContent");
+        const text = responseContent?.textContent || "";
+
+        return (
+            text.includes('"api": "acquireTokenSilent"') &&
+            text.includes('"result"') &&
+            !text.includes('"status": "Executing..."')
+        );
+    });
+    await screenshot.takeScreenshot(page, "Force refresh completed");
+
+    const tokenKeysAfter = await browserCache.getTokens();
+
+    expect(tokenKeysAfter.idTokens.length).toEqual(
+        tokenKeysBefore.idTokens.length
+    );
+    expect(tokenKeysAfter.accessTokens.length).toEqual(
+        tokenKeysBefore.accessTokens.length
+    );
+    expect(tokenKeysAfter.refreshTokens.length).toEqual(
+        tokenKeysBefore.refreshTokens.length
+    );
 }
 
 /**

--- a/samples/msal-browser-samples/ExpressSample/test/test-helpers.ts
+++ b/samples/msal-browser-samples/ExpressSample/test/test-helpers.ts
@@ -39,12 +39,12 @@ export async function verifyCacheWasUsed(page: puppeteer.Page, screenshot: Scree
 }
 
 /**
- * Force refresh tokens after an upgrade and verify the cache does not contain more token entries than before.
+ * Force refresh tokens after an upgrade and verify the cache does not contain more or less token entries than before.
  * @param page
  * @param screenshot
  * @param browserCache
  */
-export async function forceRefreshAndVerifyTokenCountsDoNotIncrease(
+export async function forceRefreshAndVerifyTokenCountsDoNotChange(
     page: puppeteer.Page,
     screenshot: Screenshot,
     browserCache: BrowserCacheUtils

--- a/samples/msal-browser-samples/ExpressSample/test/upgrade-downgrade.spec.ts
+++ b/samples/msal-browser-samples/ExpressSample/test/upgrade-downgrade.spec.ts
@@ -6,9 +6,14 @@ import {
     LabApiQueryParams,
     AzureEnvironments,
     AppTypes,
-    BrowserCacheUtils
+    BrowserCacheUtils,
 } from "e2e-test-utils";
-import { verifyCacheWasUsed, switchToVersion, signIn } from "./test-helpers";
+import {
+    forceRefreshAndVerifyTokenCountsDoNotIncrease,
+    verifyCacheWasUsed,
+    switchToVersion,
+    signIn,
+} from "./test-helpers";
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/upgrade-downgrade-tests`;
 
@@ -61,8 +66,8 @@ describe("Upgrade/Downgrade Tests", () => {
      */
     test("Verify Schema Version", async () => {
         // DO NOT UPDATE THESE CONSTANTS UNTIL TESTS HAVE BEEN ADDED!!
-        const currentAccountSchemaVersion = 2;
-        const currentTokenSchemaVersion = 2;
+        const currentAccountSchemaVersion = 3;
+        const currentTokenSchemaVersion = 3;
 
         const testName = "schemaVersion";
         const screenshot = new Screenshot(
@@ -105,6 +110,11 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
+            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+                page,
+                screenshot,
+                BrowserCache
+            );
         });
 
         test("acquireTokenSilent can return tokens from the cache after upgrading from the latest v4 version", async () => {
@@ -119,6 +129,30 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
+            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+                page,
+                screenshot,
+                BrowserCache
+            );
+        });
+
+        test("acquireTokenSilent can return tokens from the cache after upgrading from 5.7.0 (cache schema v2)", async () => {
+            const testName = "upgradeV5-7-0";
+            const screenshot = new Screenshot(
+                `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
+            );
+            await screenshot.takeScreenshot(page, "Page loaded");
+
+            await switchToVersion("5.7.0", page, screenshot);
+            await signIn(page, screenshot, username, accountPwd);
+            await switchToVersion("local", page, screenshot);
+
+            await verifyCacheWasUsed(page, screenshot);
+            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+                page,
+                screenshot,
+                BrowserCache
+            );
         });
 
         test("acquireTokenSilent can return tokens from the cache after upgrading from 4.25.0 (cache schema v1)", async () => {
@@ -133,6 +167,11 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
+            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+                page,
+                screenshot,
+                BrowserCache
+            );
         });
 
         test("acquireTokenSilent can return tokens from the cache after upgrading from 4.18.0 (cache schema v0)", async () => {
@@ -147,6 +186,11 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
+            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+                page,
+                screenshot,
+                BrowserCache
+            );
         });
 
         test("acquireTokenSilent can return tokens from the cache after downgrading to v3 and then upgrading back to local version", async () => {
@@ -166,6 +210,11 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
+            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+                page,
+                screenshot,
+                BrowserCache
+            );
         });
     });
     
@@ -209,6 +258,23 @@ describe("Upgrade/Downgrade Tests", () => {
             await verifyCacheWasUsed(page, screenshot);
 
             await switchToVersion("latest-v4", page, screenshot);
+            await verifyCacheWasUsed(page, screenshot);
+        });
+
+        test("acquireTokenSilent can return tokens from the cache after downgrading back to 5.7.0 (cache schema v2)", async () => {
+            const testName = "downgradeLatestTo5-7-0";
+            const screenshot = new Screenshot(
+                `${SCREENSHOT_BASE_FOLDER_NAME}/${testName}`
+            );
+            await screenshot.takeScreenshot(page, "Page loaded");
+
+            await switchToVersion("5.7.0", page, screenshot);
+            await signIn(page, screenshot, username, accountPwd);
+
+            await switchToVersion("local", page, screenshot);
+            await verifyCacheWasUsed(page, screenshot);
+
+            await switchToVersion("5.7.0", page, screenshot);
             await verifyCacheWasUsed(page, screenshot);
         });
 

--- a/samples/msal-browser-samples/ExpressSample/test/upgrade-downgrade.spec.ts
+++ b/samples/msal-browser-samples/ExpressSample/test/upgrade-downgrade.spec.ts
@@ -9,7 +9,7 @@ import {
     BrowserCacheUtils,
 } from "e2e-test-utils";
 import {
-    forceRefreshAndVerifyTokenCountsDoNotIncrease,
+    forceRefreshAndVerifyTokenCountsDoNotChange,
     verifyCacheWasUsed,
     switchToVersion,
     signIn,
@@ -110,7 +110,7 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
-            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+            await forceRefreshAndVerifyTokenCountsDoNotChange(
                 page,
                 screenshot,
                 BrowserCache
@@ -129,7 +129,7 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
-            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+            await forceRefreshAndVerifyTokenCountsDoNotChange(
                 page,
                 screenshot,
                 BrowserCache
@@ -148,7 +148,7 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
-            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+            await forceRefreshAndVerifyTokenCountsDoNotChange(
                 page,
                 screenshot,
                 BrowserCache
@@ -167,7 +167,7 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
-            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+            await forceRefreshAndVerifyTokenCountsDoNotChange(
                 page,
                 screenshot,
                 BrowserCache
@@ -186,7 +186,7 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
-            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+            await forceRefreshAndVerifyTokenCountsDoNotChange(
                 page,
                 screenshot,
                 BrowserCache
@@ -210,7 +210,7 @@ describe("Upgrade/Downgrade Tests", () => {
             await switchToVersion("local", page, screenshot);
 
             await verifyCacheWasUsed(page, screenshot);
-            await forceRefreshAndVerifyTokenCountsDoNotIncrease(
+            await forceRefreshAndVerifyTokenCountsDoNotChange(
                 page,
                 screenshot,
                 BrowserCache


### PR DESCRIPTION
This pull request introduces a new cache schema version (v3) for MSAL Browser, updates the credential and account key formats, and enhances migration logic and tests to ensure smooth upgrades and downgrades across schema versions. The changes ensure backward compatibility and robust migration from previous cache schemas, with thorough test coverage validating token integrity and cache key handling.

**Schema Version Upgrade and Key Format Changes:**

- Bumped `CREDENTIAL_SCHEMA_VERSION` and `ACCOUNT_SCHEMA_VERSION` from 2 to 3 in `CacheKeys.ts`, establishing a new schema version for cache entries.
- Clarified the schema versioning in documentation.

**Migration Logic Improvements:**

- Improved migration logic in `BrowserCacheManager` to ensure new v3 keys are only added if they don't already exist, preventing duplicate entries during migration.
- Added comprehensive migration test to verify that schema 2 (v2) credential keys are correctly migrated to schema 3 (v3) without deleting the original v2 keys, ensuring backward compatibility and data integrity.

**Test Enhancements for Upgrade/Downgrade Scenarios:**

- Updated upgrade/downgrade tests to reflect the new schema version (v3), including checks that token counts do not increase after forced refreshes post-upgrade, guarding against cache bloat or duplication. [[1]](diffhunk://#diff-e41b43706be7e3a838d4934809bd7201a6012abd1985538f9249179c98b75572L64-R70) [[2]](diffhunk://#diff-e41b43706be7e3a838d4934809bd7201a6012abd1985538f9249179c98b75572R113-R117) [[3]](diffhunk://#diff-e41b43706be7e3a838d4934809bd7201a6012abd1985538f9249179c98b75572R132-R155) [[4]](diffhunk://#diff-e41b43706be7e3a838d4934809bd7201a6012abd1985538f9249179c98b75572R170-R174) [[5]](diffhunk://#diff-e41b43706be7e3a838d4934809bd7201a6012abd1985538f9249179c98b75572R189-R193) [[6]](diffhunk://#diff-e41b43706be7e3a838d4934809bd7201a6012abd1985538f9249179c98b75572R213-R217)
- Added new test cases to cover migration from and downgrades to previous schema versions (v1 and v2), verifying cache usability and token retrieval after version transitions.

**Test Utility and Helper Updates:**

- Introduced a new helper function `forceRefreshAndVerifyTokenCountsDoNotIncrease` in test utilities to automate validation that token counts remain stable after schema upgrades and forced refreshes.
- Minor updates to test descriptions for clarity regarding migration to the "current schema" rather than a specific version. [[1]](diffhunk://#diff-1f474f3b5ffedcb4da969f60d720532be75a02c6d91e65b7d1e3c107b0a4f13dL250-R250) [[2]](diffhunk://#diff-1f474f3b5ffedcb4da969f60d720532be75a02c6d91e65b7d1e3c107b0a4f13dL351-R351)

These changes collectively ensure a robust, backward-compatible cache migration path as the MSAL Browser library evolves its schema.