### PR TITLE
Bump nightly-build pipeline to Node 22 for Angular 22

### DIFF
--- a/.pipelines/nightly-build.yml
+++ b/.pipelines/nightly-build.yml
@@ -22,7 +22,7 @@ jobs:
           - task: NodeTool@0
             displayName: "Install Node.js"
             inputs:
-                versionSpec: "20.x"
+                versionSpec: "22.x"
 
           - task: Npm@1
             displayName: "Install Dependencies"


### PR DESCRIPTION
msal-angular was upgraded to Angular 22 (#8646), whose CLI requires Node >= 22.22.3. The nightly-build pipeline pinned Node 20.x, so `ng build` fails with exit code 3 in the Build Libraries step. This bumps `.pipelines/nightly-build.yml` to Node 22.x, matching 1P CI (which already runs Node 22).