### PR TITLE
Add allowPlatformBrokerWithDOM experimental config flag

### DIFF
--- a/change/@azure-msal-browser-allow-platform-broker-with-dom.json
+++ b/change/@azure-msal-browser-allow-platform-broker-with-dom.json
@@ -1,0 +1,7 @@
+{
+    "type": "minor",
+    "comment": "Add allowPlatformBrokerWithDOM experimental config flag for DOM-based platform brokering",
+    "packageName": "@azure/msal-browser",
+    "email": "lalimasharda@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-allow-platform-broker-with-dom.json
+++ b/change/@azure-msal-browser-allow-platform-broker-with-dom.json
@@ -1,6 +1,6 @@
 {
     "type": "minor",
-    "comment": "Add allowPlatformBrokerWithDOM experimental config flag for DOM-based platform brokering",
+    "comment": "Add allowPlatformBrokerWithDOM experimental config flag for DOM-based platform brokering [#8589](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8589)",
     "packageName": "@azure/msal-browser",
     "email": "lalimasharda@microsoft.com",
     "dependentChangeType": "patch"

--- a/change/@azure-msal-common-allow-platform-broker-with-dom.json
+++ b/change/@azure-msal-common-allow-platform-broker-with-dom.json
@@ -1,6 +1,6 @@
 {
     "type": "patch",
-    "comment": "Add invalidPlatformBrokerConfiguration error code for DOM-based platform brokering",
+    "comment": "Add invalidPlatformBrokerConfiguration error code for DOM-based platform brokering [#8589](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8589)",
     "packageName": "@azure/msal-common",
     "email": "lalimasharda@microsoft.com",
     "dependentChangeType": "patch"

--- a/change/@azure-msal-common-allow-platform-broker-with-dom.json
+++ b/change/@azure-msal-common-allow-platform-broker-with-dom.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Add invalidPlatformBrokerConfiguration error code for DOM-based platform brokering",
+    "packageName": "@azure/msal-common",
+    "email": "lalimasharda@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -261,6 +261,10 @@ This error occurs when MSAL.js surpasses the allotted storage limit when attempt
 
 -   Cannot set allowPlatformBroker parameter to true when not in AAD protocol mode.
 
+### `invalid_platform_broker_configuration`
+
+-   Invalid platform broker configuration. `allowPlatformBrokerWithDOM` requires `allowPlatformBroker` to also be set to `true`.
+
 ### `authority_mismatch`
 
 -   Authority mismatch error. Authority provided in login request or PublicClientApplication config does not match the environment of the provided account. Please use a matching account or make an interactive request to login to this authority.

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -339,6 +339,7 @@ export { BrowserConfigurationAuthErrorCodes }
 // @internal (undocumented)
 export type BrowserExperimentalOptions = {
     iframeTimeoutTelemetry?: boolean;
+    allowPlatformBrokerWithDOM?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "BrowserPerformanceClient" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -911,13 +912,10 @@ function isInIframe(): boolean;
 // @public
 function isInPopup(): boolean;
 
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "isPlatformBrokerAvailable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function isPlatformBrokerAvailable(loggerOptions?: LoggerOptions, perfClient?: IPerformanceClient, correlationId?: string): Promise<boolean>;
+export function isPlatformBrokerAvailable(domConfig: boolean, loggerOptions?: LoggerOptions, perfClient?: IPerformanceClient, correlationId?: string): Promise<boolean>;
 
 // Warning: (ae-missing-release-tag) "IWindowStorage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1544,8 +1542,8 @@ export type WrapperSKU = (typeof WrapperSKU)[keyof typeof WrapperSKU];
 // src/cache/LocalStorage.ts:366:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/LocalStorage.ts:429:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/cache/LocalStorage.ts:460:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/config/Configuration.ts:213:5 - (ae-incompatible-release-tags) The symbol "experimental" is marked as @public, but its signature references "BrowserExperimentalOptions" which is marked as @internal
-// src/config/Configuration.ts:222:5 - (ae-forgotten-export) The symbol "InternalAuthOptions" needs to be exported by the entry point index.d.ts
+// src/config/Configuration.ts:217:5 - (ae-incompatible-release-tags) The symbol "experimental" is marked as @public, but its signature references "BrowserExperimentalOptions" which is marked as @internal
+// src/config/Configuration.ts:226:5 - (ae-forgotten-export) The symbol "InternalAuthOptions" needs to be exported by the entry point index.d.ts
 // src/event/EventHandler.ts:116:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/event/EventHandler.ts:143:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/index.ts:8:12 - (tsdoc-characters-after-block-tag) The token "@azure" looks like a TSDoc tag but contains an invalid character "/"; if it is not a tag, use a backslash to escape the "@"

--- a/lib/msal-browser/docs/device-bound-tokens.md
+++ b/lib/msal-browser/docs/device-bound-tokens.md
@@ -78,4 +78,4 @@ const msalConfig = {
 
 Note: The `allowPlatformBroker` flag must also be set to true in order to use this feature. There will be a configuration error - `invalid_platform_broker_configuration` if `allowPlatformBrokerWithDOM` is set to true while `allowPlatformBroker` is false.
 
-Eventually, in a future major version, this flag will be merged with `allowPlatformBroker` and MSAL.js will make the decision to use either the browser extension or DOM APIs based on the environment automatically.
+Eventually, in a future major version, this flag will be merged with `allowPlatformBroker` and MSAL.js will make the decision to use either the browser extension or DOM APIs based on the environment automatically. The behavior and availability of `experimental` flags is subject to change at any time, without following semver rules.

--- a/lib/msal-browser/docs/device-bound-tokens.md
+++ b/lib/msal-browser/docs/device-bound-tokens.md
@@ -1,12 +1,12 @@
-# Acquiring Device Bound Tokens using Web Account Manager (WAM) on Windows
+# Acquiring Device Bound Tokens using platform brokers
 
-MSAL.js supports acquiring tokens from the Web Account Manager (WAM) on Windows. These tokens are bound to the device they were acquired on and are not cached in the browser's localStorage or sessionStorage.
+MSAL.js supports acquiring tokens from the platform broker, say Web Account Manager (WAM) on Windows and Mac Broker on Mac. These tokens are bound to the device they were acquired on and are not cached in the browser's localStorage or sessionStorage.
 
 ## Supported Environment
 
 This feature is currently only supported in the following environment:
 
--   A machine running a Windows build that supports the feature (more to come on this)
+-   A machine running a Windows build that supports the feature (more to come on this) or a Company Portal managed Mac with a specific Mac OS version (more to come on this).
 -   Chrome and Edge browsers or Teams
 -   [Windows Accounts extension](https://chrome.google.com/webstore/detail/windows-accounts/ppnbnpeolgkicgegkbkbjmhlideopiji) (version 1.0.5 or higher) is installed if using Chrome or Edge
 -   App must be hosted on `https`
@@ -45,10 +45,37 @@ pca.acquireTokenSilent();
 
 No other changes are needed to support this new feature. Any user accessing your app from a supported environment will now be able to acquire device bound tokens. Users in non-supported environments will continue to acquire tokens through the traditional web-based flows.
 
-## Differences when using WAM to acquire tokens
+## Differences when using Platform Broker to acquire tokens
 
-There are a few things that may behave a little differently when acquiring tokens through WAM.
+There are a few things that may behave a little differently when acquiring tokens through the platform broker.
 
--   All cache related configuration applies only to MSAL's local cache. The native broker controls its own, more secure, cache which is used instead of browser storage and it does not support configuration of its cache behavior. This means you may receive a cached token regardless of the value of request parameters such as: `forceRefresh`, `cacheLookupPolicy` or `storeInCache`. In addition, tokens received from the native broker are _not_ stored in local or session storage regardless of what you have configured on PublicClientApplication.
--   If WAM needs to prompt the user for interaction a system prompt will be opened. This prompt looks a bit different from the browser popup windows you may be used to.
--   Switching your account in the WAM prompt is not supported and MSAL.js will throw an error (Error Code: user_switch) if this happens. It is your app's responsibility to catch this error and handle it in a way that makes sense for your scenarios (e.g. Show an error page, retry with the new account, retry with the original account, etc.)
+-   All cache related configuration applies only to MSAL's local cache. The platform broker controls its own, more secure, cache which is used instead of browser storage and it does not support configuration of its cache behavior. This means you may receive a cached token regardless of the value of request parameters such as: `forceRefresh`, `cacheLookupPolicy` or `storeInCache`. In addition, tokens received from the platform broker are _not_ stored in local or session storage regardless of what you have configured on PublicClientApplication.
+-   If the platform broker needs to prompt the user for interaction a system prompt will be opened. This prompt looks a bit different from the browser popup windows you may be used to.
+-   Switching your account in the platform broker prompt is not supported and MSAL.js will throw an error (Error Code: user_switch) if this happens. It is your app's responsibility to catch this error and handle it in a way that makes sense for your scenarios (e.g. Show an error page, retry with the new account, retry with the original account, etc.)
+
+## Acquiring Device Bound Tokens using DOM API
+
+MSAL.js also supports acquiring tokens from the platform broker using DOM APIs in Edge. Instead of using a browser extension to communicate with the platform broker, MSAL.js can directly call a DOM API in the Edge browser, which in turn invokes the platform broker to acquire tokens.
+
+-   This feature is currently only supported in the Edge browser and all other OS requirements mentioned above still apply. (more details to come).
+-   This feature is currently only in private-preview and requires special enablement.
+
+To enable this feature, set the `allowPlatformBrokerWithDOM` flag to true in the `experimental` section of your configuration object like so:
+
+```javascript
+const msalConfig = {
+    auth: {
+        clientId: "insert-clientId",
+    },
+    system: {
+        allowPlatformBroker: true,
+    },
+    experimental: {
+        allowPlatformBrokerWithDOM: true,
+    },
+};
+```
+
+Note: The `allowPlatformBroker` flag must also be set to true in order to use this feature. There will be a configuration error - `invalid_platform_broker_configuration` if `allowPlatformBrokerWithDOM` is set to true while `allowPlatformBroker` is false.
+
+Eventually, in a future major version, this flag will be merged with `allowPlatformBroker` and MSAL.js will make the decision to use either the browser extension or DOM APIs based on the environment automatically.

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
@@ -9,6 +9,8 @@ import {
     Logger,
     Constants,
     StubPerformanceClient,
+    createClientConfigurationError,
+    ClientConfigurationErrorCodes,
 } from "@azure/msal-common/browser";
 import { name, version } from "../../packageMetadata.js";
 import {
@@ -18,50 +20,57 @@ import {
 import { PlatformAuthExtensionHandler } from "./PlatformAuthExtensionHandler.js";
 import { IPlatformAuthHandler } from "./IPlatformAuthHandler.js";
 import { PlatformAuthDOMHandler } from "./PlatformAuthDOMHandler.js";
-import { BrowserCacheLocation } from "../../utils/BrowserConstants.js";
-import { PLATFORM_AUTH_DOM_SUPPORT } from "../../cache/CacheKeys.js";
+import { createNewGuid } from "../../crypto/BrowserCrypto.js";
 
 /**
  * Checks if the platform broker is available in the current environment.
- * @param loggerOptions
- * @param perfClient
- * @param correlationId
- * @returns
+ * @param domConfig - Whether to enable platform broker DOM API support (required)
+ * @param loggerOptions - Optional logger options
+ * @param perfClient - Optional performance client
+ * @param correlationId - Optional correlation ID
+ * @returns Promise<boolean> indicating if platform broker is available
  */
 export async function isPlatformBrokerAvailable(
+    domConfig: boolean,
     loggerOptions?: LoggerOptions,
     perfClient?: IPerformanceClient,
     correlationId?: string
 ): Promise<boolean> {
     const logger = new Logger(loggerOptions || {}, name, version);
-    const cid = correlationId || "";
-
-    logger.trace("isPlatformBrokerAvailable called", cid);
 
     const performanceClient = perfClient || new StubPerformanceClient();
 
     if (typeof window === "undefined") {
-        logger.trace("Non-browser environment detected, returning false", cid);
+        logger.trace(
+            "Non-browser environment detected, returning false",
+            correlationId || createNewGuid()
+        );
         return false;
     }
 
-    return !!(await getPlatformAuthProvider(logger, performanceClient, cid));
+    return !!(await getPlatformAuthProvider(
+        logger,
+        performanceClient,
+        correlationId || createNewGuid(),
+        undefined,
+        domConfig
+    ));
 }
 
 export async function getPlatformAuthProvider(
     logger: Logger,
     performanceClient: IPerformanceClient,
     correlationId: string,
-    nativeBrokerHandshakeTimeout?: number
+    nativeBrokerHandshakeTimeout?: number,
+    enablePlatformBrokerDOMSupport?: boolean
 ): Promise<IPlatformAuthHandler | undefined> {
     logger.trace("getPlatformAuthProvider called", correlationId);
-
-    const enablePlatformBrokerDOMSupport = isDomEnabledForPlatformAuth();
 
     logger.trace(
         `Has client allowed platform auth via DOM API: '${enablePlatformBrokerDOMSupport}'`,
         correlationId
     );
+
     let platformAuthProvider: IPlatformAuthHandler | undefined;
     try {
         if (enablePlatformBrokerDOMSupport) {
@@ -97,22 +106,6 @@ export async function getPlatformAuthProvider(
 }
 
 /**
- * Returns true if the DOM API support for platform auth is enabled in session storage
- * @returns boolean
- * @deprecated
- */
-export function isDomEnabledForPlatformAuth(): boolean {
-    let sessionStorage: Storage | undefined;
-    try {
-        sessionStorage = window[BrowserCacheLocation.SessionStorage];
-        // Mute errors if it's a non-browser environment or cookies are blocked.
-        return sessionStorage?.getItem(PLATFORM_AUTH_DOM_SUPPORT) === "true";
-    } catch (e) {
-        return false;
-    }
-}
-
-/**
  * Returns boolean indicating whether or not the request should attempt to use platform broker
  * @param logger
  * @param config
@@ -128,6 +121,17 @@ export function isPlatformAuthAllowed(
     authenticationScheme?: Constants.AuthenticationScheme
 ): boolean {
     logger.trace("isPlatformAuthAllowed called", correlationId);
+
+    // throw an error if allowPlatformBroker is not enabled and allowPlatformBrokerWithDOM is enabled
+    if (
+        !config.system.allowPlatformBroker &&
+        config.experimental.allowPlatformBrokerWithDOM
+    ) {
+        throw createClientConfigurationError(
+            ClientConfigurationErrorCodes.invalidPlatformBrokerConfiguration
+        );
+    }
+
     if (!config.system.allowPlatformBroker) {
         logger.trace(
             "isPlatformAuthAllowed: allowPlatformBroker is not enabled, returning false",

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -175,6 +175,10 @@ export type BrowserExperimentalOptions = {
      * Enables iframe timeout telemetry experiment for silent iframe bridge monitoring.
      */
     iframeTimeoutTelemetry?: boolean;
+    /**
+     * Flag to enable native broker support through DOM APIs in Edge
+     */
+    allowPlatformBrokerWithDOM?: boolean;
 };
 
 /**
@@ -329,6 +333,7 @@ export function buildConfiguration(
 
     const DEFAULT_EXPERIMENTAL_OPTIONS: Required<BrowserExperimentalOptions> = {
         iframeTimeoutTelemetry: false,
+        allowPlatformBrokerWithDOM: false,
     };
 
     // Throw an error if user has set OIDCOptions without being in OIDC protocol mode

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -369,7 +369,8 @@ export class StandardController implements IController {
                     this.logger,
                     this.performanceClient,
                     correlationId,
-                    this.config.system.nativeBrokerHandshakeTimeout
+                    this.config.system.nativeBrokerHandshakeTimeout,
+                    this.config.experimental.allowPlatformBrokerWithDOM
                 );
             } catch (e) {
                 this.logger.verbose(e as string, correlationId);

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -499,13 +499,6 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 },
             };
 
-            jest.spyOn(
-                PlatformAuthProvider,
-                "isDomEnabledForPlatformAuth"
-            ).mockImplementation(() => {
-                return false;
-            });
-
             const getPlatformAuthProviderSpy = jest.spyOn(
                 PlatformAuthProvider,
                 "getPlatformAuthProvider"
@@ -558,7 +551,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(pca.platformAuthProvider).toBeUndefined();
         });
 
-        it("creates platform auth dom handler if allowPlatformBroker is true and dom APIs are present", async () => {
+        it("creates platform auth dom handler if allowPlatformBrokerWithDOM is true and dom APIs are present", async () => {
             const getPlatformAuthProviderSpy = jest.spyOn(
                 PlatformAuthProvider,
                 "getPlatformAuthProvider"
@@ -571,13 +564,12 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 system: {
                     allowPlatformBroker: true,
                 },
+                experimental: {
+                    allowPlatformBrokerWithDOM: true,
+                },
             };
 
             pca = new PublicClientApplication(config);
-            window.sessionStorage.setItem(
-                "msal.browser.platform.auth.dom",
-                "true"
-            );
 
             const createDOMProviderSpy = stubDOMProvider(config);
             await pca.initialize();

--- a/lib/msal-browser/test/broker/PlatformAuthProvider.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthProvider.spec.ts
@@ -2,6 +2,7 @@ import {
     Logger,
     IPerformanceClient,
     Constants,
+    ClientConfigurationErrorCodes,
 } from "@azure/msal-common/browser";
 import * as PlatformAuthProvider from "../../src/broker/nativeBroker/PlatformAuthProvider.js";
 import { getDefaultPerformanceClient } from "../utils/TelemetryUtils.js";
@@ -12,9 +13,6 @@ import {
     Configuration,
 } from "../../src/config/Configuration.js";
 import { PlatformAuthExtensionHandler } from "../../src/broker/nativeBroker/PlatformAuthExtensionHandler.js";
-import exp from "constants";
-import { log } from "console";
-import { BrowserAuthError } from "../../src/index.js";
 import { TEST_CONFIG } from "../utils/StringConstants.js";
 
 describe("PlatformAuthProvider tests", () => {
@@ -60,6 +58,7 @@ describe("PlatformAuthProvider tests", () => {
             //@ts-ignore
             delete global.window;
             const result = await PlatformAuthProvider.isPlatformBrokerAvailable(
+                true,
                 {},
                 performanceClient,
                 "test-correlation-id"
@@ -69,24 +68,15 @@ describe("PlatformAuthProvider tests", () => {
         });
 
         it("should return true if its a browser app and dom handler is available", async () => {
-            window.sessionStorage.setItem(
-                "msal.browser.platform.auth.dom",
-                "true"
-            );
-            const getItemSpy = jest.spyOn(
-                Object.getPrototypeOf(sessionStorage),
-                "getItem"
-            );
-
             const domProviderSpy = stubDOMProvider();
 
             const result = await PlatformAuthProvider.isPlatformBrokerAvailable(
-                {},
+                true,
+                undefined,
                 performanceClient,
-                TEST_CONFIG.CORRELATION_ID
+                "test-correlation-id"
             );
             expect(result).toBe(true);
-            expect(getItemSpy).toHaveBeenCalled();
             expect(domProviderSpy).toHaveBeenCalled();
         });
 
@@ -94,6 +84,7 @@ describe("PlatformAuthProvider tests", () => {
             const extensionProviderSpy = stubExtensionProvider();
 
             const result = await PlatformAuthProvider.isPlatformBrokerAvailable(
+                false,
                 {},
                 performanceClient,
                 TEST_CONFIG.CORRELATION_ID
@@ -118,6 +109,7 @@ describe("PlatformAuthProvider tests", () => {
             });
 
             const result = await PlatformAuthProvider.isPlatformBrokerAvailable(
+                true,
                 {},
                 performanceClient,
                 TEST_CONFIG.CORRELATION_ID
@@ -151,25 +143,17 @@ describe("PlatformAuthProvider tests", () => {
         });
 
         it("returns dom handler when available", async () => {
-            window.sessionStorage.setItem(
-                "msal.browser.platform.auth.dom",
-                "true"
-            );
-            const getItemSpy = jest.spyOn(
-                Object.getPrototypeOf(sessionStorage),
-                "getItem"
-            );
-
             const domProviderSpy = stubDOMProvider();
 
             const result = await PlatformAuthProvider.getPlatformAuthProvider(
                 logger,
                 performanceClient,
-                "test-correlation-id"
+                "test-correlation-id",
+                undefined,
+                true
             );
             expect(result).not.toBe(undefined);
             expect(result).toBeInstanceOf(PlatformAuthDOMHandler);
-            expect(getItemSpy).toHaveBeenCalled();
             expect(domProviderSpy).toHaveBeenCalled();
         });
 
@@ -184,33 +168,6 @@ describe("PlatformAuthProvider tests", () => {
             expect(result).not.toBe(undefined);
             expect(result).toBeInstanceOf(PlatformAuthExtensionHandler);
             expect(extensionProviderSpy).toHaveBeenCalled();
-        });
-    });
-
-    describe("isDomEnabledForPlatformAuth tests", () => {
-        it("should return false if session storage is not set with DOM API flag", () => {
-            expect(PlatformAuthProvider.isDomEnabledForPlatformAuth()).toBe(
-                false
-            );
-        });
-
-        it("should return true if session storage is set with DOM API flag", () => {
-            window.sessionStorage.setItem(
-                "msal.browser.platform.auth.dom",
-                "true"
-            );
-            expect(PlatformAuthProvider.isDomEnabledForPlatformAuth()).toBe(
-                true
-            );
-        });
-
-        it("should return false if session storage errors out", () => {
-            const { sessionStorage } = global.window;
-            //@ts-ignore
-            delete global.window.sessionStorage;
-            const result = PlatformAuthProvider.isDomEnabledForPlatformAuth();
-            expect(result).toBe(false);
-            global.window.sessionStorage = sessionStorage; // Restore sessionStorage
         });
     });
 
@@ -274,6 +231,43 @@ describe("PlatformAuthProvider tests", () => {
         });
 
         it("returns true when platform auth provider is initialized and authentication scheme is supported", () => {
+            const result = PlatformAuthProvider.isPlatformAuthAllowed(
+                config,
+                logger,
+                TEST_CONFIG.CORRELATION_ID,
+                new PlatformAuthDOMHandler(
+                    logger,
+                    performanceClient,
+                    "test-correlation-id"
+                ),
+                Constants.AuthenticationScheme.BEARER
+            );
+            expect(result).toBe(true);
+        });
+
+        it("throws error when allowPlatformBrokerWithDOM is enabled without allowPlatformBroker", () => {
+            config.system.allowPlatformBroker = false;
+            config.experimental.allowPlatformBrokerWithDOM = true;
+            expect(() => {
+                PlatformAuthProvider.isPlatformAuthAllowed(
+                    config,
+                    logger,
+                    TEST_CONFIG.CORRELATION_ID,
+                    new PlatformAuthDOMHandler(
+                        logger,
+                        performanceClient,
+                        "test-correlation-id"
+                    ),
+                    Constants.AuthenticationScheme.BEARER
+                );
+            }).toThrow(
+                ClientConfigurationErrorCodes.invalidPlatformBrokerConfiguration
+            );
+        });
+
+        it("returns true when both allowPlatformBroker and allowPlatformBrokerWithDOM are enabled", () => {
+            config.system.allowPlatformBroker = true;
+            config.experimental.allowPlatformBrokerWithDOM = true;
             const result = PlatformAuthProvider.isPlatformAuthAllowed(
                 config,
                 logger,

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1582,6 +1582,7 @@ declare namespace ClientConfigurationErrorCodes {
         cannotAllowPlatformBroker,
         authorityMismatch,
         invalidRequestMethodForEAR,
+        invalidPlatformBrokerConfiguration,
         issuerValidationFailed
     }
 }
@@ -2743,6 +2744,11 @@ const invalidCloudDiscoveryMetadata = "invalid_cloud_discovery_metadata";
 //
 // @public (undocumented)
 const invalidCodeChallengeMethod = "invalid_code_challenge_method";
+
+// Warning: (ae-missing-release-tag) "invalidPlatformBrokerConfiguration" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const invalidPlatformBrokerConfiguration = "invalid_platform_broker_configuration";
 
 // Warning: (ae-missing-release-tag) "invalidRequestMethodForEAR" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/lib/msal-common/src/error/ClientConfigurationErrorCodes.ts
+++ b/lib/msal-common/src/error/ClientConfigurationErrorCodes.ts
@@ -26,4 +26,6 @@ export const cannotSetOIDCOptions = "cannot_set_OIDCOptions";
 export const cannotAllowPlatformBroker = "cannot_allow_platform_broker";
 export const authorityMismatch = "authority_mismatch";
 export const invalidRequestMethodForEAR = "invalid_request_method_for_EAR";
+export const invalidPlatformBrokerConfiguration =
+    "invalid_platform_broker_configuration";
 export const issuerValidationFailed = "issuer_validation_failed";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11205,7 +11205,6 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
             "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "dependencies": {
@@ -11244,12 +11243,10 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11265,12 +11262,10 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11286,12 +11281,10 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11307,12 +11300,10 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11328,12 +11319,10 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11349,12 +11338,10 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11370,12 +11357,10 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11391,12 +11376,10 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11412,12 +11395,10 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11433,12 +11414,10 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11454,12 +11433,10 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11475,12 +11452,10 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11496,12 +11471,10 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -11514,7 +11487,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-            "dev": true,
             "optional": true,
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
@@ -11527,7 +11499,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@pkgjs/parseargs": {
@@ -13929,7 +13900,6 @@
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
             "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -19316,7 +19286,6 @@
             "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "prr": "~1.0.1"
             },
@@ -22868,7 +22837,6 @@
             "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "bin": {
                 "image-size": "bin/image-size.js"
             },
@@ -23207,7 +23175,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -23269,7 +23237,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -25618,7 +25586,6 @@
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -25632,7 +25599,6 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -27031,7 +26997,6 @@
             "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "sax": "^1.2.4"
@@ -27049,7 +27014,6 @@
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -30692,7 +30656,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -31270,8 +31233,7 @@
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/psl": {
             "version": "1.15.0",


### PR DESCRIPTION
Add experimental config flag 'allowPlatformBrokerWithDOM' under BrowserExperimentalOptions to enable platform broker support through DOM APIs in Edge. When both allowPlatformBroker and allowPlatformBrokerWithDOM are set, MSAL first checks for DOM API availability before falling back to PlatformAuthExtensionHandler.

- Add allowPlatformBrokerWithDOM to BrowserExperimentalOptions (default: false)
- Replace session storage-based isDomEnabledForPlatformAuth with explicit config parameter
- Add invalidPlatformBrokerConfiguration error code for invalid config combinations
- Add config validation in isPlatformAuthAllowed
- Pass config flag through StandardController to getPlatformAuthProvider