### PR TITLE
AB#3677516: Add DPoP proof foundation

### DIFF
--- a/change/@azure-msal-browser-dpop-key-lifecycle.json
+++ b/change/@azure-msal-browser-dpop-key-lifecycle.json
@@ -1,6 +1,6 @@
 {
     "type": "minor",
-    "comment": "Add browser token-binding key lifecycle support for scoped ES256 DPoP keys [#8708](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8708)",
+    "comment": "Add browser token-binding key lifecycle support for scoped ES256 DPoP keys [#8725](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8725)",
     "packageName": "@azure/msal-browser",
     "email": "hectormmg@microsoft.com",
     "dependentChangeType": "minor"

--- a/change/@azure-msal-browser-dpop-key-lifecycle.json
+++ b/change/@azure-msal-browser-dpop-key-lifecycle.json
@@ -1,0 +1,7 @@
+{
+    "type": "minor",
+    "comment": "Add browser token-binding key lifecycle support for scoped ES256 DPoP keys [#8708](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8708)",
+    "packageName": "@azure/msal-browser",
+    "email": "hectormmg@microsoft.com",
+    "dependentChangeType": "minor"
+}

--- a/change/@azure-msal-common-dpop-key-lifecycle.json
+++ b/change/@azure-msal-common-dpop-key-lifecycle.json
@@ -1,0 +1,7 @@
+{
+    "type": "minor",
+    "comment": "Add internal token-binding key lifecycle contracts for DPoP proof generation [#8708](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8708)",
+    "packageName": "@azure/msal-common",
+    "email": "hectormmg@microsoft.com",
+    "dependentChangeType": "minor"
+}

--- a/change/@azure-msal-common-dpop-key-lifecycle.json
+++ b/change/@azure-msal-common-dpop-key-lifecycle.json
@@ -1,6 +1,6 @@
 {
     "type": "minor",
-    "comment": "Add internal token-binding key lifecycle contracts for DPoP proof generation [#8708](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8708)",
+    "comment": "Add internal token-binding key lifecycle contracts for DPoP proof generation [#8725](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8725)",
     "packageName": "@azure/msal-common",
     "email": "hectormmg@microsoft.com",
     "dependentChangeType": "minor"

--- a/change/@azure-msal-node-dpop-key-lifecycle.json
+++ b/change/@azure-msal-node-dpop-key-lifecycle.json
@@ -1,6 +1,6 @@
 {
     "type": "minor",
-    "comment": "Clarify the legacy node SHR signing stub deprecation [#8708](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8708)",
+    "comment": "Clarify the legacy node SHR signing stub deprecation [#8725](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8725)",
     "packageName": "@azure/msal-node",
     "email": "hectormmg@microsoft.com",
     "dependentChangeType": "minor"

--- a/change/@azure-msal-node-dpop-key-lifecycle.json
+++ b/change/@azure-msal-node-dpop-key-lifecycle.json
@@ -1,0 +1,7 @@
+{
+    "type": "minor",
+    "comment": "Clarify the legacy node SHR signing stub deprecation [#8708](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8708)",
+    "packageName": "@azure/msal-node",
+    "email": "hectormmg@microsoft.com",
+    "dependentChangeType": "minor"
+}

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -258,6 +258,10 @@ This error occurs when MSAL.js surpasses the allotted storage limit when attempt
 
 -   Missing sshKid in SSH certificate request. A string that uniquely identifies the public SSH key is required when using the SSH authentication scheme.
 
+### `unsupported_authentication_scheme`
+
+-   Unsupported authentication scheme. MSAL.js only accepts authentication schemes that are explicitly enabled for the current runtime.
+
 ### `missing_nonce_authentication_header`
 
 -   Unable to find an authentication header containing server nonce. Either the Authentication-Info or WWW-Authenticate headers must be present in order to obtain a server nonce.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -258,10 +258,6 @@ This error occurs when MSAL.js surpasses the allotted storage limit when attempt
 
 -   Missing sshKid in SSH certificate request. A string that uniquely identifies the public SSH key is required when using the SSH authentication scheme.
 
-### `unsupported_authentication_scheme`
-
--   Unsupported authentication scheme. MSAL.js only accepts authentication schemes that are explicitly enabled for the current runtime.
-
 ### `missing_nonce_authentication_header`
 
 -   Unable to find an authentication header containing server nonce. Either the Authentication-Info or WWW-Authenticate headers must be present in order to obtain a server nonce.
@@ -859,10 +855,6 @@ msalInstance.acquireTokenSilent(); // This will also no longer throw this error
 ### `invalid_pop_token_request`
 
 -   Invalid PoP token request. The request should not have both a popKid value and signPopToken set to true.
-
-### `missing_token_binding_jwt_algorithm`
-
--   The token-binding JWT header is missing the required alg value.
 
 ### `unsupported_token_binding_algorithm`
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -258,6 +258,10 @@ This error occurs when MSAL.js surpasses the allotted storage limit when attempt
 
 -   Missing sshKid in SSH certificate request. A string that uniquely identifies the public SSH key is required when using the SSH authentication scheme.
 
+### `unsupported_authentication_scheme`
+
+-   Unsupported authentication scheme. MSAL.js only accepts authentication schemes that are explicitly enabled for the current runtime.
+
 ### `missing_nonce_authentication_header`
 
 -   Unable to find an authentication header containing server nonce. Either the Authentication-Info or WWW-Authenticate headers must be present in order to obtain a server nonce.
@@ -341,6 +345,14 @@ This error occurs when MSAL.js surpasses the allotted storage limit when attempt
 ### `missing_alg_error`
 
 -   The JOSE Header for the requested JWT, JWS or JWK object requires an algorithm to be specified as the 'alg' header claim. No 'alg' value was provided.
+
+### `missing_jwk_error`
+
+-   The JOSE Header for the requested JWT, JWS or JWK object requires a public key to be specified as the 'jwk' header claim. No 'jwk' value was provided.
+
+### `invalid_jwk_error`
+
+-   The JOSE Header for the requested JWT, JWS or JWK object requires a supported public key in the 'jwk' header claim.
 
 ## Browser auth errors
 
@@ -750,6 +762,13 @@ If you do not want to use a dedicated `redirectUri` for this purpose, you should
 ### `invalid_public_jwk`
 
 -   Public JWK must include the required RFC 7638 thumbprint members for its supported key type.
+-   This error may include one of the following sub-errors:
+    -   `token_binding_key_jwk_thumbprint_mismatch` - The token-binding JWT header JWK thumbprint does not match the signing key identifier.
+
+### `token_binding_key_jwk_thumbprint_mismatch`
+
+-   Sub-error of `invalid_public_jwk`.
+-   The token-binding JWT header JWK thumbprint does not match the signing key identifier.
 
 ### `auth_code_required`
 
@@ -840,6 +859,21 @@ msalInstance.acquireTokenSilent(); // This will also no longer throw this error
 ### `invalid_pop_token_request`
 
 -   Invalid PoP token request. The request should not have both a popKid value and signPopToken set to true.
+
+### `missing_token_binding_jwt_algorithm`
+
+-   The token-binding JWT header is missing the required alg value.
+
+### `unsupported_token_binding_algorithm`
+
+-   The token-binding key algorithm is not supported by the browser crypto implementation.
+-   This error may include one of the following sub-errors:
+    -   `token_binding_key_algorithm_mismatch` - The requested token-binding JWT alg is supported, but is incompatible with the stored key material.
+
+### `token_binding_key_algorithm_mismatch`
+
+-   Sub-error of `unsupported_token_binding_algorithm`.
+-   The requested token-binding JWT alg is supported, but is incompatible with the stored key material.
 
 ### `failed_to_build_headers`
 

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -213,6 +213,10 @@ declare namespace BrowserAuthErrorCodes {
         nativePromptNotSupported,
         invalidBase64String,
         invalidPopTokenRequest,
+        missingTokenBindingJwtAlgorithm,
+        unsupportedTokenBindingAlgorithm,
+        tokenBindingKeyAlgorithmMismatch,
+        tokenBindingKeyJwkThumbprintMismatch,
         failedToBuildHeaders,
         failedToParseHeaders,
         failedToDecryptEarResponse,
@@ -736,6 +740,7 @@ export const JsonWebTokenTypes: {
     readonly Jwt: "JWT";
     readonly Jwk: "JWK";
     readonly Pop: "pop";
+    readonly Dpop: "dpop+jwt";
 };
 
 // @public (undocumented)
@@ -809,6 +814,9 @@ export class MemoryStorage<T> implements IWindowStorage<T> {
     // (undocumented)
     setUserData(key: string, value: T): Promise<void>;
 }
+
+// @public (undocumented)
+const missingTokenBindingJwtAlgorithm = "missing_token_binding_jwt_algorithm";
 
 // @public (undocumented)
 const nativeConnectionNotEstablished = "native_connection_not_established";
@@ -1091,6 +1099,12 @@ export { TenantProfile }
 const timedOut = "timed_out";
 
 // @public (undocumented)
+const tokenBindingKeyAlgorithmMismatch = "token_binding_key_algorithm_mismatch";
+
+// @public (undocumented)
+const tokenBindingKeyJwkThumbprintMismatch = "token_binding_key_jwk_thumbprint_mismatch";
+
+// @public (undocumented)
 const unableToAcquireTokenFromNativePlatform = "unable_to_acquire_token_from_native_platform";
 
 // @public (undocumented)
@@ -1104,6 +1118,9 @@ const unableToParseTokenRequestCacheError = "unable_to_parse_token_request_cache
 
 // @public (undocumented)
 const uninitializedPublicClientApplication = "uninitialized_public_client_application";
+
+// @public (undocumented)
+const unsupportedTokenBindingAlgorithm = "unsupported_token_binding_algorithm";
 
 // @public (undocumented)
 const userCancelled = "user_cancelled";

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -213,7 +213,6 @@ declare namespace BrowserAuthErrorCodes {
         nativePromptNotSupported,
         invalidBase64String,
         invalidPopTokenRequest,
-        missingTokenBindingJwtAlgorithm,
         unsupportedTokenBindingAlgorithm,
         tokenBindingKeyAlgorithmMismatch,
         tokenBindingKeyJwkThumbprintMismatch,
@@ -814,9 +813,6 @@ export class MemoryStorage<T> implements IWindowStorage<T> {
     // (undocumented)
     setUserData(key: string, value: T): Promise<void>;
 }
-
-// @public (undocumented)
-const missingTokenBindingJwtAlgorithm = "missing_token_binding_jwt_algorithm";
 
 // @public (undocumented)
 const nativeConnectionNotEstablished = "native_connection_not_established";

--- a/lib/msal-browser/docs/browser-compat-map.md
+++ b/lib/msal-browser/docs/browser-compat-map.md
@@ -12,13 +12,13 @@ This document catalogs browser Web APIs that MSAL Browser depends on, their role
 |-----|-----------|----------|
 | `sessionStorage` | Interaction status, PKCE verifier, redirect origin URL, redirect bridge response cache | `MemoryStorage` (response lost on navigation) |
 | `localStorage` | Persistent token cache (when `cacheLocation: "localStorage"`) | None if configured; not used by default |
-| `IndexedDB` | PoP token RSA keypairs | In-memory (keys lost on reload) |
+| `IndexedDB` | PoP token RSA keypairs and DPoP token-binding keypairs | In-memory (keys lost on reload) |
 | `document.cookie` | Encryption key for localStorage cache | None — cache cannot be decrypted without it |
 
 **MSAL-specific restrictions:**
 - Safari PB: `sessionStorage.setItem()` immediately before `location.replace()` may lose data — affects redirect bridge (`handleRedirectPromise` returns `null`)
 - Safari ITP: 7-day cap on script-writable `localStorage`/cookies — tokens evicted without user interaction
-- Firefox PB: `indexedDB.open()` throws `SecurityError` — PoP falls back to memory
+- Firefox PB: `indexedDB.open()` throws `SecurityError` — PoP/DPoP key storage falls back to memory
 - Chrome 115+ / Safari 16.1+: storage partitioned in cross-origin iframes — affects NAA and embedded apps
 
 ### Crypto

--- a/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
+++ b/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
@@ -106,12 +106,13 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
             return Array.from(new Set([...cacheKeys, ...persistentCacheKeys]));
         } catch (e) {
             if (
-                !(
-                    e instanceof BrowserAuthError &&
-                    e.errorCode === BrowserAuthErrorCodes.databaseUnavailable
-                ) &&
-                cacheKeys.length > 0
+                e instanceof BrowserAuthError &&
+                e.errorCode === BrowserAuthErrorCodes.databaseUnavailable
             ) {
+                return cacheKeys;
+            }
+
+            if (cacheKeys.length > 0) {
                 this.logger.warning(
                     "Persistent storage key enumeration failed. Returning in-memory keys.",
                     correlationId

--- a/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
+++ b/lib/msal-browser/src/cache/AsyncMemoryStorage.ts
@@ -96,23 +96,32 @@ export class AsyncMemoryStorage<T> implements IAsyncStorage<T> {
     }
 
     /**
-     * Get all the keys from the in-memory cache as an iterable array of strings. If no keys are found, query the keys in the
-     * asynchronous storage object.
+     * Get all keys from both in-memory and persistent storage.
      * @param correlationId
      */
     async getKeys(correlationId: string): Promise<string[]> {
         const cacheKeys = this.inMemoryCache.getKeys();
-        if (cacheKeys.length === 0) {
-            try {
-                this.logger.verbose(
-                    "In-memory cache is empty, now querying persistent storage.",
+        try {
+            const persistentCacheKeys = await this.indexedDBCache.getKeys();
+            return Array.from(new Set([...cacheKeys, ...persistentCacheKeys]));
+        } catch (e) {
+            if (
+                !(
+                    e instanceof BrowserAuthError &&
+                    e.errorCode === BrowserAuthErrorCodes.databaseUnavailable
+                ) &&
+                cacheKeys.length > 0
+            ) {
+                this.logger.warning(
+                    "Persistent storage key enumeration failed. Returning in-memory keys.",
                     correlationId
                 );
-                return await this.indexedDBCache.getKeys();
-            } catch (e) {
-                this.handleDatabaseAccessError(e, correlationId);
+                return cacheKeys;
             }
+
+            this.handleDatabaseAccessError(e, correlationId);
         }
+
         return cacheKeys;
     }
 

--- a/lib/msal-browser/src/crypto/BrowserCrypto.ts
+++ b/lib/msal-browser/src/crypto/BrowserCrypto.ts
@@ -237,7 +237,7 @@ export async function importJwk(
  */
 export async function sign(
     key: CryptoKey,
-    data: ArrayBuffer,
+    data: BufferSource,
     algorithm: AlgorithmIdentifier
 ): Promise<ArrayBuffer> {
     return window.crypto.subtle.sign(
@@ -463,13 +463,14 @@ const JWK_THUMBPRINT_REQUIRED_MEMBERS: Record<string, Array<string>> = {
 };
 
 function getJwkThumbprintMembers(
-    publicJwk: JsonWebKey
+    publicJwk: JsonWebKey,
+    correlationId: string
 ): Record<string, string> {
     const kty = publicJwk.kty;
     if (typeof kty !== "string" || kty.length === 0) {
         throw createBrowserAuthError(
             BrowserAuthErrorCodes.invalidPublicJwk,
-            "",
+            correlationId,
             MISSING_JWK_KTY_SUBERROR
         );
     }
@@ -478,7 +479,7 @@ function getJwkThumbprintMembers(
     if (!requiredMembers) {
         throw createBrowserAuthError(
             BrowserAuthErrorCodes.invalidPublicJwk,
-            "",
+            correlationId,
             UNSUPPORTED_JWK_KTY_SUBERROR
         );
     }
@@ -488,7 +489,7 @@ function getJwkThumbprintMembers(
         if (typeof memberValue !== "string") {
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.invalidPublicJwk,
-                "",
+                correlationId,
                 MISSING_JWK_MEMBER_SUBERROR
             );
         }
@@ -496,7 +497,7 @@ function getJwkThumbprintMembers(
         if (memberValue.length === 0) {
             throw createBrowserAuthError(
                 BrowserAuthErrorCodes.invalidPublicJwk,
-                "",
+                correlationId,
                 EMPTY_JWK_MEMBER_SUBERROR
             );
         }
@@ -513,9 +514,10 @@ function getJwkThumbprintMembers(
  * @internal
  */
 export async function computeJwkThumbprint(
-    publicJwk: JsonWebKey
+    publicJwk: JsonWebKey,
+    correlationId: string = ""
 ): Promise<string> {
-    const thumbprintMembers = getJwkThumbprintMembers(publicJwk);
+    const thumbprintMembers = getJwkThumbprintMembers(publicJwk, correlationId);
     // RFC 7638 §3.3: use only required members, sorted lexicographically
     const thumbprintJson = JSON.stringify(
         thumbprintMembers,

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -4,16 +4,11 @@
  */
 
 import {
-    ClientAuthErrorCodes,
-    createClientAuthError,
     ICrypto,
     IPerformanceClient,
-    JoseHeader,
     Logger,
-    ShrOptions,
-    SignedHttpRequest,
-    SignedHttpRequestParameters,
 } from "@azure/msal-common/browser";
+import type { TokenBindingKeyContext } from "@azure/msal-common/browser";
 import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
 import {
     base64Encode,
@@ -23,16 +18,23 @@ import {
 import { base64Decode } from "../encode/Base64Decode.js";
 import * as BrowserCrypto from "./BrowserCrypto.js";
 import {
-    createBrowserAuthError,
+    CachedKeyPair,
+    TOKEN_BINDING_KEY_ALGORITHMS,
+    TokenBindingKeyTelemetry,
+    TokenBindingKeyManager,
+} from "./TokenBindingKeyManager.js";
+import {
     BrowserAuthErrorCodes,
+    createBrowserAuthError,
 } from "../error/BrowserAuthError.js";
-import { AsyncMemoryStorage } from "../cache/AsyncMemoryStorage.js";
 
-export type CachedKeyPair = {
-    publicKey: CryptoKey;
-    privateKey: CryptoKey;
-    requestMethod?: string;
-    requestUri?: string;
+type TokenBindingKeySigningAlgorithm = {
+    signAlgorithm: AlgorithmIdentifier;
+};
+
+type TokenBindingSigningHeader = {
+    alg: string;
+    jwk?: JsonWebKey;
 };
 
 /**
@@ -47,10 +49,7 @@ export class CryptoOps implements ICrypto {
      * meaning there won't be a performance manager available.
      */
     private performanceClient: IPerformanceClient | undefined;
-
-    private static POP_KEY_USAGES: Array<KeyUsage> = ["sign", "verify"];
-    private static EXTRACTABLE: boolean = true;
-    private cache: AsyncMemoryStorage<CachedKeyPair>;
+    private tokenBindingKeyManager: TokenBindingKeyManager;
 
     constructor(
         logger: Logger,
@@ -62,8 +61,11 @@ export class CryptoOps implements ICrypto {
         BrowserCrypto.validateCryptoAvailable(
             skipValidateSubtleCrypto ?? false
         );
-        this.cache = new AsyncMemoryStorage<CachedKeyPair>(this.logger);
         this.performanceClient = performanceClient;
+        this.tokenBindingKeyManager = new TokenBindingKeyManager(
+            this.logger,
+            this.performanceClient
+        );
     }
 
     /**
@@ -108,85 +110,20 @@ export class CryptoOps implements ICrypto {
     }
 
     /**
-     * Generates a keypair, stores it and returns a thumbprint
-     * @param request
-     */
-    async getPublicKeyThumbprint(
-        request: SignedHttpRequestParameters
-    ): Promise<string> {
-        const publicKeyThumbMeasurement =
-            this.performanceClient?.startMeasurement(
-                BrowserPerformanceEvents.CryptoOptsGetPublicKeyThumbprint,
-                request.correlationId
-            );
-
-        // Generate Keypair
-        const keyPair: CryptoKeyPair = await BrowserCrypto.generateKeyPair(
-            CryptoOps.EXTRACTABLE,
-            CryptoOps.POP_KEY_USAGES,
-            BrowserCrypto.RSA_KEYGEN_ALGORITHM_OPTIONS
-        );
-
-        // Generate Thumbprint for Public Key
-        const publicKeyJwk: JsonWebKey = await BrowserCrypto.exportJwk(
-            keyPair.publicKey
-        );
-
-        const publicJwkHash = await BrowserCrypto.computeJwkThumbprint(
-            publicKeyJwk
-        );
-
-        // Generate Thumbprint for Private Key
-        const privateKeyJwk: JsonWebKey = await BrowserCrypto.exportJwk(
-            keyPair.privateKey
-        );
-        // Re-import private key to make it unextractable
-        const unextractablePrivateKey: CryptoKey =
-            await BrowserCrypto.importJwk(
-                privateKeyJwk,
-                false,
-                ["sign"],
-                BrowserCrypto.RSA_KEYGEN_ALGORITHM_OPTIONS
-            );
-
-        // Store Keypair data in keystore
-        await this.cache.setItem(
-            publicJwkHash,
-            {
-                privateKey: unextractablePrivateKey,
-                publicKey: keyPair.publicKey,
-                requestMethod: request.resourceRequestMethod,
-                requestUri: request.resourceRequestUri,
-            },
-            request.correlationId
-        );
-
-        if (publicKeyThumbMeasurement) {
-            publicKeyThumbMeasurement.end({
-                success: true,
-            });
-        }
-
-        return publicJwkHash;
-    }
-
-    /**
      * Removes cryptographic keypair from key store matching the keyId passed in
      * @param kid
      * @param correlationId
      */
     async removeTokenBindingKey(
         kid: string,
-        correlationId: string
+        correlationId: string,
+        context?: TokenBindingKeyContext
     ): Promise<void> {
-        await this.cache.removeItem(kid, correlationId);
-        const keyFound = await this.cache.containsKey(kid, correlationId);
-        if (keyFound) {
-            throw createClientAuthError(
-                ClientAuthErrorCodes.bindingKeyNotRemoved,
-                correlationId
-            );
-        }
+        await this.tokenBindingKeyManager.removeTokenBindingKey(
+            kid,
+            correlationId,
+            context
+        );
     }
 
     /**
@@ -194,104 +131,71 @@ export class CryptoOps implements ICrypto {
      * @param correlationId
      */
     async clearKeystore(correlationId: string): Promise<boolean> {
-        // Delete in-memory keystores
-        this.cache.clearInMemory(correlationId);
-
-        /**
-         * There is only one database, so calling clearPersistent on asymmetric keystore takes care of
-         * every persistent keystore
-         */
-        try {
-            await this.cache.clearPersistent(correlationId);
-            return true;
-        } catch (e) {
-            if (e instanceof Error) {
-                this.logger.error(
-                    `Clearing keystore failed with error: '${e.message}'`,
-                    correlationId
-                );
-            } else {
-                this.logger.error(
-                    "Clearing keystore failed with unknown error",
-                    correlationId
-                );
-            }
-
-            return false;
-        }
+        return this.tokenBindingKeyManager.clearKeystore(correlationId);
     }
 
-    /**
-     * Signs the given object as a jwt payload with private key retrieved by given kid.
-     * @param payload
-     * @param kid
-     */
-    async signJwt(
-        payload: SignedHttpRequest,
+    /** @internal */
+    async signTokenBindingJwt(
+        header: object,
+        payload: object,
         kid: string,
-        shrOptions?: ShrOptions,
-        correlationId?: string
+        correlationId: string,
+        context?: TokenBindingKeyContext
     ): Promise<string> {
-        const signJwtMeasurement = this.performanceClient?.startMeasurement(
-            BrowserPerformanceEvents.CryptoOptsSignJwt,
-            correlationId
-        );
-        const cachedKeyPair = await this.cache.getItem(
-            kid,
-            correlationId || ""
-        );
-
-        if (!cachedKeyPair) {
-            throw createBrowserAuthError(
-                BrowserAuthErrorCodes.cryptoKeyNotFound,
-                correlationId || ""
+        let telemetry: TokenBindingKeyTelemetry = {};
+        const signTokenBindingJwtMeasurement =
+            this.performanceClient?.startMeasurement(
+                BrowserPerformanceEvents.CryptoOptsSignJwt,
+                correlationId
             );
-        }
+        try {
+            const cachedKeyPair =
+                await this.tokenBindingKeyManager.getTokenBindingKeyPair(
+                    kid,
+                    correlationId,
+                    context
+                );
+            const jwtHeader = validateTokenBindingSigningHeader(
+                header,
+                correlationId
+            );
+            await this.validateTokenBindingJwtHeaderKey(
+                jwtHeader,
+                kid,
+                correlationId
+            );
+            telemetry = this.tokenBindingKeyManager.getTokenBindingKeyTelemetry(
+                cachedKeyPair,
+                jwtHeader.alg
+            );
 
-        // Get public key as JWK
-        const publicKeyJwk = await BrowserCrypto.exportJwk(
-            cachedKeyPair.publicKey
-        );
-        const publicKeyJwkString = getSortedObjectString(publicKeyJwk);
-        // Base64URL encode public key thumbprint with keyId only: BASE64URL({ kid: "FULL_PUBLIC_KEY_HASH" })
-        const encodedKeyIdThumbprint = urlEncode(JSON.stringify({ kid: kid }));
-        // Generate header
-        const shrHeader = JoseHeader.getShrHeaderString({
-            ...shrOptions?.header,
-            alg: publicKeyJwk.alg,
-            kid: encodedKeyIdThumbprint,
-        });
+            const signingAlgorithm = this.getTokenBindingKeySigningAlgorithm(
+                cachedKeyPair,
+                jwtHeader.alg,
+                correlationId
+            );
 
-        const encodedShrHeader = urlEncode(shrHeader);
+            const tokenString = `${urlEncode(
+                JSON.stringify(jwtHeader)
+            )}.${urlEncode(JSON.stringify(payload))}`;
+            const encodedSignature = await this.signInput(
+                cachedKeyPair,
+                tokenString,
+                signingAlgorithm.signAlgorithm
+            );
 
-        // Generate payload
-        payload.cnf = {
-            jwk: JSON.parse(publicKeyJwkString),
-        };
-        const encodedPayload = urlEncode(JSON.stringify(payload));
-
-        // Form token string
-        const tokenString = `${encodedShrHeader}.${encodedPayload}`;
-
-        // Sign token
-        const encoder = new TextEncoder();
-        const tokenBuffer = encoder.encode(tokenString);
-        const signatureBuffer = await BrowserCrypto.sign(
-            cachedKeyPair.privateKey,
-            tokenBuffer,
-            BrowserCrypto.RSA_SIGN_ALGORITHM_OPTIONS
-        );
-        const encodedSignature = urlEncodeArr(new Uint8Array(signatureBuffer));
-
-        const signedJwt = `${tokenString}.${encodedSignature}`;
-
-        if (signJwtMeasurement) {
-            signJwtMeasurement.end({
+            signTokenBindingJwtMeasurement?.end({
                 success: true,
+                ...telemetry,
             });
+            return `${tokenString}.${encodedSignature}`;
+        } catch (e) {
+            signTokenBindingJwtMeasurement?.end({
+                success: false,
+                ...telemetry,
+            });
+            throw e;
         }
-
-        return signedJwt;
     }
 
     /**
@@ -301,8 +205,123 @@ export class CryptoOps implements ICrypto {
     async hashString(plainText: string): Promise<string> {
         return BrowserCrypto.hashString(plainText);
     }
+
+    private async signInput(
+        cachedKeyPair: CachedKeyPair,
+        signingInput: string,
+        algorithm: AlgorithmIdentifier
+    ): Promise<string> {
+        const encoder = new TextEncoder();
+        const signatureBuffer = await BrowserCrypto.sign(
+            cachedKeyPair.privateKey,
+            encoder.encode(signingInput),
+            algorithm
+        );
+
+        return urlEncodeArr(new Uint8Array(signatureBuffer));
+    }
+
+    private getTokenBindingKeySigningAlgorithm(
+        cachedKeyPair: CachedKeyPair,
+        requestedAlgorithm: string,
+        correlationId: string
+    ): TokenBindingKeySigningAlgorithm {
+        const keyAlgorithm = cachedKeyPair.privateKey.algorithm;
+        if (
+            requestedAlgorithm === TOKEN_BINDING_KEY_ALGORITHMS.RS256 &&
+            keyAlgorithm.name === BrowserCrypto.RSA_SIGN_ALGORITHM_OPTIONS.name
+        ) {
+            return {
+                signAlgorithm: BrowserCrypto.RSA_SIGN_ALGORITHM_OPTIONS,
+            };
+        }
+
+        if (
+            requestedAlgorithm === TOKEN_BINDING_KEY_ALGORITHMS.ES256 &&
+            keyAlgorithm.name ===
+                BrowserCrypto.ECDSA_SHA256_SIGN_ALGORITHM_OPTIONS.name &&
+            (keyAlgorithm as EcKeyAlgorithm).namedCurve ===
+                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS.namedCurve
+        ) {
+            return {
+                signAlgorithm:
+                    BrowserCrypto.ECDSA_SHA256_SIGN_ALGORITHM_OPTIONS,
+            };
+        }
+
+        if (
+            requestedAlgorithm === TOKEN_BINDING_KEY_ALGORITHMS.RS256 ||
+            requestedAlgorithm === TOKEN_BINDING_KEY_ALGORITHMS.ES256
+        ) {
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.unsupportedTokenBindingAlgorithm,
+                correlationId,
+                BrowserAuthErrorCodes.tokenBindingKeyAlgorithmMismatch
+            );
+        }
+
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.unsupportedTokenBindingAlgorithm,
+            correlationId
+        );
+    }
+
+    private async validateTokenBindingJwtHeaderKey(
+        header: TokenBindingSigningHeader,
+        kid: string,
+        correlationId: string
+    ): Promise<void> {
+        if (!header.jwk) {
+            return;
+        }
+
+        const headerKeyId = await BrowserCrypto.computeJwkThumbprint(
+            header.jwk,
+            correlationId
+        );
+        if (headerKeyId !== kid) {
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.invalidPublicJwk,
+                correlationId,
+                BrowserAuthErrorCodes.tokenBindingKeyJwkThumbprintMismatch
+            );
+        }
+    }
 }
 
-function getSortedObjectString(obj: object): string {
-    return JSON.stringify(obj, Object.keys(obj).sort());
+function validateTokenBindingSigningHeader(
+    header: object,
+    correlationId: string
+): TokenBindingSigningHeader {
+    if (!isRecord(header) || typeof header.alg !== "string" || !header.alg) {
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.missingTokenBindingJwtAlgorithm,
+            correlationId
+        );
+    }
+
+    const tokenBindingJwtHeader: TokenBindingSigningHeader = {
+        alg: header.alg,
+    };
+
+    if (!("jwk" in header) || typeof header.jwk === "undefined") {
+        return tokenBindingJwtHeader;
+    }
+
+    if (isRecord(header.jwk)) {
+        return {
+            ...tokenBindingJwtHeader,
+            jwk: header.jwk,
+        };
+    }
+
+    throw createBrowserAuthError(
+        BrowserAuthErrorCodes.invalidPublicJwk,
+        correlationId,
+        BrowserAuthErrorCodes.tokenBindingKeyJwkThumbprintMismatch
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
 }

--- a/lib/msal-browser/src/crypto/CryptoOps.ts
+++ b/lib/msal-browser/src/crypto/CryptoOps.ts
@@ -6,6 +6,7 @@
 import {
     ICrypto,
     IPerformanceClient,
+    JoseHeader,
     Logger,
 } from "@azure/msal-common/browser";
 import type { TokenBindingKeyContext } from "@azure/msal-common/browser";
@@ -30,11 +31,6 @@ import {
 
 type TokenBindingKeySigningAlgorithm = {
     signAlgorithm: AlgorithmIdentifier;
-};
-
-type TokenBindingSigningHeader = {
-    alg: string;
-    jwk?: JsonWebKey;
 };
 
 /**
@@ -136,7 +132,7 @@ export class CryptoOps implements ICrypto {
 
     /** @internal */
     async signTokenBindingJwt(
-        header: object,
+        header: JoseHeader,
         payload: object,
         kid: string,
         correlationId: string,
@@ -155,28 +151,24 @@ export class CryptoOps implements ICrypto {
                     correlationId,
                     context
                 );
-            const jwtHeader = validateTokenBindingSigningHeader(
-                header,
-                correlationId
-            );
             await this.validateTokenBindingJwtHeaderKey(
-                jwtHeader,
+                header,
                 kid,
                 correlationId
             );
             telemetry = this.tokenBindingKeyManager.getTokenBindingKeyTelemetry(
                 cachedKeyPair,
-                jwtHeader.alg
+                header.alg
             );
 
             const signingAlgorithm = this.getTokenBindingKeySigningAlgorithm(
                 cachedKeyPair,
-                jwtHeader.alg,
+                header.alg,
                 correlationId
             );
 
             const tokenString = `${urlEncode(
-                JSON.stringify(jwtHeader)
+                JSON.stringify(header)
             )}.${urlEncode(JSON.stringify(payload))}`;
             const encodedSignature = await this.signInput(
                 cachedKeyPair,
@@ -267,7 +259,7 @@ export class CryptoOps implements ICrypto {
     }
 
     private async validateTokenBindingJwtHeaderKey(
-        header: TokenBindingSigningHeader,
+        header: JoseHeader,
         kid: string,
         correlationId: string
     ): Promise<void> {
@@ -287,41 +279,4 @@ export class CryptoOps implements ICrypto {
             );
         }
     }
-}
-
-function validateTokenBindingSigningHeader(
-    header: object,
-    correlationId: string
-): TokenBindingSigningHeader {
-    if (!isRecord(header) || typeof header.alg !== "string" || !header.alg) {
-        throw createBrowserAuthError(
-            BrowserAuthErrorCodes.missingTokenBindingJwtAlgorithm,
-            correlationId
-        );
-    }
-
-    const tokenBindingJwtHeader: TokenBindingSigningHeader = {
-        alg: header.alg,
-    };
-
-    if (!("jwk" in header) || typeof header.jwk === "undefined") {
-        return tokenBindingJwtHeader;
-    }
-
-    if (isRecord(header.jwk)) {
-        return {
-            ...tokenBindingJwtHeader,
-            jwk: header.jwk,
-        };
-    }
-
-    throw createBrowserAuthError(
-        BrowserAuthErrorCodes.invalidPublicJwk,
-        correlationId,
-        BrowserAuthErrorCodes.tokenBindingKeyJwkThumbprintMismatch
-    );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
 }

--- a/lib/msal-browser/src/crypto/SignedHttpRequest.ts
+++ b/lib/msal-browser/src/crypto/SignedHttpRequest.ts
@@ -4,6 +4,7 @@
  */
 
 import { CryptoOps } from "./CryptoOps.js";
+import { TokenBindingKeyManager } from "./TokenBindingKeyManager.js";
 import {
     Logger,
     LoggerOptions,
@@ -30,8 +31,10 @@ export class SignedHttpRequest {
         const loggerOptions = (shrOptions && shrOptions.loggerOptions) || {};
         this.logger = new Logger(loggerOptions, name, version);
         this.cryptoOps = new CryptoOps(this.logger);
+        const tokenBindingKeyManager = new TokenBindingKeyManager(this.logger);
         this.popTokenGenerator = new PopTokenGenerator(
             this.cryptoOps,
+            tokenBindingKeyManager,
             new StubPerformanceClient()
         );
         this.shrParameters = shrParameters;

--- a/lib/msal-browser/src/crypto/TokenBindingKeyManager.ts
+++ b/lib/msal-browser/src/crypto/TokenBindingKeyManager.ts
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    ClientAuthErrorCodes,
+    createClientAuthError,
+    IPerformanceClient,
+    Logger,
+} from "@azure/msal-common/browser";
+import type {
+    ITokenBindingKeyManager,
+    TokenBindingKeyContext,
+    TokenBindingKeyProvisioningParameters,
+} from "@azure/msal-common/browser";
+import * as BrowserPerformanceEvents from "../telemetry/BrowserPerformanceEvents.js";
+import { urlEncode } from "../encode/Base64Encode.js";
+import * as BrowserCrypto from "./BrowserCrypto.js";
+import {
+    BrowserAuthError,
+    createBrowserAuthError,
+    BrowserAuthErrorCodes,
+} from "../error/BrowserAuthError.js";
+import { AsyncMemoryStorage } from "../cache/AsyncMemoryStorage.js";
+
+/**
+ * Browser keystore record for asymmetric token-binding keys.
+ */
+export type CachedKeyPair = {
+    /**
+     * Public WebCrypto key.
+     */
+    publicKey: CryptoKey;
+    /**
+     * Private WebCrypto key used for signing.
+     */
+    privateKey: CryptoKey;
+    /**
+     * Protocol or token-binding family that owns the key.
+     */
+    tokenBindingKeyType?: string;
+    /**
+     * JOSE algorithm policy associated with the key.
+     */
+    tokenBindingKeyAlgorithm?: string;
+    /**
+     * Optional stable scope used to resolve scoped keys.
+     */
+    keyScope?: string;
+    /**
+     * JWK thumbprint used as the key identifier.
+     */
+    keyId?: string;
+};
+
+type GeneratedKeyPair = CachedKeyPair & { keyId: string };
+
+/**
+ * Token-binding key metadata emitted in performance measurements.
+ */
+export type TokenBindingKeyTelemetry = {
+    /**
+     * Protocol or token-binding family that owns the key.
+     */
+    tokenBindingKeyType?: string;
+    /**
+     * JOSE algorithm policy associated with the key.
+     */
+    tokenBindingKeyAlgorithm?: string;
+};
+
+/**
+ * Supported token-binding key algorithm names.
+ * @internal
+ */
+export const TOKEN_BINDING_KEY_ALGORITHMS = {
+    ES256: "ES256",
+    RS256: "RS256",
+} as const;
+
+/**
+ * Owns browser token-binding key lifecycle and storage lookup.
+ * @internal
+ */
+export class TokenBindingKeyManager implements ITokenBindingKeyManager {
+    private static TOKEN_BINDING_KEY_USAGES: Array<KeyUsage> = [
+        "sign",
+        "verify",
+    ];
+    private static tokenBindingKeyStorage: AsyncMemoryStorage<CachedKeyPair>;
+    private static activeScopedKeyRequests: Map<string, Promise<string>> =
+        new Map();
+    private cache: AsyncMemoryStorage<CachedKeyPair>;
+    private logger: Logger;
+    private performanceClient: IPerformanceClient | undefined;
+
+    constructor(logger: Logger, performanceClient?: IPerformanceClient) {
+        this.logger = logger;
+        this.cache = TokenBindingKeyManager.getTokenBindingKeyStorage(
+            this.logger
+        );
+        this.performanceClient = performanceClient;
+    }
+
+    private static getTokenBindingKeyStorage(
+        logger: Logger
+    ): AsyncMemoryStorage<CachedKeyPair> {
+        if (!TokenBindingKeyManager.tokenBindingKeyStorage) {
+            TokenBindingKeyManager.tokenBindingKeyStorage =
+                new AsyncMemoryStorage<CachedKeyPair>(logger);
+        }
+
+        return TokenBindingKeyManager.tokenBindingKeyStorage;
+    }
+
+    /**
+     * Provisions or reuses a browser token-binding key and returns its key identifier.
+     * @param request - Key provisioning policy and cache scope.
+     */
+    async provisionTokenBindingKey(
+        request: TokenBindingKeyProvisioningParameters
+    ): Promise<string> {
+        if (!request.keyScope) {
+            return this.provisionTokenBindingKeyInternal(request);
+        }
+
+        const scopedRequestFingerprint =
+            this.getScopedRequestFingerprint(request);
+        const activeRequest =
+            TokenBindingKeyManager.activeScopedKeyRequests.get(
+                scopedRequestFingerprint
+            );
+        if (activeRequest) {
+            return this.observeCoalescedScopedKeyRequest(
+                request,
+                activeRequest
+            );
+        }
+
+        return this.startScopedKeyRequest(scopedRequestFingerprint, request);
+    }
+
+    private async provisionTokenBindingKeyInternal(
+        request: TokenBindingKeyProvisioningParameters
+    ): Promise<string> {
+        const publicKeyThumbMeasurement =
+            this.performanceClient?.startMeasurement(
+                BrowserPerformanceEvents.CryptoOptsGetPublicKeyThumbprint,
+                request.correlationId
+            );
+        let cachedKeyPair: GeneratedKeyPair | null = null;
+        try {
+            cachedKeyPair = request.keyScope
+                ? await this.getScopedTokenBindingKeyPair(request)
+                : null;
+            const activeKeyPair =
+                cachedKeyPair || (await this.createTokenBindingKey(request));
+
+            publicKeyThumbMeasurement?.end({
+                success: true,
+                ...this.getTokenBindingKeyTelemetry(activeKeyPair),
+                tokenBindingKeyCacheHit: !!cachedKeyPair?.keyId,
+            });
+
+            return activeKeyPair.keyId;
+        } catch (e) {
+            publicKeyThumbMeasurement?.end({
+                success: false,
+                ...(cachedKeyPair
+                    ? this.getTokenBindingKeyTelemetry(cachedKeyPair)
+                    : {
+                          tokenBindingKeyType: request.tokenBindingKeyType,
+                          tokenBindingKeyAlgorithm:
+                              request.tokenBindingKeyAlgorithm,
+                      }),
+                tokenBindingKeyCacheHit: !!cachedKeyPair?.keyId,
+            });
+            throw e;
+        }
+    }
+
+    /**
+     * Removes a browser token-binding key by identifier and optional lookup context.
+     * @param kid - Token-binding key identifier.
+     * @param correlationId - Request correlation identifier.
+     * @param context - Optional scoped lookup context.
+     */
+    async removeTokenBindingKey(
+        kid: string,
+        correlationId: string,
+        context?: TokenBindingKeyContext
+    ): Promise<void> {
+        await this.removeKey(
+            this.getTokenBindingCacheKey(kid, context),
+            correlationId
+        );
+    }
+
+    /**
+     * Clears browser token-binding keys from memory and persistent storage.
+     * @param correlationId - Request correlation identifier.
+     */
+    async clearKeystore(correlationId: string): Promise<boolean> {
+        this.cache.clearInMemory(correlationId);
+
+        try {
+            await this.cache.clearPersistent(correlationId);
+            return true;
+        } catch (e) {
+            if (e instanceof Error) {
+                this.logger.error(
+                    `Clearing keystore failed with error: '${e.message}'`,
+                    correlationId
+                );
+            } else {
+                this.logger.error(
+                    "Clearing keystore failed with unknown error",
+                    correlationId
+                );
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * Gets a token-binding public key as a JWK by identifier and optional lookup context.
+     * @param keyId - Token-binding key identifier.
+     * @param correlationId - Request correlation identifier.
+     * @param context - Optional scoped lookup context.
+     */
+    async getTokenBindingPublicKeyJwk(
+        keyId: string,
+        correlationId: string,
+        context?: TokenBindingKeyContext
+    ): Promise<JsonWebKey> {
+        const cachedKeyPair = await this.getTokenBindingKeyPair(
+            keyId,
+            correlationId,
+            context
+        );
+
+        return BrowserCrypto.exportJwk(cachedKeyPair.publicKey);
+    }
+
+    private async createTokenBindingKey(
+        request: TokenBindingKeyProvisioningParameters
+    ): Promise<GeneratedKeyPair> {
+        const keyGenAlgorithm = this.getTokenBindingKeyGenAlgorithmOptions(
+            request.tokenBindingKeyAlgorithm,
+            request.correlationId
+        );
+        const generatedKeyPair = await this.generateKeyPairAndThumbprint(
+            TokenBindingKeyManager.TOKEN_BINDING_KEY_USAGES,
+            keyGenAlgorithm,
+            request.correlationId
+        );
+        await this.cache.setItem(
+            this.getTokenBindingCacheKey(generatedKeyPair.keyId, request),
+            {
+                ...generatedKeyPair,
+                keyScope: request.keyScope,
+                tokenBindingKeyType: request.tokenBindingKeyType,
+                tokenBindingKeyAlgorithm: request.tokenBindingKeyAlgorithm,
+            },
+            request.correlationId
+        );
+
+        return {
+            ...generatedKeyPair,
+            keyScope: request.keyScope,
+            tokenBindingKeyType: request.tokenBindingKeyType,
+            tokenBindingKeyAlgorithm: request.tokenBindingKeyAlgorithm,
+        };
+    }
+
+    private async generateKeyPairAndThumbprint(
+        usages: Array<KeyUsage>,
+        keyGenAlgorithm: AlgorithmIdentifier,
+        correlationId: string
+    ): Promise<GeneratedKeyPair> {
+        const keyPair: CryptoKeyPair = await BrowserCrypto.generateKeyPair(
+            false,
+            usages,
+            keyGenAlgorithm
+        );
+        const publicJwk: JsonWebKey = await BrowserCrypto.exportJwk(
+            keyPair.publicKey
+        );
+        const keyId = await BrowserCrypto.computeJwkThumbprint(
+            publicJwk,
+            correlationId
+        );
+        return {
+            publicKey: keyPair.publicKey,
+            privateKey: keyPair.privateKey,
+            keyId,
+        };
+    }
+
+    private async getScopedTokenBindingKeyPair(
+        request: TokenBindingKeyProvisioningParameters
+    ): Promise<GeneratedKeyPair | null> {
+        const scopedCacheKeyPrefix = `${urlEncode(request.keyScope || "")}.`;
+        const cacheKeys =
+            (await this.cache.getKeys(request.correlationId)) || [];
+        const scopedCacheKeys = cacheKeys
+            .filter((cacheKey) => cacheKey.startsWith(scopedCacheKeyPrefix))
+            .sort();
+
+        for (const scopedCacheKey of scopedCacheKeys) {
+            const cachedKeyPair = await this.cache.getItem(
+                scopedCacheKey,
+                request.correlationId
+            );
+            if (
+                cachedKeyPair?.keyId &&
+                cachedKeyPair.keyScope === request.keyScope &&
+                cachedKeyPair.tokenBindingKeyType ===
+                    request.tokenBindingKeyType &&
+                cachedKeyPair.tokenBindingKeyAlgorithm ===
+                    request.tokenBindingKeyAlgorithm
+            ) {
+                return {
+                    ...cachedKeyPair,
+                    keyId: cachedKeyPair.keyId,
+                };
+            }
+        }
+
+        return null;
+    }
+
+    /** @internal */
+    async getTokenBindingKeyPair(
+        keyId: string,
+        correlationId: string,
+        context?: TokenBindingKeyContext
+    ): Promise<CachedKeyPair> {
+        return this.getKeyPair(
+            this.getTokenBindingCacheKey(keyId, context),
+            correlationId
+        );
+    }
+
+    private async getKeyPair(
+        cacheKey: string,
+        correlationId: string
+    ): Promise<CachedKeyPair> {
+        const cachedKeyPair = await this.cache.getItem(cacheKey, correlationId);
+        if (!cachedKeyPair) {
+            throw createBrowserAuthError(
+                BrowserAuthErrorCodes.cryptoKeyNotFound,
+                correlationId
+            );
+        }
+
+        return cachedKeyPair;
+    }
+
+    private async removeKey(
+        cacheKey: string,
+        correlationId: string
+    ): Promise<void> {
+        await this.cache.removeItem(cacheKey, correlationId);
+        const keyFound = await this.cache.containsKey(cacheKey, correlationId);
+        if (keyFound) {
+            throw createClientAuthError(
+                ClientAuthErrorCodes.bindingKeyNotRemoved,
+                correlationId
+            );
+        }
+    }
+
+    /** @internal */
+    getTokenBindingKeyTelemetry(
+        cachedKeyPair: CachedKeyPair,
+        fallbackAlgorithm?: string
+    ): TokenBindingKeyTelemetry {
+        return {
+            ...(cachedKeyPair.tokenBindingKeyType && {
+                tokenBindingKeyType: cachedKeyPair.tokenBindingKeyType,
+            }),
+            ...(cachedKeyPair.tokenBindingKeyAlgorithm || fallbackAlgorithm
+                ? {
+                      tokenBindingKeyAlgorithm:
+                          cachedKeyPair.tokenBindingKeyAlgorithm ||
+                          fallbackAlgorithm,
+                  }
+                : {}),
+        };
+    }
+
+    private getTokenBindingKeyGenAlgorithmOptions(
+        tokenBindingKeyAlgorithm: string,
+        correlationId: string
+    ): AlgorithmIdentifier {
+        if (tokenBindingKeyAlgorithm === TOKEN_BINDING_KEY_ALGORITHMS.RS256) {
+            return BrowserCrypto.RSA_KEYGEN_ALGORITHM_OPTIONS;
+        }
+
+        if (tokenBindingKeyAlgorithm === TOKEN_BINDING_KEY_ALGORITHMS.ES256) {
+            return BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS;
+        }
+
+        throw createBrowserAuthError(
+            BrowserAuthErrorCodes.unsupportedTokenBindingAlgorithm,
+            correlationId
+        );
+    }
+
+    private getTokenBindingCacheKey(
+        keyId: string,
+        context?: TokenBindingKeyContext
+    ): string {
+        return context?.keyScope
+            ? `${urlEncode(context.keyScope)}.${keyId}`
+            : keyId;
+    }
+
+    private startScopedKeyRequest(
+        scopedRequestFingerprint: string,
+        request: TokenBindingKeyProvisioningParameters
+    ): Promise<string> {
+        const requestPromise = this.provisionTokenBindingKeyInternal(
+            request
+        ).finally(() => {
+            if (
+                TokenBindingKeyManager.activeScopedKeyRequests.get(
+                    scopedRequestFingerprint
+                ) === requestPromise
+            ) {
+                TokenBindingKeyManager.activeScopedKeyRequests.delete(
+                    scopedRequestFingerprint
+                );
+            }
+        });
+        TokenBindingKeyManager.activeScopedKeyRequests.set(
+            scopedRequestFingerprint,
+            requestPromise
+        );
+        return requestPromise;
+    }
+
+    private async observeCoalescedScopedKeyRequest(
+        request: TokenBindingKeyProvisioningParameters,
+        activeRequest: Promise<string>
+    ): Promise<string> {
+        const measurement = this.performanceClient?.startMeasurement(
+            BrowserPerformanceEvents.CryptoOptsGetPublicKeyThumbprint,
+            request.correlationId
+        );
+        try {
+            const keyId = await activeRequest;
+            measurement?.end({
+                success: true,
+                tokenBindingKeyType: request.tokenBindingKeyType,
+                tokenBindingKeyAlgorithm: request.tokenBindingKeyAlgorithm,
+                tokenBindingKeyRequestCoalesced: true,
+            });
+            return keyId;
+        } catch (e) {
+            measurement?.end({
+                success: false,
+                tokenBindingKeyType: request.tokenBindingKeyType,
+                tokenBindingKeyAlgorithm: request.tokenBindingKeyAlgorithm,
+                tokenBindingKeyRequestCoalesced: true,
+            });
+            if (e instanceof BrowserAuthError) {
+                throw createBrowserAuthError(
+                    e.errorCode,
+                    request.correlationId,
+                    e.subError
+                );
+            }
+            throw e;
+        }
+    }
+
+    private getScopedRequestFingerprint(
+        request: TokenBindingKeyProvisioningParameters
+    ): string {
+        return JSON.stringify([
+            request.keyScope,
+            request.tokenBindingKeyType,
+            request.tokenBindingKeyAlgorithm,
+        ]);
+    }
+}

--- a/lib/msal-browser/src/crypto/TokenBindingKeyManager.ts
+++ b/lib/msal-browser/src/crypto/TokenBindingKeyManager.ts
@@ -191,10 +191,15 @@ export class TokenBindingKeyManager implements ITokenBindingKeyManager {
         correlationId: string,
         context?: TokenBindingKeyContext
     ): Promise<void> {
-        await this.removeKey(
-            this.getTokenBindingCacheKey(kid, context),
-            correlationId
-        );
+        const cacheKey = this.getTokenBindingCacheKey(kid, context);
+        await this.cache.removeItem(cacheKey, correlationId);
+        const keyFound = await this.cache.containsKey(cacheKey, correlationId);
+        if (keyFound) {
+            throw createClientAuthError(
+                ClientAuthErrorCodes.bindingKeyNotRemoved,
+                correlationId
+            );
+        }
     }
 
     /**
@@ -338,16 +343,7 @@ export class TokenBindingKeyManager implements ITokenBindingKeyManager {
         correlationId: string,
         context?: TokenBindingKeyContext
     ): Promise<CachedKeyPair> {
-        return this.getKeyPair(
-            this.getTokenBindingCacheKey(keyId, context),
-            correlationId
-        );
-    }
-
-    private async getKeyPair(
-        cacheKey: string,
-        correlationId: string
-    ): Promise<CachedKeyPair> {
+        const cacheKey = this.getTokenBindingCacheKey(keyId, context);
         const cachedKeyPair = await this.cache.getItem(cacheKey, correlationId);
         if (!cachedKeyPair) {
             throw createBrowserAuthError(
@@ -357,20 +353,6 @@ export class TokenBindingKeyManager implements ITokenBindingKeyManager {
         }
 
         return cachedKeyPair;
-    }
-
-    private async removeKey(
-        cacheKey: string,
-        correlationId: string
-    ): Promise<void> {
-        await this.cache.removeItem(cacheKey, correlationId);
-        const keyFound = await this.cache.containsKey(cacheKey, correlationId);
-        if (keyFound) {
-            throw createClientAuthError(
-                ClientAuthErrorCodes.bindingKeyNotRemoved,
-                correlationId
-            );
-        }
     }
 
     /** @internal */

--- a/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
+++ b/lib/msal-browser/src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.ts
@@ -212,6 +212,7 @@ export class CustomAuthSilentCacheClient extends CustomAuthInteractionClientBase
                 correlationId: correlationId,
             },
             cryptoInterface: this.browserCrypto,
+            tokenBindingKeyManager: this.tokenBindingKeyManager,
             networkInterface: this.networkClient,
             storageInterface: this.browserStorage,
             serverTelemetryManager: serverTelemetryManager,

--- a/lib/msal-browser/src/error/BrowserAuthErrorCodes.ts
+++ b/lib/msal-browser/src/error/BrowserAuthErrorCodes.ts
@@ -60,8 +60,6 @@ export const uninitializedPublicClientApplication =
 export const nativePromptNotSupported = "native_prompt_not_supported";
 export const invalidBase64String = "invalid_base64_string";
 export const invalidPopTokenRequest = "invalid_pop_token_request";
-export const missingTokenBindingJwtAlgorithm =
-    "missing_token_binding_jwt_algorithm";
 export const unsupportedTokenBindingAlgorithm =
     "unsupported_token_binding_algorithm";
 export const tokenBindingKeyAlgorithmMismatch =

--- a/lib/msal-browser/src/error/BrowserAuthErrorCodes.ts
+++ b/lib/msal-browser/src/error/BrowserAuthErrorCodes.ts
@@ -60,6 +60,14 @@ export const uninitializedPublicClientApplication =
 export const nativePromptNotSupported = "native_prompt_not_supported";
 export const invalidBase64String = "invalid_base64_string";
 export const invalidPopTokenRequest = "invalid_pop_token_request";
+export const missingTokenBindingJwtAlgorithm =
+    "missing_token_binding_jwt_algorithm";
+export const unsupportedTokenBindingAlgorithm =
+    "unsupported_token_binding_algorithm";
+export const tokenBindingKeyAlgorithmMismatch =
+    "token_binding_key_algorithm_mismatch";
+export const tokenBindingKeyJwkThumbprintMismatch =
+    "token_binding_key_jwk_thumbprint_mismatch";
 export const failedToBuildHeaders = "failed_to_build_headers";
 export const failedToParseHeaders = "failed_to_parse_headers";
 export const failedToDecryptEarResponse = "failed_to_decrypt_ear_response";

--- a/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/BaseInteractionClient.ts
@@ -36,6 +36,7 @@ import { INavigationClient } from "../navigation/INavigationClient.js";
 import { AuthenticationResult } from "../response/AuthenticationResult.js";
 import { ClearCacheRequest } from "../request/ClearCacheRequest.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
+import { TokenBindingKeyManager } from "../crypto/TokenBindingKeyManager.js";
 
 export abstract class BaseInteractionClient {
     protected config: BrowserConfiguration;
@@ -48,6 +49,7 @@ export abstract class BaseInteractionClient {
     protected platformAuthProvider: IPlatformAuthHandler | undefined;
     protected correlationId: string;
     protected performanceClient: IPerformanceClient;
+    protected tokenBindingKeyManager: TokenBindingKeyManager;
 
     constructor(
         config: BrowserConfiguration,
@@ -58,7 +60,8 @@ export abstract class BaseInteractionClient {
         navigationClient: INavigationClient,
         performanceClient: IPerformanceClient,
         correlationId: string,
-        platformAuthProvider?: IPlatformAuthHandler
+        platformAuthProvider?: IPlatformAuthHandler,
+        tokenBindingKeyManager?: TokenBindingKeyManager
     ) {
         this.config = config;
         this.browserStorage = storageImpl;
@@ -70,6 +73,9 @@ export abstract class BaseInteractionClient {
         this.correlationId = correlationId;
         this.logger = logger.clone(name, version);
         this.performanceClient = performanceClient;
+        this.tokenBindingKeyManager =
+            tokenBindingKeyManager ||
+            new TokenBindingKeyManager(this.logger, this.performanceClient);
     }
 
     abstract acquireToken(

--- a/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/PlatformAuthInteractionClient.ts
@@ -80,6 +80,7 @@ import {
     initializeServerTelemetryManager,
 } from "./BaseInteractionClient.js";
 import { SilentCacheClient } from "./SilentCacheClient.js";
+import { TokenBindingKeyManager } from "../crypto/TokenBindingKeyManager.js";
 
 export class PlatformAuthInteractionClient extends BaseInteractionClient {
     protected apiId: ApiId;
@@ -101,7 +102,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
         provider: IPlatformAuthHandler,
         accountId: string,
         nativeStorageImpl: BrowserCacheManager,
-        correlationId: string
+        correlationId: string,
+        tokenBindingKeyManager?: TokenBindingKeyManager
     ) {
         super(
             config,
@@ -112,7 +114,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             navigationClient,
             performanceClient,
             correlationId,
-            provider
+            provider,
+            tokenBindingKeyManager
         );
         this.apiId = apiId;
         this.accountId = accountId;
@@ -127,7 +130,8 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             navigationClient,
             performanceClient,
             correlationId,
-            provider
+            provider,
+            this.tokenBindingKeyManager
         );
 
         const extensionName = this.platformAuthProvider.getExtensionName();
@@ -689,6 +693,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
             // Generate SHR in msal js if WAM does not compute it when POP is enabled
             const popTokenGenerator: PopTokenGenerator = new PopTokenGenerator(
                 this.browserCrypto,
+                this.tokenBindingKeyManager,
                 this.performanceClient
             );
             const shrParameters: SignedHttpRequestParameters = {
@@ -1080,6 +1085,7 @@ export class PlatformAuthInteractionClient extends BaseInteractionClient {
 
             const popTokenGenerator = new PopTokenGenerator(
                 this.browserCrypto,
+                this.tokenBindingKeyManager,
                 this.performanceClient
             );
 

--- a/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
+++ b/lib/msal-browser/src/interaction_client/StandardInteractionClient.ts
@@ -293,6 +293,7 @@ export abstract class StandardInteractionClient extends BaseInteractionClient {
                 correlationId: this.correlationId,
             },
             cryptoInterface: this.browserCrypto,
+            tokenBindingKeyManager: this.tokenBindingKeyManager,
             networkInterface: this.networkClient,
             storageInterface: this.browserStorage,
             serverTelemetryManager: serverTelemetryManager,

--- a/lib/msal-browser/src/protocol/Authorize.ts
+++ b/lib/msal-browser/src/protocol/Authorize.ts
@@ -43,6 +43,7 @@ import { PlatformAuthInteractionClient } from "../interaction_client/PlatformAut
 import { EventHandler } from "../event/EventHandler.js";
 import { decryptEarResponse } from "../crypto/BrowserCrypto.js";
 import { IPlatformAuthHandler } from "../broker/nativeBroker/IPlatformAuthHandler.js";
+import { TokenBindingKeyManager } from "../crypto/TokenBindingKeyManager.js";
 
 /**
  * Parsed representation of the clientdata response parameter from the /authorize endpoint.
@@ -189,8 +190,13 @@ async function getStandardParameters(
             request.authenticationScheme === Constants.AuthenticationScheme.POP
         ) {
             const cryptoOps = new CryptoOps(logger, performanceClient);
+            const tokenBindingKeyManager = new TokenBindingKeyManager(
+                logger,
+                performanceClient
+            );
             const popTokenGenerator = new PopTokenGenerator(
                 cryptoOps,
+                tokenBindingKeyManager,
                 performanceClient
             );
 
@@ -709,7 +715,8 @@ export async function handleResponseEAR(
         logger,
         performanceClient,
         null,
-        null
+        null,
+        new TokenBindingKeyManager(logger, performanceClient)
     );
 
     // Validate response. This function throws a server error if an error is returned by the server.

--- a/lib/msal-browser/src/request/RequestHelpers.ts
+++ b/lib/msal-browser/src/request/RequestHelpers.ts
@@ -21,6 +21,12 @@ import { SilentRequest } from "./SilentRequest.js";
 import { PopupRequest } from "./PopupRequest.js";
 import { RedirectRequest } from "./RedirectRequest.js";
 
+const SUPPORTED_AUTHENTICATION_SCHEMES = new Set<string>([
+    Constants.AuthenticationScheme.BEARER,
+    Constants.AuthenticationScheme.POP,
+    Constants.AuthenticationScheme.SSH,
+]);
+
 /**
  * Initializer function for all request APIs
  * @param request
@@ -56,6 +62,17 @@ export async function initializeBaseRequest(
             correlationId
         );
     } else {
+        if (
+            !SUPPORTED_AUTHENTICATION_SCHEMES.has(
+                validatedRequest.authenticationScheme
+            )
+        ) {
+            throw createClientConfigurationError(
+                ClientConfigurationErrorCodes.unsupportedAuthenticationScheme,
+                correlationId
+            );
+        }
+
         if (
             validatedRequest.authenticationScheme ===
             Constants.AuthenticationScheme.SSH

--- a/lib/msal-browser/src/telemetry/BrowserPerformanceEvents.ts
+++ b/lib/msal-browser/src/telemetry/BrowserPerformanceEvents.ts
@@ -22,15 +22,15 @@ export const AcquireTokenByRefreshToken = "acquireTokenByRefreshToken";
 export const AcquireTokenSilentAsync = "acquireTokenSilentAsync";
 
 /**
- * getPublicKeyThumbprint API in CryptoOpts class (msal-browser).
- * Used to generate a public/private keypair and generate a public key thumbprint for pop requests.
+ * provisionTokenBindingKey API in TokenBindingKeyManager class (msal-browser).
+ * Used to provision token-binding key material and return a key identifier.
  */
 export const CryptoOptsGetPublicKeyThumbprint =
     "cryptoOptsGetPublicKeyThumbprint";
 
 /**
- * signJwt API in CryptoOpts class (msal-browser).
- * Used to signed a pop token.
+ * signTokenBindingJwt API in CryptoOpts class (msal-browser).
+ * Used to sign token-binding JWTs.
  */
 export const CryptoOptsSignJwt = "cryptoOptsSignJwt";
 

--- a/lib/msal-browser/test/cache/AsyncMemoryStorage.spec.ts
+++ b/lib/msal-browser/test/cache/AsyncMemoryStorage.spec.ts
@@ -82,6 +82,12 @@ jest.mock("../../src/cache/DatabaseStorage", () => {
                 },
                 getKeys: () => {
                     callCounter.getKeysPersistent += 1;
+                    if (mockDatabase[TEST_DB_TABLE_NAME][DB_UNAVAILABLE]) {
+                        throw createBrowserAuthError(
+                            BrowserAuthErrorCodes.databaseUnavailable,
+                            ""
+                        );
+                    }
                     if (mockDatabase[UNEXPECTED_ERROR] === UNEXPECTED_ERROR) {
                         throw new Error(UNEXPECTED_ERROR);
                     }
@@ -475,6 +481,31 @@ describe("AsyncMemoryStorage Unit Tests", () => {
                         "Could not access persistent storage. This may be caused by browser privacy features which block persistent storage in third-party contexts."
                     )
                 ).not.toBe(-1);
+            });
+        });
+
+        describe("getKeys", () => {
+            beforeEach(() => {
+                resetCallCounter();
+                logMessages = [];
+                mockDatabase[TEST_DB_TABLE_NAME] = {};
+                mockInMemoryCache[TEST_DB_TABLE_NAME] = {};
+            });
+
+            it("should return in-memory keys without logging an error if persistent storage is unavailable or inaccessible", async () => {
+                mockInMemoryCache[TEST_DB_TABLE_NAME]["memory-key"] =
+                    TEST_CACHE_ITEMS.TestItem.value;
+                mockDatabase[TEST_DB_TABLE_NAME][DB_UNAVAILABLE] =
+                    DB_UNAVAILABLE;
+
+                const keys = await asyncMemoryStorage.getKeys(
+                    TEST_CONFIG.CORRELATION_ID
+                );
+
+                expect(callCounter.getKeys).toBe(1);
+                expect(callCounter.getKeysPersistent).toBe(1);
+                expect(keys).toEqual(["memory-key"]);
+                expect(logMessages).toHaveLength(0);
             });
         });
     });

--- a/lib/msal-browser/test/cache/AsyncMemoryStorage.spec.ts
+++ b/lib/msal-browser/test/cache/AsyncMemoryStorage.spec.ts
@@ -23,6 +23,7 @@ const callCounter = {
     clearInMemory: 0,
     clearPersistent: 0,
     getKeys: 0,
+    getKeysPersistent: 0,
     getItem: 0,
     setItem: 0,
     removeItem: 0,
@@ -79,6 +80,13 @@ jest.mock("../../src/cache/DatabaseStorage", () => {
 
                     delete mockDatabase[TEST_DB_TABLE_NAME][kid];
                 },
+                getKeys: () => {
+                    callCounter.getKeysPersistent += 1;
+                    if (mockDatabase[UNEXPECTED_ERROR] === UNEXPECTED_ERROR) {
+                        throw new Error(UNEXPECTED_ERROR);
+                    }
+                    return Object.keys(mockDatabase[TEST_DB_TABLE_NAME]);
+                },
                 containsKey: (kid: string) => {
                     return !!mockDatabase[TEST_DB_TABLE_NAME][kid];
                 },
@@ -111,7 +119,6 @@ jest.mock("../../src/cache/MemoryStorage", () => {
                 },
                 getKeys: () => {
                     callCounter.getKeys += 1;
-                    const cacheKeys: string[] = [];
                     return Object.keys(mockInMemoryCache[TEST_DB_TABLE_NAME]);
                 },
                 removeItem: (kid: string) => {
@@ -260,6 +267,69 @@ describe("AsyncMemoryStorage Unit Tests", () => {
                         TEST_CACHE_ITEMS.TestItem.key
                     ]
                 ).toBe(undefined);
+            });
+        });
+
+        describe("getKeys", () => {
+            beforeEach(() => {
+                resetCallCounter();
+                logMessages = [];
+                mockDatabase[TEST_DB_TABLE_NAME] = {};
+                mockInMemoryCache[TEST_DB_TABLE_NAME] = {};
+            });
+
+            it("should return unique keys from in-memory and persistent storage", async () => {
+                mockInMemoryCache[TEST_DB_TABLE_NAME]["memory-key"] =
+                    TEST_CACHE_ITEMS.TestItem.value;
+                mockInMemoryCache[TEST_DB_TABLE_NAME]["shared-key"] =
+                    TEST_CACHE_ITEMS.TestItem.value;
+                mockDatabase[TEST_DB_TABLE_NAME]["persistent-key"] =
+                    TEST_CACHE_ITEMS.TestItem.value;
+                mockDatabase[TEST_DB_TABLE_NAME]["shared-key"] =
+                    TEST_CACHE_ITEMS.TestItem.value;
+
+                const keys = await asyncMemoryStorage.getKeys(
+                    TEST_CONFIG.CORRELATION_ID
+                );
+
+                expect(callCounter.getKeys).toBe(1);
+                expect(callCounter.getKeysPersistent).toBe(1);
+                expect(keys.sort()).toEqual([
+                    "memory-key",
+                    "persistent-key",
+                    "shared-key",
+                ]);
+            });
+
+            it("should return in-memory keys when persistent key enumeration fails", async () => {
+                mockInMemoryCache[TEST_DB_TABLE_NAME]["memory-key"] =
+                    TEST_CACHE_ITEMS.TestItem.value;
+                mockDatabase[UNEXPECTED_ERROR] = UNEXPECTED_ERROR;
+
+                const keys = await asyncMemoryStorage.getKeys(
+                    TEST_CONFIG.CORRELATION_ID
+                );
+
+                const lastLog = logMessages[logMessages.length - 1];
+                expect(callCounter.getKeys).toBe(1);
+                expect(callCounter.getKeysPersistent).toBe(1);
+                expect(keys).toEqual(["memory-key"]);
+                expect(lastLog["level"]).toBe(1);
+                expect(
+                    lastLog["message"].indexOf(
+                        "Persistent storage key enumeration failed. Returning in-memory keys."
+                    )
+                ).not.toBe(-1);
+            });
+
+            it("should throw unexpected key enumeration errors when no in-memory keys exist", async () => {
+                mockDatabase[UNEXPECTED_ERROR] = UNEXPECTED_ERROR;
+
+                await expect(
+                    asyncMemoryStorage.getKeys(TEST_CONFIG.CORRELATION_ID)
+                ).rejects.toThrow(UNEXPECTED_ERROR);
+                expect(callCounter.getKeys).toBe(1);
+                expect(callCounter.getKeysPersistent).toBe(1);
             });
         });
 

--- a/lib/msal-browser/test/crypto/CryptoOps.spec.ts
+++ b/lib/msal-browser/test/crypto/CryptoOps.spec.ts
@@ -1,7 +1,7 @@
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import * as BrowserCrypto from "../../src/crypto/BrowserCrypto";
 import { createHash } from "crypto";
-import { PkceCodes, BaseAuthRequest, Logger } from "@azure/msal-common";
+import { PkceCodes, Logger, PerformanceEventStatus } from "@azure/msal-common";
 import {
     RANDOM_TEST_GUID,
     TEST_CONFIG,
@@ -14,16 +14,34 @@ import {
 import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
 import { generatePkceCodes } from "../../src/crypto/PkceGenerator";
 import { StubPerformanceClient } from "@azure/msal-common";
+import { DpopProofGenerator } from "../../../msal-common/src/crypto/DpopProofGenerator.js";
+import * as BrowserPerformanceEvents from "../../src/telemetry/BrowserPerformanceEvents";
+import { TokenBindingKeyManager } from "../../src/crypto/TokenBindingKeyManager";
 
 let mockDatabase = {
     "TestDB.keys": {},
 };
 
+const DPOP_KEY_CONTEXT = {
+    tokenBindingKeyType: "dpop",
+    tokenBindingKeyAlgorithm: "ES256",
+    keyScope: `dpop.${TEST_CONFIG.MSAL_CLIENT_ID}.${TEST_CONFIG.validAuthority}`,
+    correlationId: TEST_CONFIG.CORRELATION_ID,
+} as const;
+
+const SHR_KEY_CONTEXT = {
+    tokenBindingKeyType: "shr",
+    tokenBindingKeyAlgorithm: "RS256",
+    correlationId: TEST_CONFIG.CORRELATION_ID,
+} as const;
+
 describe("CryptoOps.ts Unit Tests", () => {
     let cryptoObj: CryptoOps;
+    let tokenBindingKeyManager: TokenBindingKeyManager;
 
     beforeEach(() => {
         cryptoObj = new CryptoOps(new Logger({}));
+        tokenBindingKeyManager = new TokenBindingKeyManager(new Logger({}));
 
         // Mock DatabaseStorage
         jest.spyOn(DatabaseStorage.prototype, "open").mockImplementation(
@@ -50,9 +68,23 @@ describe("CryptoOps.ts Unit Tests", () => {
                 return !!mockDatabase["TestDB.keys"][kid];
             }
         );
+        jest.spyOn(DatabaseStorage.prototype, "getKeys").mockImplementation(
+            async () => {
+                return Object.keys(mockDatabase["TestDB.keys"]);
+            }
+        );
+        jest.spyOn(
+            DatabaseStorage.prototype,
+            "deleteDatabase"
+        ).mockImplementation(async () => {
+            mockDatabase["TestDB.keys"] = {};
+            return true;
+        });
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+        await cryptoObj.clearKeystore(TEST_CONFIG.CORRELATION_ID);
+        await tokenBindingKeyManager.clearKeystore(TEST_CONFIG.CORRELATION_ID);
         jest.restoreAllMocks();
         mockDatabase = {
             "TestDB.keys": {},
@@ -259,7 +291,7 @@ describe("CryptoOps.ts Unit Tests", () => {
         expect(regExp.test(generatedCodes.verifier)).toBe(true);
     });
 
-    it("getPublicKeyThumbprint() generates a valid request thumbprint", async () => {
+    it("TokenBindingKeyManager.provisionTokenBindingKey() generates a valid request thumbprint", async () => {
         jest.setTimeout(30000);
         jest.spyOn(
             BrowserCrypto,
@@ -272,16 +304,18 @@ describe("CryptoOps.ts Unit Tests", () => {
         });
         const generateKeyPairSpy = jest.spyOn(BrowserCrypto, "generateKeyPair");
         const exportJwkSpy = jest.spyOn(BrowserCrypto, "exportJwk");
-        const pkThumbprint = await cryptoObj.getPublicKeyThumbprint({
-            resourceRequestMethod: "POST",
-            resourceRequestUri: TEST_URIS.TEST_AUTH_ENDPT_WITH_PARAMS,
-        } as BaseAuthRequest);
+        const pkThumbprint =
+            await tokenBindingKeyManager.provisionTokenBindingKey({
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                tokenBindingKeyType: "shr",
+                tokenBindingKeyAlgorithm: "RS256",
+            });
         /**
          * Contains alphanumeric, dash '-', underscore '_', plus '+', or slash '/' with length of 43.
          */
         const regExp = new RegExp("[A-Za-z0-9-_+/]{43}");
         expect(generateKeyPairSpy).toHaveBeenCalledWith(
-            true,
+            false,
             ["sign", "verify"],
             BrowserCrypto.RSA_KEYGEN_ALGORITHM_OPTIONS
         );
@@ -289,6 +323,9 @@ describe("CryptoOps.ts Unit Tests", () => {
         expect(exportJwkSpy).toHaveBeenCalledWith(result.publicKey);
         expect(regExp.test(pkThumbprint)).toBe(true);
         expect(mockDatabase["TestDB.keys"][pkThumbprint]).not.toBe(undefined);
+        expect(
+            mockDatabase["TestDB.keys"][pkThumbprint].privateKey.extractable
+        ).toBe(false);
     }, 30000);
 
     it("removeTokenBindingKey() removes the specified key from storage", async () => {
@@ -301,10 +338,12 @@ describe("CryptoOps.ts Unit Tests", () => {
                 createHash("SHA256").update(Buffer.from(data)).digest()
             );
         });
-        const pkThumbprint = await cryptoObj.getPublicKeyThumbprint({
-            resourceRequestMethod: "POST",
-            resourceRequestUri: TEST_URIS.TEST_AUTH_ENDPT_WITH_PARAMS,
-        } as BaseAuthRequest);
+        const pkThumbprint =
+            await tokenBindingKeyManager.provisionTokenBindingKey({
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                tokenBindingKeyType: "shr",
+                tokenBindingKeyAlgorithm: "RS256",
+            });
         const key = mockDatabase["TestDB.keys"][pkThumbprint];
         await cryptoObj.removeTokenBindingKey(
             pkThumbprint,
@@ -314,10 +353,319 @@ describe("CryptoOps.ts Unit Tests", () => {
         expect(mockDatabase["TestDB.keys"][pkThumbprint]).toBe(undefined);
     }, 30000);
 
-    it("signJwt() throws signingKeyNotFoundInStorage error if signing keypair is not found in storage", async () => {
-        expect(cryptoObj.signJwt({}, "testString")).rejects.toThrow(
-            createBrowserAuthError(BrowserAuthErrorCodes.cryptoKeyNotFound, "")
+    it("signTokenBindingJwt() throws signingKeyNotFoundInStorage error if signing keypair is not found in storage", async () => {
+        await expect(
+            cryptoObj.signTokenBindingJwt(
+                { alg: "RS256" },
+                {},
+                "testString",
+                TEST_CONFIG.CORRELATION_ID
+            )
+        ).rejects.toThrow(
+            createBrowserAuthError(
+                BrowserAuthErrorCodes.cryptoKeyNotFound,
+                TEST_CONFIG.CORRELATION_ID
+            )
         );
+    }, 30000);
+
+    it("emits token-binding key metadata for SHR and DPoP key generation", async () => {
+        const performanceClient = new StubPerformanceClient();
+        const endMeasurement = jest.fn();
+        jest.spyOn(performanceClient, "startMeasurement").mockImplementation(
+            (measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            })
+        );
+        tokenBindingKeyManager = new TokenBindingKeyManager(
+            new Logger({}),
+            performanceClient
+        );
+
+        await tokenBindingKeyManager.provisionTokenBindingKey(SHR_KEY_CONTEXT);
+        await tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT);
+        await tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT);
+
+        expect(performanceClient.startMeasurement).toHaveBeenCalledWith(
+            BrowserPerformanceEvents.CryptoOptsGetPublicKeyThumbprint,
+            TEST_CONFIG.CORRELATION_ID
+        );
+        expect(endMeasurement).toHaveBeenNthCalledWith(1, {
+            success: true,
+            tokenBindingKeyType: "shr",
+            tokenBindingKeyAlgorithm: "RS256",
+            tokenBindingKeyCacheHit: false,
+        });
+        expect(endMeasurement).toHaveBeenNthCalledWith(2, {
+            success: true,
+            tokenBindingKeyType: "dpop",
+            tokenBindingKeyAlgorithm: "ES256",
+            tokenBindingKeyCacheHit: false,
+        });
+        expect(endMeasurement).toHaveBeenNthCalledWith(3, {
+            success: true,
+            tokenBindingKeyType: "dpop",
+            tokenBindingKeyAlgorithm: "ES256",
+            tokenBindingKeyCacheHit: true,
+        });
+    }, 30000);
+
+    it("emits token-binding key metadata when key generation fails", async () => {
+        const performanceClient = new StubPerformanceClient();
+        const endMeasurement = jest.fn();
+        jest.spyOn(performanceClient, "startMeasurement").mockImplementation(
+            (measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            })
+        );
+        jest.spyOn(BrowserCrypto, "generateKeyPair").mockRejectedValue(
+            new Error("key generation failed")
+        );
+        tokenBindingKeyManager = new TokenBindingKeyManager(
+            new Logger({}),
+            performanceClient
+        );
+
+        await expect(
+            tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT)
+        ).rejects.toThrow("key generation failed");
+
+        expect(endMeasurement).toHaveBeenCalledWith({
+            success: false,
+            tokenBindingKeyType: "dpop",
+            tokenBindingKeyAlgorithm: "ES256",
+            tokenBindingKeyCacheHit: false,
+        });
+    }, 30000);
+
+    it("emits token-binding key metadata when scoped key lookup fails", async () => {
+        const performanceClient = new StubPerformanceClient();
+        const endMeasurement = jest.fn();
+        jest.spyOn(performanceClient, "startMeasurement").mockImplementation(
+            (measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            })
+        );
+        jest.spyOn(DatabaseStorage.prototype, "getKeys").mockRejectedValueOnce(
+            new Error("scoped lookup failed")
+        );
+        tokenBindingKeyManager = new TokenBindingKeyManager(
+            new Logger({}),
+            performanceClient
+        );
+
+        await expect(
+            tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT)
+        ).rejects.toThrow("scoped lookup failed");
+
+        expect(endMeasurement).toHaveBeenCalledWith({
+            success: false,
+            tokenBindingKeyType: "dpop",
+            tokenBindingKeyAlgorithm: "ES256",
+            tokenBindingKeyCacheHit: false,
+        });
+    }, 30000);
+
+    it("emits SHR key generation metadata when key generation fails", async () => {
+        const performanceClient = new StubPerformanceClient();
+        const endMeasurement = jest.fn();
+        jest.spyOn(performanceClient, "startMeasurement").mockImplementation(
+            (measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            })
+        );
+        jest.spyOn(BrowserCrypto, "generateKeyPair").mockRejectedValue(
+            new Error("key generation failed")
+        );
+        tokenBindingKeyManager = new TokenBindingKeyManager(
+            new Logger({}),
+            performanceClient
+        );
+
+        await expect(
+            tokenBindingKeyManager.provisionTokenBindingKey(SHR_KEY_CONTEXT)
+        ).rejects.toThrow("key generation failed");
+
+        expect(endMeasurement).toHaveBeenCalledWith({
+            success: false,
+            tokenBindingKeyType: "shr",
+            tokenBindingKeyAlgorithm: "RS256",
+            tokenBindingKeyCacheHit: false,
+        });
+    }, 30000);
+
+    it("emits token-binding signing metadata for SHR and DPoP signatures", async () => {
+        const performanceClient = new StubPerformanceClient();
+        const endMeasurement = jest.fn();
+        jest.spyOn(performanceClient, "startMeasurement").mockImplementation(
+            (measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            })
+        );
+        cryptoObj = new CryptoOps(new Logger({}), performanceClient);
+
+        const popKeyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+            SHR_KEY_CONTEXT
+        );
+        await tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT);
+        const dpopKeyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+            DPOP_KEY_CONTEXT
+        );
+        const dpopPublicJwk =
+            await tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                dpopKeyId,
+                TEST_CONFIG.CORRELATION_ID,
+                DPOP_KEY_CONTEXT
+            );
+        endMeasurement.mockClear();
+
+        await cryptoObj.signTokenBindingJwt(
+            { alg: "RS256", typ: "pop", kid: "pop-kid" },
+            { at: "access-token" },
+            popKeyId,
+            TEST_CONFIG.CORRELATION_ID
+        );
+        await cryptoObj.signTokenBindingJwt(
+            { alg: "ES256", typ: "dpop+jwt", jwk: dpopPublicJwk },
+            { htm: "POST", htu: TEST_URIS.TEST_AUTH_ENDPT, iat: 1, jti: "jti" },
+            dpopKeyId,
+            TEST_CONFIG.CORRELATION_ID,
+            DPOP_KEY_CONTEXT
+        );
+
+        expect(performanceClient.startMeasurement).toHaveBeenCalledWith(
+            BrowserPerformanceEvents.CryptoOptsSignJwt,
+            TEST_CONFIG.CORRELATION_ID
+        );
+        expect(endMeasurement).toHaveBeenNthCalledWith(1, {
+            success: true,
+            tokenBindingKeyType: "shr",
+            tokenBindingKeyAlgorithm: "RS256",
+        });
+        expect(endMeasurement).toHaveBeenNthCalledWith(2, {
+            success: true,
+            tokenBindingKeyType: "dpop",
+            tokenBindingKeyAlgorithm: "ES256",
+        });
+    }, 30000);
+
+    it("emits token-binding signing metadata when signing fails", async () => {
+        const performanceClient = new StubPerformanceClient();
+        const endMeasurement = jest.fn();
+        jest.spyOn(performanceClient, "startMeasurement").mockImplementation(
+            (measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            })
+        );
+        cryptoObj = new CryptoOps(new Logger({}), performanceClient);
+
+        await expect(
+            cryptoObj.signTokenBindingJwt(
+                { alg: "ES256", typ: "dpop+jwt", jwk: {} },
+                {
+                    htm: "POST",
+                    htu: TEST_URIS.TEST_AUTH_ENDPT,
+                    iat: 1,
+                    jti: "jti",
+                },
+                "missing-key-id",
+                TEST_CONFIG.CORRELATION_ID,
+                DPOP_KEY_CONTEXT
+            )
+        ).rejects.toThrow(
+            createBrowserAuthError(
+                BrowserAuthErrorCodes.cryptoKeyNotFound,
+                TEST_CONFIG.CORRELATION_ID
+            )
+        );
+
+        expect(endMeasurement).toHaveBeenCalledWith({
+            success: false,
+        });
     }, 30000);
 
     it("hashString() returns a valid SHA-256 hash of an input string", async () => {
@@ -335,68 +683,6 @@ describe("CryptoOps.ts Unit Tests", () => {
     });
 
     describe("DPoP internal crypto helpers", () => {
-        it("exposes reusable ECDSA P-256 and ECDSA SHA-256 algorithm options", () => {
-            expect(BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS).toEqual({
-                name: "ECDSA",
-                namedCurve: "P-256",
-            });
-            expect(BrowserCrypto.ECDSA_SHA256_SIGN_ALGORITHM_OPTIONS).toEqual({
-                name: "ECDSA",
-                hash: { name: "SHA-256" },
-            });
-        });
-
-        it("UT-04: generateKeyPair supports DPoP EC keys with public-only JWK export", async () => {
-            const keyPair = await BrowserCrypto.generateKeyPair(
-                false,
-                ["sign", "verify"],
-                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
-            );
-            const publicJwk = await BrowserCrypto.exportJwk(keyPair.publicKey);
-
-            // EC P-256 public key fields must be present
-            expect(publicJwk.kty).toBe("EC");
-            expect(publicJwk.crv).toBe("P-256");
-            expect(typeof publicJwk.x).toBe("string");
-            expect(typeof publicJwk.y).toBe("string");
-
-            // Private field MUST NOT appear in the exported public JWK
-            expect(publicJwk.d).toBeUndefined();
-        }, 10000);
-
-        it("importJwk supports DPoP EC keys when passed ECDSA params", async () => {
-            const keyPair = await BrowserCrypto.generateKeyPair(
-                true,
-                ["sign", "verify"],
-                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
-            );
-            const publicJwk = await BrowserCrypto.exportJwk(keyPair.publicKey);
-            const importedPublicKey = await BrowserCrypto.importJwk(
-                publicJwk,
-                true,
-                ["verify"],
-                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
-            );
-
-            expect(importedPublicKey.type).toBe("public");
-            expect(importedPublicKey.algorithm.name).toBe("ECDSA");
-        }, 10000);
-
-        it("RT-02: generated private DPoP key is non-extractable", async () => {
-            const keyPair = await BrowserCrypto.generateKeyPair(
-                false,
-                ["sign", "verify"],
-                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
-            );
-
-            expect(keyPair.privateKey.extractable).toBe(false);
-
-            // Attempting to export a non-extractable key must reject
-            await expect(
-                window.crypto.subtle.exportKey("jwk", keyPair.privateKey)
-            ).rejects.toBeDefined();
-        }, 10000);
-
         it("computeJwkThumbprint returns a valid base64url string of expected length", async () => {
             jest.spyOn(
                 BrowserCrypto,
@@ -499,22 +785,451 @@ describe("CryptoOps.ts Unit Tests", () => {
             });
         });
 
-        it("sign supports DPoP EC signatures when passed ECDSA params", async () => {
+        it("signTokenBindingJwt uses requested signing params when compatible with the stored key", async () => {
+            const performanceClient = new StubPerformanceClient();
+            const endMeasurement = jest.fn();
+            jest.spyOn(
+                performanceClient,
+                "startMeasurement"
+            ).mockImplementation((measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            }));
+            cryptoObj = new CryptoOps(new Logger({}), performanceClient);
             const keyPair = await BrowserCrypto.generateKeyPair(
                 false,
                 ["sign", "verify"],
                 BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
             );
+            const publicJwk = await BrowserCrypto.exportJwk(keyPair.publicKey);
+            const keyId = await BrowserCrypto.computeJwkThumbprint(publicJwk);
+            mockDatabase["TestDB.keys"][keyId] = {
+                privateKey: keyPair.privateKey,
+                publicKey: keyPair.publicKey,
+                tokenBindingKeyType: "dpop",
+                tokenBindingKeyAlgorithm: "ES256",
+            };
+            const signSpy = jest.spyOn(BrowserCrypto, "sign");
 
-            const data = new TextEncoder().encode("header.payload");
-            const signature = await BrowserCrypto.sign(
-                keyPair.privateKey,
-                data,
-                BrowserCrypto.ECDSA_SHA256_SIGN_ALGORITHM_OPTIONS
+            const proof = await cryptoObj.signTokenBindingJwt(
+                { alg: "ES256", typ: "dpop+jwt", jwk: publicJwk },
+                {
+                    htm: "POST",
+                    htu: TEST_URIS.TEST_AUTH_ENDPT,
+                    iat: 1,
+                    jti: "jti",
+                },
+                keyId,
+                TEST_CONFIG.CORRELATION_ID
             );
 
-            expect(signature).toBeDefined();
-            expect(signature.byteLength).toBeGreaterThan(0);
+            expect(endMeasurement).toHaveBeenCalledWith({
+                success: true,
+                tokenBindingKeyType: "dpop",
+                tokenBindingKeyAlgorithm: "ES256",
+            });
+            expect(signSpy.mock.calls[0][0]).toBe(keyPair.privateKey);
+            expect(signSpy.mock.calls[0][2]).toEqual(
+                BrowserCrypto.ECDSA_SHA256_SIGN_ALGORITHM_OPTIONS
+            );
+            const [encodedHeader, encodedPayload, signature] = proof.split(".");
+            const verified = await window.crypto.subtle.verify(
+                BrowserCrypto.ECDSA_SHA256_SIGN_ALGORITHM_OPTIONS,
+                keyPair.publicKey,
+                Buffer.from(signature, "base64url"),
+                new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`)
+            );
+            expect(verified).toBe(true);
+        }, 10000);
+
+        it("signTokenBindingJwt signs the validated header even if the caller mutates the original header", async () => {
+            const keyPair = await BrowserCrypto.generateKeyPair(
+                false,
+                ["sign", "verify"],
+                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
+            );
+            const publicJwk = await BrowserCrypto.exportJwk(keyPair.publicKey);
+            const keyId = await BrowserCrypto.computeJwkThumbprint(publicJwk);
+            mockDatabase["TestDB.keys"][keyId] = {
+                privateKey: keyPair.privateKey,
+                publicKey: keyPair.publicKey,
+                tokenBindingKeyType: "dpop",
+                tokenBindingKeyAlgorithm: "ES256",
+            };
+            const header = { alg: "ES256", typ: "dpop+jwt", jwk: publicJwk };
+            const computeJwkThumbprint =
+                BrowserCrypto.computeJwkThumbprint.bind(BrowserCrypto);
+            jest.spyOn(
+                BrowserCrypto,
+                "computeJwkThumbprint"
+            ).mockImplementation(async (jwk, correlationId) => {
+                header.typ = "mutated+jwt";
+                return computeJwkThumbprint(jwk, correlationId);
+            });
+
+            const proof = await cryptoObj.signTokenBindingJwt(
+                header,
+                {
+                    htm: "POST",
+                    htu: TEST_URIS.TEST_AUTH_ENDPT,
+                    iat: 1,
+                    jti: "jti",
+                },
+                keyId,
+                TEST_CONFIG.CORRELATION_ID
+            );
+
+            const [encodedHeader, encodedPayload, signature] = proof.split(".");
+            const proofHeader = JSON.parse(
+                Buffer.from(encodedHeader, "base64url").toString("utf8")
+            );
+            const verified = await window.crypto.subtle.verify(
+                BrowserCrypto.ECDSA_SHA256_SIGN_ALGORITHM_OPTIONS,
+                keyPair.publicKey,
+                Buffer.from(signature, "base64url"),
+                new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`)
+            );
+
+            expect(header.typ).toBe("mutated+jwt");
+            expect(proofHeader).toEqual({
+                alg: "ES256",
+                jwk: publicJwk,
+            });
+            expect(verified).toBe(true);
+        }, 10000);
+
+        it("signTokenBindingJwt rejects DPoP header JWKs that do not match the signing key", async () => {
+            const signingKeyPair = await BrowserCrypto.generateKeyPair(
+                false,
+                ["sign", "verify"],
+                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
+            );
+            const signingPublicJwk = await BrowserCrypto.exportJwk(
+                signingKeyPair.publicKey
+            );
+            const signingKeyId = await BrowserCrypto.computeJwkThumbprint(
+                signingPublicJwk
+            );
+            mockDatabase["TestDB.keys"][signingKeyId] = {
+                privateKey: signingKeyPair.privateKey,
+                publicKey: signingKeyPair.publicKey,
+                tokenBindingKeyType: "dpop",
+                tokenBindingKeyAlgorithm: "ES256",
+            };
+            const mismatchedKeyPair = await BrowserCrypto.generateKeyPair(
+                false,
+                ["sign", "verify"],
+                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
+            );
+            const mismatchedPublicJwk = await BrowserCrypto.exportJwk(
+                mismatchedKeyPair.publicKey
+            );
+
+            await expect(
+                cryptoObj.signTokenBindingJwt(
+                    { alg: "ES256", typ: "dpop+jwt", jwk: mismatchedPublicJwk },
+                    {
+                        htm: "POST",
+                        htu: TEST_URIS.TEST_AUTH_ENDPT,
+                        iat: 1,
+                        jti: "jti",
+                    },
+                    signingKeyId,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).rejects.toThrow(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.invalidPublicJwk,
+                    TEST_CONFIG.CORRELATION_ID,
+                    BrowserAuthErrorCodes.tokenBindingKeyJwkThumbprintMismatch
+                )
+            );
+        }, 10000);
+
+        it("signTokenBindingJwt rejects malformed DPoP header JWKs with caller correlation", async () => {
+            const signingKeyPair = await BrowserCrypto.generateKeyPair(
+                false,
+                ["sign", "verify"],
+                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
+            );
+            const signingPublicJwk = await BrowserCrypto.exportJwk(
+                signingKeyPair.publicKey
+            );
+            const signingKeyId = await BrowserCrypto.computeJwkThumbprint(
+                signingPublicJwk
+            );
+            mockDatabase["TestDB.keys"][signingKeyId] = {
+                privateKey: signingKeyPair.privateKey,
+                publicKey: signingKeyPair.publicKey,
+                tokenBindingKeyType: "dpop",
+                tokenBindingKeyAlgorithm: "ES256",
+            };
+
+            await expect(
+                cryptoObj.signTokenBindingJwt(
+                    {
+                        alg: "ES256",
+                        typ: "dpop+jwt",
+                        jwk: {
+                            crv: "P-256",
+                            x: "x-coordinate",
+                            y: "y-coordinate",
+                        },
+                    },
+                    {
+                        htm: "POST",
+                        htu: TEST_URIS.TEST_AUTH_ENDPT,
+                        iat: 1,
+                        jti: "jti",
+                    },
+                    signingKeyId,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).rejects.toThrow(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.invalidPublicJwk,
+                    TEST_CONFIG.CORRELATION_ID,
+                    "missing_jwk_kty"
+                )
+            );
+        }, 10000);
+
+        it("signTokenBindingJwt rejects requested algorithms incompatible with the stored key", async () => {
+            const performanceClient = new StubPerformanceClient();
+            const endMeasurement = jest.fn();
+            jest.spyOn(
+                performanceClient,
+                "startMeasurement"
+            ).mockImplementation((measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            }));
+            cryptoObj = new CryptoOps(new Logger({}), performanceClient);
+            const keyPair = await BrowserCrypto.generateKeyPair(
+                false,
+                ["sign", "verify"],
+                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
+            );
+            const publicJwk = await BrowserCrypto.exportJwk(keyPair.publicKey);
+            const keyId = await BrowserCrypto.computeJwkThumbprint(publicJwk);
+            mockDatabase["TestDB.keys"][keyId] = {
+                privateKey: keyPair.privateKey,
+                publicKey: keyPair.publicKey,
+                tokenBindingKeyType: "dpop",
+                tokenBindingKeyAlgorithm: "ES256",
+            };
+
+            await expect(
+                cryptoObj.signTokenBindingJwt(
+                    { alg: "RS256", typ: "dpop+jwt", jwk: publicJwk },
+                    {
+                        htm: "POST",
+                        htu: TEST_URIS.TEST_AUTH_ENDPT,
+                        iat: 1,
+                        jti: "jti",
+                    },
+                    keyId,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).rejects.toThrow(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.unsupportedTokenBindingAlgorithm,
+                    TEST_CONFIG.CORRELATION_ID,
+                    BrowserAuthErrorCodes.tokenBindingKeyAlgorithmMismatch
+                )
+            );
+
+            expect(endMeasurement).toHaveBeenCalledWith({
+                success: false,
+                tokenBindingKeyType: "dpop",
+                tokenBindingKeyAlgorithm: "ES256",
+            });
+        }, 10000);
+
+        it("signTokenBindingJwt rejects unsupported stored key algorithms", async () => {
+            mockDatabase["TestDB.keys"]["unsupported-key-id"] = {
+                privateKey: {
+                    algorithm: {
+                        name: "ECDSA",
+                        namedCurve: "P-384",
+                    },
+                    extractable: false,
+                    type: "private",
+                    usages: ["sign"],
+                } as CryptoKey,
+                publicKey: {
+                    algorithm: {
+                        name: "ECDSA",
+                        namedCurve: "P-384",
+                    },
+                    extractable: true,
+                    type: "public",
+                    usages: ["verify"],
+                } as CryptoKey,
+            };
+
+            await expect(
+                cryptoObj.signTokenBindingJwt(
+                    { alg: "ES384", typ: "dpop+jwt" },
+                    {
+                        htm: "POST",
+                        htu: TEST_URIS.TEST_AUTH_ENDPT,
+                        iat: 1,
+                        jti: "jti",
+                    },
+                    "unsupported-key-id",
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).rejects.toThrow(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.unsupportedTokenBindingAlgorithm,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            );
+        });
+
+        it("signTokenBindingJwt rejects missing JWT header algorithm", async () => {
+            const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+                DPOP_KEY_CONTEXT
+            );
+
+            await expect(
+                cryptoObj.signTokenBindingJwt(
+                    { typ: "dpop+jwt", jwk: {} },
+                    {
+                        htm: "POST",
+                        htu: TEST_URIS.TEST_AUTH_ENDPT,
+                        iat: 1,
+                        jti: "jti",
+                    },
+                    keyId,
+                    TEST_CONFIG.CORRELATION_ID,
+                    DPOP_KEY_CONTEXT
+                )
+            ).rejects.toThrow(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.missingTokenBindingJwtAlgorithm,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            );
+        });
+
+        it("generates a DPoP proof whose embedded public key verifies the signature", async () => {
+            const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+                DPOP_KEY_CONTEXT
+            );
+            const publicJwk =
+                await tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                    keyId,
+                    TEST_CONFIG.CORRELATION_ID,
+                    DPOP_KEY_CONTEXT
+                );
+            const dpopPublicJwk: Record<string, unknown> = {};
+            Object.entries(publicJwk).forEach(([key, value]) => {
+                dpopPublicJwk[key] = value;
+            });
+            const dpopProofGenerator = new DpopProofGenerator(
+                cryptoObj,
+                tokenBindingKeyManager
+            );
+            const proof = await dpopProofGenerator.generateTokenProof(
+                {
+                    tokenEndpoint: TEST_URIS.TEST_AUTH_ENDPT,
+                    keyId,
+                    keyContext: DPOP_KEY_CONTEXT,
+                },
+                TEST_CONFIG.CORRELATION_ID
+            );
+            const [encodedHeader, encodedClaims, signature] = proof.split(".");
+            if (!encodedHeader || !encodedClaims || !signature) {
+                throw new Error("Expected compact DPoP proof JWT");
+            }
+            const proofHeader = JSON.parse(
+                Buffer.from(encodedHeader, "base64url").toString("utf8")
+            );
+            const proofPublicKey = await BrowserCrypto.importJwk(
+                proofHeader.jwk,
+                true,
+                ["verify"],
+                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
+            );
+            const verified = await window.crypto.subtle.verify(
+                BrowserCrypto.ECDSA_SHA256_SIGN_ALGORITHM_OPTIONS,
+                proofPublicKey,
+                Buffer.from(signature, "base64url"),
+                new TextEncoder().encode(`${encodedHeader}.${encodedClaims}`)
+            );
+
+            expect(proofHeader.jwk).toEqual(dpopPublicJwk);
+            expect(verified).toBe(true);
+        }, 10000);
+
+        it("generates a DPoP proof when IndexedDB is unavailable and signing uses a separate manager", async () => {
+            jest.spyOn(DatabaseStorage.prototype, "setItem").mockRejectedValue(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.databaseUnavailable,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            );
+            jest.spyOn(DatabaseStorage.prototype, "getItem").mockRejectedValue(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.databaseUnavailable,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            );
+            jest.spyOn(DatabaseStorage.prototype, "getKeys").mockRejectedValue(
+                createBrowserAuthError(
+                    BrowserAuthErrorCodes.databaseUnavailable,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            );
+            const provisioningKeyManager = new TokenBindingKeyManager(
+                new Logger({})
+            );
+            const dpopProofGenerator = new DpopProofGenerator(
+                cryptoObj,
+                provisioningKeyManager
+            );
+
+            const keyId = await provisioningKeyManager.provisionTokenBindingKey(
+                DPOP_KEY_CONTEXT
+            );
+            const proof = await dpopProofGenerator.generateTokenProof(
+                {
+                    tokenEndpoint: TEST_URIS.TEST_AUTH_ENDPT,
+                    keyId,
+                    keyContext: DPOP_KEY_CONTEXT,
+                },
+                TEST_CONFIG.CORRELATION_ID
+            );
+
+            expect(proof.split(".")).toHaveLength(3);
         }, 10000);
     });
 

--- a/lib/msal-browser/test/crypto/CryptoOps.spec.ts
+++ b/lib/msal-browser/test/crypto/CryptoOps.spec.ts
@@ -1,7 +1,13 @@
 import { CryptoOps } from "../../src/crypto/CryptoOps";
 import * as BrowserCrypto from "../../src/crypto/BrowserCrypto";
 import { createHash } from "crypto";
-import { PkceCodes, Logger, PerformanceEventStatus } from "@azure/msal-common";
+import {
+    Constants,
+    JoseHeader,
+    PkceCodes,
+    Logger,
+    PerformanceEventStatus,
+} from "@azure/msal-common";
 import {
     RANDOM_TEST_GUID,
     TEST_CONFIG,
@@ -356,7 +362,7 @@ describe("CryptoOps.ts Unit Tests", () => {
     it("signTokenBindingJwt() throws signingKeyNotFoundInStorage error if signing keypair is not found in storage", async () => {
         await expect(
             cryptoObj.signTokenBindingJwt(
-                { alg: "RS256" },
+                new JoseHeader({ alg: "RS256" }),
                 {},
                 "testString",
                 TEST_CONFIG.CORRELATION_ID
@@ -590,13 +596,17 @@ describe("CryptoOps.ts Unit Tests", () => {
         endMeasurement.mockClear();
 
         await cryptoObj.signTokenBindingJwt(
-            { alg: "RS256", typ: "pop", kid: "pop-kid" },
+            JoseHeader.getShrHeader({
+                alg: "RS256",
+                typ: Constants.JsonWebTokenTypes.Pop,
+                kid: "pop-kid",
+            }),
             { at: "access-token" },
             popKeyId,
             TEST_CONFIG.CORRELATION_ID
         );
         await cryptoObj.signTokenBindingJwt(
-            { alg: "ES256", typ: "dpop+jwt", jwk: dpopPublicJwk },
+            JoseHeader.getDpopHeader({ alg: "ES256", jwk: dpopPublicJwk }),
             { htm: "POST", htu: TEST_URIS.TEST_AUTH_ENDPT, iat: 1, jti: "jti" },
             dpopKeyId,
             TEST_CONFIG.CORRELATION_ID,
@@ -645,7 +655,15 @@ describe("CryptoOps.ts Unit Tests", () => {
 
         await expect(
             cryptoObj.signTokenBindingJwt(
-                { alg: "ES256", typ: "dpop+jwt", jwk: {} },
+                JoseHeader.getDpopHeader({
+                    alg: "ES256",
+                    jwk: {
+                        kty: "EC",
+                        crv: "P-256",
+                        x: "A".repeat(43),
+                        y: "B".repeat(43),
+                    },
+                }),
                 {
                     htm: "POST",
                     htu: TEST_URIS.TEST_AUTH_ENDPT,
@@ -825,7 +843,7 @@ describe("CryptoOps.ts Unit Tests", () => {
             const signSpy = jest.spyOn(BrowserCrypto, "sign");
 
             const proof = await cryptoObj.signTokenBindingJwt(
-                { alg: "ES256", typ: "dpop+jwt", jwk: publicJwk },
+                JoseHeader.getDpopHeader({ alg: "ES256", jwk: publicJwk }),
                 {
                     htm: "POST",
                     htu: TEST_URIS.TEST_AUTH_ENDPT,
@@ -855,7 +873,7 @@ describe("CryptoOps.ts Unit Tests", () => {
             expect(verified).toBe(true);
         }, 10000);
 
-        it("signTokenBindingJwt signs the validated header even if the caller mutates the original header", async () => {
+        it("signTokenBindingJwt signs the provided validated DPoP header", async () => {
             const keyPair = await BrowserCrypto.generateKeyPair(
                 false,
                 ["sign", "verify"],
@@ -869,15 +887,9 @@ describe("CryptoOps.ts Unit Tests", () => {
                 tokenBindingKeyType: "dpop",
                 tokenBindingKeyAlgorithm: "ES256",
             };
-            const header = { alg: "ES256", typ: "dpop+jwt", jwk: publicJwk };
-            const computeJwkThumbprint =
-                BrowserCrypto.computeJwkThumbprint.bind(BrowserCrypto);
-            jest.spyOn(
-                BrowserCrypto,
-                "computeJwkThumbprint"
-            ).mockImplementation(async (jwk, correlationId) => {
-                header.typ = "mutated+jwt";
-                return computeJwkThumbprint(jwk, correlationId);
+            const header = JoseHeader.getDpopHeader({
+                alg: "ES256",
+                jwk: publicJwk,
             });
 
             const proof = await cryptoObj.signTokenBindingJwt(
@@ -903,10 +915,55 @@ describe("CryptoOps.ts Unit Tests", () => {
                 new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`)
             );
 
-            expect(header.typ).toBe("mutated+jwt");
             expect(proofHeader).toEqual({
                 alg: "ES256",
+                typ: "dpop+jwt",
                 jwk: publicJwk,
+            });
+            expect(verified).toBe(true);
+        }, 10000);
+
+        it("signTokenBindingJwt preserves caller-provided SHR header fields", async () => {
+            const keyPair = await BrowserCrypto.generateKeyPair(
+                false,
+                ["sign", "verify"],
+                BrowserCrypto.RSA_KEYGEN_ALGORITHM_OPTIONS
+            );
+            const publicJwk = await BrowserCrypto.exportJwk(keyPair.publicKey);
+            const keyId = await BrowserCrypto.computeJwkThumbprint(publicJwk);
+            mockDatabase["TestDB.keys"][keyId] = {
+                privateKey: keyPair.privateKey,
+                publicKey: keyPair.publicKey,
+                tokenBindingKeyType: "shr",
+                tokenBindingKeyAlgorithm: "RS256",
+            };
+
+            const proof = await cryptoObj.signTokenBindingJwt(
+                JoseHeader.getShrHeader({
+                    alg: "RS256",
+                    typ: Constants.JsonWebTokenTypes.Pop,
+                    kid: "pop-key-id",
+                }),
+                { at: "access-token" },
+                keyId,
+                TEST_CONFIG.CORRELATION_ID
+            );
+
+            const [encodedHeader, encodedPayload, signature] = proof.split(".");
+            const proofHeader = JSON.parse(
+                Buffer.from(encodedHeader, "base64url").toString("utf8")
+            );
+            const verified = await window.crypto.subtle.verify(
+                BrowserCrypto.RSA_SIGN_ALGORITHM_OPTIONS,
+                keyPair.publicKey,
+                Buffer.from(signature, "base64url"),
+                new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`)
+            );
+
+            expect(proofHeader).toEqual({
+                alg: "RS256",
+                typ: "pop",
+                kid: "pop-key-id",
             });
             expect(verified).toBe(true);
         }, 10000);
@@ -940,7 +997,10 @@ describe("CryptoOps.ts Unit Tests", () => {
 
             await expect(
                 cryptoObj.signTokenBindingJwt(
-                    { alg: "ES256", typ: "dpop+jwt", jwk: mismatchedPublicJwk },
+                    JoseHeader.getDpopHeader({
+                        alg: "ES256",
+                        jwk: mismatchedPublicJwk,
+                    }),
                     {
                         htm: "POST",
                         htu: TEST_URIS.TEST_AUTH_ENDPT,
@@ -955,54 +1015,6 @@ describe("CryptoOps.ts Unit Tests", () => {
                     BrowserAuthErrorCodes.invalidPublicJwk,
                     TEST_CONFIG.CORRELATION_ID,
                     BrowserAuthErrorCodes.tokenBindingKeyJwkThumbprintMismatch
-                )
-            );
-        }, 10000);
-
-        it("signTokenBindingJwt rejects malformed DPoP header JWKs with caller correlation", async () => {
-            const signingKeyPair = await BrowserCrypto.generateKeyPair(
-                false,
-                ["sign", "verify"],
-                BrowserCrypto.ECDSA_P256_KEYGEN_ALGORITHM_OPTIONS
-            );
-            const signingPublicJwk = await BrowserCrypto.exportJwk(
-                signingKeyPair.publicKey
-            );
-            const signingKeyId = await BrowserCrypto.computeJwkThumbprint(
-                signingPublicJwk
-            );
-            mockDatabase["TestDB.keys"][signingKeyId] = {
-                privateKey: signingKeyPair.privateKey,
-                publicKey: signingKeyPair.publicKey,
-                tokenBindingKeyType: "dpop",
-                tokenBindingKeyAlgorithm: "ES256",
-            };
-
-            await expect(
-                cryptoObj.signTokenBindingJwt(
-                    {
-                        alg: "ES256",
-                        typ: "dpop+jwt",
-                        jwk: {
-                            crv: "P-256",
-                            x: "x-coordinate",
-                            y: "y-coordinate",
-                        },
-                    },
-                    {
-                        htm: "POST",
-                        htu: TEST_URIS.TEST_AUTH_ENDPT,
-                        iat: 1,
-                        jti: "jti",
-                    },
-                    signingKeyId,
-                    TEST_CONFIG.CORRELATION_ID
-                )
-            ).rejects.toThrow(
-                createBrowserAuthError(
-                    BrowserAuthErrorCodes.invalidPublicJwk,
-                    TEST_CONFIG.CORRELATION_ID,
-                    "missing_jwk_kty"
                 )
             );
         }, 10000);
@@ -1047,7 +1059,7 @@ describe("CryptoOps.ts Unit Tests", () => {
 
             await expect(
                 cryptoObj.signTokenBindingJwt(
-                    { alg: "RS256", typ: "dpop+jwt", jwk: publicJwk },
+                    JoseHeader.getDpopHeader({ alg: "RS256", jwk: publicJwk }),
                     {
                         htm: "POST",
                         htu: TEST_URIS.TEST_AUTH_ENDPT,
@@ -1096,7 +1108,10 @@ describe("CryptoOps.ts Unit Tests", () => {
 
             await expect(
                 cryptoObj.signTokenBindingJwt(
-                    { alg: "ES384", typ: "dpop+jwt" },
+                    new JoseHeader({
+                        alg: "ES384",
+                        typ: Constants.JsonWebTokenTypes.Dpop,
+                    }),
                     {
                         htm: "POST",
                         htu: TEST_URIS.TEST_AUTH_ENDPT,
@@ -1109,32 +1124,6 @@ describe("CryptoOps.ts Unit Tests", () => {
             ).rejects.toThrow(
                 createBrowserAuthError(
                     BrowserAuthErrorCodes.unsupportedTokenBindingAlgorithm,
-                    TEST_CONFIG.CORRELATION_ID
-                )
-            );
-        });
-
-        it("signTokenBindingJwt rejects missing JWT header algorithm", async () => {
-            const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
-                DPOP_KEY_CONTEXT
-            );
-
-            await expect(
-                cryptoObj.signTokenBindingJwt(
-                    { typ: "dpop+jwt", jwk: {} },
-                    {
-                        htm: "POST",
-                        htu: TEST_URIS.TEST_AUTH_ENDPT,
-                        iat: 1,
-                        jti: "jti",
-                    },
-                    keyId,
-                    TEST_CONFIG.CORRELATION_ID,
-                    DPOP_KEY_CONTEXT
-                )
-            ).rejects.toThrow(
-                createBrowserAuthError(
-                    BrowserAuthErrorCodes.missingTokenBindingJwtAlgorithm,
                     TEST_CONFIG.CORRELATION_ID
                 )
             );

--- a/lib/msal-browser/test/crypto/TokenBindingKeyManager.spec.ts
+++ b/lib/msal-browser/test/crypto/TokenBindingKeyManager.spec.ts
@@ -1,0 +1,473 @@
+import {
+    Logger,
+    PerformanceEventStatus,
+    StubPerformanceClient,
+} from "@azure/msal-common";
+import { DatabaseStorage } from "../../src/cache/DatabaseStorage";
+import * as BrowserCrypto from "../../src/crypto/BrowserCrypto";
+import {
+    TOKEN_BINDING_KEY_ALGORITHMS,
+    TokenBindingKeyManager,
+} from "../../src/crypto/TokenBindingKeyManager";
+import {
+    BrowserAuthErrorCodes,
+    createBrowserAuthError,
+} from "../../src/error/BrowserAuthError";
+import { TEST_CONFIG } from "../utils/StringConstants";
+import * as BrowserPerformanceEvents from "../../src/telemetry/BrowserPerformanceEvents";
+
+let mockDatabase = {
+    "TestDB.keys": {},
+};
+
+const DPOP_KEY_CONTEXT = {
+    tokenBindingKeyType: "dpop",
+    tokenBindingKeyAlgorithm: TOKEN_BINDING_KEY_ALGORITHMS.ES256,
+    keyScope: `dpop.${TEST_CONFIG.MSAL_CLIENT_ID}.${TEST_CONFIG.validAuthority}`,
+    correlationId: TEST_CONFIG.CORRELATION_ID,
+} as const;
+
+const ALTERNATE_DPOP_KEY_CONTEXT = {
+    ...DPOP_KEY_CONTEXT,
+    keyScope: `dpop.${TEST_CONFIG.MSAL_CLIENT_ID}.${TEST_CONFIG.alternateValidAuthority}`,
+};
+
+const SHR_KEY_CONTEXT = {
+    tokenBindingKeyType: "shr",
+    tokenBindingKeyAlgorithm: TOKEN_BINDING_KEY_ALGORITHMS.RS256,
+    correlationId: TEST_CONFIG.CORRELATION_ID,
+} as const;
+
+function getCacheKeysByScope(keyScope: string): Array<string> {
+    return Object.keys(mockDatabase["TestDB.keys"]).filter((cacheKey) => {
+        return mockDatabase["TestDB.keys"][cacheKey]?.keyScope === keyScope;
+    });
+}
+
+describe("TokenBindingKeyManager.ts Unit Tests", () => {
+    let tokenBindingKeyManager: TokenBindingKeyManager;
+
+    beforeEach(() => {
+        tokenBindingKeyManager = new TokenBindingKeyManager(new Logger({}));
+
+        jest.spyOn(DatabaseStorage.prototype, "open").mockImplementation(
+            async () => {}
+        );
+        jest.spyOn(DatabaseStorage.prototype, "getItem").mockImplementation(
+            async (kid: string) => {
+                return mockDatabase["TestDB.keys"][kid];
+            }
+        );
+        jest.spyOn(DatabaseStorage.prototype, "setItem").mockImplementation(
+            async (kid: string, payload: any) => {
+                mockDatabase["TestDB.keys"][kid] = payload;
+                return mockDatabase["TestDB.keys"][kid];
+            }
+        );
+        jest.spyOn(DatabaseStorage.prototype, "removeItem").mockImplementation(
+            async (kid: string) => {
+                delete mockDatabase["TestDB.keys"][kid];
+            }
+        );
+        jest.spyOn(DatabaseStorage.prototype, "containsKey").mockImplementation(
+            async (kid: string) => {
+                return !!mockDatabase["TestDB.keys"][kid];
+            }
+        );
+        jest.spyOn(DatabaseStorage.prototype, "getKeys").mockImplementation(
+            async () => {
+                return Object.keys(mockDatabase["TestDB.keys"]);
+            }
+        );
+        jest.spyOn(
+            DatabaseStorage.prototype,
+            "deleteDatabase"
+        ).mockImplementation(async () => {
+            mockDatabase["TestDB.keys"] = {};
+            return true;
+        });
+    });
+
+    afterEach(async () => {
+        await tokenBindingKeyManager.clearKeystore(TEST_CONFIG.CORRELATION_ID);
+        jest.restoreAllMocks();
+        mockDatabase = {
+            "TestDB.keys": {},
+        };
+    });
+
+    it("provisions and reuses an ES256 scoped key", async () => {
+        const generateKeyPairSpy = jest.spyOn(BrowserCrypto, "generateKeyPair");
+
+        const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+            DPOP_KEY_CONTEXT
+        );
+        const reusedKeyId =
+            await tokenBindingKeyManager.provisionTokenBindingKey(
+                DPOP_KEY_CONTEXT
+            );
+        const dpopCacheKeys = getCacheKeysByScope(DPOP_KEY_CONTEXT.keyScope);
+        const cachedKeyPair = mockDatabase["TestDB.keys"][dpopCacheKeys[0]];
+
+        expect(reusedKeyId).toBe(keyId);
+        expect(generateKeyPairSpy).toHaveBeenCalledTimes(1);
+        expect(dpopCacheKeys).toHaveLength(1);
+        expect(cachedKeyPair.keyId).toBe(keyId);
+        expect(cachedKeyPair.keyScope).toBe(DPOP_KEY_CONTEXT.keyScope);
+        expect(cachedKeyPair.tokenBindingKeyType).toBe("dpop");
+        expect(cachedKeyPair.tokenBindingKeyAlgorithm).toBe(
+            TOKEN_BINDING_KEY_ALGORITHMS.ES256
+        );
+        expect(cachedKeyPair.publicKey.extractable).toBe(true);
+        expect(cachedKeyPair.privateKey.extractable).toBe(false);
+        expect(cachedKeyPair.publicJwk).toBeUndefined();
+        await expect(
+            tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                keyId,
+                TEST_CONFIG.CORRELATION_ID,
+                DPOP_KEY_CONTEXT
+            )
+        ).resolves.toMatchObject({
+            crv: "P-256",
+            kty: "EC",
+        });
+    }, 10000);
+
+    it("reuses persisted scoped keys when memory contains unrelated keys", async () => {
+        const generateKeyPairSpy = jest.spyOn(BrowserCrypto, "generateKeyPair");
+        const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+            DPOP_KEY_CONTEXT
+        );
+
+        tokenBindingKeyManager = new TokenBindingKeyManager(new Logger({}));
+        await tokenBindingKeyManager.provisionTokenBindingKey(SHR_KEY_CONTEXT);
+
+        const reusedKeyId =
+            await tokenBindingKeyManager.provisionTokenBindingKey(
+                DPOP_KEY_CONTEXT
+            );
+
+        expect(reusedKeyId).toBe(keyId);
+        expect(generateKeyPairSpy).toHaveBeenCalledTimes(2);
+        expect(getCacheKeysByScope(DPOP_KEY_CONTEXT.keyScope)).toHaveLength(1);
+    }, 10000);
+
+    it("does not reuse scoped keys with mismatched policy metadata", async () => {
+        const generateKeyPairSpy = jest.spyOn(BrowserCrypto, "generateKeyPair");
+        const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+            DPOP_KEY_CONTEXT
+        );
+        const alternateAlgorithmKeyId =
+            await tokenBindingKeyManager.provisionTokenBindingKey({
+                ...DPOP_KEY_CONTEXT,
+                tokenBindingKeyAlgorithm: TOKEN_BINDING_KEY_ALGORITHMS.RS256,
+            });
+        const alternateTypeKeyId =
+            await tokenBindingKeyManager.provisionTokenBindingKey({
+                ...DPOP_KEY_CONTEXT,
+                tokenBindingKeyType: "shr",
+            });
+
+        expect(alternateAlgorithmKeyId).not.toBe(keyId);
+        expect(alternateTypeKeyId).not.toBe(keyId);
+        expect(generateKeyPairSpy).toHaveBeenCalledTimes(3);
+        expect(getCacheKeysByScope(DPOP_KEY_CONTEXT.keyScope)).toHaveLength(3);
+    }, 30000);
+
+    it("serializes concurrent scoped key provisioning", async () => {
+        const generateKeyPairSpy = jest.spyOn(BrowserCrypto, "generateKeyPair");
+
+        const [keyId, concurrentKeyId] = await Promise.all([
+            tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT),
+            tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT),
+        ]);
+
+        expect(concurrentKeyId).toBe(keyId);
+        expect(generateKeyPairSpy).toHaveBeenCalledTimes(1);
+        expect(DatabaseStorage.prototype.getKeys).toHaveBeenCalledTimes(1);
+        expect(getCacheKeysByScope(DPOP_KEY_CONTEXT.keyScope)).toHaveLength(1);
+    }, 10000);
+
+    it("serializes concurrent scoped key provisioning across manager instances", async () => {
+        const generateKeyPairSpy = jest.spyOn(BrowserCrypto, "generateKeyPair");
+        const concurrentTokenBindingKeyManager = new TokenBindingKeyManager(
+            new Logger({})
+        );
+
+        const [keyId, concurrentKeyId] = await Promise.all([
+            tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT),
+            concurrentTokenBindingKeyManager.provisionTokenBindingKey(
+                DPOP_KEY_CONTEXT
+            ),
+        ]);
+
+        expect(concurrentKeyId).toBe(keyId);
+        expect(generateKeyPairSpy).toHaveBeenCalledTimes(1);
+        expect(DatabaseStorage.prototype.getKeys).toHaveBeenCalledTimes(1);
+        expect(getCacheKeysByScope(DPOP_KEY_CONTEXT.keyScope)).toHaveLength(1);
+    }, 10000);
+
+    it("emits per-caller telemetry when joining a coalesced scoped key request", async () => {
+        const performanceClient = new StubPerformanceClient();
+        const endMeasurement = jest.fn();
+        jest.spyOn(performanceClient, "startMeasurement").mockImplementation(
+            (measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            })
+        );
+        tokenBindingKeyManager = new TokenBindingKeyManager(
+            new Logger({}),
+            performanceClient
+        );
+        const secondCorrelationId = "second-correlation-id";
+        const generateKeyPairSpy = jest.spyOn(BrowserCrypto, "generateKeyPair");
+
+        const [keyId, concurrentKeyId] = await Promise.all([
+            tokenBindingKeyManager.provisionTokenBindingKey(DPOP_KEY_CONTEXT),
+            tokenBindingKeyManager.provisionTokenBindingKey({
+                ...DPOP_KEY_CONTEXT,
+                correlationId: secondCorrelationId,
+            }),
+        ]);
+
+        expect(concurrentKeyId).toBe(keyId);
+        expect(generateKeyPairSpy).toHaveBeenCalledTimes(1);
+        expect(performanceClient.startMeasurement).toHaveBeenCalledWith(
+            BrowserPerformanceEvents.CryptoOptsGetPublicKeyThumbprint,
+            secondCorrelationId
+        );
+        expect(endMeasurement).toHaveBeenCalledWith({
+            success: true,
+            tokenBindingKeyType: "dpop",
+            tokenBindingKeyAlgorithm: TOKEN_BINDING_KEY_ALGORITHMS.ES256,
+            tokenBindingKeyRequestCoalesced: true,
+        });
+    }, 10000);
+
+    it("correlates coalesced scoped key request failures to the joining caller", async () => {
+        const performanceClient = new StubPerformanceClient();
+        const endMeasurement = jest.fn();
+        jest.spyOn(performanceClient, "startMeasurement").mockImplementation(
+            (measureName, correlationId) => ({
+                end: endMeasurement,
+                discard: jest.fn(),
+                add: jest.fn(),
+                increment: jest.fn(),
+                event: {
+                    eventId: "test-event-id",
+                    status: PerformanceEventStatus.InProgress,
+                    authority: "",
+                    libraryName: "",
+                    libraryVersion: "",
+                    clientId: "",
+                    name: measureName,
+                    startTimeMs: Date.now(),
+                    correlationId: correlationId || "",
+                },
+            })
+        );
+        tokenBindingKeyManager = new TokenBindingKeyManager(
+            new Logger({}),
+            performanceClient
+        );
+        const firstCorrelationId = "first-correlation-id";
+        const secondCorrelationId = "second-correlation-id";
+        const unsupportedContext = {
+            tokenBindingKeyType: "dpop",
+            tokenBindingKeyAlgorithm: "unsupported",
+            keyScope: DPOP_KEY_CONTEXT.keyScope,
+            correlationId: firstCorrelationId,
+        };
+
+        const results = await Promise.allSettled([
+            tokenBindingKeyManager.provisionTokenBindingKey(unsupportedContext),
+            tokenBindingKeyManager.provisionTokenBindingKey({
+                ...unsupportedContext,
+                correlationId: secondCorrelationId,
+            }),
+        ]);
+
+        expect(results[0].status).toBe("rejected");
+        expect(results[1].status).toBe("rejected");
+        expect((results[0] as PromiseRejectedResult).reason).toMatchObject({
+            errorCode: BrowserAuthErrorCodes.unsupportedTokenBindingAlgorithm,
+            correlationId: firstCorrelationId,
+        });
+        expect((results[1] as PromiseRejectedResult).reason).toMatchObject({
+            errorCode: BrowserAuthErrorCodes.unsupportedTokenBindingAlgorithm,
+            correlationId: secondCorrelationId,
+        });
+        expect(endMeasurement).toHaveBeenCalledWith({
+            success: false,
+            tokenBindingKeyType: "dpop",
+            tokenBindingKeyAlgorithm: "unsupported",
+            tokenBindingKeyRequestCoalesced: true,
+        });
+    }, 10000);
+
+    it("enumerates storage keys once per scoped key lookup", async () => {
+        const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+            DPOP_KEY_CONTEXT
+        );
+        jest.clearAllMocks();
+
+        const reusedKeyId =
+            await tokenBindingKeyManager.provisionTokenBindingKey(
+                DPOP_KEY_CONTEXT
+            );
+
+        expect(reusedKeyId).toBe(keyId);
+        expect(DatabaseStorage.prototype.getKeys).toHaveBeenCalledTimes(1);
+    }, 10000);
+
+    it("does not coalesce distinct scoped requests with colliding dot-joined values", async () => {
+        const generateKeyPairSpy = jest.spyOn(BrowserCrypto, "generateKeyPair");
+        const collidingScopeContext = {
+            tokenBindingKeyType: "c",
+            tokenBindingKeyAlgorithm: TOKEN_BINDING_KEY_ALGORITHMS.ES256,
+            keyScope: "a.b",
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+        };
+        const collidingTypeContext = {
+            tokenBindingKeyType: "b.c",
+            tokenBindingKeyAlgorithm: TOKEN_BINDING_KEY_ALGORITHMS.ES256,
+            keyScope: "a",
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+        };
+
+        const [scopedKeyId, typedKeyId] = await Promise.all([
+            tokenBindingKeyManager.provisionTokenBindingKey(
+                collidingScopeContext
+            ),
+            tokenBindingKeyManager.provisionTokenBindingKey(
+                collidingTypeContext
+            ),
+        ]);
+
+        expect(typedKeyId).not.toBe(scopedKeyId);
+        expect(generateKeyPairSpy).toHaveBeenCalledTimes(2);
+        expect(
+            getCacheKeysByScope(collidingScopeContext.keyScope)
+        ).toHaveLength(1);
+        expect(getCacheKeysByScope(collidingTypeContext.keyScope)).toHaveLength(
+            1
+        );
+    }, 10000);
+
+    it("isolates and removes keys by caller-owned scope", async () => {
+        const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+            DPOP_KEY_CONTEXT
+        );
+        const alternateAuthorityKeyId =
+            await tokenBindingKeyManager.provisionTokenBindingKey(
+                ALTERNATE_DPOP_KEY_CONTEXT
+            );
+
+        expect(alternateAuthorityKeyId).not.toBe(keyId);
+        expect(
+            getCacheKeysByScope(DPOP_KEY_CONTEXT.keyScope).concat(
+                getCacheKeysByScope(ALTERNATE_DPOP_KEY_CONTEXT.keyScope)
+            )
+        ).toHaveLength(2);
+        await expect(
+            tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                keyId,
+                TEST_CONFIG.CORRELATION_ID,
+                ALTERNATE_DPOP_KEY_CONTEXT
+            )
+        ).rejects.toMatchObject({
+            errorCode: BrowserAuthErrorCodes.cryptoKeyNotFound,
+        });
+
+        await tokenBindingKeyManager.removeTokenBindingKey(
+            keyId,
+            TEST_CONFIG.CORRELATION_ID,
+            DPOP_KEY_CONTEXT
+        );
+
+        await expect(
+            tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                keyId,
+                TEST_CONFIG.CORRELATION_ID,
+                DPOP_KEY_CONTEXT
+            )
+        ).rejects.toMatchObject({
+            errorCode: BrowserAuthErrorCodes.cryptoKeyNotFound,
+        });
+    }, 10000);
+
+    it("shares memory fallback storage when IndexedDB is unavailable", async () => {
+        jest.spyOn(DatabaseStorage.prototype, "setItem").mockRejectedValue(
+            createBrowserAuthError(
+                BrowserAuthErrorCodes.databaseUnavailable,
+                TEST_CONFIG.CORRELATION_ID
+            )
+        );
+        jest.spyOn(DatabaseStorage.prototype, "getItem").mockRejectedValue(
+            createBrowserAuthError(
+                BrowserAuthErrorCodes.databaseUnavailable,
+                TEST_CONFIG.CORRELATION_ID
+            )
+        );
+        jest.spyOn(DatabaseStorage.prototype, "getKeys").mockRejectedValue(
+            createBrowserAuthError(
+                BrowserAuthErrorCodes.databaseUnavailable,
+                TEST_CONFIG.CORRELATION_ID
+            )
+        );
+        const provisioningKeyManager = new TokenBindingKeyManager(
+            new Logger({})
+        );
+        const lookupKeyManager = new TokenBindingKeyManager(new Logger({}));
+
+        const keyId = await provisioningKeyManager.provisionTokenBindingKey(
+            DPOP_KEY_CONTEXT
+        );
+
+        await expect(
+            lookupKeyManager.getTokenBindingPublicKeyJwk(
+                keyId,
+                TEST_CONFIG.CORRELATION_ID,
+                DPOP_KEY_CONTEXT
+            )
+        ).resolves.toMatchObject({
+            crv: "P-256",
+            kty: "EC",
+        });
+    }, 10000);
+
+    it("clearKeystore removes stored scoped keys", async () => {
+        const keyId = await tokenBindingKeyManager.provisionTokenBindingKey(
+            DPOP_KEY_CONTEXT
+        );
+
+        expect(
+            await tokenBindingKeyManager.clearKeystore(
+                TEST_CONFIG.CORRELATION_ID
+            )
+        ).toBe(true);
+        await expect(
+            tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                keyId,
+                TEST_CONFIG.CORRELATION_ID,
+                DPOP_KEY_CONTEXT
+            )
+        ).rejects.toMatchObject({
+            errorCode: BrowserAuthErrorCodes.cryptoKeyNotFound,
+        });
+    }, 10000);
+});

--- a/lib/msal-browser/test/interaction_client/StandardInteractionClient.spec.ts
+++ b/lib/msal-browser/test/interaction_client/StandardInteractionClient.spec.ts
@@ -34,11 +34,12 @@ import {
 import { RedirectRequest } from "../../src/request/RedirectRequest.js";
 import * as PkceGenerator from "../../src/crypto/PkceGenerator.js";
 import { FetchClient } from "../../src/network/FetchClient.js";
-import { InteractionType } from "../../src/utils/BrowserConstants.js";
+import { ApiId, InteractionType } from "../../src/utils/BrowserConstants.js";
 import { buildAccountFromIdTokenClaims } from "msal-test-utils";
 import {
     clearCacheOnLogout,
     getDiscoveredAuthority,
+    initializeServerTelemetryManager,
 } from "../../src/interaction_client/BaseInteractionClient.js";
 import {
     IdTokenEntity,
@@ -236,6 +237,31 @@ describe("StandardInteractionClient", () => {
             InteractionType.Silent
         );
         expect(authCodeRequest.account).toEqual(testAccount);
+    });
+
+    it("getClientConfiguration passes tokenBindingKeyManager to common clients", async () => {
+        const authority = await testClient.getDiscoveredAuthority({});
+        const serverTelemetryManager = initializeServerTelemetryManager(
+            ApiId.acquireTokenRedirect,
+            TEST_CONFIG.MSAL_CLIENT_ID,
+            TEST_CONFIG.CORRELATION_ID,
+            // @ts-ignore
+            pca.browserStorage,
+            // @ts-ignore
+            pca.logger,
+            undefined,
+            // @ts-ignore
+            pca.config.system.serverTelemetryEnabled
+        );
+
+        const clientConfig = await testClient["getClientConfiguration"]({
+            serverTelemetryManager,
+            authority,
+        });
+
+        expect(clientConfig.tokenBindingKeyManager).toBe(
+            testClient["tokenBindingKeyManager"]
+        );
     });
 
     it("initializeAuthorizationRequest persists account in request", async () => {

--- a/lib/msal-browser/test/request/RequestHelpers.spec.ts
+++ b/lib/msal-browser/test/request/RequestHelpers.spec.ts
@@ -87,6 +87,30 @@ describe("RequestHelpers tests", () => {
                 )
             );
         });
+
+        it("should throw an error if an unsupported authentication scheme is used", async () => {
+            const request: Partial<BaseAuthRequest> & {
+                correlationId: string;
+            } = {
+                correlationId: "test-correlation-id",
+                authenticationScheme: "dpop" as Constants.AuthenticationScheme,
+            };
+
+            await expect(
+                RequestHelpers.initializeBaseRequest(
+                    request,
+                    mockConfig,
+                    mockPerformanceClient,
+                    mockLogger,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            ).rejects.toThrowError(
+                new ClientConfigurationError(
+                    ClientConfigurationErrorCodes.unsupportedAuthenticationScheme,
+                    TEST_CONFIG.CORRELATION_ID
+                )
+            );
+        });
     });
 
     describe("initializeSilentRequest", () => {

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1092,6 +1092,7 @@ declare namespace ClientConfigurationErrorCodes {
         untrustedAuthority,
         missingSshJwk,
         missingSshKid,
+        unsupportedAuthenticationScheme,
         missingNonceAuthenticationHeader,
         invalidAuthenticationHeader,
         cannotSetOIDCOptions,
@@ -3347,6 +3348,9 @@ const unexpectedCredentialType = "unexpected_credential_type";
 
 // @public
 const unexpectedError = "unexpected_error";
+
+// @public (undocumented)
+const unsupportedAuthenticationScheme = "unsupported_authentication_scheme";
 
 // @public (undocumented)
 const untrustedAuthority = "untrusted_authority";

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2057,7 +2057,7 @@ export interface IUri {
 export class JoseHeader {
     constructor(options: JoseHeaderOptions & {
         alg: string;
-    });
+    }, correlationId?: string);
     // (undocumented)
     alg: string;
     static getDpopHeader(dpopHeaderOptions: JoseHeaderOptions, correlationId?: string): JoseHeader;

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1767,7 +1767,8 @@ export interface ICrypto {
     encodeKid(inputKid: string): string;
     hashString(plainText: string): Promise<string>;
     removeTokenBindingKey(kid: string, correlationId: string, context?: TokenBindingKeyContext): Promise<void>;
-    signTokenBindingJwt(header: object, payload: object, kid: string, correlationId: string, context?: TokenBindingKeyContext): Promise<string>;
+    // @internal
+    signTokenBindingJwt(header: JoseHeader, payload: object, kid: string, correlationId: string, context?: TokenBindingKeyContext): Promise<string>;
 }
 
 // @public (undocumented)
@@ -2054,14 +2055,15 @@ export interface IUri {
 
 // @internal (undocumented)
 export class JoseHeader {
-    constructor(options: JoseHeaderOptions);
+    constructor(options: JoseHeaderOptions & {
+        alg: string;
+    });
     // (undocumented)
-    alg?: string;
+    alg: string;
     static getDpopHeader(dpopHeaderOptions: JoseHeaderOptions, correlationId?: string): JoseHeader;
     static getShrHeader(shrHeaderOptions: JoseHeaderOptions, correlationId?: string): JoseHeader;
-    static getShrHeaderString(shrHeaderOptions: JoseHeaderOptions, correlationId?: string): string;
     // (undocumented)
-    jwk?: object;
+    jwk?: JsonWebKey;
     // (undocumented)
     kid?: string;
     // (undocumented)

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1060,6 +1060,7 @@ export type ClientConfiguration = {
     storageInterface?: CacheManager;
     networkInterface?: INetworkModule;
     cryptoInterface?: ICrypto;
+    tokenBindingKeyManager?: ITokenBindingKeyManager;
     clientCredentials?: ClientCredentials;
     libraryInfo?: LibraryInfo;
     telemetry?: TelemetryOptions;
@@ -1176,6 +1177,7 @@ export type CommonClientConfiguration = {
     storageInterface: CacheManager;
     networkInterface: INetworkModule;
     cryptoInterface: Required<ICrypto>;
+    tokenBindingKeyManager: ITokenBindingKeyManager;
     libraryInfo: LibraryInfo;
     telemetry: Required<TelemetryOptions>;
     serverTelemetryManager: ServerTelemetryManager | null;
@@ -1585,6 +1587,15 @@ function generateAccountId(accountEntity: AccountEntity): string;
 // @public
 function generateAppMetadataKey(input: AppMetadataEntity): string;
 
+// @internal (undocumented)
+export type GenerateAuthenticationResultOptions = {
+    idTokenClaims?: TokenClaims;
+    requestState?: RequestStateObject;
+    serverTokenResponse?: ServerAuthorizationTokenResponse;
+    requestId?: string;
+    tokenBindingKeyManager?: ITokenBindingKeyManager;
+};
+
 // @public
 function generateAuthorityMetadataExpiresAt(): number;
 
@@ -1754,10 +1765,9 @@ export interface ICrypto {
     clearKeystore(correlationId: string): Promise<boolean>;
     createNewGuid(): string;
     encodeKid(inputKid: string): string;
-    getPublicKeyThumbprint(request: SignedHttpRequestParameters): Promise<string>;
     hashString(plainText: string): Promise<string>;
-    removeTokenBindingKey(kid: string, correlationId: string): Promise<void>;
-    signJwt(payload: SignedHttpRequest, kid: string, shrOptions?: ShrOptions, correlationId?: string): Promise<string>;
+    removeTokenBindingKey(kid: string, correlationId: string, context?: TokenBindingKeyContext): Promise<void>;
+    signTokenBindingJwt(header: object, payload: object, kid: string, correlationId: string, context?: TokenBindingKeyContext): Promise<string>;
 }
 
 // @public (undocumented)
@@ -2017,6 +2027,13 @@ function isThrottlingEntity(key: string, entity?: object): boolean;
 // @public
 function isTokenExpired(expiresOn: string, offset: number): boolean;
 
+// @internal
+export interface ITokenBindingKeyManager {
+    getTokenBindingPublicKeyJwk(kid: string, correlationId: string, context?: TokenBindingKeyContext): Promise<JsonWebKey>;
+    provisionTokenBindingKey(request: TokenBindingKeyProvisioningParameters): Promise<string>;
+    removeTokenBindingKey(kid: string, correlationId: string, context?: TokenBindingKeyContext): Promise<void>;
+}
+
 // @public
 export interface IUri {
     // (undocumented)
@@ -2040,7 +2057,11 @@ export class JoseHeader {
     constructor(options: JoseHeaderOptions);
     // (undocumented)
     alg?: string;
-    static getShrHeaderString(shrHeaderOptions: JoseHeaderOptions): string;
+    static getDpopHeader(dpopHeaderOptions: JoseHeaderOptions, correlationId?: string): JoseHeader;
+    static getShrHeader(shrHeaderOptions: JoseHeaderOptions, correlationId?: string): JoseHeader;
+    static getShrHeaderString(shrHeaderOptions: JoseHeaderOptions, correlationId?: string): string;
+    // (undocumented)
+    jwk?: object;
     // (undocumented)
     kid?: string;
     // (undocumented)
@@ -2052,6 +2073,7 @@ const JsonWebTokenTypes: {
     readonly Jwt: "JWT";
     readonly Jwk: "JWK";
     readonly Pop: "pop";
+    readonly Dpop: "dpop+jwt";
 };
 
 // @public (undocumented)
@@ -2376,6 +2398,10 @@ export type PerformanceEvent = {
     requestId?: string;
     cacheLookupPolicy?: number | undefined;
     cacheOutcome?: number;
+    tokenBindingKeyType?: string;
+    tokenBindingKeyAlgorithm?: string;
+    tokenBindingKeyCacheHit?: boolean;
+    tokenBindingKeyRequestCoalesced?: boolean;
     incompleteSubMeasurements?: Map<string, SubMeasurement>;
     visibilityChangeCount?: number;
     onlineStatusChangeCount?: number;
@@ -2577,7 +2603,7 @@ const PopTokenGenerateCnf = "popTokenGenerateCnf";
 
 // @internal (undocumented)
 export class PopTokenGenerator {
-    constructor(cryptoUtils: ICrypto, performanceClient: IPerformanceClient);
+    constructor(cryptoUtils: ICrypto, tokenBindingKeyManager: ITokenBindingKeyManager, performanceClient: IPerformanceClient);
     generateCnf(request: SignedHttpRequestParameters, logger: Logger): Promise<ReqCnfData>;
     generateKid(request: SignedHttpRequestParameters): Promise<ReqCnf>;
     signPayload(payload: string, keyId: string, request: SignedHttpRequestParameters, claims?: object): Promise<string>;
@@ -2822,8 +2848,8 @@ const RESPONSE_TYPE = "response_type";
 
 // @internal
 export class ResponseHandler {
-    constructor(clientId: string, cacheStorage: CacheManager, cryptoObj: ICrypto, logger: Logger, performanceClient: IPerformanceClient, serializableCache: ISerializableTokenCache | null, persistencePlugin: ICachePlugin | null);
-    static generateAuthenticationResult(cryptoObj: ICrypto, authority: Authority, cacheRecord: CacheRecord, fromTokenCache: boolean, request: BaseAuthRequest, performanceClient: IPerformanceClient, idTokenClaims?: TokenClaims, requestState?: RequestStateObject, serverTokenResponse?: ServerAuthorizationTokenResponse, requestId?: string): Promise<AuthenticationResult>;
+    constructor(clientId: string, cacheStorage: CacheManager, cryptoObj: ICrypto, logger: Logger, performanceClient: IPerformanceClient, serializableCache: ISerializableTokenCache | null, persistencePlugin: ICachePlugin | null, tokenBindingKeyManager?: ITokenBindingKeyManager);
+    static generateAuthenticationResult(cryptoObj: ICrypto, authority: Authority, cacheRecord: CacheRecord, fromTokenCache: boolean, request: BaseAuthRequest, performanceClient: IPerformanceClient, options?: GenerateAuthenticationResultOptions): Promise<AuthenticationResult>;
     handleServerTokenResponse(serverTokenResponse: ServerAuthorizationTokenResponse, authority: Authority, reqTimestamp: number, request: BaseAuthRequest, apiId: number, authCodePayload?: AuthorizationCodePayload, userAssertionHash?: string, handlingRefreshTokenResponse?: boolean, forceCacheRefreshTokenResponse?: boolean, serverRequestId?: string, additionalCacheKeyComponents?: Record<string, string>): Promise<AuthenticationResult>;
     validateTokenResponse(serverResponse: ServerAuthorizationTokenResponse, correlationId: string, refreshAccessToken?: boolean): void;
 }
@@ -3215,6 +3241,19 @@ function toDateFromSeconds(seconds: number | string | undefined): Date;
 
 // @public (undocumented)
 const TOKEN_TYPE = "token_type";
+
+// @public
+export type TokenBindingKeyContext = {
+    keyScope?: string;
+};
+
+// @public
+export type TokenBindingKeyProvisioningParameters = {
+    tokenBindingKeyType: string;
+    tokenBindingKeyAlgorithm: string;
+    correlationId: string;
+    keyScope?: string;
+};
 
 // @public
 export class TokenCacheContext {

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -168,7 +168,8 @@ export class AuthorizationCodeClient {
             this.logger,
             this.performanceClient,
             this.config.serializableCache,
-            this.config.persistencePlugin
+            this.config.persistencePlugin,
+            this.config.tokenBindingKeyManager
         );
 
         // Validate response. This function throws a server error if an error is returned by the server.
@@ -409,6 +410,7 @@ export class AuthorizationCodeClient {
         ) {
             const popTokenGenerator = new PopTokenGenerator(
                 this.cryptoUtils,
+                this.config.tokenBindingKeyManager,
                 this.performanceClient
             );
 

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -139,7 +139,8 @@ export class RefreshTokenClient {
             this.logger,
             this.performanceClient,
             this.config.serializableCache,
-            this.config.persistencePlugin
+            this.config.persistencePlugin,
+            this.config.tokenBindingKeyManager
         );
         responseHandler.validateTokenResponse(
             response.body,
@@ -475,6 +476,7 @@ export class RefreshTokenClient {
         ) {
             const popTokenGenerator = new PopTokenGenerator(
                 this.cryptoUtils,
+                this.config.tokenBindingKeyManager,
                 this.performanceClient
             );
 

--- a/lib/msal-common/src/client/SilentFlowClient.ts
+++ b/lib/msal-common/src/client/SilentFlowClient.ts
@@ -263,7 +263,10 @@ export class SilentFlowClient {
             true,
             request,
             this.performanceClient,
-            idTokenClaims
+            {
+                idTokenClaims,
+                tokenBindingKeyManager: this.config.tokenBindingKeyManager,
+            }
         );
     }
 }

--- a/lib/msal-common/src/config/ClientConfiguration.ts
+++ b/lib/msal-common/src/config/ClientConfiguration.ts
@@ -5,6 +5,10 @@
 
 import { INetworkModule } from "../network/INetworkModule.js";
 import { DEFAULT_CRYPTO_IMPLEMENTATION, ICrypto } from "../crypto/ICrypto.js";
+import {
+    DEFAULT_TOKEN_BINDING_KEY_MANAGER,
+    ITokenBindingKeyManager,
+} from "../crypto/ITokenBindingKeyManager.js";
 import { ILoggerCallback, Logger, LogLevel } from "../logger/Logger.js";
 import {
     DEFAULT_COMMON_TENANT,
@@ -32,6 +36,7 @@ import { StubPerformanceClient } from "../telemetry/performance/StubPerformanceC
  * This object allows you to configure important elements of MSAL functionality:
  * - authOptions                - Authentication for application
  * - cryptoInterface            - Implementation of crypto functions
+ * - tokenBindingKeyManager     - Implementation of token-binding key lifecycle functions
  * - libraryInfo                - Library metadata
  * - telemetry                  - Telemetry options and data
  * - loggerOptions              - Logging for application
@@ -48,6 +53,7 @@ export type ClientConfiguration = {
     storageInterface?: CacheManager;
     networkInterface?: INetworkModule;
     cryptoInterface?: ICrypto;
+    tokenBindingKeyManager?: ITokenBindingKeyManager;
     clientCredentials?: ClientCredentials;
     libraryInfo?: LibraryInfo;
     telemetry?: TelemetryOptions;
@@ -66,6 +72,7 @@ export type CommonClientConfiguration = {
     storageInterface: CacheManager;
     networkInterface: INetworkModule;
     cryptoInterface: Required<ICrypto>;
+    tokenBindingKeyManager: ITokenBindingKeyManager;
     libraryInfo: LibraryInfo;
     telemetry: Required<TelemetryOptions>;
     serverTelemetryManager: ServerTelemetryManager | null;
@@ -226,6 +233,7 @@ export function buildClientConfiguration({
     storageInterface: storageImplementation,
     networkInterface: networkImplementation,
     cryptoInterface: cryptoImplementation,
+    tokenBindingKeyManager: tokenBindingKeyManager,
     clientCredentials: clientCredentials,
     libraryInfo: libraryInfo,
     telemetry: telemetry,
@@ -253,6 +261,8 @@ export function buildClientConfiguration({
         networkInterface:
             networkImplementation || DEFAULT_NETWORK_IMPLEMENTATION,
         cryptoInterface: cryptoImplementation || DEFAULT_CRYPTO_IMPLEMENTATION,
+        tokenBindingKeyManager:
+            tokenBindingKeyManager || DEFAULT_TOKEN_BINDING_KEY_MANAGER,
         clientCredentials: clientCredentials || DEFAULT_CLIENT_CREDENTIALS,
         libraryInfo: { ...DEFAULT_LIBRARY_INFO, ...libraryInfo },
         telemetry: { ...DEFAULT_TELEMETRY_OPTIONS, ...telemetry },

--- a/lib/msal-common/src/crypto/DpopProofGenerator.ts
+++ b/lib/msal-common/src/crypto/DpopProofGenerator.ts
@@ -84,8 +84,11 @@ export type DpopProofGenerationParams = {
  * @internal
  */
 export interface ITokenBindingJwtSigner {
+    /**
+     * @internal
+     */
     signTokenBindingJwt(
-        header: object,
+        header: JoseHeader,
         payload: object,
         kid: string,
         correlationId: string,

--- a/lib/msal-common/src/crypto/DpopProofGenerator.ts
+++ b/lib/msal-common/src/crypto/DpopProofGenerator.ts
@@ -4,11 +4,17 @@
  */
 
 import { ICrypto, JsonWebTokenAlgorithms } from "./ICrypto.js";
+import {
+    ITokenBindingKeyManager,
+    TokenBindingKeyContext,
+} from "./ITokenBindingKeyManager.js";
 import * as TimeUtils from "../utils/TimeUtils.js";
 import {
     createClientConfigurationError,
     ClientConfigurationErrorCodes,
 } from "../error/ClientConfigurationError.js";
+import { JoseHeader } from "./JoseHeader.js";
+import { JsonWebTokenTypes } from "../utils/Constants.js";
 
 /**
  * RFC 9449 DPoP proof JWT payload claims.
@@ -45,29 +51,23 @@ export type DpopResourceProofParams = {
 };
 
 /**
- * Public JWK embedded in the DPoP proof header.
+ * Parameters for provisioning a DPoP key and producing its JWK thumbprint
+ * (`dpop_jkt`).
  * @internal
  */
-export type DpopPublicJwk = Record<string, unknown>;
+export type DpopJktGenerationParams = {
+    clientId: string;
+    authority: string;
+};
 
 /**
  * RFC 9449 DPoP proof JWT header.
  * @internal
  */
 export type DpopProofHeader = {
-    typ: typeof DPOP_JWT_HEADER_TYPE;
+    typ: typeof JsonWebTokenTypes.Dpop;
     alg: string;
-    jwk: DpopPublicJwk;
-};
-
-/**
- * Signs the ASCII DPoP JWT signing input with the declared JOSE alg
- * and returns a base64url-encoded signature.
- * @internal
- */
-export type DpopProofSigner = {
-    alg: string;
-    sign: (signingInput: string, correlationId: string) => Promise<string>;
+    jwk: JsonWebKey;
 };
 
 /**
@@ -75,20 +75,40 @@ export type DpopProofSigner = {
  * @internal
  */
 export type DpopProofGenerationParams = {
-    publicJwk: DpopPublicJwk;
-    signer: DpopProofSigner;
+    keyId: string;
+    keyContext: TokenBindingKeyContext;
 };
 
+/**
+ * Internal crypto operation used to sign compact JWTs with token-binding keys.
+ * @internal
+ */
+export interface ITokenBindingJwtSigner {
+    signTokenBindingJwt(
+        header: object,
+        payload: object,
+        kid: string,
+        correlationId: string,
+        context?: TokenBindingKeyContext
+    ): Promise<string>;
+}
+
 const DPOP_HTM_REGEX = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
-export const DPOP_JWT_HEADER_TYPE = "dpop+jwt";
+const DPOP_TOKEN_BINDING_KEY_TYPE = "dpop";
+export const DPOP_JWT_HEADER_TYPE = JsonWebTokenTypes.Dpop;
 export const DPOP_JWT_HEADER_ALGORITHM = JsonWebTokenAlgorithms.ES256;
 
-function buildProofHeader(params: DpopProofGenerationParams): DpopProofHeader {
-    return {
-        typ: DPOP_JWT_HEADER_TYPE,
-        alg: params.signer.alg,
-        jwk: params.publicJwk,
-    };
+function buildProofHeader(
+    publicJwk: JsonWebKey,
+    correlationId: string
+): JoseHeader {
+    return JoseHeader.getDpopHeader(
+        {
+            alg: DPOP_JWT_HEADER_ALGORITHM,
+            jwk: publicJwk,
+        },
+        correlationId
+    );
 }
 
 function normalizeHtm(htm: string, correlationId: string): string {
@@ -148,10 +168,31 @@ function normalizeHtu(url: string, correlationId: string): string {
  * @internal
  */
 export class DpopProofGenerator {
-    private cryptoUtils: ICrypto;
+    private cryptoUtils: ICrypto & ITokenBindingJwtSigner;
+    private tokenBindingKeyManager: ITokenBindingKeyManager;
 
-    constructor(cryptoUtils: ICrypto) {
+    constructor(
+        cryptoUtils: ICrypto & ITokenBindingJwtSigner,
+        tokenBindingKeyManager: ITokenBindingKeyManager
+    ) {
         this.cryptoUtils = cryptoUtils;
+        this.tokenBindingKeyManager = tokenBindingKeyManager;
+    }
+
+    /**
+     * Provisions or reuses the DPoP key for a client/authority pair and
+     * returns the RFC 7638 JWK thumbprint used as `dpop_jkt`.
+     */
+    async generateJkt(
+        params: DpopJktGenerationParams,
+        correlationId: string = ""
+    ): Promise<string> {
+        return this.tokenBindingKeyManager.provisionTokenBindingKey({
+            tokenBindingKeyType: DPOP_TOKEN_BINDING_KEY_TYPE,
+            tokenBindingKeyAlgorithm: DPOP_JWT_HEADER_ALGORITHM,
+            keyScope: this.getKeyScope(params),
+            correlationId,
+        });
     }
 
     /**
@@ -233,15 +274,23 @@ export class DpopProofGenerator {
         params: DpopProofGenerationParams,
         correlationId: string
     ): Promise<string> {
-        const encodedHeader = this.cryptoUtils.base64UrlEncode(
-            JSON.stringify(buildProofHeader(params))
-        );
-        const encodedClaims = this.cryptoUtils.base64UrlEncode(
-            JSON.stringify(claims)
-        );
-        const signingInput = `${encodedHeader}.${encodedClaims}`;
-        const signature = await params.signer.sign(signingInput, correlationId);
+        const publicJwk =
+            await this.tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                params.keyId,
+                correlationId,
+                params.keyContext
+            );
 
-        return `${signingInput}.${signature}`;
+        return this.cryptoUtils.signTokenBindingJwt(
+            buildProofHeader(publicJwk, correlationId),
+            claims,
+            params.keyId,
+            correlationId,
+            params.keyContext
+        );
+    }
+
+    private getKeyScope(params: DpopJktGenerationParams): string {
+        return `${DPOP_TOKEN_BINDING_KEY_TYPE}.${params.clientId}.${params.authority}`;
     }
 }

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -9,6 +9,7 @@ import {
 } from "../error/ClientAuthError.js";
 import type { BaseAuthRequest } from "../request/BaseAuthRequest.js";
 import type { TokenBindingKeyContext } from "./ITokenBindingKeyManager.js";
+import type { JoseHeader } from "./JoseHeader.js";
 
 /**
  * PKCE code verifier and challenge pair used by authorization code flows.
@@ -86,6 +87,7 @@ export interface ICrypto {
     clearKeystore(correlationId: string): Promise<boolean>;
     /**
      * Signs a compact JWT with the token-binding key identified by kid.
+     * @internal
      * @param header
      * @param payload
      * @param kid
@@ -93,7 +95,7 @@ export interface ICrypto {
      * @param context
      */
     signTokenBindingJwt(
-        header: object,
+        header: JoseHeader,
         payload: object,
         kid: string,
         correlationId: string,

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -155,10 +155,18 @@ export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
             correlationId
         );
     },
-    async signTokenBindingJwt(): Promise<string> {
+    async signTokenBindingJwt(
+        header: JoseHeader,
+        payload: object,
+        kid: string,
+        correlationId: string
+    ): Promise<string> {
+        void header;
+        void payload;
+        void kid;
         throw createClientAuthError(
             ClientAuthErrorCodes.methodNotImplemented,
-            ""
+            correlationId
         );
     },
     async hashString(): Promise<string> {

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -8,7 +8,7 @@ import {
     createClientAuthError,
 } from "../error/ClientAuthError.js";
 import type { BaseAuthRequest } from "../request/BaseAuthRequest.js";
-import type { ShrOptions, SignedHttpRequest } from "./SignedHttpRequest.js";
+import type { TokenBindingKeyContext } from "./ITokenBindingKeyManager.js";
 
 /**
  * PKCE code verifier and challenge pair used by authorization code flows.
@@ -38,6 +38,7 @@ export type SignedHttpRequestParameters = Pick<
  */
 export const JsonWebTokenAlgorithms = {
     ES256: "ES256",
+    RS256: "RS256",
 } as const;
 /**
  * Interface for crypto functions used by library
@@ -68,32 +69,35 @@ export interface ICrypto {
      */
     encodeKid(inputKid: string): string;
     /**
-     * Generates an JWK RSA S256 Thumbprint
-     * @param request
-     */
-    getPublicKeyThumbprint(
-        request: SignedHttpRequestParameters
-    ): Promise<string>;
-    /**
      * Removes cryptographic keypair from key store matching the keyId passed in
      * @param kid
      * @param correlationId
+     * @param context
      */
-    removeTokenBindingKey(kid: string, correlationId: string): Promise<void>;
+    removeTokenBindingKey(
+        kid: string,
+        correlationId: string,
+        context?: TokenBindingKeyContext
+    ): Promise<void>;
     /**
      * Removes all cryptographic keys from IndexedDB storage
      * @param correlationId
      */
     clearKeystore(correlationId: string): Promise<boolean>;
     /**
-     * Returns a signed proof-of-possession token with a given acces token that contains a cnf claim with the required kid.
-     * @param accessToken
+     * Signs a compact JWT with the token-binding key identified by kid.
+     * @param header
+     * @param payload
+     * @param kid
+     * @param correlationId
+     * @param context
      */
-    signJwt(
-        payload: SignedHttpRequest,
+    signTokenBindingJwt(
+        header: object,
+        payload: object,
         kid: string,
-        shrOptions?: ShrOptions,
-        correlationId?: string
+        correlationId: string,
+        context?: TokenBindingKeyContext
     ): Promise<string>;
     /**
      * Returns the SHA-256 hash of an input string
@@ -137,12 +141,6 @@ export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
             ""
         );
     },
-    async getPublicKeyThumbprint(): Promise<string> {
-        throw createClientAuthError(
-            ClientAuthErrorCodes.methodNotImplemented,
-            ""
-        );
-    },
     async removeTokenBindingKey(): Promise<void> {
         throw createClientAuthError(
             ClientAuthErrorCodes.methodNotImplemented,
@@ -155,7 +153,7 @@ export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
             ""
         );
     },
-    async signJwt(): Promise<string> {
+    async signTokenBindingJwt(): Promise<string> {
         throw createClientAuthError(
             ClientAuthErrorCodes.methodNotImplemented,
             ""

--- a/lib/msal-common/src/crypto/ICrypto.ts
+++ b/lib/msal-common/src/crypto/ICrypto.ts
@@ -149,10 +149,10 @@ export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
             ""
         );
     },
-    async clearKeystore(): Promise<boolean> {
+    async clearKeystore(correlationId: string): Promise<boolean> {
         throw createClientAuthError(
             ClientAuthErrorCodes.methodNotImplemented,
-            ""
+            correlationId
         );
     },
     async signTokenBindingJwt(): Promise<string> {

--- a/lib/msal-common/src/crypto/ITokenBindingKeyManager.ts
+++ b/lib/msal-common/src/crypto/ITokenBindingKeyManager.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    ClientAuthErrorCodes,
+    createClientAuthError,
+} from "../error/ClientAuthError.js";
+
+/**
+ * Parameters used by token-binding key managers to provision browser-managed
+ * token-binding keys. Callers own the protocol policy (key type, JOSE
+ * algorithm, and optional cache scope); implementations generate, store,
+ * retrieve, and use the requested key material.
+ */
+export type TokenBindingKeyProvisioningParameters = {
+    tokenBindingKeyType: string;
+    tokenBindingKeyAlgorithm: string;
+    correlationId: string;
+    /**
+     * Optional stable scope used to reuse a key before the JWK thumbprint is
+     * known. Implementations append the generated thumbprint to this scope when
+     * storing the key.
+     */
+    keyScope?: string;
+};
+
+/**
+ * Parameters used by token-binding key managers to resolve existing keys.
+ * Lookup/signing APIs do not carry key generation policy.
+ */
+export type TokenBindingKeyContext = {
+    keyScope?: string;
+};
+
+/**
+ * Internal key lifecycle abstraction for browser token-binding keys.
+ * @internal
+ */
+export interface ITokenBindingKeyManager {
+    /**
+     * Provisions or reuses a token-binding key and returns the key identifier.
+     * @param request - Key provisioning policy and cache scope.
+     */
+    provisionTokenBindingKey(
+        request: TokenBindingKeyProvisioningParameters
+    ): Promise<string>;
+    /**
+     * Removes a token-binding key by identifier and optional lookup context.
+     * @param kid - Token-binding key identifier.
+     * @param correlationId - Request correlation identifier.
+     * @param context - Optional scoped lookup context.
+     */
+    removeTokenBindingKey(
+        kid: string,
+        correlationId: string,
+        context?: TokenBindingKeyContext
+    ): Promise<void>;
+    /**
+     * Gets a token-binding public key as a JWK by identifier and optional lookup context.
+     * @param kid - Token-binding key identifier.
+     * @param correlationId - Request correlation identifier.
+     * @param context - Optional scoped lookup context.
+     */
+    getTokenBindingPublicKeyJwk(
+        kid: string,
+        correlationId: string,
+        context?: TokenBindingKeyContext
+    ): Promise<JsonWebKey>;
+}
+
+/**
+ * Default token-binding key manager used when a platform-specific implementation
+ * has not been provided.
+ * @internal
+ */
+export const DEFAULT_TOKEN_BINDING_KEY_MANAGER: ITokenBindingKeyManager = {
+    async provisionTokenBindingKey(
+        request: TokenBindingKeyProvisioningParameters
+    ): Promise<string> {
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            request.correlationId
+        );
+    },
+    async removeTokenBindingKey(
+        _kid: string,
+        correlationId: string
+    ): Promise<void> {
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            correlationId
+        );
+    },
+    async getTokenBindingPublicKeyJwk(
+        _kid: string,
+        correlationId: string
+    ): Promise<JsonWebKey> {
+        throw createClientAuthError(
+            ClientAuthErrorCodes.methodNotImplemented,
+            correlationId
+        );
+    },
+};

--- a/lib/msal-common/src/crypto/JoseHeader.ts
+++ b/lib/msal-common/src/crypto/JoseHeader.ts
@@ -23,7 +23,17 @@ export class JoseHeader {
     public kid?: string;
     public jwk?: JsonWebKey;
 
-    constructor(options: JoseHeaderOptions & { alg: string }) {
+    constructor(
+        options: JoseHeaderOptions & { alg: string },
+        correlationId: string = ""
+    ) {
+        if (typeof options.alg !== "string" || !options.alg) {
+            throw createJoseHeaderError(
+                JoseHeaderErrorCodes.missingAlgError,
+                correlationId
+            );
+        }
+
         this.typ = options.typ;
         this.alg = options.alg;
         this.kid = options.kid;
@@ -58,12 +68,15 @@ export class JoseHeader {
             );
         }
 
-        return new JoseHeader({
-            // Access Token PoP headers must have type pop, but the type header can be overriden for special cases
-            typ: shrHeaderOptions.typ || JsonWebTokenTypes.Pop,
-            kid: shrHeaderOptions.kid,
-            alg: shrHeaderOptions.alg,
-        });
+        return new JoseHeader(
+            {
+                // Access Token PoP headers must have type pop, but the type header can be overriden for special cases
+                typ: shrHeaderOptions.typ || JsonWebTokenTypes.Pop,
+                kid: shrHeaderOptions.kid,
+                alg: shrHeaderOptions.alg,
+            },
+            correlationId
+        );
     }
 
     /**
@@ -101,11 +114,14 @@ export class JoseHeader {
             );
         }
 
-        return new JoseHeader({
-            typ: JsonWebTokenTypes.Dpop,
-            alg: dpopHeaderOptions.alg,
-            jwk: dpopHeaderOptions.jwk,
-        });
+        return new JoseHeader(
+            {
+                typ: JsonWebTokenTypes.Dpop,
+                alg: dpopHeaderOptions.alg,
+                jwk: dpopHeaderOptions.jwk,
+            },
+            correlationId
+        );
     }
 }
 

--- a/lib/msal-common/src/crypto/JoseHeader.ts
+++ b/lib/msal-common/src/crypto/JoseHeader.ts
@@ -13,17 +13,17 @@ export type JoseHeaderOptions = {
     typ?: JsonWebTokenTypes;
     alg?: string;
     kid?: string;
-    jwk?: object;
+    jwk?: JsonWebKey;
 };
 
 /** @internal */
 export class JoseHeader {
     public typ?: JsonWebTokenTypes;
-    public alg?: string;
+    public alg: string;
     public kid?: string;
-    public jwk?: object;
+    public jwk?: JsonWebKey;
 
-    constructor(options: JoseHeaderOptions) {
+    constructor(options: JoseHeaderOptions & { alg: string }) {
         this.typ = options.typ;
         this.alg = options.alg;
         this.kid = options.kid;
@@ -32,8 +32,7 @@ export class JoseHeader {
 
     /**
      * Builds SignedHttpRequest formatted JOSE Header from the
-     * JOSE Header options provided or previously set on the object and returns
-     * the stringified header object.
+     * JOSE Header options provided or previously set on the object.
      * Throws if keyId or algorithm aren't provided since they are required for Access Token Binding.
      * @param shrHeaderOptions
      * @param correlationId
@@ -44,7 +43,7 @@ export class JoseHeader {
         correlationId: string = ""
     ): JoseHeader {
         // KeyID is required on the SHR header
-        if (!shrHeaderOptions.kid) {
+        if (typeof shrHeaderOptions.kid !== "string" || !shrHeaderOptions.kid) {
             throw createJoseHeaderError(
                 JoseHeaderErrorCodes.missingKidError,
                 correlationId
@@ -52,7 +51,7 @@ export class JoseHeader {
         }
 
         // Alg is required on the SHR header
-        if (!shrHeaderOptions.alg) {
+        if (typeof shrHeaderOptions.alg !== "string" || !shrHeaderOptions.alg) {
             throw createJoseHeaderError(
                 JoseHeaderErrorCodes.missingAlgError,
                 correlationId
@@ -68,24 +67,6 @@ export class JoseHeader {
     }
 
     /**
-     * Builds SignedHttpRequest formatted JOSE Header from the
-     * JOSE Header options provided or previously set on the object and returns
-     * the stringified header object.
-     * Throws if keyId or algorithm aren't provided since they are required for Access Token Binding.
-     * @param shrHeaderOptions
-     * @param correlationId
-     * @returns
-     */
-    static getShrHeaderString(
-        shrHeaderOptions: JoseHeaderOptions,
-        correlationId: string = ""
-    ): string {
-        return JSON.stringify(
-            JoseHeader.getShrHeader(shrHeaderOptions, correlationId)
-        );
-    }
-
-    /**
      * Builds a DPoP formatted JOSE Header from the JOSE Header options provided.
      * Throws if public JWK or algorithm aren't provided since they are required for DPoP.
      * @param dpopHeaderOptions
@@ -96,14 +77,17 @@ export class JoseHeader {
         dpopHeaderOptions: JoseHeaderOptions,
         correlationId: string = ""
     ): JoseHeader {
-        if (!dpopHeaderOptions.jwk) {
+        if (!isRecord(dpopHeaderOptions.jwk)) {
             throw createJoseHeaderError(
                 JoseHeaderErrorCodes.missingJwkError,
                 correlationId
             );
         }
 
-        if (!dpopHeaderOptions.alg) {
+        if (
+            typeof dpopHeaderOptions.alg !== "string" ||
+            !dpopHeaderOptions.alg
+        ) {
             throw createJoseHeaderError(
                 JoseHeaderErrorCodes.missingAlgError,
                 correlationId
@@ -123,4 +107,8 @@ export class JoseHeader {
             jwk: dpopHeaderOptions.jwk,
         });
     }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
 }

--- a/lib/msal-common/src/crypto/JoseHeader.ts
+++ b/lib/msal-common/src/crypto/JoseHeader.ts
@@ -13,6 +13,7 @@ export type JoseHeaderOptions = {
     typ?: JsonWebTokenTypes;
     alg?: string;
     kid?: string;
+    jwk?: object;
 };
 
 /** @internal */
@@ -20,11 +21,13 @@ export class JoseHeader {
     public typ?: JsonWebTokenTypes;
     public alg?: string;
     public kid?: string;
+    public jwk?: object;
 
     constructor(options: JoseHeaderOptions) {
         this.typ = options.typ;
         this.alg = options.alg;
         this.kid = options.kid;
+        this.jwk = options.jwk;
     }
 
     /**
@@ -33,14 +36,18 @@ export class JoseHeader {
      * the stringified header object.
      * Throws if keyId or algorithm aren't provided since they are required for Access Token Binding.
      * @param shrHeaderOptions
+     * @param correlationId
      * @returns
      */
-    static getShrHeaderString(shrHeaderOptions: JoseHeaderOptions): string {
+    static getShrHeader(
+        shrHeaderOptions: JoseHeaderOptions,
+        correlationId: string = ""
+    ): JoseHeader {
         // KeyID is required on the SHR header
         if (!shrHeaderOptions.kid) {
             throw createJoseHeaderError(
                 JoseHeaderErrorCodes.missingKidError,
-                ""
+                correlationId
             );
         }
 
@@ -48,17 +55,72 @@ export class JoseHeader {
         if (!shrHeaderOptions.alg) {
             throw createJoseHeaderError(
                 JoseHeaderErrorCodes.missingAlgError,
-                ""
+                correlationId
             );
         }
 
-        const shrHeader = new JoseHeader({
+        return new JoseHeader({
             // Access Token PoP headers must have type pop, but the type header can be overriden for special cases
             typ: shrHeaderOptions.typ || JsonWebTokenTypes.Pop,
             kid: shrHeaderOptions.kid,
             alg: shrHeaderOptions.alg,
         });
+    }
 
-        return JSON.stringify(shrHeader);
+    /**
+     * Builds SignedHttpRequest formatted JOSE Header from the
+     * JOSE Header options provided or previously set on the object and returns
+     * the stringified header object.
+     * Throws if keyId or algorithm aren't provided since they are required for Access Token Binding.
+     * @param shrHeaderOptions
+     * @param correlationId
+     * @returns
+     */
+    static getShrHeaderString(
+        shrHeaderOptions: JoseHeaderOptions,
+        correlationId: string = ""
+    ): string {
+        return JSON.stringify(
+            JoseHeader.getShrHeader(shrHeaderOptions, correlationId)
+        );
+    }
+
+    /**
+     * Builds a DPoP formatted JOSE Header from the JOSE Header options provided.
+     * Throws if public JWK or algorithm aren't provided since they are required for DPoP.
+     * @param dpopHeaderOptions
+     * @param correlationId
+     * @returns
+     */
+    static getDpopHeader(
+        dpopHeaderOptions: JoseHeaderOptions,
+        correlationId: string = ""
+    ): JoseHeader {
+        if (!dpopHeaderOptions.jwk) {
+            throw createJoseHeaderError(
+                JoseHeaderErrorCodes.missingJwkError,
+                correlationId
+            );
+        }
+
+        if (!dpopHeaderOptions.alg) {
+            throw createJoseHeaderError(
+                JoseHeaderErrorCodes.missingAlgError,
+                correlationId
+            );
+        }
+
+        if (Object.keys(dpopHeaderOptions.jwk).length === 0) {
+            throw createJoseHeaderError(
+                JoseHeaderErrorCodes.invalidJwkError,
+                correlationId
+            );
+        }
+
+        return new JoseHeader({
+            typ: JsonWebTokenTypes.Dpop,
+            alg: dpopHeaderOptions.alg,
+            jwk: dpopHeaderOptions.jwk,
+        });
     }
 }

--- a/lib/msal-common/src/crypto/PopTokenGenerator.ts
+++ b/lib/msal-common/src/crypto/PopTokenGenerator.ts
@@ -3,13 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { ICrypto, SignedHttpRequestParameters } from "./ICrypto.js";
+import {
+    ICrypto,
+    JsonWebTokenAlgorithms,
+    SignedHttpRequestParameters,
+} from "./ICrypto.js";
 import * as TimeUtils from "../utils/TimeUtils.js";
 import { UrlString } from "../url/UrlString.js";
 import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
 import * as PerformanceEvents from "../telemetry/performance/PerformanceEvents.js";
 import { invokeAsync } from "../utils/FunctionWrappers.js";
 import { Logger } from "../logger/Logger.js";
+import { JoseHeader } from "./JoseHeader.js";
+import { SignedHttpRequest } from "./SignedHttpRequest.js";
+import { ITokenBindingKeyManager } from "./ITokenBindingKeyManager.js";
 
 /**
  * See eSTS docs for more info.
@@ -34,13 +41,22 @@ const KeyLocation = {
 } as const;
 export type KeyLocation = (typeof KeyLocation)[keyof typeof KeyLocation];
 
+const SHR_TOKEN_BINDING_KEY_TYPE = "shr";
+const SHR_TOKEN_BINDING_KEY_ALGORITHM = JsonWebTokenAlgorithms.RS256;
+
 /** @internal */
 export class PopTokenGenerator {
     private cryptoUtils: ICrypto;
+    private tokenBindingKeyManager: ITokenBindingKeyManager;
     private performanceClient: IPerformanceClient;
 
-    constructor(cryptoUtils: ICrypto, performanceClient: IPerformanceClient) {
+    constructor(
+        cryptoUtils: ICrypto,
+        tokenBindingKeyManager: ITokenBindingKeyManager,
+        performanceClient: IPerformanceClient
+    ) {
         this.cryptoUtils = cryptoUtils;
+        this.tokenBindingKeyManager = tokenBindingKeyManager;
         this.performanceClient = performanceClient;
     }
 
@@ -77,9 +93,12 @@ export class PopTokenGenerator {
      * @returns
      */
     async generateKid(request: SignedHttpRequestParameters): Promise<ReqCnf> {
-        const kidThumbprint = await this.cryptoUtils.getPublicKeyThumbprint(
-            request
-        );
+        const kidThumbprint =
+            await this.tokenBindingKeyManager.provisionTokenBindingKey({
+                correlationId: request.correlationId,
+                tokenBindingKeyType: SHR_TOKEN_BINDING_KEY_TYPE,
+                tokenBindingKeyAlgorithm: SHR_TOKEN_BINDING_KEY_ALGORITHM,
+            });
 
         return {
             kid: kidThumbprint,
@@ -128,22 +147,47 @@ export class PopTokenGenerator {
             ? new UrlString(resourceRequestUri, request.correlationId)
             : undefined;
         const resourceUrlComponents = resourceUrlString?.getUrlComponents();
-        return this.cryptoUtils.signJwt(
+        const publicKeyJwk =
+            await this.tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                keyId,
+                request.correlationId
+            );
+        const encodedKeyIdThumbprint = this.cryptoUtils.base64UrlEncode(
+            JSON.stringify({ kid: keyId })
+        );
+        const shrAlgorithm =
+            shrOptions?.header?.alg ||
+            publicKeyJwk.alg ||
+            SHR_TOKEN_BINDING_KEY_ALGORITHM;
+        const shrHeader = JoseHeader.getShrHeader(
             {
-                at: payload,
-                ts: TimeUtils.nowSeconds(),
-                m: resourceRequestMethod?.toUpperCase(),
-                u: resourceUrlComponents?.HostNameAndPort,
-                nonce: shrNonce || this.cryptoUtils.createNewGuid(),
-                p: resourceUrlComponents?.AbsolutePath,
-                q: resourceUrlComponents?.QueryString
-                    ? [[], resourceUrlComponents.QueryString]
-                    : undefined,
-                client_claims: shrClaims || undefined,
-                ...claims,
+                ...shrOptions?.header,
+                alg: shrAlgorithm,
+                kid: encodedKeyIdThumbprint,
             },
+            request.correlationId
+        );
+        const shrPayload: SignedHttpRequest = {
+            at: payload,
+            ts: TimeUtils.nowSeconds(),
+            m: resourceRequestMethod?.toUpperCase(),
+            u: resourceUrlComponents?.HostNameAndPort,
+            nonce: shrNonce || this.cryptoUtils.createNewGuid(),
+            p: resourceUrlComponents?.AbsolutePath,
+            q: resourceUrlComponents?.QueryString
+                ? [[], resourceUrlComponents.QueryString]
+                : undefined,
+            client_claims: shrClaims || undefined,
+            ...claims,
+            cnf: {
+                jwk: publicKeyJwk,
+            },
+        };
+
+        return this.cryptoUtils.signTokenBindingJwt(
+            shrHeader,
+            shrPayload,
             keyId,
-            shrOptions,
             request.correlationId
         );
     }

--- a/lib/msal-common/src/error/ClientConfigurationErrorCodes.ts
+++ b/lib/msal-common/src/error/ClientConfigurationErrorCodes.ts
@@ -19,6 +19,8 @@ export const invalidAuthorityMetadata = "invalid_authority_metadata";
 export const untrustedAuthority = "untrusted_authority";
 export const missingSshJwk = "missing_ssh_jwk";
 export const missingSshKid = "missing_ssh_kid";
+export const unsupportedAuthenticationScheme =
+    "unsupported_authentication_scheme";
 export const missingNonceAuthenticationHeader =
     "missing_nonce_authentication_header";
 export const invalidAuthenticationHeader = "invalid_authentication_header";

--- a/lib/msal-common/src/error/JoseHeaderErrorCodes.ts
+++ b/lib/msal-common/src/error/JoseHeaderErrorCodes.ts
@@ -5,3 +5,5 @@
 
 export const missingKidError = "missing_kid_error";
 export const missingAlgError = "missing_alg_error";
+export const missingJwkError = "missing_jwk_error";
+export const invalidJwkError = "invalid_jwk_error";

--- a/lib/msal-common/src/exports-common.ts
+++ b/lib/msal-common/src/exports-common.ts
@@ -105,6 +105,11 @@ export {
     DEFAULT_CRYPTO_IMPLEMENTATION,
     SignedHttpRequestParameters,
 } from "./crypto/ICrypto.js";
+export {
+    ITokenBindingKeyManager,
+    TokenBindingKeyContext,
+    TokenBindingKeyProvisioningParameters,
+} from "./crypto/ITokenBindingKeyManager.js";
 
 export * as AuthorizeProtocol from "./protocol/Authorize.js";
 export * as TokenProtocol from "./protocol/Token.js";
@@ -127,6 +132,7 @@ export { AuthorizationCodePayload } from "./response/AuthorizationCodePayload.js
 export { AuthorizeResponse } from "./response/AuthorizeResponse.js";
 export { ServerAuthorizationTokenResponse } from "./response/ServerAuthorizationTokenResponse.js";
 export {
+    GenerateAuthenticationResultOptions,
     ResponseHandler,
     buildAccountToCache,
 } from "./response/ResponseHandler.js";

--- a/lib/msal-common/src/response/ResponseHandler.ts
+++ b/lib/msal-common/src/response/ResponseHandler.ts
@@ -29,6 +29,10 @@ import * as CacheHelpers from "../cache/utils/CacheHelpers.js";
 import { ICrypto } from "../crypto/ICrypto.js";
 import { PopTokenGenerator } from "../crypto/PopTokenGenerator.js";
 import {
+    DEFAULT_TOKEN_BINDING_KEY_MANAGER,
+    ITokenBindingKeyManager,
+} from "../crypto/ITokenBindingKeyManager.js";
+import {
     ClientAuthErrorCodes,
     createClientAuthError,
 } from "../error/ClientAuthError.js";
@@ -49,6 +53,15 @@ import { AuthenticationResult } from "./AuthenticationResult.js";
 import { AuthorizationCodePayload } from "./AuthorizationCodePayload.js";
 import { ServerAuthorizationTokenResponse } from "./ServerAuthorizationTokenResponse.js";
 
+/** @internal */
+export type GenerateAuthenticationResultOptions = {
+    idTokenClaims?: TokenClaims;
+    requestState?: RequestStateObject;
+    serverTokenResponse?: ServerAuthorizationTokenResponse;
+    requestId?: string;
+    tokenBindingKeyManager?: ITokenBindingKeyManager;
+};
+
 /**
  * Class that handles response parsing.
  * @internal
@@ -57,6 +70,7 @@ export class ResponseHandler {
     private clientId: string;
     private cacheStorage: CacheManager;
     private cryptoObj: ICrypto;
+    private tokenBindingKeyManager: ITokenBindingKeyManager;
     private logger: Logger;
     private homeAccountIdentifier: string;
     private performanceClient: IPerformanceClient;
@@ -70,11 +84,13 @@ export class ResponseHandler {
         logger: Logger,
         performanceClient: IPerformanceClient,
         serializableCache: ISerializableTokenCache | null,
-        persistencePlugin: ICachePlugin | null
+        persistencePlugin: ICachePlugin | null,
+        tokenBindingKeyManager: ITokenBindingKeyManager = DEFAULT_TOKEN_BINDING_KEY_MANAGER
     ) {
         this.clientId = clientId;
         this.cacheStorage = cacheStorage;
         this.cryptoObj = cryptoObj;
+        this.tokenBindingKeyManager = tokenBindingKeyManager;
         this.logger = logger;
         this.performanceClient = performanceClient;
         this.serializableCache = serializableCache;
@@ -298,10 +314,12 @@ export class ResponseHandler {
                         false,
                         request,
                         this.performanceClient,
-                        idTokenClaims,
-                        requestStateObj,
-                        undefined,
-                        serverRequestId
+                        {
+                            idTokenClaims,
+                            requestState: requestStateObj,
+                            requestId: serverRequestId,
+                            tokenBindingKeyManager: this.tokenBindingKeyManager,
+                        }
                     );
                 }
             }
@@ -333,10 +351,13 @@ export class ResponseHandler {
             false,
             request,
             this.performanceClient,
-            idTokenClaims,
-            requestStateObj,
-            serverTokenResponse,
-            serverRequestId
+            {
+                idTokenClaims,
+                requestState: requestStateObj,
+                serverTokenResponse,
+                requestId: serverRequestId,
+                tokenBindingKeyManager: this.tokenBindingKeyManager,
+            }
         );
     }
 
@@ -522,11 +543,15 @@ export class ResponseHandler {
         fromTokenCache: boolean,
         request: BaseAuthRequest,
         performanceClient: IPerformanceClient,
-        idTokenClaims?: TokenClaims,
-        requestState?: RequestStateObject,
-        serverTokenResponse?: ServerAuthorizationTokenResponse,
-        requestId?: string
+        options: GenerateAuthenticationResultOptions = {}
     ): Promise<AuthenticationResult> {
+        const {
+            idTokenClaims,
+            requestState,
+            serverTokenResponse,
+            requestId,
+            tokenBindingKeyManager = DEFAULT_TOKEN_BINDING_KEY_MANAGER,
+        } = options;
         let accessToken: string = "";
         let responseScopes: Array<string> = [];
         let expiresOn: Date | null = null;
@@ -545,7 +570,11 @@ export class ResponseHandler {
                 !request.popKid
             ) {
                 const popTokenGenerator: PopTokenGenerator =
-                    new PopTokenGenerator(cryptoObj, performanceClient);
+                    new PopTokenGenerator(
+                        cryptoObj,
+                        tokenBindingKeyManager,
+                        performanceClient
+                    );
                 const { secret, keyId } = cacheRecord.accessToken;
 
                 if (!keyId) {

--- a/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
+++ b/lib/msal-common/src/telemetry/performance/PerformanceEvent.ts
@@ -203,6 +203,26 @@ export type PerformanceEvent = {
     cacheOutcome?: number;
 
     /**
+     * Token binding key type used by crypto operations.
+     */
+    tokenBindingKeyType?: string;
+
+    /**
+     * JOSE algorithm used by token binding crypto operations.
+     */
+    tokenBindingKeyAlgorithm?: string;
+
+    /**
+     * Whether crypto key thumbprint generation reused existing key material.
+     */
+    tokenBindingKeyCacheHit?: boolean;
+
+    /**
+     * Whether crypto key thumbprint generation joined an active scoped request.
+     */
+    tokenBindingKeyRequestCoalesced?: boolean;
+
+    /**
      * Sub-measurements for internal use. To be deleted before flushing.
      */
     incompleteSubMeasurements?: Map<string, SubMeasurement>;

--- a/lib/msal-common/src/utils/Constants.ts
+++ b/lib/msal-common/src/utils/Constants.ts
@@ -342,6 +342,7 @@ export const JsonWebTokenTypes = {
     Jwt: "JWT",
     Jwk: "JWK",
     Pop: "pop",
+    Dpop: "dpop+jwt",
 } as const;
 export type JsonWebTokenTypes =
     (typeof JsonWebTokenTypes)[keyof typeof JsonWebTokenTypes];

--- a/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
+++ b/lib/msal-common/test/client/AuthorizationCodeClient.spec.ts
@@ -1097,16 +1097,16 @@ describe("AuthorizationCodeClient unit tests", () => {
             const signedJwt =
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJjbmYiOnsia2lkIjoiTnpiTHNYaDh1RENjZC02TU53WEY0V183bm9XWEZaQWZIa3hac1JHQzlYcyJ9fQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
-            config.cryptoInterface.signJwt = async (
-                // @ts-ignore
-                payload: SignedHttpRequest,
-                kid: string
-            ): Promise<string> => {
-                expect(payload.at).toBe(
+            jest.spyOn(
+                config.cryptoInterface,
+                "signTokenBindingJwt"
+            ).mockImplementation(async (header, payload, kid) => {
+                expect((payload as { at?: string }).at).toBe(
                     POP_AUTHENTICATION_RESULT.body.access_token
                 );
+                expect(kid).toBe(TEST_POP_VALUES.KID);
                 return signedJwt;
-            };
+            });
             // Set up stubs
             const idTokenClaims = {
                 ver: "2.0",
@@ -1290,16 +1290,16 @@ describe("AuthorizationCodeClient unit tests", () => {
             const signedJwt =
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJjbmYiOnsia2lkIjoiTnpiTHNYaDh1RENjZC02TU53WEY0V183bm9XWEZaQWZIa3hac1JHQzlYcyJ9fQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
-            config.cryptoInterface.signJwt = async (
-                // @ts-ignore
-                payload: SignedHttpRequest,
-                kid: string
-            ): Promise<string> => {
-                expect(payload.at).toBe(
+            jest.spyOn(
+                config.cryptoInterface,
+                "signTokenBindingJwt"
+            ).mockImplementation(async (header, payload, kid) => {
+                expect((payload as { at?: string }).at).toBe(
                     POP_AUTHENTICATION_RESULT.body.access_token
                 );
+                expect(kid).toBe(TEST_POP_VALUES.KID);
                 return signedJwt;
-            };
+            });
             // Set up stubs
             const idTokenClaims = {
                 ver: "2.0",
@@ -1478,16 +1478,16 @@ describe("AuthorizationCodeClient unit tests", () => {
             };
             const signedJwt = "signedJwt";
 
-            config.cryptoInterface.signJwt = async (
-                // @ts-ignore
-                payload: SignedHttpRequest,
-                kid: string
-            ): Promise<string> => {
-                expect(payload.at).toBe(
+            jest.spyOn(
+                config.cryptoInterface,
+                "signTokenBindingJwt"
+            ).mockImplementation(async (header, payload, kid) => {
+                expect((payload as { at?: string }).at).toBe(
                     POP_AUTHENTICATION_RESULT.body.access_token
                 );
+                expect(kid).toBe(TEST_POP_VALUES.KID);
                 return signedJwt;
-            };
+            });
             // Set up stubs
             const idTokenClaims = {
                 ver: "2.0",

--- a/lib/msal-common/test/client/ClientTestUtils.ts
+++ b/lib/msal-common/test/client/ClientTestUtils.ts
@@ -43,6 +43,7 @@ import * as AccountEntityUtils from "../../src/cache/utils/AccountEntityUtils.js
 import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 import { CredentialEntity } from "../../src/cache/entities/CredentialEntity.js";
 import { AccountInfo } from "../../src/account/AccountInfo.js";
+import { ITokenBindingKeyManager } from "../../src/crypto/ITokenBindingKeyManager.js";
 
 const ACCOUNT_KEYS = "ACCOUNT_KEYS";
 const TOKEN_KEYS = "TOKEN_KEYS";
@@ -275,13 +276,10 @@ export const mockCrypto = {
             EncodingTypes.UTF8
         ).toString("base64url");
     },
-    async getPublicKeyThumbprint(): Promise<string> {
-        return TEST_POP_VALUES.KID;
-    },
     async removeTokenBindingKey(keyId: string): Promise<void> {
         return Promise.resolve();
     },
-    async signJwt(): Promise<string> {
+    async signTokenBindingJwt(): Promise<string> {
         return TEST_TOKENS.POP_TOKEN;
     },
     async clearKeystore(): Promise<boolean> {
@@ -289,6 +287,21 @@ export const mockCrypto = {
     },
     async hashString(): Promise<string> {
         return Promise.resolve(TEST_CRYPTO_VALUES.TEST_SHA256_HASH);
+    },
+};
+
+export const mockShrTokenBindingKeyManager: ITokenBindingKeyManager = {
+    async provisionTokenBindingKey(): Promise<string> {
+        return TEST_POP_VALUES.KID;
+    },
+    async getTokenBindingPublicKeyJwk(): Promise<JsonWebKey> {
+        return {
+            kty: "RSA",
+            alg: "RS256",
+        };
+    },
+    async removeTokenBindingKey(): Promise<void> {
+        return Promise.resolve();
     },
 };
 
@@ -347,6 +360,7 @@ export class ClientTestUtils {
             storageInterface: mockStorage,
             networkInterface: mockNetworkClient,
             cryptoInterface: mockCrypto,
+            tokenBindingKeyManager: mockShrTokenBindingKeyManager,
             loggerOptions: {
                 loggerCallback: testLoggerCallback,
             },

--- a/lib/msal-common/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-common/test/config/ClientConfiguration.spec.ts
@@ -117,6 +117,52 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
         expect(emptyConfig.telemetry.application.appVersion).toHaveLength(0);
     });
 
+    it("default token-binding key manager propagates correlation IDs", async () => {
+        const emptyConfig: CommonClientConfiguration = buildClientConfiguration(
+            {
+                //@ts-ignore
+                authOptions: {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                },
+            }
+        );
+
+        await expect(
+            emptyConfig.tokenBindingKeyManager.provisionTokenBindingKey({
+                tokenBindingKeyType: "pop",
+                tokenBindingKeyAlgorithm: "ES256",
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+            })
+        ).rejects.toMatchObject(
+            createClientAuthError(
+                ClientAuthErrorCodes.methodNotImplemented,
+                TEST_CONFIG.CORRELATION_ID
+            )
+        );
+        await expect(
+            emptyConfig.tokenBindingKeyManager.removeTokenBindingKey(
+                "kid",
+                TEST_CONFIG.CORRELATION_ID
+            )
+        ).rejects.toMatchObject(
+            createClientAuthError(
+                ClientAuthErrorCodes.methodNotImplemented,
+                TEST_CONFIG.CORRELATION_ID
+            )
+        );
+        await expect(
+            emptyConfig.tokenBindingKeyManager.getTokenBindingPublicKeyJwk(
+                "kid",
+                TEST_CONFIG.CORRELATION_ID
+            )
+        ).rejects.toMatchObject(
+            createClientAuthError(
+                ClientAuthErrorCodes.methodNotImplemented,
+                TEST_CONFIG.CORRELATION_ID
+            )
+        );
+    });
+
     const cacheStorageMock = new MockStorageClass(
         TEST_CONFIG.MSAL_CLIENT_ID,
         mockCrypto,

--- a/lib/msal-common/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-common/test/config/ClientConfiguration.spec.ts
@@ -161,6 +161,16 @@ describe("ClientConfiguration.ts Class Unit Tests", () => {
                 TEST_CONFIG.CORRELATION_ID
             )
         );
+        await expect(
+            emptyConfig.cryptoInterface.clearKeystore(
+                TEST_CONFIG.CORRELATION_ID
+            )
+        ).rejects.toMatchObject(
+            createClientAuthError(
+                ClientAuthErrorCodes.methodNotImplemented,
+                TEST_CONFIG.CORRELATION_ID
+            )
+        );
     });
 
     const cacheStorageMock = new MockStorageClass(

--- a/lib/msal-common/test/crypto/DpopProofGenerator.spec.ts
+++ b/lib/msal-common/test/crypto/DpopProofGenerator.spec.ts
@@ -8,10 +8,14 @@ import {
     DPOP_JWT_HEADER_TYPE,
     DpopProofClaims,
     DpopProofHeader,
-    DpopProofSigner,
     DpopProofGenerator,
+    ITokenBindingJwtSigner,
 } from "../../src/crypto/DpopProofGenerator.js";
 import { ICrypto } from "../../src/crypto/ICrypto.js";
+import {
+    ITokenBindingKeyManager,
+    TokenBindingKeyContext,
+} from "../../src/crypto/ITokenBindingKeyManager.js";
 import * as TimeUtils from "../../src/utils/TimeUtils.js";
 import { ClientConfigurationErrorCodes } from "../../src/error/ClientConfigurationError.js";
 import crypto from "crypto";
@@ -24,7 +28,15 @@ import {
 
 describe("DpopProofGenerator Unit Tests", () => {
     let generator: DpopProofGenerator;
-    const cryptoInterface: ICrypto = { ...mockCrypto };
+    const cryptoInterface: ICrypto & ITokenBindingJwtSigner = {
+        ...mockCrypto,
+        signTokenBindingJwt: jest.fn(),
+    };
+    const tokenBindingKeyManager: ITokenBindingKeyManager = {
+        provisionTokenBindingKey: jest.fn(),
+        removeTokenBindingKey: jest.fn(),
+        getTokenBindingPublicKeyJwk: jest.fn(),
+    };
     const publicJwk = {
         kty: "EC",
         crv: "P-256",
@@ -32,19 +44,29 @@ describe("DpopProofGenerator Unit Tests", () => {
         y: "B".repeat(43),
     };
     const dpopSignature = "A".repeat(86);
-
-    function createSigner(
-        sign: jest.Mock = jest.fn().mockResolvedValue(dpopSignature),
-        alg: string = DPOP_JWT_HEADER_ALGORITHM
-    ): DpopProofSigner {
-        return {
-            alg,
-            sign,
-        };
-    }
+    const dpopKeyId = "dpop-key-id";
+    const dpopKeyContext: TokenBindingKeyContext = {
+        keyScope: `dpop.${TEST_CONFIG.MSAL_CLIENT_ID}.${TEST_CONFIG.validAuthority}`,
+    };
 
     beforeEach(() => {
-        generator = new DpopProofGenerator(cryptoInterface);
+        generator = new DpopProofGenerator(
+            cryptoInterface,
+            tokenBindingKeyManager
+        );
+        jest.spyOn(
+            tokenBindingKeyManager,
+            "getTokenBindingPublicKeyJwk"
+        ).mockResolvedValue(publicJwk);
+        jest.spyOn(cryptoInterface, "signTokenBindingJwt").mockImplementation(
+            async (header, payload) => {
+                return `${cryptoInterface.base64UrlEncode(
+                    JSON.stringify(header)
+                )}.${cryptoInterface.base64UrlEncode(
+                    JSON.stringify(payload)
+                )}.${dpopSignature}`;
+            }
+        );
     });
 
     afterEach(() => {
@@ -70,6 +92,30 @@ describe("DpopProofGenerator Unit Tests", () => {
             signature,
         };
     }
+
+    describe("generateJkt", () => {
+        it("provisions a DPoP ES256 key and returns the generated JWK thumbprint", async () => {
+            const provisionTokenBindingKeySpy = jest
+                .spyOn(tokenBindingKeyManager, "provisionTokenBindingKey")
+                .mockResolvedValue(dpopKeyId);
+
+            const dpopJkt = await generator.generateJkt(
+                {
+                    clientId: TEST_CONFIG.MSAL_CLIENT_ID,
+                    authority: TEST_CONFIG.validAuthority,
+                },
+                TEST_CONFIG.CORRELATION_ID
+            );
+
+            expect(dpopJkt).toBe(dpopKeyId);
+            expect(provisionTokenBindingKeySpy).toHaveBeenCalledWith({
+                tokenBindingKeyType: "dpop",
+                tokenBindingKeyAlgorithm: DPOP_JWT_HEADER_ALGORITHM,
+                keyScope: `dpop.${TEST_CONFIG.MSAL_CLIENT_ID}.${TEST_CONFIG.validAuthority}`,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+            });
+        });
+    });
 
     describe("buildTokenProofClaims", () => {
         it("UT-01: Token-endpoint DPoP proof uses RFC 9449 claims (htm=POST, normalized htu, iat, jti)", () => {
@@ -535,8 +581,6 @@ describe("DpopProofGenerator Unit Tests", () => {
     describe("generateTokenProof", () => {
         it("builds and signs a compact DPoP proof JWT for token requests", async () => {
             const currTime = TimeUtils.nowSeconds();
-            const sign = jest.fn().mockResolvedValue(dpopSignature);
-            const signer = createSigner(sign);
             jest.spyOn(TimeUtils, "nowSeconds").mockReturnValue(currTime);
 
             const proof = await generator.generateTokenProof(
@@ -544,8 +588,8 @@ describe("DpopProofGenerator Unit Tests", () => {
                     tokenEndpoint:
                         "https://login.microsoftonline.com/tenant/oauth2/v2.0/token?client_id=abc",
                     nonce: "server-nonce",
-                    publicJwk,
-                    signer,
+                    keyId: dpopKeyId,
+                    keyContext: dpopKeyContext,
                 },
                 TEST_CONFIG.CORRELATION_ID
             );
@@ -563,55 +607,52 @@ describe("DpopProofGenerator Unit Tests", () => {
                 iat: currTime,
                 nonce: "server-nonce",
             });
-            expect(signer.sign).toHaveBeenCalledWith(
-                decodedProof.signingInput,
-                TEST_CONFIG.CORRELATION_ID
+            expect(
+                tokenBindingKeyManager.getTokenBindingPublicKeyJwk
+            ).toHaveBeenCalledWith(
+                dpopKeyId,
+                TEST_CONFIG.CORRELATION_ID,
+                dpopKeyContext
+            );
+            expect(cryptoInterface.signTokenBindingJwt).toHaveBeenCalledWith(
+                decodedProof.header,
+                decodedProof.claims,
+                dpopKeyId,
+                TEST_CONFIG.CORRELATION_ID,
+                dpopKeyContext
             );
             expect(decodedProof.signature).toBe(dpopSignature);
         });
 
-        it("uses the DPoP proof header algorithm declared by the signer", async () => {
+        it("uses the DPoP proof header algorithm", async () => {
             const proof = await generator.generateTokenProof({
                 tokenEndpoint:
                     "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
-                publicJwk,
-                signer: createSigner(
-                    jest.fn().mockResolvedValue(dpopSignature),
-                    "custom-alg"
-                ),
+                keyId: dpopKeyId,
+                keyContext: dpopKeyContext,
             });
             const decodedProof = decodeDpopProof(proof);
 
-            expect(decodedProof.header.alg).toBe("custom-alg");
+            expect(decodedProof.header.alg).toBe(DPOP_JWT_HEADER_ALGORITHM);
         });
 
-        it("passes signer-declared alg and matching public JWK through", async () => {
-            const rsaPublicJwk = {
-                kty: "RSA",
-                n: "test-modulus",
-                e: "AQAB",
-            };
+        it("uses the public JWK resolved from the token-binding key", async () => {
             const proof = await generator.generateTokenProof({
                 tokenEndpoint:
                     "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
-                publicJwk: rsaPublicJwk,
-                signer: createSigner(
-                    jest.fn().mockResolvedValue(dpopSignature),
-                    "PS256"
-                ),
+                keyId: dpopKeyId,
+                keyContext: dpopKeyContext,
             });
             const decodedProof = decodeDpopProof(proof);
 
-            expect(decodedProof.header.alg).toBe("PS256");
-            expect(decodedProof.header.jwk).toEqual(rsaPublicJwk);
+            expect(decodedProof.header.alg).toBe(DPOP_JWT_HEADER_ALGORITHM);
+            expect(decodedProof.header.jwk).toEqual(publicJwk);
         });
     });
 
     describe("generateResourceProof", () => {
         it("builds and signs a compact DPoP proof JWT for resource requests", async () => {
             const currTime = TimeUtils.nowSeconds();
-            const sign = jest.fn().mockResolvedValue(dpopSignature);
-            const signer = createSigner(sign);
             jest.spyOn(TimeUtils, "nowSeconds").mockReturnValue(currTime);
 
             const proof = await generator.generateResourceProof(
@@ -621,8 +662,8 @@ describe("DpopProofGenerator Unit Tests", () => {
                     htm: "get",
                     ath: TEST_DPOP_VALUES.ACCESS_TOKEN_ATH,
                     nonce: "resource-nonce",
-                    publicJwk,
-                    signer,
+                    keyId: dpopKeyId,
+                    keyContext: dpopKeyContext,
                 },
                 TEST_CONFIG.CORRELATION_ID
             );
@@ -641,9 +682,19 @@ describe("DpopProofGenerator Unit Tests", () => {
                 iat: currTime,
                 nonce: "resource-nonce",
             });
-            expect(signer.sign).toHaveBeenCalledWith(
-                decodedProof.signingInput,
-                TEST_CONFIG.CORRELATION_ID
+            expect(
+                tokenBindingKeyManager.getTokenBindingPublicKeyJwk
+            ).toHaveBeenCalledWith(
+                dpopKeyId,
+                TEST_CONFIG.CORRELATION_ID,
+                dpopKeyContext
+            );
+            expect(cryptoInterface.signTokenBindingJwt).toHaveBeenCalledWith(
+                decodedProof.header,
+                decodedProof.claims,
+                dpopKeyId,
+                TEST_CONFIG.CORRELATION_ID,
+                dpopKeyContext
             );
             expect(decodedProof.signature).toBe(dpopSignature);
         });
@@ -652,13 +703,16 @@ describe("DpopProofGenerator Unit Tests", () => {
     describe("jti uniqueness (UT-03, RT-01)", () => {
         it("UT-03: jti values are unique across consecutive token proof builds", () => {
             let callCount = 0;
-            const uniqueGuidCrypto: ICrypto = {
+            const uniqueGuidCrypto: ICrypto & ITokenBindingJwtSigner = {
                 ...cryptoInterface,
                 createNewGuid(): string {
                     return `unique-jti-${++callCount}`;
                 },
             };
-            const uniqueGenerator = new DpopProofGenerator(uniqueGuidCrypto);
+            const uniqueGenerator = new DpopProofGenerator(
+                uniqueGuidCrypto,
+                tokenBindingKeyManager
+            );
             const endpoint =
                 "https://login.microsoftonline.com/common/oauth2/v2.0/token";
 
@@ -699,13 +753,16 @@ describe("DpopProofGenerator Unit Tests", () => {
 
         it("UT-03: resource proof jti values are unique across consecutive builds", () => {
             let callCount = 0;
-            const uniqueGuidCrypto: ICrypto = {
+            const uniqueGuidCrypto: ICrypto & ITokenBindingJwtSigner = {
                 ...cryptoInterface,
                 createNewGuid(): string {
                     return `res-unique-jti-${++callCount}`;
                 },
             };
-            const uniqueGenerator = new DpopProofGenerator(uniqueGuidCrypto);
+            const uniqueGenerator = new DpopProofGenerator(
+                uniqueGuidCrypto,
+                tokenBindingKeyManager
+            );
 
             const proof1 = uniqueGenerator.buildResourceProofClaims(
                 {

--- a/lib/msal-common/test/crypto/JoseHeader.spec.ts
+++ b/lib/msal-common/test/crypto/JoseHeader.spec.ts
@@ -3,6 +3,7 @@ import { JoseHeaderErrorCodes } from "../../src/error/JoseHeaderError";
 import { JsonWebTokenTypes } from "../../src/utils/Constants";
 import {
     TEST_CRYPTO_ALGORITHMS,
+    TEST_CONFIG,
     TEST_POP_VALUES,
 } from "../test_kit/StringConstants";
 import { getDefaultErrorMessage } from "../../src/error/AuthError.js";
@@ -44,6 +45,24 @@ describe("JoseHeader.ts Unit Tests", () => {
             );
         });
 
+        it("should include correlationId in missing kid errors when provided", () => {
+            try {
+                JoseHeader.getShrHeader(
+                    {
+                        alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                        typ: JsonWebTokenTypes.Pop,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                );
+                throw new Error("Expected getShrHeader to throw");
+            } catch (e) {
+                expect(e).toHaveProperty(
+                    "correlationId",
+                    TEST_CONFIG.CORRELATION_ID
+                );
+            }
+        });
+
         it("should throw if alg header is missing", () => {
             expect(() =>
                 JoseHeader.getShrHeaderString({
@@ -52,6 +71,57 @@ describe("JoseHeader.ts Unit Tests", () => {
                 })
             ).toThrowError(
                 getDefaultErrorMessage(JoseHeaderErrorCodes.missingAlgError)
+            );
+        });
+    });
+
+    describe("getDpopHeader", () => {
+        it("should return a DPoP header with the provided JWK", () => {
+            const jwk = {
+                kty: "EC",
+                crv: "P-256",
+                x: "A".repeat(43),
+                y: "B".repeat(43),
+            };
+            const dpopHeader = JoseHeader.getDpopHeader({
+                alg: "ES256",
+                jwk,
+            });
+
+            expect(dpopHeader).toEqual(
+                new JoseHeader({
+                    typ: JsonWebTokenTypes.Dpop,
+                    alg: "ES256",
+                    jwk,
+                })
+            );
+        });
+
+        it("should include correlationId in missing jwk errors when provided", () => {
+            try {
+                JoseHeader.getDpopHeader(
+                    {
+                        alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                    },
+                    TEST_CONFIG.CORRELATION_ID
+                );
+                throw new Error("Expected getDpopHeader to throw");
+            } catch (e) {
+                expect(e).toHaveProperty(
+                    "correlationId",
+                    TEST_CONFIG.CORRELATION_ID
+                );
+            }
+        });
+
+        it("should throw if DPoP public JWK is empty", () => {
+            expect(() =>
+                JoseHeader.getDpopHeader({
+                    alg: "ES256",
+                    jwk: {},
+                })
+            ).toThrowError(
+                getDefaultErrorMessage(JoseHeaderErrorCodes.invalidJwkError)
             );
         });
     });

--- a/lib/msal-common/test/crypto/JoseHeader.spec.ts
+++ b/lib/msal-common/test/crypto/JoseHeader.spec.ts
@@ -9,34 +9,60 @@ import {
 import { getDefaultErrorMessage } from "../../src/error/AuthError.js";
 
 describe("JoseHeader.ts Unit Tests", () => {
-    describe("getShrHeaderString", () => {
-        it("should return the correct stringified header", () => {
-            const shrHeaderString = JoseHeader.getShrHeaderString({
+    describe("getShrHeader", () => {
+        it("should return the correct header", () => {
+            const shrHeader = JoseHeader.getShrHeader({
                 alg: TEST_CRYPTO_ALGORITHMS.rsa,
                 kid: TEST_POP_VALUES.KID,
                 typ: JsonWebTokenTypes.Pop,
             });
 
-            expect(shrHeaderString).toBe(
-                `{"typ":"${JsonWebTokenTypes.Pop}","alg":"${TEST_CRYPTO_ALGORITHMS.rsa}","kid":"${TEST_POP_VALUES.KID}"}`
+            expect(shrHeader).toEqual(
+                new JoseHeader({
+                    typ: JsonWebTokenTypes.Pop,
+                    alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                    kid: TEST_POP_VALUES.KID,
+                })
             );
         });
 
         it("should override the typ header if provided", () => {
-            const shrHeaderString = JoseHeader.getShrHeaderString({
+            const shrHeader = JoseHeader.getShrHeader({
                 alg: TEST_CRYPTO_ALGORITHMS.rsa,
                 kid: TEST_POP_VALUES.KID,
                 typ: JsonWebTokenTypes.Jwt,
             });
 
-            expect(shrHeaderString).toBe(
-                `{"typ":"${JsonWebTokenTypes.Jwt}","alg":"${TEST_CRYPTO_ALGORITHMS.rsa}","kid":"${TEST_POP_VALUES.KID}"}`
+            expect(shrHeader).toEqual(
+                new JoseHeader({
+                    typ: JsonWebTokenTypes.Jwt,
+                    alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                    kid: TEST_POP_VALUES.KID,
+                })
+            );
+        });
+
+        it("should drop unsupported SHR header members", () => {
+            const shrHeader = JoseHeader.getShrHeader({
+                alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                kid: TEST_POP_VALUES.KID,
+                typ: JsonWebTokenTypes.Pop,
+                crit: ["x-test"],
+                "x-test": true,
+            } as any);
+
+            expect(shrHeader).toEqual(
+                new JoseHeader({
+                    typ: JsonWebTokenTypes.Pop,
+                    alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                    kid: TEST_POP_VALUES.KID,
+                })
             );
         });
 
         it("should throw if kid header is missing", () => {
             expect(() =>
-                JoseHeader.getShrHeaderString({
+                JoseHeader.getShrHeader({
                     alg: TEST_CRYPTO_ALGORITHMS.rsa,
                     typ: JsonWebTokenTypes.Pop,
                 })
@@ -63,9 +89,21 @@ describe("JoseHeader.ts Unit Tests", () => {
             }
         });
 
+        it("should throw if kid header is not a string", () => {
+            expect(() =>
+                JoseHeader.getShrHeader({
+                    alg: TEST_CRYPTO_ALGORITHMS.rsa,
+                    kid: 123,
+                    typ: JsonWebTokenTypes.Pop,
+                } as any)
+            ).toThrowError(
+                getDefaultErrorMessage(JoseHeaderErrorCodes.missingKidError)
+            );
+        });
+
         it("should throw if alg header is missing", () => {
             expect(() =>
-                JoseHeader.getShrHeaderString({
+                JoseHeader.getShrHeader({
                     kid: TEST_POP_VALUES.KID,
                     typ: JsonWebTokenTypes.Pop,
                 })
@@ -87,6 +125,30 @@ describe("JoseHeader.ts Unit Tests", () => {
                 alg: "ES256",
                 jwk,
             });
+
+            expect(dpopHeader).toEqual(
+                new JoseHeader({
+                    typ: JsonWebTokenTypes.Dpop,
+                    alg: "ES256",
+                    jwk,
+                })
+            );
+        });
+
+        it("should drop unsupported DPoP header members", () => {
+            const jwk = {
+                kty: "EC",
+                crv: "P-256",
+                x: "A".repeat(43),
+                y: "B".repeat(43),
+            };
+            const dpopHeader = JoseHeader.getDpopHeader({
+                alg: "ES256",
+                typ: JsonWebTokenTypes.Dpop,
+                jwk,
+                crit: ["x-test"],
+                "x-test": true,
+            } as any);
 
             expect(dpopHeader).toEqual(
                 new JoseHeader({
@@ -122,6 +184,18 @@ describe("JoseHeader.ts Unit Tests", () => {
                 })
             ).toThrowError(
                 getDefaultErrorMessage(JoseHeaderErrorCodes.invalidJwkError)
+            );
+        });
+
+        it("should throw if DPoP public JWK is not an object", () => {
+            expect(() =>
+                JoseHeader.getDpopHeader({
+                    alg: "ES256",
+                    typ: JsonWebTokenTypes.Dpop,
+                    jwk: "not-a-jwk",
+                } as any)
+            ).toThrowError(
+                getDefaultErrorMessage(JoseHeaderErrorCodes.missingJwkError)
             );
         });
     });

--- a/lib/msal-common/test/crypto/JoseHeader.spec.ts
+++ b/lib/msal-common/test/crypto/JoseHeader.spec.ts
@@ -111,6 +111,19 @@ describe("JoseHeader.ts Unit Tests", () => {
                 getDefaultErrorMessage(JoseHeaderErrorCodes.missingAlgError)
             );
         });
+
+        it("should throw if alg header is empty during direct construction", () => {
+            expect(
+                () =>
+                    new JoseHeader({
+                        typ: JsonWebTokenTypes.Pop,
+                        alg: "",
+                        kid: TEST_POP_VALUES.KID,
+                    })
+            ).toThrowError(
+                getDefaultErrorMessage(JoseHeaderErrorCodes.missingAlgError)
+            );
+        });
     });
 
     describe("getDpopHeader", () => {

--- a/lib/msal-common/test/crypto/PopTokenGenerator.spec.ts
+++ b/lib/msal-common/test/crypto/PopTokenGenerator.spec.ts
@@ -10,10 +10,10 @@ import { BaseAuthRequest } from "../../src/request/BaseAuthRequest.js";
 import * as TimeUtils from "../../src/utils/TimeUtils.js";
 import { UrlString } from "../../src/url/UrlString.js";
 import { AuthenticationScheme } from "../../src/utils/Constants.js";
-import { SignedHttpRequest } from "../../src/crypto/SignedHttpRequest.js";
 import { Logger } from "../../src/logger/Logger.js";
 import { mockCrypto } from "../client/ClientTestUtils.js";
 import { StubPerformanceClient } from "../../src/index.js";
+import { ITokenBindingKeyManager } from "../../src/crypto/ITokenBindingKeyManager.js";
 
 describe("PopTokenGenerator Unit Tests", () => {
     afterEach(() => {
@@ -21,6 +21,16 @@ describe("PopTokenGenerator Unit Tests", () => {
     });
 
     const cryptoInterface: ICrypto = mockCrypto;
+    const tokenBindingKeyManager: ITokenBindingKeyManager = {
+        provisionTokenBindingKey: jest
+            .fn()
+            .mockResolvedValue(TEST_POP_VALUES.KID),
+        removeTokenBindingKey: jest.fn().mockResolvedValue(undefined),
+        getTokenBindingPublicKeyJwk: jest.fn().mockResolvedValue({
+            kty: "RSA",
+            alg: "RS256",
+        }),
+    };
 
     describe("generateCnf", () => {
         const testRequest = {
@@ -33,12 +43,22 @@ describe("PopTokenGenerator Unit Tests", () => {
         it("Generates the req_cnf correctly", async () => {
             const popTokenGenerator = new PopTokenGenerator(
                 cryptoInterface,
+                tokenBindingKeyManager,
                 new StubPerformanceClient()
+            );
+            const provisionTokenBindingKeySpy = jest.spyOn(
+                tokenBindingKeyManager,
+                "provisionTokenBindingKey"
             );
             const reqCnfData = await popTokenGenerator.generateCnf(
                 testRequest,
                 new Logger({})
             );
+            expect(provisionTokenBindingKeySpy).toHaveBeenCalledWith({
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+                tokenBindingKeyType: "shr",
+                tokenBindingKeyAlgorithm: "RS256",
+            });
             expect(reqCnfData.reqCnfString).toBe(
                 TEST_POP_VALUES.ENCODED_REQ_CNF
             );
@@ -63,6 +83,7 @@ describe("PopTokenGenerator Unit Tests", () => {
         it("Signs the proof-of-possession JWT token with all PoP parameters in the request", (done) => {
             const popTokenGenerator = new PopTokenGenerator(
                 cryptoInterface,
+                tokenBindingKeyManager,
                 new StubPerformanceClient()
             );
             const accessToken = TEST_POP_VALUES.SAMPLE_POP_AT;
@@ -84,10 +105,10 @@ describe("PopTokenGenerator Unit Tests", () => {
                 shrNonce: shrNonce,
             };
 
-            cryptoInterface.signJwt = (
-                payload: SignedHttpRequest,
-                kid: string
-            ): Promise<string> => {
+            jest.spyOn(
+                cryptoInterface,
+                "signTokenBindingJwt"
+            ).mockImplementation((header, payload, kid, correlationId) => {
                 expect(kid).toBe(TEST_POP_VALUES.KID);
                 const expectedPayload = {
                     at: accessToken,
@@ -98,12 +119,26 @@ describe("PopTokenGenerator Unit Tests", () => {
                     p: resourceUrlComponents.AbsolutePath,
                     q: [[], resourceUrlComponents.QueryString],
                     client_claims: shrClaims,
+                    cnf: {
+                        jwk: {
+                            kty: "RSA",
+                            alg: "RS256",
+                        },
+                    },
                 };
 
+                expect(header).toEqual({
+                    typ: "pop",
+                    alg: "RS256",
+                    kid: cryptoInterface.base64UrlEncode(
+                        JSON.stringify({ kid: TEST_POP_VALUES.KID })
+                    ),
+                });
                 expect(payload).toEqual(expectedPayload);
+                expect(correlationId).toBe(TEST_CONFIG.CORRELATION_ID);
                 done();
                 return Promise.resolve("");
-            };
+            });
             popTokenGenerator.signPopToken(
                 accessToken,
                 TEST_POP_VALUES.KID,
@@ -114,14 +149,15 @@ describe("PopTokenGenerator Unit Tests", () => {
         it("Signs the proof-of-possession JWT token when PoP parameters are undefined", (done) => {
             const popTokenGenerator = new PopTokenGenerator(
                 cryptoInterface,
+                tokenBindingKeyManager,
                 new StubPerformanceClient()
             );
             const accessToken = TEST_POP_VALUES.SAMPLE_POP_AT;
             const currTime = TimeUtils.nowSeconds();
-            cryptoInterface.signJwt = (
-                payload: SignedHttpRequest,
-                kid: string
-            ): Promise<string> => {
+            jest.spyOn(
+                cryptoInterface,
+                "signTokenBindingJwt"
+            ).mockImplementation((header, payload, kid, correlationId) => {
                 expect(kid).toBe(TEST_POP_VALUES.KID);
                 const expectedPayload = {
                     at: accessToken,
@@ -132,17 +168,73 @@ describe("PopTokenGenerator Unit Tests", () => {
                     p: undefined,
                     q: undefined,
                     client_claims: undefined,
+                    cnf: {
+                        jwk: {
+                            kty: "RSA",
+                            alg: "RS256",
+                        },
+                    },
                 };
 
+                expect(header).toEqual({
+                    typ: "pop",
+                    alg: "RS256",
+                    kid: cryptoInterface.base64UrlEncode(
+                        JSON.stringify({ kid: TEST_POP_VALUES.KID })
+                    ),
+                });
                 expect(payload).toEqual(expectedPayload);
+                expect(correlationId).toBe(TEST_CONFIG.CORRELATION_ID);
                 done();
                 return Promise.resolve("");
-            };
+            });
             popTokenGenerator.signPopToken(
                 accessToken,
                 TEST_POP_VALUES.KID,
                 testRequest
             );
+        });
+
+        it("falls back to caller and default SHR algorithms when public JWK alg is missing", async () => {
+            const popTokenGenerator = new PopTokenGenerator(
+                cryptoInterface,
+                tokenBindingKeyManager,
+                new StubPerformanceClient()
+            );
+            jest.spyOn(
+                tokenBindingKeyManager,
+                "getTokenBindingPublicKeyJwk"
+            ).mockResolvedValue({
+                kty: "RSA",
+            });
+            const signTokenBindingJwtSpy = jest
+                .spyOn(cryptoInterface, "signTokenBindingJwt")
+                .mockResolvedValue("");
+
+            await popTokenGenerator.signPopToken(
+                TEST_POP_VALUES.SAMPLE_POP_AT,
+                TEST_POP_VALUES.KID,
+                {
+                    ...testRequest,
+                    shrOptions: {
+                        header: {
+                            alg: "RS256",
+                        },
+                    },
+                }
+            );
+            expect(signTokenBindingJwtSpy.mock.calls[0][0]).toMatchObject({
+                alg: "RS256",
+            });
+
+            await popTokenGenerator.signPopToken(
+                TEST_POP_VALUES.SAMPLE_POP_AT,
+                TEST_POP_VALUES.KID,
+                testRequest
+            );
+            expect(signTokenBindingJwtSpy.mock.calls[1][0]).toMatchObject({
+                alg: "RS256",
+            });
         });
     });
 });

--- a/lib/msal-common/test/response/ResponseHandler.spec.ts
+++ b/lib/msal-common/test/response/ResponseHandler.spec.ts
@@ -35,7 +35,11 @@ import { ServerAuthorizationTokenResponse } from "../../src/response/ServerAutho
 import { StubPerformanceClient } from "../../src/telemetry/performance/StubPerformanceClient.js";
 import { AuthenticationScheme } from "../../src/utils/Constants.js";
 import * as TimeUtils from "../../src/utils/TimeUtils.js";
-import { mockCrypto, MockStorageClass } from "../client/ClientTestUtils.js";
+import {
+    mockCrypto,
+    mockShrTokenBindingKeyManager,
+    MockStorageClass,
+} from "../client/ClientTestUtils.js";
 import {
     AUTHENTICATION_RESULT,
     ID_TOKEN_CLAIMS,
@@ -542,17 +546,7 @@ describe("ResponseHandler.ts", () => {
                 ResponseHandler,
                 "generateAuthenticationResult"
             ).mockImplementation(
-                async (
-                    _cryptoObj,
-                    _authority,
-                    cacheRecord,
-                    _fromTokenCache,
-                    _request,
-                    _idTokenClaims,
-                    _requestState,
-                    _serverTokenResponse,
-                    _requestId
-                ) => {
+                async (_cryptoObj, _authority, cacheRecord) => {
                     expect(cacheRecord.accessToken?.realm).toBeDefined();
 
                     done();
@@ -639,7 +633,8 @@ describe("ResponseHandler.ts", () => {
                 logger,
                 stubPerformanceClient,
                 null,
-                null
+                null,
+                mockShrTokenBindingKeyManager
             );
             const timestamp = TimeUtils.nowSeconds();
             const result = await responseHandler.handleServerTokenResponse(

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -173,10 +173,9 @@ export class CryptoProvider implements ICrypto {
     createNewGuid(): string;
     encodeKid(): string;
     generatePkceCodes(): Promise<PkceCodes>;
-    getPublicKeyThumbprint(): Promise<string>;
     hashString(plainText: string): Promise<string>;
     removeTokenBindingKey(): Promise<void>;
-    signJwt(): Promise<string>;
+    signTokenBindingJwt(): Promise<string>;
 }
 
 // @internal

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -169,7 +169,7 @@ export class CryptoProvider implements ICrypto {
     base64Decode(input: string): string;
     base64Encode(input: string): string;
     base64UrlEncode(): string;
-    clearKeystore(): Promise<boolean>;
+    clearKeystore(correlationId: string): Promise<boolean>;
     createNewGuid(): string;
     encodeKid(): string;
     generatePkceCodes(): Promise<PkceCodes>;

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -58,7 +58,7 @@ import { LoggerOptions } from '@azure/msal-common/node';
 import { LogLevel } from '@azure/msal-common/node';
 import { NetworkRequestOptions } from '@azure/msal-common/node';
 import { NetworkResponse } from '@azure/msal-common/node';
-import { PkceCodes } from '@azure/msal-common/node';
+import type { PkceCodes } from '@azure/msal-common/node';
 import { ProtocolMode } from '@azure/msal-common/node';
 import { RefreshTokenCache } from '@azure/msal-common/node';
 import { RefreshTokenEntity } from '@azure/msal-common/node';
@@ -68,6 +68,7 @@ import { ServerTelemetryManager } from '@azure/msal-common/node';
 import { StaticAuthorityOptions } from '@azure/msal-common/node';
 import { StringDict } from '@azure/msal-common/node';
 import { ThrottlingEntity } from '@azure/msal-common/node';
+import type { TokenBindingKeyContext } from '@azure/msal-common/node';
 import { TokenCacheContext } from '@azure/msal-common/node';
 import { TokenKeys } from '@azure/msal-common/node';
 import { ValidCacheType } from '@azure/msal-common/node';
@@ -175,7 +176,7 @@ export class CryptoProvider implements ICrypto {
     generatePkceCodes(): Promise<PkceCodes>;
     hashString(plainText: string): Promise<string>;
     removeTokenBindingKey(): Promise<void>;
-    signTokenBindingJwt(): Promise<string>;
+    signTokenBindingJwt(header: object, payload: object, kid: string, correlationId: string, context?: TokenBindingKeyContext): Promise<string>;
 }
 
 // @internal

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -221,7 +221,10 @@ export class ClientCredentialClient extends BaseClient {
                 },
                 true,
                 request,
-                this.performanceClient
+                this.performanceClient,
+                {
+                    tokenBindingKeyManager: this.config.tokenBindingKeyManager,
+                }
             ),
             lastCacheOutcome,
         ];
@@ -353,7 +356,8 @@ export class ClientCredentialClient extends BaseClient {
             this.logger,
             this.performanceClient,
             this.config.serializableCache,
-            this.config.persistencePlugin
+            this.config.persistencePlugin,
+            this.config.tokenBindingKeyManager
         );
 
         responseHandler.validateTokenResponse(

--- a/lib/msal-node/src/client/DeviceCodeClient.ts
+++ b/lib/msal-node/src/client/DeviceCodeClient.ts
@@ -58,7 +58,8 @@ export class DeviceCodeClient extends BaseClient {
             this.logger,
             this.performanceClient,
             this.config.serializableCache,
-            this.config.persistencePlugin
+            this.config.persistencePlugin,
+            this.config.tokenBindingKeyManager
         );
 
         // Validate response. This function throws a server error if an error is returned by the server.

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -177,7 +177,10 @@ export class OnBehalfOfClient extends BaseClient {
             true,
             request,
             this.performanceClient,
-            idTokenClaims
+            {
+                idTokenClaims,
+                tokenBindingKeyManager: this.config.tokenBindingKeyManager,
+            }
         );
     }
 
@@ -308,7 +311,8 @@ export class OnBehalfOfClient extends BaseClient {
             this.logger,
             this.performanceClient,
             this.config.serializableCache,
-            this.config.persistencePlugin
+            this.config.persistencePlugin,
+            this.config.tokenBindingKeyManager
         );
 
         responseHandler.validateTokenResponse(

--- a/lib/msal-node/src/client/UserFederatedIdentityCredentialClient.ts
+++ b/lib/msal-node/src/client/UserFederatedIdentityCredentialClient.ts
@@ -98,7 +98,8 @@ export class UserFederatedIdentityCredentialClient extends BaseClient {
             this.logger,
             this.performanceClient,
             this.config.serializableCache,
-            this.config.persistencePlugin
+            this.config.persistencePlugin,
+            this.config.tokenBindingKeyManager
         );
 
         responseHandler.validateTokenResponse(

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -62,7 +62,8 @@ export class UsernamePasswordClient extends BaseClient {
             this.logger,
             this.performanceClient,
             this.config.serializableCache,
-            this.config.persistencePlugin
+            this.config.persistencePlugin,
+            this.config.tokenBindingKeyManager
         );
 
         // Validate response. This function throws a server error if an error is returned by the server.

--- a/lib/msal-node/src/crypto/CryptoProvider.ts
+++ b/lib/msal-node/src/crypto/CryptoProvider.ts
@@ -82,8 +82,10 @@ export class CryptoProvider implements ICrypto {
 
     /**
      * Removes all cryptographic keys from Keystore
+     * @param correlationId - correlation id
      */
-    clearKeystore(): Promise<boolean> {
+    clearKeystore(correlationId: string): Promise<boolean> {
+        void correlationId;
         throw new Error("Method not implemented.");
     }
 

--- a/lib/msal-node/src/crypto/CryptoProvider.ts
+++ b/lib/msal-node/src/crypto/CryptoProvider.ts
@@ -73,13 +73,6 @@ export class CryptoProvider implements ICrypto {
     }
 
     /**
-     * Generates a keypair, stores it and returns a thumbprint - not yet implemented for node
-     */
-    getPublicKeyThumbprint(): Promise<string> {
-        throw new Error("Method not implemented.");
-    }
-
-    /**
      * Removes cryptographic keypair from key store matching the keyId passed in
      * @param kid - public key id
      */
@@ -95,9 +88,9 @@ export class CryptoProvider implements ICrypto {
     }
 
     /**
-     * Signs the given object as a jwt payload with private key retrieved by given kid - currently not implemented for node
+     * Signs a compact JWT with a token-binding key - not yet implemented for node
      */
-    signJwt(): Promise<string> {
+    signTokenBindingJwt(): Promise<string> {
         throw new Error("Method not implemented.");
     }
 

--- a/lib/msal-node/src/crypto/CryptoProvider.ts
+++ b/lib/msal-node/src/crypto/CryptoProvider.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { Constants, ICrypto, PkceCodes } from "@azure/msal-common/node";
+import { Constants } from "@azure/msal-common/node";
+import type {
+    ICrypto,
+    PkceCodes,
+    TokenBindingKeyContext,
+} from "@azure/msal-common/node";
 import { GuidGenerator } from "./GuidGenerator.js";
 import { EncodingUtils } from "../utils/EncodingUtils.js";
 import { PkceGenerator } from "./PkceGenerator.js";
@@ -91,8 +96,24 @@ export class CryptoProvider implements ICrypto {
 
     /**
      * Signs a compact JWT with a token-binding key - not yet implemented for node
+     * @param header - JOSE header
+     * @param payload - JWT payload
+     * @param kid - public key id
+     * @param correlationId - correlation id
+     * @param context - token-binding key context
      */
-    signTokenBindingJwt(): Promise<string> {
+    signTokenBindingJwt(
+        header: object,
+        payload: object,
+        kid: string,
+        correlationId: string,
+        context?: TokenBindingKeyContext
+    ): Promise<string> {
+        void header;
+        void payload;
+        void kid;
+        void correlationId;
+        void context;
         throw new Error("Method not implemented.");
     }
 

--- a/lib/msal-node/test/client/ClientTestUtils.ts
+++ b/lib/msal-node/test/client/ClientTestUtils.ts
@@ -264,13 +264,10 @@ export const mockCrypto = {
             verifier: TEST_CONFIG.TEST_VERIFIER,
         };
     },
-    async getPublicKeyThumbprint(): Promise<string> {
-        return TEST_POP_VALUES.KID;
-    },
     async removeTokenBindingKey(): Promise<void> {
         return Promise.resolve();
     },
-    async signJwt(): Promise<string> {
+    async signTokenBindingJwt(): Promise<string> {
         return "";
     },
     async clearKeystore(): Promise<boolean> {

--- a/lib/msal-node/test/utils/TestConstants.ts
+++ b/lib/msal-node/test/utils/TestConstants.ts
@@ -117,12 +117,6 @@ export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
             ""
         );
     },
-    async getPublicKeyThumbprint(): Promise<string> {
-        throw createClientAuthError(
-            ClientAuthErrorCodes.methodNotImplemented,
-            ""
-        );
-    },
     async removeTokenBindingKey(): Promise<void> {
         throw createClientAuthError(
             ClientAuthErrorCodes.methodNotImplemented,
@@ -135,7 +129,7 @@ export const DEFAULT_CRYPTO_IMPLEMENTATION: ICrypto = {
             ""
         );
     },
-    async signJwt(): Promise<string> {
+    async signTokenBindingJwt(): Promise<string> {
         throw createClientAuthError(
             ClientAuthErrorCodes.methodNotImplemented,
             ""


### PR DESCRIPTION
## Summary

Splits the internal DPoP proof/signing foundation out of PR #8708 so the browser request/cache wiring can be reviewed as a smaller stacked PR.

This PR includes:
- Shared token-binding key manager contracts and crypto interface updates
- DPoP/PoP proof signing and JOSE header validation updates
- Browser token-binding key manager internals and focused tests
- Node/client wiring needed for the shared token-binding manager seam
- API review, errors docs, and changefiles

## Stacking

PR #8708 is intended to be retargeted to this branch and should contain only the remaining browser request/cache wiring while this PR merges to `dev` first.

## Validation

- `npm run build:all` for `msal-common`, `msal-browser`, and `msal-node`
- `npm run apiExtractor -- --local` for `msal-common`, `msal-browser`, and `msal-node`
- Focused `msal-browser` tests: `CryptoOps.spec.ts`, `TokenBindingKeyManager.spec.ts`, `AsyncMemoryStorage.spec.ts`
- Focused `msal-common` tests: `DpopProofGenerator.spec.ts`, `JoseHeader.spec.ts`, `PopTokenGenerator.spec.ts`, `ResponseHandler.spec.ts`, `AuthorizationCodeClient.spec.ts`, `ClientConfiguration.spec.ts`
- `npm run format:check` for `msal-common`, `msal-browser`, and `msal-node`