### PR TITLE
Fix duplicate redirect flows clearing in-flight interaction state

### DIFF
--- a/change/@azure-msal-browser-5029e424-63f7-4e8a-8c02-d8e53d21daf1.json
+++ b/change/@azure-msal-browser-5029e424-63f7-4e8a-8c02-d8e53d21daf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix duplicate redirect flows clearing in-flight interaction state [#8637](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8637)",
+  "packageName": "@azure/msal-browser",
+  "email": "thomas.norling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/controllers/StandardController.ts
+++ b/lib/msal-browser/src/controllers/StandardController.ts
@@ -657,6 +657,12 @@ export class StandardController implements IController {
         const correlationId = this.getRequestCorrelationId(request);
         this.logger.verbose("acquireTokenRedirect called", correlationId);
 
+        BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
+        this.browserStorage.setInteractionInProgress(
+            true,
+            INTERACTION_TYPE.SIGNIN
+        );
+
         const atrMeasurement = this.performanceClient.startMeasurement(
             BrowserRootPerformanceEvents.AcquireTokenPreRedirect,
             correlationId
@@ -684,13 +690,7 @@ export class StandardController implements IController {
         };
 
         try {
-            BrowserUtils.redirectPreflightCheck(this.initialized, this.config);
             enforceResourceParameter(this.config.auth.isMcp, request);
-            this.browserStorage.setInteractionInProgress(
-                true,
-                INTERACTION_TYPE.SIGNIN
-            );
-
             this.eventHandler.emitEvent(
                 EventType.ACQUIRE_TOKEN_START,
                 correlationId,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -1905,6 +1905,38 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             );
         });
 
+        it("does not clear in-progress interaction state when a concurrent redirect throws interaction_in_progress", async () => {
+            /*
+             * Regression test for GitHub issue #8633: a duplicate loginRedirect/acquireTokenRedirect
+             * call that throws interaction_in_progress must not reset the request cache, otherwise it
+             * destroys the temporary cache and interaction_in_progress flag owned by the first in-flight
+             * redirect, causing its redirect handler to silently fail.
+             */
+
+            // Simulate a first redirect that has already claimed the interaction and cached its request.
+            browserStorage.setInteractionInProgress(true);
+            browserStorage.cacheAuthorizeRequest(
+                testRequest,
+                RANDOM_TEST_GUID,
+                TEST_CONFIG.TEST_VERIFIER
+            );
+
+            // A second concurrent redirect must reject without tearing down the first interaction's state.
+            await expect(
+                pca.acquireTokenRedirect({ scopes: ["openid"] })
+            ).rejects.toMatchObject(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.interactionInProgress
+                )
+            );
+
+            // The first interaction's state must survive so its redirect handler can complete.
+            expect(browserStorage.isInteractionInProgress(true)).toBe(true);
+            expect(() =>
+                browserStorage.getCachedRequest(RANDOM_TEST_GUID)
+            ).not.toThrow();
+        });
+
         it("throws error if called in a popup", (done) => {
             Object.defineProperty(window, "location", {
                 configurable: true,
@@ -2351,7 +2383,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             });
         });
 
-        it("instruments initialization error", (done) => {
+        it("does not emit telemetry for initialization error since preflight checks run before instrumentation starts", async () => {
             pca = new PublicClientApplication({
                 auth: {
                     clientId: TEST_CONFIG.MSAL_CLIENT_ID,
@@ -2364,20 +2396,21 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     },
                 },
             });
-            const callbackId = pca.addPerformanceCallback((events) => {
-                expect(events[0].success).toBe(false);
-                expect(events[0].errorCode).toBe(
-                    "uninitialized_public_client_application"
-                );
-                pca.removePerformanceCallback(callbackId);
-                done();
+            let performanceEventEmitted = false;
+            const callbackId = pca.addPerformanceCallback(() => {
+                performanceEventEmitted = true;
             });
 
-            pca.acquireTokenRedirect({ scopes: [] })
-                .then(() => {
-                    throw new Error("success path should not be reached");
-                })
-                .catch((e) => {});
+            await expect(
+                pca.acquireTokenRedirect({ scopes: [] })
+            ).rejects.toMatchObject(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.uninitializedPublicClientApplication
+                )
+            );
+
+            pca.removePerformanceCallback(callbackId);
+            expect(performanceEventEmitted).toBe(false);
         });
 
         it("throws an error if isMcp is true and resource is not provided in request", async () => {


### PR DESCRIPTION
## Summary

Fixes #8633.

Calling `loginRedirect`/`acquireTokenRedirect` a second time before the first call navigates away cancelled the entire interaction, leaving the user stranded on the redirect handler.

## Root cause

In `StandardController.acquireTokenRedirect`, `setInteractionInProgress(true)` was inside the instrumented `try` block. When a second redirect ran before the first navigated:

1. The first call claimed `interaction_in_progress` and cached its request.
2. The second call generated a new `correlationId` and called `setInteractionInProgress(true)`, which detected the existing interaction and threw `interaction_in_progress`.
3. The `catch` block unconditionally called `resetRequestCache(correlationId)`, which cleared the temporary cache **and** the `interaction_in_progress` flag — both owned by the **first** (legitimate) redirect (same `clientId`).

Once the first redirect navigated and the IdP redirected back, no interaction state remained, so `handleRedirectPromise` silently no-opped.

The popup flow never had this bug because it claims the interaction outside its instrumented `try/catch`.

## Fix

Restructure `acquireTokenRedirect` to mirror `acquireTokenPopup`: run `redirectPreflightCheck` and `setInteractionInProgress` **before** `startMeasurement` and the `try` block. Failures that occur before this call claims ownership of the interaction now reject without:

- resetting the request cache (so a concurrent redirect's state survives),
- emitting failure telemetry, or
- firing `ACQUIRE_TOKEN_FAILURE`.

`enforceResourceParameter` remains inside the instrumented `try` (it runs after the interaction is claimed, so failures there belong to this call).

## Behavior change

Preflight failures for the redirect flow (including `uninitialized_public_client_application`) are no longer instrumented, since they now throw before the performance measurement starts. This matches the user-facing throw behavior already covered by existing tests; only the pre-redirect telemetry event for these specific pre-claim errors is removed.

## Tests

- Added regression test: `does not clear in-progress interaction state when a concurrent redirect throws interaction_in_progress`.
- Updated `instruments initialization error` → `does not emit telemetry for initialization error since preflight checks run before instrumentation starts` to lock in the intended behavior.

Full `msal-browser` suite passes (1675 passed, 3 pre-existing skips). `build:all`, `lint`, `format:check`, and `apiExtractor` (no public API change) all pass.
