### PR TITLE
Enhance logging functionality by injecting runtime variables into decoded messages

### DIFF
--- a/change/@azure-msal-browser-25df37e2-92d2-4536-a2bb-de898084d275.json
+++ b/change/@azure-msal-browser-25df37e2-92d2-4536-a2bb-de898084d275.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enhance logging functionality by injecting runtime variables into decoded messages [#8644](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8644)",
+  "packageName": "@azure/msal-browser",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-c5c4c316-545d-47db-8278-d2315b32ce8b.json
+++ b/change/@azure-msal-common-c5c4c316-545d-47db-8278-d2315b32ce8b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Enhance logging functionality by injecting runtime variables into decoded messages [#8644](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8644)      ",
+  "comment": "Enhance logging functionality by injecting runtime variables into decoded messages [#8644](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8644)",
   "packageName": "@azure/msal-common",
   "email": "kshabelko@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-msal-common-c5c4c316-545d-47db-8278-d2315b32ce8b.json
+++ b/change/@azure-msal-common-c5c4c316-545d-47db-8278-d2315b32ce8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enhance logging functionality by injecting runtime variables into decoded messages [#8644](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8644)      ",
+  "packageName": "@azure/msal-common",
+  "email": "kshabelko@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/scripts/README.md
+++ b/lib/msal-browser/scripts/README.md
@@ -10,14 +10,29 @@ The MSAL Browser library hashes logging strings to reduce bundle size. When runn
 
 The script expects log files where each MSAL log entry follows this format:
 ```
-[timestamp] : [correlation-id] : @azure/[module]@[version] : [LogLevel] - [hash]
+[timestamp] : [correlation-id] : @azure/[module]@[version] : [LogLevel] - [hash][ values...]
 ```
+
+The `[hash]` is a 6-character code. It may be followed by one or more
+space-separated runtime values when the log message originally contained
+interpolated variables (the library appends these after the hash so they stay
+visible in console logs while keeping the bundle small). The decoder injects
+those values back into the message's placeholders, so **do not strip the
+trailing tokens** — removing them prevents variable injection during decode.
 
 Example:
 ```
 [Tue, 07 Oct 2025 16:50:29 GMT] : [] : @azure/msal-browser@4.13.1 : Verbose - 0hoqeo
 [Tue, 07 Oct 2025 16:50:30 GMT] : [abc-123] : @azure/msal-common@15.7.0 : Info - 1atvtd
+[Thu, 11 Jun 2026 21:02:51 GMT] : [019eb87e] : @azure/msal-common@16.6.1 : Verbose - 1q3g2x 69f988bf-86f1-41af-91ab-2d7cd746hg47 {tenantid}
 ```
+
+In the third line, `1q3g2x` is the hash and the two trailing tokens are runtime
+values injected into the decoded message's `${...}` placeholders.
+
+The package/SKU token before `@[version]` may also be a SKU name such as
+`msal.js.browser` (and msal-common messages can appear under that browser SKU
+header); the decoder normalizes these automatically.
 
 Non-MSAL log lines are preserved unchanged in the output.
 

--- a/lib/msal-browser/scripts/decode-logs.cjs
+++ b/lib/msal-browser/scripts/decode-logs.cjs
@@ -337,22 +337,58 @@ async function extractFileFromTarball(tarballBuffer, targetPath) {
  * Parses a log line and extracts module@version and hash information
  */
 function parseLogLine(line) {
-    // Match lines that look like MSAL log entries
-    // Format: [timestamp] : [correlation-id] : @azure/msal-browser@4.13.1 : LogLevel - hash
-    const msalRegex = /:\s*@azure\/(msal-[^@]+)@([^:\s]+)\s*:\s*\w+\s*-\s*([a-zA-Z0-9]{6})/;
+    // Generic matcher: <pkgOrSku>@<version> : <LogLevel> - <hash>[ vars...]
+    // The package token is either a scoped @azure/msal-* package or a dotted
+    // msal.js* SKU. The version stops at the first whitespace or ':'.
+    const msalRegex = /(@azure\/msal-[a-z-]+|msal(?:\.[a-z]+)+)@([^:\s]+)\s*:\s*\w+\s*-\s*([a-zA-Z0-9]{6})([^\r\n]*)/;
     const match = line.match(msalRegex);
 
-    if (match) {
-        const [, module, version, hash] = match;
+    if (!match) {
+        return null;
+    }
 
-        // Only process msal-browser and msal-common modules, skip msal-react etc.
-        if (module === 'msal-browser' || module === 'msal-common') {
-            return {
-                fullLine: line,
-                moduleVersion: `@azure/${module}@${version}`,
-                hash: hash
-            };
-        }
+    const [, rawPackage, version, hash, rawArgs] = match;
+    const module = normalizeModuleName(rawPackage);
+
+    // Only msal-browser and msal-common strings are decodable by this script.
+    // Other libraries (msal-react, msal-angular, msal-node, ...) are skipped.
+    if (!module) {
+        return null;
+    }
+
+    return {
+        fullLine: line,
+        moduleVersion: `@azure/${module}@${version}`,
+        hash: hash,
+        // Trailing variable values appended after the hash (may be empty)
+        rawArgs: rawArgs || ''
+    };
+}
+
+/**
+ * Normalizes any MSAL package name or SKU to a canonical module family used as
+ * the mapping pool key. Returns "msal-browser", "msal-common", or null when the
+ * package is not one this script can decode.
+ *
+ * Examples:
+ *   "@azure/msal-browser" -> "msal-browser"
+ *   "msal.js.browser"     -> "msal-browser"  (browser SKU)
+ *   "msal.js"             -> "msal-browser"  (generic browser SKU fallback)
+ *   "@azure/msal-common"  -> "msal-common"
+ *   "@azure/msal-react"   -> null            (not decoded here)
+ */
+function normalizeModuleName(rawPackage) {
+    if (rawPackage === '@azure/msal-common') {
+        return 'msal-common';
+    }
+
+    // Everything in the browser family: the scoped package, the browser SKU, or
+    // the generic "msal.js" SKU.
+    if (
+        rawPackage === '@azure/msal-browser' ||
+        rawPackage.startsWith('msal.js')
+    ) {
+        return 'msal-browser';
     }
 
     return null;
@@ -427,6 +463,103 @@ async function loadMappings(moduleVersions) {
 }
 
 /**
+ * Finds all `${...}` placeholder spans in a decoded template message, in source
+ * order. Brace depth is tracked so nested braces (e.g. `${JSON.stringify({a:1})}`)
+ * are handled correctly. Returns an array of { start, end } where `start` is the
+ * index of the `$` and `end` is the index of the matching closing `}`.
+ */
+function findPlaceholders(template) {
+    const spans = [];
+    let i = 0;
+
+    while (i < template.length) {
+        if (template[i] === '$' && template[i + 1] === '{') {
+            const start = i;
+            let j = i + 2;
+            let depth = 1;
+
+            while (j < template.length && depth > 0) {
+                if (template[j] === '{') {
+                    depth++;
+                } else if (template[j] === '}') {
+                    depth--;
+                    if (depth === 0) {
+                        break;
+                    }
+                }
+                j++;
+            }
+
+            spans.push({ start, end: j });
+            i = j + 1;
+        } else {
+            i++;
+        }
+    }
+
+    return spans;
+}
+
+/**
+ * Injects the runtime variable values captured after a hash into the decoded
+ * template's `${...}` placeholders.
+ *
+ * Values are appended by the logger-minify plugin in the same source order as
+ * the placeholders, separated by single spaces. They are mapped one-to-one onto
+ * the placeholders; if more tokens than placeholders are present (e.g. a trailing
+ * value contained spaces), the final placeholder absorbs the remaining tokens.
+ * Placeholders without a corresponding value are left intact so it is obvious the
+ * value was not captured.
+ *
+ * @param {string} template Decoded message, e.g. "'${a}' from '${b}'"
+ * @param {string} rawArgs  Trailing values from the log line, e.g. " oob ext-id"
+ * @returns {string} The template with placeholders substituted by their values
+ */
+function injectVariables(template, rawArgs) {
+    const spans = findPlaceholders(template);
+    if (spans.length === 0) {
+        return template;
+    }
+
+    const argsString = (rawArgs || '').trim();
+    if (!argsString) {
+        // No values captured (e.g. legacy logs or telemetry-style bare hash)
+        return template;
+    }
+
+    const tokens = argsString.split(/\s+/);
+
+    // Map tokens onto placeholders in order
+    const values = [];
+    if (tokens.length <= spans.length) {
+        for (let k = 0; k < spans.length; k++) {
+            values.push(k < tokens.length ? tokens[k] : null);
+        }
+    } else {
+        for (let k = 0; k < spans.length - 1; k++) {
+            values.push(tokens[k]);
+        }
+        // Last placeholder absorbs any remaining tokens
+        values.push(tokens.slice(spans.length - 1).join(' '));
+    }
+
+    // Replace from end to start to keep earlier indices valid
+    let result = template;
+    for (let k = spans.length - 1; k >= 0; k--) {
+        const value = values[k];
+        if (value === null || value === undefined) {
+            continue;
+        }
+        result =
+            result.slice(0, spans[k].start) +
+            value +
+            result.slice(spans[k].end + 1);
+    }
+
+    return result;
+}
+
+/**
  * Decodes log entries using the provided mappings while preserving all original lines
  */
 function decodeLogEntries(entries, mappings, allLines, useColors = true) {
@@ -465,13 +598,21 @@ function decodeLogEntries(entries, mappings, allLines, useColors = true) {
             const logLevelMatch = entry.fullLine.match(/\b(Error|ErrorPii|Warning|Info|InfoPii|Verbose|VerbosePii|Trace|TracePii)\b/i);
             const logLevel = logLevelMatch ? logLevelMatch[1].toLowerCase() : 'unknown';
 
-            let decodedLine;
-            if (useColors) {
-                const levelColor = logLevelColors[logLevel] || colors.gray;
-                decodedLine = entry.fullLine.replace(entry.hash, `${levelColor}${decodedMessage}${colors.reset}`);
-            } else {
-                decodedLine = entry.fullLine.replace(entry.hash, decodedMessage);
-            }
+            // Inject any runtime variable values captured after the hash into the
+            // decoded template's ${...} placeholders
+            const injectedMessage = injectVariables(decodedMessage, entry.rawArgs);
+
+            // The encoded span in the original line is the hash plus its trailing
+            // variable values; replace the whole span so the raw values are not
+            // left duplicated after the decoded message.
+            const encoded = `${entry.hash}${entry.rawArgs || ''}`;
+            const replacementText = useColors
+                ? `${logLevelColors[logLevel] || colors.gray}${injectedMessage}${colors.reset}`
+                : injectedMessage;
+
+            // Use a function replacement so '$' sequences in values/messages are
+            // treated literally (not as String.replace special patterns).
+            const decodedLine = entry.fullLine.replace(encoded, () => replacementText);
 
             // Replace the line at the correct index
             decodedLines[entry.lineIndex] = decodedLine;
@@ -619,8 +760,11 @@ module.exports = {
     extractFileFromTarball,
     parseLogLine,
     parseLogFile,
+    normalizeModuleName,
     loadMappings,
     decodeLogEntries,
+    findPlaceholders,
+    injectVariables,
     parseArguments,
     showUsage,
     main

--- a/lib/msal-browser/scripts/decode-logs.cjs
+++ b/lib/msal-browser/scripts/decode-logs.cjs
@@ -338,6 +338,7 @@ async function extractFileFromTarball(tarballBuffer, targetPath) {
  */
 function parseLogLine(line) {
     const msalRegex = /(@azure\/msal-[a-z-]+|msal(?:\.[a-z]+)+)@([^:\s]+)\s*:\s*\w+\s*-\s*([a-zA-Z0-9]{6})(?=\s|$)([^\r\n]*)/;
+    const match = line.match(msalRegex);
 
     if (!match) {
         return null;
@@ -666,10 +667,15 @@ ${colors.bright}Examples:${colors.reset}
 
 ${colors.bright}Log Format:${colors.reset}
   Expected format per line:
-  [timestamp] : [correlation-id] : @azure/[module]@[version] : [LogLevel] - [hash]
+  [timestamp] : [correlation-id] : @azure/[module]@[version] : [LogLevel] - [hash][ values...]
+
+  The [hash] is a 6-character code, optionally followed by space-separated
+  runtime values that are injected into the message's placeholders. Keep those
+  trailing tokens intact - stripping them prevents variable injection.
 
   Example:
   [Tue, 07 Oct 2025 16:50:29 GMT] : [] : @azure/msal-browser@4.13.1 : Verbose - 0hoqeo
+  [Thu, 11 Jun 2026 21:02:51 GMT] : [019eb87e] : @azure/msal-common@16.6.1 : Verbose - 1q3g2x 72f988bf {tenantid}
 `);
 }
 

--- a/lib/msal-browser/scripts/decode-logs.cjs
+++ b/lib/msal-browser/scripts/decode-logs.cjs
@@ -337,11 +337,7 @@ async function extractFileFromTarball(tarballBuffer, targetPath) {
  * Parses a log line and extracts module@version and hash information
  */
 function parseLogLine(line) {
-    // Generic matcher: <pkgOrSku>@<version> : <LogLevel> - <hash>[ vars...]
-    // The package token is either a scoped @azure/msal-* package or a dotted
-    // msal.js* SKU. The version stops at the first whitespace or ':'.
-    const msalRegex = /(@azure\/msal-[a-z-]+|msal(?:\.[a-z]+)+)@([^:\s]+)\s*:\s*\w+\s*-\s*([a-zA-Z0-9]{6})([^\r\n]*)/;
-    const match = line.match(msalRegex);
+    const msalRegex = /(@azure\/msal-[a-z-]+|msal(?:\.[a-z]+)+)@([^:\s]+)\s*:\s*\w+\s*-\s*([a-zA-Z0-9]{6})(?=\s|$)([^\r\n]*)/;
 
     if (!match) {
         return null;

--- a/lib/msal-common/src/logger/Logger.ts
+++ b/lib/msal-common/src/logger/Logger.ts
@@ -147,25 +147,40 @@ export function getCachedCorrelationIds(): string[] {
 }
 
 /**
- * Checks if a string is already a hashed logging string (6 alphanumeric characters)
+ * Extracts the leading minification hash from a log message, if present.
+ *
+ * Minified messages are produced by the logger-minify rollup plugin and are
+ * either a bare 6-character alphanumeric hash, or that hash followed by a space
+ * and runtime variables appended for local (console) logging, e.g.
+ * "abc123 user-1 popup". Only the leading hash is returned so that telemetry
+ * never captures the appended variables. Returns null when the message is not
+ * a minified message.
  */
-function isHashedString(str: string): boolean {
-    if (str.length !== 6) {
-        return false;
+function getMessageHash(str: string): string | null {
+    if (str.length < 6) {
+        return null;
     }
 
-    for (let i = 0; i < str.length; i++) {
+    /*
+     * If the message is longer than the hash, the hash must be delimited by a
+     * space (the separator the plugin inserts before appended variables).
+     */
+    if (str.length > 6 && str[6] !== " ") {
+        return null;
+    }
+
+    for (let i = 0; i < 6; i++) {
         const char = str[i];
         const isAlphaNumeric =
             (char >= "a" && char <= "z") ||
             (char >= "A" && char <= "Z") ||
             (char >= "0" && char <= "9");
         if (!isAlphaNumeric) {
-            return false;
+            return null;
         }
     }
 
-    return true;
+    return str.substring(0, 6);
 }
 
 /**
@@ -241,11 +256,11 @@ export class Logger {
         options: LoggerMessageOptions
     ): void {
         const correlationId = options.correlationId;
-        const isHashedInput = isHashedString(logMessage);
+        const messageHash = getMessageHash(logMessage);
 
-        if (isHashedInput) {
+        if (messageHash) {
             const loggedMessage: LoggedMessage = {
-                hash: logMessage,
+                hash: messageHash,
                 level: options.logLevel,
                 containsPii: options.containsPii || false,
                 milliseconds: 0, // Will be calculated in addLogToCache

--- a/lib/msal-common/test/logger/Logger.spec.ts
+++ b/lib/msal-common/test/logger/Logger.spec.ts
@@ -488,6 +488,35 @@ describe("Logger.ts Class Unit Tests", () => {
                 expect(cachedLogs[0].hash).toHaveLength(6);
             });
 
+            it("should cache only the leading hash when variables are appended to a hashed message", () => {
+                const logger = new Logger(loggerOptions);
+                const correlationId = "test-correlation-vars";
+                // The minify plugin emits the hash followed by runtime variables
+                const messageWithVars = "abc123 user-1 popup";
+
+                logger.info(messageWithVars, correlationId);
+
+                const cachedLogs = getLogsFromCache(correlationId);
+
+                // Telemetry must only ever see the hash, never the variables
+                expect(cachedLogs).toHaveLength(1);
+                expect(cachedLogs[0].hash).toBe("abc123");
+                expect(cachedLogs[0].hash).toHaveLength(6);
+            });
+
+            it("should pass the full message including variables to the logger callback", () => {
+                const logger = new Logger(loggerOptions);
+                const correlationId = "test-correlation-vars-callback";
+                const messageWithVars = "abc123 user-1 popup";
+
+                logger.info(messageWithVars, correlationId);
+
+                // The console callback should still receive the appended variables
+                expect(logStore[LogLevel.Info]).toContain(
+                    "abc123 user-1 popup"
+                );
+            });
+
             it("should not cache plain text log messages", () => {
                 const logger = new Logger(loggerOptions);
                 const correlationId = "test-correlation-plain";

--- a/shared-configs/rollup-msal/logger-minify-plugin.js
+++ b/shared-configs/rollup-msal/logger-minify-plugin.js
@@ -18,7 +18,7 @@ const LOGGER_CALL_START = new RegExp(
 /**
  * Efficiently find string literals within logger calls using linear parsing
  * instead of complex regex that can cause quadratic performance.
- * 
+ *
  * Supports both direct logger calls and chained method calls:
  * - Direct: logger.verbose(...), commonLogger.info(...), log.error(...)
  * - Chained: this.getLogger().verbose(...), obj.getLogger().info(...)
@@ -253,6 +253,83 @@ function normalizeTemplateVariables(str) {
 }
 
 /**
+ * Extracts the interpolated expressions (the contents of each `${...}`) from a
+ * template literal, in source order. Returns an array of the raw expression
+ * strings, e.g. for `` `User ${id} did ${action.toUpperCase()}` `` it returns
+ * ['id', 'action.toUpperCase()'].
+ *
+ * Uses a linear parser (no regex backtracking) and correctly handles nested
+ * braces, string literals, and nested template literals inside expressions.
+ */
+function extractTemplateExpressions(templateText) {
+    const expressions = [];
+    // Skip the surrounding backticks
+    const end = templateText.length - 1;
+    let i = 1;
+
+    while (i < end) {
+        const char = templateText[i];
+
+        if (char === '\\') {
+            // Skip escaped character in the literal portion
+            i += 2;
+            continue;
+        }
+
+        if (char === '$' && templateText[i + 1] === '{') {
+            // Start of an interpolation
+            let j = i + 2;
+            let depth = 1;
+
+            while (j < templateText.length && depth > 0) {
+                const c = templateText[j];
+
+                if (c === '\\') {
+                    j += 2;
+                    continue;
+                }
+
+                if (c === '{') {
+                    depth++;
+                } else if (c === '}') {
+                    depth--;
+                    if (depth === 0) {
+                        break;
+                    }
+                } else if (c === '"' || c === "'" || c === '`') {
+                    // Skip over a nested string/template literal
+                    const quote = c;
+                    j++;
+                    while (j < templateText.length) {
+                        if (templateText[j] === '\\') {
+                            j += 2;
+                            continue;
+                        }
+                        if (templateText[j] === quote) {
+                            break;
+                        }
+                        j++;
+                    }
+                }
+
+                j++;
+            }
+
+            const expression = templateText.slice(i + 2, j).trim();
+            if (expression.length > 0) {
+                expressions.push(expression);
+            }
+            i = j + 1; // Skip past the closing brace
+            continue;
+        }
+
+        i++;
+    }
+
+    return expressions;
+}
+
+/**
  * Creates the rollup plugin for logger string minification
  */
 function loggerMinifyPlugin(options = {}) {
@@ -284,8 +361,18 @@ function loggerMinifyPlugin(options = {}) {
 
                 const originalString = cleanMessage(quotedString);
 
-                // Skip if this looks like a hash (6 character alphanumeric string)
-                if (/^[a-z0-9]{6}$/.test(originalString)) {
+                // Skip strings that are already minified to avoid creating a
+                // "hash of a hash". This happens when an already-minified bundle
+                // is processed again (e.g. msal-browser re-bundles the minified
+                // msal-common output). An already-minified message is either:
+                //   - a bare 6-char hash: "0nxk52", or
+                //   - a 6-char hash followed by appended ${...} variables:
+                //     "0nxk52 ${subMeasurement.name} ${event.name}"
+                // The hash alphabet is lowercase base36 (see createStringHash).
+                if (
+                    /^[a-z0-9]{6}$/.test(originalString) ||
+                    /^[a-z0-9]{6} \$\{/.test(originalString)
+                ) {
                     continue;
                 }
 
@@ -310,8 +397,24 @@ function loggerMinifyPlugin(options = {}) {
                 });
                 hasChanges = true;
 
-                // Replace the entire logger call
-                const replacement = `${prefix}${middle}"${hash}"${suffix}`;
+                // Replace the message with the hash. For template literals that
+                // contain interpolated variables, preserve those variables by
+                // appending them after the hash so they remain visible in local
+                // (console) logs. The static text - which dominates bundle size -
+                // is still dropped in favor of the hash. The leading hash is what
+                // telemetry captures, so the appended variables never reach telemetry.
+                let minifiedMessage = `"${hash}"`;
+                if (isTemplateLiteral) {
+                    const expressions = extractTemplateExpressions(quotedString);
+                    if (expressions.length > 0) {
+                        const interpolations = expressions
+                            .map((expression) => `\${${expression}}`)
+                            .join(' ');
+                        minifiedMessage = `\`${hash} ${interpolations}\``;
+                    }
+                }
+
+                const replacement = `${prefix}${middle}${minifiedMessage}${suffix}`;
                 transformedCode = transformedCode.slice(0, startPos) + replacement + transformedCode.slice(endPos);
             }
 


### PR DESCRIPTION
- Shared client logs now can be decoded with runtime variables
- Only log hash gets captured by the telemetry pipeline - no changes here
- Minified Build size increase = 1.6Kb (0.6%)