### PR TITLE
fix(msal-common): harden authorize response deserialization for newer @types/node

### DIFF
--- a/change/@azure-msal-common-5c25fc6f-371a-45db-b1a6-05719d026636.json
+++ b/change/@azure-msal-common-5c25fc6f-371a-45db-b1a6-05719d026636.json
@@ -1,6 +1,6 @@
 {
   "dependentChangeType": "patch",
-  "comment": "Harden authorize response deserialization against URLSearchParams iterator typing changes in newer @types/node",
+  "comment": "Harden authorize response deserialization against URLSearchParams iterator typing changes in newer @types/node [#8707](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8707)",
   "type": "patch",
   "packageName": "@azure/msal-common",
   "email": "lalima.sharda@gmail.com"

--- a/change/@azure-msal-common-5c25fc6f-371a-45db-b1a6-05719d026636.json
+++ b/change/@azure-msal-common-5c25fc6f-371a-45db-b1a6-05719d026636.json
@@ -1,0 +1,7 @@
+{
+  "dependentChangeType": "patch",
+  "comment": "Harden authorize response deserialization against URLSearchParams iterator typing changes in newer @types/node",
+  "type": "patch",
+  "packageName": "@azure/msal-common",
+  "email": "lalima.sharda@gmail.com"
+}

--- a/lib/msal-common/src/utils/UrlUtils.ts
+++ b/lib/msal-common/src/utils/UrlUtils.ts
@@ -45,9 +45,10 @@ export function getDeserializedResponse(
         // Strip the # or ? symbol if present
         const normalizedResponse = stripLeadingHashOrQuery(responseString);
         // If # symbol was not present, above will return empty string, so give original hash value
-        const deserializedHash: AuthorizeResponse = Object.fromEntries(
-            new URLSearchParams(normalizedResponse)
-        );
+        const deserializedHash: AuthorizeResponse = {};
+        new URLSearchParams(normalizedResponse).forEach((value, key) => {
+            deserializedHash[key as keyof AuthorizeResponse] = value;
+        });
 
         // Check for known response properties
         if (


### PR DESCRIPTION
## Summary

Hardens `getDeserializedResponse` in `msal-common` against a forward-compatibility issue with newer `@types/node`.

`Object.fromEntries(new URLSearchParams(...))` relies on the `URLSearchParams` iterator type matching the `Object.fromEntries` overload. Newer `@types/node` versions (22+) change the iterator return type (`URLSearchParamsIterator` / `IteratorObject`), which no longer satisfies that overload under the repo's TypeScript, producing a compile error in our own source.

This replaces the pattern with an explicit `URLSearchParams.forEach` loop that populates the `AuthorizeResponse` object directly. `forEach` is supported on all target browsers and Node 20+, and produces **identical runtime behavior**.

## Why now

This is proactive forward-compat hardening. CI currently pins `@types/node@20`, so the repo is green today; this change removes one blocker to bumping `@types/node` later.

## Testing

- `npm run build --workspace @azure/msal-common` — succeeds
- `npx jest test/utils/UrlUtils.spec.ts` — 30/30 pass, behavior unchanged

## Scope

Intentionally scoped to the `URLSearchParams` deserialization issue only. Other `@types/node` 22+/26 incompatibilities (e.g. `Array.prototype.at`, `encodeInto`, `Disposable`/`Symbol.dispose`) are separate concerns tied to a TypeScript version bump and are out of scope here.