### PR TITLE
check account loginHint before idTokenClaims setting logoutHint

### DIFF
--- a/change/@azure-msal-browser-logout-hint-fix.json
+++ b/change/@azure-msal-browser-logout-hint-fix.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix logoutHint to check account loginHint before falling back to idTokenClaims [#8591](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8591)",
+  "packageName": "@azure/msal-browser",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -83,7 +83,7 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
                         );
                     if (logoutHint) {
                         this.logger.verbose(
-                            "Setting logoutHint to login_hint value for the account provided",
+                            "Setting logoutHint value to loginHint of the account provided",
                             this.correlationId
                         );
                         validLogoutRequest.logoutHint = logoutHint;
@@ -169,6 +169,10 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
         const idTokenClaims: IdTokenClaims | undefined = account.idTokenClaims;
         if (idTokenClaims) {
             if (idTokenClaims.login_hint) {
+                this.logger.verbose(
+                    "Extracted login_hint claim from account ID Token Claims to be used as logoutHint",
+                    this.correlationId
+                );
                 return idTokenClaims.login_hint;
             } else {
                 this.logger.verbose(

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -73,15 +73,17 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
          * and logoutHint attribute wasn't manually set in logout request
          */
         if (logoutRequest) {
-            // If logoutHint isn't set and an account was passed in, try to extract logoutHint from ID Token Claims
+            // If logoutHint isn't set and an account was passed in, try to extract logoutHint from account loginHint or ID Token Claims
             if (!logoutRequest.logoutHint) {
                 if (logoutRequest.account) {
-                    const logoutHint = this.getLogoutHintFromIdTokenClaims(
-                        logoutRequest.account
-                    );
+                    const logoutHint =
+                        logoutRequest.account.loginHint ||
+                        this.getLogoutHintFromIdTokenClaims(
+                            logoutRequest.account
+                        );
                     if (logoutHint) {
                         this.logger.verbose(
-                            "Setting logoutHint to login_hint ID Token Claim value for the account provided",
+                            "Setting logoutHint to login_hint value for the account provided",
                             this.correlationId
                         );
                         validLogoutRequest.logoutHint = logoutHint;

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -2595,6 +2595,120 @@ describe("RedirectClient", () => {
                 );
         });
 
+        it("gets logouthint from account loginhint first before checking idtokenclaims", (done) => {
+            const logoutHint = "accountloginhint@user.com";
+            const testIdTokenClaims: TokenClaims = {
+                ver: "2.0",
+                iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                name: "Abe Lincoln",
+                preferred_username: "AbeLi@microsoft.com",
+                oid: "00000000-0000-0000-66f3-3332eca7ea81",
+                tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                nonce: "123523",
+            };
+
+            const testAccountInfo: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || "",
+                loginHint: logoutHint,
+                idTokenClaims: testIdTokenClaims,
+            };
+
+            const testAccount: AccountEntity = {
+                homeAccountId: testAccountInfo.homeAccountId,
+                localAccountId: testAccountInfo.localAccountId,
+                environment: testAccountInfo.environment,
+                realm: testAccountInfo.tenantId,
+                username: testAccountInfo.username,
+                name: testAccountInfo.name,
+                authorityType: "MSSTS",
+                clientInfo: TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED,
+                lastUpdatedAt: Date.now().toString(),
+            };
+
+            jest.spyOn(
+                NavigationClient.prototype,
+                "navigateExternal"
+            ).mockImplementation(
+                (
+                    urlNavigate: string,
+                    options: NavigationOptions
+                ): Promise<boolean> => {
+                    expect(urlNavigate).toContain(
+                        `logout_hint=${encodeURIComponent(logoutHint)}`
+                    );
+                    done();
+                    return Promise.resolve(true);
+                }
+            );
+            browserStorage
+                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true, 0)
+                .then(() =>
+                    redirectClient.logout({ account: testAccountInfo })
+                );
+        });
+
+        it("falls back to idTokenClaims login_hint when account loginHint is not available", (done) => {
+            const idTokenLoginHint = "idtoken@user.com";
+            const testIdTokenClaims: TokenClaims = {
+                ver: "2.0",
+                iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                name: "Abe Lincoln",
+                preferred_username: "AbeLi@microsoft.com",
+                oid: "00000000-0000-0000-66f3-3332eca7ea81",
+                tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                nonce: "123523",
+                login_hint: idTokenLoginHint,
+            };
+
+            const testAccountInfo: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || "",
+                idTokenClaims: testIdTokenClaims,
+            };
+
+            const testAccount: AccountEntity = {
+                homeAccountId: testAccountInfo.homeAccountId,
+                localAccountId: testAccountInfo.localAccountId,
+                environment: testAccountInfo.environment,
+                realm: testAccountInfo.tenantId,
+                username: testAccountInfo.username,
+                name: testAccountInfo.name,
+                authorityType: "MSSTS",
+                clientInfo: TEST_DATA_CLIENT_INFO.TEST_CLIENT_INFO_B64ENCODED,
+                lastUpdatedAt: Date.now().toString(),
+            };
+
+            jest.spyOn(
+                NavigationClient.prototype,
+                "navigateExternal"
+            ).mockImplementation(
+                (
+                    urlNavigate: string,
+                    options: NavigationOptions
+                ): Promise<boolean> => {
+                    expect(urlNavigate).toContain(
+                        `logout_hint=${encodeURIComponent(idTokenLoginHint)}`
+                    );
+                    done();
+                    return Promise.resolve(true);
+                }
+            );
+            browserStorage
+                .setAccount(testAccount, TEST_CONFIG.CORRELATION_ID, true, 0)
+                .then(() =>
+                    redirectClient.logout({ account: testAccountInfo })
+                );
+        });
+
         it("logoutHint attribute takes precedence over ID Token Claims from provided account when setting logout_hint", (done) => {
             const logoutHint = "test@user.com";
             const loginHint = "anothertest@user.com";


### PR DESCRIPTION
This pull request updates the logic for setting the `logoutHint` during logout in the `StandardInteractionClient`. The main improvement is that the code now prioritizes using the `loginHint` from the account object before falling back to extracting the hint from the ID Token Claims.

Enhancement to logout hint resolution:

* Updated the logic in `StandardInteractionClient` (`StandardInteractionClient.ts`) so that when a logout request is made without a `logoutHint`, the code first checks for a `loginHint` on the account and uses it if present; if not, it falls back to extracting the hint from the ID Token Claims. This ensures the most direct hint is used for logout and improves reliability.