### PR TITLE
fix: use client_info="1" string value in native auth token requests

### DIFF
--- a/change/@azure-msal-browser-9cb0f4b5-9b7b-4481-ba13-dd9a3d2e44d7.json
+++ b/change/@azure-msal-browser-9cb0f4b5-9b7b-4481-ba13-dd9a3d2e44d7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: use client_info=\"1\" string value in native auth token requests",
+  "comment": "Use client_info=\"1\" string value in native auth token requests [#8562](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8562)",
   "packageName": "@azure/msal-browser",
   "email": "jiashen@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-9cb0f4b5-9b7b-4481-ba13-dd9a3d2e44d7.json
+++ b/change/@azure-msal-browser-9cb0f4b5-9b7b-4481-ba13-dd9a3d2e44d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use client_info=\"1\" string value in native auth token requests",
+  "packageName": "@azure/msal-browser",
+  "email": "jiashen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
@@ -146,7 +146,7 @@ export class SignInApiClient extends BaseApiClient {
                 continuation_token: params.continuation_token,
                 scope: params.scope,
                 grant_type: GrantType.CONTINUATION_TOKEN,
-                client_info: true,
+                client_info: "1",
                 ...(params.claims && { claims: params.claims }),
                 ...(params.username && { username: params.username }),
             },
@@ -185,7 +185,7 @@ export class SignInApiClient extends BaseApiClient {
         correlationId: string
     ): Promise<SignInTokenResponse> {
         // The client_info parameter is required for MSAL to return the uid and utid in the response.
-        requestData.client_info = true;
+        requestData.client_info = "1";
 
         const result = await this.request<SignInTokenResponse>(
             CustomAuthApiEndpoint.SIGNIN_TOKEN,

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
@@ -146,7 +146,6 @@ export class SignInApiClient extends BaseApiClient {
                 continuation_token: params.continuation_token,
                 scope: params.scope,
                 grant_type: GrantType.CONTINUATION_TOKEN,
-                client_info: "1",
                 ...(params.claims && { claims: params.claims }),
                 ...(params.username && { username: params.username }),
             },
@@ -180,7 +179,7 @@ export class SignInApiClient extends BaseApiClient {
     }
 
     private async requestTokens(
-        requestData: Record<string, string | boolean>,
+        requestData: Record<string, string>,
         telemetryManager: ServerTelemetryManager,
         correlationId: string
     ): Promise<SignInTokenResponse> {


### PR DESCRIPTION
## Problem

In native auth (custom auth), the `/token` endpoint request was sending `client_info: true` (boolean). This doesn't work when the `RefactorAndReturnXmsAcbinClientInfo` feature flag is enabled on the service side.

## Fix

Changed `client_info` value from `true` to `"1"` (string) in `SignInApiClient.ts` to match the value used by msal-common's `RequestParameterBuilder.addClientInfo()`.

### Changes
- `lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts`: Updated `client_info` from `true` to `"1"` in both `requestTokenWithContinuationToken` and the shared `requestTokens` method.

## Testing

All existing SignInApiClient tests pass without modification (17/17).
