### PR TITLE
fix(msal-node): replace uuid with node:crypto.randomUUID() (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/change/@azure-msal-node-5f105308-eb84-4458-b68f-82c907dacb5b.json
+++ b/change/@azure-msal-node-5f105308-eb84-4458-b68f-82c907dacb5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(msal-node): replace uuid with node:crypto to resolve GHSA-w5hq-g745-h8pq",
+  "packageName": "@azure/msal-node",
+  "email": "pieter.willaert@colruytgroup.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -70,7 +70,6 @@
     "@types/jest": "^29.5.0",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/node": "^20.3.1",
-    "@types/uuid": "^7.0.0",
     "eslint-config-msal": "file:../../shared-configs/eslint-config-msal",
     "jest": "^29.5.0",
     "jest-junit": "^16.0.0",
@@ -84,8 +83,7 @@
   },
   "dependencies": {
     "@azure/msal-common": "16.5.1",
-    "jsonwebtoken": "^9.0.0",
-    "uuid": "^8.3.0"
+    "jsonwebtoken": "^9.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/lib/msal-node/src/crypto/GuidGenerator.ts
+++ b/lib/msal-node/src/crypto/GuidGenerator.ts
@@ -4,16 +4,15 @@
  */
 
 import { IGuidGenerator } from "@azure/msal-common/node";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 
 export class GuidGenerator implements IGuidGenerator {
     /**
-     *
-     * RFC4122: The version 4 UUID is meant for generating UUIDs from truly-random or pseudo-random numbers.
-     * uuidv4 generates guids from cryprtographically-string random
+     * Generates a random [RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.txt) version 4 UUID. The UUID is generated using a
+     * cryptographic pseudorandom number generator.
      */
     generateGuid(): string {
-        return uuidv4();
+        return randomUUID();
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1583,8 +1583,7 @@
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-common": "16.5.1",
-                "jsonwebtoken": "^9.0.0",
-                "uuid": "^8.3.0"
+                "jsonwebtoken": "^9.0.0"
             },
             "devDependencies": {
                 "@microsoft/api-extractor": "^7.43.4",
@@ -1593,7 +1592,6 @@
                 "@types/jest": "^29.5.0",
                 "@types/jsonwebtoken": "^9.0.1",
                 "@types/node": "^20.3.1",
-                "@types/uuid": "^7.0.0",
                 "eslint-config-msal": "file:../../shared-configs/eslint-config-msal",
                 "jest": "^29.5.0",
                 "jest-junit": "^16.0.0",
@@ -13868,12 +13866,6 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
             "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-            "dev": true
-        },
-        "node_modules/@types/uuid": {
-            "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.8.tgz",
-            "integrity": "sha512-95N4tyM4B5u1sj2m8Tht09qWHju2ht413GBFz8CHtxp8aIiJUF6t51MsR7jC9OF4rRVf93AxE++WJe7+Puc1UA==",
             "dev": true
         },
         "node_modules/@types/warning": {
@@ -50418,20 +50410,6 @@
             "devDependencies": {
                 "@azure/msal-common": "^16.0.0",
                 "typescript": "^4.9.5"
-            }
-        },
-        "node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
             }
         }
     }


### PR DESCRIPTION
## Summary

Removes the `uuid` npm package from `@azure/msal-node` and replaces its
usage with the built-in `node:crypto` module's `randomUUID()` function.

## Motivation

The `uuid` package has a moderate severity security advisory:
[GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)
(CVE-2026-41988) — a missing buffer bounds check in `v3`/`v5`/`v6` when
an external output `buf` is provided.

While `msal-node` only used `uuid.v4()` without a buffer argument and was
not directly exploitable, removing the dependency entirely is the correct
mitigation and reduces the overall supply-chain attack surface.

## Changes

- `GuidGenerator.ts`: replaced `import { v4 as uuidv4 } from "uuid"` with
  `import { randomUUID } from "node:crypto"` and updated the call site
- `package.json`: removed `uuid` from `dependencies` and `@types/uuid`
  from `devDependencies`
- Updated `package-lock.json` accordingly

## Compatibility

`crypto.randomUUID()` produces a standards-compliant
[RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.txt) version 4 UUID
using a cryptographically secure pseudorandom number generator — identical
behaviour to `uuid.v4()`. It is stable in all Node.js versions >= 14.17,
well within `msal-node`'s declared engine requirement of `>= 20`.

No public API is changed.