### PR TITLE
Fix silent iframe redirect-bridge listener race condition

### DIFF
--- a/change/@azure-msal-browser-02bc7ddf-e1ea-44d6-b765-6de99c055979.json
+++ b/change/@azure-msal-browser-02bc7ddf-e1ea-44d6-b765-6de99c055979.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix silent iframe redirect-bridge listener race condition by registering the response listener before navigating the iframe [#8636](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8636)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -37,6 +37,7 @@ import {
     BrowserConstants,
 } from "../utils/BrowserConstants.js";
 import {
+    createHiddenIframe,
     initiateCodeRequest,
     initiateCodeFlowWithPost,
     initiateEarRequest,
@@ -309,30 +310,37 @@ export class SilentIframeClient extends StandardInteractionClient {
             earJwk: earJwk,
             codeChallenge: pkceCodes.challenge,
         };
-        const iframe = await invokeAsync(
-            initiateEarRequest,
-            BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
-            this.logger,
-            this.performanceClient,
-            correlationId
-        )(
-            this.config,
-            discoveredAuthority,
-            silentRequest,
-            this.logger,
-            this.performanceClient
-        );
+
+        // Create the iframe, register the response listener, then navigate, so the listener is active before the iframe can respond.
+        const iframe = createHiddenIframe();
 
         const responseType = this.config.auth.OIDCOptions.responseMode;
         let responseString: string;
         try {
-            responseString = await invokeAsync(
+            const responsePromise = invokeAsync(
                 this.waitForIframeResponse.bind(this),
                 BrowserPerformanceEvents.SilentHandlerMonitorIframeForHash,
                 this.logger,
                 this.performanceClient,
                 correlationId
             )(iframe, request);
+
+            await invokeAsync(
+                initiateEarRequest,
+                BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
+                this.logger,
+                this.performanceClient,
+                correlationId
+            )(
+                iframe,
+                this.config,
+                discoveredAuthority,
+                silentRequest,
+                this.logger,
+                this.performanceClient
+            );
+
+            responseString = await responsePromise;
         } finally {
             invoke(
                 removeHiddenIframe,
@@ -577,58 +585,63 @@ export class SilentIframeClient extends StandardInteractionClient {
             codeChallenge: pkceCodes.challenge,
         };
 
-        let iframe: HTMLIFrameElement;
-        if (request.httpMethod === Constants.HttpMethod.POST) {
-            iframe = await invokeAsync(
-                initiateCodeFlowWithPost,
-                BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
-                this.logger,
-                this.performanceClient,
-                correlationId
-            )(
-                this.config,
-                authClient.authority,
-                silentRequest,
-                this.logger,
-                this.performanceClient
-            );
-        } else {
-            // Create authorize request url
-            const navigateUrl = await invokeAsync(
-                Authorize.getAuthCodeRequestUrl,
-                PerformanceEvents.GetAuthCodeUrl,
-                this.logger,
-                this.performanceClient,
-                correlationId
-            )(
-                this.config,
-                authClient.authority,
-                silentRequest,
-                this.logger,
-                this.performanceClient
-            );
-
-            // Get the frame handle for the silent request
-            iframe = await invokeAsync(
-                initiateCodeRequest,
-                BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
-                this.logger,
-                this.performanceClient,
-                correlationId
-            )(navigateUrl, this.performanceClient, this.logger, correlationId);
-        }
+        // Create the iframe, register the response listener, then navigate, so the listener is active before the iframe can respond.
+        const iframe = createHiddenIframe();
 
         const responseType = this.config.auth.OIDCOptions.responseMode;
         // Wait for response from the redirect bridge.
         let responseString: string;
         try {
-            responseString = await invokeAsync(
+            const responsePromise = invokeAsync(
                 this.waitForIframeResponse.bind(this),
                 BrowserPerformanceEvents.SilentHandlerMonitorIframeForHash,
                 this.logger,
                 this.performanceClient,
                 correlationId
             )(iframe, request);
+
+            if (request.httpMethod === Constants.HttpMethod.POST) {
+                await invokeAsync(
+                    initiateCodeFlowWithPost,
+                    BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
+                    this.logger,
+                    this.performanceClient,
+                    correlationId
+                )(
+                    iframe,
+                    this.config,
+                    authClient.authority,
+                    silentRequest,
+                    this.logger,
+                    this.performanceClient
+                );
+            } else {
+                // Create authorize request url
+                const navigateUrl = await invokeAsync(
+                    Authorize.getAuthCodeRequestUrl,
+                    PerformanceEvents.GetAuthCodeUrl,
+                    this.logger,
+                    this.performanceClient,
+                    correlationId
+                )(
+                    this.config,
+                    authClient.authority,
+                    silentRequest,
+                    this.logger,
+                    this.performanceClient
+                );
+
+                // Navigate the iframe to the authorize request url
+                await invokeAsync(
+                    initiateCodeRequest,
+                    BrowserPerformanceEvents.SilentHandlerInitiateAuthRequest,
+                    this.logger,
+                    this.performanceClient,
+                    correlationId
+                )(iframe, navigateUrl, this.logger, correlationId);
+            }
+
+            responseString = await responsePromise;
         } finally {
             invoke(
                 removeHiddenIframe,

--- a/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
+++ b/lib/msal-browser/src/interaction_client/SilentIframeClient.ts
@@ -324,6 +324,14 @@ export class SilentIframeClient extends StandardInteractionClient {
                 this.performanceClient,
                 correlationId
             )(iframe, request);
+            responsePromise.catch(() => {
+                /*
+                 * If navigation below throws before responsePromise is awaited,
+                 * the listener still rejects on timeout. Swallow it here so it
+                 * does not surface as an unhandled rejection; the navigation
+                 * error is propagated instead.
+                 */
+            });
 
             await invokeAsync(
                 initiateEarRequest,
@@ -599,6 +607,15 @@ export class SilentIframeClient extends StandardInteractionClient {
                 this.performanceClient,
                 correlationId
             )(iframe, request);
+            responsePromise.catch(() => {
+                /*
+                 * If URL creation or navigation below throws before
+                 * responsePromise is awaited, the listener still rejects on
+                 * timeout. Swallow it here so it does not surface as an
+                 * unhandled rejection; the navigation error is propagated
+                 * instead.
+                 */
+            });
 
             if (request.httpMethod === Constants.HttpMethod.POST) {
                 await invokeAsync(

--- a/lib/msal-browser/src/interaction_handler/SilentHandler.ts
+++ b/lib/msal-browser/src/interaction_handler/SilentHandler.ts
@@ -6,11 +6,9 @@
 import {
     Logger,
     IPerformanceClient,
-    invoke,
     Authority,
     CommonAuthorizationUrlRequest,
 } from "@azure/msal-common/browser";
-import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
 import {
     createBrowserAuthError,
     BrowserAuthErrorCodes,
@@ -19,13 +17,13 @@ import { BrowserConfiguration } from "../config/Configuration.js";
 import { getCodeForm, getEARForm } from "../protocol/Authorize.js";
 
 /**
- * Creates a hidden iframe to given URL using user-requested scopes as an id.
- * @param urlNavigate
- * @param userRequestScopes
+ * Navigates the given hidden iframe to the provided URL.
+ * @param frame
+ * @param requestUrl
  */
 export async function initiateCodeRequest(
+    frame: HTMLIFrameElement,
     requestUrl: string,
-    performanceClient: IPerformanceClient,
     logger: Logger,
     correlationId: string
 ): Promise<HTMLIFrameElement> {
@@ -35,23 +33,18 @@ export async function initiateCodeRequest(
         throw createBrowserAuthError(BrowserAuthErrorCodes.emptyNavigateUri);
     }
 
-    return invoke(
-        loadFrameSync,
-        BrowserPerformanceEvents.SilentHandlerLoadFrameSync,
-        logger,
-        performanceClient,
-        correlationId
-    )(requestUrl);
+    frame.src = requestUrl;
+    return frame;
 }
 
 export async function initiateCodeFlowWithPost(
+    frame: HTMLIFrameElement,
     config: BrowserConfiguration,
     authority: Authority,
     request: CommonAuthorizationUrlRequest,
     logger: Logger,
     performanceClient: IPerformanceClient
 ): Promise<HTMLIFrameElement> {
-    const frame = createHiddenIframe();
     if (!frame.contentDocument) {
         throw "No document associated with iframe!";
     }
@@ -68,13 +61,13 @@ export async function initiateCodeFlowWithPost(
 }
 
 export async function initiateEarRequest(
+    frame: HTMLIFrameElement,
     config: BrowserConfiguration,
     authority: Authority,
     request: CommonAuthorizationUrlRequest,
     logger: Logger,
     performanceClient: IPerformanceClient
 ): Promise<HTMLIFrameElement> {
-    const frame = createHiddenIframe();
     if (!frame.contentDocument) {
         throw "No document associated with iframe!";
     }
@@ -92,25 +85,11 @@ export async function initiateEarRequest(
 
 /**
  * @hidden
- * Loads the iframe synchronously when the navigateTimeFrame is set to `0`
- * @param urlNavigate
- * @param frameName
- * @param logger
- */
-function loadFrameSync(urlNavigate: string): HTMLIFrameElement {
-    const frameHandle = createHiddenIframe();
-
-    frameHandle.src = urlNavigate;
-
-    return frameHandle;
-}
-
-/**
- * @hidden
- * Creates a new hidden iframe or gets an existing one for silent token renewal.
+ * Creates a new hidden iframe for silent token renewal. Callers navigate it
+ * (set `src` or submit a form) after registering the response listener.
  * @ignore
  */
-function createHiddenIframe(): HTMLIFrameElement {
+export function createHiddenIframe(): HTMLIFrameElement {
     const authFrame = document.createElement("iframe");
 
     authFrame.className = "msalSilentIframe";

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceEvents.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceEvents.ts
@@ -121,7 +121,6 @@ export const SilentHandlerInitiateAuthRequest =
 export const SilentHandlerMonitorIframeForHash =
     "silentHandlerMonitorIframeForHash";
 export const SilentHandlerLoadFrame = "silentHandlerLoadFrame";
-export const SilentHandlerLoadFrameSync = "silentHandlerLoadFrameSync";
 
 /**
  * Helper functions in StandardInteractionClient class (msal-browser)

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -1296,6 +1296,9 @@ describe("SilentIframeClient", () => {
             it("removes hidden iframe after successful token acquisition", async () => {
                 const iframe = document.createElement("iframe");
                 document.body.appendChild(iframe);
+                jest.spyOn(SilentHandler, "createHiddenIframe").mockReturnValue(
+                    iframe
+                );
                 jest.spyOn(
                     AuthorizeProtocol,
                     "getAuthCodeRequestUrl"
@@ -1322,6 +1325,9 @@ describe("SilentIframeClient", () => {
             it("removes hidden iframe even when waitForBridgeResponse rejects", async () => {
                 const iframe = document.createElement("iframe");
                 document.body.appendChild(iframe);
+                jest.spyOn(SilentHandler, "createHiddenIframe").mockReturnValue(
+                    iframe
+                );
                 jest.spyOn(ProtocolUtils, "setRequestState").mockReturnValue(
                     TEST_STATE_VALUES.TEST_STATE_SILENT
                 );
@@ -1369,6 +1375,169 @@ describe("SilentIframeClient", () => {
 
                 expect(removeIframeSpy).toHaveBeenCalledWith(iframe);
                 expect(document.body.contains(iframe)).toBe(false);
+            });
+        });
+
+        describe("redirect bridge listener race condition (regression)", () => {
+            /*
+             * Regression coverage for the silent-iframe redirect-bridge race.
+             *
+             * The hidden iframe must have its BroadcastChannel response listener
+             * registered BEFORE it is navigated. Otherwise a fast auth response
+             * can be broadcast before the listener exists and is missed, causing
+             * a spurious timeout.
+             *
+             * These tests drive the REAL waitForBridgeResponse (it is deliberately
+             * not mocked) and broadcast the response from inside the navigation
+             * spy - i.e. at the exact moment of navigation. Node's BroadcastChannel
+             * only delivers to channels that already exist when postMessage runs,
+             * so the flow resolves only if the listener was registered first
+             * (create -> listen -> navigate). If the order regresses back to
+             * create -> navigate -> listen, the broadcast is missed and the
+             * acquireToken call rejects with a bridge timeout, failing the test.
+             */
+            const testAuthResult = getTestAuthenticationResult();
+
+            // MSAL derives the bridge channel id from the request state; the
+            // mocked silent state (TEST_STATE_SILENT) encodes RANDOM_TEST_GUID.
+            const broadcastBridgeResponse = (payload: string): void => {
+                const channel = new BroadcastChannel(RANDOM_TEST_GUID);
+                channel.postMessage({ v: 1, payload });
+                channel.close();
+            };
+
+            // Short iframe timeout so a regression fails fast (reject) rather
+            // than hanging until the default bridge timeout.
+            const buildSilentClient = async (
+                system: object
+            ): Promise<SilentIframeClient> => {
+                const racePca = new PublicClientApplication({
+                    auth: { clientId: TEST_CONFIG.MSAL_CLIENT_ID },
+                    system,
+                });
+                await racePca.initialize();
+                const controller: any = (racePca as any).controller;
+                return new SilentIframeClient(
+                    controller.config,
+                    controller.browserStorage,
+                    controller.browserCrypto,
+                    controller.logger,
+                    controller.eventHandler,
+                    controller.navigationClient,
+                    ApiId.acquireTokenSilent_authCode,
+                    controller.performanceClient,
+                    controller.nativeInternalStorage,
+                    TEST_CONFIG.CORRELATION_ID
+                );
+            };
+
+            beforeEach(() => {
+                mockSetRequestState.mockReturnValue(
+                    TEST_STATE_VALUES.TEST_STATE_SILENT
+                );
+                jest.spyOn(
+                    PkceGenerator,
+                    "generatePkceCodes"
+                ).mockResolvedValue({
+                    challenge: TEST_CONFIG.TEST_CHALLENGE,
+                    verifier: TEST_CONFIG.TEST_VERIFIER,
+                });
+                jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                    RANDOM_TEST_GUID
+                );
+            });
+
+            it("catches a response broadcast at navigation time - GET auth code flow", async () => {
+                const raceClient = await buildSilentClient({
+                    iframeBridgeTimeout: 3000,
+                });
+                jest.spyOn(
+                    AuthorizeProtocol,
+                    "getAuthCodeRequestUrl"
+                ).mockResolvedValue(testNavUrl);
+                jest.spyOn(
+                    InteractionHandler.prototype,
+                    "handleCodeResponse"
+                ).mockResolvedValue(testAuthResult);
+                const initiateCodeRequestSpy = jest
+                    .spyOn(SilentHandler, "initiateCodeRequest")
+                    .mockImplementation(async (frame) => {
+                        broadcastBridgeResponse(
+                            TEST_HASHES.TEST_SUCCESS_CODE_HASH_SILENT
+                        );
+                        return frame;
+                    });
+
+                const result = await raceClient.acquireToken({
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    loginHint: "testLoginHint",
+                    httpMethod: Constants.HttpMethod.GET,
+                });
+
+                expect(initiateCodeRequestSpy).toHaveBeenCalled();
+                expect(result).toEqual(testAuthResult);
+            });
+
+            it("catches a response broadcast at navigation time - POST auth code flow", async () => {
+                const raceClient = await buildSilentClient({
+                    iframeBridgeTimeout: 3000,
+                });
+                jest.spyOn(
+                    InteractionHandler.prototype,
+                    "handleCodeResponse"
+                ).mockResolvedValue(testAuthResult);
+                const initiateCodeFlowWithPostSpy = jest
+                    .spyOn(SilentHandler, "initiateCodeFlowWithPost")
+                    .mockImplementation(async (frame) => {
+                        broadcastBridgeResponse(
+                            TEST_HASHES.TEST_SUCCESS_CODE_HASH_SILENT
+                        );
+                        return frame;
+                    });
+
+                const result = await raceClient.acquireToken({
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    loginHint: "testLoginHint",
+                    httpMethod: Constants.HttpMethod.POST,
+                });
+
+                expect(initiateCodeFlowWithPostSpy).toHaveBeenCalled();
+                expect(result).toEqual(testAuthResult);
+            });
+
+            it("catches a response broadcast at navigation time - EAR flow", async () => {
+                const raceClient = await buildSilentClient({
+                    protocolMode: ProtocolMode.EAR,
+                    iframeBridgeTimeout: 3000,
+                });
+                jest.spyOn(BrowserCrypto, "generateEarKey").mockResolvedValue(
+                    validEarJWK
+                );
+                /*
+                 * Broadcast a code response (rather than ear_jwe) so EAR falls
+                 * back to the auth-code path, letting us assert via a mocked
+                 * handleResponseCode without real EAR decryption.
+                 */
+                jest.spyOn(
+                    AuthorizeProtocol,
+                    "handleResponseCode"
+                ).mockResolvedValue(testAuthResult);
+                const initiateEarRequestSpy = jest
+                    .spyOn(SilentHandler, "initiateEarRequest")
+                    .mockImplementation(async (frame) => {
+                        broadcastBridgeResponse(
+                            `#code=validCode&state=${TEST_STATE_VALUES.TEST_STATE_SILENT}`
+                        );
+                        return frame;
+                    });
+
+                const result = await raceClient.acquireToken({
+                    redirectUri: TEST_URIS.TEST_REDIR_URI,
+                    loginHint: "testLoginHint",
+                });
+
+                expect(initiateEarRequestSpy).toHaveBeenCalled();
+                expect(result).toEqual(testAuthResult);
             });
         });
 

--- a/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/SilentIframeClient.spec.ts
@@ -1539,6 +1539,56 @@ describe("SilentIframeClient", () => {
                 expect(initiateEarRequestSpy).toHaveBeenCalled();
                 expect(result).toEqual(testAuthResult);
             });
+
+            it("propagates a navigation error without an unhandled rejection", async () => {
+                const raceClient = await buildSilentClient({
+                    iframeBridgeTimeout: 3000,
+                });
+                jest.spyOn(
+                    AuthorizeProtocol,
+                    "getAuthCodeRequestUrl"
+                ).mockResolvedValue(testNavUrl);
+                const navError = new Error("navigation failed");
+                jest.spyOn(
+                    SilentHandler,
+                    "initiateCodeRequest"
+                ).mockRejectedValue(navError);
+
+                /*
+                 * The response listener promise is created before navigation. If
+                 * navigation throws, that listener still rejects later (as it
+                 * would on a real bridge timeout) - it must not surface as an
+                 * unhandled rejection. Use a sentinel rejection so we can assert
+                 * specifically that THIS rejection was handled, while acquireToken
+                 * rejects with the navigation error.
+                 */
+                const listenerError = new Error("bridge-listener-sentinel");
+                jest.spyOn(
+                    BrowserUtils,
+                    "waitForBridgeResponse"
+                ).mockImplementation(() => Promise.reject(listenerError));
+
+                const unhandledReasons: unknown[] = [];
+                const onUnhandled = (reason: unknown): void => {
+                    unhandledReasons.push(reason);
+                };
+                process.on("unhandledRejection", onUnhandled);
+                try {
+                    await expect(
+                        raceClient.acquireToken({
+                            redirectUri: TEST_URIS.TEST_REDIR_URI,
+                            loginHint: "testLoginHint",
+                            httpMethod: Constants.HttpMethod.GET,
+                        })
+                    ).rejects.toBe(navError);
+
+                    // Flush macrotasks so any unhandled rejection would surface.
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                    expect(unhandledReasons).not.toContain(listenerError);
+                } finally {
+                    process.off("unhandledRejection", onUnhandled);
+                }
+            });
         });
 
         describe("storeInCache tests", () => {

--- a/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
+++ b/lib/msal-browser/test/interaction_handler/SilentHandler.spec.ts
@@ -52,8 +52,8 @@ describe("SilentHandler.ts Unit Tests", () => {
         it("throws error if requestUrl is empty", async () => {
             await expect(
                 SilentHandler.initiateCodeRequest(
+                    SilentHandler.createHiddenIframe(),
                     "",
-                    performanceClient,
                     browserRequestLogger,
                     RANDOM_TEST_GUID
                 )
@@ -62,35 +62,33 @@ describe("SilentHandler.ts Unit Tests", () => {
             );
         });
 
-        it("Creates a frame", async () => {
+        it("Navigates the provided frame to the request url", async () => {
+            const frame = SilentHandler.createHiddenIframe();
             const authFrame = await SilentHandler.initiateCodeRequest(
+                frame,
                 testNavUrl,
-                performanceClient,
                 browserRequestLogger,
                 RANDOM_TEST_GUID
             );
+            expect(authFrame).toBe(frame);
+        });
+    });
+
+    describe("createHiddenIframe()", () => {
+        it("Creates a frame", () => {
+            const authFrame = SilentHandler.createHiddenIframe();
             expect(authFrame instanceof HTMLIFrameElement).toBe(true);
         });
 
-        it("Sets the allow attribute for local network access on iframe", async () => {
-            const authFrame = await SilentHandler.initiateCodeRequest(
-                testNavUrl,
-                performanceClient,
-                browserRequestLogger,
-                RANDOM_TEST_GUID
-            );
+        it("Sets the allow attribute for local network access on iframe", () => {
+            const authFrame = SilentHandler.createHiddenIframe();
             expect(authFrame.getAttribute("allow")).toBe(
                 "local-network-access *"
             );
         });
 
-        it("Sets a title attribute on the iframe for accessibility", async () => {
-            const authFrame = await SilentHandler.initiateCodeRequest(
-                testNavUrl,
-                performanceClient,
-                browserRequestLogger,
-                RANDOM_TEST_GUID
-            );
+        it("Sets a title attribute on the iframe for accessibility", () => {
+            const authFrame = SilentHandler.createHiddenIframe();
             expect(authFrame.title).toBe("Microsoft Authentication");
         });
     });


### PR DESCRIPTION
## Summary

Fixes a race condition in the silent-iframe redirect-bridge flow. The hidden iframe was navigated **before** its `BroadcastChannel` response listener was registered. If the auth response completed and broadcast in that window, the message was missed and the request failed with a spurious `timed_out` error.

## Root cause

In `SilentIframeClient`, the iframe was created **and navigated** inside the `await`ed `initiate*` helper, and the listener (`waitForIframeResponse` → `waitForBridgeResponse`) was only registered on the next statement, after the `await` resumed. That `await` is an event-loop yield between navigation and listener registration — the exact window where a fast response can be lost.

The popup flows do **not** have this issue: their navigation (`window.open` / `form.submit()`) is followed synchronously by `waitForPopupResponse` with no `await` in between, so the listener is always registered in the same synchronous turn as navigation.

## Fix

Reorder the silent flows to **create the iframe → register the listener → navigate** (`create → listen → navigate`):

- `SilentHandler` `initiate*` helpers now navigate a caller-provided iframe instead of creating one. `createHiddenIframe` is exported so the client creates the iframe up front.
- The client registers `waitForIframeResponse` on the created iframe, then calls `initiate*` to navigate, then awaits the response promise.
- Removed the now-trivial `loadFrameSync` wrapper (inlined `frame.src`) and its unused `SilentHandlerLoadFrameSync` telemetry event.

No public API change (all affected functions are internal/`@hidden`). The `SilentHandlerInitiateAuthRequest` telemetry measurement is preserved.

## Tests

Added regression tests covering all three silent navigation seams (GET, POST, EAR). They drive the **real** `BroadcastChannel` bridge and broadcast the response **at navigation time** (from inside the navigation spy). Because Node's `BroadcastChannel` only delivers to channels that already exist, the flow resolves only if the listener was registered before navigation.

Verified the tests fail on the old order and pass on the new one:

| Order | Result |
|-------|--------|
| Fixed (`create → listen → navigate`) | 3 passed (~30–110 ms) |
| Buggy (`create → navigate → listen`) | 3 failed — `timed_out: redirect_bridge_timeout` (~3050 ms each) |

Full `msal-browser` suite passes; lint, format, and API Extractor are clean.
