### PR TITLE
fix(msal-node): upgrade uuid to v14 to patch CVE

### DIFF
--- a/lib/msal-node/jest.config.cjs
+++ b/lib/msal-node/jest.config.cjs
@@ -8,17 +8,7 @@ module.exports = {
     moduleFileExtensions: ["ts", "tsx", "js", "json", "jsx", "node"],
     reporters: ["default", "jest-junit"],
     testMatch: ["<rootDir>/test/**/*.spec.ts"],
-    transform: {
-        "^.+\\.(ts|tsx|js)$": [
-            "ts-jest",
-            {
-                useESM: true,
-                diagnostics: {
-                    ignoreCodes: [151001],
-                },
-            },
-        ],
-    },
+    transform: {"^.+\\.(ts|tsx|js)$": ["ts-jest", { useESM: true }]},
     /**
      * uuid v12+ ships as ESM-only with no CommonJS build. Jest runs in CJS mode by default,
      * so without this exception tests will fail with "SyntaxError: Cannot use import statement in a module".

--- a/lib/msal-node/jest.config.cjs
+++ b/lib/msal-node/jest.config.cjs
@@ -9,8 +9,23 @@ module.exports = {
     reporters: ["default", "jest-junit"],
     testMatch: ["<rootDir>/test/**/*.spec.ts"],
     transform: {
-        "^.+\\.(ts|tsx)$": "ts-jest",
+        "^.+\\.(ts|tsx|js)$": [
+            "ts-jest",
+            {
+                useESM: true,
+                diagnostics: {
+                    ignoreCodes: [151001],
+                },
+            },
+        ],
     },
+    /**
+     * uuid v12+ ships as ESM-only with no CommonJS build. Jest runs in CJS mode by default,
+     * so without this exception tests will fail with "SyntaxError: Cannot use import statement in a module".
+     * https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md#-breaking-changes-2
+     * note: Jest's ESM support is experimental; consider migrating to Vitest which is ESM-native.
+     */
+    transformIgnorePatterns: ["/node_modules/(?!uuid)"],
     /**
      * "Not a ts-jest issue" but a jest one. Consider vitest?
      *  this morphs "./some/relative/path.js" to "./some/relative/path"

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -70,7 +70,7 @@
     "@types/jest": "^29.5.0",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/node": "^20.3.1",
-    "@types/uuid": "^7.0.0",
+    "@types/uuid": "^10.0.0",
     "eslint-config-msal": "file:../../shared-configs/eslint-config-msal",
     "jest": "^29.5.0",
     "jest-junit": "^16.0.0",
@@ -85,7 +85,7 @@
   "dependencies": {
     "@azure/msal-common": "16.5.1",
     "jsonwebtoken": "^9.0.0",
-    "uuid": "^8.3.0"
+    "uuid": "^14.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1584,7 +1584,7 @@
             "dependencies": {
                 "@azure/msal-common": "16.5.1",
                 "jsonwebtoken": "^9.0.0",
-                "uuid": "^8.3.0"
+                "uuid": "^14.0.0"
             },
             "devDependencies": {
                 "@microsoft/api-extractor": "^7.43.4",
@@ -1593,7 +1593,7 @@
                 "@types/jest": "^29.5.0",
                 "@types/jsonwebtoken": "^9.0.1",
                 "@types/node": "^20.3.1",
-                "@types/uuid": "^7.0.0",
+                "@types/uuid": "^10.0.0",
                 "eslint-config-msal": "file:../../shared-configs/eslint-config-msal",
                 "jest": "^29.5.0",
                 "jest-junit": "^16.0.0",
@@ -1623,6 +1623,19 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
+        },
+        "lib/msal-node/node_modules/uuid": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist-node/bin/uuid"
+            }
         },
         "lib/msal-react": {
             "name": "@azure/msal-react",
@@ -13871,10 +13884,11 @@
             "dev": true
         },
         "node_modules/@types/uuid": {
-            "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.8.tgz",
-            "integrity": "sha512-95N4tyM4B5u1sj2m8Tht09qWHju2ht413GBFz8CHtxp8aIiJUF6t51MsR7jC9OF4rRVf93AxE++WJe7+Puc1UA==",
-            "dev": true
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/warning": {
             "version": "3.0.3",
@@ -50418,20 +50432,6 @@
             "devDependencies": {
                 "@azure/msal-common": "^16.0.0",
                 "typescript": "^4.9.5"
-            }
-        },
-        "node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR upgrades `uuid` from `8.3.0` to `14.0.0` in `@azure/msal-node` to address a known security advisory, 
and updates the Jest configuration to handle uuid dependency which is now ESM-only

## Security Advisory

Resolves [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)

## Changes

### `uuid` upgrade (`8.3.0` → `14.0.0`)
- Bumps `uuid` to a version that resolves the security advisory above.

### Jest config (`jest.config.cjs`)

uuid v12+ ships as ESM-only (no CommonJS build), which required the Jest config changes below to keep tests passing.
see [changelog uuid 12](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md#-breaking-changes-2)

Added `transformIgnorePatterns` to exempt `uuid` from Jest's default "do not transform `node_modules`" rule — required because Jest runs in CJS mode by default and cannot parse ESM-only packages without transformation.