### PR TITLE
ci: grant pull-requests:write to client-credential benchmark workflow

### DIFF
--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -15,6 +15,15 @@ on:
     merge_group:
         types: [checks_requested]
 
+permissions:
+    # Read access for actions/checkout
+    contents: read
+    # Write access so github-action-benchmark can post the regression alert as a PR comment.
+    # Intentionally NOT contents:write — this workflow runs untrusted PR code and must not be
+    # able to modify repo contents. Baseline publishing to gh-pages is handled separately by
+    # msal-node-confidential-client-benchmarks.yml, which only runs on push to dev.
+    pull-requests: write
+
 jobs:
     benchmark:
         name: Run msal-node client-credential Regression Test


### PR DESCRIPTION
## What

Adds a minimal top-level `permissions:` block to `.github/workflows/client-credential-benchmark.yml` (the msal-node client-credential PR regression guard) so it can post its benchmark alert comment instead of crashing.

## Why

The workflow sets `comment-on-alert: true` but had **no `permissions:` block**, so `GITHUB_TOKEN` inherited the repo's read-only default. When a benchmark alert fires, `github-action-benchmark` tries to POST a PR review comment and gets:

```
error RequestError [HttpError]: Resource not accessible by integration
status: 403
url: .../pulls/{n}/reviews
x-accepted-github-permissions: pull_requests=write
```

That thrown error crashes the job — even though `fail-on-alert: false` means the perf alert itself was never meant to fail the run. This is a latent gap dating back to the workflow's original introduction (#6276); it likely worked when the org's default `GITHUB_TOKEN` was read-write and broke silently once that default was hardened to read-only.

## Fix

```yaml
permissions:
    contents: read
    pull-requests: write
```

- `pull-requests: write` — lets `github-action-benchmark` post the alert comment.
- `contents: read` — for `actions/checkout`.
- **Intentionally NOT `contents: write`.** This workflow runs untrusted PR code and must not be able to modify repo contents. Baseline publishing to `gh-pages` stays in the sibling `msal-node-confidential-client-benchmarks.yml`, which runs only on `push` to `dev` and legitimately holds the write scope.