### PR TITLE
Bump @azure/msal-browser to 5.17.2 to match @azure/msal-browser-1p

### DIFF
--- a/change/@azure-msal-browser-lockstep-msal-browser-1p.json
+++ b/change/@azure-msal-browser-lockstep-msal-browser-1p.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Bump @azure/msal-browser to match @azure/msal-browser-1p [#8726](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8726)",
+    "packageName": "@azure/msal-browser",
+    "email": "sameera.gajjarapu@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-lockstep-msal-browser-1p.json
+++ b/change/@azure-msal-browser-lockstep-msal-browser-1p.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Bump @azure/msal-browser to match @azure/msal-browser-1p",
+    "packageName": "@azure/msal-browser",
+    "email": "sameera.gajjarapu@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-browser-lockstep-msal-browser-1p.json
+++ b/change/@azure-msal-browser-lockstep-msal-browser-1p.json
@@ -1,7 +1,0 @@
-{
-    "type": "patch",
-    "comment": "Bump @azure/msal-browser to match @azure/msal-browser-1p [#8726](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8726)",
-    "packageName": "@azure/msal-browser",
-    "email": "sameera.gajjarapu@microsoft.com",
-    "dependentChangeType": "patch"
-}

--- a/change/@azure-msal-browser-lockstep-msal-browser-1p.json
+++ b/change/@azure-msal-browser-lockstep-msal-browser-1p.json
@@ -1,7 +1,0 @@
-{
-    "type": "patch",
-    "comment": "Bump @azure/msal-browser to match @azure/msal-browser-1p",
-    "packageName": "@azure/msal-browser",
-    "email": "sameera.gajjarapu@microsoft.com",
-    "dependentChangeType": "patch"
-}

--- a/change/@azure-msal-browser-lockstep-none.json
+++ b/change/@azure-msal-browser-lockstep-none.json
@@ -1,0 +1,7 @@
+{
+    "type": "none",
+    "comment": "Bump @azure/msal-browser to 5.17.2 to match @azure/msal-browser-1p [#8726](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8726)",
+    "packageName": "@azure/msal-browser",
+    "email": "sameera.gajjarapu@microsoft.com",
+    "dependentChangeType": "none"
+}

--- a/lib/msal-browser/CHANGELOG.json
+++ b/lib/msal-browser/CHANGELOG.json
@@ -11,7 +11,7 @@
             "author": "sameera.gajjarapu@microsoft.com",
             "package": "@azure/msal-browser",
             "commit": "not available",
-            "comment": "Bump @azure/msal-browser to match @azure/msal-browser-1p"
+            "comment": "Bump @azure/msal-browser to match @azure/msal-browser-1p [#8726](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8726)"
           }
         ]
       }

--- a/lib/msal-browser/CHANGELOG.json
+++ b/lib/msal-browser/CHANGELOG.json
@@ -6,7 +6,7 @@
       "version": "5.17.2",
       "tag": "@azure/msal-browser_v5.17.2",
       "comments": {
-        "patch": [
+        "none": [
           {
             "author": "sameera.gajjarapu@microsoft.com",
             "package": "@azure/msal-browser",

--- a/lib/msal-browser/CHANGELOG.json
+++ b/lib/msal-browser/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@azure/msal-browser",
   "entries": [
     {
+      "date": "Thu, 23 Jul 2026 02:42:29 GMT",
+      "version": "5.17.2",
+      "tag": "@azure/msal-browser_v5.17.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "sameera.gajjarapu@microsoft.com",
+            "package": "@azure/msal-browser",
+            "commit": "not available",
+            "comment": "Bump @azure/msal-browser to match @azure/msal-browser-1p"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 15 Jul 2026 22:35:35 GMT",
       "version": "5.17.1",
       "tag": "@azure/msal-browser_v5.17.1",

--- a/lib/msal-browser/CHANGELOG.json
+++ b/lib/msal-browser/CHANGELOG.json
@@ -2,21 +2,6 @@
   "name": "@azure/msal-browser",
   "entries": [
     {
-      "date": "Thu, 23 Jul 2026 02:42:29 GMT",
-      "version": "5.17.2",
-      "tag": "@azure/msal-browser_v5.17.2",
-      "comments": {
-        "patch": [
-          {
-            "author": "sameera.gajjarapu@microsoft.com",
-            "package": "@azure/msal-browser",
-            "commit": "not available",
-            "comment": "Bump @azure/msal-browser to match @azure/msal-browser-1p"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 15 Jul 2026 22:35:35 GMT",
       "version": "5.17.1",
       "tag": "@azure/msal-browser_v5.17.1",

--- a/lib/msal-browser/CHANGELOG.md
+++ b/lib/msal-browser/CHANGELOG.md
@@ -1,16 +1,8 @@
 # Change Log - @azure/msal-browser
 
-<!-- This log was last generated on Thu, 23 Jul 2026 02:42:29 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 15 Jul 2026 22:35:35 GMT and should not be manually modified. -->
 
 <!-- Start content -->
-
-## 5.17.2
-
-Thu, 23 Jul 2026 02:42:29 GMT
-
-### Patches
-
-- Bump @azure/msal-browser to match @azure/msal-browser-1p (sameera.gajjarapu@microsoft.com)
 
 ## 5.17.1
 

--- a/lib/msal-browser/CHANGELOG.md
+++ b/lib/msal-browser/CHANGELOG.md
@@ -8,10 +8,6 @@
 
 Thu, 23 Jul 2026 02:42:29 GMT
 
-### Patches
-
-- Bump @azure/msal-browser to match @azure/msal-browser-1p (sameera.gajjarapu@microsoft.com)
-
 ## 5.17.1
 
 Wed, 15 Jul 2026 22:35:35 GMT

--- a/lib/msal-browser/CHANGELOG.md
+++ b/lib/msal-browser/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @azure/msal-browser
 
-<!-- This log was last generated on Wed, 15 Jul 2026 22:35:35 GMT and should not be manually modified. -->
+<!-- This log was last generated on Thu, 23 Jul 2026 02:42:29 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 5.17.2
+
+Thu, 23 Jul 2026 02:42:29 GMT
+
+### Patches
+
+- Bump @azure/msal-browser to match @azure/msal-browser-1p (sameera.gajjarapu@microsoft.com)
 
 ## 5.17.1
 

--- a/lib/msal-browser/CHANGELOG.md
+++ b/lib/msal-browser/CHANGELOG.md
@@ -10,7 +10,7 @@ Thu, 23 Jul 2026 02:42:29 GMT
 
 ### Patches
 
-- Bump @azure/msal-browser to match @azure/msal-browser-1p (sameera.gajjarapu@microsoft.com)
+- Bump @azure/msal-browser to match @azure/msal-browser-1p [#8726](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8726) (sameera.gajjarapu@microsoft.com)
 
 ## 5.17.1
 

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1109,7 +1109,7 @@ const uninitializedPublicClientApplication = "uninitialized_public_client_applic
 const userCancelled = "user_cancelled";
 
 // @public (undocumented)
-export const version = "5.17.1";
+export const version = "5.17.2";
 
 // @public (undocumented)
 const WaitForBridgeLateResponse = "waitForBridgeLateResponse";

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -1109,7 +1109,7 @@ const uninitializedPublicClientApplication = "uninitialized_public_client_applic
 const userCancelled = "user_cancelled";
 
 // @public (undocumented)
-export const version = "5.17.2";
+export const version = "5.17.1";
 
 // @public (undocumented)
 const WaitForBridgeLateResponse = "waitForBridgeLateResponse";

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "5.17.2",
+  "version": "5.17.1",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",

--- a/lib/msal-browser/package.json
+++ b/lib/msal-browser/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/microsoft-authentication-library-for-js.git"
   },
-  "version": "5.17.1",
+  "version": "5.17.2",
   "description": "Microsoft Authentication Library for js",
   "keywords": [
     "implicit",

--- a/lib/msal-browser/src/packageMetadata.ts
+++ b/lib/msal-browser/src/packageMetadata.ts
@@ -1,3 +1,3 @@
 /* eslint-disable header/header */
 export const name = "@azure/msal-browser";
-export const version = "5.17.1";
+export const version = "5.17.2";

--- a/lib/msal-browser/src/packageMetadata.ts
+++ b/lib/msal-browser/src/packageMetadata.ts
@@ -1,3 +1,3 @@
 /* eslint-disable header/header */
 export const name = "@azure/msal-browser";
-export const version = "5.17.2";
+export const version = "5.17.1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -2286,7 +2286,7 @@
         },
         "lib/msal-browser": {
             "name": "@azure/msal-browser",
-            "version": "5.17.1",
+            "version": "5.17.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-common": "16.11.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2286,7 +2286,7 @@
         },
         "lib/msal-browser": {
             "name": "@azure/msal-browser",
-            "version": "5.17.2",
+            "version": "5.17.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-common": "16.11.2"


### PR DESCRIPTION
## Summary
Manually bumps `@azure/msal-browser` **5.17.1 → 5.17.2** so it reaches parity with `@azure/msal-browser-1p` (already at 5.17.2). An msal-node-only release spuriously advanced msal-browser-1p to 5.17.2 while msal-browser stayed at 5.17.1; this restores the `5.17.x` lockstep.

Once merged, both browser packages sit at **5.17.2** in source, after which a regular release brings the published versions to parity.

## What changed
- `@azure/msal-browser` **5.17.1 → 5.17.2** (version-only; **no code changes**).
- Standard post-release artifacts: `package.json`, `src/packageMetadata.ts`, `apiReview/msal-browser.api.md`, `CHANGELOG.{json,md}`, and the root `package-lock.json` workspace version.

## Notes
- Scoped to `@azure/msal-browser` only (no cascade to msal-react/msal-angular); their `^5.17.1` ranges already satisfy 5.17.2.
- A **separate pipeline fix** addresses the root cause for this gap.