### PR TITLE
Validate Managed Identity endpoint host to prevent credential redirection

### DIFF
--- a/change/@azure-msal-node-c30af408-852d-4a8c-a236-70697d5e7d78.json
+++ b/change/@azure-msal-node-c30af408-852d-4a8c-a236-70697d5e7d78.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Restrict Managed Identity endpoint environment variables to loopback and link-local hosts to prevent the credential request from being redirected to an untrusted host [#8682](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8682)",
+    "packageName": "@azure/msal-node",
+    "email": "rginsburg@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-node/docs/managed-identity.md
+++ b/lib/msal-node/docs/managed-identity.md
@@ -117,3 +117,7 @@ For failed requests the error response contains a correlation ID that can be use
 #### `ManagedIdentityError` Error Code: `invalid_resource` Error Message: The supplied resource is an invalid URL.
 
 This exception might mean that the resource you are trying to acquire a token for is either not supported or is provided using the wrong resource ID format. Examples of correct resource ID formats include `https://management.azure.com/.default`, `https://management.azure.com`, and `https://graph.microsoft.com`.
+
+#### `ManagedIdentityError` Error Code: `invalid_managed_identity_endpoint` Error Message: The Managed Identity endpoint URL specified by the environment variable is not allowed. Managed Identity endpoints must use a loopback (localhost, 127.0.0.0/8, [::1]) or link-local (169.254.0.0/16) address. This prevents the credential request from being redirected to an untrusted host.
+
+This error means the managed identity endpoint environment variable (for example `IDENTITY_ENDPOINT`, `MSI_ENDPOINT`, `IMDS_ENDPOINT`, or `AZURE_POD_IDENTITY_AUTHORITY_HOST`) resolved to a host that is not loopback or link-local. MSAL only contacts the node-local managed identity endpoint, so a non-local host indicates the variable has been altered to point elsewhere. Verify that the environment variable is set by the trusted hosting environment (App Service, Azure Arc, Cloud Shell, Machine Learning, Service Fabric, or IMDS) and has not been overridden.

--- a/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/AzureArc.ts
@@ -205,10 +205,6 @@ export class AzureArc extends BaseManagedIdentitySource {
                     ManagedIdentitySourceNames.AZURE_ARC,
                     logger
                 );
-            // remove trailing slash
-            validatedIdentityEndpoint.endsWith("/")
-                ? validatedIdentityEndpoint.slice(0, -1)
-                : validatedIdentityEndpoint;
 
             AzureArc.getValidatedEnvVariableUrlString(
                 ManagedIdentityEnvironmentVariableNames.IMDS_ENDPOINT,

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -390,9 +390,103 @@ export abstract class BaseManagedIdentitySource {
     }
 
     /**
-     * Validates and normalizes an environment variable containing a URL string.
-     * This static utility method ensures that environment variables used for managed identity
-     * endpoints contain properly formatted URLs and provides informative error messages when validation fails.
+     * Returns true only if the given URL host (as produced by the WHATWG URL parser)
+     * is a loopback or link-local address.
+     *
+     * Managed Identity credential endpoints are always served by a node-local agent
+     * (IMDS on link-local 169.254.169.254; Azure Arc, App Service, Cloud Shell, Machine
+     * Learning and Service Fabric on loopback). Any other host indicates the endpoint
+     * environment variable has been tampered with to redirect the credential request -
+     * and the secret it carries - to an attacker-controlled server.
+     *
+     * The host must come from URL.hostname (not UrlString's regex) so that userinfo such
+     * as "http://127.0.0.1@evil.com" correctly resolves to host "evil.com" and is
+     * rejected. The WHATWG parser also normalizes alternate IPv4 encodings (decimal,
+     * hexadecimal, short form) to dotted-decimal, so the octet checks below can assume
+     * base-10 notation.
+     *
+     * @param hostname - The host component of the endpoint URL (URL.hostname)
+     * @returns true if the host is loopback or link-local, false otherwise
+     */
+    private static isAllowedManagedIdentityHost(hostname: string): boolean {
+        const host: string = hostname.toLowerCase();
+
+        /*
+         * localhost and the bracketed IPv6 loopback that URL.hostname returns
+         * (e.g. "[::1]") are always node-local.
+         */
+        if (host === "localhost" || host === "[::1]") {
+            return true;
+        }
+
+        const octets: number[] | null =
+            BaseManagedIdentitySource.parseIPv4Octets(host);
+        if (octets) {
+            /*
+             * IPv4 loopback (127.0.0.0/8) and link-local (169.254.0.0/16). The
+             * latter includes the well-known IMDS endpoint 169.254.169.254.
+             */
+            if (octets[0] === 127) {
+                return true;
+            }
+            if (octets[0] === 169 && octets[1] === 254) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Parses a host string as a dotted-decimal IPv4 address (e.g. "127.0.0.1").
+     *
+     * URL.hostname has already normalized alternate IPv4 encodings (decimal,
+     * hexadecimal, short form) to dotted-decimal, so a node-local literal always
+     * reaches this method as four base-10 octets. Anything that is not exactly four
+     * numeric octets in the 0-255 range (including real domain names such as
+     * "127.0.0.1.evil.com") returns null and is therefore treated as disallowed.
+     *
+     * @param host - The lower-cased host component to parse
+     * @returns The four octets as numbers, or null if host is not a dotted-decimal IPv4 address
+     */
+    private static parseIPv4Octets(host: string): number[] | null {
+        const parts: string[] = host.split(".");
+        if (parts.length !== 4) {
+            return null;
+        }
+
+        const octets: number[] = [];
+        for (const part of parts) {
+            if (part.length < 1 || part.length > 3) {
+                return null;
+            }
+
+            for (let i: number = 0; i < part.length; i++) {
+                const charCode: number = part.charCodeAt(i);
+                if (charCode < 0x30 || charCode > 0x39) {
+                    return null;
+                }
+            }
+
+            const octet: number = Number(part);
+            if (octet > 255) {
+                return null;
+            }
+            octets.push(octet);
+        }
+
+        return octets;
+    }
+
+    /**
+     * Validates and normalizes an environment variable containing a Managed Identity
+     * endpoint URL.
+     *
+     * Beyond ensuring the value is a parseable URL, this pins the endpoint host to a
+     * node-local (loopback or link-local) address. Managed Identity endpoint URLs are
+     * read from environment variables and are used together with credential material, so
+     * host pinning prevents an in-process attacker from redirecting the credential
+     * request to an arbitrary server.
      *
      * @param envVariableStringName - The name of the environment variable being validated (for error reporting)
      * @param envVariable - The environment variable value containing the URL string
@@ -401,7 +495,8 @@ export abstract class BaseManagedIdentitySource {
      *
      * @returns The validated and normalized URL string
      *
-     * @throws {ManagedIdentityError} When the environment variable contains a malformed URL
+     * @throws {ManagedIdentityError} When the value is not a parseable URL, or when its
+     *         host is not a loopback / link-local address
      */
     public static getValidatedEnvVariableUrlString = (
         envVariableStringName: keyof typeof ManagedIdentityErrorCodes.MsiEnvironmentVariableUrlMalformedErrorCodes,
@@ -409,9 +504,15 @@ export abstract class BaseManagedIdentitySource {
         sourceName: string,
         logger: Logger
     ): string => {
+        let endpointHost: string;
         try {
-            // Static boot-time helper invoked from each MI source's tryCreate() before any request exists
-            return new UrlString(envVariable, "").urlString;
+            /*
+             * Parse with the WHATWG URL parser so the host is cleanly separated
+             * from any userinfo (e.g. "http://127.0.0.1@evil.com" resolves to
+             * host "evil.com"). This helper runs from each MI source's
+             * tryCreate() before any request object exists.
+             */
+            endpointHost = new URL(envVariable).hostname;
         } catch (error) {
             logger.info(
                 `[Managed Identity] ${sourceName} managed identity is unavailable because the '${envVariableStringName}' environment variable is malformed.`,
@@ -426,5 +527,28 @@ export abstract class BaseManagedIdentitySource {
                 ""
             );
         }
+
+        /*
+         * Managed Identity endpoints are always node-local. Reject any other
+         * host so a co-located attacker cannot redirect the credential request
+         * (and its secret) to an arbitrary server via this environment variable.
+         */
+        if (
+            !BaseManagedIdentitySource.isAllowedManagedIdentityHost(
+                endpointHost
+            )
+        ) {
+            logger.error(
+                `[Managed Identity] ${sourceName} managed identity is unavailable because the '${envVariableStringName}' environment variable points to a disallowed host '${endpointHost}'. Managed Identity endpoints must use a loopback or link-local address.`,
+                ""
+            );
+
+            throw createManagedIdentityError(
+                ManagedIdentityErrorCodes.invalidManagedIdentityEndpoint,
+                ""
+            );
+        }
+
+        return new UrlString(envVariable, "").urlString;
     };
 }

--- a/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
+++ b/lib/msal-node/src/client/ManagedIdentitySources/BaseManagedIdentitySource.ts
@@ -413,7 +413,11 @@ export abstract class BaseManagedIdentitySource {
 
         /*
          * localhost and the bracketed IPv6 loopback that URL.hostname returns
-         * (e.g. "[::1]") are always node-local.
+         * (e.g. "[::1]") are always node-local. Allowing localhost by name is
+         * intentional: the threat mitigated here is redirection to an off-box
+         * attacker server. A co-located process that can both bind localhost and
+         * set these environment variables already has local code execution, which
+         * is outside the scope of this control.
          */
         if (host === "localhost" || host === "[::1]") {
             return true;
@@ -434,6 +438,11 @@ export abstract class BaseManagedIdentitySource {
             }
         }
 
+        /*
+         * Everything else is rejected, including IPv6 link-local (fe80::/10) and
+         * IPv4-mapped IPv6 such as "[::ffff:127.0.0.1]". Real Managed Identity
+         * endpoints never use those forms, so failing closed is the safe choice.
+         */
         return false;
     }
 
@@ -549,6 +558,12 @@ export abstract class BaseManagedIdentitySource {
             );
         }
 
+        /*
+         * Re-parse with UrlString for canonicalization parity with the rest of
+         * msal. This intentionally sits outside the try/catch above: UrlString's
+         * constructor only throws on an empty value, which the new URL() parse has
+         * already rejected, so any value reaching here is non-empty and safe.
+         */
         return new UrlString(envVariable, "").urlString;
     };
 }

--- a/lib/msal-node/src/error/ManagedIdentityError.ts
+++ b/lib/msal-node/src/error/ManagedIdentityError.ts
@@ -32,6 +32,8 @@ export const ManagedIdentityErrorMessages = {
         .IMDS_ENDPOINT]: `The Managed Identity's '${ManagedIdentityEnvironmentVariableNames.IMDS_ENDPOINT}' environment variable is malformed.`,
     [ManagedIdentityErrorCodes.MsiEnvironmentVariableUrlMalformedErrorCodes
         .MSI_ENDPOINT]: `The Managed Identity's '${ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT}' environment variable is malformed.`,
+    [ManagedIdentityErrorCodes.invalidManagedIdentityEndpoint]:
+        "The Managed Identity endpoint URL specified by the environment variable is not allowed. Managed Identity endpoints must use a loopback (localhost, 127.0.0.0/8, [::1]) or link-local (169.254.0.0/16) address. This prevents the credential request from being redirected to an untrusted host.",
     [ManagedIdentityErrorCodes.networkUnavailable]:
         "Authentication unavailable. The request to the managed identity endpoint timed out.",
     [ManagedIdentityErrorCodes.unableToCreateAzureArc]:

--- a/lib/msal-node/src/error/ManagedIdentityErrorCodes.ts
+++ b/lib/msal-node/src/error/ManagedIdentityErrorCodes.ts
@@ -17,6 +17,8 @@ export const unableToCreateCloudShell = "unable_to_create_cloud_shell";
 export const unableToCreateSource = "unable_to_create_source";
 export const unableToReadSecretFile = "unable_to_read_secret_file";
 export const urlParseError = "url_parse_error";
+export const invalidManagedIdentityEndpoint =
+    "invalid_managed_identity_endpoint";
 export const userAssignedNotAvailableAtRuntime =
     "user_assigned_not_available_at_runtime";
 export const wwwAuthenticateHeaderMissing = "www_authenticate_header_missing";

--- a/lib/msal-node/test/client/ManagedIdentitySources/AppService.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/AppService.spec.ts
@@ -35,7 +35,7 @@ import { ManagedIdentityUserAssignedIdQueryParameterNames } from "../../../src/c
 describe("Acquires a token successfully via an App Service Managed Identity", () => {
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
-            "fake_IDENTITY_ENDPOINT";
+            "http://127.0.0.1:41564/msi/token";
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER] =
             "fake_IDENTITY_HEADER";
     });

--- a/lib/msal-node/test/client/ManagedIdentitySources/AppService.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/AppService.spec.ts
@@ -10,6 +10,7 @@ import {
     MANAGED_IDENTITY_APP_SERVICE_NETWORK_REQUEST_400_ERROR,
     MANAGED_IDENTITY_RESOURCE,
     MANAGED_IDENTITY_RESOURCE_ID,
+    MANAGED_IDENTITY_TEST_ENDPOINTS,
 } from "../../test_kit/StringConstants.js";
 
 import {
@@ -35,7 +36,7 @@ import { ManagedIdentityUserAssignedIdQueryParameterNames } from "../../../src/c
 describe("Acquires a token successfully via an App Service Managed Identity", () => {
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
-            "http://127.0.0.1:41564/msi/token";
+            MANAGED_IDENTITY_TEST_ENDPOINTS.APP_SERVICE;
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER] =
             "fake_IDENTITY_HEADER";
     });

--- a/lib/msal-node/test/client/ManagedIdentitySources/AzureArc.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/AzureArc.spec.ts
@@ -11,6 +11,7 @@ import {
     MANAGED_IDENTITY_CONTENT_TYPE_HEADER,
     MANAGED_IDENTITY_RESOURCE,
     MANAGED_IDENTITY_RESOURCE_BASE,
+    MANAGED_IDENTITY_TEST_ENDPOINTS,
     TEST_TOKENS,
 } from "../../test_kit/StringConstants.js";
 
@@ -49,9 +50,9 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
 
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
-            "http://127.0.0.1:40342/metadata/identity/oauth2/token";
+            MANAGED_IDENTITY_TEST_ENDPOINTS.AZURE_ARC;
         process.env[ManagedIdentityEnvironmentVariableNames.IMDS_ENDPOINT] =
-            "http://127.0.0.1:40342/metadata/identity/oauth2/token";
+            MANAGED_IDENTITY_TEST_ENDPOINTS.AZURE_ARC;
 
         originalPlatform = process.platform;
         Object.defineProperty(process, "platform", {
@@ -171,9 +172,9 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
             // reset the environment variables to expected values for Azure Arc tests
             process.env[
                 ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT
-            ] = "http://127.0.0.1:40342/metadata/identity/oauth2/token";
+            ] = MANAGED_IDENTITY_TEST_ENDPOINTS.AZURE_ARC;
             process.env[ManagedIdentityEnvironmentVariableNames.IMDS_ENDPOINT] =
-                "http://127.0.0.1:40342/metadata/identity/oauth2/token";
+                MANAGED_IDENTITY_TEST_ENDPOINTS.AZURE_ARC;
         });
 
         test("returns an already acquired token from the cache", async () => {

--- a/lib/msal-node/test/client/ManagedIdentitySources/AzureArc.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/AzureArc.spec.ts
@@ -49,9 +49,9 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
 
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
-            "fake_IDENTITY_ENDPOINT";
+            "http://127.0.0.1:40342/metadata/identity/oauth2/token";
         process.env[ManagedIdentityEnvironmentVariableNames.IMDS_ENDPOINT] =
-            "fake_IMDS_ENDPOINT";
+            "http://127.0.0.1:40342/metadata/identity/oauth2/token";
 
         originalPlatform = process.platform;
         Object.defineProperty(process, "platform", {
@@ -171,9 +171,9 @@ describe("Acquires a token successfully via an Azure Arc Managed Identity", () =
             // reset the environment variables to expected values for Azure Arc tests
             process.env[
                 ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT
-            ] = "fake_IDENTITY_ENDPOINT";
+            ] = "http://127.0.0.1:40342/metadata/identity/oauth2/token";
             process.env[ManagedIdentityEnvironmentVariableNames.IMDS_ENDPOINT] =
-                "fake_IMDS_ENDPOINT";
+                "http://127.0.0.1:40342/metadata/identity/oauth2/token";
         });
 
         test("returns an already acquired token from the cache", async () => {

--- a/lib/msal-node/test/client/ManagedIdentitySources/CloudShell.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/CloudShell.spec.ts
@@ -8,6 +8,7 @@ import {
     DEFAULT_SYSTEM_ASSIGNED_MANAGED_IDENTITY_AUTHENTICATION_RESULT,
     MANAGED_IDENTITY_CLOUD_SHELL_NETWORK_REQUEST_400_ERROR,
     MANAGED_IDENTITY_RESOURCE,
+    MANAGED_IDENTITY_TEST_ENDPOINTS,
     MANAGED_IDENTITY_TOKEN_RETRIEVAL_ERROR,
     MANAGED_IDENTITY_TOKEN_RETRIEVAL_ERROR_MESSAGE,
 } from "../../test_kit/StringConstants.js";
@@ -37,7 +38,7 @@ import {
 describe("Acquires a token successfully via an App Service Managed Identity", () => {
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT] =
-            "http://localhost:50342/metadata/identity/oauth2/token";
+            MANAGED_IDENTITY_TEST_ENDPOINTS.CLOUD_SHELL;
     });
 
     afterAll(() => {

--- a/lib/msal-node/test/client/ManagedIdentitySources/CloudShell.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/CloudShell.spec.ts
@@ -35,7 +35,7 @@ import {
     createManagedIdentityError,
 } from "../../../src/error/ManagedIdentityError.js";
 
-describe("Acquires a token successfully via an App Service Managed Identity", () => {
+describe("Acquires a token successfully via a Cloud Shell Managed Identity", () => {
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT] =
             MANAGED_IDENTITY_TEST_ENDPOINTS.CLOUD_SHELL;

--- a/lib/msal-node/test/client/ManagedIdentitySources/CloudShell.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/CloudShell.spec.ts
@@ -37,7 +37,7 @@ import {
 describe("Acquires a token successfully via an App Service Managed Identity", () => {
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT] =
-            "msi_IDENTITY_ENDPOINT";
+            "http://localhost:50342/metadata/identity/oauth2/token";
     });
 
     afterAll(() => {

--- a/lib/msal-node/test/client/ManagedIdentitySources/DefaultManagedIdentityRetryPolicy.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/DefaultManagedIdentityRetryPolicy.spec.ts
@@ -7,6 +7,7 @@ import { ManagedIdentityApplication } from "../../../src/client/ManagedIdentityA
 import {
     DEFAULT_USER_SYSTEM_ASSIGNED_MANAGED_IDENTITY_AUTHENTICATION_RESULT,
     MANAGED_IDENTITY_SERVICE_FABRIC_NETWORK_REQUEST_400_ERROR,
+    MANAGED_IDENTITY_TEST_ENDPOINTS,
     MANAGED_IDENTITY_TOKEN_RETRIEVAL_ERROR_MESSAGE,
     ONE_HUNDRED_TIMES_FASTER,
 } from "../../test_kit/StringConstants.js";
@@ -34,7 +35,7 @@ describe("Linear Retry Policy (App Service, Azure Arc, Cloud Shell, Machine Lear
     beforeAll(() => {
         // The managed identity's source will be set to Service Fabric for these tests
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
-            "https://localhost:2377/metadata/identity/oauth2/token";
+            MANAGED_IDENTITY_TEST_ENDPOINTS.SERVICE_FABRIC;
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER] =
             "fake_IDENTITY_HEADER";
         process.env[

--- a/lib/msal-node/test/client/ManagedIdentitySources/DefaultManagedIdentityRetryPolicy.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/DefaultManagedIdentityRetryPolicy.spec.ts
@@ -34,7 +34,7 @@ describe("Linear Retry Policy (App Service, Azure Arc, Cloud Shell, Machine Lear
     beforeAll(() => {
         // The managed identity's source will be set to Service Fabric for these tests
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
-            "fake_IDENTITY_ENDPOINT";
+            "https://localhost:2377/metadata/identity/oauth2/token";
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER] =
             "fake_IDENTITY_HEADER";
         process.env[

--- a/lib/msal-node/test/client/ManagedIdentitySources/MachineLearning.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/MachineLearning.spec.ts
@@ -39,7 +39,7 @@ describe("Acquires a token successfully via an Machine Learning Managed Identity
             ManagedIdentityEnvironmentVariableNames.DEFAULT_IDENTITY_CLIENT_ID
         ] = "fake_DEFAULT_IDENTITY_CLIENT_ID";
         process.env[ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT] =
-            "fake_MSI_ENDPOINT";
+            "http://127.0.0.1:42424/msi/token";
         process.env[ManagedIdentityEnvironmentVariableNames.MSI_SECRET] =
             "fake_MSI_SECRET";
     });

--- a/lib/msal-node/test/client/ManagedIdentitySources/MachineLearning.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/MachineLearning.spec.ts
@@ -9,6 +9,7 @@ import {
     DEFAULT_USER_SYSTEM_ASSIGNED_MANAGED_IDENTITY_AUTHENTICATION_RESULT,
     MANAGED_IDENTITY_MACHINE_LEARNING_NETWORK_REQUEST_400_ERROR,
     MANAGED_IDENTITY_RESOURCE,
+    MANAGED_IDENTITY_TEST_ENDPOINTS,
 } from "../../test_kit/StringConstants.js";
 
 import {
@@ -39,7 +40,7 @@ describe("Acquires a token successfully via an Machine Learning Managed Identity
             ManagedIdentityEnvironmentVariableNames.DEFAULT_IDENTITY_CLIENT_ID
         ] = "fake_DEFAULT_IDENTITY_CLIENT_ID";
         process.env[ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT] =
-            "http://127.0.0.1:42424/msi/token";
+            MANAGED_IDENTITY_TEST_ENDPOINTS.MACHINE_LEARNING;
         process.env[ManagedIdentityEnvironmentVariableNames.MSI_SECRET] =
             "fake_MSI_SECRET";
     });

--- a/lib/msal-node/test/client/ManagedIdentitySources/ManagedIdentityEndpointValidation.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/ManagedIdentityEndpointValidation.spec.ts
@@ -34,13 +34,14 @@ const logger = new Logger({});
 // Invoke the shared validator and return the thrown error (or undefined if it did not throw).
 const validate = (
     envVar: keyof typeof ManagedIdentityErrorCodes.MsiEnvironmentVariableUrlMalformedErrorCodes,
-    value: string
+    value: string,
+    sourceName: string = ManagedIdentitySourceNames.APP_SERVICE
 ): unknown => {
     try {
         BaseManagedIdentitySource.getValidatedEnvVariableUrlString(
             envVar,
             value,
-            ManagedIdentitySourceNames.APP_SERVICE,
+            sourceName,
             logger
         );
         return undefined;
@@ -103,35 +104,61 @@ describe("Managed Identity endpoint host validation", () => {
     });
 
     describe("accepts loopback and link-local endpoints", () => {
-        const allowed: Array<[string, string]> = [
+        /*
+         * [label, env var, endpoint, source]. The source-mapped rows are
+         * validated through the env var and source name their real source uses,
+         * so the path exercised matches the label; the alternate-encoding rows
+         * are host-shape checks not tied to a particular source.
+         */
+        const allowed: Array<
+            [
+                string,
+                keyof typeof ManagedIdentityErrorCodes.MsiEnvironmentVariableUrlMalformedErrorCodes,
+                string,
+                string
+            ]
+        > = [
             [
                 "IPv4 loopback (Azure Arc)",
+                ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT,
                 MANAGED_IDENTITY_TEST_ENDPOINTS.AZURE_ARC,
+                ManagedIdentitySourceNames.AZURE_ARC,
             ],
             [
                 "localhost (Cloud Shell)",
+                ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT,
                 MANAGED_IDENTITY_TEST_ENDPOINTS.CLOUD_SHELL,
+                ManagedIdentitySourceNames.CLOUD_SHELL,
             ],
             [
                 "https localhost (Service Fabric)",
+                ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT,
                 MANAGED_IDENTITY_TEST_ENDPOINTS.SERVICE_FABRIC,
+                ManagedIdentitySourceNames.SERVICE_FABRIC,
             ],
-            ["IPv4 link-local (IMDS)", MANAGED_IDENTITY_TEST_ENDPOINTS.IMDS],
+            [
+                "IPv4 link-local (IMDS)",
+                ManagedIdentityEnvironmentVariableNames.AZURE_POD_IDENTITY_AUTHORITY_HOST,
+                MANAGED_IDENTITY_TEST_ENDPOINTS.IMDS,
+                ManagedIdentitySourceNames.IMDS,
+            ],
             [
                 "IPv6 loopback",
+                ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT,
                 "http://[::1]:40342/metadata/identity/oauth2/token",
+                ManagedIdentitySourceNames.APP_SERVICE,
             ],
             // alternate IPv4 encodings normalize to 127.0.0.1 under the WHATWG parser
-            ["decimal-encoded loopback", "http://2130706433/token"],
+            [
+                "decimal-encoded loopback",
+                ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT,
+                "http://2130706433/token",
+                ManagedIdentitySourceNames.APP_SERVICE,
+            ],
         ];
 
-        test.each(allowed)("%s", (_name, value) => {
-            expect(
-                validate(
-                    ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT,
-                    value
-                )
-            ).toBeUndefined();
+        test.each(allowed)("%s", (_name, envVar, value, sourceName) => {
+            expect(validate(envVar, value, sourceName)).toBeUndefined();
         });
     });
 

--- a/lib/msal-node/test/client/ManagedIdentitySources/ManagedIdentityEndpointValidation.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/ManagedIdentityEndpointValidation.spec.ts
@@ -19,6 +19,7 @@ import {
     systemAssignedConfig,
     managedIdentityRequestParams,
 } from "../../test_kit/ManagedIdentityTestUtils.js";
+import { MANAGED_IDENTITY_TEST_ENDPOINTS } from "../../test_kit/StringConstants.js";
 
 /*
  * Regression coverage for the Managed Identity endpoint-redirect vulnerability:
@@ -105,20 +106,17 @@ describe("Managed Identity endpoint host validation", () => {
         const allowed: Array<[string, string]> = [
             [
                 "IPv4 loopback (Azure Arc)",
-                "http://127.0.0.1:40342/metadata/identity/oauth2/token",
+                MANAGED_IDENTITY_TEST_ENDPOINTS.AZURE_ARC,
             ],
             [
                 "localhost (Cloud Shell)",
-                "http://localhost:50342/metadata/identity/oauth2/token",
+                MANAGED_IDENTITY_TEST_ENDPOINTS.CLOUD_SHELL,
             ],
             [
                 "https localhost (Service Fabric)",
-                "https://localhost:2377/metadata/identity/oauth2/token",
+                MANAGED_IDENTITY_TEST_ENDPOINTS.SERVICE_FABRIC,
             ],
-            [
-                "IPv4 link-local (IMDS)",
-                "http://169.254.169.254/metadata/identity/oauth2/token",
-            ],
+            ["IPv4 link-local (IMDS)", MANAGED_IDENTITY_TEST_ENDPOINTS.IMDS],
             [
                 "IPv6 loopback",
                 "http://[::1]:40342/metadata/identity/oauth2/token",

--- a/lib/msal-node/test/client/ManagedIdentitySources/ManagedIdentityEndpointValidation.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/ManagedIdentityEndpointValidation.spec.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Logger } from "@azure/msal-common";
+import { ManagedIdentityApplication } from "../../../src/client/ManagedIdentityApplication.js";
+import { BaseManagedIdentitySource } from "../../../src/client/ManagedIdentitySources/BaseManagedIdentitySource.js";
+import {
+    ManagedIdentityEnvironmentVariableNames,
+    ManagedIdentitySourceNames,
+} from "../../../src/utils/Constants.js";
+import {
+    ManagedIdentityErrorCodes,
+    createManagedIdentityError,
+} from "../../../src/error/ManagedIdentityError.js";
+import { ManagedIdentityClient } from "../../../src/client/ManagedIdentityClient.js";
+import {
+    systemAssignedConfig,
+    managedIdentityRequestParams,
+} from "../../test_kit/ManagedIdentityTestUtils.js";
+
+/*
+ * Regression coverage for the Managed Identity endpoint-redirect vulnerability:
+ * the endpoint URL is read from process.env and used with credential material, so
+ * its host must be pinned to a node-local (loopback / link-local) address. Otherwise
+ * an in-process attacker can redirect the credential request (and its secret) to an
+ * attacker-controlled server.
+ */
+
+const logger = new Logger({});
+
+// Invoke the shared validator and return the thrown error (or undefined if it did not throw).
+const validate = (
+    envVar: keyof typeof ManagedIdentityErrorCodes.MsiEnvironmentVariableUrlMalformedErrorCodes,
+    value: string
+): unknown => {
+    try {
+        BaseManagedIdentitySource.getValidatedEnvVariableUrlString(
+            envVar,
+            value,
+            ManagedIdentitySourceNames.APP_SERVICE,
+            logger
+        );
+        return undefined;
+    } catch (e) {
+        return e;
+    }
+};
+
+describe("Managed Identity endpoint host validation", () => {
+    describe("rejects endpoints whose host is not loopback or link-local", () => {
+        const disallowed: Array<[string, string]> = [
+            ["off-box https host", "https://attacker.contoso.com/metadata"],
+            ["off-box http host", "http://evil.example.com"],
+            // userinfo confusion: the real host is evil.com, not 127.0.0.1
+            ["userinfo confusion", "http://127.0.0.1@evil.com/"],
+            // suffix trick: a domain that merely starts with the IMDS IP
+            ["link-local suffix trick", "http://169.254.169.254.evil.com/"],
+            ["private non-loopback host", "http://10.0.0.5/"],
+            ["wildcard address", "http://0.0.0.0/"],
+        ];
+
+        test.each(disallowed)("%s", (_name, value) => {
+            expect(
+                validate(
+                    ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT,
+                    value
+                )
+            ).toMatchObject(
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidManagedIdentityEndpoint,
+                    ""
+                )
+            );
+        });
+    });
+
+    describe("rejects malformed (unparseable) endpoint URLs", () => {
+        const malformed: Array<[string, string]> = [
+            ["non-URL string", "fake_IDENTITY_ENDPOINT"],
+            ["empty string", ""],
+        ];
+
+        test.each(malformed)("%s", (_name, value) => {
+            expect(
+                validate(
+                    ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT,
+                    value
+                )
+            ).toMatchObject(
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes
+                        .MsiEnvironmentVariableUrlMalformedErrorCodes[
+                        ManagedIdentityEnvironmentVariableNames
+                            .IDENTITY_ENDPOINT
+                    ],
+                    ""
+                )
+            );
+        });
+    });
+
+    describe("accepts loopback and link-local endpoints", () => {
+        const allowed: Array<[string, string]> = [
+            [
+                "IPv4 loopback (Azure Arc)",
+                "http://127.0.0.1:40342/metadata/identity/oauth2/token",
+            ],
+            [
+                "localhost (Cloud Shell)",
+                "http://localhost:50342/metadata/identity/oauth2/token",
+            ],
+            [
+                "https localhost (Service Fabric)",
+                "https://localhost:2377/metadata/identity/oauth2/token",
+            ],
+            [
+                "IPv4 link-local (IMDS)",
+                "http://169.254.169.254/metadata/identity/oauth2/token",
+            ],
+            [
+                "IPv6 loopback",
+                "http://[::1]:40342/metadata/identity/oauth2/token",
+            ],
+            // alternate IPv4 encodings normalize to 127.0.0.1 under the WHATWG parser
+            ["decimal-encoded loopback", "http://2130706433/token"],
+        ];
+
+        test.each(allowed)("%s", (_name, value) => {
+            expect(
+                validate(
+                    ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT,
+                    value
+                )
+            ).toBeUndefined();
+        });
+    });
+
+    describe("a source refuses to acquire a token from a redirected endpoint", () => {
+        afterEach(() => {
+            delete process.env[
+                ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT
+            ];
+            delete process.env[
+                ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER
+            ];
+            delete process.env[
+                ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT
+            ];
+            delete process.env[
+                ManagedIdentityEnvironmentVariableNames.MSI_SECRET
+            ];
+
+            // reset cached static state between tests
+            delete ManagedIdentityClient["identitySource"];
+            delete ManagedIdentityApplication["nodeStorage"];
+            jest.restoreAllMocks();
+        });
+
+        test("App Service does not send IDENTITY_HEADER to an attacker host", async () => {
+            process.env[
+                ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT
+            ] = "http://evil.example.com";
+            process.env[
+                ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER
+            ] = "super-secret-header";
+
+            const app = new ManagedIdentityApplication(systemAssignedConfig);
+            await expect(
+                app.acquireToken(managedIdentityRequestParams)
+            ).rejects.toMatchObject(
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidManagedIdentityEndpoint,
+                    ""
+                )
+            );
+        });
+
+        test("Cloud Shell does not POST to an attacker host", async () => {
+            process.env[ManagedIdentityEnvironmentVariableNames.MSI_ENDPOINT] =
+                "http://attacker.contoso.com/token";
+
+            const app = new ManagedIdentityApplication(systemAssignedConfig);
+            await expect(
+                app.acquireToken(managedIdentityRequestParams)
+            ).rejects.toMatchObject(
+                createManagedIdentityError(
+                    ManagedIdentityErrorCodes.invalidManagedIdentityEndpoint,
+                    ""
+                )
+            );
+        });
+    });
+});

--- a/lib/msal-node/test/client/ManagedIdentitySources/ServiceFabric.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/ServiceFabric.spec.ts
@@ -37,7 +37,7 @@ import {
 } from "../../../src/utils/Constants.js";
 import { ManagedIdentityUserAssignedIdQueryParameterNames } from "../../../src/client/ManagedIdentitySources/BaseManagedIdentitySource.js";
 
-describe("Acquires a token successfully via an App Service Managed Identity", () => {
+describe("Acquires a token successfully via a Service Fabric Managed Identity", () => {
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
             MANAGED_IDENTITY_TEST_ENDPOINTS.SERVICE_FABRIC;

--- a/lib/msal-node/test/client/ManagedIdentitySources/ServiceFabric.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/ServiceFabric.spec.ts
@@ -12,6 +12,7 @@ import {
     MANAGED_IDENTITY_RESOURCE,
     MANAGED_IDENTITY_RESOURCE_ID,
     MANAGED_IDENTITY_SERVICE_FABRIC_NETWORK_REQUEST_400_ERROR,
+    MANAGED_IDENTITY_TEST_ENDPOINTS,
     TEST_CONFIG,
 } from "../../test_kit/StringConstants.js";
 
@@ -39,7 +40,7 @@ import { ManagedIdentityUserAssignedIdQueryParameterNames } from "../../../src/c
 describe("Acquires a token successfully via an App Service Managed Identity", () => {
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
-            "https://localhost:2377/metadata/identity/oauth2/token";
+            MANAGED_IDENTITY_TEST_ENDPOINTS.SERVICE_FABRIC;
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER] =
             "fake_IDENTITY_HEADER";
         process.env[

--- a/lib/msal-node/test/client/ManagedIdentitySources/ServiceFabric.spec.ts
+++ b/lib/msal-node/test/client/ManagedIdentitySources/ServiceFabric.spec.ts
@@ -39,7 +39,7 @@ import { ManagedIdentityUserAssignedIdQueryParameterNames } from "../../../src/c
 describe("Acquires a token successfully via an App Service Managed Identity", () => {
     beforeAll(() => {
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_ENDPOINT] =
-            "fake_IDENTITY_ENDPOINT";
+            "https://localhost:2377/metadata/identity/oauth2/token";
         process.env[ManagedIdentityEnvironmentVariableNames.IDENTITY_HEADER] =
             "fake_IDENTITY_HEADER";
         process.env[

--- a/lib/msal-node/test/test_kit/StringConstants.ts
+++ b/lib/msal-node/test/test_kit/StringConstants.ts
@@ -9,6 +9,7 @@ import {
     DEFAULT_MANAGED_IDENTITY_ID,
 } from "../../src/utils/Constants.js";
 import { ManagedIdentityTokenResponse } from "../../src/response/ManagedIdentityTokenResponse.js";
+import { DEFAULT_AZURE_ARC_IDENTITY_ENDPOINT } from "../../src/client/ManagedIdentitySources/AzureArc.js";
 
 // This file contains the string constants used by the test classes.
 
@@ -374,6 +375,25 @@ export const AUTHENTICATION_RESULT_DEFAULT_SCOPES = {
 export const MANAGED_IDENTITY_AZURE_ARC_WWW_AUTHENTICATE_HEADER: string = `Basic ${TEST_TOKENS.ACCESS_TOKEN}`;
 export const MANAGED_IDENTITY_CONTENT_TYPE_HEADER: string =
     "application/x-www-form-urlencoded;charset=utf-8";
+
+/*
+ * Representative node-local Managed Identity endpoints used by the source specs.
+ * Only the host (loopback / link-local) is load-bearing: the network layer is
+ * mocked in these tests, so the port and path are never dialed or asserted.
+ * Azure Arc reuses the real source default and IMDS uses the real link-local
+ * host. The platform-assigned sources (App Service, Cloud Shell, Machine
+ * Learning, Service Fabric) have no fixed port, so these are representative
+ * loopback values; Service Fabric uses a port from the IANA dynamic/ephemeral
+ * range, reflecting that its endpoint port is assigned at runtime.
+ */
+export const MANAGED_IDENTITY_TEST_ENDPOINTS = {
+    APP_SERVICE: "http://127.0.0.1:41564/msi/token",
+    AZURE_ARC: DEFAULT_AZURE_ARC_IDENTITY_ENDPOINT,
+    CLOUD_SHELL: "http://localhost:50342/metadata/identity/oauth2/token",
+    IMDS: "http://169.254.169.254/metadata/identity/oauth2/token",
+    MACHINE_LEARNING: "http://127.0.0.1:42424/msi/token",
+    SERVICE_FABRIC: "https://localhost:49152/metadata/identity/oauth2/token",
+};
 
 export const MANAGED_IDENTITY_TOKEN_RETRIEVAL_ERROR_MESSAGE: string =
     "There was an error retrieving the access token from the managed identity.";


### PR DESCRIPTION
## Summary

Managed Identity (MI) credential sources in `@azure/msal-node` read their endpoint URLs from environment variables (`IDENTITY_ENDPOINT`, `MSI_ENDPOINT`, `IMDS_ENDPOINT`, `AZURE_POD_IDENTITY_AUTHORITY_HOST`) and use them together with credential material — the `X-IDENTITY-HEADER` secret and the Azure Arc HIMDS key. The shared validator `getValidatedEnvVariableUrlString` only **canonicalized** the URL (lowercase + trailing slash) and never checked the **host**. As a result, an in-process actor (e.g. a malicious transitive dependency) that can influence `process.env` could repoint an MI endpoint at an arbitrary host and have the SDK deliver the credential to it.

These endpoints are always served by a node-local agent (IMDS on link-local `169.254.169.254`; Azure Arc, App Service, Cloud Shell, Machine Learning, and Service Fabric on loopback), so the endpoint host can be safely pinned.

## Fix

Centralized host pinning in the single shared helper every MI source already calls before constructing a request:

- Parse the endpoint with the WHATWG `URL` parser so userinfo such as `http://127.0.0.1@evil.com` correctly resolves to host `evil.com` and is rejected.
- Allow only **loopback / link-local** hosts: `localhost`, `127.0.0.0/8`, `[::1]`, and `169.254.0.0/16` (covers the IMDS endpoint). Host matching uses an explicit bounded octet parser — no regex, so there is no ReDoS surface. Alternate IPv4 encodings (decimal, hex, short form) are normalized by the URL parser before the check, and look-alike domains such as `169.254.169.254.evil.com` are rejected.
- Two failure modes: an unparseable value yields the existing per-variable "malformed" error; a parseable value with a disallowed host yields the new `invalid_managed_identity_endpoint` error.
- Scheme is intentionally **not** restricted — MI legitimately uses `http` on loopback, and host pinning already rejects hostless schemes like `file:`.
- Removed dead trailing-slash handling in `AzureArc` (a no-op ternary whose result was discarded).

## Testing

- New `ManagedIdentityEndpointValidation.spec.ts` (16 cases): disallowed hosts (off-box, userinfo confusion, look-alike suffix, private/non-loopback, wildcard), malformed input, accepted loopback/link-local (incl. IPv6 and decimal-encoded), and **two end-to-end tests** asserting `acquireToken` now refuses to send the credential to an attacker host. Each accepted case runs through the env var and source name its real source uses (e.g. IMDS via `AZURE_POD_IDENTITY_AUTHORITY_HOST`).
- Updated the six existing MI specs to use realistic loopback endpoint URLs (they previously used non-URL placeholder strings that host validation now correctly rejects), centralized in a shared `MANAGED_IDENTITY_TEST_ENDPOINTS` constant that reuses the real Azure Arc / IMDS source values.
- Full Managed Identity suite green (89/89), `tsc` build, `eslint`, and Prettier all pass.

## Notes for reviewers

- The fix is contained entirely in the shared helper, so all six MI sources are protected without changing the value each passes to its constructor.
- No public API change; this is additive (one new error code) and behavior-preserving for legitimate node-local endpoints.
- **`localhost` is allowed by name on purpose.** The threat being mitigated is redirection to an *off-box* attacker server. A co-located process that can both bind `localhost` and set these environment variables already has local code execution, which is outside this control's scope. IPv6 link-local (`fe80::/10`) and IPv4-mapped IPv6 (`[::ffff:127.0.0.1]`) are intentionally rejected (fail-closed) since real MI endpoints never use those forms.
- The host-validation cases use a small data-driven `validate()` helper that calls the static validator directly, rather than the per-source `acquireToken` harness — intentional for exercising a pure function. The end-to-end refusal tests still follow the existing MI spec conventions.