### PR TITLE
fix: respect redirectStartPage in PlatformAuthInteractionClient.acquireTokenRedirect

### DIFF
--- a/change/@azure-msal-browser-2e902c2f-9b1b-46de-8b45-6986b25c5526.json
+++ b/change/@azure-msal-browser-2e902c2f-9b1b-46de-8b45-6986b25c5526.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Respect redirectStartPage in PlatformAuthInteractionClient.acquireTokenRedirect [#8604](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8604)",
+  "packageName": "@azure/msal-browser",
+  "email": "lalimasharda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -72,6 +72,7 @@ import {
     PlatformAuthConstants,
     TemporaryCacheKeys,
 } from "../utils/BrowserConstants.js";
+import { getCurrentUri } from "../utils/BrowserUtils.js";
 import {
     BaseInteractionClient,
     getDiscoveredAuthority,
@@ -388,7 +389,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             noHistory: false,
         };
         const redirectUri = navigateToLoginRequestUrl
-            ? request.redirectStartPage || window.location.href
+            ? UrlString.getAbsoluteUrl(
+                  request.redirectStartPage || window.location.href,
+                  getCurrentUri()
+              )
             : getRedirectUri(
                   request.redirectUri,
                   this.config.auth.redirectUri,

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -388,7 +388,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             noHistory: false,
         };
         const redirectUri = navigateToLoginRequestUrl
-            ? window.location.href
+            ? request.redirectStartPage || window.location.href
             : getRedirectUri(
                   request.redirectUri,
                   this.config.auth.redirectUri,

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1535,6 +1535,54 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 failedRequests: [],
             });
         });
+
+        it("navigates to redirectStartPage when provided and navigateToLoginRequestUrl is true", (done) => {
+            const redirectStartPage = "https://localhost:3000/startPage";
+            jest.spyOn(
+                NavigationClient.prototype,
+                "navigateExternal"
+            ).mockImplementation((url: string) => {
+                expect(url).toBe(redirectStartPage);
+                done();
+                return Promise.resolve(true);
+            });
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+            platformAuthInteractionClient.acquireTokenRedirect(
+                {
+                    scopes: ["User.Read"],
+                    redirectStartPage: redirectStartPage,
+                },
+                perfMeasurement
+            );
+        });
+
+        it("navigates to window.location.href when redirectStartPage is not provided and navigateToLoginRequestUrl is true", (done) => {
+            jest.spyOn(
+                NavigationClient.prototype,
+                "navigateExternal"
+            ).mockImplementation((url: string) => {
+                expect(url).toBe(window.location.href);
+                done();
+                return Promise.resolve(true);
+            });
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockImplementation((): Promise<PlatformAuthResponse> => {
+                return Promise.resolve(MOCK_WAM_RESPONSE);
+            });
+            platformAuthInteractionClient.acquireTokenRedirect(
+                {
+                    scopes: ["User.Read"],
+                },
+                perfMeasurement
+            );
+        });
     });
 
     describe("handleRedirectPromise tests", () => {


### PR DESCRIPTION
## Description

**Bug:** `PlatformAuthInteractionClient.acquireTokenRedirect` ignored `request.redirectStartPage` when `navigateToLoginRequestUrl` was `true`, always navigating to `window.location.href` instead.

**Fix:** When `navigateToLoginRequestUrl` is `true`, use `request.redirectStartPage || window.location.href` so that callers who set `redirectStartPage` are respected. When `navigateToLoginRequestUrl` is `false`, behavior is unchanged (falls back to `redirectUri`).

This aligns `PlatformAuthInteractionClient` with the existing behavior in `RedirectClient`, which already honors `redirectStartPage`.

## Changes

- **`lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts`** — use `request.redirectStartPage` (with `window.location.href` fallback) when `navigateToLoginRequestUrl` is `true`
- **`lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts`** — added two tests:
  - Navigates to `redirectStartPage` when provided
  - Falls back to `window.location.href` when `redirectStartPage` is not provided
