### PR TITLE
Custom Auth: add requestInterceptor for custom x-* request headers

### DIFF
--- a/change/@azure-msal-browser-ec2f3299-3059-4820-b675-ab278d78e0ae.json
+++ b/change/@azure-msal-browser-ec2f3299-3059-4820-b675-ab278d78e0ae.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Custom Auth: add `requestInterceptor` configuration option that lets apps attach additional `x-*` headers to custom-auth backend requests (e.g., for fraud/bot-detection vendors). Headers without the `x-` prefix and headers starting with reserved prefixes (`x-client-`, `x-ms-`, `x-broker-`, `x-app-`) are filtered out.",
+  "comment": "Custom Auth: add `requestInterceptor` configuration option that lets apps attach additional `x-*` headers to custom-auth backend requests (e.g., for fraud/bot-detection vendors). Headers without the `x-` prefix and headers starting with reserved prefixes (`x-client-`, `x-ms-`, `x-broker-`, `x-app-`) are filtered out. [#8587](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8587)",
   "packageName": "@azure/msal-browser",
   "email": "shen.jian@live.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-ec2f3299-3059-4820-b675-ab278d78e0ae.json
+++ b/change/@azure-msal-browser-ec2f3299-3059-4820-b675-ab278d78e0ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Custom Auth: add `requestInterceptor` configuration option that lets apps attach additional `x-*` headers to custom-auth backend requests (e.g., for fraud/bot-detection vendors). Headers without the `x-` prefix and headers starting with reserved prefixes (`x-client-`, `x-ms-`, `x-broker-`, `x-app-`) are filtered out.",
+  "packageName": "@azure/msal-browser",
+  "email": "shen.jian@live.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/custom_auth/CustomAuthConstants.ts
+++ b/lib/msal-browser/src/custom_auth/CustomAuthConstants.ts
@@ -33,6 +33,16 @@ export const HttpHeaderKeys = {
     X_MS_REQUEST_ID: "x-ms-request-id",
 } as const;
 
+export const CustomHeaderConstants = {
+    REQUIRED_PREFIX: "x-",
+    RESERVED_PREFIXES: [
+        "x-client-",
+        "x-ms-",
+        "x-broker-",
+        "x-app-",
+    ] as ReadonlyArray<string>,
+} as const;
+
 export const DefaultPackageInfo = {
     SKU: "msal.browser",
     VERSION: version,

--- a/lib/msal-browser/src/custom_auth/configuration/CustomAuthConfiguration.ts
+++ b/lib/msal-browser/src/custom_auth/configuration/CustomAuthConfiguration.ts
@@ -7,12 +7,14 @@ import {
     BrowserConfiguration,
     Configuration,
 } from "../../config/Configuration.js";
+import { CustomAuthRequestInterceptor } from "./CustomAuthRequestInterceptor.js";
 
 export type CustomAuthOptions = {
     challengeTypes?: Array<string>;
     authApiProxyUrl: string;
     customAuthApiQueryParams?: Record<string, string>;
     capabilities?: Array<string>;
+    requestInterceptor?: CustomAuthRequestInterceptor;
 };
 
 export type CustomAuthConfiguration = Configuration & {

--- a/lib/msal-browser/src/custom_auth/configuration/CustomAuthRequestInterceptor.ts
+++ b/lib/msal-browser/src/custom_auth/configuration/CustomAuthRequestInterceptor.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Result type returned by {@link CustomAuthRequestInterceptor.addAdditionalHeaderFields}.
+ *
+ * Implementations may return either a synchronous value or a `Promise` resolving to one of
+ * the following:
+ * - A `Record<string, string>` of additional headers to add to the outgoing request.
+ * - `null` (or `undefined`) when no additional headers should be added for the request.
+ */
+export type CustomAuthAdditionalHeaderFieldsResult =
+    | Record<string, string>
+    | null
+    | undefined;
+
+/**
+ * Interface for intercepting custom auth network requests in order to attach additional
+ * headers to outgoing requests.
+ *
+ * Implementations are invoked by MSAL before each backend request used by custom auth
+ * (sign-in, sign-up, reset-password, and register endpoints). Use this hook to integrate
+ * with third-party fraud and bot-detection SDKs that require custom `x-*` headers.
+ *
+ * MSAL applies the following rules when evaluating the headers you provide:
+ * - Headers must start with `x-` (case-insensitive). Headers that don't start with `x-`
+ *   are ignored.
+ * - Headers that start with any of the following reserved prefixes are ignored:
+ *   `x-client-`, `x-ms-`, `x-broker-`, `x-app-`.
+ * - Headers that pass both rules are added to the network request. If a header you
+ *   provide has the same name as one of MSAL's own internal headers, your value takes
+ *   precedence.
+ */
+export interface CustomAuthRequestInterceptor {
+    /**
+     * Returns additional headers to add to a custom-auth network request.
+     *
+     * Scope your headers to specific endpoints by inspecting `requestUrl`. Sending
+     * headers to unrelated endpoints can degrade signal quality and increase false
+     * positives for fraud/bot-detection vendors.
+     *
+     * @param requestUrl - The full URL of the outgoing custom-auth request.
+     * @returns A record of headers to add (or `null`/`undefined` if no extra headers
+     *          are needed for the request). May be returned synchronously or as a
+     *          `Promise`.
+     */
+    addAdditionalHeaderFields(
+        requestUrl: URL
+    ):
+        | CustomAuthAdditionalHeaderFieldsResult
+        | Promise<CustomAuthAdditionalHeaderFieldsResult>;
+}

--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -125,7 +125,9 @@ export class CustomAuthStandardController
                     this.customAuthConfig.auth.clientId,
                     new FetchHttpClient(this.logger),
                     this.customAuthConfig.customAuth?.capabilities?.join(" "),
-                    this.customAuthConfig.customAuth?.customAuthApiQueryParams
+                    this.customAuthConfig.customAuth?.customAuthApiQueryParams,
+                    this.customAuthConfig.customAuth?.requestInterceptor,
+                    this.logger
                 ),
             this.authority
         );

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/BaseApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/BaseApiClient.ts
@@ -17,9 +17,12 @@ import {
 } from "../../error/CustomAuthApiError.js";
 import {
     AADServerParamKeys,
+    Logger,
     ServerTelemetryManager,
 } from "@azure/msal-common/browser";
 import { ApiErrorResponse } from "./types/ApiErrorResponseTypes.js";
+import { CustomAuthRequestInterceptor } from "../../../configuration/CustomAuthRequestInterceptor.js";
+import { filterCustomHeaders } from "../../utils/CustomHeaderUtils.js";
 
 export abstract class BaseApiClient {
     private readonly baseRequestUrl: URL;
@@ -28,7 +31,9 @@ export abstract class BaseApiClient {
         baseUrl: string,
         private readonly clientId: string,
         private httpClient: IHttpClient,
-        private customAuthApiQueryParams?: Record<string, string>
+        private customAuthApiQueryParams?: Record<string, string>,
+        private requestInterceptor?: CustomAuthRequestInterceptor,
+        private logger?: Logger
     ) {
         this.baseRequestUrl = parseUrl(
             !baseUrl.endsWith("/") ? `${baseUrl}/` : baseUrl
@@ -45,12 +50,22 @@ export abstract class BaseApiClient {
             client_id: this.clientId,
             ...data,
         });
-        const headers = this.getCommonHeaders(correlationId, telemetryManager);
+        const commonHeaders = this.getCommonHeaders(
+            correlationId,
+            telemetryManager
+        );
         const url = buildUrl(
             this.baseRequestUrl.href,
             endpoint,
             this.customAuthApiQueryParams
         );
+
+        const additionalHeaders = await this.getAdditionalHeaders(
+            url,
+            correlationId
+        );
+
+        const headers = { ...commonHeaders, ...additionalHeaders };
 
         let response: Response;
 
@@ -172,5 +187,29 @@ export abstract class BaseApiClient {
             responseError.trace_id,
             responseError.timestamp
         );
+    }
+
+    private async getAdditionalHeaders(
+        url: URL,
+        correlationId: string
+    ): Promise<Record<string, string>> {
+        if (!this.requestInterceptor) {
+            return {};
+        }
+
+        try {
+            const result = await Promise.resolve(
+                this.requestInterceptor.addAdditionalHeaderFields(url)
+            );
+
+            return filterCustomHeaders(result);
+        } catch (e) {
+            this.logger?.warningPii(
+                `CustomAuthRequestInterceptor.addAdditionalHeaderFields threw an error; continuing without additional headers: ${e}`,
+                correlationId
+            );
+
+            return {};
+        }
     }
 }

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/BaseApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/BaseApiClient.ts
@@ -202,7 +202,7 @@ export abstract class BaseApiClient {
                 this.requestInterceptor.addAdditionalHeaderFields(url)
             );
 
-            return filterCustomHeaders(result);
+            return filterCustomHeaders(result, this.logger, correlationId);
         } catch (e) {
             this.logger?.warningPii(
                 `CustomAuthRequestInterceptor.addAdditionalHeaderFields threw an error; continuing without additional headers: ${e}`,

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.ts
@@ -9,6 +9,8 @@ import { SignInApiClient } from "./SignInApiClient.js";
 import { RegisterApiClient } from "./RegisterApiClient.js";
 import { ICustomAuthApiClient } from "./ICustomAuthApiClient.js";
 import { IHttpClient } from "../http_client/IHttpClient.js";
+import { Logger } from "@azure/msal-common/browser";
+import { CustomAuthRequestInterceptor } from "../../../configuration/CustomAuthRequestInterceptor.js";
 
 export class CustomAuthApiClient implements ICustomAuthApiClient {
     signInApi: SignInApiClient;
@@ -21,34 +23,44 @@ export class CustomAuthApiClient implements ICustomAuthApiClient {
         clientId: string,
         httpClient: IHttpClient,
         capabilities?: string,
-        customAuthApiQueryParams?: Record<string, string>
+        customAuthApiQueryParams?: Record<string, string>,
+        requestInterceptor?: CustomAuthRequestInterceptor,
+        logger?: Logger
     ) {
         this.signInApi = new SignInApiClient(
             customAuthApiBaseUrl,
             clientId,
             httpClient,
             capabilities,
-            customAuthApiQueryParams
+            customAuthApiQueryParams,
+            requestInterceptor,
+            logger
         );
         this.signUpApi = new SignupApiClient(
             customAuthApiBaseUrl,
             clientId,
             httpClient,
             capabilities,
-            customAuthApiQueryParams
+            customAuthApiQueryParams,
+            requestInterceptor,
+            logger
         );
         this.resetPasswordApi = new ResetPasswordApiClient(
             customAuthApiBaseUrl,
             clientId,
             httpClient,
             capabilities,
-            customAuthApiQueryParams
+            customAuthApiQueryParams,
+            requestInterceptor,
+            logger
         );
         this.registerApi = new RegisterApiClient(
             customAuthApiBaseUrl,
             clientId,
             httpClient,
-            customAuthApiQueryParams
+            customAuthApiQueryParams,
+            requestInterceptor,
+            logger
         );
     }
 }

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/ResetPasswordApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/ResetPasswordApiClient.ts
@@ -10,6 +10,7 @@ import {
 import { CustomAuthApiError } from "../../error/CustomAuthApiError.js";
 import { BaseApiClient } from "./BaseApiClient.js";
 import { IHttpClient } from "../http_client/IHttpClient.js";
+import { Logger } from "@azure/msal-common/browser";
 import * as CustomAuthApiEndpoint from "./CustomAuthApiEndpoint.js";
 import * as CustomAuthApiErrorCode from "./types/ApiErrorCodes.js";
 import {
@@ -26,6 +27,7 @@ import {
     ResetPasswordStartResponse,
     ResetPasswordSubmitResponse,
 } from "./types/ApiResponseTypes.js";
+import { CustomAuthRequestInterceptor } from "../../../configuration/CustomAuthRequestInterceptor.js";
 
 export class ResetPasswordApiClient extends BaseApiClient {
     private readonly capabilities?: string;
@@ -35,13 +37,17 @@ export class ResetPasswordApiClient extends BaseApiClient {
         clientId: string,
         httpClient: IHttpClient,
         capabilities?: string,
-        customAuthApiQueryParams?: Record<string, string>
+        customAuthApiQueryParams?: Record<string, string>,
+        requestInterceptor?: CustomAuthRequestInterceptor,
+        logger?: Logger
     ) {
         super(
             customAuthApiBaseUrl,
             clientId,
             httpClient,
-            customAuthApiQueryParams
+            customAuthApiQueryParams,
+            requestInterceptor,
+            logger
         );
         this.capabilities = capabilities;
     }

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ServerTelemetryManager } from "@azure/msal-common/browser";
+import { Logger, ServerTelemetryManager } from "@azure/msal-common/browser";
 import { GrantType } from "../../../CustomAuthConstants.js";
 import { CustomAuthApiError } from "../../error/CustomAuthApiError.js";
 import { BaseApiClient } from "./BaseApiClient.js";
@@ -24,6 +24,7 @@ import {
     SignInIntrospectResponse,
     SignInTokenResponse,
 } from "./types/ApiResponseTypes.js";
+import { CustomAuthRequestInterceptor } from "../../../configuration/CustomAuthRequestInterceptor.js";
 
 export class SignInApiClient extends BaseApiClient {
     private readonly capabilities?: string;
@@ -33,13 +34,17 @@ export class SignInApiClient extends BaseApiClient {
         clientId: string,
         httpClient: IHttpClient,
         capabilities?: string,
-        customAuthApiQueryParams?: Record<string, string>
+        customAuthApiQueryParams?: Record<string, string>,
+        requestInterceptor?: CustomAuthRequestInterceptor,
+        logger?: Logger
     ) {
         super(
             customAuthApiBaseUrl,
             clientId,
             httpClient,
-            customAuthApiQueryParams
+            customAuthApiQueryParams,
+            requestInterceptor,
+            logger
         );
         this.capabilities = capabilities;
     }

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignupApiClient.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/SignupApiClient.ts
@@ -6,6 +6,7 @@
 import { GrantType } from "../../../CustomAuthConstants.js";
 import { BaseApiClient } from "./BaseApiClient.js";
 import { IHttpClient } from "../http_client/IHttpClient.js";
+import { Logger } from "@azure/msal-common/browser";
 import * as CustomAuthApiEndpoint from "./CustomAuthApiEndpoint.js";
 import {
     SignUpChallengeRequest,
@@ -19,6 +20,7 @@ import {
     SignUpContinueResponse,
     SignUpStartResponse,
 } from "./types/ApiResponseTypes.js";
+import { CustomAuthRequestInterceptor } from "../../../configuration/CustomAuthRequestInterceptor.js";
 
 export class SignupApiClient extends BaseApiClient {
     private readonly capabilities?: string;
@@ -28,13 +30,17 @@ export class SignupApiClient extends BaseApiClient {
         clientId: string,
         httpClient: IHttpClient,
         capabilities?: string,
-        customAuthApiQueryParams?: Record<string, string>
+        customAuthApiQueryParams?: Record<string, string>,
+        requestInterceptor?: CustomAuthRequestInterceptor,
+        logger?: Logger
     ) {
         super(
             customAuthApiBaseUrl,
             clientId,
             httpClient,
-            customAuthApiQueryParams
+            customAuthApiQueryParams,
+            requestInterceptor,
+            logger
         );
         this.capabilities = capabilities;
     }

--- a/lib/msal-browser/src/custom_auth/core/utils/CustomHeaderUtils.ts
+++ b/lib/msal-browser/src/custom_auth/core/utils/CustomHeaderUtils.ts
@@ -3,10 +3,31 @@
  * Licensed under the MIT License.
  */
 
+import { Logger } from "@azure/msal-common/browser";
 import { CustomHeaderConstants } from "../../CustomAuthConstants.js";
 
+/**
+ * Filters the headers returned by a {@link CustomAuthRequestInterceptor},
+ * keeping only those that conform to the custom-auth header naming rules.
+ *
+ * Rules (mirrors the iOS / Android native auth implementations):
+ *  - Header names must start with `x-` (case-insensitive); others are dropped.
+ *  - Header names that start with any reserved prefix (`x-client-`, `x-ms-`,
+ *    `x-broker-`, `x-app-`) are dropped.
+ *  - Headers with empty/whitespace-only names or null/undefined values are dropped.
+ *
+ * Dropped headers are logged as warnings (PII-safe) when a logger is provided.
+ *
+ * @param headers - Raw headers returned by the interceptor.
+ * @param logger - Optional logger used to emit warnings for dropped headers.
+ * @param correlationId - Optional correlation id forwarded to the logger.
+ * @returns A new record containing only the headers that pass the filter,
+ *          preserving the original casing of header names.
+ */
 export function filterCustomHeaders(
-    headers: Record<string, string> | null | undefined
+    headers: Record<string, string> | null | undefined,
+    logger?: Logger,
+    correlationId?: string
 ): Record<string, string> {
     const filtered: Record<string, string> = {};
 
@@ -28,15 +49,22 @@ export function filterCustomHeaders(
         const lowerName = trimmedName.toLowerCase();
 
         if (!lowerName.startsWith(CustomHeaderConstants.REQUIRED_PREFIX)) {
+            logger?.warningPii(
+                `Additional header field "${trimmedName}" must start with the "${CustomHeaderConstants.REQUIRED_PREFIX}" prefix. Ignoring.`,
+                correlationId ?? ""
+            );
             continue;
         }
 
-        const startsWithReservedPrefix =
-            CustomHeaderConstants.RESERVED_PREFIXES.some((prefix) =>
-                lowerName.startsWith(prefix)
-            );
+        const reservedPrefix = CustomHeaderConstants.RESERVED_PREFIXES.find(
+            (prefix) => lowerName.startsWith(prefix)
+        );
 
-        if (startsWithReservedPrefix) {
+        if (reservedPrefix) {
+            logger?.warningPii(
+                `Additional header field "${trimmedName}" uses reserved prefix "${reservedPrefix}". Ignoring.`,
+                correlationId ?? ""
+            );
             continue;
         }
 

--- a/lib/msal-browser/src/custom_auth/core/utils/CustomHeaderUtils.ts
+++ b/lib/msal-browser/src/custom_auth/core/utils/CustomHeaderUtils.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { CustomHeaderConstants } from "../../CustomAuthConstants.js";
+
+export function filterCustomHeaders(
+    headers: Record<string, string> | null | undefined
+): Record<string, string> {
+    const filtered: Record<string, string> = {};
+
+    if (!headers) {
+        return filtered;
+    }
+
+    for (const [name, value] of Object.entries(headers)) {
+        if (!name || value === undefined || value === null) {
+            continue;
+        }
+
+        const trimmedName = name.trim();
+
+        if (!trimmedName) {
+            continue;
+        }
+
+        const lowerName = trimmedName.toLowerCase();
+
+        if (!lowerName.startsWith(CustomHeaderConstants.REQUIRED_PREFIX)) {
+            continue;
+        }
+
+        const startsWithReservedPrefix =
+            CustomHeaderConstants.RESERVED_PREFIXES.some((prefix) =>
+                lowerName.startsWith(prefix)
+            );
+
+        if (startsWithReservedPrefix) {
+            continue;
+        }
+
+        filtered[trimmedName] = value;
+    }
+
+    return filtered;
+}

--- a/lib/msal-browser/src/custom_auth/index.ts
+++ b/lib/msal-browser/src/custom_auth/index.ts
@@ -19,6 +19,10 @@ export { ICustomAuthPublicClientApplication } from "./ICustomAuthPublicClientApp
 
 // Configuration
 export { CustomAuthConfiguration } from "./configuration/CustomAuthConfiguration.js";
+export {
+    CustomAuthRequestInterceptor,
+    CustomAuthAdditionalHeaderFieldsResult,
+} from "./configuration/CustomAuthRequestInterceptor.js";
 
 // Models
 export { CustomAuthAccountData } from "./get_account/auth_flow/CustomAuthAccountData.js";

--- a/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/BaseApiClientInterceptor.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/BaseApiClientInterceptor.spec.ts
@@ -9,7 +9,18 @@ import {
 } from "@azure/msal-common/browser";
 import { SignInApiClient } from "../../../../../src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.js";
 import { CustomAuthRequestInterceptor } from "../../../../../src/custom_auth/configuration/CustomAuthRequestInterceptor.js";
+import { CustomHeaderConstants } from "../../../../../src/custom_auth/CustomAuthConstants.js";
 import { getDefaultLogger } from "../../../test_resources/TestModules.js";
+
+const isUserCustomHeader = (name: string): boolean => {
+    const lowerName = name.toLowerCase();
+    return (
+        lowerName.startsWith(CustomHeaderConstants.REQUIRED_PREFIX) &&
+        !CustomHeaderConstants.RESERVED_PREFIXES.some((prefix) =>
+            lowerName.startsWith(prefix)
+        )
+    );
+};
 
 const mockTelemetryManager = {
     generateCurrentRequestHeaderValue: jest.fn(() => "cur"),
@@ -84,16 +95,8 @@ describe("BaseApiClient request interceptor behaviour", () => {
         expect(headers[AADServerParamKeys.CLIENT_REQUEST_ID]).toBe("corr");
         // Confirm no user-vendor header (i.e., x-* not starting with reserved prefixes)
         // is present when no interceptor is configured.
-        const customHeaderKeys = Object.keys(headers).filter((k) => {
-            const lk = k.toLowerCase();
-            return (
-                lk.startsWith("x-") &&
-                !lk.startsWith("x-client-") &&
-                !lk.startsWith("x-ms-") &&
-                !lk.startsWith("x-broker-") &&
-                !lk.startsWith("x-app-")
-            );
-        });
+        const customHeaderKeys =
+            Object.keys(headers).filter(isUserCustomHeader);
         expect(customHeaderKeys).toEqual([]);
     });
 
@@ -265,14 +268,7 @@ describe("BaseApiClient request interceptor behaviour", () => {
 
         // Spot-check: no non-MSAL custom header was added
         const headers = lastSentHeaders();
-        const userHeaders = Object.keys(headers).filter((k) => {
-            const lk = k.toLowerCase();
-            return (
-                lk.startsWith("x-") &&
-                !lk.startsWith("x-client-") &&
-                !lk.startsWith("x-ms-")
-            );
-        });
+        const userHeaders = Object.keys(headers).filter(isUserCustomHeader);
         expect(userHeaders).toEqual([]);
     });
 

--- a/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/BaseApiClientInterceptor.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/BaseApiClientInterceptor.spec.ts
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    AADServerParamKeys,
+    ServerTelemetryManager,
+} from "@azure/msal-common/browser";
+import { SignInApiClient } from "../../../../../src/custom_auth/core/network_client/custom_auth_api/SignInApiClient.js";
+import { CustomAuthRequestInterceptor } from "../../../../../src/custom_auth/configuration/CustomAuthRequestInterceptor.js";
+import { getDefaultLogger } from "../../../test_resources/TestModules.js";
+
+const mockTelemetryManager = {
+    generateCurrentRequestHeaderValue: jest.fn(() => "cur"),
+    generateLastRequestHeaderValue: jest.fn(() => "last"),
+} as unknown as ServerTelemetryManager;
+
+const buildOkResponse = (
+    body: Record<string, unknown>,
+    headers: Record<string, string> = {}
+) =>
+    ({
+        ok: true,
+        json: async () => body,
+        headers: { get: (name: string) => headers[name] || null },
+    } as unknown as Response);
+
+const buildInitiateResponse = () =>
+    buildOkResponse(
+        { continuation_token: "ct" },
+        { "x-ms-request-id": "corr" }
+    );
+
+describe("BaseApiClient request interceptor behaviour", () => {
+    const baseUrl = "https://customauth.test/";
+    const clientId = "client-id";
+
+    let mockHttpClient: { post: jest.Mock };
+
+    beforeEach(() => {
+        mockHttpClient = { post: jest.fn() };
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const lastSentHeaders = (): Record<string, string> => {
+        expect(mockHttpClient.post).toHaveBeenCalled();
+        const headers = mockHttpClient.post.mock.calls[0][2] as Record<
+            string,
+            string
+        >;
+        return headers;
+    };
+
+    const lastSentUrl = (): URL => {
+        expect(mockHttpClient.post).toHaveBeenCalled();
+        return mockHttpClient.post.mock.calls[0][0] as URL;
+    };
+
+    it("does not call interceptor when none is configured and sends only common headers", async () => {
+        const client = new SignInApiClient(
+            baseUrl,
+            clientId,
+            mockHttpClient as any,
+            undefined,
+            undefined,
+            undefined,
+            getDefaultLogger()
+        );
+
+        mockHttpClient.post.mockResolvedValue(buildInitiateResponse());
+
+        await client.initiate({
+            username: "u",
+            challenge_type: "email-otp",
+            telemetryManager: mockTelemetryManager,
+            correlationId: "corr",
+        });
+
+        const headers = lastSentHeaders();
+        expect(headers[AADServerParamKeys.CLIENT_REQUEST_ID]).toBe("corr");
+        // Confirm no user-vendor header (i.e., x-* not starting with reserved prefixes)
+        // is present when no interceptor is configured.
+        const customHeaderKeys = Object.keys(headers).filter((k) => {
+            const lk = k.toLowerCase();
+            return (
+                lk.startsWith("x-") &&
+                !lk.startsWith("x-client-") &&
+                !lk.startsWith("x-ms-") &&
+                !lk.startsWith("x-broker-") &&
+                !lk.startsWith("x-app-")
+            );
+        });
+        expect(customHeaderKeys).toEqual([]);
+    });
+
+    it("invokes the interceptor with the full request URL and merges returned headers", async () => {
+        const interceptor: CustomAuthRequestInterceptor = {
+            addAdditionalHeaderFields: jest.fn(async (url: URL) => {
+                expect(url).toBeInstanceOf(URL);
+                expect(url.pathname).toBe("/oauth2/v2.0/initiate");
+                return { "X-Fraud-Vendor-Token": "vendor-1" };
+            }),
+        };
+
+        const client = new SignInApiClient(
+            baseUrl,
+            clientId,
+            mockHttpClient as any,
+            undefined,
+            undefined,
+            interceptor,
+            getDefaultLogger()
+        );
+
+        mockHttpClient.post.mockResolvedValue(buildInitiateResponse());
+
+        await client.initiate({
+            username: "u",
+            challenge_type: "email-otp",
+            telemetryManager: mockTelemetryManager,
+            correlationId: "corr",
+        });
+
+        expect(interceptor.addAdditionalHeaderFields).toHaveBeenCalledTimes(1);
+        const headers = lastSentHeaders();
+        expect(headers["X-Fraud-Vendor-Token"]).toBe("vendor-1");
+        expect(lastSentUrl().toString()).toBe(
+            "https://customauth.test/oauth2/v2.0/initiate"
+        );
+    });
+
+    it("filters out headers without the x- prefix and with reserved prefixes", async () => {
+        const interceptor: CustomAuthRequestInterceptor = {
+            addAdditionalHeaderFields: () => ({
+                authorization: "Bearer drop",
+                "x-client-header": "drop",
+                "x-ms-something": "drop",
+                "x-broker-id": "drop",
+                "x-app-version": "drop",
+                "X-my-custom-header": "keep",
+            }),
+        };
+
+        const client = new SignInApiClient(
+            baseUrl,
+            clientId,
+            mockHttpClient as any,
+            undefined,
+            undefined,
+            interceptor,
+            getDefaultLogger()
+        );
+
+        mockHttpClient.post.mockResolvedValue(buildInitiateResponse());
+
+        await client.initiate({
+            username: "u",
+            challenge_type: "email-otp",
+            telemetryManager: mockTelemetryManager,
+            correlationId: "corr",
+        });
+
+        const headers = lastSentHeaders();
+        expect(headers["X-my-custom-header"]).toBe("keep");
+        expect(headers["authorization"]).toBeUndefined();
+        expect(headers["x-client-header"]).toBeUndefined();
+        expect(headers["x-ms-something"]).toBeUndefined();
+        expect(headers["x-broker-id"]).toBeUndefined();
+        expect(headers["x-app-version"]).toBeUndefined();
+
+        // MSAL's own x-client-* headers are still present
+        expect(headers[AADServerParamKeys.X_CLIENT_SKU]).toBeDefined();
+        expect(headers[AADServerParamKeys.X_CLIENT_VER]).toBeDefined();
+    });
+
+    it("user headers take precedence over common MSAL headers when names collide after filtering", async () => {
+        // The filter normally strips x-client-* / x-ms-* etc., so a real collision
+        // would only happen with a non-reserved header name that MSAL happens to
+        // set. We assert the merge order directly with a header we can collide on.
+        const interceptor: CustomAuthRequestInterceptor = {
+            addAdditionalHeaderFields: () => ({
+                // This is allowed by the filter (starts with x-, no reserved prefix)
+                "x-custom-override": "user-value",
+            }),
+        };
+
+        const client = new SignInApiClient(
+            baseUrl,
+            clientId,
+            mockHttpClient as any,
+            undefined,
+            undefined,
+            interceptor,
+            getDefaultLogger()
+        );
+
+        mockHttpClient.post.mockResolvedValue(buildInitiateResponse());
+
+        await client.initiate({
+            username: "u",
+            challenge_type: "email-otp",
+            telemetryManager: mockTelemetryManager,
+            correlationId: "corr",
+        });
+
+        const headers = lastSentHeaders();
+        // The user header is present and uses the user's value
+        expect(headers["x-custom-override"]).toBe("user-value");
+    });
+
+    it("supports synchronous interceptor return values", async () => {
+        const interceptor: CustomAuthRequestInterceptor = {
+            addAdditionalHeaderFields: () => ({ "x-sync-header": "sync" }),
+        };
+
+        const client = new SignInApiClient(
+            baseUrl,
+            clientId,
+            mockHttpClient as any,
+            undefined,
+            undefined,
+            interceptor,
+            getDefaultLogger()
+        );
+
+        mockHttpClient.post.mockResolvedValue(buildInitiateResponse());
+
+        await client.initiate({
+            username: "u",
+            challenge_type: "email-otp",
+            telemetryManager: mockTelemetryManager,
+            correlationId: "corr",
+        });
+
+        expect(lastSentHeaders()["x-sync-header"]).toBe("sync");
+    });
+
+    it("treats null return value as no additional headers", async () => {
+        const interceptor: CustomAuthRequestInterceptor = {
+            addAdditionalHeaderFields: () => null,
+        };
+
+        const client = new SignInApiClient(
+            baseUrl,
+            clientId,
+            mockHttpClient as any,
+            undefined,
+            undefined,
+            interceptor,
+            getDefaultLogger()
+        );
+
+        mockHttpClient.post.mockResolvedValue(buildInitiateResponse());
+
+        await client.initiate({
+            username: "u",
+            challenge_type: "email-otp",
+            telemetryManager: mockTelemetryManager,
+            correlationId: "corr",
+        });
+
+        // Spot-check: no non-MSAL custom header was added
+        const headers = lastSentHeaders();
+        const userHeaders = Object.keys(headers).filter((k) => {
+            const lk = k.toLowerCase();
+            return (
+                lk.startsWith("x-") &&
+                !lk.startsWith("x-client-") &&
+                !lk.startsWith("x-ms-")
+            );
+        });
+        expect(userHeaders).toEqual([]);
+    });
+
+    it("swallows interceptor errors and still sends the request", async () => {
+        const logger = getDefaultLogger();
+        const warningSpy = jest
+            .spyOn(logger, "warningPii")
+            .mockImplementation(() => {});
+        const interceptor: CustomAuthRequestInterceptor = {
+            addAdditionalHeaderFields: () => {
+                throw new Error("interceptor exploded");
+            },
+        };
+
+        const client = new SignInApiClient(
+            baseUrl,
+            clientId,
+            mockHttpClient as any,
+            undefined,
+            undefined,
+            interceptor,
+            logger
+        );
+
+        mockHttpClient.post.mockResolvedValue(buildInitiateResponse());
+
+        const result = await client.initiate({
+            username: "u",
+            challenge_type: "email-otp",
+            telemetryManager: mockTelemetryManager,
+            correlationId: "corr",
+        });
+
+        expect(result.continuation_token).toBe("ct");
+        expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+        expect(warningSpy).toHaveBeenCalled();
+    });
+
+    it("swallows interceptor rejections from async functions", async () => {
+        const logger = getDefaultLogger();
+        const warningSpy = jest
+            .spyOn(logger, "warningPii")
+            .mockImplementation(() => {});
+        const interceptor: CustomAuthRequestInterceptor = {
+            addAdditionalHeaderFields: async () => {
+                throw new Error("async failure");
+            },
+        };
+
+        const client = new SignInApiClient(
+            baseUrl,
+            clientId,
+            mockHttpClient as any,
+            undefined,
+            undefined,
+            interceptor,
+            logger
+        );
+
+        mockHttpClient.post.mockResolvedValue(buildInitiateResponse());
+
+        const result = await client.initiate({
+            username: "u",
+            challenge_type: "email-otp",
+            telemetryManager: mockTelemetryManager,
+            correlationId: "corr",
+        });
+
+        expect(result.continuation_token).toBe("ct");
+        expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+        expect(warningSpy).toHaveBeenCalled();
+    });
+});

--- a/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/CustomAuthApiClient.spec.ts
@@ -147,4 +147,47 @@ describe("CustomAuthApiClient", () => {
             expect(apiClient.resetPasswordApi).toBeDefined();
         });
     });
+
+    describe("requestInterceptor", () => {
+        it("should accept a requestInterceptor and logger when provided", () => {
+            const logger = getDefaultLogger();
+            const interceptor = {
+                addAdditionalHeaderFields: jest.fn(() => null),
+            };
+
+            const apiClient = new CustomAuthApiClient(
+                "https://test.com",
+                "client_id",
+                new FetchHttpClient(logger),
+                undefined,
+                undefined,
+                interceptor,
+                logger
+            );
+
+            expect(apiClient.signInApi).toBeDefined();
+            expect(apiClient.signUpApi).toBeDefined();
+            expect(apiClient.resetPasswordApi).toBeDefined();
+            expect(apiClient.registerApi).toBeDefined();
+        });
+
+        it("should initialize without requestInterceptor", () => {
+            const logger = getDefaultLogger();
+
+            const apiClient = new CustomAuthApiClient(
+                "https://test.com",
+                "client_id",
+                new FetchHttpClient(logger),
+                undefined,
+                undefined,
+                undefined,
+                logger
+            );
+
+            expect(apiClient.signInApi).toBeDefined();
+            expect(apiClient.signUpApi).toBeDefined();
+            expect(apiClient.resetPasswordApi).toBeDefined();
+            expect(apiClient.registerApi).toBeDefined();
+        });
+    });
 });

--- a/lib/msal-browser/test/custom_auth/core/utils/CustomHeaderUtils.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/utils/CustomHeaderUtils.spec.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { filterCustomHeaders } from "../../../../src/custom_auth/core/utils/CustomHeaderUtils.js";
+
+describe("CustomHeaderUtils.filterCustomHeaders", () => {
+    it("returns an empty record when headers are undefined", () => {
+        expect(filterCustomHeaders(undefined)).toEqual({});
+    });
+
+    it("returns an empty record when headers are null", () => {
+        expect(filterCustomHeaders(null)).toEqual({});
+    });
+
+    it("returns an empty record when headers are an empty object", () => {
+        expect(filterCustomHeaders({})).toEqual({});
+    });
+
+    it("keeps headers that start with x- (lowercase)", () => {
+        const result = filterCustomHeaders({
+            "x-vendor-token": "abc",
+            "x-correlation-id": "123",
+        });
+
+        expect(result).toEqual({
+            "x-vendor-token": "abc",
+            "x-correlation-id": "123",
+        });
+    });
+
+    it("keeps headers that start with X- (uppercase) preserving original casing", () => {
+        const result = filterCustomHeaders({
+            "X-Vendor-Token": "abc",
+            "X-My-Header": "value",
+        });
+
+        expect(result).toEqual({
+            "X-Vendor-Token": "abc",
+            "X-My-Header": "value",
+        });
+    });
+
+    it("keeps headers with mixed casing that start with x-", () => {
+        const result = filterCustomHeaders({
+            "X-vendor-Token": "abc",
+            "x-Custom-HEADER": "value",
+        });
+
+        expect(result).toEqual({
+            "X-vendor-Token": "abc",
+            "x-Custom-HEADER": "value",
+        });
+    });
+
+    it("drops headers that do not start with x-", () => {
+        const result = filterCustomHeaders({
+            authorization: "Bearer abc",
+            "content-type": "application/json",
+            value_1: "customer_header_1",
+        });
+
+        expect(result).toEqual({});
+    });
+
+    it("drops headers that start with the reserved prefix x-client-", () => {
+        const result = filterCustomHeaders({
+            "x-client-header": "should-be-dropped",
+            "x-client-VER": "should-be-dropped",
+            "x-vendor": "kept",
+        });
+
+        expect(result).toEqual({ "x-vendor": "kept" });
+    });
+
+    it("drops headers that start with the reserved prefix x-ms-", () => {
+        const result = filterCustomHeaders({
+            "x-ms-request-id": "should-be-dropped",
+            "X-MS-Custom": "should-be-dropped",
+            "x-vendor": "kept",
+        });
+
+        expect(result).toEqual({ "x-vendor": "kept" });
+    });
+
+    it("drops headers that start with the reserved prefix x-broker-", () => {
+        const result = filterCustomHeaders({
+            "x-broker-id": "should-be-dropped",
+            "X-Broker-Version": "should-be-dropped",
+            "x-vendor": "kept",
+        });
+
+        expect(result).toEqual({ "x-vendor": "kept" });
+    });
+
+    it("drops headers that start with the reserved prefix x-app-", () => {
+        const result = filterCustomHeaders({
+            "x-app-version": "should-be-dropped",
+            "X-App-Name": "should-be-dropped",
+            "x-vendor": "kept",
+        });
+
+        expect(result).toEqual({ "x-vendor": "kept" });
+    });
+
+    it("matches reserved prefixes case-insensitively", () => {
+        const result = filterCustomHeaders({
+            "X-CLIENT-SOMETHING": "drop",
+            "x-Ms-thing": "drop",
+            "X-Broker-X": "drop",
+            "X-App-Z": "drop",
+            "X-vendor": "keep",
+        });
+
+        expect(result).toEqual({ "X-vendor": "keep" });
+    });
+
+    it("keeps headers whose names contain reserved prefix substrings but do not start with them", () => {
+        const result = filterCustomHeaders({
+            "x-foo-client-bar": "kept",
+            "x-not-ms-thing": "kept",
+        });
+
+        expect(result).toEqual({
+            "x-foo-client-bar": "kept",
+            "x-not-ms-thing": "kept",
+        });
+    });
+
+    it("filters a mixed set as described in the documentation example", () => {
+        const result = filterCustomHeaders({
+            value_1: "customer_header_1",
+            "x-client-header": "customer_header_2",
+            "X-my-custom-header": "my data",
+        });
+
+        expect(result).toEqual({
+            "X-my-custom-header": "my data",
+        });
+    });
+
+    it("drops headers with empty or whitespace-only names", () => {
+        const result = filterCustomHeaders({
+            "": "empty-name",
+            "   ": "whitespace-name",
+            "x-keep": "value",
+        });
+
+        expect(result).toEqual({ "x-keep": "value" });
+    });
+
+    it("trims whitespace around header names before applying rules", () => {
+        const result = filterCustomHeaders({
+            "  x-vendor  ": "trimmed",
+        });
+
+        expect(result).toEqual({ "x-vendor": "trimmed" });
+    });
+});

--- a/lib/msal-browser/test/custom_auth/core/utils/CustomHeaderUtils.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/utils/CustomHeaderUtils.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { filterCustomHeaders } from "../../../../src/custom_auth/core/utils/CustomHeaderUtils.js";
+import { Logger } from "@azure/msal-common/browser";
 
 describe("CustomHeaderUtils.filterCustomHeaders", () => {
     it("returns an empty record when headers are undefined", () => {
@@ -156,5 +157,120 @@ describe("CustomHeaderUtils.filterCustomHeaders", () => {
         });
 
         expect(result).toEqual({ "x-vendor": "trimmed" });
+    });
+
+    it("keeps differently-cased variants of the same name as distinct entries (case-sensitive keys, case-insensitive prefix match)", () => {
+        const result = filterCustomHeaders({
+            "x-Custom-header": "first",
+            "x-custom-Header": "second",
+            "X-CUSTOM-HEADER": "third",
+        });
+
+        expect(result).toEqual({
+            "x-Custom-header": "first",
+            "x-custom-Header": "second",
+            "X-CUSTOM-HEADER": "third",
+        });
+    });
+
+    it("treats reserved-prefix checks case-insensitively across casings of the same logical name", () => {
+        const result = filterCustomHeaders({
+            "x-Client-Header": "drop",
+            "X-CLIENT-header": "drop",
+            "x-client-Header": "drop",
+        });
+
+        expect(result).toEqual({});
+    });
+
+    it("logs a PII-safe warning for headers that do not start with x-", () => {
+        const logger = new Logger({}, "test", "1.0.0");
+        const warningSpy = jest
+            .spyOn(logger, "warningPii")
+            .mockImplementation(() => {});
+
+        const result = filterCustomHeaders(
+            {
+                authorization: "Bearer abc",
+                value_1: "customer_header_1",
+            },
+            logger,
+            "corr-1"
+        );
+
+        expect(result).toEqual({});
+        expect(warningSpy).toHaveBeenCalledTimes(2);
+        expect(warningSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Additional header field "authorization" must start with the "x-" prefix. Ignoring.'
+            ),
+            "corr-1"
+        );
+        expect(warningSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Additional header field "value_1" must start with the "x-" prefix. Ignoring.'
+            ),
+            "corr-1"
+        );
+    });
+
+    it("logs a PII-safe warning naming the matched reserved prefix", () => {
+        const logger = new Logger({}, "test", "1.0.0");
+        const warningSpy = jest
+            .spyOn(logger, "warningPii")
+            .mockImplementation(() => {});
+
+        const result = filterCustomHeaders(
+            {
+                "x-client-header": "drop",
+                "X-MS-Custom": "drop",
+                "x-broker-id": "drop",
+                "x-app-version": "drop",
+            },
+            logger,
+            "corr-2"
+        );
+
+        expect(result).toEqual({});
+        expect(warningSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Additional header field "x-client-header" uses reserved prefix "x-client-". Ignoring.'
+            ),
+            "corr-2"
+        );
+        expect(warningSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Additional header field "X-MS-Custom" uses reserved prefix "x-ms-". Ignoring.'
+            ),
+            "corr-2"
+        );
+        expect(warningSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Additional header field "x-broker-id" uses reserved prefix "x-broker-". Ignoring.'
+            ),
+            "corr-2"
+        );
+        expect(warningSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Additional header field "x-app-version" uses reserved prefix "x-app-". Ignoring.'
+            ),
+            "corr-2"
+        );
+    });
+
+    it("does not emit warnings for kept headers", () => {
+        const logger = new Logger({}, "test", "1.0.0");
+        const warningSpy = jest
+            .spyOn(logger, "warningPii")
+            .mockImplementation(() => {});
+
+        const result = filterCustomHeaders(
+            { "X-my-custom-header": "keep" },
+            logger,
+            "corr-3"
+        );
+
+        expect(result).toEqual({ "X-my-custom-header": "keep" });
+        expect(warningSpy).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary

Adds a new `requestInterceptor` option to `CustomAuthOptions` that lets applications attach additional `x-*` headers to every custom-auth backend request (sign-in, sign-up, reset-password, register).

The primary use case is integrating with third-party fraud / bot-detection SDKs that require vendor-supplied headers on the auth endpoints.

## API

```ts
import { CustomAuthRequestInterceptor } from "@azure/msal-browser/custom-auth";

const interceptor: CustomAuthRequestInterceptor = {
    addAdditionalHeaderFields(requestUrl: URL) {
        if (requestUrl.pathname.includes("/oauth2/v2.0/initiate")) {
            return {
                value_1: "customer_header_1",          // Ignored: no "x-" prefix
                "x-client-header": "customer_header_2",  // Ignored: reserved prefix
                "X-my-custom-header": "my data",         // Sent
            };
        }
        return null;
    },
};

const config: CustomAuthConfiguration = {
    auth: { clientId, authority },
    customAuth: {
        authApiProxyUrl,
        requestInterceptor: interceptor,
    },
};
```

The interceptor may return either a synchronous record or a `Promise`.

## Filter rules (same as iOS doc)

* Names must start with `x-` (case-insensitive); others are dropped.
* Reserved prefixes are dropped: `x-client-`, `x-ms-`, `x-broker-`, `x-app-`.
* User headers that pass the filter take precedence over MSAL's common headers.
* Exceptions thrown by the interceptor are captured and logged via `Logger.warningPii`; the request still goes through so user-supplied code cannot break authentication.

## Scope

* Filtering applied only to custom-auth backend requests (anything routed through `BaseApiClient.request`).
* Wiring: `CustomAuthStandardController` → `CustomAuthApiClient` → each sub-client (`SignInApiClient`, `SignupApiClient`, `ResetPasswordApiClient`, `RegisterApiClient`) → `BaseApiClient`.
* No cache schema impact.

## Tests

* `CustomHeaderUtils.spec.ts` — 16 cases covering each filter rule, casing, and edge cases.
* `BaseApiClientInterceptor.spec.ts` — 8 cases covering: no-interceptor, URL passed to interceptor, filtering, precedence, sync return, async return, null return, sync throw, async rejection (all swallowed).
* `CustomAuthApiClient.spec.ts` extended with 2 construction cases.
* Full `lib/msal-browser` suite: **1643 tests pass**; lint, format, build, and api-extractor all clean.

## Changefile

`change/@azure-msal-browser-ec2f3299-….json` — `minor` (new public option).
