### PR TITLE
Add attributeTokens request parameter support

### DIFF
--- a/change/@azure-msal-common-attributeTokens-1.json
+++ b/change/@azure-msal-common-attributeTokens-1.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add attributeTokens request support to msal-common token requests",
-  "packageName": "@azure/msal-common",
-  "email": "spingale@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@azure-msal-common-attributeTokens-1.json
+++ b/change/@azure-msal-common-attributeTokens-1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add attributeTokens request support to msal-common token requests",
+  "packageName": "@azure/msal-common",
+  "email": "spingale@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-ceeed517-6a7b-49e6-a7aa-12191bb0f758.json
+++ b/change/@azure-msal-common-ceeed517-6a7b-49e6-a7aa-12191bb0f758.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add attributeTokens request parameter support [#8651](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8651)",
+  "packageName": "@azure/msal-common",
+  "email": "spingale@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -72,6 +72,7 @@ declare namespace AADServerParamKeys {
         CLIENT_ASSERTION_TYPE,
         TOKEN_TYPE,
         REQ_CNF,
+        ATTRIBUTE_TOKENS,
         OBO_ASSERTION,
         REQUESTED_TOKEN_USE,
         ON_BEHALF_OF,
@@ -217,6 +218,13 @@ export type ActiveAccountFilters = {
 //
 // @public
 function addApplicationTelemetry(parameters: Map<string, string>, appTelemetry: ApplicationTelemetry): void;
+
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (ae-missing-release-tag) "addAttributeTokens" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function addAttributeTokens(parameters: Map<string, string>, attributeTokens?: Array<string>): void;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "addAuthorizationCode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -534,6 +542,11 @@ export type AppTokenProviderResult = {
     expiresInSeconds: number;
     refreshInSeconds?: number;
 };
+
+// Warning: (ae-missing-release-tag) "ATTRIBUTE_TOKENS" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const ATTRIBUTE_TOKENS = "attribute_tokens";
 
 // Warning: (ae-missing-release-tag) "AuthClientCreateTokenRequestBody" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -979,6 +992,7 @@ export type BaseAuthRequest = {
     azureCloudOptions?: AzureCloudOptions;
     maxAge?: number;
     storeInCache?: StoreInCache;
+    attributeTokens?: Array<string>;
     scenarioId?: string;
     popKid?: string;
     embeddedClientId?: string;
@@ -3952,6 +3966,7 @@ declare namespace RequestParameterBuilder {
         addGrantType,
         addClientInfo,
         addCliData,
+        addAttributeTokens,
         addInstanceAware,
         addExtraParameters,
         addClientCapabilitiesToClaims,
@@ -4931,7 +4946,7 @@ const X_MS_LIB_CAPABILITY_VALUE: string;
 // src/client/AuthorizationCodeClient.ts:222:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:223:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/AuthorizationCodeClient.ts:300:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/client/AuthorizationCodeClient.ts:532:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/client/AuthorizationCodeClient.ts:539:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:243:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:328:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/client/RefreshTokenClient.ts:329:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -500,6 +500,13 @@ export class AuthorizationCodeClient {
             );
         }
 
+        if (request.attributeTokens) {
+            RequestParameterBuilder.addAttributeTokens(
+                parameters,
+                request.attributeTokens
+            );
+        }
+
         // Add hybrid spa parameters if not already provided
         if (
             request.enableSpaAuthorizationCode &&

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -546,6 +546,13 @@ export class RefreshTokenClient {
             });
         }
 
+        if (request.attributeTokens) {
+            RequestParameterBuilder.addAttributeTokens(
+                parameters,
+                request.attributeTokens
+            );
+        }
+
         RequestParameterBuilder.instrumentBrokerParams(
             parameters,
             request.correlationId,

--- a/lib/msal-common/src/constants/AADServerParamKeys.ts
+++ b/lib/msal-common/src/constants/AADServerParamKeys.ts
@@ -44,6 +44,7 @@ export const CLIENT_ASSERTION = "client_assertion";
 export const CLIENT_ASSERTION_TYPE = "client_assertion_type";
 export const TOKEN_TYPE = "token_type";
 export const REQ_CNF = "req_cnf";
+export const ATTRIBUTE_TOKENS = "attribute_tokens";
 export const OBO_ASSERTION = "assertion";
 export const REQUESTED_TOKEN_USE = "requested_token_use";
 export const ON_BEHALF_OF = "on_behalf_of";

--- a/lib/msal-common/src/request/BaseAuthRequest.ts
+++ b/lib/msal-common/src/request/BaseAuthRequest.ts
@@ -76,6 +76,10 @@ export type BaseAuthRequest = {
      */
     storeInCache?: StoreInCache;
     /**
+     * Attribute tokens to send on token requests as a space-delimited attribute_tokens parameter.
+     */
+    attributeTokens?: Array<string>;
+    /**
      * Scenario id to track custom user prompts
      */
     scenarioId?: string;

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -472,6 +472,30 @@ export function addCliData(parameters: Map<string, string>): void {
     parameters.set(AADServerParamKeys.CLI_DATA, "1");
 }
 
+/**
+ * Add attribute_tokens to request body
+ * @param parameters
+ * @param attributeTokens
+ */
+export function addAttributeTokens(
+    parameters: Map<string, string>,
+    attributeTokens?: Array<string>
+): void {
+    if (attributeTokens?.length) {
+        // Sanitize: trim each token and filter out empty strings
+        const sanitized = attributeTokens
+            .map((token) => token.trim())
+            .filter((token) => token.length > 0);
+
+        if (sanitized.length > 0) {
+            parameters.set(
+                AADServerParamKeys.ATTRIBUTE_TOKENS,
+                sanitized.join(" ")
+            );
+        }
+    }
+}
+
 export function addInstanceAware(parameters: Map<string, string>): void {
     if (!parameters.has(AADServerParamKeys.INSTANCE_AWARE)) {
         parameters.set(AADServerParamKeys.INSTANCE_AWARE, "true");

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -2853,6 +2853,86 @@ describe("AuthorizationCodeClient unit tests", () => {
             expect(queryString).toContain(`client_id=child_client_id`);
         });
 
+        it("serializes attribute tokens into a single attribute_tokens parameter", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    attributeTokens: ["token-1", "token-2"],
+                });
+
+            expect(queryString).toContain(
+                `attribute_tokens=${encodeURIComponent("token-1 token-2")}`
+            );
+        });
+
+        it("omits attribute_tokens when undefined", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    attributeTokens: undefined,
+                });
+
+            expect(queryString).not.toContain(`attribute_tokens=`);
+        });
+
+        it("omits attribute_tokens when empty array", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    attributeTokens: [],
+                });
+
+            expect(queryString).not.toContain(`attribute_tokens=`);
+        });
+
+        it("sanitizes attribute_tokens with whitespace elements", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new AuthorizationCodeClient(
+                config,
+                stubPerformanceClient
+            );
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    attributeTokens: ["  token-1  ", "   ", "token-2\t"],
+                });
+
+            expect(queryString).toContain(
+                `attribute_tokens=${encodeURIComponent("token-1 token-2")}`
+            );
+        });
+
         it("pick up broker params", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();

--- a/lib/msal-common/test/client/RefreshTokenClient.spec.ts
+++ b/lib/msal-common/test/client/RefreshTokenClient.spec.ts
@@ -1839,6 +1839,90 @@ describe("RefreshTokenClient unit tests", () => {
             );
         });
 
+        it("serializes attribute tokens into a single attribute_tokens parameter", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    refreshToken: "refresh-token",
+                    attributeTokens: ["token-1", "token-2"],
+                });
+
+            expect(queryString).toContain(
+                `attribute_tokens=${encodeURIComponent("token-1 token-2")}`
+            );
+        });
+
+        it("omits attribute_tokens when undefined", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    refreshToken: "refresh-token",
+                    attributeTokens: undefined,
+                });
+
+            expect(queryString).not.toContain(`attribute_tokens=`);
+        });
+
+        it("omits attribute_tokens when empty array", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    refreshToken: "refresh-token",
+                    attributeTokens: [],
+                });
+
+            expect(queryString).not.toContain(`attribute_tokens=`);
+        });
+
+        it("sanitizes attribute_tokens with whitespace elements", async () => {
+            const config: ClientConfiguration =
+                await ClientTestUtils.createTestClientConfiguration();
+            const client = new RefreshTokenClient(
+                config,
+                stubPerformanceClient
+            );
+
+            const queryString =
+                // @ts-ignore
+                await client.createTokenRequestBody({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    refreshToken: "refresh-token",
+                    attributeTokens: ["  token-1  ", "   ", "token-2\t"],
+                });
+
+            expect(queryString).toContain(
+                `attribute_tokens=${encodeURIComponent("token-1 token-2")}`
+            );
+        });
+
         it("broker params take precedence over extra params", async () => {
             const config: ClientConfiguration =
                 await ClientTestUtils.createTestClientConfiguration();

--- a/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
+++ b/lib/msal-common/test/request/RequestParameterBuilder.spec.ts
@@ -736,6 +736,59 @@ describe("RequestParameterBuilder unit tests", () => {
         });
     });
 
+    describe("addAttributeTokens tests", () => {
+        it("adds attribute_tokens as a single space-delimited parameter", () => {
+            const parameters = new Map<string, string>();
+
+            RequestParameterBuilder.addAttributeTokens(parameters, [
+                "token-1",
+                "token-2",
+                "token-3",
+            ]);
+
+            expect(parameters.get(AADServerParamKeys.ATTRIBUTE_TOKENS)).toBe(
+                "token-1 token-2 token-3"
+            );
+        });
+
+        it("omits attribute_tokens when undefined or empty", () => {
+            const parameters = new Map<string, string>();
+
+            RequestParameterBuilder.addAttributeTokens(parameters, undefined);
+            expect(parameters.has(AADServerParamKeys.ATTRIBUTE_TOKENS)).toBe(
+                false
+            );
+
+            RequestParameterBuilder.addAttributeTokens(parameters, []);
+            expect(parameters.has(AADServerParamKeys.ATTRIBUTE_TOKENS)).toBe(
+                false
+            );
+        });
+
+        it("sanitizes whitespace and omits if all tokens become empty after trim", () => {
+            const parameters = new Map<string, string>();
+
+            // Test: only whitespace elements
+            RequestParameterBuilder.addAttributeTokens(parameters, [
+                "   ",
+                "\t",
+            ]);
+            expect(parameters.has(AADServerParamKeys.ATTRIBUTE_TOKENS)).toBe(
+                false
+            );
+
+            // Test: mix of valid and whitespace
+            RequestParameterBuilder.addAttributeTokens(parameters, [
+                "  token-1  ",
+                "   ",
+                "token-2\t",
+            ]);
+            expect(parameters.get(AADServerParamKeys.ATTRIBUTE_TOKENS)).toBe(
+                "token-1 token-2"
+            );
+        });
+    });
+
     describe("broker parameters tests", () => {
         const redirectUri = "embedded-redirect-uri";
         const clientId = "embedded-client-id";


### PR DESCRIPTION
Add opt-in attributeTokens field to BaseAuthRequest that serializes as a single space-delimited attribute_tokens parameter on the /token endpoint.

Changes:
- BaseAuthRequest: add attributeTokens?: Array<string>
- AADServerParamKeys: add ATTRIBUTE_TOKENS constant
- RequestParameterBuilder: add addAttributeTokens() helper
- AuthorizationCodeClient: call addAttributeTokens() in createTokenRequestBody
- RefreshTokenClient: call addAttributeTokens() in createTokenRequestBody

Tests added for RequestParameterBuilder, AuthorizationCodeClient, and RefreshTokenClient covering space-delimited serialization and omission when undefined or empty.

Does not affect /authorize endpoint or existing bearer token paths.