### PR TITLE
fix(e2e): resolve puppeteer from cwd and fix sourceBranch variable in pipeline

### DIFF
--- a/.pipelines/1p-build.yml
+++ b/.pipelines/1p-build.yml
@@ -12,10 +12,6 @@ variables:
     LinuxContainerImage: "mcr.microsoft.com/onebranch/cbl-mariner/build:2.0" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
     WindowsContainerImage: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
     DEBIAN_FRONTEND: noninteractive
-    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
-        sourceBranchName: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
-    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
-        sourceBranchName: ${{ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') }}
 
 resources:
     repositories:

--- a/.pipelines/1p-e2e.yml
+++ b/.pipelines/1p-e2e.yml
@@ -37,7 +37,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: dev
+          ref: refs/heads/fix/prewarm-puppeteer-cwd-resolution
 
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/1p-e2e.yml
+++ b/.pipelines/1p-e2e.yml
@@ -34,7 +34,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: refs/heads/dev
+          ref: dev
 
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/1p-e2e.yml
+++ b/.pipelines/1p-e2e.yml
@@ -34,7 +34,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: refs/heads/fix/prewarm-puppeteer-cwd-resolution
+          ref: refs/heads/dev
 
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates

--- a/.pipelines/1p-e2e.yml
+++ b/.pipelines/1p-e2e.yml
@@ -22,10 +22,7 @@ variables:
     CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
     LinuxContainerImage: "mcr.microsoft.com/onebranch/cbl-mariner/build:2.0" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
     DEBIAN_FRONTEND: noninteractive
-    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
-        sourceBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
-    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
-        sourceBranch: ${{ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') }}
+    sourceBranch: $[coalesce(replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', ''), replace(variables['Build.SourceBranch'], 'refs/heads/', ''))]
     sourceRepo: "microsoft-authentication-library-for-js"
 
 resources:

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -51,7 +51,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: refs/heads/dev
+          ref: dev
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
     parameters:

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -39,10 +39,7 @@ variables:
     CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
     LinuxContainerImage: "mcr.microsoft.com/onebranch/cbl-mariner/build:2.0" # Docker image which is used to build the project https://aka.ms/obpipelines/containers
     DEBIAN_FRONTEND: noninteractive
-    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
-        sourceBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
-    ${{ if startsWith(variables['System.PullRequest.SourceBranch'], 'refs/pull/') }}:
-        sourceBranch: ${{ replace(variables['System.PullRequest.SourceBranch'], 'refs/pull/', '') }}
+    sourceBranch: $[coalesce(replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', ''), replace(variables['Build.SourceBranch'], 'refs/heads/', ''))]
     sourceRepo: "microsoft-authentication-library-for-js"
 
 resources:

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -51,7 +51,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: refs/heads/fix/prewarm-puppeteer-cwd-resolution
+          ref: refs/heads/dev
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
     parameters:

--- a/.pipelines/3p-e2e.yml
+++ b/.pipelines/3p-e2e.yml
@@ -54,7 +54,7 @@ resources:
         - repository: 1P
           type: git
           name: IDDP/msal-javascript-1p
-          ref: dev
+          ref: refs/heads/fix/prewarm-puppeteer-cwd-resolution
 extends:
     template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
     parameters:

--- a/.pipelines/scripts/prewarm-puppeteer.js
+++ b/.pipelines/scripts/prewarm-puppeteer.js
@@ -1,0 +1,43 @@
+// Launches and immediately closes a Puppeteer/Chrome instance so that the
+// browser binary is unpacked and cached before tests run.  Errors here are
+// non-fatal: the step is run with continueOnError: true in CI.
+//
+// require() resolves modules relative to this script file's directory, not
+// process.cwd(). Since puppeteer is installed in the sample's node_modules
+// (the pipeline sets cwd to the sample path), we resolve from cwd instead.
+const { createRequire } = require("module");
+const requireFromCwd = createRequire(require("path").join(process.cwd(), "package.json"));
+Promise.resolve()
+    .then(() => requireFromCwd("puppeteer"))
+    .then((puppeteer) => puppeteer.launch({ headless: true, timeout: 120000 }))
+    .then((b) =>
+        b.close().catch((e) => {
+            if (e.code === "EBUSY")
+                console.warn(
+                    "[pre-warm] Chrome temp profile cleanup hit a file lock (non-fatal on Windows):",
+                    e.message
+                );
+            else if (
+                e.message &&
+                (e.message.includes("Target closed") ||
+                    e.message.includes("Protocol error"))
+            )
+                console.warn(
+                    "[pre-warm] Chrome exited before close() completed (non-fatal):",
+                    e.message
+                );
+            else
+                console.warn(
+                    "[pre-warm] Unexpected browser cleanup error (non-fatal, tests will still run):",
+                    e.message
+                );
+        })
+    )
+    .then(() => console.log("Browser ready"))
+    .catch((e) => {
+        console.error(
+            "[pre-warm] Browser launch failed (non-fatal, tests will still run):",
+            e.message
+        );
+        process.exit(1);
+    });


### PR DESCRIPTION
## Problem

### 1. Puppeteer pre-warm resolution

The pre-warm script (`.pipelines/scripts/prewarm-puppeteer.js`) used `require('puppeteer')`, which Node resolves relative to the **script file's directory**. In the `3p-e2e.yml` pipeline, the script lives in the 3P repo so puppeteer is found correctly, but the module resolution was still fragile.

Additionally, the script previously only lived in the 1P repo, so in the `3p-e2e.yml` context (`./` = 3P root) the file was not found at all.

### 2. `sourceBranch` always empty in E2E pipelines

`1p-e2e.yml` and `3p-e2e.yml` used compile-time template expressions (`${{ if ... }}`) to set `sourceBranch` from `Build.SourceBranch` / `System.PullRequest.SourceBranch`. These expressions are evaluated at pipeline compilation time — before runtime variables are populated — so both conditions always evaluated to false and `sourceBranch` was never set.

As a result, the checkout step always fell back to `origin/dev`, meaning E2E tests were **never validating the actual PR branch** — they were silently re-testing `dev` on every PR.

## Fix

### Puppeteer pre-warm
- Move `prewarm-puppeteer.js` here (3P repo) so it is available in both pipeline contexts via `./` in the template path.
- Use `createRequire(process.cwd())` so puppeteer is resolved from the sample's `node_modules` (the pipeline sets cwd to the sample path), which is reliable in all three pipelines:
  - `1p-e2e.yml` (1P samples) ✅
  - `3p-e2e.yml` (3P samples) ✅
  - Release pipeline (3P samples via submodule) ✅

### `sourceBranch` variable
- Replace compile-time `${{ if }}` conditionals with a single runtime `$[coalesce(...)]` expression in both `1p-e2e.yml` and `3p-e2e.yml`:
  ```yaml
  sourceBranch: $[coalesce(replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', ''), replace(variables['Build.SourceBranch'], 'refs/heads/', ''))]
  ```
  - **PR builds**: `System.PullRequest.SourceBranch` = `refs/heads/my-branch` → `my-branch` ✅
  - **CI builds**: `System.PullRequest.SourceBranch` is empty, coalesce falls through to `Build.SourceBranch` = `refs/heads/dev` → `dev` ✅
- Remove unused `sourceBranchName` dead code from `1p-build.yml` (was set with the same broken pattern but never passed to any template).

## Related

Companion 1P PR updates the template path to use `./` and removes the now-redundant copy of the script from the 1P repo.
