### PR TITLE
fix: increase waitForSelector timeout to 60s in b2c e2e test utils

### DIFF
--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -203,7 +203,7 @@ export async function b2cAadPpeAccountEnterCredentials(
     username: string,
     accountPwd: string
 ): Promise<void> {
-    await page.waitForSelector(HtmlSelectors.B2C_AAD_ID4SLAB2_SIGNIN_PAGE);
+    await page.waitForSelector(HtmlSelectors.B2C_AAD_ID4SLAB2_SIGNIN_PAGE, { timeout: 60000 });
     await screenshot.takeScreenshot(page, "b2cSignInPage");
     // Select Lab Provider
     await page.click(HtmlSelectors.B2C_AAD_ID4SLAB2_SIGNIN_PAGE);
@@ -217,7 +217,7 @@ export async function b2cMsaAccountEnterCredentials(
     username: string,
     accountPwd: string
 ): Promise<void> {
-    await page.waitForSelector(HtmlSelectors.B2C_MSA_SIGNIN_PAGE);
+    await page.waitForSelector(HtmlSelectors.B2C_MSA_SIGNIN_PAGE, { timeout: 60000 });
     await screenshot.takeScreenshot(page, "b2cSignInPage");
     // Select Lab Provider
     await page.click(HtmlSelectors.B2C_MSA_SIGNIN_PAGE);


### PR DESCRIPTION
## Problem

The \2c-sample\ e2e test \Edits profile with the policy\ has been consistently failing in CI with:

\\\
TimeoutError: Timed out after waiting 30000ms
waiting for selector \#MicrosoftAccountExchange, input[name='MicrosoftAccountExchange']\
\\\

## Root Cause

\2cMsaAccountEnterCredentials()\ and \2cAadPpeAccountEnterCredentials()\ in \TestUtils.ts\ called \page.waitForSelector()\ with no explicit timeout, relying on Puppeteer's 30s default. In CI environments (slower network/machine), navigating to the B2C page and rendering the IDP buttons (\#MicrosoftAccountExchange\) can exceed 30 seconds.

**Confirmed locally:** The test passes in ~40-50 seconds end-to-end, meaning the IDP button can legitimately take longer than 30s to appear under slower conditions.

## Fix

Increase \waitForSelector\ timeout to 60s in both affected functions, matching the jest \	estTimeout: 120000\ and Puppeteer browser launch \	imeout: 60000\ already configured for this suite.

## Testing

- Ran \msa-account.spec.ts\ locally twice — passes in ~40-50s both times
- No other test changes needed