### PR TITLE
Send OIDC max_age on authorization request and fix auth_time unit bug

### DIFF
--- a/change/@azure-msal-common-max-age-param.json
+++ b/change/@azure-msal-common-max-age-param.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Send the OIDC max_age parameter on the authorization request when request.maxAge is set, and fix an auth_time seconds/milliseconds unit bug in checkMaxAge [#8659](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8659)",
+  "packageName": "@azure/msal-common",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-max-age-param.json
+++ b/change/@azure-msal-common-max-age-param.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Send the OIDC max_age parameter on the authorization request when request.maxAge is set, and fix an auth_time seconds/milliseconds unit bug in checkMaxAge [#8659](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8659)",
+  "comment": "Send the OIDC max_age parameter on the authorization request, add maxAgeSeconds (seconds) and deprecate maxAge (milliseconds), and fix an auth_time seconds/milliseconds unit bug in checkMaxAge [#8659](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8659)",
   "packageName": "@azure/msal-common",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -263,7 +263,7 @@ function addLoginHint(parameters: Map<string, string>, loginHint: string): void;
 function addLogoutHint(parameters: Map<string, string>, logoutHint: string): void;
 
 // @public
-function addMaxAge(parameters: Map<string, string>, maxAge: number): void;
+function addMaxAge(parameters: Map<string, string>, maxAgeSeconds: number): void;
 
 // @public
 function addNativeBroker(parameters: Map<string, string>): void;
@@ -710,6 +710,7 @@ export type BaseAuthRequest = {
     sshKid?: string;
     azureCloudOptions?: AzureCloudOptions;
     maxAge?: number;
+    maxAgeSeconds?: number;
     storeInCache?: StoreInCache;
     scenarioId?: string;
     popKid?: string;
@@ -940,7 +941,7 @@ export const CcsCredentialType: {
 export type CcsCredentialType = (typeof CcsCredentialType)[keyof typeof CcsCredentialType];
 
 // @public
-function checkMaxAge(authTime: number, maxAge: number): void;
+function checkMaxAge(authTime: number, maxAgeSeconds: number): void;
 
 // @public (undocumented)
 const CIAM_AUTH_URL = ".ciamlogin.com";

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -41,6 +41,7 @@ declare namespace AADServerParamKeys {
         STATE,
         NONCE,
         PROMPT,
+        MAX_AGE,
         SESSION_STATE,
         CLIENT_INFO_2 as CLIENT_INFO,
         CODE,
@@ -260,6 +261,9 @@ function addLoginHint(parameters: Map<string, string>, loginHint: string): void;
 
 // @public
 function addLogoutHint(parameters: Map<string, string>, logoutHint: string): void;
+
+// @public
+function addMaxAge(parameters: Map<string, string>, maxAge: number): void;
 
 // @public
 function addNativeBroker(parameters: Map<string, string>): void;
@@ -2116,6 +2120,9 @@ const logoutRequestEmpty = "logout_request_empty";
 function mapToQueryString(parameters: Map<string, string>): string;
 
 // @public (undocumented)
+const MAX_AGE = "max_age";
+
+// @public (undocumented)
 const maxAgeTranspired = "max_age_transpired";
 
 // @public (undocumented)
@@ -2739,6 +2746,7 @@ declare namespace RequestParameterBuilder {
         addLibraryInfo,
         addApplicationTelemetry,
         addPrompt,
+        addMaxAge,
         addState,
         addNonce,
         addCodeChallengeParams,

--- a/lib/msal-common/src/account/AuthToken.ts
+++ b/lib/msal-common/src/account/AuthToken.ts
@@ -8,6 +8,7 @@ import {
     createClientAuthError,
     ClientAuthErrorCodes,
 } from "../error/ClientAuthError.js";
+import { nowSeconds } from "../utils/TimeUtils.js";
 
 /**
  * Extract token by decoding the rawToken
@@ -79,17 +80,20 @@ export function getJWSPayload(authToken: string): string {
 
 /**
  * Determine if the token's max_age has transpired
+ * @param authTime - the auth_time claim from the token, in seconds (per OIDC)
+ * @param maxAgeSeconds - maximum allowed age of the authentication, in seconds
  */
-export function checkMaxAge(authTime: number, maxAge: number): void {
+export function checkMaxAge(authTime: number, maxAgeSeconds: number): void {
     /*
      * per https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
      * To force an immediate re-authentication: If an app requires that a user re-authenticate prior to access,
      * provide a value of 0 for the max_age parameter and the AS will force a fresh login.
      */
-    const fiveMinuteSkew = 300000; // five minutes in milliseconds
-    // auth_time is expressed in seconds (per OIDC); maxAge is in milliseconds
-    const authTimeMs = authTime * 1000;
-    if (maxAge === 0 || Date.now() - fiveMinuteSkew > authTimeMs + maxAge) {
+    const fiveMinuteSkewSeconds = 300; // five minutes in seconds
+    if (
+        maxAgeSeconds === 0 ||
+        nowSeconds() - fiveMinuteSkewSeconds > authTime + maxAgeSeconds
+    ) {
         throw createClientAuthError(ClientAuthErrorCodes.maxAgeTranspired);
     }
 }

--- a/lib/msal-common/src/account/AuthToken.ts
+++ b/lib/msal-common/src/account/AuthToken.ts
@@ -87,7 +87,9 @@ export function checkMaxAge(authTime: number, maxAge: number): void {
      * provide a value of 0 for the max_age parameter and the AS will force a fresh login.
      */
     const fiveMinuteSkew = 300000; // five minutes in milliseconds
-    if (maxAge === 0 || Date.now() - fiveMinuteSkew > authTime + maxAge) {
+    // auth_time is expressed in seconds (per OIDC); maxAge is in milliseconds
+    const authTimeMs = authTime * 1000;
+    if (maxAge === 0 || Date.now() - fiveMinuteSkew > authTimeMs + maxAge) {
         throw createClientAuthError(ClientAuthErrorCodes.maxAgeTranspired);
     }
 }

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -9,6 +9,7 @@ import {
     CommonClientConfiguration,
 } from "../config/ClientConfiguration.js";
 import { CommonSilentFlowRequest } from "../request/CommonSilentFlowRequest.js";
+import { getMaxAgeSeconds } from "../request/BaseAuthRequest.js";
 import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import * as TimeUtils from "../utils/TimeUtils.js";
 import {
@@ -248,7 +249,8 @@ export class SilentFlowClient {
         }
 
         // token max_age check
-        if (request.maxAge || request.maxAge === 0) {
+        const maxAgeSeconds = getMaxAgeSeconds(request);
+        if (maxAgeSeconds !== undefined) {
             const authTime = idTokenClaims?.auth_time;
             if (!authTime) {
                 throw createClientAuthError(
@@ -256,7 +258,7 @@ export class SilentFlowClient {
                 );
             }
 
-            checkMaxAge(authTime, request.maxAge);
+            checkMaxAge(authTime, maxAgeSeconds);
         }
 
         return ResponseHandler.generateAuthenticationResult(

--- a/lib/msal-common/src/constants/AADServerParamKeys.ts
+++ b/lib/msal-common/src/constants/AADServerParamKeys.ts
@@ -20,6 +20,7 @@ export const REFRESH_TOKEN_EXPIRES_IN = "refresh_token_expires_in";
 export const STATE = "state";
 export const NONCE = "nonce";
 export const PROMPT = "prompt";
+export const MAX_AGE = "max_age";
 export const SESSION_STATE = "session_state";
 export const CLIENT_INFO = "client_info";
 export const CODE = "code";

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -235,6 +235,10 @@ export function getStandardAuthorizeRequestParameters(
         RequestParameterBuilder.addNonce(parameters, request.nonce);
     }
 
+    if (request.maxAge !== undefined) {
+        RequestParameterBuilder.addMaxAge(parameters, request.maxAge);
+    }
+
     if (request.state) {
         RequestParameterBuilder.addState(parameters, request.state);
     }

--- a/lib/msal-common/src/protocol/Authorize.ts
+++ b/lib/msal-common/src/protocol/Authorize.ts
@@ -4,6 +4,7 @@
  */
 
 import { CommonAuthorizationUrlRequest } from "../request/CommonAuthorizationUrlRequest.js";
+import { getMaxAgeSeconds } from "../request/BaseAuthRequest.js";
 import * as RequestParameterBuilder from "../request/RequestParameterBuilder.js";
 import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
 import * as AADServerParamKeys from "../constants/AADServerParamKeys.js";
@@ -235,8 +236,9 @@ export function getStandardAuthorizeRequestParameters(
         RequestParameterBuilder.addNonce(parameters, request.nonce);
     }
 
-    if (request.maxAge !== undefined) {
-        RequestParameterBuilder.addMaxAge(parameters, request.maxAge);
+    const maxAgeSeconds = getMaxAgeSeconds(request);
+    if (maxAgeSeconds !== undefined) {
+        RequestParameterBuilder.addMaxAge(parameters, maxAgeSeconds);
     }
 
     if (request.state) {

--- a/lib/msal-common/src/request/BaseAuthRequest.ts
+++ b/lib/msal-common/src/request/BaseAuthRequest.ts
@@ -69,8 +69,16 @@ export type BaseAuthRequest = {
     azureCloudOptions?: AzureCloudOptions;
     /**
      * Maximum allowed age, in milliseconds, of the user's authentication before a new sign-in is required.
+     * @deprecated Use `maxAgeSeconds` instead. The OIDC `max_age` parameter is expressed in seconds;
+     * `maxAge` (milliseconds) is retained for backwards compatibility and is converted to seconds internally.
+     * If both are provided, `maxAgeSeconds` takes precedence.
      */
     maxAge?: number;
+    /**
+     * Maximum allowed age, in seconds, of the user's authentication before a new sign-in is required.
+     * Sent to the authorization server as the OIDC `max_age` parameter. A value of 0 forces an immediate re-authentication.
+     */
+    maxAgeSeconds?: number;
     /**
      * Object containing boolean values indicating whether to store tokens in the cache or not (default is true)
      */
@@ -147,4 +155,25 @@ function containsResourceParam(params?: StringDict): boolean {
     }
 
     return Object.prototype.hasOwnProperty.call(params, "resource");
+}
+
+/**
+ * Resolves the effective maximum authentication age, in seconds, from a request.
+ * Prefers the seconds-based `maxAgeSeconds`; falls back to the deprecated
+ * millisecond-based `maxAge`, converting it to seconds.
+ * @param request - Auth request
+ * @returns the max age in seconds, or undefined if neither property is set
+ */
+export function getMaxAgeSeconds(
+    request: Pick<BaseAuthRequest, "maxAge" | "maxAgeSeconds">
+): number | undefined {
+    if (request.maxAgeSeconds !== undefined) {
+        return request.maxAgeSeconds;
+    }
+
+    if (request.maxAge !== undefined) {
+        return Math.floor(request.maxAge / 1000);
+    }
+
+    return undefined;
 }

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -300,18 +300,13 @@ export function addPrompt(
 
 /**
  * add max_age
- * The maxAge request property is in milliseconds; the OIDC max_age request
- * parameter is expressed in seconds, so it is converted here.
- * @param maxAge - maximum allowed age, in milliseconds, of the user's authentication
+ * @param maxAgeSeconds - maximum allowed age, in seconds, of the user's authentication
  */
 export function addMaxAge(
     parameters: Map<string, string>,
-    maxAge: number
+    maxAgeSeconds: number
 ): void {
-    parameters.set(
-        AADServerParamKeys.MAX_AGE,
-        Math.floor(maxAge / 1000).toString()
-    );
+    parameters.set(AADServerParamKeys.MAX_AGE, maxAgeSeconds.toString());
 }
 
 /**

--- a/lib/msal-common/src/request/RequestParameterBuilder.ts
+++ b/lib/msal-common/src/request/RequestParameterBuilder.ts
@@ -299,6 +299,22 @@ export function addPrompt(
 }
 
 /**
+ * add max_age
+ * The maxAge request property is in milliseconds; the OIDC max_age request
+ * parameter is expressed in seconds, so it is converted here.
+ * @param maxAge - maximum allowed age, in milliseconds, of the user's authentication
+ */
+export function addMaxAge(
+    parameters: Map<string, string>,
+    maxAge: number
+): void {
+    parameters.set(
+        AADServerParamKeys.MAX_AGE,
+        Math.floor(maxAge / 1000).toString()
+    );
+}
+
+/**
  * add state
  * @param state
  */

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -42,7 +42,10 @@ import {
 } from "../error/InteractionRequiredAuthError.js";
 import { ServerError } from "../error/ServerError.js";
 import { Logger } from "../logger/Logger.js";
-import { BaseAuthRequest } from "../request/BaseAuthRequest.js";
+import {
+    BaseAuthRequest,
+    getMaxAgeSeconds,
+} from "../request/BaseAuthRequest.js";
 import { ScopeSet } from "../request/ScopeSet.js";
 import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
 import * as Constants from "../utils/Constants.js";
@@ -215,7 +218,8 @@ export class ResponseHandler {
             }
 
             // token max_age check
-            if (request.maxAge || request.maxAge === 0) {
+            const maxAgeSeconds = getMaxAgeSeconds(request);
+            if (maxAgeSeconds !== undefined) {
                 const authTime = idTokenClaims.auth_time;
                 if (!authTime) {
                     throw createClientAuthError(
@@ -223,7 +227,7 @@ export class ResponseHandler {
                     );
                 }
 
-                checkMaxAge(authTime, request.maxAge);
+                checkMaxAge(authTime, maxAgeSeconds);
             }
         }
 

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -547,7 +547,9 @@ describe("AuthorizationCodeClient unit tests", () => {
                 oid: "00000000-0000-0000-66f3-3332eca7ea81",
                 tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
                 nonce: "123523",
-                auth_time: Date.now() - Constants.ONE_DAY_IN_MS * 2,
+                auth_time: Math.floor(
+                    (Date.now() - Constants.ONE_DAY_IN_MS * 2) / 1000
+                ),
             };
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims
@@ -937,7 +939,9 @@ describe("AuthorizationCodeClient unit tests", () => {
                 oid: "00000000-0000-0000-66f3-3332eca7ea81",
                 tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
                 nonce: "123523",
-                auth_time: Date.now() - Constants.ONE_DAY_IN_MS * 2,
+                auth_time: Math.floor(
+                    (Date.now() - Constants.ONE_DAY_IN_MS * 2) / 1000
+                ),
             };
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaims

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -985,6 +985,34 @@ describe("SilentFlowClient unit tests", () => {
             );
         });
 
+        it("Throws error if maxAgeSeconds has transpired since the last end-user authentication", async () => {
+            const client = new SilentFlowClient(config, stubPerformanceClient);
+            jest.spyOn(TimeUtils, <any>"isTokenExpired").mockReturnValue(false);
+
+            const idTokenClaimsWithAuthTime = {
+                ...ID_TOKEN_CLAIMS,
+                auth_time: Math.floor((Date.now() - ONE_DAY_IN_MS * 2) / 1000),
+            };
+            jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
+                idTokenClaimsWithAuthTime
+            );
+
+            const silentFlowRequest: CommonSilentFlowRequest = {
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                account: testAccount,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                forceRefresh: false,
+                maxAgeSeconds: 3600, // one hour, auth occurred two days ago
+            };
+
+            await expect(
+                client.acquireCachedToken(silentFlowRequest)
+            ).rejects.toMatchObject(
+                createClientAuthError(ClientAuthErrorCodes.maxAgeTranspired)
+            );
+        });
+
         it("Throws error if max age is requested and auth time is not included in the token claims", async () => {
             const client = new SilentFlowClient(config, stubPerformanceClient);
             jest.spyOn(TimeUtils, <any>"isTokenExpired").mockReturnValue(false);

--- a/lib/msal-common/test/client/SilentFlowClient.spec.ts
+++ b/lib/msal-common/test/client/SilentFlowClient.spec.ts
@@ -386,7 +386,7 @@ describe("SilentFlowClient unit tests", () => {
 
             const idTokenClaimsWithAuthTime = {
                 ...ID_TOKEN_CLAIMS,
-                auth_time: Date.now() - ONE_DAY_IN_MS * 2,
+                auth_time: Math.floor((Date.now() - ONE_DAY_IN_MS * 2) / 1000),
             };
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaimsWithAuthTime
@@ -963,7 +963,7 @@ describe("SilentFlowClient unit tests", () => {
 
             const idTokenClaimsWithAuthTime = {
                 ...ID_TOKEN_CLAIMS,
-                auth_time: Date.now() - ONE_DAY_IN_MS * 2,
+                auth_time: Math.floor((Date.now() - ONE_DAY_IN_MS * 2) / 1000),
             };
             jest.spyOn(AuthToken, "extractTokenClaims").mockReturnValue(
                 idTokenClaimsWithAuthTime

--- a/lib/msal-common/test/protocol/Authorize.spec.ts
+++ b/lib/msal-common/test/protocol/Authorize.spec.ts
@@ -1268,6 +1268,83 @@ describe("Authorize Protocol Tests", () => {
             expect(queryString.includes("instance_aware")).toBeFalsy();
         });
 
+        it("adds max_age (converted from milliseconds to seconds) when maxAge is set", async () => {
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: Constants.ResponseMode.FRAGMENT,
+                prompt: Constants.PromptValue.LOGIN,
+                redirectUri: "localhost",
+                maxAge: Constants.ONE_DAY_IN_MS,
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptions,
+                    request,
+                    new Logger({})
+                );
+            const queryString = UrlUtils.mapToQueryString(params);
+
+            expect(queryString).toContain(
+                `${AADServerParamKeys.MAX_AGE}=${
+                    Constants.ONE_DAY_IN_MS / 1000
+                }`
+            );
+        });
+
+        it("adds max_age=0 when maxAge is 0 to force re-authentication", async () => {
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: Constants.ResponseMode.FRAGMENT,
+                prompt: Constants.PromptValue.LOGIN,
+                redirectUri: "localhost",
+                maxAge: 0,
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptions,
+                    request,
+                    new Logger({})
+                );
+            const queryString = UrlUtils.mapToQueryString(params);
+
+            expect(queryString).toContain(`${AADServerParamKeys.MAX_AGE}=0`);
+        });
+
+        it("does not add max_age when maxAge is not set", async () => {
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: Constants.ResponseMode.FRAGMENT,
+                prompt: Constants.PromptValue.LOGIN,
+                redirectUri: "localhost",
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptions,
+                    request,
+                    new Logger({})
+                );
+            const queryString = UrlUtils.mapToQueryString(params);
+
+            expect(
+                queryString.includes(AADServerParamKeys.MAX_AGE)
+            ).toBeFalsy();
+        });
+
         it("pick up instance_aware EQ param when config is set to false", async () => {
             authOptions.instanceAware = false;
 

--- a/lib/msal-common/test/protocol/Authorize.spec.ts
+++ b/lib/msal-common/test/protocol/Authorize.spec.ts
@@ -1268,7 +1268,7 @@ describe("Authorize Protocol Tests", () => {
             expect(queryString.includes("instance_aware")).toBeFalsy();
         });
 
-        it("adds max_age (converted from milliseconds to seconds) when maxAge is set", async () => {
+        it("adds max_age (converted from milliseconds to seconds) when deprecated maxAge is set", async () => {
             const request: CommonAuthorizationUrlRequest = {
                 scopes: ["User.Read"],
                 nonce: RANDOM_TEST_GUID,
@@ -1296,7 +1296,80 @@ describe("Authorize Protocol Tests", () => {
             );
         });
 
-        it("adds max_age=0 when maxAge is 0 to force re-authentication", async () => {
+        it("adds max_age (in seconds) when maxAgeSeconds is set", async () => {
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: Constants.ResponseMode.FRAGMENT,
+                prompt: Constants.PromptValue.LOGIN,
+                redirectUri: "localhost",
+                maxAgeSeconds: 3600,
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptions,
+                    request,
+                    new Logger({})
+                );
+            const queryString = UrlUtils.mapToQueryString(params);
+
+            expect(queryString).toContain(`${AADServerParamKeys.MAX_AGE}=3600`);
+        });
+
+        it("prefers maxAgeSeconds over deprecated maxAge", async () => {
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: Constants.ResponseMode.FRAGMENT,
+                prompt: Constants.PromptValue.LOGIN,
+                redirectUri: "localhost",
+                maxAgeSeconds: 3600,
+                maxAge: Constants.ONE_DAY_IN_MS,
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptions,
+                    request,
+                    new Logger({})
+                );
+            const queryString = UrlUtils.mapToQueryString(params);
+
+            expect(queryString).toContain(`${AADServerParamKeys.MAX_AGE}=3600`);
+        });
+
+        it("adds max_age=0 when maxAgeSeconds is 0 to force re-authentication", async () => {
+            const request: CommonAuthorizationUrlRequest = {
+                scopes: ["User.Read"],
+                nonce: RANDOM_TEST_GUID,
+                state: TEST_CONFIG.STATE,
+                authority: TEST_CONFIG.validAuthority,
+                correlationId: RANDOM_TEST_GUID,
+                responseMode: Constants.ResponseMode.FRAGMENT,
+                prompt: Constants.PromptValue.LOGIN,
+                redirectUri: "localhost",
+                maxAgeSeconds: 0,
+            };
+
+            const params =
+                AuthorizeProtocol.getStandardAuthorizeRequestParameters(
+                    authOptions,
+                    request,
+                    new Logger({})
+                );
+            const queryString = UrlUtils.mapToQueryString(params);
+
+            expect(queryString).toContain(`${AADServerParamKeys.MAX_AGE}=0`);
+        });
+
+        it("adds max_age=0 when deprecated maxAge is 0 to force re-authentication", async () => {
             const request: CommonAuthorizationUrlRequest = {
                 scopes: ["User.Read"],
                 nonce: RANDOM_TEST_GUID,


### PR DESCRIPTION
## Summary

The `maxAge` request property (added in #5125) only ever drove **client-side validation** of the returned `auth_time` claim — it was never emitted as the OIDC `max_age` parameter on the `/authorize` request. As a result the authorization server was never asked to re-authenticate the user, so the feature didn't actually enforce a maximum authentication age end-to-end. (Today the only way to send `max_age` is manually via `extraQueryParameters`.)

While investigating, a second, latent bug surfaced in the validation half: `checkMaxAge` compared `auth_time` (epoch **seconds**, per OIDC) directly against `Date.now()` (epoch **milliseconds**), which makes the comparison always true for realistic `maxAge` values — i.e. `request.maxAge` would throw `max_age_transpired` even for a token issued seconds ago. The existing tests masked this by faking `auth_time` in milliseconds, so they stayed green while production was broken.

## Changes

- **Send `max_age`**: new `MAX_AGE` server param key and `RequestParameterBuilder.addMaxAge`, wired into `getStandardAuthorizeRequestParameters` (Authorize.ts). Emitted whenever `request.maxAge` is defined, including `max_age=0` to force immediate re-auth. The public `maxAge` property stays in **milliseconds** (no breaking change) and is converted to **seconds** for the param.
- **Fix `checkMaxAge` units**: convert `auth_time` (seconds) to milliseconds before comparing. Behavior is shared across PCA and CCA (all msal-common).
- **Tests**: added outbound-URL assertions for `max_age` (set / `0` / unset) and corrected the `auth_time` fixtures to use seconds.

## Validation

- `npm run build` ✅
- `npm test` ✅ (1024 passed)
- `npm run lint` ✅ (0 errors)
- `npm run format:check` ✅
- `npm run apiExtractor` ✅ (API review updated — additive only)
