### PR TITLE
[correlationId 3/4] Thread correlationId through createAccessTokenEntity and createAccountEntity (breaking)

### DIFF
--- a/lib/msal-browser/src/app/IPublicClientApplication.ts
+++ b/lib/msal-browser/src/app/IPublicClientApplication.ts
@@ -80,27 +80,42 @@ export interface IPublicClientApplication {
 export const stubbedPublicClientApplication: IPublicClientApplication = {
     initialize: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     acquireTokenPopup: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     acquireTokenRedirect: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     acquireTokenSilent: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     acquireTokenByCode: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     getAllAccounts: () => {
@@ -111,32 +126,50 @@ export const stubbedPublicClientApplication: IPublicClientApplication = {
     },
     handleRedirectPromise: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     loginPopup: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     loginRedirect: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     logoutRedirect: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     logoutPopup: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     ssoSilent: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     addEventCallback: () => {
@@ -152,7 +185,10 @@ export const stubbedPublicClientApplication: IPublicClientApplication = {
         return false;
     },
     getLogger: () => {
-        throw createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "");
+        throw createBrowserConfigurationAuthError(
+            BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+            ""
+        );
     },
     setLogger: () => {
         return;
@@ -170,16 +206,25 @@ export const stubbedPublicClientApplication: IPublicClientApplication = {
         return;
     },
     getConfiguration: () => {
-        throw createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "");
+        throw createBrowserConfigurationAuthError(
+            BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+            ""
+        );
     },
     hydrateCache: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
     clearCache: () => {
         return Promise.reject(
-            createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled, "")
+            createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.stubbedPublicClientApplicationCalled,
+                ""
+            )
         );
     },
 };

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthProvider.ts
@@ -127,7 +127,10 @@ export function isPlatformAuthAllowed(
         !config.system.allowPlatformBroker &&
         config.experimental.allowPlatformBrokerWithDOM
     ) {
-        throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidPlatformBrokerConfiguration, "");
+        throw createClientConfigurationError(
+            ClientConfigurationErrorCodes.invalidPlatformBrokerConfiguration,
+            ""
+        );
     }
 
     if (!config.system.allowPlatformBroker) {

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -2111,7 +2111,10 @@ export class BrowserCacheManager extends CacheManager {
             true
         );
         if (!encodedTokenRequest) {
-            throw createBrowserAuthError(BrowserAuthErrorCodes.noTokenRequestCacheError, "");
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.noTokenRequestCacheError,
+                ""
+            );
         }
         const encodedVerifier = this.getTemporaryCache(
             TemporaryCacheKeys.VERIFIER,
@@ -2135,7 +2138,10 @@ export class BrowserCacheManager extends CacheManager {
                 `Parsing cached token request threw with error: '${e}'`,
                 correlationId
             );
-            throw createBrowserAuthError(BrowserAuthErrorCodes.unableToParseTokenRequestCacheError, "");
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.unableToParseTokenRequestCacheError,
+                ""
+            );
         }
 
         return [parsedRequest, verifier];
@@ -2234,7 +2240,10 @@ export class BrowserCacheManager extends CacheManager {
                     // Clear existing interaction to allow new one
                     this.removeTemporaryItem(key);
                 } else {
-                    throw createBrowserAuthError(BrowserAuthErrorCodes.interactionInProgress, "");
+                    throw createBrowserAuthError(
+                        BrowserAuthErrorCodes.interactionInProgress,
+                        ""
+                    );
                 }
             }
             // Set new interaction

--- a/lib/msal-browser/src/cache/BrowserCacheManager.ts
+++ b/lib/msal-browser/src/cache/BrowserCacheManager.ts
@@ -2295,6 +2295,7 @@ export class BrowserCacheManager extends CacheManager {
                 ? TimeUtils.toSecondsFromDate(result.extExpiresOn)
                 : 0,
             base64Decode,
+            request.correlationId || "",
             undefined, // refreshOn
             result.tokenType as Constants.AuthenticationScheme,
             undefined, // userAssertionHash

--- a/lib/msal-browser/src/cache/CookieStorage.ts
+++ b/lib/msal-browser/src/cache/CookieStorage.ts
@@ -46,7 +46,10 @@ export class CookieStorage implements IWindowStorage<string> {
     }
 
     getUserData(): string | null {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
 
     setItem(

--- a/lib/msal-browser/src/cache/DatabaseStorage.ts
+++ b/lib/msal-browser/src/cache/DatabaseStorage.ts
@@ -64,7 +64,10 @@ export class DatabaseStorage<T> implements IAsyncStorage<T> {
             });
             openDB.addEventListener("error", () =>
                 reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.databaseUnavailable, "")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.databaseUnavailable,
+                        ""
+                    )
                 )
             );
         });
@@ -101,7 +104,10 @@ export class DatabaseStorage<T> implements IAsyncStorage<T> {
             // TODO: Add timeouts?
             if (!this.db) {
                 return reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.databaseNotOpen, "")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.databaseNotOpen,
+                        ""
+                    )
                 );
             }
             const transaction = this.db.transaction(
@@ -135,7 +141,10 @@ export class DatabaseStorage<T> implements IAsyncStorage<T> {
             // TODO: Add timeouts?
             if (!this.db) {
                 return reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.databaseNotOpen, "")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.databaseNotOpen,
+                        ""
+                    )
                 );
             }
             const transaction = this.db.transaction(
@@ -168,7 +177,10 @@ export class DatabaseStorage<T> implements IAsyncStorage<T> {
         return new Promise<void>((resolve: Function, reject: Function) => {
             if (!this.db) {
                 return reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.databaseNotOpen, "")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.databaseNotOpen,
+                        ""
+                    )
                 );
             }
 
@@ -199,7 +211,10 @@ export class DatabaseStorage<T> implements IAsyncStorage<T> {
         return new Promise<string[]>((resolve: Function, reject: Function) => {
             if (!this.db) {
                 return reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.databaseNotOpen, "")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.databaseNotOpen,
+                        ""
+                    )
                 );
             }
 
@@ -233,7 +248,10 @@ export class DatabaseStorage<T> implements IAsyncStorage<T> {
         return new Promise<boolean>((resolve: Function, reject: Function) => {
             if (!this.db) {
                 return reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.databaseNotOpen, "")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.databaseNotOpen,
+                        ""
+                    )
                 );
             }
 

--- a/lib/msal-browser/src/cache/LocalStorage.ts
+++ b/lib/msal-browser/src/cache/LocalStorage.ts
@@ -59,7 +59,10 @@ export class LocalStorage implements IWindowStorage<string> {
         performanceClient: IPerformanceClient
     ) {
         if (!window.localStorage) {
-            throw createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.storageNotSupported, "");
+            throw createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.storageNotSupported,
+                ""
+            );
         }
         this.memoryStorage = new MemoryStorage<string>();
         this.initialized = false;
@@ -161,7 +164,10 @@ export class LocalStorage implements IWindowStorage<string> {
 
     getUserData(key: string): string | null {
         if (!this.initialized) {
-            throw createBrowserAuthError(BrowserAuthErrorCodes.uninitializedPublicClientApplication, "");
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.uninitializedPublicClientApplication,
+                ""
+            );
         }
         return this.memoryStorage.getItem(key);
     }
@@ -172,7 +178,10 @@ export class LocalStorage implements IWindowStorage<string> {
         correlationId: string
     ): Promise<object | null> {
         if (!this.initialized || !this.encryptionCookie) {
-            throw createBrowserAuthError(BrowserAuthErrorCodes.uninitializedPublicClientApplication, "");
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.uninitializedPublicClientApplication,
+                ""
+            );
         }
 
         if (data.id !== this.encryptionCookie.id) {
@@ -227,7 +236,10 @@ export class LocalStorage implements IWindowStorage<string> {
         kmsi: boolean
     ): Promise<void> {
         if (!this.initialized || !this.encryptionCookie) {
-            throw createBrowserAuthError(BrowserAuthErrorCodes.uninitializedPublicClientApplication, "");
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.uninitializedPublicClientApplication,
+                ""
+            );
         }
 
         if (kmsi) {

--- a/lib/msal-browser/src/cache/SessionStorage.ts
+++ b/lib/msal-browser/src/cache/SessionStorage.ts
@@ -12,7 +12,10 @@ import { IWindowStorage } from "./IWindowStorage.js";
 export class SessionStorage implements IWindowStorage<string> {
     constructor() {
         if (!window.sessionStorage) {
-            throw createBrowserConfigurationAuthError(BrowserConfigurationAuthErrorCodes.storageNotSupported, "");
+            throw createBrowserConfigurationAuthError(
+                BrowserConfigurationAuthErrorCodes.storageNotSupported,
+                ""
+            );
         }
     }
 

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -254,7 +254,10 @@ async function loadAccount(
             "TokenCache - if an account is not provided on the request, clientInfo or idToken must be provided instead.",
             correlationId
         );
-        throw createBrowserAuthError(BrowserAuthErrorCodes.unableToLoadToken, "");
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.unableToLoadToken,
+            ""
+        );
     }
 
     const homeAccountId = AccountEntityUtils.generateHomeAccountId(

--- a/lib/msal-browser/src/cache/TokenCache.ts
+++ b/lib/msal-browser/src/cache/TokenCache.ts
@@ -397,7 +397,8 @@ async function loadAccessToken(
         scopes.printScopes(),
         expiresOn,
         extendedExpiresOn,
-        base64Decode
+        base64Decode,
+        correlationId
     );
 
     await storage.setAccessTokenCredential(

--- a/lib/msal-browser/src/config/Configuration.ts
+++ b/lib/msal-browser/src/config/Configuration.ts
@@ -344,7 +344,10 @@ export function buildConfiguration(
         const logger = new Logger(providedSystemOptions.loggerOptions);
         logger.warning(
             JSON.stringify(
-                createClientConfigurationError(ClientConfigurationErrorCodes.cannotSetOIDCOptions, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.cannotSetOIDCOptions,
+                    ""
+                )
             ),
             ""
         );
@@ -356,7 +359,10 @@ export function buildConfiguration(
         userInputSystem.protocolMode === ProtocolMode.OIDC &&
         providedSystemOptions?.allowPlatformBroker
     ) {
-        throw createClientConfigurationError(ClientConfigurationErrorCodes.cannotAllowPlatformBroker, "");
+        throw createClientConfigurationError(
+            ClientConfigurationErrorCodes.cannotAllowPlatformBroker,
+            ""
+        );
     }
 
     const overlayedConfig: BrowserConfiguration = {

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1306,7 +1306,9 @@ export class StandardController implements IController {
         try {
             if (request.code && request.nativeAccountId) {
                 // Throw error in case server returns both spa_code and spa_accountid in exchange for auth code.
-                throw createBrowserAuthError(BrowserAuthErrorCodes.spaCodeAndNativeAccountIdPresent, correlationId
+                throw createBrowserAuthError(
+                    BrowserAuthErrorCodes.spaCodeAndNativeAccountIdPresent,
+                    correlationId
                 );
             } else if (request.code) {
                 const hybridAuthCode = request.code;
@@ -1402,11 +1404,15 @@ export class StandardController implements IController {
                     );
                     return result;
                 } else {
-                    throw createBrowserAuthError(BrowserAuthErrorCodes.unableToAcquireTokenFromNativePlatform, correlationId
+                    throw createBrowserAuthError(
+                        BrowserAuthErrorCodes.unableToAcquireTokenFromNativePlatform,
+                        correlationId
                     );
                 }
             } else {
-                throw createBrowserAuthError(BrowserAuthErrorCodes.authCodeOrNativeAccountIdRequired, correlationId
+                throw createBrowserAuthError(
+                    BrowserAuthErrorCodes.authCodeOrNativeAccountIdRequired,
+                    correlationId
                 );
             }
         } catch (e) {
@@ -1501,7 +1507,9 @@ export class StandardController implements IController {
                     commonRequest.correlationId
                 )(commonRequest);
             default:
-                throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, commonRequest.correlationId
+                throw createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    commonRequest.correlationId
                 );
         }
     }
@@ -1533,7 +1541,9 @@ export class StandardController implements IController {
                     commonRequest.correlationId
                 )(commonRequest);
             default:
-                throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, commonRequest.correlationId
+                throw createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    commonRequest.correlationId
                 );
         }
     }
@@ -1779,7 +1789,9 @@ export class StandardController implements IController {
         const correlationId = this.getRequestCorrelationId(request);
         this.logger.trace("acquireTokenNative called", correlationId);
         if (!this.platformAuthProvider) {
-            throw createBrowserAuthError(BrowserAuthErrorCodes.nativeConnectionNotEstablished, correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.nativeConnectionNotEstablished,
+                correlationId
             );
         }
 
@@ -2188,7 +2200,9 @@ export class StandardController implements IController {
 
         const account = request.account || this.getActiveAccount();
         if (!account) {
-            throw createBrowserAuthError(BrowserAuthErrorCodes.noAccountError, correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.noAccountError,
+                correlationId
             );
         }
 
@@ -2523,7 +2537,9 @@ export class StandardController implements IController {
                     );
                     this.platformAuthProvider = undefined; // Prevent future requests from continuing to attempt
                     // Cache will not contain tokens, given that previous WAM requests succeeded. Skip cache and RT renewal and go straight to iframe renewal
-                    throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, silentRequest.correlationId
+                    throw createClientAuthError(
+                        ClientAuthErrorCodes.tokenRefreshRequired,
+                        silentRequest.correlationId
                     );
                 }
                 throw e;

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -1733,6 +1733,7 @@ export class StandardController implements IController {
                     ? TimeUtils.toSecondsFromDate(result.extExpiresOn)
                     : 0,
                 base64Decode,
+                request.correlationId || "",
                 undefined, // refreshOn
                 result.tokenType as Constants.AuthenticationScheme,
                 undefined, // userAssertionHash

--- a/lib/msal-browser/src/encode/Base64Decode.ts
+++ b/lib/msal-browser/src/encode/Base64Decode.ts
@@ -37,7 +37,10 @@ export function base64DecToArr(base64String: string): Uint8Array {
             encodedString += "=";
             break;
         default:
-            throw createBrowserAuthError(BrowserAuthErrorCodes.invalidBase64String, "");
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.invalidBase64String,
+                ""
+            );
     }
     const binString = atob(encodedString);
     return Uint8Array.from(binString, (m) => m.codePointAt(0) || 0);

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -863,6 +863,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 tokenExpirationSeconds,
                 0,
                 base64Decode,
+                request.correlationId,
                 undefined,
                 request.tokenType as Constants.AuthenticationScheme,
                 undefined,

--- a/lib/msal-browser/src/interaction_client/PopupClient.ts
+++ b/lib/msal-browser/src/interaction_client/PopupClient.ts
@@ -878,7 +878,9 @@ export class PopupClient extends StandardInteractionClient {
         } else {
             // Throw error if request URL is empty.
             this.logger.error("Navigate url is empty", this.correlationId);
-            throw createBrowserAuthError(BrowserAuthErrorCodes.emptyNavigateUri, this.correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.emptyNavigateUri,
+                this.correlationId
             );
         }
     }
@@ -918,7 +920,9 @@ export class PopupClient extends StandardInteractionClient {
 
             // Popup will be null if popups are blocked
             if (!popupWindow) {
-                throw createBrowserAuthError(BrowserAuthErrorCodes.emptyWindowError, this.correlationId
+                throw createBrowserAuthError(
+                    BrowserAuthErrorCodes.emptyWindowError,
+                    this.correlationId
                 );
             }
             if (popupWindow.focus) {
@@ -932,7 +936,9 @@ export class PopupClient extends StandardInteractionClient {
                 `error opening popup '${(e as AuthError).message}'`,
                 this.correlationId
             );
-            throw createBrowserAuthError(BrowserAuthErrorCodes.popupWindowError, this.correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.popupWindowError,
+                this.correlationId
             );
         }
     }

--- a/lib/msal-browser/src/interaction_client/RedirectClient.ts
+++ b/lib/msal-browser/src/interaction_client/RedirectClient.ts
@@ -337,7 +337,11 @@ export class RedirectClient extends StandardInteractionClient {
         return new Promise<void>((resolve, reject) => {
             setTimeout(() => {
                 reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "failed_to_redirect")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.timedOut,
+                        "",
+                        "failed_to_redirect"
+                    )
                 );
             }, this.config.system.redirectNavigationTimeout);
         });
@@ -381,7 +385,11 @@ export class RedirectClient extends StandardInteractionClient {
         return new Promise<void>((resolve, reject) => {
             setTimeout(() => {
                 reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "failed_to_redirect")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.timedOut,
+                        "",
+                        "failed_to_redirect"
+                    )
                 );
             }, this.config.system.redirectNavigationTimeout);
         });
@@ -649,7 +657,9 @@ export class RedirectClient extends StandardInteractionClient {
     ): Promise<AuthenticationResult> {
         const state = serverParams.state;
         if (!state) {
-            throw createBrowserAuthError(BrowserAuthErrorCodes.noStateInHash, request.correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.noStateInHash,
+                request.correlationId
             );
         }
 
@@ -792,7 +802,9 @@ export class RedirectClient extends StandardInteractionClient {
                 "RedirectHandler.initiateAuthRequest: Navigate url is empty",
                 this.correlationId
             );
-            throw createBrowserAuthError(BrowserAuthErrorCodes.emptyNavigateUri, this.correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.emptyNavigateUri,
+                this.correlationId
             );
         }
     }

--- a/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentAuthCodeClient.ts
@@ -72,7 +72,9 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
     ): Promise<AuthenticationResult> {
         // Auth code payload is required
         if (!request.code) {
-            throw createBrowserAuthError(BrowserAuthErrorCodes.authCodeRequired, this.correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.authCodeRequired,
+                this.correlationId
             );
         }
 
@@ -178,7 +180,10 @@ export class SilentAuthCodeClient extends StandardInteractionClient {
     logout(): Promise<void> {
         // Synchronous so we must reject
         return Promise.reject(
-            createBrowserAuthError(BrowserAuthErrorCodes.silentLogoutUnsupported, "")
+            createBrowserAuthError(
+                BrowserAuthErrorCodes.silentLogoutUnsupported,
+                ""
+            )
         );
     }
 }

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -480,7 +480,10 @@ export class SilentIframeClient extends StandardInteractionClient {
     logout(): Promise<void> {
         // Synchronous so we must reject
         return Promise.reject(
-            createBrowserAuthError(BrowserAuthErrorCodes.silentLogoutUnsupported, "")
+            createBrowserAuthError(
+                BrowserAuthErrorCodes.silentLogoutUnsupported,
+                ""
+            )
         );
     }
 

--- a/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentRefreshClient.ts
@@ -101,7 +101,10 @@ export class SilentRefreshClient extends StandardInteractionClient {
     logout(): Promise<void> {
         // Synchronous so we must reject
         return Promise.reject(
-            createBrowserAuthError(BrowserAuthErrorCodes.silentLogoutUnsupported, "")
+            createBrowserAuthError(
+                BrowserAuthErrorCodes.silentLogoutUnsupported,
+                ""
+            )
         );
     }
 

--- a/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/InteractionHandler.ts
@@ -73,7 +73,9 @@ export class InteractionHandler {
                 e.subError === BrowserAuthErrorCodes.userCancelled
             ) {
                 // Translate server error caused by user closing native prompt to corresponding first class MSAL error
-                throw createBrowserAuthError(BrowserAuthErrorCodes.userCancelled, request.correlationId
+                throw createBrowserAuthError(
+                    BrowserAuthErrorCodes.userCancelled,
+                    request.correlationId
                 );
             } else {
                 throw e;

--- a/lib/msal-browser/src/interaction_handler/SilentHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/SilentHandler.ts
@@ -32,7 +32,9 @@ export async function initiateCodeRequest(
     if (!requestUrl) {
         // Throw error if request URL is empty.
         logger.info("Navigate url is empty", correlationId);
-        throw createBrowserAuthError(BrowserAuthErrorCodes.emptyNavigateUri, correlationId
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.emptyNavigateUri,
+            correlationId
         );
     }
 

--- a/lib/msal-browser/src/navigation/NavigationClient.ts
+++ b/lib/msal-browser/src/navigation/NavigationClient.ts
@@ -53,7 +53,11 @@ export class NavigationClient implements INavigationClient {
         return new Promise((resolve, reject) => {
             setTimeout(() => {
                 reject(
-                    createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "failed_to_redirect")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.timedOut,
+                        "",
+                        "failed_to_redirect"
+                    )
                 );
             }, options.timeout);
         });

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -283,7 +283,9 @@ export async function getEARForm(
     performanceClient: IPerformanceClient
 ): Promise<HTMLFormElement> {
     if (!request.earJwk) {
-        throw createBrowserAuthError(BrowserAuthErrorCodes.earJwkEmpty, request.correlationId
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.earJwkEmpty,
+            request.correlationId
         );
     }
 
@@ -443,7 +445,9 @@ export async function handleResponsePlatformBroker(
     );
 
     if (!platformAuthProvider) {
-        throw createBrowserAuthError(BrowserAuthErrorCodes.nativeConnectionNotEstablished, request.correlationId
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.nativeConnectionNotEstablished,
+            request.correlationId
         );
     }
     const browserCrypto = new CryptoOps(logger, performanceClient);
@@ -605,12 +609,16 @@ export async function handleResponseEAR(
     );
 
     if (!response.ear_jwe) {
-        throw createBrowserAuthError(BrowserAuthErrorCodes.earJweEmpty, request.correlationId
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.earJweEmpty,
+            request.correlationId
         );
     }
 
     if (!request.earJwk) {
-        throw createBrowserAuthError(BrowserAuthErrorCodes.earJwkEmpty, request.correlationId
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.earJwkEmpty,
+            request.correlationId
         );
     }
 

--- a/lib/msal-browser/src/request/RequestHelpers.ts
+++ b/lib/msal-browser/src/request/RequestHelpers.ts
@@ -61,10 +61,16 @@ export async function initializeBaseRequest(
             Constants.AuthenticationScheme.SSH
         ) {
             if (!request.sshJwk) {
-                throw createClientConfigurationError(ClientConfigurationErrorCodes.missingSshJwk, "");
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshJwk,
+                    ""
+                );
             }
             if (!request.sshKid) {
-                throw createClientConfigurationError(ClientConfigurationErrorCodes.missingSshKid, "");
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshKid,
+                    ""
+                );
             }
         }
         logger.verbose(
@@ -115,7 +121,10 @@ export function validateRequestMethod(
     if (protocolMode === ProtocolMode.EAR) {
         // Validate that method can only be POST when protocol mode is EAR
         if (requestMethod && requestMethod !== Constants.HttpMethod.POST) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidRequestMethodForEAR, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.invalidRequestMethodForEAR,
+                ""
+            );
         } else {
             httpMethod = Constants.HttpMethod.POST;
         }

--- a/lib/msal-browser/src/response/ResponseHandler.ts
+++ b/lib/msal-browser/src/response/ResponseHandler.ts
@@ -31,7 +31,9 @@ export function deserializeResponse(
                 `The request has returned to the redirectUri but a '${responseLocation}' is not present. It's likely that the '${responseLocation}' has been removed or the page has been redirected by code running on the redirectUri page.`,
                 correlationId
             );
-            throw createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError, correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.hashEmptyError,
+                correlationId
             );
         } else {
             logger.error(
@@ -42,7 +44,9 @@ export function deserializeResponse(
                 `The '${responseLocation}' detected is: '${responseString}'`,
                 correlationId
             );
-            throw createBrowserAuthError(BrowserAuthErrorCodes.hashDoesNotContainKnownProperties, correlationId
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.hashDoesNotContainKnownProperties,
+                correlationId
             );
         }
     }
@@ -59,7 +63,10 @@ export function validateInteractionType(
     correlationId: string
 ): void {
     if (!response.state) {
-        throw createBrowserAuthError(BrowserAuthErrorCodes.noStateInHash, correlationId);
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.noStateInHash,
+            correlationId
+        );
     }
 
     const platformStateObj = extractBrowserRequestState(
@@ -68,10 +75,16 @@ export function validateInteractionType(
         correlationId
     );
     if (!platformStateObj) {
-        throw createBrowserAuthError(BrowserAuthErrorCodes.unableToParseState, correlationId);
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.unableToParseState,
+            correlationId
+        );
     }
 
     if (platformStateObj.interactionType !== interactionType) {
-        throw createBrowserAuthError(BrowserAuthErrorCodes.stateInteractionTypeMismatch, correlationId);
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.stateInteractionTypeMismatch,
+            correlationId
+        );
     }
 }

--- a/lib/msal-browser/src/utils/BrowserProtocolUtils.ts
+++ b/lib/msal-browser/src/utils/BrowserProtocolUtils.ts
@@ -32,9 +32,16 @@ export function extractBrowserRequestState(
 
     try {
         const requestStateObj: RequestStateObject =
-            ProtocolUtils.parseRequestState(browserCrypto.base64Decode, state, correlationId);
+            ProtocolUtils.parseRequestState(
+                browserCrypto.base64Decode,
+                state,
+                correlationId
+            );
         return requestStateObj.libraryState.meta as BrowserStateObject;
     } catch (e) {
-        throw createClientAuthError(ClientAuthErrorCodes.invalidState, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.invalidState,
+            correlationId
+        );
     }
 }

--- a/lib/msal-browser/test/cache/AsyncMemoryStorage.spec.ts
+++ b/lib/msal-browser/test/cache/AsyncMemoryStorage.spec.ts
@@ -45,7 +45,10 @@ jest.mock("../../src/cache/DatabaseStorage", () => {
                     const item = mockDatabase[TEST_DB_TABLE_NAME][kid];
 
                     if (item === DB_UNAVAILABLE) {
-                        throw createBrowserAuthError(BrowserAuthErrorCodes.databaseUnavailable, "");
+                        throw createBrowserAuthError(
+                            BrowserAuthErrorCodes.databaseUnavailable,
+                            ""
+                        );
                     }
 
                     return item;
@@ -54,7 +57,10 @@ jest.mock("../../src/cache/DatabaseStorage", () => {
                     callCounter.setItemPersistent += 1;
 
                     if (payload === DB_UNAVAILABLE) {
-                        throw createBrowserAuthError(BrowserAuthErrorCodes.databaseUnavailable, "");
+                        throw createBrowserAuthError(
+                            BrowserAuthErrorCodes.databaseUnavailable,
+                            ""
+                        );
                     }
 
                     mockDatabase[TEST_DB_TABLE_NAME][kid] = payload;
@@ -65,7 +71,10 @@ jest.mock("../../src/cache/DatabaseStorage", () => {
                     const item = mockDatabase[TEST_DB_TABLE_NAME][kid];
 
                     if (item === DB_UNAVAILABLE) {
-                        throw createBrowserAuthError(BrowserAuthErrorCodes.databaseUnavailable, "");
+                        throw createBrowserAuthError(
+                            BrowserAuthErrorCodes.databaseUnavailable,
+                            ""
+                        );
                     }
 
                     delete mockDatabase[TEST_DB_TABLE_NAME][kid];

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -1902,6 +1902,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -1915,6 +1916,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -2001,6 +2003,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -2014,6 +2017,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -2027,6 +2031,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -2121,6 +2126,7 @@ describe("BrowserCacheManager tests", () => {
                     1000,
                     1000,
                     browserCrypto.base64Decode,
+                    "",
                     500,
                     Constants.AuthenticationScheme.BEARER
                 );
@@ -2197,6 +2203,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -2210,6 +2217,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -2299,6 +2307,7 @@ describe("BrowserCacheManager tests", () => {
                     1000,
                     1000,
                     browserCrypto.base64Decode,
+                    "",
                     500,
                     Constants.AuthenticationScheme.BEARER
                 );
@@ -2376,6 +2385,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -2389,6 +2399,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -2402,6 +2413,7 @@ describe("BrowserCacheManager tests", () => {
                 1000,
                 1000,
                 browserCrypto.base64Decode,
+                "",
                 500,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -3072,7 +3084,8 @@ describe("BrowserCacheManager tests", () => {
                             msGraphHost: "msGraphHost",
                         },
                         authority
-                    );
+                    ,
+                        "");
 
                     await browserLocalStorage.setAccount(
                         testAccount,
@@ -3305,6 +3318,7 @@ describe("BrowserCacheManager tests", () => {
                             1000,
                             1000,
                             browserCrypto.base64Decode,
+                            "",
                             500,
                             Constants.AuthenticationScheme.BEARER,
                             "oboAssertion"
@@ -3352,6 +3366,7 @@ describe("BrowserCacheManager tests", () => {
                             1000,
                             1000,
                             browserCrypto.base64Decode,
+                            "",
                             500,
                             Constants.AuthenticationScheme.BEARER,
                             "oboAssertion"
@@ -3367,6 +3382,7 @@ describe("BrowserCacheManager tests", () => {
                             1000,
                             1000,
                             browserCrypto.base64Decode,
+                            "",
                             500,
                             Constants.AuthenticationScheme.POP,
                             "oboAssertion"
@@ -3412,6 +3428,7 @@ describe("BrowserCacheManager tests", () => {
                             1000,
                             1000,
                             browserCrypto.base64Decode,
+                            "",
                             500,
                             Constants.AuthenticationScheme.BEARER,
                             "oboAssertion"
@@ -3427,6 +3444,7 @@ describe("BrowserCacheManager tests", () => {
                             1000,
                             1000,
                             browserCrypto.base64Decode,
+                            "",
                             500,
                             Constants.AuthenticationScheme.POP,
                             "oboAssertion"
@@ -3500,6 +3518,7 @@ describe("BrowserCacheManager tests", () => {
                             1000,
                             1000,
                             browserCrypto.base64Decode,
+                            "",
                             500,
                             Constants.AuthenticationScheme.BEARER,
                             "oboAssertion"
@@ -3515,6 +3534,7 @@ describe("BrowserCacheManager tests", () => {
                             1000,
                             1000,
                             browserCrypto.base64Decode,
+                            "",
                             500,
                             Constants.AuthenticationScheme.POP,
                             "oboAssertion"
@@ -3591,6 +3611,7 @@ describe("BrowserCacheManager tests", () => {
                         1000,
                         1000,
                         browserCrypto.base64Decode,
+                        "",
                         500,
                         Constants.AuthenticationScheme.BEARER,
                         "oboAssertion"
@@ -3609,6 +3630,7 @@ describe("BrowserCacheManager tests", () => {
                         1000,
                         1000,
                         browserCrypto.base64Decode,
+                        "",
                         500,
                         Constants.AuthenticationScheme.BEARER
                     );
@@ -4242,6 +4264,7 @@ describe("BrowserCacheManager tests", () => {
                             1000,
                             1000,
                             browserCrypto.base64Decode,
+                            "",
                             500,
                             Constants.AuthenticationScheme.BEARER,
                             "oboAssertion"

--- a/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
+++ b/lib/msal-browser/test/cache/BrowserCacheManager.spec.ts
@@ -3083,9 +3083,9 @@ describe("BrowserCacheManager tests", () => {
                             cloudGraphHostName: "cloudGraphHost",
                             msGraphHost: "msGraphHost",
                         },
-                        authority
-                    ,
-                        "");
+                        authority,
+                        ""
+                    );
 
                     await browserLocalStorage.setAccount(
                         testAccount,
@@ -4648,7 +4648,10 @@ describe("BrowserCacheManager tests", () => {
             expect(() =>
                 browserStorage.getCachedRequest(TEST_CONFIG.CORRELATION_ID)
             ).toThrow(
-                new BrowserAuthError(BrowserAuthErrorCodes.noTokenRequestCacheError, "")
+                new BrowserAuthError(
+                    BrowserAuthErrorCodes.noTokenRequestCacheError,
+                    ""
+                )
             );
         });
 
@@ -4685,7 +4688,10 @@ describe("BrowserCacheManager tests", () => {
             expect(() =>
                 browserStorage.getCachedRequest(TEST_CONFIG.CORRELATION_ID)
             ).toThrow(
-                new BrowserAuthError(BrowserAuthErrorCodes.unableToParseTokenRequestCacheError, "")
+                new BrowserAuthError(
+                    BrowserAuthErrorCodes.unableToParseTokenRequestCacheError,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-browser/test/cache/TokenCache.spec.ts
+++ b/lib/msal-browser/test/cache/TokenCache.spec.ts
@@ -332,7 +332,10 @@ describe("TokenCache tests", () => {
             loadExternalTokens(configuration, request, response, options).catch(
                 (e) => {
                     expect(e).toEqual(
-                        createBrowserAuthError(BrowserAuthErrorCodes.unableToLoadToken, "")
+                        createBrowserAuthError(
+                            BrowserAuthErrorCodes.unableToLoadToken,
+                            ""
+                        )
                     );
                     done();
                 }

--- a/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
+++ b/lib/msal-browser/test/controllers/NestedAppAuthController.spec.ts
@@ -148,7 +148,10 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
                     correlationId: NAA_CORRELATION_ID,
                 } as any)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.resourceParameterRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.resourceParameterRequired,
+                    ""
+                )
             );
         });
 
@@ -175,7 +178,10 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
                     },
                 } as any)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.misplacedResourceParam, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.misplacedResourceParam,
+                    ""
+                )
             );
         });
 
@@ -202,7 +208,10 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
                     },
                 } as any)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.misplacedResourceParam, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.misplacedResourceParam,
+                    ""
+                )
             );
         });
 
@@ -445,7 +454,10 @@ describe("NestedAppAuthController.ts Class Unit Tests", () => {
                 NestedAppAuthAdapter.prototype as any,
                 "fromNaaTokenResponse"
             ).mockImplementation(() => {
-                throw createClientAuthError(ClientAuthErrorCodes.nullOrEmptyToken, "");
+                throw createClientAuthError(
+                    ClientAuthErrorCodes.nullOrEmptyToken,
+                    ""
+                );
             });
 
             const testRequest = {

--- a/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
@@ -439,6 +439,7 @@ function createAccessTokenEntity(browserCrypto: ICrypto): AccessTokenEntity {
         expiresOn,
         expiresOn + 0,
         browserCrypto.base64Decode,
+        "",
         undefined,
         TestServerTokenResponse.token_type as Constants.AuthenticationScheme
     );

--- a/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
+++ b/lib/msal-browser/test/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.spec.ts
@@ -297,7 +297,10 @@ describe("CustomAuthSilentCacheClient", () => {
                 accessTokenEntityToCache
             );
 
-            const mockNoTokensFoundError = createInteractionRequiredAuthError(InteractionRequiredAuthErrorCodes.noTokensFound, "");
+            const mockNoTokensFoundError = createInteractionRequiredAuthError(
+                InteractionRequiredAuthErrorCodes.noTokensFound,
+                ""
+            );
 
             commonSilentFlowRequest.forceRefresh = true;
 
@@ -318,7 +321,10 @@ describe("CustomAuthSilentCacheClient", () => {
             );
 
             const mockRefreshTokenExpiredError =
-                createInteractionRequiredAuthError(InteractionRequiredAuthErrorCodes.refreshTokenExpired, "");
+                createInteractionRequiredAuthError(
+                    InteractionRequiredAuthErrorCodes.refreshTokenExpired,
+                    ""
+                );
 
             commonSilentFlowRequest.forceRefresh = true;
 

--- a/lib/msal-browser/test/error/NativeAuthError.spec.ts
+++ b/lib/msal-browser/test/error/NativeAuthError.spec.ts
@@ -18,7 +18,9 @@ describe("NativeAuthError Unit Tests", () => {
     describe("NativeAuthError", () => {
         describe("isFatal tests", () => {
             it("should return false for isFatal when WAM status is PERSISTENT_ERROR", () => {
-                const error = new NativeAuthError("testError", "",
+                const error = new NativeAuthError(
+                    "testError",
+                    "",
                     "testErrorDescription",
                     {
                         error: 1,
@@ -31,7 +33,9 @@ describe("NativeAuthError Unit Tests", () => {
             });
 
             it("should return true for isFatal when WAM status is DISABLED", () => {
-                const error = new NativeAuthError("testError", "",
+                const error = new NativeAuthError(
+                    "testError",
+                    "",
                     "testErrorDescription",
                     {
                         error: 1,
@@ -44,7 +48,9 @@ describe("NativeAuthError Unit Tests", () => {
             });
 
             it("should return true for isFatal when WAM status is INVALID_METHOD_ERROR", () => {
-                const error = new NativeAuthError("OSError", "",
+                const error = new NativeAuthError(
+                    "OSError",
+                    "",
                     "Error processing request.",
                     { error: -2147186943 }
                 );
@@ -52,21 +58,27 @@ describe("NativeAuthError Unit Tests", () => {
             });
 
             it("should return true for isFatal when extension throws an error", () => {
-                const error = new NativeAuthError(NativeAuthErrorCodes.contentError, "",
+                const error = new NativeAuthError(
+                    NativeAuthErrorCodes.contentError,
+                    "",
                     "extension threw error"
                 );
                 expect(isFatalNativeAuthError(error)).toBe(true);
             });
 
             it("should return true for isFatal when extension throws an error", () => {
-                const error = new NativeAuthError(NativeAuthErrorCodes.pageException, "",
+                const error = new NativeAuthError(
+                    NativeAuthErrorCodes.pageException,
+                    "",
                     "extension threw error"
                 );
                 expect(isFatalNativeAuthError(error)).toBe(true);
             });
 
             it("should return false for isFatal", () => {
-                const error = new NativeAuthError("testError", "",
+                const error = new NativeAuthError(
+                    "testError",
+                    "",
                     "testErrorDescription",
                     {
                         error: 1,
@@ -81,28 +93,42 @@ describe("NativeAuthError Unit Tests", () => {
 
         describe("createError tests", () => {
             it("Returns a NativeAuthError", () => {
-                const error = createNativeAuthError("testError", "", "testWamError");
+                const error = createNativeAuthError(
+                    "testError",
+                    "",
+                    "testWamError"
+                );
                 expect(error).toBeInstanceOf(NativeAuthError);
             });
 
             it("translates USER_INTERACTION_REQUIRED status into corresponding InteractionRequiredError", () => {
-                const error = createNativeAuthError("interaction_required", "", "interaction is required", {
+                const error = createNativeAuthError(
+                    "interaction_required",
+                    "",
+                    "interaction is required",
+                    {
                         error: 1,
                         protocol_error: "testProtocolError",
                         properties: {},
                         status: NativeStatusCode.USER_INTERACTION_REQUIRED,
-                    });
+                    }
+                );
                 expect(error).toBeInstanceOf(InteractionRequiredAuthError);
                 expect(error.errorCode).toBe("interaction_required");
             });
 
             it("translates ACCOUNT_UNAVAILABLE status into corresponding InteractionRequiredError", () => {
-                const error = createNativeAuthError("interaction_required", "", "interaction is required", {
+                const error = createNativeAuthError(
+                    "interaction_required",
+                    "",
+                    "interaction is required",
+                    {
                         error: 1,
                         protocol_error: "testProtocolError",
                         properties: {},
                         status: NativeStatusCode.ACCOUNT_UNAVAILABLE,
-                    });
+                    }
+                );
                 expect(error).toBeInstanceOf(InteractionRequiredAuthError);
                 expect(error.errorCode).toBe(
                     InteractionRequiredAuthErrorCodes.nativeAccountUnavailable
@@ -110,12 +136,17 @@ describe("NativeAuthError Unit Tests", () => {
             });
 
             it("translates UX_NOT_ALLOWED status into corresponding InteractionRequiredError", () => {
-                const error = createNativeAuthError("interaction_required", "", "interaction is required", {
+                const error = createNativeAuthError(
+                    "interaction_required",
+                    "",
+                    "interaction is required",
+                    {
                         error: 1,
                         protocol_error: "testProtocolError",
                         properties: {},
                         status: NativeStatusCode.UX_NOT_ALLOWED,
-                    });
+                    }
+                );
                 expect(error).toBeInstanceOf(InteractionRequiredAuthError);
                 expect(error.errorCode).toBe(
                     InteractionRequiredAuthErrorCodes.uxNotAllowed
@@ -123,12 +154,17 @@ describe("NativeAuthError Unit Tests", () => {
             });
 
             it("translates USER_CANCEL status into corresponding BrowserAuthError", () => {
-                const error = createNativeAuthError("user_cancel", "", "user cancelled", {
+                const error = createNativeAuthError(
+                    "user_cancel",
+                    "",
+                    "user cancelled",
+                    {
                         error: 1,
                         protocol_error: "testProtocolError",
                         properties: {},
                         status: NativeStatusCode.USER_CANCEL,
-                    });
+                    }
+                );
                 expect(error).toBeInstanceOf(BrowserAuthError);
                 expect(error.errorCode).toBe(
                     BrowserAuthErrorCodes.userCancelled
@@ -136,12 +172,17 @@ describe("NativeAuthError Unit Tests", () => {
             });
 
             it("translates NO_NETWORK status into corresponding BrowserAuthError", () => {
-                const error = createNativeAuthError("no_network", "", "no network", {
+                const error = createNativeAuthError(
+                    "no_network",
+                    "",
+                    "no network",
+                    {
                         error: 1,
                         protocol_error: "testProtocolError",
                         properties: {},
                         status: NativeStatusCode.NO_NETWORK,
-                    });
+                    }
+                );
                 expect(error).toBeInstanceOf(BrowserAuthError);
                 expect(error.errorCode).toBe(
                     BrowserAuthErrorCodes.noNetworkConnectivity
@@ -150,43 +191,63 @@ describe("NativeAuthError Unit Tests", () => {
 
             it("sets correlationId on translated NativeAuthError when provided", () => {
                 const TEST_CORRELATION_ID = "test-correlation-id";
-                const error = createNativeAuthError("testError", TEST_CORRELATION_ID, "testWamError", undefined);
+                const error = createNativeAuthError(
+                    "testError",
+                    TEST_CORRELATION_ID,
+                    "testWamError",
+                    undefined
+                );
                 expect(error).toBeInstanceOf(NativeAuthError);
                 expect(error.correlationId).toBe(TEST_CORRELATION_ID);
             });
 
             it("sets correlationId on translated InteractionRequiredAuthError (USER_INTERACTION_REQUIRED) when provided", () => {
                 const TEST_CORRELATION_ID = "test-correlation-id";
-                const error = createNativeAuthError("interaction_required", TEST_CORRELATION_ID, "interaction is required", {
+                const error = createNativeAuthError(
+                    "interaction_required",
+                    TEST_CORRELATION_ID,
+                    "interaction is required",
+                    {
                         error: 1,
                         protocol_error: "testProtocolError",
                         properties: {},
                         status: NativeStatusCode.USER_INTERACTION_REQUIRED,
-                    });
+                    }
+                );
                 expect(error).toBeInstanceOf(InteractionRequiredAuthError);
                 expect(error.correlationId).toBe(TEST_CORRELATION_ID);
             });
 
             it("sets correlationId on translated InteractionRequiredAuthError (ACCOUNT_UNAVAILABLE) when provided", () => {
                 const TEST_CORRELATION_ID = "test-correlation-id";
-                const error = createNativeAuthError("interaction_required", TEST_CORRELATION_ID, "interaction is required", {
+                const error = createNativeAuthError(
+                    "interaction_required",
+                    TEST_CORRELATION_ID,
+                    "interaction is required",
+                    {
                         error: 1,
                         protocol_error: "testProtocolError",
                         properties: {},
                         status: NativeStatusCode.ACCOUNT_UNAVAILABLE,
-                    });
+                    }
+                );
                 expect(error).toBeInstanceOf(InteractionRequiredAuthError);
                 expect(error.correlationId).toBe(TEST_CORRELATION_ID);
             });
 
             it("sets correlationId on translated BrowserAuthError (USER_CANCEL) when provided", () => {
                 const TEST_CORRELATION_ID = "test-correlation-id";
-                const error = createNativeAuthError("user_cancel", TEST_CORRELATION_ID, "user cancelled", {
+                const error = createNativeAuthError(
+                    "user_cancel",
+                    TEST_CORRELATION_ID,
+                    "user cancelled",
+                    {
                         error: 1,
                         protocol_error: "testProtocolError",
                         properties: {},
                         status: NativeStatusCode.USER_CANCEL,
-                    });
+                    }
+                );
                 expect(error).toBeInstanceOf(BrowserAuthError);
                 expect(error.correlationId).toBe(TEST_CORRELATION_ID);
             });

--- a/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/BaseInteractionClient.spec.ts
@@ -283,7 +283,10 @@ describe("BaseInteractionClient", () => {
                 })
                 .catch((error) => {
                     expect(error).toStrictEqual(
-                        createClientConfigurationError(ClientConfigurationErrorCodes.authorityMismatch, "")
+                        createClientConfigurationError(
+                            ClientConfigurationErrorCodes.authorityMismatch,
+                            ""
+                        )
                     );
                 });
         });

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1169,7 +1169,12 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 .mockImplementationOnce(
                     (message): Promise<PlatformAuthResponse> => {
                         return Promise.reject(
-                            new NativeAuthError("test_native_error_code", "", "test_error_desc", { status: NativeStatusCodes.PERSISTENT_ERROR })
+                            new NativeAuthError(
+                                "test_native_error_code",
+                                "",
+                                "test_error_desc",
+                                { status: NativeStatusCodes.PERSISTENT_ERROR }
+                            )
                         );
                     }
                 )
@@ -1375,7 +1380,11 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 "sendMessage"
             ).mockImplementation((): Promise<PlatformAuthResponse> => {
                 return Promise.reject(
-                    new NativeAuthError("ContentError", "", "problem getting response from extension")
+                    new NativeAuthError(
+                        "ContentError",
+                        "",
+                        "problem getting response from extension"
+                    )
                 );
             });
             platformAuthInteractionClient
@@ -1465,7 +1474,12 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 .mockImplementationOnce(
                     (message): Promise<PlatformAuthResponse> => {
                         return Promise.reject(
-                            new NativeAuthError("test_native_error_code", "", "test_error_desc", { status: NativeStatusCodes.PERSISTENT_ERROR })
+                            new NativeAuthError(
+                                "test_native_error_code",
+                                "",
+                                "test_error_desc",
+                                { status: NativeStatusCodes.PERSISTENT_ERROR }
+                            )
                         );
                     }
                 )

--- a/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PopupClient.spec.ts
@@ -176,7 +176,10 @@ describe("PopupClient", () => {
             };
 
             await expect(popupClient.acquireToken(request)).rejects.toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.missingSshJwk, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshJwk,
+                    ""
+                )
             );
         });
 
@@ -195,7 +198,10 @@ describe("PopupClient", () => {
             };
 
             await expect(popupClient.acquireToken(request)).rejects.toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.missingSshKid, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshKid,
+                    ""
+                )
             );
         });
 
@@ -667,7 +673,10 @@ describe("PopupClient", () => {
                 })
                 .catch((e) => {
                     expect(e).toEqual(
-                        createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError, "")
+                        createBrowserAuthError(
+                            BrowserAuthErrorCodes.hashEmptyError,
+                            ""
+                        )
                     );
                     done();
                 });
@@ -685,7 +694,10 @@ describe("PopupClient", () => {
                 })
                 .catch((e) => {
                     expect(e).toEqual(
-                        createBrowserAuthError(BrowserAuthErrorCodes.hashDoesNotContainKnownProperties, "")
+                        createBrowserAuthError(
+                            BrowserAuthErrorCodes.hashDoesNotContainKnownProperties,
+                            ""
+                        )
                     );
                     done();
                 });
@@ -1022,7 +1034,10 @@ describe("PopupClient", () => {
                 await expect(
                     pca.acquireTokenPopup(validRequest)
                 ).rejects.toThrow(
-                    createClientConfigurationError(ClientConfigurationErrorCodes.invalidRequestMethodForEAR, "")
+                    createClientConfigurationError(
+                        ClientConfigurationErrorCodes.invalidRequestMethodForEAR,
+                        ""
+                    )
                 );
             });
         });
@@ -1896,7 +1911,7 @@ describe("PopupClient", () => {
                 clientImpl.browserCrypto,
                 "",
                 testLibraryState,
-            ""
+                ""
             );
 
             const request: CommonAuthorizationUrlRequest = {
@@ -1934,7 +1949,7 @@ describe("PopupClient", () => {
                 clientImpl.browserCrypto,
                 "",
                 testLibraryState,
-            ""
+                ""
             );
 
             const request: CommonAuthorizationUrlRequest = {
@@ -1972,7 +1987,7 @@ describe("PopupClient", () => {
                 clientImpl.browserCrypto,
                 "",
                 testLibraryState,
-            ""
+                ""
             );
 
             const request: CommonAuthorizationUrlRequest = {
@@ -1989,7 +2004,11 @@ describe("PopupClient", () => {
 
             // Mock waitForBridgeResponse to simulate a timeout error
             jest.spyOn(BrowserUtils, "waitForBridgeResponse").mockRejectedValue(
-                createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "redirect_bridge_timeout")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.timedOut,
+                    "",
+                    "redirect_bridge_timeout"
+                )
             );
 
             await expect(
@@ -2015,13 +2034,13 @@ describe("PopupClient", () => {
                 clientImpl.browserCrypto,
                 "",
                 testLibraryState1,
-            ""
+                ""
             );
             const testState2 = ProtocolUtils.setRequestState(
                 clientImpl.browserCrypto,
                 "",
                 testLibraryState2,
-            ""
+                ""
             );
 
             const request1: CommonAuthorizationUrlRequest = {
@@ -2308,7 +2327,10 @@ describe("PopupClient", () => {
                     }
                 )
             ).toThrow(
-                createBrowserAuthError(BrowserAuthErrorCodes.popupWindowError, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.popupWindowError,
+                    ""
+                )
             );
         });
 
@@ -2333,7 +2355,10 @@ describe("PopupClient", () => {
                     }
                 )
             ).toThrow(
-                createBrowserAuthError(BrowserAuthErrorCodes.popupWindowError, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.popupWindowError,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/RedirectClient.spec.ts
@@ -557,7 +557,7 @@ describe("RedirectClient", () => {
             const stateId = ProtocolUtils.parseRequestState(
                 browserCrypto.base64Decode,
                 stateString,
-            ""
+                ""
             ).libraryState.id;
 
             window.sessionStorage.setItem(
@@ -700,7 +700,7 @@ describe("RedirectClient", () => {
             const stateId = ProtocolUtils.parseRequestState(
                 browserCrypto.base64Decode,
                 stateString,
-            ""
+                ""
             ).libraryState.id;
 
             window.sessionStorage.setItem(
@@ -766,7 +766,7 @@ describe("RedirectClient", () => {
             const stateId = ProtocolUtils.parseRequestState(
                 browserCrypto.base64Decode,
                 stateString,
-            ""
+                ""
             ).libraryState.id;
 
             window.sessionStorage.setItem(
@@ -805,7 +805,7 @@ describe("RedirectClient", () => {
             const stateId = ProtocolUtils.parseRequestState(
                 browserCrypto.base64Decode,
                 stateString,
-            ""
+                ""
             ).libraryState.id;
 
             window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
@@ -948,7 +948,7 @@ describe("RedirectClient", () => {
             const stateId = ProtocolUtils.parseRequestState(
                 browserCrypto.base64Decode,
                 stateString,
-            ""
+                ""
             ).libraryState.id;
 
             window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
@@ -1106,7 +1106,7 @@ describe("RedirectClient", () => {
             const stateId = ProtocolUtils.parseRequestState(
                 browserCrypto.base64Decode,
                 stateString,
-            ""
+                ""
             ).libraryState.id;
 
             window.location.hash = TEST_HASHES.TEST_SUCCESS_CODE_HASH_REDIRECT;
@@ -1831,7 +1831,10 @@ describe("RedirectClient", () => {
             await expect(
                 redirectClient.acquireToken(loginRequest)
             ).rejects.toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.missingSshJwk, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshJwk,
+                    ""
+                )
             );
         });
 
@@ -1850,7 +1853,10 @@ describe("RedirectClient", () => {
             };
 
             await expect(redirectClient.acquireToken(request)).rejects.toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.missingSshKid, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshKid,
+                    ""
+                )
             );
         });
 
@@ -2777,7 +2783,10 @@ describe("RedirectClient", () => {
         });
 
         it("errors thrown are cached for telemetry and logout failure event is raised", (done) => {
-            const testError = createBrowserAuthError(BrowserAuthErrorCodes.emptyNavigateUri, "");
+            const testError = createBrowserAuthError(
+                BrowserAuthErrorCodes.emptyNavigateUri,
+                ""
+            );
             jest.spyOn(
                 NavigationClient.prototype,
                 "navigateExternal"

--- a/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentAuthCodeClient.spec.ts
@@ -93,7 +93,10 @@ describe("SilentAuthCodeClient", () => {
                     code: "",
                 })
             ).rejects.toMatchObject(
-                createBrowserAuthError(BrowserAuthErrorCodes.authCodeRequired, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.authCodeRequired,
+                    ""
+                )
             );
         });
 
@@ -264,7 +267,10 @@ describe("SilentAuthCodeClient", () => {
     describe("logout", () => {
         it("logout throws unsupported error", async () => {
             await expect(silentAuthCodeClient.logout).rejects.toMatchObject(
-                createBrowserAuthError(BrowserAuthErrorCodes.silentLogoutUnsupported, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.silentLogoutUnsupported,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -233,7 +233,11 @@ describe("SilentIframeClient", () => {
                 "getAuthCodeRequestUrl"
             ).mockResolvedValue(testNavUrl);
             jest.spyOn(BrowserUtils, "waitForBridgeResponse").mockRejectedValue(
-                createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "redirect_bridge_timeout")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.timedOut,
+                    "",
+                    "redirect_bridge_timeout"
+                )
             );
             jest.spyOn(PkceGenerator, "generatePkceCodes").mockResolvedValue({
                 challenge: TEST_CONFIG.TEST_CHALLENGE,
@@ -246,7 +250,11 @@ describe("SilentIframeClient", () => {
                 .spyOn(ServerTelemetryManager.prototype, "cacheFailedRequest")
                 .mockImplementation((e) => {
                     expect(e).toMatchObject(
-                        createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "redirect_bridge_timeout")
+                        createBrowserAuthError(
+                            BrowserAuthErrorCodes.timedOut,
+                            "",
+                            "redirect_bridge_timeout"
+                        )
                     );
                 });
 
@@ -668,7 +676,10 @@ describe("SilentIframeClient", () => {
                 })
                 .catch((e) => {
                     expect(e).toEqual(
-                        createBrowserAuthError(BrowserAuthErrorCodes.hashEmptyError, "")
+                        createBrowserAuthError(
+                            BrowserAuthErrorCodes.hashEmptyError,
+                            ""
+                        )
                     );
                     done();
                 });
@@ -684,7 +695,10 @@ describe("SilentIframeClient", () => {
                 })
                 .catch((e) => {
                     expect(e).toEqual(
-                        createBrowserAuthError(BrowserAuthErrorCodes.hashDoesNotContainKnownProperties, "")
+                        createBrowserAuthError(
+                            BrowserAuthErrorCodes.hashDoesNotContainKnownProperties,
+                            ""
+                        )
                     );
                     done();
                 });
@@ -1334,7 +1348,11 @@ describe("SilentIframeClient", () => {
                     BrowserUtils,
                     "waitForBridgeResponse"
                 ).mockRejectedValue(
-                    createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "redirect_bridge_timeout")
+                    createBrowserAuthError(
+                        BrowserAuthErrorCodes.timedOut,
+                        "",
+                        "redirect_bridge_timeout"
+                    )
                 );
                 const removeIframeSpy = jest.spyOn(
                     SilentHandler,
@@ -1534,7 +1552,10 @@ describe("SilentIframeClient", () => {
                         httpMethod: Constants.HttpMethod.GET,
                     })
                 ).rejects.toThrow(
-                    createClientConfigurationError(ClientConfigurationErrorCodes.invalidRequestMethodForEAR, "")
+                    createClientConfigurationError(
+                        ClientConfigurationErrorCodes.invalidRequestMethodForEAR,
+                        ""
+                    )
                 );
             });
         });
@@ -1710,7 +1731,11 @@ describe("SilentIframeClient", () => {
                 "getAuthCodeRequestUrl"
             ).mockResolvedValue(testNavUrl);
             jest.spyOn(BrowserUtils, "waitForBridgeResponse").mockRejectedValue(
-                createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "redirect_bridge_timeout")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.timedOut,
+                    "",
+                    "redirect_bridge_timeout"
+                )
             );
             jest.spyOn(PkceGenerator, "generatePkceCodes").mockResolvedValue({
                 challenge: TEST_CONFIG.TEST_CHALLENGE,
@@ -1739,7 +1764,10 @@ describe("SilentIframeClient", () => {
     describe("logout", () => {
         it("logout throws unsupported error", async () => {
             await expect(silentIframeClient.logout).rejects.toMatchObject(
-                createBrowserAuthError(BrowserAuthErrorCodes.silentLogoutUnsupported, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.silentLogoutUnsupported,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentRefreshClient.spec.ts
@@ -330,7 +330,10 @@ describe("SilentRefreshClient", () => {
     describe("logout", () => {
         it("logout throws unsupported error", async () => {
             await expect(silentRefreshClient.logout).rejects.toMatchObject(
-                createBrowserAuthError(BrowserAuthErrorCodes.silentLogoutUnsupported, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.silentLogoutUnsupported,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -58,7 +58,10 @@ describe("SilentHandler.ts Unit Tests", () => {
                     RANDOM_TEST_GUID
                 )
             ).rejects.toMatchObject(
-                createBrowserAuthError(BrowserAuthErrorCodes.emptyNavigateUri, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.emptyNavigateUri,
+                    ""
+                )
             );
         });
 
@@ -98,7 +101,7 @@ describe("SilentHandler.ts Unit Tests", () => {
                 browserCrypto,
                 "",
                 testLibraryState,
-            ""
+                ""
             );
 
             const request: CommonAuthorizationUrlRequest = {
@@ -135,7 +138,7 @@ describe("SilentHandler.ts Unit Tests", () => {
                 browserCrypto,
                 "",
                 testLibraryState,
-            ""
+                ""
             );
 
             const request: CommonAuthorizationUrlRequest = {
@@ -172,7 +175,7 @@ describe("SilentHandler.ts Unit Tests", () => {
                 browserCrypto,
                 "",
                 testLibraryState,
-            ""
+                ""
             );
 
             const request: CommonAuthorizationUrlRequest = {
@@ -189,7 +192,11 @@ describe("SilentHandler.ts Unit Tests", () => {
 
             // Mock waitForBridgeResponse to simulate a timeout error
             jest.spyOn(BrowserUtils, "waitForBridgeResponse").mockRejectedValue(
-                createBrowserAuthError(BrowserAuthErrorCodes.timedOut, "", "redirect_bridge_timeout")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.timedOut,
+                    "",
+                    "redirect_bridge_timeout"
+                )
             );
 
             await expect(
@@ -214,13 +221,13 @@ describe("SilentHandler.ts Unit Tests", () => {
                 browserCrypto,
                 "",
                 testLibraryState1,
-            ""
+                ""
             );
             const testState2 = ProtocolUtils.setRequestState(
                 browserCrypto,
                 "",
                 testLibraryState2,
-            ""
+                ""
             );
 
             const request1: CommonAuthorizationUrlRequest = {

--- a/lib/msal-browser/test/request/RequestHelpers.spec.ts
+++ b/lib/msal-browser/test/request/RequestHelpers.spec.ts
@@ -81,7 +81,10 @@ describe("RequestHelpers tests", () => {
                     TEST_CONFIG.CORRELATION_ID
                 )
             ).rejects.toThrowError(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.missingSshJwk, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshJwk,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-browser/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-browser/test/response/ResponseHandler.spec.ts
@@ -131,7 +131,10 @@ describe("ResponseHandler tests", () => {
                     TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
-                createBrowserAuthError(BrowserAuthErrorCodes.hashDoesNotContainKnownProperties, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.hashDoesNotContainKnownProperties,
+                    ""
+                )
             );
             expect(() =>
                 ResponseHandler.deserializeResponse(
@@ -141,7 +144,10 @@ describe("ResponseHandler tests", () => {
                     TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
-                createBrowserAuthError(BrowserAuthErrorCodes.hashDoesNotContainKnownProperties, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.hashDoesNotContainKnownProperties,
+                    ""
+                )
             );
 
             expect(() =>
@@ -152,7 +158,10 @@ describe("ResponseHandler tests", () => {
                     TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
-                createBrowserAuthError(BrowserAuthErrorCodes.hashDoesNotContainKnownProperties, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.hashDoesNotContainKnownProperties,
+                    ""
+                )
             );
 
             expect(() =>
@@ -163,7 +172,10 @@ describe("ResponseHandler tests", () => {
                     TEST_CONFIG.CORRELATION_ID
                 )
             ).toThrowError(
-                createBrowserAuthError(BrowserAuthErrorCodes.hashDoesNotContainKnownProperties, "")
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.hashDoesNotContainKnownProperties,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-browser/test/utils/BrowserProtocolUtils.spec.ts
+++ b/lib/msal-browser/test/utils/BrowserProtocolUtils.spec.ts
@@ -37,11 +37,15 @@ describe("BrowserProtocolUtils.ts Unit Tests", () => {
             cryptoInterface,
             //@ts-ignore
             null,
-        ""
+            ""
         );
         expect(requestState1).toBeNull();
 
-        const requestState2 = extractBrowserRequestState(cryptoInterface, "", "");
+        const requestState2 = extractBrowserRequestState(
+            cryptoInterface,
+            "",
+            ""
+        );
         expect(requestState2).toBeNull();
     });
 
@@ -50,18 +54,18 @@ describe("BrowserProtocolUtils.ts Unit Tests", () => {
             cryptoInterface,
             undefined,
             browserRedirectRequestState,
-        ""
+            ""
         );
         const popupState = ProtocolUtils.setRequestState(
             cryptoInterface,
             undefined,
             browserPopupRequestState,
-        ""
+            ""
         );
         const redirectPlatformState = extractBrowserRequestState(
             cryptoInterface,
             redirectState,
-        ""
+            ""
         );
         expect(redirectPlatformState!.interactionType).toBe(
             InteractionType.Redirect
@@ -69,7 +73,7 @@ describe("BrowserProtocolUtils.ts Unit Tests", () => {
         const popupPlatformState = extractBrowserRequestState(
             cryptoInterface,
             popupState,
-        ""
+            ""
         );
         expect(popupPlatformState!.interactionType).toBe(InteractionType.Popup);
     });

--- a/lib/msal-common/src/account/AuthToken.ts
+++ b/lib/msal-common/src/account/AuthToken.ts
@@ -80,7 +80,11 @@ export function getJWSPayload(authToken: string): string {
 /**
  * Determine if the token's max_age has transpired
  */
-export function checkMaxAge(authTime: number, maxAge: number, correlationId: string): void {
+export function checkMaxAge(
+    authTime: number,
+    maxAge: number,
+    correlationId: string
+): void {
     /*
      * per https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
      * To force an immediate re-authentication: If an app requires that a user re-authenticate prior to access,
@@ -88,6 +92,9 @@ export function checkMaxAge(authTime: number, maxAge: number, correlationId: str
      */
     const fiveMinuteSkew = 300000; // five minutes in milliseconds
     if (maxAge === 0 || Date.now() - fiveMinuteSkew > authTime + maxAge) {
-        throw createClientAuthError(ClientAuthErrorCodes.maxAgeTranspired, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.maxAgeTranspired,
+            correlationId
+        );
     }
 }

--- a/lib/msal-common/src/account/ClientInfo.ts
+++ b/lib/msal-common/src/account/ClientInfo.ts
@@ -31,14 +31,20 @@ export function buildClientInfo(
     base64Decode: (input: string) => string
 ): ClientInfo {
     if (!rawClientInfo) {
-        throw createClientAuthError(ClientAuthErrorCodes.clientInfoEmptyError, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.clientInfoEmptyError,
+            ""
+        );
     }
 
     try {
         const decodedClientInfo: string = base64Decode(rawClientInfo);
         return JSON.parse(decodedClientInfo) as ClientInfo;
     } catch (e) {
-        throw createClientAuthError(ClientAuthErrorCodes.clientInfoDecodingError, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.clientInfoDecodingError,
+            ""
+        );
     }
 }
 
@@ -50,7 +56,10 @@ export function buildClientInfoFromHomeAccountId(
     homeAccountId: string
 ): ClientInfo {
     if (!homeAccountId) {
-        throw createClientAuthError(ClientAuthErrorCodes.clientInfoDecodingError, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.clientInfoDecodingError,
+            ""
+        );
     }
     const clientInfoParts: string[] = homeAccountId.split(
         Constants.CLIENT_INFO_SEPARATOR,

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -218,7 +218,10 @@ export class Authority {
         if (this.discoveryComplete()) {
             return this.replacePath(this.metadata.authorization_endpoint);
         } else {
-            throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, this.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.endpointResolutionError,
+                this.correlationId
+            );
         }
     }
 
@@ -229,7 +232,10 @@ export class Authority {
         if (this.discoveryComplete()) {
             return this.replacePath(this.metadata.token_endpoint);
         } else {
-            throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, this.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.endpointResolutionError,
+                this.correlationId
+            );
         }
     }
 
@@ -239,7 +245,10 @@ export class Authority {
                 this.metadata.token_endpoint.replace("/token", "/devicecode")
             );
         } else {
-            throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, this.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.endpointResolutionError,
+                this.correlationId
+            );
         }
     }
 
@@ -250,11 +259,17 @@ export class Authority {
         if (this.discoveryComplete()) {
             // ROPC policies may not have end_session_endpoint set
             if (!this.metadata.end_session_endpoint) {
-                throw createClientAuthError(ClientAuthErrorCodes.endSessionEndpointNotSupported, this.correlationId);
+                throw createClientAuthError(
+                    ClientAuthErrorCodes.endSessionEndpointNotSupported,
+                    this.correlationId
+                );
             }
             return this.replacePath(this.metadata.end_session_endpoint);
         } else {
-            throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, this.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.endpointResolutionError,
+                this.correlationId
+            );
         }
     }
 
@@ -265,7 +280,10 @@ export class Authority {
         if (this.discoveryComplete()) {
             return this.replacePath(this.metadata.issuer);
         } else {
-            throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, this.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.endpointResolutionError,
+                this.correlationId
+            );
         }
     }
 
@@ -276,7 +294,10 @@ export class Authority {
         if (this.discoveryComplete()) {
             return this.replacePath(this.metadata.jwks_uri);
         } else {
-            throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, this.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.endpointResolutionError,
+                this.correlationId
+            );
         }
     }
 
@@ -666,7 +687,10 @@ export class Authority {
                     this.authorityOptions.authorityMetadata
                 ) as OpenIdConfigResponse;
             } catch (e) {
-                throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidAuthorityMetadata, this.correlationId);
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.invalidAuthorityMetadata,
+                    this.correlationId
+                );
             }
         }
 
@@ -818,7 +842,10 @@ export class Authority {
         }
 
         // Metadata could not be obtained from the config, cache, network or hardcoded values
-        throw createClientConfigurationError(ClientConfigurationErrorCodes.untrustedAuthority, this.correlationId);
+        throw createClientConfigurationError(
+            ClientConfigurationErrorCodes.untrustedAuthority,
+            this.correlationId
+        );
     }
 
     private updateCloudDiscoveryMetadataFromLocalSources(
@@ -960,7 +987,10 @@ export class Authority {
                     "Unable to parse the cloud discovery metadata. Throwing Invalid Cloud Discovery Metadata Error.",
                     this.correlationId
                 );
-                throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidCloudDiscoveryMetadata, this.correlationId);
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.invalidCloudDiscoveryMetadata,
+                    this.correlationId
+                );
             }
         }
 
@@ -1158,7 +1188,10 @@ export class Authority {
         } else if (this.discoveryComplete()) {
             return this.metadata.preferred_cache;
         } else {
-            throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, this.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.endpointResolutionError,
+                this.correlationId
+            );
         }
     }
 
@@ -1204,7 +1237,10 @@ export class Authority {
      */
     private validateIssuer(issuer: string): void {
         if (!issuer) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.issuerValidationFailed, this.correlationId);
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.issuerValidationFailed,
+                this.correlationId
+            );
         }
 
         // Parse with the WHATWG URL API. URL normalizes scheme + host to lowercase per RFC 3986.
@@ -1212,7 +1248,10 @@ export class Authority {
         try {
             issuerUrl = new URL(issuer);
         } catch {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.issuerValidationFailed, this.correlationId);
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.issuerValidationFailed,
+                this.correlationId
+            );
         }
         const issuerScheme = issuerUrl.protocol;
         const issuerHost = issuerUrl.host;
@@ -1275,7 +1314,10 @@ export class Authority {
         }
 
         // issuer validation fails if none of the above rules are satisfied
-        throw createClientConfigurationError(ClientConfigurationErrorCodes.issuerValidationFailed, this.correlationId);
+        throw createClientConfigurationError(
+            ClientConfigurationErrorCodes.issuerValidationFailed,
+            this.correlationId
+        );
     }
 
     /**
@@ -1524,7 +1566,10 @@ export function buildStaticAuthorityOptions(
         try {
             cloudDiscoveryMetadata = JSON.parse(rawCloudDiscoveryMetadata);
         } catch (e) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidCloudDiscoveryMetadata, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.invalidCloudDiscoveryMetadata,
+                ""
+            );
         }
     }
     return {

--- a/lib/msal-common/src/authority/AuthorityFactory.ts
+++ b/lib/msal-common/src/authority/AuthorityFactory.ts
@@ -67,6 +67,9 @@ export async function createDiscoveredInstance(
         )();
         return acquireTokenAuthority;
     } catch (e) {
-        throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.endpointResolutionError,
+            correlationId
+        );
     }
 }

--- a/lib/msal-common/src/cache/CacheManager.ts
+++ b/lib/msal-common/src/cache/CacheManager.ts
@@ -605,7 +605,10 @@ export abstract class CacheManager implements ICacheManager {
         storeInCache?: StoreInCache
     ): Promise<void> {
         if (!cacheRecord) {
-            throw createClientAuthError(ClientAuthErrorCodes.invalidCacheRecord, correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.invalidCacheRecord,
+                correlationId
+            );
         }
 
         try {
@@ -1601,7 +1604,10 @@ export abstract class CacheManager implements ICacheManager {
         if (numAppMetadata < 1) {
             return null;
         } else if (numAppMetadata > 1) {
-            throw createClientAuthError(ClientAuthErrorCodes.multipleMatchingAppMetadata, correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.multipleMatchingAppMetadata,
+                correlationId
+            );
         }
 
         return appMetadataEntries[0] as AppMetadataEntity;
@@ -1955,72 +1961,141 @@ export abstract class CacheManager implements ICacheManager {
 /** @internal */
 export class DefaultStorageClass extends CacheManager {
     async setAccount(): Promise<void> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getAccount(): AccountEntity {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     async setIdTokenCredential(): Promise<void> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getIdTokenCredential(): IdTokenEntity {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     async setAccessTokenCredential(): Promise<void> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getAccessTokenCredential(): AccessTokenEntity {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     async setRefreshTokenCredential(): Promise<void> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getRefreshTokenCredential(): RefreshTokenEntity {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     setAppMetadata(): void {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getAppMetadata(): AppMetadataEntity {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     setServerTelemetry(): void {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getServerTelemetry(): ServerTelemetryEntity {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     setAuthorityMetadata(): void {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getAuthorityMetadata(): AuthorityMetadataEntity | null {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getAuthorityMetadataKeys(): Array<string> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     setThrottlingCache(): void {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getThrottlingCache(): ThrottlingEntity {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     removeItem(): boolean {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getKeys(): string[] {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getAccountKeys(): string[] {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     getTokenKeys(): TokenKeys {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     generateCredentialKey(): string {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
     generateAccountKey(): string {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     }
 }

--- a/lib/msal-common/src/cache/utils/AccountEntityUtils.ts
+++ b/lib/msal-common/src/cache/utils/AccountEntityUtils.ts
@@ -99,6 +99,7 @@ export function createAccountEntity(
         tenantProfiles?: Array<TenantProfile>;
     },
     authority: Authority,
+    correlationId: string,
     base64Decode?: (input: string) => string
 ): AccountEntity {
     let authorityType;
@@ -125,7 +126,7 @@ export function createAccountEntity(
         (authority && authority.getPreferredCache());
 
     if (!env) {
-        throw createClientAuthError(ClientAuthErrorCodes.invalidCacheEnvironment, "");
+        throw createClientAuthError(ClientAuthErrorCodes.invalidCacheEnvironment, correlationId);
     }
 
     /*

--- a/lib/msal-common/src/cache/utils/AccountEntityUtils.ts
+++ b/lib/msal-common/src/cache/utils/AccountEntityUtils.ts
@@ -126,7 +126,10 @@ export function createAccountEntity(
         (authority && authority.getPreferredCache());
 
     if (!env) {
-        throw createClientAuthError(ClientAuthErrorCodes.invalidCacheEnvironment, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.invalidCacheEnvironment,
+            correlationId
+        );
     }
 
     /*

--- a/lib/msal-common/src/cache/utils/CacheHelpers.ts
+++ b/lib/msal-common/src/cache/utils/CacheHelpers.ts
@@ -68,6 +68,7 @@ export function createAccessTokenEntity(
     expiresOn: number,
     extExpiresOn: number,
     base64Decode: (input: string) => string,
+    correlationId: string,
     refreshOn?: number,
     tokenType?: Constants.AuthenticationScheme,
     userAssertionHash?: string,
@@ -114,7 +115,7 @@ export function createAccessTokenEntity(
                     base64Decode
                 );
                 if (!tokenClaims?.cnf?.kid) {
-                    throw createClientAuthError(ClientAuthErrorCodes.tokenClaimsCnfRequiredForSignedJwt, "");
+                    throw createClientAuthError(ClientAuthErrorCodes.tokenClaimsCnfRequiredForSignedJwt, correlationId);
                 }
                 atEntity.keyId = tokenClaims.cnf.kid;
                 break;

--- a/lib/msal-common/src/cache/utils/CacheHelpers.ts
+++ b/lib/msal-common/src/cache/utils/CacheHelpers.ts
@@ -115,7 +115,10 @@ export function createAccessTokenEntity(
                     base64Decode
                 );
                 if (!tokenClaims?.cnf?.kid) {
-                    throw createClientAuthError(ClientAuthErrorCodes.tokenClaimsCnfRequiredForSignedJwt, correlationId);
+                    throw createClientAuthError(
+                        ClientAuthErrorCodes.tokenClaimsCnfRequiredForSignedJwt,
+                        correlationId
+                    );
                 }
                 atEntity.keyId = tokenClaims.cnf.kid;
                 break;

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -131,7 +131,10 @@ export class AuthorizationCodeClient {
         authCodePayload?: AuthorizationCodePayload
     ): Promise<AuthenticationResult> {
         if (!request.code) {
-            throw createClientAuthError(ClientAuthErrorCodes.requestCannotBeMade, request.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.requestCannotBeMade,
+                request.correlationId
+            );
         }
 
         // Check for new cloud instance
@@ -202,7 +205,10 @@ export class AuthorizationCodeClient {
     getLogoutUri(logoutRequest: CommonEndSessionRequest): string {
         // Throw error if logoutRequest is null/undefined
         if (!logoutRequest) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.logoutRequestEmpty, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.logoutRequestEmpty,
+                ""
+            );
         }
         const queryString = this.createLogoutUrlQueryString(logoutRequest);
 
@@ -314,7 +320,10 @@ export class AuthorizationCodeClient {
         if (!this.includeRedirectUri) {
             // Just validate
             if (!request.redirectUri) {
-                throw createClientConfigurationError(ClientConfigurationErrorCodes.redirectUriEmpty, request.correlationId);
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.redirectUriEmpty,
+                    request.correlationId
+                );
             }
         } else {
             // Validate and include redirect uri
@@ -424,7 +433,10 @@ export class AuthorizationCodeClient {
             if (request.sshJwk) {
                 RequestParameterBuilder.addSshJwk(parameters, request.sshJwk);
             } else {
-                throw createClientConfigurationError(ClientConfigurationErrorCodes.missingSshJwk, request.correlationId);
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshJwk,
+                    request.correlationId
+                );
             }
         }
 

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -176,11 +176,17 @@ export class RefreshTokenClient {
     ): Promise<AuthenticationResult> {
         // Cannot renew token if no request object is given.
         if (!request) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.tokenRequestEmpty, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.tokenRequestEmpty,
+                ""
+            );
         }
         // We currently do not support silent flow for account === null use cases; This will be revisited for confidential flow usecases
         if (!request.account) {
-            throw createClientAuthError(ClientAuthErrorCodes.noAccountInSilentRequest, request.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.noAccountInSilentRequest,
+                request.correlationId
+            );
         }
 
         // try checking if FOCI is enabled for the given application
@@ -253,7 +259,10 @@ export class RefreshTokenClient {
         )(request.account, foci, request.correlationId, undefined);
 
         if (!refreshToken) {
-            throw createInteractionRequiredAuthError(InteractionRequiredAuthErrorCodes.noTokensFound, request.correlationId);
+            throw createInteractionRequiredAuthError(
+                InteractionRequiredAuthErrorCodes.noTokensFound,
+                request.correlationId
+            );
         }
 
         if (refreshToken.expiresOn) {
@@ -269,7 +278,10 @@ export class RefreshTokenClient {
             );
 
             if (TimeUtils.isTokenExpired(refreshToken.expiresOn, offset)) {
-                throw createInteractionRequiredAuthError(InteractionRequiredAuthErrorCodes.refreshTokenExpired, request.correlationId);
+                throw createInteractionRequiredAuthError(
+                    InteractionRequiredAuthErrorCodes.refreshTokenExpired,
+                    request.correlationId
+                );
             }
         }
         // attach cached RT size to the current measurement
@@ -488,7 +500,10 @@ export class RefreshTokenClient {
             if (request.sshJwk) {
                 RequestParameterBuilder.addSshJwk(parameters, request.sshJwk);
             } else {
-                throw createClientConfigurationError(ClientConfigurationErrorCodes.missingSshJwk, request.correlationId);
+                throw createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshJwk,
+                    request.correlationId
+                );
             }
         }
 

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -105,12 +105,18 @@ export class SilentFlowClient {
                 CacheOutcome.FORCE_REFRESH_OR_CLAIMS,
                 request.correlationId
             );
-            throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, request.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.tokenRefreshRequired,
+                request.correlationId
+            );
         }
 
         // We currently do not support silent flow for account === null use cases; This will be revisited for confidential flow usecases
         if (!request.account) {
-            throw createClientAuthError(ClientAuthErrorCodes.noAccountInSilentRequest, request.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.noAccountInSilentRequest,
+                request.correlationId
+            );
         }
 
         const requestTenantId =
@@ -130,7 +136,10 @@ export class SilentFlowClient {
                 CacheOutcome.NO_CACHED_ACCESS_TOKEN,
                 request.correlationId
             );
-            throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, request.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.tokenRefreshRequired,
+                request.correlationId
+            );
         } else if (
             TimeUtils.wasClockTurnedBack(cachedAccessToken.cachedAt) ||
             TimeUtils.isTokenExpired(
@@ -143,7 +152,10 @@ export class SilentFlowClient {
                 CacheOutcome.CACHED_ACCESS_TOKEN_EXPIRED,
                 request.correlationId
             );
-            throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, request.correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.tokenRefreshRequired,
+                request.correlationId
+            );
         } else if (request.resource) {
             // cached access token must have a resource that matches the request resource for MCP scenarios
             if (cachedAccessToken.resource !== request.resource) {
@@ -151,7 +163,10 @@ export class SilentFlowClient {
                     CacheOutcome.NO_CACHED_ACCESS_TOKEN,
                     request.correlationId
                 );
-                throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, request.correlationId);
+                throw createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    request.correlationId
+                );
             }
         } else if (
             cachedAccessToken.refreshOn &&
@@ -241,7 +256,10 @@ export class SilentFlowClient {
         if (request.maxAge || request.maxAge === 0) {
             const authTime = idTokenClaims?.auth_time;
             if (!authTime) {
-                throw createClientAuthError(ClientAuthErrorCodes.authTimeNotFound, request.correlationId);
+                throw createClientAuthError(
+                    ClientAuthErrorCodes.authTimeNotFound,
+                    request.correlationId
+                );
             }
 
             checkMaxAge(authTime, request.maxAge, request.correlationId);

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -171,10 +171,16 @@ const DEFAULT_LOGGER_IMPLEMENTATION: Required<LoggerOptions> = {
 
 const DEFAULT_NETWORK_IMPLEMENTATION: INetworkModule = {
     async sendGetRequestAsync<T>(): Promise<T> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async sendPostRequestAsync<T>(): Promise<T> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
 };
 

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -96,33 +96,63 @@ export interface ICrypto {
 
 export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
     createNewGuid: (): string => {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     base64Decode: (): string => {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     base64Encode: (): string => {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     base64UrlEncode: (): string => {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     encodeKid: (): string => {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async getPublicKeyThumbprint(): Promise<string> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async removeTokenBindingKey(): Promise<void> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async clearKeystore(): Promise<boolean> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async signJwt(): Promise<string> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async hashString(): Promise<string> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
 };

--- a/lib/msal-common/src/crypto/JoseHeader.ts
+++ b/lib/msal-common/src/crypto/JoseHeader.ts
@@ -38,12 +38,18 @@ export class JoseHeader {
     static getShrHeaderString(shrHeaderOptions: JoseHeaderOptions): string {
         // KeyID is required on the SHR header
         if (!shrHeaderOptions.kid) {
-            throw createJoseHeaderError(JoseHeaderErrorCodes.missingKidError, "");
+            throw createJoseHeaderError(
+                JoseHeaderErrorCodes.missingKidError,
+                ""
+            );
         }
 
         // Alg is required on the SHR header
         if (!shrHeaderOptions.alg) {
-            throw createJoseHeaderError(JoseHeaderErrorCodes.missingAlgError, "");
+            throw createJoseHeaderError(
+                JoseHeaderErrorCodes.missingAlgError,
+                ""
+            );
         }
 
         const shrHeader = new JoseHeader({

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -356,7 +356,10 @@ export function validateAuthorizationResponse(
     }
 
     if (decodedServerResponseState !== decodedRequestState) {
-        throw createClientAuthError(ClientAuthErrorCodes.stateMismatch, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.stateMismatch,
+            correlationId
+        );
     }
 
     // Check for error

--- a/lib/msal-common/src/protocol/Token.ts
+++ b/lib/msal-common/src/protocol/Token.ts
@@ -215,7 +215,10 @@ export async function sendPostRequest<
         if (e instanceof AuthError) {
             throw e;
         } else {
-            throw createClientAuthError(ClientAuthErrorCodes.networkError, correlationId);
+            throw createClientAuthError(
+                ClientAuthErrorCodes.networkError,
+                correlationId
+            );
         }
     }
 

--- a/lib/msal-common/src/request/AuthenticationHeaderParser.ts
+++ b/lib/msal-common/src/request/AuthenticationHeaderParser.ts
@@ -43,7 +43,10 @@ export class AuthenticationHeaderParser {
             if (authenticationInfoChallenges.nextnonce) {
                 return authenticationInfoChallenges.nextnonce;
             }
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidAuthenticationHeader, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.invalidAuthenticationHeader,
+                ""
+            );
         }
 
         // Attempt to parse nonce from WWW-Authenticate
@@ -56,11 +59,17 @@ export class AuthenticationHeaderParser {
             if (wwwAuthenticateChallenges.nonce) {
                 return wwwAuthenticateChallenges.nonce;
             }
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidAuthenticationHeader, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.invalidAuthenticationHeader,
+                ""
+            );
         }
 
         // If neither header is present, throw missing headers error
-        throw createClientConfigurationError(ClientConfigurationErrorCodes.missingNonceAuthenticationHeader, "");
+        throw createClientConfigurationError(
+            ClientConfigurationErrorCodes.missingNonceAuthenticationHeader,
+            ""
+        );
     }
 
     /**

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -234,7 +234,10 @@ export function addClaims(
         try {
             JSON.parse(mergedClaims);
         } catch (e) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidClaims, correlationId);
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.invalidClaims,
+                correlationId
+            );
         }
         parameters.set(AADServerParamKeys.CLAIMS, mergedClaims);
     }
@@ -334,7 +337,10 @@ export function addCodeChallengeParams(
             codeChallengeMethod
         );
     } else {
-        throw createClientConfigurationError(ClientConfigurationErrorCodes.pkceParamsMissing, "");
+        throw createClientConfigurationError(
+            ClientConfigurationErrorCodes.pkceParamsMissing,
+            ""
+        );
     }
 }
 
@@ -504,7 +510,10 @@ export function addClientCapabilitiesToClaims(
         try {
             mergedClaims = JSON.parse(claims);
         } catch (e) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.invalidClaims, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.invalidClaims,
+                ""
+            );
         }
     }
 

--- a/lib/msal-common/src/request/ScopeSet.ts
+++ b/lib/msal-common/src/request/ScopeSet.ts
@@ -38,7 +38,10 @@ export class ScopeSet {
 
         // Check if scopes array has at least one member
         if (!filteredInput || !filteredInput.length) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.emptyInputScopesError, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.emptyInputScopesError,
+                ""
+            );
         }
 
         this.scopes = new Set<string>(); // Iterator in constructor not supported by IE11
@@ -139,7 +142,10 @@ export class ScopeSet {
         try {
             newScopes.forEach((newScope) => this.appendScope(newScope));
         } catch (e) {
-            throw createClientAuthError(ClientAuthErrorCodes.cannotAppendScopeSet, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.cannotAppendScopeSet,
+                ""
+            );
         }
     }
 
@@ -149,7 +155,10 @@ export class ScopeSet {
      */
     removeScope(scope: string): void {
         if (!scope) {
-            throw createClientAuthError(ClientAuthErrorCodes.cannotRemoveEmptyScope, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.cannotRemoveEmptyScope,
+                ""
+            );
         }
         this.scopes.delete(scope.trim());
     }
@@ -170,7 +179,10 @@ export class ScopeSet {
      */
     unionScopeSets(otherScopes: ScopeSet): Set<string> {
         if (!otherScopes) {
-            throw createClientAuthError(ClientAuthErrorCodes.emptyInputScopeSet, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.emptyInputScopeSet,
+                ""
+            );
         }
         const unionScopes = new Set<string>(); // Iterator in constructor not supported in IE11
         otherScopes.scopes.forEach((scope) =>
@@ -186,7 +198,10 @@ export class ScopeSet {
      */
     intersectingScopeSets(otherScopes: ScopeSet): boolean {
         if (!otherScopes) {
-            throw createClientAuthError(ClientAuthErrorCodes.emptyInputScopeSet, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.emptyInputScopeSet,
+                ""
+            );
         }
 
         // Do not allow OIDC scopes to be the only intersecting scopes

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -451,6 +451,7 @@ export class ResponseHandler {
                 tokenExpirationSeconds,
                 extendedTokenExpirationSeconds,
                 this.cryptoObj.base64Decode,
+                request.correlationId,
                 refreshOnSeconds,
                 serverTokenResponse.token_type,
                 userAssertionHash,
@@ -697,6 +698,7 @@ export function buildAccountToCache(
                 nativeAccountId: nativeAccountId,
             },
             authority,
+            correlationId,
             base64Decode
         );
 

--- a/lib/msal-common/src/url/UrlString.ts
+++ b/lib/msal-common/src/url/UrlString.ts
@@ -25,7 +25,10 @@ export class UrlString {
         this._urlString = url;
         if (!this._urlString) {
             // Throws error if url is empty
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.urlEmptyError, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlEmptyError,
+                ""
+            );
         }
 
         if (!url.includes("#")) {
@@ -66,12 +69,18 @@ export class UrlString {
         try {
             components = this.getUrlComponents();
         } catch (e) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.urlParseError, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlParseError,
+                ""
+            );
         }
 
         // Throw error if URI or path segments are not parseable.
         if (!components.HostNameAndPort || !components.PathSegments) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.urlParseError, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlParseError,
+                ""
+            );
         }
 
         // Throw error if uri is insecure.
@@ -79,7 +88,10 @@ export class UrlString {
             !components.Protocol ||
             components.Protocol.toLowerCase() !== "https:"
         ) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.authorityUriInsecure, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.authorityUriInsecure,
+                ""
+            );
         }
     }
 
@@ -138,7 +150,10 @@ export class UrlString {
         // If url string does not match regEx, we throw an error
         const match = this.urlString.match(regEx);
         if (!match) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.urlParseError, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlParseError,
+                ""
+            );
         }
 
         // Url component object
@@ -171,7 +186,10 @@ export class UrlString {
         const match = url.match(regEx);
 
         if (!match) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.urlParseError, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlParseError,
+                ""
+            );
         }
 
         return match[2];

--- a/lib/msal-common/src/utils/ProtocolUtils.ts
+++ b/lib/msal-common/src/utils/ProtocolUtils.ts
@@ -42,7 +42,10 @@ export function generateLibraryState(
     meta?: Record<string, string>
 ): string {
     if (!cryptoObj) {
-        throw createClientAuthError(ClientAuthErrorCodes.noCryptoObject, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.noCryptoObject,
+            correlationId
+        );
     }
 
     // Create a state object containing a unique id and the timestamp of the request creation
@@ -71,11 +74,17 @@ export function parseRequestState(
     correlationId: string
 ): RequestStateObject {
     if (!base64Decode) {
-        throw createClientAuthError(ClientAuthErrorCodes.noCryptoObject, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.noCryptoObject,
+            correlationId
+        );
     }
 
     if (!state) {
-        throw createClientAuthError(ClientAuthErrorCodes.invalidState, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.invalidState,
+            correlationId
+        );
     }
 
     try {
@@ -95,6 +104,9 @@ export function parseRequestState(
             libraryState: libraryStateObj,
         };
     } catch (e) {
-        throw createClientAuthError(ClientAuthErrorCodes.invalidState, correlationId);
+        throw createClientAuthError(
+            ClientAuthErrorCodes.invalidState,
+            correlationId
+        );
     }
 }

--- a/lib/msal-common/src/utils/UrlUtils.ts
+++ b/lib/msal-common/src/utils/UrlUtils.ts
@@ -82,7 +82,10 @@ export function getDeserializedResponse(
             return deserializedHash;
         }
     } catch (e) {
-        throw createClientAuthError(ClientAuthErrorCodes.hashNotDeserialized, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.hashNotDeserialized,
+            ""
+        );
     }
 
     return null;

--- a/lib/msal-common/test/account/ClientInfo.spec.ts
+++ b/lib/msal-common/test/account/ClientInfo.spec.ts
@@ -26,13 +26,19 @@ describe("ClientInfo.ts Class Unit Tests", () => {
         it("Throws error if clientInfo is null or empty", () => {
             // @ts-ignore
             expect(() => buildClientInfo(null, cryptoInterface)).toThrow(
-                new ClientAuthError(ClientAuthErrorCodes.clientInfoEmptyError, "")
+                new ClientAuthError(
+                    ClientAuthErrorCodes.clientInfoEmptyError,
+                    ""
+                )
             );
 
             expect(() =>
                 buildClientInfo("", cryptoInterface.base64Decode)
             ).toThrow(
-                new ClientAuthError(ClientAuthErrorCodes.clientInfoEmptyError, "")
+                new ClientAuthError(
+                    ClientAuthErrorCodes.clientInfoEmptyError,
+                    ""
+                )
             );
         });
 
@@ -43,7 +49,10 @@ describe("ClientInfo.ts Class Unit Tests", () => {
                     cryptoInterface.base64Decode
                 )
             ).toThrow(
-                new ClientAuthError(ClientAuthErrorCodes.clientInfoDecodingError, "")
+                new ClientAuthError(
+                    ClientAuthErrorCodes.clientInfoDecodingError,
+                    ""
+                )
             );
         });
 
@@ -139,7 +148,10 @@ describe("ClientInfo.ts Class Unit Tests", () => {
                 ClientAuthError
             );
             expect(() => buildClientInfoFromHomeAccountId("")).toThrowError(
-                createClientAuthError(ClientAuthErrorCodes.clientInfoDecodingError, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.clientInfoDecodingError,
+                    ""
+                )
             );
         });
 

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -158,7 +158,10 @@ describe("Authority.ts Class Unit Tests", () => {
                         new StubPerformanceClient()
                     )
             ).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.authorityUriInsecure, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.authorityUriInsecure,
+                    ""
+                )
             );
             expect(
                 () =>
@@ -172,7 +175,10 @@ describe("Authority.ts Class Unit Tests", () => {
                         new StubPerformanceClient()
                     )
             ).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.urlParseError, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.urlParseError,
+                    ""
+                )
             );
             expect(
                 () =>
@@ -186,7 +192,10 @@ describe("Authority.ts Class Unit Tests", () => {
                         new StubPerformanceClient()
                     )
             ).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.urlEmptyError, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.urlEmptyError,
+                    ""
+                )
             );
         });
     });
@@ -234,7 +243,10 @@ describe("Authority.ts Class Unit Tests", () => {
                     (authority.canonicalAuthority =
                         "http://login.microsoftonline.com/common")
             ).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.authorityUriInsecure, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.authorityUriInsecure,
+                    ""
+                )
             );
             expect(
                 () =>
@@ -244,7 +256,10 @@ describe("Authority.ts Class Unit Tests", () => {
             expect(
                 () => (authority.canonicalAuthority = "This is not a URI")
             ).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.urlParseError, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.urlParseError,
+                    ""
+                )
             );
 
             authority.canonicalAuthority = `${TEST_URIS.ALTERNATE_INSTANCE}/${RANDOM_TEST_GUID}`;
@@ -351,22 +366,40 @@ describe("Authority.ts Class Unit Tests", () => {
                     new StubPerformanceClient()
                 );
                 expect(() => authority.authorizationEndpoint).toThrowError(
-                    createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "")
+                    createClientAuthError(
+                        ClientAuthErrorCodes.endpointResolutionError,
+                        ""
+                    )
                 );
                 expect(() => authority.tokenEndpoint).toThrowError(
-                    createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "")
+                    createClientAuthError(
+                        ClientAuthErrorCodes.endpointResolutionError,
+                        ""
+                    )
                 );
                 expect(() => authority.endSessionEndpoint).toThrowError(
-                    createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "")
+                    createClientAuthError(
+                        ClientAuthErrorCodes.endpointResolutionError,
+                        ""
+                    )
                 );
                 expect(() => authority.deviceCodeEndpoint).toThrowError(
-                    createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "")
+                    createClientAuthError(
+                        ClientAuthErrorCodes.endpointResolutionError,
+                        ""
+                    )
                 );
                 expect(() => authority.selfSignedJwtAudience).toThrowError(
-                    createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "")
+                    createClientAuthError(
+                        ClientAuthErrorCodes.endpointResolutionError,
+                        ""
+                    )
                 );
                 expect(() => authority.jwksUri).toThrowError(
-                    createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "")
+                    createClientAuthError(
+                        ClientAuthErrorCodes.endpointResolutionError,
+                        ""
+                    )
                 );
             });
 
@@ -1130,7 +1163,10 @@ describe("Authority.ts Class Unit Tests", () => {
                 await authority.resolveEndpointsAsync();
 
                 expect(() => authority.endSessionEndpoint).toThrowError(
-                    createClientAuthError(ClientAuthErrorCodes.endSessionEndpointNotSupported, "")
+                    createClientAuthError(
+                        ClientAuthErrorCodes.endSessionEndpointNotSupported,
+                        ""
+                    )
                 );
             });
 
@@ -1626,7 +1662,10 @@ describe("Authority.ts Class Unit Tests", () => {
 
             describe("validateIssuer", () => {
                 const issuerValidationFailedError =
-                    createClientConfigurationError(ClientConfigurationErrorCodes.issuerValidationFailed, "");
+                    createClientConfigurationError(
+                        ClientConfigurationErrorCodes.issuerValidationFailed,
+                        ""
+                    );
 
                 const buildAuthority = (
                     authorityUrl: string,
@@ -2915,7 +2954,10 @@ describe("Authority.ts Class Unit Tests", () => {
 
             it("getPreferredCache throws error if discovery is not complete", () => {
                 expect(() => authority.getPreferredCache()).toThrowError(
-                    createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "")
+                    createClientAuthError(
+                        ClientAuthErrorCodes.endpointResolutionError,
+                        ""
+                    )
                 );
             });
         });
@@ -3233,7 +3275,10 @@ describe("Authority.ts Class Unit Tests", () => {
                     invalidCloudDiscoveryMetadataOptions
                 );
             }).toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.invalidCloudDiscoveryMetadata, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.invalidCloudDiscoveryMetadata,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-common/test/cache/AccountEntityUtils.spec.ts
+++ b/lib/msal-common/test/cache/AccountEntityUtils.spec.ts
@@ -127,7 +127,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 idTokenClaims: idTokenClaims,
             },
             authority
-        );
+        , "");
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -167,7 +167,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 idTokenClaims: idTokenClaims,
             },
             authority
-        );
+        , "");
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -207,7 +207,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 idTokenClaims: idTokenClaims,
             },
             authority
-        );
+        , "");
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
         ).toEqual(`${homeAccountId}-login.windows.net-${idTokenClaims.tid}`);
@@ -261,7 +261,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 idTokenClaims: idTokenClaims,
             },
             authority
-        );
+        , "");
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -320,7 +320,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 ),
             },
             authority
-        );
+        , "");
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -435,7 +435,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     idTokenClaims: idTokenClaims,
                     clientInfo: encodedClientInfo,
                 },
-                authority,
+                authority, "",
                 cryptoInterface.base64Decode
             );
 
@@ -472,7 +472,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     clientInfo:
                         TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
                 },
-                authority,
+                authority, "",
                 cryptoInterface.base64Decode
             );
 
@@ -507,7 +507,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     homeAccountId,
                     idTokenClaims: idTokenClaims,
                 },
-                authority,
+                authority, "",
                 cryptoInterface.base64Decode
             );
 
@@ -553,7 +553,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     idTokenClaims: idTokenClaims,
                     clientInfo: encodedClientInfo,
                 },
-                authority,
+                authority, "",
                 cryptoInterface.base64Decode
             );
 
@@ -599,7 +599,7 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     idTokenClaims: idTokenClaims,
                     clientInfo: encodedClientInfo,
                 },
-                authority,
+                authority, "",
                 cryptoInterface.base64Decode
             );
 
@@ -663,7 +663,7 @@ describe("AccountEntityUtils.ts Unit Tests for ADFS", () => {
                 ),
             },
             authority
-        );
+        , "");
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -724,7 +724,7 @@ describe("AccountEntityUtils.ts Unit Tests for ADFS", () => {
                 ),
             },
             authority
-        );
+        , "");
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))

--- a/lib/msal-common/test/cache/AccountEntityUtils.spec.ts
+++ b/lib/msal-common/test/cache/AccountEntityUtils.spec.ts
@@ -606,6 +606,34 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
             expect(acc.dataBoundary).toBeUndefined();
         });
     });
+
+    describe("correlationId propagation", () => {
+        it("createAccountEntity propagates correlationId when no environment is available", () => {
+            jest.spyOn(
+                Authority.prototype,
+                "getPreferredCache"
+            ).mockReturnValue("");
+
+            const correlationId = "account-entity-corr-id";
+            try {
+                AccountEntityUtils.createAccountEntity(
+                    {
+                        homeAccountId: "test-home-account-id",
+                        idTokenClaims: ID_TOKEN_CLAIMS,
+                    },
+                    authority,
+                    correlationId,
+                    cryptoInterface.base64Decode
+                );
+                throw new Error("Expected createAccountEntity to throw");
+            } catch (err) {
+                expect(err).toBeInstanceOf(Error);
+                expect(
+                    (err as { correlationId?: string }).correlationId
+                ).toBe(correlationId);
+            }
+        });
+    });
 });
 
 describe("AccountEntityUtils.ts Unit Tests for ADFS", () => {

--- a/lib/msal-common/test/cache/AccountEntityUtils.spec.ts
+++ b/lib/msal-common/test/cache/AccountEntityUtils.spec.ts
@@ -126,8 +126,9 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 homeAccountId,
                 idTokenClaims: idTokenClaims,
             },
-            authority
-        , "");
+            authority,
+            ""
+        );
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -166,8 +167,9 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 homeAccountId,
                 idTokenClaims: idTokenClaims,
             },
-            authority
-        , "");
+            authority,
+            ""
+        );
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -206,8 +208,9 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 homeAccountId,
                 idTokenClaims: idTokenClaims,
             },
-            authority
-        , "");
+            authority,
+            ""
+        );
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
         ).toEqual(`${homeAccountId}-login.windows.net-${idTokenClaims.tid}`);
@@ -260,8 +263,9 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 homeAccountId,
                 idTokenClaims: idTokenClaims,
             },
-            authority
-        , "");
+            authority,
+            ""
+        );
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -319,8 +323,9 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     cryptoInterface.base64Decode
                 ),
             },
-            authority
-        , "");
+            authority,
+            ""
+        );
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -435,7 +440,8 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     idTokenClaims: idTokenClaims,
                     clientInfo: encodedClientInfo,
                 },
-                authority, "",
+                authority,
+                "",
                 cryptoInterface.base64Decode
             );
 
@@ -472,7 +478,8 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     clientInfo:
                         TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO_GUIDS,
                 },
-                authority, "",
+                authority,
+                "",
                 cryptoInterface.base64Decode
             );
 
@@ -507,7 +514,8 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     homeAccountId,
                     idTokenClaims: idTokenClaims,
                 },
-                authority, "",
+                authority,
+                "",
                 cryptoInterface.base64Decode
             );
 
@@ -553,7 +561,8 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     idTokenClaims: idTokenClaims,
                     clientInfo: encodedClientInfo,
                 },
-                authority, "",
+                authority,
+                "",
                 cryptoInterface.base64Decode
             );
 
@@ -599,7 +608,8 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                     idTokenClaims: idTokenClaims,
                     clientInfo: encodedClientInfo,
                 },
-                authority, "",
+                authority,
+                "",
                 cryptoInterface.base64Decode
             );
 
@@ -628,9 +638,9 @@ describe("AccountEntityUtils.ts Unit Tests", () => {
                 throw new Error("Expected createAccountEntity to throw");
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
-                expect(
-                    (err as { correlationId?: string }).correlationId
-                ).toBe(correlationId);
+                expect((err as { correlationId?: string }).correlationId).toBe(
+                    correlationId
+                );
             }
         });
     });
@@ -690,8 +700,9 @@ describe("AccountEntityUtils.ts Unit Tests for ADFS", () => {
                     cryptoInterface.base64Decode
                 ),
             },
-            authority
-        , "");
+            authority,
+            ""
+        );
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))
@@ -751,8 +762,9 @@ describe("AccountEntityUtils.ts Unit Tests for ADFS", () => {
                     cryptoInterface.base64Decode
                 ),
             },
-            authority
-        , "");
+            authority,
+            ""
+        );
 
         expect(
             generateAccountKey(AccountEntityUtils.getAccountInfo(acc))

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -169,8 +169,8 @@ describe("CacheManager.ts test cases", () => {
                 "User.Read",
                 TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP,
                 TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP,
-                mockCrypto.base64Decode
-            );
+                mockCrypto.base64Decode,
+                "");
 
             const atKey = generateCredentialKey(at);
             const cacheRecord: CacheRecord = {};
@@ -2020,10 +2020,10 @@ describe("CacheManager.ts test cases", () => {
                     4600,
                     4600,
                     mockCrypto.base64Decode,
+                    "",
                     500,
                     AuthenticationScheme.BEARER,
-                    TEST_TOKENS.ACCESS_TOKEN
-                );
+                    TEST_TOKENS.ACCESS_TOKEN);
 
             const mockedAtEntity2: AccessTokenEntity =
                 CacheHelpers.createAccessTokenEntity(
@@ -2036,10 +2036,10 @@ describe("CacheManager.ts test cases", () => {
                     4600,
                     4600,
                     mockCrypto.base64Decode,
+                    "",
                     500,
                     AuthenticationScheme.BEARER,
-                    TEST_TOKENS.ACCESS_TOKEN
-                );
+                    TEST_TOKENS.ACCESS_TOKEN);
 
             const accountData = {
                 username: "John Doe",
@@ -2111,10 +2111,10 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.BEARER,
-                TEST_TOKENS.ACCESS_TOKEN
-            );
+                TEST_TOKENS.ACCESS_TOKEN);
 
         const mockedPopAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2127,10 +2127,10 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.POP,
-                TEST_TOKENS.ACCESS_TOKEN
-            );
+                TEST_TOKENS.ACCESS_TOKEN);
 
         const mockedSshAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2143,11 +2143,11 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.SSH,
                 undefined,
-                TEST_SSH_VALUES.SSH_KID
-            );
+                TEST_SSH_VALUES.SSH_KID);
 
         const accountData = {
             username: "John Doe",
@@ -2209,11 +2209,11 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 // @ts-ignore
                 AuthenticationScheme.BEARER.toLowerCase(),
-                TEST_TOKENS.ACCESS_TOKEN
-            );
+                TEST_TOKENS.ACCESS_TOKEN);
 
         const accountData = {
             username: "John Doe",
@@ -2270,10 +2270,10 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.BEARER,
-                TEST_TOKENS.ACCESS_TOKEN
-            );
+                TEST_TOKENS.ACCESS_TOKEN);
 
         const mockedPopAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2286,10 +2286,10 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.POP,
-                TEST_TOKENS.ACCESS_TOKEN
-            );
+                TEST_TOKENS.ACCESS_TOKEN);
 
         const mockedSshAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2302,11 +2302,11 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.SSH,
                 undefined,
-                TEST_SSH_VALUES.SSH_KID
-            );
+                TEST_SSH_VALUES.SSH_KID);
 
         const accountData = {
             username: "John Doe",
@@ -2369,11 +2369,11 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.BEARER,
                 undefined,
-                undefined
-            );
+                undefined);
 
         const mockedPopAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2386,11 +2386,11 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.POP,
                 undefined,
-                TEST_POP_VALUES.KID
-            );
+                TEST_POP_VALUES.KID);
 
         const mockedSshAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2403,11 +2403,11 @@ describe("CacheManager.ts test cases", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 500,
                 AuthenticationScheme.SSH,
                 undefined,
-                TEST_SSH_VALUES.SSH_KID
-            );
+                TEST_SSH_VALUES.SSH_KID);
 
         const accountData = {
             username: "John Doe",

--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -170,7 +170,8 @@ describe("CacheManager.ts test cases", () => {
                 TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP,
                 TEST_TOKEN_LIFETIMES.TEST_ACCESS_TOKEN_EXP,
                 mockCrypto.base64Decode,
-                "");
+                ""
+            );
 
             const atKey = generateCredentialKey(at);
             const cacheRecord: CacheRecord = {};
@@ -2023,7 +2024,8 @@ describe("CacheManager.ts test cases", () => {
                     "",
                     500,
                     AuthenticationScheme.BEARER,
-                    TEST_TOKENS.ACCESS_TOKEN);
+                    TEST_TOKENS.ACCESS_TOKEN
+                );
 
             const mockedAtEntity2: AccessTokenEntity =
                 CacheHelpers.createAccessTokenEntity(
@@ -2039,7 +2041,8 @@ describe("CacheManager.ts test cases", () => {
                     "",
                     500,
                     AuthenticationScheme.BEARER,
-                    TEST_TOKENS.ACCESS_TOKEN);
+                    TEST_TOKENS.ACCESS_TOKEN
+                );
 
             const accountData = {
                 username: "John Doe",
@@ -2114,7 +2117,8 @@ describe("CacheManager.ts test cases", () => {
                 "",
                 500,
                 AuthenticationScheme.BEARER,
-                TEST_TOKENS.ACCESS_TOKEN);
+                TEST_TOKENS.ACCESS_TOKEN
+            );
 
         const mockedPopAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2130,7 +2134,8 @@ describe("CacheManager.ts test cases", () => {
                 "",
                 500,
                 AuthenticationScheme.POP,
-                TEST_TOKENS.ACCESS_TOKEN);
+                TEST_TOKENS.ACCESS_TOKEN
+            );
 
         const mockedSshAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2147,7 +2152,8 @@ describe("CacheManager.ts test cases", () => {
                 500,
                 AuthenticationScheme.SSH,
                 undefined,
-                TEST_SSH_VALUES.SSH_KID);
+                TEST_SSH_VALUES.SSH_KID
+            );
 
         const accountData = {
             username: "John Doe",
@@ -2213,7 +2219,8 @@ describe("CacheManager.ts test cases", () => {
                 500,
                 // @ts-ignore
                 AuthenticationScheme.BEARER.toLowerCase(),
-                TEST_TOKENS.ACCESS_TOKEN);
+                TEST_TOKENS.ACCESS_TOKEN
+            );
 
         const accountData = {
             username: "John Doe",
@@ -2273,7 +2280,8 @@ describe("CacheManager.ts test cases", () => {
                 "",
                 500,
                 AuthenticationScheme.BEARER,
-                TEST_TOKENS.ACCESS_TOKEN);
+                TEST_TOKENS.ACCESS_TOKEN
+            );
 
         const mockedPopAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2289,7 +2297,8 @@ describe("CacheManager.ts test cases", () => {
                 "",
                 500,
                 AuthenticationScheme.POP,
-                TEST_TOKENS.ACCESS_TOKEN);
+                TEST_TOKENS.ACCESS_TOKEN
+            );
 
         const mockedSshAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2306,7 +2315,8 @@ describe("CacheManager.ts test cases", () => {
                 500,
                 AuthenticationScheme.SSH,
                 undefined,
-                TEST_SSH_VALUES.SSH_KID);
+                TEST_SSH_VALUES.SSH_KID
+            );
 
         const accountData = {
             username: "John Doe",
@@ -2373,7 +2383,8 @@ describe("CacheManager.ts test cases", () => {
                 500,
                 AuthenticationScheme.BEARER,
                 undefined,
-                undefined);
+                undefined
+            );
 
         const mockedPopAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2390,7 +2401,8 @@ describe("CacheManager.ts test cases", () => {
                 500,
                 AuthenticationScheme.POP,
                 undefined,
-                TEST_POP_VALUES.KID);
+                TEST_POP_VALUES.KID
+            );
 
         const mockedSshAtEntity: AccessTokenEntity =
             CacheHelpers.createAccessTokenEntity(
@@ -2407,7 +2419,8 @@ describe("CacheManager.ts test cases", () => {
                 500,
                 AuthenticationScheme.SSH,
                 undefined,
-                TEST_SSH_VALUES.SSH_KID);
+                TEST_SSH_VALUES.SSH_KID
+            );
 
         const accountData = {
             username: "John Doe",

--- a/lib/msal-common/test/cache/utils/CacheHelpers.spec.ts
+++ b/lib/msal-common/test/cache/utils/CacheHelpers.spec.ts
@@ -1,0 +1,32 @@
+import * as CacheHelpers from "../../../src/cache/utils/CacheHelpers.js";
+import { AuthenticationScheme } from "../../../src/utils/Constants.js";
+import { TEST_TOKENS, TEST_CONFIG } from "../../test_kit/StringConstants.js";
+import { mockCrypto } from "../../client/ClientTestUtils.js";
+
+describe("CacheHelpers.ts correlationId propagation", () => {
+    it("createAccessTokenEntity propagates correlationId when POP token is missing cnf.kid", () => {
+        const correlationId = "cache-helpers-corr-id";
+        try {
+            CacheHelpers.createAccessTokenEntity(
+                "uid.utid",
+                "login.microsoftonline.com",
+                TEST_TOKENS.IDTOKEN_V2, // valid jwt but has no cnf.kid claim
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                TEST_CONFIG.TENANT,
+                "User.Read",
+                4600,
+                4600,
+                mockCrypto.base64Decode,
+                correlationId,
+                500,
+                AuthenticationScheme.POP
+            );
+            throw new Error("Expected createAccessTokenEntity to throw");
+        } catch (err) {
+            expect(err).toBeInstanceOf(Error);
+            expect((err as { correlationId?: string }).correlationId).toBe(
+                correlationId
+            );
+        }
+    });
+});

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -85,7 +85,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 // @ts-ignore
                 client.acquireToken({ code: null }, null)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.requestCannotBeMade, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.requestCannotBeMade,
+                    ""
+                )
             );
             // @ts-ignore
             expect(config.storageInterface.getKeys().length).toBe(1);
@@ -125,7 +128,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                 // @ts-ignore
                 client.acquireToken(codeRequest, null)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.requestCannotBeMade, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.requestCannotBeMade,
+                    ""
+                )
             );
             // @ts-ignore
             expect(config.storageInterface.getKeys().length).toBe(1);
@@ -1924,7 +1930,10 @@ describe("AuthorizationCodeClient unit tests", () => {
                     state: testState,
                 })
             ).rejects.toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.missingSshJwk, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingSshJwk,
+                    ""
+                )
             );
         });
 

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -411,7 +411,10 @@ export async function getDiscoveredAuthority(
     );
 
     await authority.resolveEndpointsAsync().catch((error) => {
-        throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.endpointResolutionError,
+            ""
+        );
     });
 
     return authority;

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -368,7 +368,10 @@ describe("SilentFlowClient unit tests", () => {
             await expect(
                 client.acquireCachedToken(silentFlowRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
 
@@ -531,7 +534,10 @@ describe("SilentFlowClient unit tests", () => {
                     forceRefresh: false,
                 })
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.noAccountInSilentRequest, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.noAccountInSilentRequest,
+                    ""
+                )
             );
             await expect(
                 client.acquireCachedToken({
@@ -543,7 +549,10 @@ describe("SilentFlowClient unit tests", () => {
                     forceRefresh: false,
                 })
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.noAccountInSilentRequest, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.noAccountInSilentRequest,
+                    ""
+                )
             );
         });
 
@@ -581,7 +590,10 @@ describe("SilentFlowClient unit tests", () => {
             await expect(
                 client.acquireCachedToken(tokenRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
 
@@ -622,7 +634,10 @@ describe("SilentFlowClient unit tests", () => {
             expect(
                 client.acquireCachedToken(silentFlowRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
 
@@ -662,7 +677,10 @@ describe("SilentFlowClient unit tests", () => {
             expect(
                 client.acquireCachedToken(silentFlowRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
 
@@ -704,7 +722,10 @@ describe("SilentFlowClient unit tests", () => {
             expect(
                 client.acquireCachedToken(silentFlowRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
 
@@ -764,7 +785,10 @@ describe("SilentFlowClient unit tests", () => {
             await expect(
                 client.acquireCachedToken(silentFlowRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
 
@@ -804,7 +828,10 @@ describe("SilentFlowClient unit tests", () => {
             expect(
                 client.acquireCachedToken(silentFlowRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
 
@@ -863,7 +890,10 @@ describe("SilentFlowClient unit tests", () => {
             await expect(
                 client.acquireCachedToken(silentFlowRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
     });
@@ -1016,7 +1046,10 @@ describe("SilentFlowClient unit tests", () => {
             expect(
                 client.acquireCachedToken(silentFlowRequest)
             ).rejects.toMatchObject(
-                createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "")
+                createClientAuthError(
+                    ClientAuthErrorCodes.tokenRefreshRequired,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-common/test/protocol/Authorize.spec.ts
+++ b/lib/msal-common/test/protocol/Authorize.spec.ts
@@ -1554,11 +1554,15 @@ describe("Authorize Protocol Tests", () => {
     describe("getAuthorizationCodePayload", () => {
         it("returns valid server code response", () => {
             const authCodePayload =
-                AuthorizeProtocol.getAuthorizationCodePayload({
-                        code: "thisIsATestCode", state: TEST_STATE_VALUES.ENCODED_LIB_STATE,
+                AuthorizeProtocol.getAuthorizationCodePayload(
+                    {
+                        code: "thisIsATestCode",
+                        state: TEST_STATE_VALUES.ENCODED_LIB_STATE,
                         client_info: TEST_DATA_CLIENT_INFO.TEST_RAW_CLIENT_INFO,
                     },
-                    TEST_STATE_VALUES.ENCODED_LIB_STATE, "");
+                    TEST_STATE_VALUES.ENCODED_LIB_STATE,
+                    ""
+                );
             expect(authCodePayload.code).toBe("thisIsATestCode");
             expect(authCodePayload.state).toBe(
                 TEST_STATE_VALUES.ENCODED_LIB_STATE
@@ -1568,11 +1572,15 @@ describe("Authorize Protocol Tests", () => {
         it("throws server error when error is in hash", () => {
             let error: AuthError | null = null;
             try {
-                AuthorizeProtocol.getAuthorizationCodePayload({
-                        error: "error_code", error_description: "msal error description",
+                AuthorizeProtocol.getAuthorizationCodePayload(
+                    {
+                        error: "error_code",
+                        error_description: "msal error description",
                         state: TEST_STATE_VALUES.ENCODED_LIB_STATE,
                     },
-                    TEST_STATE_VALUES.ENCODED_LIB_STATE, "");
+                    TEST_STATE_VALUES.ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 error = e as AuthError;
             }
@@ -1591,7 +1599,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, "differentState", "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    "differentState",
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ClientAuthError);
                 // @ts-ignore
@@ -1607,7 +1619,11 @@ describe("Authorize Protocol Tests", () => {
                 state: TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
             };
 
-            AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+            AuthorizeProtocol.validateAuthorizationResponse(
+                testServerCodeResponse,
+                TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                ""
+            );
         });
 
         it("Does not throw state mismatch error when Uri encoded characters have different casing", () => {
@@ -1620,7 +1636,11 @@ describe("Authorize Protocol Tests", () => {
             const testAltState =
                 "eyJpZCI6IjExNTUzYTliLTcxMTYtNDhiMS05ZDQ4LWY2ZDRhOGZmODM3MSIsInRzIjoxNTkyODQ2NDgyfQ%3d%3d";
 
-            AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, testAltState, "");
+            AuthorizeProtocol.validateAuthorizationResponse(
+                testServerCodeResponse,
+                testAltState,
+                ""
+            );
         });
 
         it("throws interactionRequiredError", (done) => {
@@ -1632,7 +1652,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(InteractionRequiredAuthError);
                 done();
@@ -1648,7 +1672,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 done();
@@ -1664,7 +1692,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 done();
@@ -1680,7 +1712,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 done();
@@ -1695,7 +1731,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, "dummy-state-%20%%%30%%%%%40", "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    "dummy-state-%20%%%30%%%%%40",
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ClientAuthError);
                 const err = e as ClientAuthError;
@@ -1715,7 +1755,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 const serverError = e as ServerError;
@@ -1735,7 +1779,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(InteractionRequiredAuthError);
                 const serverError = e as InteractionRequiredAuthError;
@@ -1754,7 +1802,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 const serverError = e as ServerError;
@@ -1773,7 +1825,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 const serverError = e as ServerError;
@@ -1792,7 +1848,11 @@ describe("Authorize Protocol Tests", () => {
             };
 
             try {
-                AuthorizeProtocol.validateAuthorizationResponse(testServerCodeResponse, TEST_STATE_VALUES.URI_ENCODED_LIB_STATE, "");
+                AuthorizeProtocol.validateAuthorizationResponse(
+                    testServerCodeResponse,
+                    TEST_STATE_VALUES.URI_ENCODED_LIB_STATE,
+                    ""
+                );
             } catch (e) {
                 expect(e).toBeInstanceOf(ServerError);
                 const serverError = e as ServerError;

--- a/lib/msal-common/test/request/AuthenticationHeaderParser.spec.ts
+++ b/lib/msal-common/test/request/AuthenticationHeaderParser.spec.ts
@@ -43,7 +43,10 @@ describe("AuthenticationHeaderParser unit tests", () => {
                 {}
             );
             expect(() => authenticationHeaderParser.getShrNonce()).toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.missingNonceAuthenticationHeader, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.missingNonceAuthenticationHeader,
+                    ""
+                )
             );
         });
 
@@ -54,7 +57,10 @@ describe("AuthenticationHeaderParser unit tests", () => {
                 headers
             );
             expect(() => authenticationHeaderParser.getShrNonce()).toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.invalidAuthenticationHeader, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.invalidAuthenticationHeader,
+                    ""
+                )
             );
         });
 
@@ -65,7 +71,10 @@ describe("AuthenticationHeaderParser unit tests", () => {
                 headers
             );
             expect(() => authenticationHeaderParser.getShrNonce()).toThrow(
-                createClientConfigurationError(ClientConfigurationErrorCodes.invalidAuthenticationHeader, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.invalidAuthenticationHeader,
+                    ""
+                )
             );
         });
     });

--- a/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
+++ b/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
@@ -55,7 +55,12 @@ describe("RequestParameterBuilder unit tests", () => {
             parameters,
             TEST_CONFIG.LOGIN_HINT
         );
-        RequestParameterBuilder.addClaims(parameters, "", TEST_CONFIG.CLAIMS, []);
+        RequestParameterBuilder.addClaims(
+            parameters,
+            "",
+            TEST_CONFIG.CLAIMS,
+            []
+        );
         RequestParameterBuilder.addCorrelationId(
             parameters,
             TEST_CONFIG.CORRELATION_ID
@@ -364,7 +369,10 @@ describe("RequestParameterBuilder unit tests", () => {
                 ""
             )
         ).toThrow(
-            new ClientConfigurationError(ClientConfigurationErrorCodes.pkceParamsMissing, "")
+            new ClientConfigurationError(
+                ClientConfigurationErrorCodes.pkceParamsMissing,
+                ""
+            )
         );
     });
 
@@ -377,7 +385,10 @@ describe("RequestParameterBuilder unit tests", () => {
                 AADServerParamKeys.CODE_CHALLENGE_METHOD
             )
         ).toThrow(
-            new ClientConfigurationError(ClientConfigurationErrorCodes.pkceParamsMissing, "")
+            new ClientConfigurationError(
+                ClientConfigurationErrorCodes.pkceParamsMissing,
+                ""
+            )
         );
     });
 
@@ -644,7 +655,10 @@ describe("RequestParameterBuilder unit tests", () => {
                     []
                 )
             ).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.invalidClaims, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.invalidClaims,
+                    ""
+                )
             );
         });
     });
@@ -821,7 +835,8 @@ describe("RequestParameterBuilder unit tests", () => {
             );
 
             RequestParameterBuilder.addClaims(
-                parameters, "",
+                parameters,
+                "",
                 JSON.stringify({ userinfo: { given_name: null } }),
                 ["CP1", "CP2"],
                 false
@@ -841,7 +856,8 @@ describe("RequestParameterBuilder unit tests", () => {
             const parameters = new Map<string, string>();
 
             RequestParameterBuilder.addClaims(
-                parameters, "",
+                parameters,
+                "",
                 JSON.stringify({ userinfo: { given_name: null } }),
                 ["CP1", "CP2"],
                 false
@@ -861,7 +877,8 @@ describe("RequestParameterBuilder unit tests", () => {
             const parameters = new Map<string, string>();
 
             RequestParameterBuilder.addClaims(
-                parameters, "",
+                parameters,
+                "",
                 JSON.stringify({ userinfo: { given_name: null } }),
                 ["CP1", "CP2"],
                 true
@@ -887,7 +904,8 @@ describe("RequestParameterBuilder unit tests", () => {
             );
 
             RequestParameterBuilder.addClaims(
-                parameters, "",
+                parameters,
+                "",
                 JSON.stringify({ userinfo: { given_name: null } }),
                 ["CP1", "CP2"],
                 true
@@ -904,7 +922,8 @@ describe("RequestParameterBuilder unit tests", () => {
             const parameters = new Map<string, string>();
 
             RequestParameterBuilder.addClaims(
-                parameters, "",
+                parameters,
+                "",
                 undefined,
                 undefined,
                 false
@@ -917,7 +936,8 @@ describe("RequestParameterBuilder unit tests", () => {
             const parameters = new Map<string, string>();
 
             RequestParameterBuilder.addClaims(
-                parameters, "",
+                parameters,
+                "",
                 undefined,
                 ["CP1"],
                 false

--- a/lib/msal-common/test/request/ScopeSet.spec.ts
+++ b/lib/msal-common/test/request/ScopeSet.spec.ts
@@ -18,11 +18,17 @@ describe("ScopeSet.ts", () => {
         it("Throws error if scopes are null or empty and required", () => {
             // @ts-ignore
             expect(() => new ScopeSet(null)).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.emptyInputScopesError, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.emptyInputScopesError,
+                    ""
+                )
             );
 
             expect(() => new ScopeSet([])).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.emptyInputScopesError, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.emptyInputScopesError,
+                    ""
+                )
             );
         });
 
@@ -66,17 +72,26 @@ describe("ScopeSet.ts", () => {
     describe("fromString Constructor", () => {
         it("Throws error if scopeString is empty, null or undefined if scopes are required", () => {
             expect(() => ScopeSet.fromString("")).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.emptyInputScopesError, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.emptyInputScopesError,
+                    ""
+                )
             );
 
             // @ts-ignore
             expect(() => ScopeSet.fromString(null)).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.emptyInputScopesError, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.emptyInputScopesError,
+                    ""
+                )
             );
 
             // @ts-ignore
             expect(() => ScopeSet.fromString(undefined)).toThrow(
-                new ClientConfigurationError(ClientConfigurationErrorCodes.emptyInputScopesError, "")
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.emptyInputScopesError,
+                    ""
+                )
             );
         });
 
@@ -194,12 +209,18 @@ describe("ScopeSet.ts", () => {
         it("appendScopes() throws error if given array is null or undefined", () => {
             // @ts-ignore
             expect(() => scopes.appendScopes(null)).toThrow(
-                new ClientAuthError(ClientAuthErrorCodes.cannotAppendScopeSet, "")
+                new ClientAuthError(
+                    ClientAuthErrorCodes.cannotAppendScopeSet,
+                    ""
+                )
             );
 
             // @ts-ignore
             expect(() => scopes.appendScopes(undefined)).toThrow(
-                new ClientAuthError(ClientAuthErrorCodes.cannotAppendScopeSet, "")
+                new ClientAuthError(
+                    ClientAuthErrorCodes.cannotAppendScopeSet,
+                    ""
+                )
             );
         });
 
@@ -251,16 +272,25 @@ describe("ScopeSet.ts", () => {
         it("removeScopes() throws error if scope is null, undefined or empty", () => {
             // @ts-ignore
             expect(() => scopes.removeScope(null)).toThrow(
-                new ClientAuthError(ClientAuthErrorCodes.cannotRemoveEmptyScope, "")
+                new ClientAuthError(
+                    ClientAuthErrorCodes.cannotRemoveEmptyScope,
+                    ""
+                )
             );
 
             // @ts-ignore
             expect(() => scopes.removeScope(undefined)).toThrow(
-                new ClientAuthError(ClientAuthErrorCodes.cannotRemoveEmptyScope, "")
+                new ClientAuthError(
+                    ClientAuthErrorCodes.cannotRemoveEmptyScope,
+                    ""
+                )
             );
 
             expect(() => scopes.removeScope("")).toThrow(
-                new ClientAuthError(ClientAuthErrorCodes.cannotRemoveEmptyScope, "")
+                new ClientAuthError(
+                    ClientAuthErrorCodes.cannotRemoveEmptyScope,
+                    ""
+                )
             );
         });
 

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -1235,7 +1235,8 @@ describe("ResponseHandler.ts", () => {
                     },
                     environment,
                 },
-                testAuthority, "",
+                testAuthority,
+                "",
                 mockCrypto.base64Decode
             );
             existingAccount.tenantProfiles = [
@@ -1332,7 +1333,8 @@ describe("ResponseHandler.ts", () => {
                     },
                     environment,
                 },
-                testAuthority, "",
+                testAuthority,
+                "",
                 mockCrypto.base64Decode
             );
             existingAccount.tenantProfiles = [
@@ -1376,7 +1378,8 @@ describe("ResponseHandler.ts", () => {
                     idTokenClaims: testIdTokenClaims,
                     environment,
                 },
-                testAuthority, "",
+                testAuthority,
+                "",
                 mockCrypto.base64Decode
             );
             const account2 = AccountEntityUtils.createAccountEntity(
@@ -1385,7 +1388,8 @@ describe("ResponseHandler.ts", () => {
                     idTokenClaims: testIdTokenClaims,
                     environment,
                 },
-                testAuthority, "",
+                testAuthority,
+                "",
                 mockCrypto.base64Decode
             );
 
@@ -1429,7 +1433,8 @@ describe("ResponseHandler.ts", () => {
                     idTokenClaims: testIdTokenClaims,
                     environment: "login.windows.net",
                 },
-                testAuthority, "",
+                testAuthority,
+                "",
                 mockCrypto.base64Decode
             );
             accountWindows.tenantProfiles = [
@@ -1447,7 +1452,8 @@ describe("ResponseHandler.ts", () => {
                     idTokenClaims: testIdTokenClaims,
                     environment: "login.other-cloud.example",
                 },
-                testAuthority, "",
+                testAuthority,
+                "",
                 mockCrypto.base64Decode
             );
 

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -1235,7 +1235,7 @@ describe("ResponseHandler.ts", () => {
                     },
                     environment,
                 },
-                testAuthority,
+                testAuthority, "",
                 mockCrypto.base64Decode
             );
             existingAccount.tenantProfiles = [
@@ -1332,7 +1332,7 @@ describe("ResponseHandler.ts", () => {
                     },
                     environment,
                 },
-                testAuthority,
+                testAuthority, "",
                 mockCrypto.base64Decode
             );
             existingAccount.tenantProfiles = [
@@ -1376,7 +1376,7 @@ describe("ResponseHandler.ts", () => {
                     idTokenClaims: testIdTokenClaims,
                     environment,
                 },
-                testAuthority,
+                testAuthority, "",
                 mockCrypto.base64Decode
             );
             const account2 = AccountEntityUtils.createAccountEntity(
@@ -1385,7 +1385,7 @@ describe("ResponseHandler.ts", () => {
                     idTokenClaims: testIdTokenClaims,
                     environment,
                 },
-                testAuthority,
+                testAuthority, "",
                 mockCrypto.base64Decode
             );
 
@@ -1429,7 +1429,7 @@ describe("ResponseHandler.ts", () => {
                     idTokenClaims: testIdTokenClaims,
                     environment: "login.windows.net",
                 },
-                testAuthority,
+                testAuthority, "",
                 mockCrypto.base64Decode
             );
             accountWindows.tenantProfiles = [
@@ -1447,7 +1447,7 @@ describe("ResponseHandler.ts", () => {
                     idTokenClaims: testIdTokenClaims,
                     environment: "login.other-cloud.example",
                 },
-                testAuthority,
+                testAuthority, "",
                 mockCrypto.base64Decode
             );
 

--- a/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
+++ b/lib/msal-common/test/telemetry/PerformanceClient.spec.ts
@@ -255,7 +255,11 @@ describe("PerformanceClient.spec.ts", () => {
         const mockPerfClient = new MockPerformanceClient();
         const correlationId = "test-correlation-id";
 
-        const publicError = new AuthError("public_test_error", "", "This error will be thrown to caller");
+        const publicError = new AuthError(
+            "public_test_error",
+            "",
+            "This error will be thrown to caller"
+        );
         const runtimeError = new TypeError("This error caused publicError");
 
         mockPerfClient.addPerformanceCallback((events) => {
@@ -301,7 +305,11 @@ describe("PerformanceClient.spec.ts", () => {
         const mockPerfClient = new MockPerformanceClient();
         const correlationId = "test-correlation-id";
 
-        const publicError = new AuthError("public_test_error", "", "This error will be thrown to caller");
+        const publicError = new AuthError(
+            "public_test_error",
+            "",
+            "This error will be thrown to caller"
+        );
         const runtimeError = new TypeError("This error caused publicError");
 
         mockPerfClient.addPerformanceCallback((events) => {
@@ -578,7 +586,13 @@ describe("PerformanceClient.spec.ts", () => {
         it("captures server error no", (done) => {
             const mockPerfClient = new MockPerformanceClient();
             const correlationId = "test-correlation-id";
-            const error = new ServerError("test-error-code", "", undefined, undefined, "70011");
+            const error = new ServerError(
+                "test-error-code",
+                "",
+                undefined,
+                undefined,
+                "70011"
+            );
 
             mockPerfClient.addPerformanceCallback((events) => {
                 expect(events.length).toBe(1);
@@ -602,7 +616,16 @@ describe("PerformanceClient.spec.ts", () => {
         it("captures interaction required error no", (done) => {
             const mockPerfClient = new MockPerformanceClient();
             const correlationId = "test-correlation-id";
-            const error = new InteractionRequiredAuthError("test-error-code", "", undefined, undefined, undefined, undefined, undefined, "70011");
+            const error = new InteractionRequiredAuthError(
+                "test-error-code",
+                "",
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                "70011"
+            );
 
             mockPerfClient.addPerformanceCallback((events) => {
                 expect(events.length).toBe(1);
@@ -626,7 +649,13 @@ describe("PerformanceClient.spec.ts", () => {
         it("does not set serverErrorNo from ServerError when serverErrorNo is already present", (done) => {
             const mockPerfClient = new MockPerformanceClient();
             const correlationId = "test-correlation-id";
-            const error = new ServerError("test-error-code", "", undefined, undefined, "70011");
+            const error = new ServerError(
+                "test-error-code",
+                "",
+                undefined,
+                undefined,
+                "70011"
+            );
 
             mockPerfClient.addPerformanceCallback((events) => {
                 expect(events.length).toBe(1);
@@ -659,7 +688,16 @@ describe("PerformanceClient.spec.ts", () => {
         it("does not set serverErrorNo from InteractionRequiredAuthError when serverErrorNo is already present", (done) => {
             const mockPerfClient = new MockPerformanceClient();
             const correlationId = "test-correlation-id";
-            const error = new InteractionRequiredAuthError("test-error-code", "", undefined, undefined, undefined, undefined, undefined, "70011");
+            const error = new InteractionRequiredAuthError(
+                "test-error-code",
+                "",
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                "70011"
+            );
 
             mockPerfClient.addPerformanceCallback((events) => {
                 expect(events.length).toBe(1);
@@ -989,7 +1027,12 @@ describe("PerformanceClient.spec.ts", () => {
         it("captures auth errors", (done) => {
             const mockPerfClient = new MockPerformanceClient();
             const correlationId = "test-correlation-id";
-            const error = new AuthError("test error code", "", "test error message", "test sub error code");
+            const error = new AuthError(
+                "test error code",
+                "",
+                "test error message",
+                "test sub error code"
+            );
 
             mockPerfClient.addPerformanceCallback((events) => {
                 expect(events.length).toBe(1);
@@ -1054,8 +1097,18 @@ describe("PerformanceClient.spec.ts", () => {
         it("captures different auth errors", (done) => {
             const mockPerfClient = new MockPerformanceClient();
             const correlationId = "test-correlation-id";
-            const error = new AuthError("test error code", "", "test error message", "test sub error code");
-            const secondError = new AuthError("test error code 2", "", "test error message 2", "test sub error code 2");
+            const error = new AuthError(
+                "test error code",
+                "",
+                "test error message",
+                "test sub error code"
+            );
+            const secondError = new AuthError(
+                "test error code 2",
+                "",
+                "test error message 2",
+                "test sub error code 2"
+            );
 
             mockPerfClient.addPerformanceCallback((events) => {
                 expect(events.length).toBe(1);
@@ -1122,7 +1175,12 @@ describe("PerformanceClient.spec.ts", () => {
         it("captures auth and non-auth errors", (done) => {
             const mockPerfClient = new MockPerformanceClient();
             const correlationId = "test-correlation-id";
-            const error = new AuthError("test error code", "", "test error message", "test sub error code");
+            const error = new AuthError(
+                "test error code",
+                "",
+                "test error message",
+                "test sub error code"
+            );
             const secondError = new TypeError("test type error");
 
             mockPerfClient.addPerformanceCallback((events) => {

--- a/lib/msal-common/test/url/UrlString.spec.ts
+++ b/lib/msal-common/test/url/UrlString.spec.ts
@@ -20,7 +20,10 @@ describe("UrlString.ts Class Unit Tests", () => {
     it("constructor throws error if uri is empty or null", () => {
         // @ts-ignore
         expect(() => new UrlString(null)).toThrowError(
-            createClientConfigurationError(ClientConfigurationErrorCodes.urlEmptyError, "")
+            createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlEmptyError,
+                ""
+            )
         );
         // @ts-ignore
         expect(() => new UrlString(null)).toThrowError(
@@ -28,7 +31,10 @@ describe("UrlString.ts Class Unit Tests", () => {
         );
 
         expect(() => new UrlString("")).toThrowError(
-            createClientConfigurationError(ClientConfigurationErrorCodes.urlEmptyError, "")
+            createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlEmptyError,
+                ""
+            )
         );
         expect(() => new UrlString("")).toThrowError(ClientConfigurationError);
     });
@@ -42,7 +48,10 @@ describe("UrlString.ts Class Unit Tests", () => {
         );
         let urlObj = new UrlString(TEST_URIS.TEST_REDIR_URI);
         expect(() => urlObj.validateAsUri()).toThrowError(
-            createClientConfigurationError(ClientConfigurationErrorCodes.urlParseError, "")
+            createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlParseError,
+                ""
+            )
         );
         expect(() => urlObj.validateAsUri()).toThrowError(
             ClientConfigurationError
@@ -53,7 +62,10 @@ describe("UrlString.ts Class Unit Tests", () => {
         const insecureUrlString = "http://login.microsoft.com/common";
         let urlObj = new UrlString(insecureUrlString);
         expect(() => urlObj.validateAsUri()).toThrowError(
-            createClientConfigurationError(ClientConfigurationErrorCodes.authorityUriInsecure, "")
+            createClientConfigurationError(
+                ClientConfigurationErrorCodes.authorityUriInsecure,
+                ""
+            )
         );
         expect(() => urlObj.validateAsUri()).toThrowError(
             ClientConfigurationError

--- a/lib/msal-common/test/utils/ProtocolUtils.spec.ts
+++ b/lib/msal-common/test/utils/ProtocolUtils.spec.ts
@@ -34,7 +34,12 @@ describe("ProtocolUtils.ts Class Unit Tests", () => {
     });
 
     it("setRequestState() only creates library state", () => {
-        const requestState = ProtocolUtils.setRequestState(cryptoInterface, "", undefined, "");
+        const requestState = ProtocolUtils.setRequestState(
+            cryptoInterface,
+            "",
+            undefined,
+            ""
+        );
         expect(requestState).toBe(encodedLibState);
     });
 
@@ -47,7 +52,11 @@ describe("ProtocolUtils.ts Class Unit Tests", () => {
 
     it("parseRequestState() throws error if given state is null or empty", () => {
         expect(() =>
-            ProtocolUtils.parseRequestState(cryptoInterface.base64Decode, "", "")
+            ProtocolUtils.parseRequestState(
+                cryptoInterface.base64Decode,
+                "",
+                ""
+            )
         ).toThrow(ClientAuthErrorCodes.invalidState);
 
         expect(() =>
@@ -66,12 +75,20 @@ describe("ProtocolUtils.ts Class Unit Tests", () => {
     });
 
     it("parseRequestState() correctly splits the state by the resource delimiter", () => {
-        const requestState = ProtocolUtils.parseRequestState(cryptoInterface.base64Decode, testState, "");
+        const requestState = ProtocolUtils.parseRequestState(
+            cryptoInterface.base64Decode,
+            testState,
+            ""
+        );
         expect(requestState.userRequestState).toBe(userState);
     });
 
     it("parseRequestState returns user state without decoding", () => {
-        const requestState = ProtocolUtils.parseRequestState(cryptoInterface.base64Decode, `${encodedLibState}${RESOURCE_DELIM}${"test%25u00f1"}`, "");
+        const requestState = ProtocolUtils.parseRequestState(
+            cryptoInterface.base64Decode,
+            `${encodedLibState}${RESOURCE_DELIM}${"test%25u00f1"}`,
+            ""
+        );
         expect(requestState.userRequestState).toBe(`${"test%25u00f1"}`);
     });
 });

--- a/lib/msal-node/src/client/ClientAssertion.ts
+++ b/lib/msal-node/src/client/ClientAssertion.ts
@@ -116,7 +116,10 @@ export class ClientAssertion {
             return this.jwt;
         }
 
-        throw createClientAuthError(NodeClientAuthErrorCodes.invalidAssertion, "");
+        throw createClientAuthError(
+            NodeClientAuthErrorCodes.invalidAssertion,
+            ""
+        );
     }
 
     /**

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -231,7 +231,10 @@ export class ClientCredentialClient extends BaseClient {
         if (accessTokens.length < 1) {
             return null;
         } else if (accessTokens.length > 1) {
-            throw createClientAuthError(ClientAuthErrorCodes.multipleMatchingTokens, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.multipleMatchingTokens,
+                ""
+            );
         }
         return accessTokens[0] as AccessTokenEntity;
     }

--- a/lib/msal-node/src/client/ConfidentialClientApplication.ts
+++ b/lib/msal-node/src/client/ConfidentialClientApplication.ts
@@ -89,7 +89,10 @@ export class ConfidentialClientApplication
             (clientAssertionNotEmpty && certificateNotEmpty) ||
             (clientSecretNotEmpty && certificateNotEmpty)
         ) {
-            throw createClientAuthError(NodeClientAuthErrorCodes.invalidClientCredential, "");
+            throw createClientAuthError(
+                NodeClientAuthErrorCodes.invalidClientCredential,
+                ""
+            );
         }
 
         if (this.config.auth.clientSecret) {
@@ -104,7 +107,10 @@ export class ConfidentialClientApplication
         }
 
         if (!certificateNotEmpty) {
-            throw createClientAuthError(NodeClientAuthErrorCodes.invalidClientCredential, "");
+            throw createClientAuthError(
+                NodeClientAuthErrorCodes.invalidClientCredential,
+                ""
+            );
         } else {
             this.clientAssertion = !!this.config.auth.clientCertificate
                 .thumbprintSha256
@@ -185,7 +191,10 @@ export class ConfidentialClientApplication
                 tenantId as Constants.AADAuthority
             )
         ) {
-            throw createClientAuthError(NodeClientAuthErrorCodes.missingTenantIdError, "");
+            throw createClientAuthError(
+                NodeClientAuthErrorCodes.missingTenantIdError,
+                ""
+            );
         }
 
         /*

--- a/lib/msal-node/src/client/ManagedIdentityApplication.ts
+++ b/lib/msal-node/src/client/ManagedIdentityApplication.ts
@@ -134,7 +134,10 @@ export class ManagedIdentityApplication {
         managedIdentityRequestParams: ManagedIdentityRequestParams
     ): Promise<AuthenticationResult> {
         if (!managedIdentityRequestParams.resource) {
-            throw createClientConfigurationError(ClientConfigurationErrorCodes.urlEmptyError, "");
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.urlEmptyError,
+                ""
+            );
         }
 
         const managedIdentityRequest: ManagedIdentityRequest = {

--- a/lib/msal-node/src/client/ManagedIdentityClient.ts
+++ b/lib/msal-node/src/client/ManagedIdentityClient.ts
@@ -180,7 +180,10 @@ export class ManagedIdentityClient {
                 disableInternalRetries
             );
         if (!source) {
-            throw createManagedIdentityError(ManagedIdentityErrorCodes.unableToCreateSource, "");
+            throw createManagedIdentityError(
+                ManagedIdentityErrorCodes.unableToCreateSource,
+                ""
+            );
         }
         return source;
     }

--- a/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
@@ -226,7 +226,10 @@ export class AzureArc extends BaseManagedIdentitySource {
         if (
             managedIdentityId.idType !== ManagedIdentityIdType.SYSTEM_ASSIGNED
         ) {
-            throw createManagedIdentityError(ManagedIdentityErrorCodes.unableToCreateAzureArc, "");
+            throw createManagedIdentityError(
+                ManagedIdentityErrorCodes.unableToCreateAzureArc,
+                ""
+            );
         }
 
         return new AzureArc(
@@ -307,10 +310,16 @@ export class AzureArc extends BaseManagedIdentitySource {
             const wwwAuthHeader: string =
                 originalResponse.headers["www-authenticate"];
             if (!wwwAuthHeader) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.wwwAuthenticateHeaderMissing, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.wwwAuthenticateHeaderMissing,
+                    ""
+                );
             }
             if (!wwwAuthHeader.includes("Basic realm=")) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.wwwAuthenticateHeaderUnsupportedFormat, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.wwwAuthenticateHeaderUnsupportedFormat,
+                    ""
+                );
             }
 
             const secretFilePath = wwwAuthHeader.split("Basic realm=")[1];
@@ -319,7 +328,10 @@ export class AzureArc extends BaseManagedIdentitySource {
             if (
                 !SUPPORTED_AZURE_ARC_PLATFORMS.hasOwnProperty(process.platform)
             ) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.platformNotSupported, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.platformNotSupported,
+                    ""
+                );
             }
 
             // get the expected Windows or Linux file path
@@ -331,7 +343,10 @@ export class AzureArc extends BaseManagedIdentitySource {
             // throw an error if the file in the file path is not a .key file
             const fileName: string = path.basename(secretFilePath);
             if (!fileName.endsWith(".key")) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.invalidFileExtension, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidFileExtension,
+                    ""
+                );
             }
 
             /*
@@ -340,7 +355,10 @@ export class AzureArc extends BaseManagedIdentitySource {
              * is running on
              */
             if (expectedSecretFilePath + fileName !== secretFilePath) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.invalidFilePath, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidFilePath,
+                    ""
+                );
             }
 
             let secretFileSize;
@@ -348,11 +366,17 @@ export class AzureArc extends BaseManagedIdentitySource {
             try {
                 secretFileSize = await statSync(secretFilePath).size;
             } catch (e) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.unableToReadSecretFile, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.unableToReadSecretFile,
+                    ""
+                );
             }
             // throw an error if the secret file's size is greater than 4096 bytes
             if (secretFileSize > AZURE_ARC_SECRET_FILE_MAX_SIZE_BYTES) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.invalidSecret, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidSecret,
+                    ""
+                );
             }
 
             // attempt to read the contents of the secret file
@@ -363,7 +387,10 @@ export class AzureArc extends BaseManagedIdentitySource {
                     Constants.EncodingTypes.UTF8
                 );
             } catch (e) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.unableToReadSecretFile, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.unableToReadSecretFile,
+                    ""
+                );
             }
             const authHeaderValue = `Basic ${secret}`;
 
@@ -385,7 +412,10 @@ export class AzureArc extends BaseManagedIdentitySource {
                 if (error instanceof AuthError) {
                     throw error;
                 } else {
-                    throw createClientAuthError(ClientAuthErrorCodes.networkError, "");
+                    throw createClientAuthError(
+                        ClientAuthErrorCodes.networkError,
+                        ""
+                    );
                 }
             }
         }

--- a/lib/msal-node/src/client/ManagedIdentitySources/CloudShell.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/CloudShell.ts
@@ -132,7 +132,10 @@ export class CloudShell extends BaseManagedIdentitySource {
         if (
             managedIdentityId.idType !== ManagedIdentityIdType.SYSTEM_ASSIGNED
         ) {
-            throw createManagedIdentityError(ManagedIdentityErrorCodes.unableToCreateCloudShell, "");
+            throw createManagedIdentityError(
+                ManagedIdentityErrorCodes.unableToCreateCloudShell,
+                ""
+            );
         }
 
         return new CloudShell(

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -104,7 +104,10 @@ export class OnBehalfOfClient extends BaseClient {
                 "SilentFlowClient:acquireCachedToken - No access token found in cache for the given properties.",
                 request.correlationId
             );
-            throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.tokenRefreshRequired,
+                ""
+            );
         } else if (
             TimeUtils.isTokenExpired(
                 cachedAccessToken.expiresOn,
@@ -119,7 +122,10 @@ export class OnBehalfOfClient extends BaseClient {
                 `OnbehalfofFlow:getCachedAuthenticationResult - Cached access token is expired or will expire within ${this.config.systemOptions.tokenRenewalOffsetSeconds} seconds.`,
                 request.correlationId
             );
-            throw createClientAuthError(ClientAuthErrorCodes.tokenRefreshRequired, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.tokenRefreshRequired,
+                ""
+            );
         }
 
         // fetch the idToken from cache
@@ -240,7 +246,10 @@ export class OnBehalfOfClient extends BaseClient {
         if (numAccessTokens < 1) {
             return null;
         } else if (numAccessTokens > 1) {
-            throw createClientAuthError(ClientAuthErrorCodes.multipleMatchingTokens, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.multipleMatchingTokens,
+                ""
+            );
         }
 
         return accessTokens[0] as AccessTokenEntity;

--- a/lib/msal-node/src/config/ManagedIdentityId.ts
+++ b/lib/msal-node/src/config/ManagedIdentityId.ts
@@ -40,21 +40,30 @@ export class ManagedIdentityId {
 
         if (userAssignedClientId) {
             if (userAssignedResourceId || userAssignedObjectId) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.invalidManagedIdentityIdType, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidManagedIdentityIdType,
+                    ""
+                );
             }
 
             this.id = userAssignedClientId;
             this.idType = ManagedIdentityIdType.USER_ASSIGNED_CLIENT_ID;
         } else if (userAssignedResourceId) {
             if (userAssignedClientId || userAssignedObjectId) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.invalidManagedIdentityIdType, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidManagedIdentityIdType,
+                    ""
+                );
             }
 
             this.id = userAssignedResourceId;
             this.idType = ManagedIdentityIdType.USER_ASSIGNED_RESOURCE_ID;
         } else if (userAssignedObjectId) {
             if (userAssignedClientId || userAssignedResourceId) {
-                throw createManagedIdentityError(ManagedIdentityErrorCodes.invalidManagedIdentityIdType, "");
+                throw createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidManagedIdentityIdType,
+                    ""
+                );
             }
 
             this.id = userAssignedObjectId;

--- a/lib/msal-node/test/cache/cache-test-files/default-cache.json
+++ b/lib/msal-node/test/cache/cache-test-files/default-cache.json
@@ -1,1 +1,87 @@
-{"Account":{"uid.utid-login.microsoftonline.com-microsoft":{"username":"John Doe","local_account_id":"object1234","realm":"microsoft","environment":"login.microsoftonline.com","home_account_id":"uid.utid","authority_type":"MSSTS","client_info":"eyJ1aWQiOiJ1aWQiLCAidXRpZCI6InV0aWQifQ=="}},"RefreshToken":{"uid.utid-login.microsoftonline.com-refreshtoken-mock_client_id----":{"environment":"login.microsoftonline.com","credential_type":"RefreshToken","secret":"a refresh token","client_id":"mock_client_id","home_account_id":"uid.utid"},"uid.utid-login.microsoftonline.com-refreshtoken-1----":{"environment":"login.microsoftonline.com","credential_type":"RefreshToken","secret":"a refresh token","client_id":"mock_client_id","home_account_id":"uid.utid","family_id":"1"}},"AccessToken":{"uid.utid-login.microsoftonline.com-accesstoken-mock_client_id-microsoft-scope1 scope2 scope3--":{"environment":"login.microsoftonline.com","credential_type":"AccessToken","secret":"an access token","realm":"microsoft","target":"scope1 scope2 scope3","client_id":"mock_client_id","cached_at":"1000","home_account_id":"uid.utid","extended_expires_on":"4600","expires_on":"4600"},"uid.utid-login.microsoftonline.com-accesstoken-mock_client_id-microsoft-scope4 scope5--":{"environment":"login.microsoftonline.com","credential_type":"AccessToken","secret":"an access token","realm":"microsoft","target":"scope4 scope5","client_id":"mock_client_id","cached_at":"1000","home_account_id":"uid.utid","extended_expires_on":"4600","expires_on":"4600"},"uid.utid-login.microsoftonline.com-accesstoken_with_authscheme-mock_client_id-microsoft-scope4 scope5--pop":{"environment":"login.microsoftonline.com","credential_type":"AccessToken_With_AuthScheme","secret":"a POP-protected access token","realm":"microsoft","target":"scope4 scope5","client_id":"mock_client_id","cached_at":"1000","home_account_id":"uid.utid","extended_expires_on":"4600","expires_on":"4600","keyId":"NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs","tokenType":"pop"}},"IdToken":{"uid.utid-login.microsoftonline.com-idtoken-mock_client_id-microsoft---":{"realm":"microsoft","environment":"login.microsoftonline.com","credential_type":"IdToken","secret":"header.eyJvaWQiOiAib2JqZWN0MTIzNCIsICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiSm9obiBEb2UiLCAic3ViIjogInN1YiJ9.signature","client_id":"mock_client_id","home_account_id":"uid.utid"}},"AppMetadata":{"appmetadata-login.microsoftonline.com-mock_client_id":{"environment":"login.microsoftonline.com","family_id":"1","client_id":"mock_client_id"}}}
+{
+    "Account": {
+        "uid.utid-login.microsoftonline.com-microsoft": {
+            "username": "John Doe",
+            "local_account_id": "object1234",
+            "realm": "microsoft",
+            "environment": "login.microsoftonline.com",
+            "home_account_id": "uid.utid",
+            "authority_type": "MSSTS",
+            "client_info": "eyJ1aWQiOiJ1aWQiLCAidXRpZCI6InV0aWQifQ=="
+        }
+    },
+    "RefreshToken": {
+        "uid.utid-login.microsoftonline.com-refreshtoken-mock_client_id----": {
+            "environment": "login.microsoftonline.com",
+            "credential_type": "RefreshToken",
+            "secret": "a refresh token",
+            "client_id": "mock_client_id",
+            "home_account_id": "uid.utid"
+        },
+        "uid.utid-login.microsoftonline.com-refreshtoken-1----": {
+            "environment": "login.microsoftonline.com",
+            "credential_type": "RefreshToken",
+            "secret": "a refresh token",
+            "client_id": "mock_client_id",
+            "home_account_id": "uid.utid",
+            "family_id": "1"
+        }
+    },
+    "AccessToken": {
+        "uid.utid-login.microsoftonline.com-accesstoken-mock_client_id-microsoft-scope1 scope2 scope3--": {
+            "environment": "login.microsoftonline.com",
+            "credential_type": "AccessToken",
+            "secret": "an access token",
+            "realm": "microsoft",
+            "target": "scope1 scope2 scope3",
+            "client_id": "mock_client_id",
+            "cached_at": "1000",
+            "home_account_id": "uid.utid",
+            "extended_expires_on": "4600",
+            "expires_on": "4600"
+        },
+        "uid.utid-login.microsoftonline.com-accesstoken-mock_client_id-microsoft-scope4 scope5--": {
+            "environment": "login.microsoftonline.com",
+            "credential_type": "AccessToken",
+            "secret": "an access token",
+            "realm": "microsoft",
+            "target": "scope4 scope5",
+            "client_id": "mock_client_id",
+            "cached_at": "1000",
+            "home_account_id": "uid.utid",
+            "extended_expires_on": "4600",
+            "expires_on": "4600"
+        },
+        "uid.utid-login.microsoftonline.com-accesstoken_with_authscheme-mock_client_id-microsoft-scope4 scope5--pop": {
+            "environment": "login.microsoftonline.com",
+            "credential_type": "AccessToken_With_AuthScheme",
+            "secret": "a POP-protected access token",
+            "realm": "microsoft",
+            "target": "scope4 scope5",
+            "client_id": "mock_client_id",
+            "cached_at": "1000",
+            "home_account_id": "uid.utid",
+            "extended_expires_on": "4600",
+            "expires_on": "4600",
+            "keyId": "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+            "tokenType": "pop"
+        }
+    },
+    "IdToken": {
+        "uid.utid-login.microsoftonline.com-idtoken-mock_client_id-microsoft---": {
+            "realm": "microsoft",
+            "environment": "login.microsoftonline.com",
+            "credential_type": "IdToken",
+            "secret": "header.eyJvaWQiOiAib2JqZWN0MTIzNCIsICJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiSm9obiBEb2UiLCAic3ViIjogInN1YiJ9.signature",
+            "client_id": "mock_client_id",
+            "home_account_id": "uid.utid"
+        }
+    },
+    "AppMetadata": {
+        "appmetadata-login.microsoftonline.com-mock_client_id": {
+            "environment": "login.microsoftonline.com",
+            "family_id": "1",
+            "client_id": "mock_client_id"
+        }
+    }
+}

--- a/lib/msal-node/test/client/ClientCredentialClient.spec.ts
+++ b/lib/msal-node/test/client/ClientCredentialClient.spec.ts
@@ -678,6 +678,7 @@ describe("ClientCredentialClient unit tests", () => {
                 Date.now() + 60 * 30 * 1000,
                 Date.now() + 60 * 30 * 1000,
                 mockCrypto.base64Decode,
+                "",
                 undefined,
                 Constants.AuthenticationScheme.BEARER
             );
@@ -725,6 +726,7 @@ describe("ClientCredentialClient unit tests", () => {
                 TimeUtils.nowSeconds() + 4600,
                 TimeUtils.nowSeconds() + 4600,
                 mockCrypto.base64Decode,
+                "",
                 TimeUtils.nowSeconds() - 4600, // expired refreshOn value
                 Constants.AuthenticationScheme.BEARER
             );
@@ -880,6 +882,7 @@ describe("ClientCredentialClient unit tests", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 undefined,
                 Constants.AuthenticationScheme.BEARER,
                 TEST_TOKENS.ACCESS_TOKEN
@@ -896,6 +899,7 @@ describe("ClientCredentialClient unit tests", () => {
                 4600,
                 4600,
                 mockCrypto.base64Decode,
+                "",
                 undefined,
                 Constants.AuthenticationScheme.BEARER,
                 TEST_TOKENS.ACCESS_TOKEN

--- a/lib/msal-node/test/client/ClientTestUtils.ts
+++ b/lib/msal-node/test/client/ClientTestUtils.ts
@@ -331,7 +331,10 @@ export class ClientTestUtils {
         );
 
         await authority.resolveEndpointsAsync().catch(() => {
-            throw createClientAuthError(ClientAuthErrorCodes.endpointResolutionError, "");
+            throw createClientAuthError(
+                ClientAuthErrorCodes.endpointResolutionError,
+                ""
+            );
         });
 
         const clientConfig: ClientConfiguration = {

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -254,7 +254,10 @@ describe("ConfidentialClientApplication", () => {
             new ConfidentialClientApplication(config);
 
         await expect(client.acquireTokenSilent(request)).rejects.toMatchObject(
-            createInteractionRequiredAuthError(InteractionRequiredAuthErrorCodes.noTokensFound, "")
+            createInteractionRequiredAuthError(
+                InteractionRequiredAuthErrorCodes.noTokensFound,
+                ""
+            )
         );
         expect(acquireTokenSilentSpy).toHaveBeenCalledTimes(1);
     });
@@ -492,7 +495,10 @@ describe("ConfidentialClientApplication", () => {
             await expect(
                 client.acquireTokenByClientCredential(request)
             ).rejects.toMatchObject(
-                createClientAuthError(NodeClientAuthErrorCodes.missingTenantIdError, "")
+                createClientAuthError(
+                    NodeClientAuthErrorCodes.missingTenantIdError,
+                    ""
+                )
             );
         });
 

--- a/lib/msal-node/test/client/ManagedIdentitySources/AzureArc.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/AzureArc.spec.ts
@@ -274,7 +274,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.unableToCreateAzureArc, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.unableToCreateAzureArc,
+                    ""
+                )
             );
         });
 
@@ -300,7 +303,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.invalidFileExtension, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidFileExtension,
+                    ""
+                )
             );
         });
 
@@ -321,7 +327,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.platformNotSupported, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.platformNotSupported,
+                    ""
+                )
             );
 
             Object.defineProperty(process, "platform", {
@@ -351,7 +360,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.invalidFilePath, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidFilePath,
+                    ""
+                )
             );
         });
 
@@ -372,7 +384,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.invalidSecret, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidSecret,
+                    ""
+                )
             );
         });
 
@@ -396,7 +411,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.wwwAuthenticateHeaderMissing, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.wwwAuthenticateHeaderMissing,
+                    ""
+                )
             );
         });
 
@@ -422,7 +440,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.wwwAuthenticateHeaderUnsupportedFormat, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.wwwAuthenticateHeaderUnsupportedFormat,
+                    ""
+                )
             );
         });
 
@@ -443,7 +464,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.unableToReadSecretFile, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.unableToReadSecretFile,
+                    ""
+                )
             );
 
             jest.spyOn(networkClient, <any>"sendGetRequestAsync")
@@ -466,7 +490,10 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.unableToReadSecretFile, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.unableToReadSecretFile,
+                    ""
+                )
             );
         });
 

--- a/lib/msal-node/test/client/ManagedIdentitySources/CloudShell.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/CloudShell.spec.ts
@@ -110,7 +110,10 @@ describe("Acquires a token successfully via an App Service Managed Identity", ()
                     managedIdentityRequestParams
                 )
             ).rejects.toMatchObject(
-                createManagedIdentityError(ManagedIdentityErrorCodes.unableToCreateCloudShell, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.unableToCreateCloudShell,
+                    ""
+                )
             );
         });
 

--- a/lib/msal-node/test/client/ManagedIdentitySources/Imds.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/Imds.spec.ts
@@ -814,7 +814,8 @@ describe("Acquires a token successfully via an IMDS Managed Identity", () => {
                     [MANAGED_IDENTITY_RESOURCE_BASE].toString(), // scopes
                     nowSeconds + 3600, // expiresOn
                     nowSeconds + 3600, // extExpiresOn
-                    mockCrypto.base64Decode, "", // cryptoUtils
+                    mockCrypto.base64Decode,
+                    "", // cryptoUtils
                     expiredRefreshOn // refreshOn
                 );
             jest.spyOn(
@@ -1049,7 +1050,10 @@ describe("Acquires a token successfully via an IMDS Managed Identity", () => {
                     resource: "",
                 })
             ).rejects.toMatchObject(
-                createClientConfigurationError(ClientConfigurationErrorCodes.urlEmptyError, "")
+                createClientConfigurationError(
+                    ClientConfigurationErrorCodes.urlEmptyError,
+                    ""
+                )
             );
         });
 
@@ -1068,7 +1072,10 @@ describe("Acquires a token successfully via an IMDS Managed Identity", () => {
             expect(() => {
                 new ManagedIdentityApplication(badUserAssignedClientIdConfig);
             }).toThrow(
-                createManagedIdentityError(ManagedIdentityErrorCodes.invalidManagedIdentityIdType, "")
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidManagedIdentityIdType,
+                    ""
+                )
             );
         });
 

--- a/lib/msal-node/test/client/ManagedIdentitySources/Imds.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/Imds.spec.ts
@@ -814,7 +814,7 @@ describe("Acquires a token successfully via an IMDS Managed Identity", () => {
                     [MANAGED_IDENTITY_RESOURCE_BASE].toString(), // scopes
                     nowSeconds + 3600, // expiresOn
                     nowSeconds + 3600, // extExpiresOn
-                    mockCrypto.base64Decode, // cryptoUtils
+                    mockCrypto.base64Decode, "", // cryptoUtils
                     expiredRefreshOn // refreshOn
                 );
             jest.spyOn(

--- a/lib/msal-node/test/client/PublicClientApplication.spec.ts
+++ b/lib/msal-node/test/client/PublicClientApplication.spec.ts
@@ -399,7 +399,10 @@ describe("PublicClientApplication", () => {
                 account: mockNativeAccountInfo,
             };
 
-            const testError = new InteractionRequiredAuthError("interaction_required", "");
+            const testError = new InteractionRequiredAuthError(
+                "interaction_required",
+                ""
+            );
             const brokerSpy = jest
                 .spyOn(MockNativeBrokerPlugin.prototype, "acquireTokenSilent")
                 .mockImplementation(() => {
@@ -951,7 +954,10 @@ describe("PublicClientApplication", () => {
                 openBrowser,
             };
 
-            const testError = createClientAuthError(ClientAuthErrorCodes.userCanceled, "");
+            const testError = createClientAuthError(
+                ClientAuthErrorCodes.userCanceled,
+                ""
+            );
             const brokerSpy = jest
                 .spyOn(
                     MockNativeBrokerPlugin.prototype,
@@ -1250,7 +1256,10 @@ describe("PublicClientApplication", () => {
             const request: SignOutRequest = {
                 account: mockNativeAccountInfo,
             };
-            const testError = createClientAuthError(ClientAuthErrorCodes.noAccountFound, "");
+            const testError = createClientAuthError(
+                ClientAuthErrorCodes.noAccountFound,
+                ""
+            );
             const brokerSpy = jest
                 .spyOn(MockNativeBrokerPlugin.prototype, "signOut")
                 .mockImplementation(() => {
@@ -1318,7 +1327,10 @@ describe("PublicClientApplication", () => {
                 },
             });
 
-            const testError = createClientAuthError(ClientAuthErrorCodes.noAccountFound, "");
+            const testError = createClientAuthError(
+                ClientAuthErrorCodes.noAccountFound,
+                ""
+            );
             const brokerSpy = jest
                 .spyOn(MockNativeBrokerPlugin.prototype, "getAllAccounts")
                 .mockImplementation(() => {

--- a/lib/msal-node/test/utils/TestConstants.ts
+++ b/lib/msal-node/test/utils/TestConstants.ts
@@ -100,34 +100,64 @@ export const AUTHENTICATION_RESULT = {
 
 export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
     createNewGuid: (): string => {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     base64Decode: (): string => {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     base64Encode: (): string => {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async getPublicKeyThumbprint(): Promise<string> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async removeTokenBindingKey(): Promise<void> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async clearKeystore(): Promise<boolean> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async signJwt(): Promise<string> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     async hashString(): Promise<string> {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     base64UrlEncode: function (): string {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
     encodeKid: function (): string {
-        throw createClientAuthError(ClientAuthErrorCodes.methodNotImplemented, "");
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            ""
+        );
     },
 };
 

--- a/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
+++ b/lib/msal-react/test/components/MsalAuthenticationTemplate.spec.tsx
@@ -650,7 +650,11 @@ describe("MsalAuthenticationTemplate tests", () => {
                     expect(request).toBeDefined();
                     expect(request.account).toBe(testAccount);
                     return Promise.reject(
-                        new InteractionRequiredAuthError("interaction_required", "", "Interaction is required")
+                        new InteractionRequiredAuthError(
+                            "interaction_required",
+                            "",
+                            "Interaction is required"
+                        )
                     );
                 });
 
@@ -700,7 +704,11 @@ describe("MsalAuthenticationTemplate tests", () => {
                     expect(request).toBeDefined();
                     expect(request.account).toBe(testAccount);
                     return Promise.reject(
-                        new InteractionRequiredAuthError("interaction_required", "", "Interaction is required")
+                        new InteractionRequiredAuthError(
+                            "interaction_required",
+                            "",
+                            "Interaction is required"
+                        )
                     );
                 });
 
@@ -749,7 +757,11 @@ describe("MsalAuthenticationTemplate tests", () => {
                     expect(request).toBeDefined();
                     expect(request.account).toBe(testAccount);
                     return Promise.reject(
-                        new InteractionRequiredAuthError("interaction_required", "", "Interaction is required")
+                        new InteractionRequiredAuthError(
+                            "interaction_required",
+                            "",
+                            "Interaction is required"
+                        )
                     );
                 });
 
@@ -849,7 +861,11 @@ describe("MsalAuthenticationTemplate tests", () => {
                     });
 
                     return Promise.reject(
-                        new InteractionRequiredAuthError("interaction_required", "", "Interaction is required")
+                        new InteractionRequiredAuthError(
+                            "interaction_required",
+                            "",
+                            "Interaction is required"
+                        )
                     );
                 });
 


### PR DESCRIPTION
## Summary

**Stacked on #8616 (which is stacked on #8609).** Adds `correlationId` as a required parameter to two public cache helpers in `msal-common`.

## Breaking changes

### `CacheHelpers.createAccessTokenEntity`
New required `correlationId: string` parameter inserted at position 9 (after `base64Decode`, before optional `refreshOn?`):

```ts
// Before
createAccessTokenEntity(homeAccountId, environment, accessToken, clientId, tenantId, scopes,
                        expiresOn, extExpiresOn, base64Decode,
                        refreshOn?, tokenType?, userAssertionHash?, keyId?)

// After
createAccessTokenEntity(homeAccountId, environment, accessToken, clientId, tenantId, scopes,
                        expiresOn, extExpiresOn, base64Decode,
                        correlationId,                            // NEW (required)
                        refreshOn?, tokenType?, userAssertionHash?, keyId?)
```

### `AccountEntityUtils.createAccountEntity`
New required `correlationId: string` parameter inserted at position 2 (after `authority`, before optional `base64Decode?`):

```ts
// Before
createAccountEntity(accountDetails, authority, base64Decode?)

// After
createAccountEntity(accountDetails, authority, correlationId, base64Decode?)
```

Both functions throw `ClientAuthError` on cache validation failures (`tokenClaimsCnfRequiredForSignedJwt`, `invalidCacheEnvironment`); those throws now carry the caller's `correlationId`.

## Affected packages

- `msal-common`: signature change + `ResponseHandler` callers updated
- `msal-browser`: 4 callers updated (`TokenCache`, `StandardController`, `BrowserCacheManager`, `PlatformAuthInteractionClient`)
- `msal-node`: no source changes; test updates only

## Tests

- `msal-common`: 1004 passing
- `msal-browser`: 1655 passing
- `msal-node`: 317 passing

## Change files

`msal-common`, `msal-browser`: **major** (public API break).

## Migration

External consumers calling these helpers directly must supply `correlationId`. Pass the request's correlation ID (or `""` if unavailable).

## Not included (deferred to follow-up PR)

- `buildClientInfo` / `buildClientInfoFromHomeAccountId` — most call sites swallow the throw in try/catch
- `ScopeSet`, `UrlString`, `extractTokenClaims`, `AuthenticationHeaderParser` — wider cascades, separate PR
