### PR TITLE
Fix: include resource in silent request thumbprint to prevent MCP cross-resource token substitution

### DIFF
--- a/change/@azure-msal-common-ec431dd3-ae70-4078-b030-5fab12296759.json
+++ b/change/@azure-msal-common-ec431dd3-ae70-4078-b030-5fab12296759.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Include resource in the silent request thumbprint so concurrent MCP token requests for different resources are not deduplicated",
+    "packageName": "@azure/msal-common",
+    "email": "joarroyo@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-ec431dd3-ae70-4078-b030-5fab12296759.json
+++ b/change/@azure-msal-common-ec431dd3-ae70-4078-b030-5fab12296759.json
@@ -1,6 +1,6 @@
 {
     "type": "patch",
-    "comment": "Include resource in the silent request thumbprint so concurrent MCP token requests for different resources are not deduplicated",
+    "comment": "Include resource in the silent request thumbprint so concurrent MCP token requests for different resources are not deduplicated [#8680](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8680)",
     "packageName": "@azure/msal-common",
     "email": "joarroyo@microsoft.com",
     "dependentChangeType": "patch"

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -5756,6 +5756,97 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
             expect(silentATStub).toHaveBeenCalledTimes(6);
         });
 
+        it("makes a network request per MCP resource when acquireTokenSilent is called in parallel for different resources", async () => {
+            const testIdTokenClaims: TokenClaims = {
+                ver: "2.0",
+                iss: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+                sub: "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
+                name: "Abe Lincoln",
+                preferred_username: "AbeLi@microsoft.com",
+                oid: "00000000-0000-0000-66f3-3332eca7ea81",
+                tid: "3338040d-6c67-4c5b-b112-36a304b66dad",
+                nonce: "123523",
+                login_hint: "testLoginHint",
+            };
+            const testAccount: AccountInfo = {
+                homeAccountId: TEST_DATA_CLIENT_INFO.TEST_HOME_ACCOUNT_ID,
+                localAccountId: TEST_DATA_CLIENT_INFO.TEST_UID,
+                environment: "login.windows.net",
+                tenantId: testIdTokenClaims.tid || "",
+                username: testIdTokenClaims.preferred_username || "",
+                loginHint: testIdTokenClaims.login_hint,
+            };
+            const baseTokenResponse: AuthenticationResult = {
+                authority: TEST_CONFIG.validAuthority,
+                uniqueId: testIdTokenClaims.oid || "",
+                tenantId: testIdTokenClaims.tid || "",
+                scopes: ["mcp.invoke"],
+                idToken: TEST_TOKENS.IDTOKEN_V2,
+                idTokenClaims: testIdTokenClaims,
+                accessToken: TEST_TOKENS.ACCESS_TOKEN,
+                fromCache: false,
+                correlationId: RANDOM_TEST_GUID,
+                expiresOn: TestTimeUtils.nowDateWithOffset(
+                    TEST_TOKEN_LIFETIMES.DEFAULT_EXPIRES_IN
+                ),
+                account: testAccount,
+                tokenType: Constants.AuthenticationScheme.BEARER,
+            };
+
+            jest.spyOn(BrowserCrypto, "createNewGuid").mockReturnValue(
+                RANDOM_TEST_GUID
+            );
+            jest.spyOn(CryptoOps.prototype, "hashString").mockResolvedValue(
+                TEST_CRYPTO_VALUES.TEST_SHA256_HASH
+            );
+
+            const RESOURCE_A = "https://resource-a.example/mcp";
+            const RESOURCE_B = "https://resource-b.example/mcp";
+
+            // Each underlying acquisition mints a token tagged with the resource
+            // it was requested for. The delay ensures both requests are in flight
+            // simultaneously, exercising the in-flight deduplication path.
+            const silentATStub: jest.SpyInstance = jest
+                .spyOn(
+                    RefreshTokenClient.prototype,
+                    "acquireTokenByRefreshToken"
+                )
+                .mockImplementation(async (request: CommonSilentFlowRequest) => {
+                    await new Promise((resolve) => setTimeout(resolve, 50));
+                    return {
+                        ...baseTokenResponse,
+                        accessToken: `token-for(${request.resource})`,
+                    };
+                });
+
+            const requestA: SilentRequest = {
+                scopes: ["mcp.invoke"],
+                account: testAccount,
+                authority: TEST_CONFIG.validAuthority,
+                authenticationScheme: Constants.AuthenticationScheme.BEARER,
+                correlationId: "corr-A",
+                forceRefresh: false,
+                resource: RESOURCE_A,
+            };
+            const requestB: SilentRequest = {
+                ...requestA,
+                correlationId: "corr-B",
+                resource: RESOURCE_B,
+            };
+
+            const [resultA, resultB] = await Promise.all([
+                pca.acquireTokenSilent(requestA),
+                pca.acquireTokenSilent(requestB),
+            ]);
+
+            // Concurrent silent requests that differ only by MCP resource must
+            // not be deduplicated, otherwise resource B could receive the bearer
+            // token acquired for resource A (cross-resource token substitution).
+            expect(silentATStub).toHaveBeenCalledTimes(2);
+            expect(resultA.accessToken).toBe(`token-for(${RESOURCE_A})`);
+            expect(resultB.accessToken).toBe(`token-for(${RESOURCE_B})`);
+        });
+
         it("makes network requests for identical requests for different embedded apps when acquireTokenSilent is called in parallel", async () => {
             const testServerTokenResponse = {
                 token_type: TEST_CONFIG.TOKEN_TYPE_BEARER,

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -5811,13 +5811,15 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     RefreshTokenClient.prototype,
                     "acquireTokenByRefreshToken"
                 )
-                .mockImplementation(async (request: CommonSilentFlowRequest) => {
-                    await new Promise((resolve) => setTimeout(resolve, 50));
-                    return {
-                        ...baseTokenResponse,
-                        accessToken: `token-for(${request.resource})`,
-                    };
-                });
+                .mockImplementation(
+                    async (request: CommonSilentFlowRequest) => {
+                        await new Promise((resolve) => setTimeout(resolve, 50));
+                        return {
+                            ...baseTokenResponse,
+                            accessToken: `token-for(${request.resource})`,
+                        };
+                    }
+                );
 
             const requestA: SilentRequest = {
                 scopes: ["mcp.invoke"],

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2780,6 +2780,7 @@ export type RequestThumbprint = {
     sshKid?: string;
     shrOptions?: ShrOptions;
     embeddedClientId?: string;
+    resource?: string;
 };
 
 // @public (undocumented)

--- a/lib/msal-common/src/network/RequestThumbprint.ts
+++ b/lib/msal-common/src/network/RequestThumbprint.ts
@@ -23,6 +23,7 @@ export type RequestThumbprint = {
     sshKid?: string;
     shrOptions?: ShrOptions;
     embeddedClientId?: string;
+    resource?: string;
 };
 
 export function getRequestThumbprint(
@@ -43,5 +44,6 @@ export function getRequestThumbprint(
         sshKid: request.sshKid,
         embeddedClientId:
             request.embeddedClientId || request.extraParameters?.clientId,
+        resource: request.resource,
     };
 }

--- a/lib/msal-common/test/network/RequestThumbprint.spec.ts
+++ b/lib/msal-common/test/network/RequestThumbprint.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getRequestThumbprint } from "../../src/network/RequestThumbprint.js";
+import { BaseAuthRequest } from "../../src/request/BaseAuthRequest.js";
+import { TEST_CONFIG, RANDOM_TEST_GUID } from "../test_kit/StringConstants.js";
+
+describe("RequestThumbprint.ts Unit Tests", () => {
+    const baseRequest: BaseAuthRequest = {
+        authority: TEST_CONFIG.validAuthority,
+        correlationId: RANDOM_TEST_GUID,
+        scopes: ["mcp.invoke"],
+    };
+
+    it("includes the resource value in the thumbprint", () => {
+        const resource = "https://resource-a.example/mcp";
+        const thumbprint = getRequestThumbprint(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            { ...baseRequest, resource },
+            "uid.utid"
+        );
+
+        expect(thumbprint.resource).toBe(resource);
+    });
+
+    it("leaves resource undefined when not provided on the request", () => {
+        const thumbprint = getRequestThumbprint(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            baseRequest,
+            "uid.utid"
+        );
+
+        expect(thumbprint.resource).toBeUndefined();
+    });
+
+    it("produces distinct thumbprints for requests that differ only by resource (prevents MCP cross-resource dedup)", () => {
+        const thumbprintA = getRequestThumbprint(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            { ...baseRequest, resource: "https://resource-a.example/mcp" },
+            "uid.utid"
+        );
+        const thumbprintB = getRequestThumbprint(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            { ...baseRequest, resource: "https://resource-b.example/mcp" },
+            "uid.utid"
+        );
+
+        // The deduplication key is the serialized thumbprint (see
+        // StandardController.acquireTokenSilentDeduped). Differing resources
+        // must not collide, otherwise a concurrent silent request for one MCP
+        // resource could receive the token acquired for another.
+        expect(JSON.stringify(thumbprintA)).not.toEqual(
+            JSON.stringify(thumbprintB)
+        );
+    });
+
+    it("produces identical thumbprints for requests with the same resource", () => {
+        const resource = "https://resource-a.example/mcp";
+        const thumbprintOne = getRequestThumbprint(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            { ...baseRequest, resource },
+            "uid.utid"
+        );
+        const thumbprintTwo = getRequestThumbprint(
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            { ...baseRequest, resource },
+            "uid.utid"
+        );
+
+        expect(JSON.stringify(thumbprintOne)).toEqual(
+            JSON.stringify(thumbprintTwo)
+        );
+    });
+});


### PR DESCRIPTION
## Summary

A concurrency flaw in MCP token acquisition could cause a silent token request for one MCP resource to receive the access token acquired for a *different* MCP resource.

The MCP `resource` value was omitted from the request thumbprint used by `StandardController.acquireTokenSilentDeduped`. Two concurrent `acquireTokenSilent` calls with the same account, authority, client id, and scopes but **different** MCP resources produced the same deduplication key, so the second caller received the in-flight result (and bearer token) acquired for the first resource. This is a cross-resource token substitution / bearer-token disclosure issue.

The existing per-resource validation in `SilentFlowClient` does not prevent this, because the deduplicated second request short-circuits before ever reaching `SilentFlowClient`.

## Fix

Add `resource` to `RequestThumbprint` and `getRequestThumbprint` so requests that differ only by MCP `resource` are no longer treated as identical in-flight requests.

## Changes

- `lib/msal-common/src/network/RequestThumbprint.ts` — add `resource?: string` to the type and `resource: request.resource` to the builder.
- `lib/msal-common/apiReview/msal-common.api.md` — regenerated API report for the new field.
- `lib/msal-common/test/network/RequestThumbprint.spec.ts` — new unit coverage for the thumbprint.
- `lib/msal-browser/test/app/PublicClientApplication.spec.ts` — new end-to-end regression test proving concurrent silent requests differing only by MCP resource each receive their own token.
- `change/` — beachball `patch` changefile.

## Validation

- msal-common: `build:all`, `lint`, `format:check`, `apiExtractor`, `test` (1034 passed)
- msal-browser: `build`, `lint`, `test` (1689 passed, 3 skipped)
