### PR TITLE
Streamline platform broker request to MSAL JS acquire-token contract params

### DIFF
--- a/change/@azure-msal-browser-streamline-platform-broker-request.json
+++ b/change/@azure-msal-browser-streamline-platform-broker-request.json
@@ -1,6 +1,6 @@
 {
     "type": "patch",
-    "comment": "Streamline the platform broker request to only include the MSAL JS acquire-token parameters defined in the platform broker contract, dropping non-contract SDK/ESTS-only fields [#8714](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8714)",
+    "comment": "Streamline the platform broker request to only include the MSAL JS acquire-token parameters defined in the platform broker contract and params required on the ESTS /token call [#8714](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8714)",
     "packageName": "@azure/msal-browser",
     "email": "lalima.sharda@gmail.com",
     "dependentChangeType": "patch"

--- a/change/@azure-msal-browser-streamline-platform-broker-request.json
+++ b/change/@azure-msal-browser-streamline-platform-broker-request.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Streamline the platform broker request to only include the MSAL JS acquire-token parameters defined in the platform broker contract, dropping non-contract SDK/ESTS-only fields [#0000](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/0000)",
+    "packageName": "@azure/msal-browser",
+    "email": "lalima.sharda@gmail.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-streamline-platform-broker-request.json
+++ b/change/@azure-msal-browser-streamline-platform-broker-request.json
@@ -1,6 +1,6 @@
 {
     "type": "patch",
-    "comment": "Streamline the platform broker request to only include the MSAL JS acquire-token parameters defined in the platform broker contract, dropping non-contract SDK/ESTS-only fields [#0000](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/0000)",
+    "comment": "Streamline the platform broker request to only include the MSAL JS acquire-token parameters defined in the platform broker contract, dropping non-contract SDK/ESTS-only fields [#8714](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8714)",
     "packageName": "@azure/msal-browser",
     "email": "lalima.sharda@gmail.com",
     "dependentChangeType": "patch"

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthDOMHandler.ts
@@ -142,8 +142,6 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
             redirectUri,
             correlationId,
             state,
-            storeInCache,
-            embeddedClientId,
             extraParameters,
             ...remainingProperties
         } = request;
@@ -167,8 +165,6 @@ export class PlatformAuthDOMHandler implements IPlatformAuthHandler {
             redirectUri: redirectUri,
             scope: scope,
             state: state,
-            storeInCache: storeInCache,
-            embeddedClientId: embeddedClientId,
         };
 
         return platformDOMRequest;

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
@@ -18,10 +18,11 @@ export type PlatformAuthRequest = {
     correlationId: string;
     windowTitleSubstring: string; // The name of the document title. This helps the native prompt properly "parent" to the window making the request
     prompt?: string;
+    isSts: boolean; // Whether the request is from STS or not
     nonce?: string;
     claims?: string;
     state?: string;
-    loginHint?: string; // Upn of the user. Contract param forwarded to the platform broker.
+    loginHint?: string; // UPN of the user
     reqCnf?: string;
     keyId?: string;
     tokenType?: string;
@@ -30,7 +31,6 @@ export type PlatformAuthRequest = {
     resourceRequestMethod?: string;
     resourceRequestUri?: string;
     extendedExpiryToken?: boolean;
-    resource?: string;
     extraParameters?: StringDict;
     storeInCache?: StoreInCache; // Object of booleans indicating whether to store tokens in the cache or not (default is true)
     signPopToken?: boolean; // Set to true only if token request deos not contain a PoP keyId

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
@@ -18,6 +18,8 @@ export type PlatformAuthRequest = {
     correlationId: string;
     windowTitleSubstring: string; // The name of the document title. This helps the native prompt properly "parent" to the window making the request
     isSts?: boolean; // Whether the request is from STS or not
+    prompt?: string;
+    nonce?: string;
     claims?: string;
     state?: string;
     loginHint?: string; // UPN of the user

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
@@ -4,7 +4,7 @@
  */
 
 import { NativeExtensionMethod } from "../../utils/BrowserConstants.js";
-import { StoreInCache, StringDict } from "@azure/msal-common/browser";
+import { StringDict } from "@azure/msal-common/browser";
 
 /**
  * Token request which native broker will use to acquire tokens
@@ -32,9 +32,7 @@ export type PlatformAuthRequest = {
     resourceRequestUri?: string;
     extendedExpiryToken?: boolean;
     extraParameters?: StringDict;
-    storeInCache?: StoreInCache; // Object of booleans indicating whether to store tokens in the cache or not (default is true)
     signPopToken?: boolean; // Set to true only if token request deos not contain a PoP keyId
-    embeddedClientId?: string;
 };
 
 /**
@@ -68,12 +66,10 @@ export type PlatformDOMTokenRequest = {
     /*
      * Known optional parameters will go into extraQueryParameters.
      * List of known parameters is:
-     * "prompt", "nonce", "claims", "loginHint", "instanceAware", "windowTitleSubstring", "extendedExpiryToken", "storeInCache",
+     * "prompt", "nonce", "claims", "loginHint", "instanceAware", "windowTitleSubstring", "extendedExpiryToken",
      * ProofOfPossessionParams: "reqCnf", "keyId", "tokenType", "shrClaims", "shrNonce", "resourceRequestMethod", "resourceRequestUri", "signPopToken"
      */
     extraParameters?: DOMExtraParameters;
-    embeddedClientId?: string;
-    storeInCache?: StoreInCache; // Object of booleans indicating whether to store tokens in the cache or not (default is true)
 };
 
 export type DOMExtraParameters = StringDict & {

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
@@ -21,6 +21,7 @@ export type PlatformAuthRequest = {
     nonce?: string;
     claims?: string;
     state?: string;
+    loginHint?: string; // Upn of the user. Contract param forwarded to the platform broker.
     reqCnf?: string;
     keyId?: string;
     tokenType?: string;

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
@@ -33,7 +33,7 @@ export type PlatformAuthRequest = {
     extendedExpiryToken?: boolean;
     extraParameters?: StringDict;
     storeInCache?: StoreInCache; // Object of booleans indicating whether to store tokens in the cache or not (default is true)
-    signPopToken?: boolean; // Set to true only if token request deos not contain a PoP keyId
+    signPopToken?: boolean; // Set to true only if token request does not contain a PoP keyId
     embeddedClientId?: string;
 };
 

--- a/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
+++ b/lib/msal-browser/src/broker/nativeBroker/PlatformAuthRequest.ts
@@ -17,9 +17,7 @@ export type PlatformAuthRequest = {
     scope: string;
     correlationId: string;
     windowTitleSubstring: string; // The name of the document title. This helps the native prompt properly "parent" to the window making the request
-    prompt?: string;
-    isSts: boolean; // Whether the request is from STS or not
-    nonce?: string;
+    isSts?: boolean; // Whether the request is from STS or not
     claims?: string;
     state?: string;
     loginHint?: string; // UPN of the user

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -1028,14 +1028,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             configClaims?.length ? configClaims : undefined
         );
 
-        /**
-         * Only the parameters defined as MSAL JS "Acquire token parameters" in the platform
-         * broker contract are forwarded to the platform broker. The full developer request must
-         * NOT be spread here, otherwise ESTS/token-endpoint-only and SDK-only fields (e.g.
-         * azureCloudOptions, maxAge, sshJwk, account, scenarioId, httpMethod, skipBrokerClaims,
-         * extraQueryParameters, sid, domainHint, instanceAware) would leak into the broker payload.
-         */
         const validatedRequest: PlatformAuthRequest = {
+            claims: mergedClaims,
             accountId: this.accountId,
             clientId: this.config.auth.clientId,
             authority: canonicalAuthority.urlString,
@@ -1046,19 +1040,18 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 this.logger,
                 this.correlationId
             ),
-            correlationId: this.correlationId,
             prompt: this.getPrompt(request.prompt),
+            correlationId: this.correlationId,
+            tokenType: request.authenticationScheme,
+            windowTitleSubstring: document.title,
             nonce: request.nonce,
             state: request.state,
             loginHint: request.loginHint,
-            windowTitleSubstring: document.title,
-            tokenType: request.authenticationScheme,
-            claims: mergedClaims,
             extraParameters: {
                 ...request.extraParameters,
                 ...(request.resource && { resource: request.resource }), // resource is set for McP scenarios
             },
-            // Internal-only fields - used by MSAL JS after the broker response, not contract params
+            extendedExpiryToken: false, // Make this configurable?
             keyId: request.popKid,
             storeInCache: request.storeInCache,
             embeddedClientId: request.embeddedClientId,

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -806,7 +806,9 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             correlationId: this.correlationId,
             state: response.state,
             fromPlatformBroker: true,
-            ...(request.resource && { resource: request.resource }),
+            ...(request.extraParameters?.resource && {
+                resource: request.extraParameters.resource,
+            }),
         };
 
         return result;
@@ -1042,6 +1044,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             ),
             prompt: this.getPrompt(request.prompt),
             correlationId: this.correlationId,
+            isSts: false,
             tokenType: request.authenticationScheme,
             windowTitleSubstring: document.title,
             nonce: request.nonce,
@@ -1055,7 +1058,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             keyId: request.popKid,
             storeInCache: request.storeInCache,
             embeddedClientId: request.embeddedClientId,
-            resource: request.resource,
             resourceRequestMethod: request.resourceRequestMethod,
             resourceRequestUri: request.resourceRequestUri,
             shrClaims: request.shrClaims,

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -1057,6 +1057,14 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             claims: mergedClaims,
             extraParameters: {
                 ...request.extraParameters,
+                /*
+                 * resource is not a broker-contract param; forward it via extraParameters
+                 * (passed to the broker's token/authorize call) so it reaches ESTS on both
+                 * the extension and DOM transport paths, matching the web /token flow.
+                 */
+                ...(request.resource
+                    ? { [AADServerParamKeys.RESOURCE]: request.resource }
+                    : {}),
             },
             // Internal-only fields - used by MSAL JS after the broker response, not contract params
             keyId: request.popKid,

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -1018,8 +1018,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 ? undefined
                 : this.config.auth.clientCapabilities;
 
-        // scopes are expected to be received by the native broker as "scope" and will be added to the request below. Other properties that should be dropped from the request to the native broker can be included in the object destructuring here.
-        const { scopes, claims, ...remainingProperties } = request;
+        // scopes are expected to be received by the native broker as "scope" and will be added to the request below.
+        const { scopes, claims } = request;
         const scopeSet = new ScopeSet(scopes || [], this.correlationId);
         scopeSet.appendScopes(Constants.OIDC_DEFAULT_SCOPES);
 
@@ -1028,9 +1028,15 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             configClaims?.length ? configClaims : undefined
         );
 
+        /**
+         * Only the parameters defined as MSAL JS "Acquire token parameters" in the platform
+         * broker contract are forwarded to the platform broker. The full developer request must
+         * NOT be spread here, otherwise ESTS/token-endpoint-only and SDK-only fields (e.g.
+         * azureCloudOptions, maxAge, sshJwk, account, scenarioId, httpMethod, skipBrokerClaims,
+         * extraQueryParameters, sid, domainHint, instanceAware) would leak into the broker payload.
+         */
         const validatedRequest: PlatformAuthRequest = {
-            ...remainingProperties,
-            claims: mergedClaims,
+            // Broker contract - MSAL JS "Acquire token parameters"
             accountId: this.accountId,
             clientId: this.config.auth.clientId,
             authority: canonicalAuthority.urlString,
@@ -1041,15 +1047,26 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 this.logger,
                 this.correlationId
             ),
-            prompt: this.getPrompt(request.prompt),
             correlationId: this.correlationId,
-            tokenType: request.authenticationScheme,
+            prompt: this.getPrompt(request.prompt),
+            nonce: request.nonce,
+            state: request.state,
+            loginHint: request.loginHint,
             windowTitleSubstring: document.title,
+            tokenType: request.authenticationScheme,
+            claims: mergedClaims,
             extraParameters: {
                 ...request.extraParameters,
             },
-            extendedExpiryToken: false, // Make this configurable?
+            // Internal-only fields - used by MSAL JS after the broker response, not contract params
             keyId: request.popKid,
+            storeInCache: request.storeInCache,
+            embeddedClientId: request.embeddedClientId,
+            resource: request.resource,
+            resourceRequestMethod: request.resourceRequestMethod,
+            resourceRequestUri: request.resourceRequestUri,
+            shrClaims: request.shrClaims,
+            shrNonce: request.shrNonce,
         };
 
         // Check for PoP token requests: signPopToken should only be set to true if popKid is not set

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -27,6 +27,7 @@ import {
     ScopeSet,
     ServerTelemetryManager,
     SignedHttpRequestParameters,
+    StoreInCache,
     TimeUtils,
     TokenClaims,
     UrlString,
@@ -223,7 +224,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             return await this.handleNativeResponse(
                 validatedResponse,
                 nativeRequest,
-                reqTimestamp
+                reqTimestamp,
+                request.storeInCache
             )
                 .then((result: AuthenticationResult) => {
                     nativeATMeasurement.end({
@@ -393,7 +395,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         }
         this.browserStorage.setTemporaryCache(
             TemporaryCacheKeys.NATIVE_REQUEST,
-            JSON.stringify(nativeRequest),
+            JSON.stringify({
+                ...nativeRequest,
+                storeInCache: request.storeInCache,
+            }),
             true
         );
 
@@ -453,7 +458,14 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             return null;
         }
 
-        const { prompt, ...request } = cachedRequest;
+        /*
+         * storeInCache is a client-side cache directive persisted alongside the cached
+         * request (not a broker-contract parameter), so extract it here before resending.
+         */
+        const { prompt, storeInCache, ...request } =
+            cachedRequest as PlatformAuthRequest & {
+                storeInCache?: StoreInCache;
+            };
         if (prompt) {
             this.logger.verbose(
                 "NativeInteractionClient - handleRedirectPromise called and prompt was included in the original request, removing prompt from cached request to prevent second interaction with native broker window.",
@@ -479,7 +491,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             const authResult = await this.handleNativeResponse(
                 response,
                 request,
-                reqTimestamp
+                reqTimestamp,
+                storeInCache
             );
 
             const serverTelemetryManager = initializeServerTelemetryManager(
@@ -523,7 +536,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected async handleNativeResponse(
         response: PlatformAuthResponse,
         request: PlatformAuthRequest,
-        reqTimestamp: number
+        reqTimestamp: number,
+        storeInCache?: StoreInCache
     ): Promise<AuthenticationResult> {
         this.logger.trace(
             "NativeInteractionClient - handleNativeResponse called.",
@@ -618,7 +632,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             idTokenClaims,
             result.tenantId,
             reqTimestamp,
-            authority.getPreferredCache() // environment
+            authority.getPreferredCache(), // environment
+            storeInCache
         );
 
         return result;
@@ -853,7 +868,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         idTokenClaims: TokenClaims,
         tenantId: string,
         reqTimestamp: number,
-        environment: string
+        environment: string,
+        storeInCache?: StoreInCache
     ): Promise<void> {
         const cachedIdToken: IdTokenEntity | null =
             CacheHelpers.createIdTokenEntity(
@@ -896,7 +912,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             );
 
         // save idtoken credential in configured browser storage
-        if (!!cachedIdToken && request.storeInCache?.idToken !== false) {
+        if (!!cachedIdToken && storeInCache?.idToken !== false) {
             await this.browserStorage.setIdTokenCredential(
                 cachedIdToken,
                 this.correlationId,
@@ -914,7 +930,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             this.correlationId,
             AuthToken.isKmsi(idTokenClaims),
             this.apiId,
-            request.storeInCache
+            storeInCache
         );
     }
 
@@ -1020,7 +1036,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 ? undefined
                 : this.config.auth.clientCapabilities;
 
-        // scopes are expected to be received by the native broker as "scope" and will be added to the request below.
+        // scopes are expected to be received by the native broker as "scope" and will be added to the request below. 'resource' is added in extraParameters for MCP scenarios.
         const { scopes, claims } = request;
         const scopeSet = new ScopeSet(scopes || [], this.correlationId);
         scopeSet.appendScopes(Constants.OIDC_DEFAULT_SCOPES);
@@ -1056,8 +1072,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             },
             extendedExpiryToken: false, // Make this configurable?
             keyId: request.popKid,
-            storeInCache: request.storeInCache,
-            embeddedClientId: request.embeddedClientId,
             resourceRequestMethod: request.resourceRequestMethod,
             resourceRequestUri: request.resourceRequestUri,
             shrClaims: request.shrClaims,
@@ -1072,7 +1086,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             );
         }
 
-        this.handleExtraBrokerParams(validatedRequest);
+        this.handleExtraBrokerParams(
+            validatedRequest,
+            request.embeddedClientId
+        );
         validatedRequest.extraParameters =
             validatedRequest.extraParameters || {};
         validatedRequest.extraParameters.telemetry =
@@ -1204,7 +1221,10 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
      * @param request {PlatformAuthRequest}
      * @private
      */
-    private handleExtraBrokerParams(request: PlatformAuthRequest): void {
+    private handleExtraBrokerParams(
+        request: PlatformAuthRequest,
+        embeddedClientId?: string
+    ): void {
         const hasExtraBrokerParams =
             request.extraParameters &&
             request.extraParameters.hasOwnProperty(
@@ -1217,16 +1237,16 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 AADServerParamKeys.CLIENT_ID
             );
 
-        if (!request.embeddedClientId && !hasExtraBrokerParams) {
+        if (!embeddedClientId && !hasExtraBrokerParams) {
             return;
         }
 
         let child_client_id: string = "";
         const child_redirect_uri = request.redirectUri;
 
-        if (request.embeddedClientId) {
+        if (embeddedClientId) {
             request.redirectUri = this.config.auth.redirectUri;
-            child_client_id = request.embeddedClientId;
+            child_client_id = embeddedClientId;
         } else if (request.extraParameters) {
             request.redirectUri =
                 request.extraParameters[AADServerParamKeys.BROKER_REDIRECT_URI];
@@ -1235,8 +1255,11 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         }
 
         const {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             [AADServerParamKeys.BROKER_CLIENT_ID]: _brkClientId,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             [AADServerParamKeys.BROKER_REDIRECT_URI]: _brkRedirectUri,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             [AADServerParamKeys.CLIENT_ID]: _clientId,
             ...remainingExtraParameters
         } = request.extraParameters || {};

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -1056,14 +1056,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             claims: mergedClaims,
             extraParameters: {
                 ...request.extraParameters,
-                /*
-                 * resource is not a broker-contract param; forward it via extraParameters
-                 * (passed to the broker's token/authorize call) so it reaches ESTS on both
-                 * the extension and DOM transport paths, matching the web /token flow.
-                 */
-                ...(request.resource
-                    ? { [AADServerParamKeys.RESOURCE]: request.resource }
-                    : {}),
+                ...(request.resource && { resource: request.resource }), // resource is set for McP scenarios
             },
             // Internal-only fields - used by MSAL JS after the broker response, not contract params
             keyId: request.popKid,

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -1232,20 +1232,18 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
                 request.extraParameters[AADServerParamKeys.CLIENT_ID];
         }
 
+        const {
+            [AADServerParamKeys.BROKER_CLIENT_ID]: _brkClientId,
+            [AADServerParamKeys.BROKER_REDIRECT_URI]: _brkRedirectUri,
+            [AADServerParamKeys.CLIENT_ID]: _clientId,
+            ...remainingExtraParameters
+        } = request.extraParameters || {};
+
         request.extraParameters = {
-            ...request.extraParameters,
+            ...remainingExtraParameters,
             child_client_id,
             child_redirect_uri,
         };
-
-        /*
-         * Remove the brk_client_id / brk_redirect_uri / client_id keys that were just
-         * translated into the child_client_id / child_redirect_uri fields, while preserving
-         * any other extraParameters (e.g. resource, developer-supplied params).
-         */
-        delete request.extraParameters[AADServerParamKeys.BROKER_CLIENT_ID];
-        delete request.extraParameters[AADServerParamKeys.BROKER_REDIRECT_URI];
-        delete request.extraParameters[AADServerParamKeys.CLIENT_ID];
 
         this.performanceClient?.addFields(
             {

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -1049,7 +1049,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             loginHint: request.loginHint,
             extraParameters: {
                 ...request.extraParameters,
-                ...(request.resource && { resource: request.resource }), // resource is set for McP scenarios
+                ...(request.resource && { resource: request.resource }), // resource is set for MCP scenarios
             },
             extendedExpiryToken: false, // Make this configurable?
             keyId: request.popKid,

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -1036,7 +1036,6 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
          * extraQueryParameters, sid, domainHint, instanceAware) would leak into the broker payload.
          */
         const validatedRequest: PlatformAuthRequest = {
-            // Broker contract - MSAL JS "Acquire token parameters"
             accountId: this.accountId,
             clientId: this.config.auth.clientId,
             authority: canonicalAuthority.urlString,
@@ -1248,9 +1247,19 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         }
 
         request.extraParameters = {
+            ...request.extraParameters,
             child_client_id,
             child_redirect_uri,
         };
+
+        /*
+         * Remove the brk_client_id / brk_redirect_uri / client_id keys that were just
+         * translated into the child_client_id / child_redirect_uri fields, while preserving
+         * any other extraParameters (e.g. resource, developer-supplied params).
+         */
+        delete request.extraParameters[AADServerParamKeys.BROKER_CLIENT_ID];
+        delete request.extraParameters[AADServerParamKeys.BROKER_REDIRECT_URI];
+        delete request.extraParameters[AADServerParamKeys.CLIENT_ID];
 
         this.performanceClient?.addFields(
             {

--- a/lib/msal-browser/test/app/PublicClientApplication.spec.ts
+++ b/lib/msal-browser/test/app/PublicClientApplication.spec.ts
@@ -874,6 +874,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 redirectUri: window.location.href,
                 correlationId: RANDOM_TEST_GUID,
                 windowTitleSubstring: "test window",
+                isSts: false,
             };
             // @ts-ignore
             pca.browserStorage.setTemporaryCache(
@@ -994,6 +995,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                     redirectUri: window.location.href,
                     correlationId: RANDOM_TEST_GUID,
                     windowTitleSubstring: "test window",
+                    isSts: false,
                 };
                 // @ts-ignore
                 pca.browserStorage.setTemporaryCache(
@@ -1037,6 +1039,7 @@ describe("PublicClientApplication.ts Class Unit Tests", () => {
                 redirectUri: window.location.href,
                 correlationId: RANDOM_TEST_GUID,
                 windowTitleSubstring: "test window",
+                isSts: false,
             };
             // @ts-ignore
             pca.controller.browserStorage.setTemporaryCache(

--- a/lib/msal-browser/test/broker/PlatformAuthDOMHandler.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthDOMHandler.spec.ts
@@ -144,6 +144,7 @@ describe("PlatformAuthDOMHandler tests", () => {
                 scope: "read openid",
                 correlationId: TEST_CONFIG.CORRELATION_ID,
                 windowTitleSubstring: "",
+                isSts: false,
                 extraParameters: {
                     extendedExpiryToken: "true",
                 },
@@ -210,6 +211,7 @@ describe("PlatformAuthDOMHandler tests", () => {
                 scope: "read openid",
                 correlationId: TEST_CONFIG.CORRELATION_ID,
                 windowTitleSubstring: "",
+                isSts: false,
                 extraParameters: {
                     extendedExpiryToken: "true",
                 },
@@ -267,6 +269,7 @@ describe("PlatformAuthDOMHandler tests", () => {
                 scope: "read openid",
                 correlationId: TEST_CONFIG.CORRELATION_ID,
                 windowTitleSubstring: "",
+                isSts: false,
                 extraParameters: {
                     extendedExpiryToken: "true",
                 },
@@ -313,6 +316,7 @@ describe("PlatformAuthDOMHandler tests", () => {
                 scope: "read openid",
                 correlationId: TEST_CONFIG.CORRELATION_ID,
                 windowTitleSubstring: "",
+                isSts: false,
                 extraParameters: {
                     extendedExpiryToken: "true",
                 },
@@ -376,6 +380,7 @@ describe("PlatformAuthDOMHandler tests", () => {
                 nonce: "test-nonce",
                 claims: "test-claims",
                 extendedExpiryToken: true,
+                isSts: false,
             };
             const platformDOMRequest =
                 //@ts-ignore
@@ -399,8 +404,6 @@ describe("PlatformAuthDOMHandler tests", () => {
                 redirectUri: testRequest.redirectUri,
                 scope: testRequest.scope,
                 state: undefined,
-                storeInCache: undefined,
-                embeddedClientId: undefined,
             });
         });
 
@@ -426,6 +429,7 @@ describe("PlatformAuthDOMHandler tests", () => {
                 nonce: "test-nonce",
                 claims: "test-claims",
                 extendedExpiryToken: true,
+                isSts: false,
                 extraParameters: {
                     customUserInput1: "test-user-input1",
                     customUserInput2: "test-user-input2",
@@ -455,8 +459,6 @@ describe("PlatformAuthDOMHandler tests", () => {
                 redirectUri: testRequest.redirectUri,
                 scope: testRequest.scope,
                 state: undefined,
-                storeInCache: undefined,
-                embeddedClientId: undefined,
             });
         });
     });

--- a/lib/msal-browser/test/broker/PlatformAuthExtensionHandler.spec.ts
+++ b/lib/msal-browser/test/broker/PlatformAuthExtensionHandler.spec.ts
@@ -32,6 +32,7 @@ const TEST_REQUEST: PlatformAuthRequest = {
     scope: "User.Read",
     correlationId: "test-correlation-id",
     windowTitleSubstring: "",
+    isSts: false,
 };
 
 describe("PlatformAuthExtensionHandler Tests", () => {

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1823,7 +1823,7 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(nativeRequest.redirectUri).toEqual("localhost");
         });
 
-        it("includes resource in native request when provided", async () => {
+        it("forwards resource via extraParameters when provided", async () => {
             const nativeRequest =
                 // @ts-ignore
                 await platformAuthInteractionClient.initializePlatformRequest({
@@ -1831,11 +1831,9 @@ describe("PlatformAuthInteractionClient Tests", () => {
                     resource: "https://graph.microsoft.com",
                 });
 
-            expect(nativeRequest.resource).toEqual(
-                "https://graph.microsoft.com"
-            );
-            // resource is also forwarded via extraParameters so it reaches ESTS
-            // on both the extension and DOM broker transport paths
+            // resource is not a top-level broker-contract param; it is forwarded via
+            // extraParameters so it reaches ESTS on both the extension and DOM paths
+            expect(nativeRequest).not.toHaveProperty("resource");
             expect(nativeRequest.extraParameters?.resource).toEqual(
                 "https://graph.microsoft.com"
             );

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1654,6 +1654,49 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(response).toEqual(testTokenResponse);
         });
 
+        it("retrieves and applies storeInCache directive persisted across the redirect", async () => {
+            // storeInCache is not a broker-contract field, so it is persisted alongside the
+            // cached native request and must be read back in handleRedirectPromise. This test
+            // proves the directive survives the redirect round-trip (cache write -> read).
+            jest.spyOn(
+                NavigationClient.prototype,
+                "navigateExternal"
+            ).mockImplementation((url: string) => {
+                expect(url).toBe(window.location.href);
+                return Promise.resolve(true);
+            });
+            jest.spyOn(
+                PlatformAuthExtensionHandler.prototype,
+                "sendMessage"
+            ).mockResolvedValue(MOCK_WAM_RESPONSE);
+            // @ts-ignore
+            pca.browserStorage.setInteractionInProgress(true);
+            await platformAuthInteractionClient.acquireTokenRedirect(
+                {
+                    scopes: ["User.Read"],
+                    storeInCache: {
+                        idToken: false,
+                    },
+                },
+                perfMeasurement
+            );
+
+            const response =
+                await platformAuthInteractionClient.handleRedirectPromise();
+            expect(response).not.toBe(null);
+            // The response still surfaces the idToken to the caller...
+            expect(response!.idToken).toEqual(MOCK_WAM_RESPONSE.id_token);
+            expect(response!.accessToken).toEqual(
+                MOCK_WAM_RESPONSE.access_token
+            );
+
+            // ...but the storeInCache directive (idToken: false) was honored, so the
+            // idToken was NOT written to the cache while the accessToken was.
+            const internalTokenKeys = internalStorage.getTokenKeys();
+            expect(internalTokenKeys.idToken).toHaveLength(0);
+            expect(internalTokenKeys.accessToken).toHaveLength(1);
+        });
+
         it("If request includes a prompt value it is ignored on the 2nd call to native broker", async () => {
             // The user should not be prompted twice, prompt value should only be used on the first call to the native broker (before returning to the redirect uri). Native broker calls from handleRedirectPromise should ignore the prompt.
             jest.spyOn(
@@ -1859,6 +1902,8 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(
                 nativeRequest.extraParameters!["child_redirect_uri"]
             ).toEqual("localhost");
+            // embeddedClientId is not a broker-contract param and must not sit on the request
+            expect(nativeRequest).not.toHaveProperty("embeddedClientId");
             // resource and developer-supplied extraParameters survive the embedded path
             expect(nativeRequest.extraParameters!["resource"]).toEqual(
                 "https://graph.microsoft.com"
@@ -1887,6 +1932,9 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 extraQueryParameters: { eqp: "value" },
                 sid: "test-sid",
                 domainHint: "contoso.com",
+                // Client-side cache directive, consumed internally and passed to
+                // cacheNativeTokens as a param rather than sent to the broker
+                storeInCache: { idToken: false },
             };
             const nativeRequest =
                 // @ts-ignore
@@ -1911,6 +1959,8 @@ describe("PlatformAuthInteractionClient Tests", () => {
                 "extraQueryParameters",
                 "sid",
                 "domainHint",
+                "storeInCache",
+                "embeddedClientId",
             ].forEach((field) => {
                 expect(nativeRequest).not.toHaveProperty(field);
             });

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1817,6 +1817,54 @@ describe("PlatformAuthInteractionClient Tests", () => {
             );
         });
 
+        it("forwards broker-contract params and drops non-contract SDK/ESTS fields", async () => {
+            // Cast to any so non-contract SDK/ESTS-only fields can be supplied without type errors
+            const requestWithExtraFields: any = {
+                scopes: ["User.Read"],
+                // Broker-contract MSAL JS acquire-token params
+                loginHint: "user@contoso.com",
+                nonce: "test-nonce",
+                state: "test-state",
+                prompt: Constants.PromptValue.LOGIN,
+                // Non-contract SDK/ESTS-only fields that must NOT reach the broker
+                azureCloudOptions: { azureCloudInstance: 1 },
+                maxAge: 3600,
+                sshJwk: "test-ssh-jwk",
+                sshKid: "test-ssh-kid",
+                scenarioId: "test-scenario",
+                skipBrokerClaims: true,
+                extraQueryParameters: { eqp: "value" },
+                sid: "test-sid",
+                domainHint: "contoso.com",
+            };
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthInteractionClient.initializePlatformRequest(
+                    requestWithExtraFields
+                );
+
+            // Contract params are forwarded
+            expect(nativeRequest.loginHint).toEqual("user@contoso.com");
+            expect(nativeRequest.nonce).toEqual("test-nonce");
+            expect(nativeRequest.state).toEqual("test-state");
+            expect(nativeRequest.prompt).toEqual(Constants.PromptValue.LOGIN);
+
+            // Non-contract fields are not present on the request sent to the broker
+            [
+                "azureCloudOptions",
+                "maxAge",
+                "sshJwk",
+                "sshKid",
+                "scenarioId",
+                "skipBrokerClaims",
+                "extraQueryParameters",
+                "sid",
+                "domainHint",
+            ].forEach((field) => {
+                expect(nativeRequest).not.toHaveProperty(field);
+            });
+        });
+
         it("merges client capabilities with empty claims", async () => {
             const pcaWithClientCapabilities = new PublicClientApplication({
                 auth: {

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1815,6 +1815,11 @@ describe("PlatformAuthInteractionClient Tests", () => {
             expect(nativeRequest.resource).toEqual(
                 "https://graph.microsoft.com"
             );
+            // resource is also forwarded via extraParameters so it reaches ESTS
+            // on both the extension and DOM broker transport paths
+            expect(nativeRequest.extraParameters?.resource).toEqual(
+                "https://graph.microsoft.com"
+            );
         });
 
         it("forwards broker-contract params and drops non-contract SDK/ESTS fields", async () => {

--- a/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/PlatformAuthInteractionClient.spec.ts
@@ -1762,10 +1762,12 @@ describe("PlatformAuthInteractionClient Tests", () => {
                     scopes: ["User.Read"],
                     prompt: Constants.PromptValue.LOGIN,
                     redirectUri: "localhost",
+                    resource: "https://graph.microsoft.com",
                     extraParameters: {
                         brk_client_id: "broker_client_id",
                         brk_redirect_uri: "https://broker_redirect_uri.com",
                         client_id: "parent_client_id",
+                        userEQP: "customUserParam",
                     },
                 });
 
@@ -1778,6 +1780,23 @@ describe("PlatformAuthInteractionClient Tests", () => {
             ).toEqual("localhost");
             expect(nativeRequest.redirectUri).toEqual(
                 "https://broker_redirect_uri.com"
+            );
+            // Translated brk_* / client_id keys are stripped from extraParameters
+            expect(nativeRequest.extraParameters).not.toHaveProperty(
+                "brk_client_id"
+            );
+            expect(nativeRequest.extraParameters).not.toHaveProperty(
+                "brk_redirect_uri"
+            );
+            expect(nativeRequest.extraParameters).not.toHaveProperty(
+                "client_id"
+            );
+            // Other extraParameters (resource, developer-supplied params) are preserved
+            expect(nativeRequest.extraParameters!["resource"]).toEqual(
+                "https://graph.microsoft.com"
+            );
+            expect(nativeRequest.extraParameters!["userEQP"]).toEqual(
+                "customUserParam"
             );
         });
 
@@ -1819,6 +1838,35 @@ describe("PlatformAuthInteractionClient Tests", () => {
             // on both the extension and DOM broker transport paths
             expect(nativeRequest.extraParameters?.resource).toEqual(
                 "https://graph.microsoft.com"
+            );
+        });
+
+        it("preserves resource and developer extraParameters when embeddedClientId is set", async () => {
+            const nativeRequest =
+                // @ts-ignore
+                await platformAuthInteractionClient.initializePlatformRequest({
+                    scopes: ["User.Read"],
+                    redirectUri: "localhost",
+                    resource: "https://graph.microsoft.com",
+                    embeddedClientId: "embedded-client-id",
+                    extraParameters: {
+                        userEQP: "customUserParam",
+                    },
+                });
+
+            // Child fields are set from embeddedClientId
+            expect(nativeRequest.extraParameters!["child_client_id"]).toEqual(
+                "embedded-client-id"
+            );
+            expect(
+                nativeRequest.extraParameters!["child_redirect_uri"]
+            ).toEqual("localhost");
+            // resource and developer-supplied extraParameters survive the embedded path
+            expect(nativeRequest.extraParameters!["resource"]).toEqual(
+                "https://graph.microsoft.com"
+            );
+            expect(nativeRequest.extraParameters!["userEQP"]).toEqual(
+                "customUserParam"
             );
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13036,7 +13036,6 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
             "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -13076,13 +13075,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13098,13 +13095,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13120,13 +13115,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13142,13 +13135,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13164,13 +13155,11 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13186,13 +13175,11 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13208,13 +13195,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13230,13 +13215,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13252,13 +13235,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13274,13 +13255,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13296,13 +13275,11 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13318,13 +13295,11 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13340,13 +13315,11 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -13359,7 +13332,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -21209,7 +21181,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "prr": "~1.0.1"
             },
@@ -25095,7 +25066,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "bin": {
                 "image-size": "bin/image-size.js"
             },
@@ -25533,7 +25503,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -25604,7 +25574,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -28196,7 +28166,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -28211,7 +28180,6 @@
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -29630,7 +29598,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "sax": "^1.2.4"
@@ -29649,7 +29616,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -32505,7 +32471,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -32730,7 +32696,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -33345,8 +33310,7 @@
             "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/psl": {
             "version": "1.15.0",


### PR DESCRIPTION
## Summary
Streamlines the request sent to the platform broker in `PlatformAuthInteractionClient.initializePlatformRequest` so it only includes the **MSAL JS "Acquire token parameters"** defined in the platform broker contract (`broker_contract.md`), instead of spreading the entire developer SDK request.

## Problem
The request was built via `...remainingProperties`, spreading the whole `PopupRequest`/`SsoSilentRequest` into the broker payload. This leaked ESTS/token-endpoint-only and SDK-only fields (`azureCloudOptions`, `maxAge`, `sshJwk`, `sshKid`, `account`, `scenarioId`, `httpMethod`, `skipBrokerClaims`, `extraQueryParameters`, `sid`, `domainHint`, `shrOptions`, `instanceAware`, ...) into the request sent to the platform broker.

## Changes
- **`PlatformAuthInteractionClient.ts`** — replaced the blind spread with an explicit whitelist of the contract MSAL JS acquire-token params (`accountId, clientId, authority, scope, redirectUri, correlationId, prompt, nonce, state, loginHint, windowTitleSubstring, tokenType, claims, extraParameters`, plus `reqCnf` for PoP). Internal-only fields still needed after the response (`keyId, storeInCache, embeddedClientId, resource, resourceRequestMethod/Uri, shrClaims, shrNonce`) are preserved.
- **`PlatformAuthRequest.ts`** — added the `loginHint?` contract param to the type (previously only carried via the spread).
- **Test** — added a regression test asserting contract params are forwarded and non-contract fields are dropped.
- **Changefile** — `patch` for `@azure/msal-browser`.

## Validation (msal-browser)
Build, lint (0 errors), format check, apiExtractor (no public-API change), and tests (interaction client + broker) all pass.

## Notes
- No breaking changes; `PlatformAuthRequest` is internal (not part of the public API surface).
