### PR TITLE
 [NAA/PWB One Bridge] PR 1/6: webBrokerBridge scaffold — shared interfaces, error taxonomy, pending-request registry

### DIFF
--- a/change/@azure-msal-browser-web-broker-bridge-scaffold.json
+++ b/change/@azure-msal-browser-web-broker-bridge-scaffold.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Add internal webBrokerBridge scaffold (shared message interfaces, error taxonomy, pending-request registry) — no callers yet, no public API surface change [#8729](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8729)",
+    "packageName": "@azure/msal-browser",
+    "email": "shylasummers@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/webBrokerBridge/IWebBrokerBridgeMessage.ts
+++ b/lib/msal-browser/src/webBrokerBridge/IWebBrokerBridgeMessage.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { WebBrokerBridgeError } from "./WebBrokerBridgeError.js";
+
+/**
+ * Structural interface shared by NAA and PWB bridge request messages.
+ *
+ * Both `BridgeRequestEnvelope` (NAA) and `BrokerAuthRequest` (PWB) satisfy
+ * this shape without any wire-format changes; concrete implementations
+ * derive `requestId` from whatever correlation identifiers they already
+ * carry.
+ */
+export interface IWebBrokerBridgeMessage {
+    /**
+     * Unique identifier used to correlate this request with its response.
+     * Format is bridge-specific (NAA uses a GUID; PWB composes
+     * `${channelId}:${messageId}`).
+     */
+    readonly requestId: string;
+
+    /**
+     * Discriminator identifying the operation this message represents
+     * (e.g. `"GetToken"`, `"AuthRequest"`, `"Handshake"`).
+     */
+    readonly method: string;
+}
+
+/**
+ * Structural interface shared by NAA and PWB bridge response messages.
+ *
+ * Responses are matched against pending requests by `requestId`.
+ */
+export interface IWebBrokerBridgeResponse extends IWebBrokerBridgeMessage {
+    /**
+     * When present, indicates the request failed and provides the
+     * unified error taxonomy code + optional context. Absent on success.
+     */
+    error?: WebBrokerBridgeError;
+}

--- a/lib/msal-browser/src/webBrokerBridge/IWebBrokerBridgeMessage.ts
+++ b/lib/msal-browser/src/webBrokerBridge/IWebBrokerBridgeMessage.ts
@@ -22,10 +22,10 @@ export interface IWebBrokerBridgeMessage {
     readonly requestId: string;
 
     /**
-     * Discriminator identifying the operation this message represents
+     * Discriminator identifying what this message represents
      * (e.g. `"GetToken"`, `"AuthRequest"`, `"Handshake"`).
      */
-    readonly method: string;
+    readonly type: string;
 }
 
 /**

--- a/lib/msal-browser/src/webBrokerBridge/PendingRequestRegistry.ts
+++ b/lib/msal-browser/src/webBrokerBridge/PendingRequestRegistry.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    IWebBrokerBridgeMessage,
+    IWebBrokerBridgeResponse,
+} from "./IWebBrokerBridgeMessage.js";
+
+interface PendingRequest<TResp> {
+    resolve: (response: TResp) => void;
+    reject: (reason: unknown) => void;
+}
+
+export type WebBrokerBridgeSendFn<TReq extends IWebBrokerBridgeMessage> = (
+    message: TReq
+) => void;
+
+/**
+ * Correlates outbound requests with inbound responses by `requestId`.
+ */
+export class PendingRequestRegistry<TResp extends IWebBrokerBridgeResponse> {
+    private readonly pending = new Map<string, PendingRequest<TResp>>();
+
+    /**
+     * Register a pending request. Returns a promise that resolves when a
+     * response with the matching `requestId` arrives, or rejects if the
+     * caller invokes `reject` for that id.
+     */
+    register(requestId: string): Promise<TResp> {
+        return new Promise<TResp>((resolve, reject) => {
+            this.pending.set(requestId, { resolve, reject });
+        });
+    }
+
+    /** Resolve a pending request. No-op if `requestId` isn't registered. */
+    resolve(requestId: string, response: TResp): void {
+        const entry = this.pending.get(requestId);
+        if (entry === undefined) {
+            return;
+        }
+        this.pending.delete(requestId);
+        entry.resolve(response);
+    }
+
+    /** Reject a pending request. No-op if `requestId` isn't registered. */
+    reject(requestId: string, reason: unknown): void {
+        const entry = this.pending.get(requestId);
+        if (entry === undefined) {
+            return;
+        }
+        this.pending.delete(requestId);
+        entry.reject(reason);
+    }
+
+    /** True if `requestId` has an in-flight registration. */
+    has(requestId: string): boolean {
+        return this.pending.has(requestId);
+    }
+
+    /**
+     * Register, then invoke `send` synchronously. If `send` throws, the
+     * pending entry is cleared and the promise rejects with the thrown
+     * error.
+     */
+    async sendAndAwait<TReq extends IWebBrokerBridgeMessage>(
+        message: TReq,
+        send: WebBrokerBridgeSendFn<TReq>
+    ): Promise<TResp> {
+        const promise = this.register(message.requestId);
+        try {
+            send(message);
+        } catch (err) {
+            this.reject(message.requestId, err);
+        }
+        return promise;
+    }
+}

--- a/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeError.ts
+++ b/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeError.ts
@@ -12,9 +12,8 @@
  * `./WebBrokerBridgeErrorMap`.
  *
  * Bridge-specific subclasses (e.g. `BrokerAuthError`, `BrowserAuthError`,
- * `ClientConfigurationError`) are reconstructed by per-bridge "glue"
- * adapters until v6, at which point callers receive the base class
- * directly.
+ * `ClientConfigurationError`) can be reconstructed by per-bridge "glue"
+ * adapters when needed; otherwise callers receive the base class directly.
  */
 export const WebBrokerBridgeErrorCode = {
     /* Interaction / auth outcomes (both bridges) */

--- a/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeError.ts
+++ b/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeError.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Unified error taxonomy shared by NAA and PWB.
+ *
+ * Each code maps to exactly one of the four base MSAL error classes
+ * (`AuthError`, `ClientAuthError`, `ServerError`,
+ * `InteractionRequiredAuthError`) via `toAuthError` in
+ * `./WebBrokerBridgeErrorMap`.
+ *
+ * Bridge-specific subclasses (e.g. `BrokerAuthError`, `BrowserAuthError`,
+ * `ClientConfigurationError`) are reconstructed by per-bridge "glue"
+ * adapters until v6, at which point callers receive the base class
+ * directly.
+ */
+export const WebBrokerBridgeErrorCode = {
+    /* Interaction / auth outcomes (both bridges) */
+    UserInteractionRequired: "user_interaction_required",
+    UserCanceled: "user_canceled",
+
+    /* Environment / connectivity (both bridges) */
+    NoNetwork: "no_network",
+    AccountUnavailable: "account_unavailable",
+    BridgeDisabled: "bridge_disabled",
+    BridgeUnavailable: "bridge_unavailable",
+
+    /* Server-side outcomes (NAA-only today; PWB will emit via glue in PR 6) */
+    TransientError: "transient_error",
+    PersistentError: "persistent_error",
+
+    /* Broker-channel failures (PWB-only today; NAA may emit in the future) */
+    BridgeTimeout: "bridge_timeout",
+    BridgeHandshakeFailed: "bridge_handshake_failed",
+    BridgeConnectionReset: "bridge_connection_reset",
+    BridgeResponseInvalid: "bridge_response_invalid",
+    PopupWillRedirect: "popup_will_redirect",
+    ShrGenerationError: "shr_generation_error",
+
+    /* Fallback */
+    Unknown: "unknown",
+} as const;
+export type WebBrokerBridgeErrorCode =
+    (typeof WebBrokerBridgeErrorCode)[keyof typeof WebBrokerBridgeErrorCode];
+
+/**
+ * Normalized error payload carried between the broker and the embedded
+ * app. Bridge-specific transports (NAA `BridgeError`, PWB `errorPayload`)
+ * are lowered into this shape before being lifted to an MSAL error class.
+ */
+export interface WebBrokerBridgeError {
+    /**
+     * Common taxonomy code — see `WebBrokerBridgeErrorCode`.
+     */
+    readonly code: WebBrokerBridgeErrorCode;
+
+    /**
+     * Underlying provider-specific error code preserved for classes that
+     * accept a variable code (e.g. `invalid_grant` on `ServerError`).
+     * Ignored for codes whose mapping is a fixed constant.
+     */
+    readonly innerErrorCode?: string;
+
+    /** Server sub-error (e.g. `consent_required`). */
+    readonly subError?: string;
+
+    /** Human-readable description forwarded from the underlying response. */
+    readonly description?: string;
+
+    /** Correlation id, when available. */
+    readonly correlationId?: string;
+}

--- a/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeError.ts
+++ b/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeError.ts
@@ -10,27 +10,23 @@
  * (`AuthError`, `ClientAuthError`, `ServerError`,
  * `InteractionRequiredAuthError`) via `toAuthError` in
  * `./WebBrokerBridgeErrorMap`.
- *
- * Bridge-specific subclasses (e.g. `BrokerAuthError`, `BrowserAuthError`,
- * `ClientConfigurationError`) can be reconstructed by per-bridge "glue"
- * adapters when needed; otherwise callers receive the base class directly.
  */
 export const WebBrokerBridgeErrorCode = {
-    /* Interaction / auth outcomes (both bridges) */
+    /* Interaction / auth outcomes */
     UserInteractionRequired: "user_interaction_required",
     UserCanceled: "user_canceled",
 
-    /* Environment / connectivity (both bridges) */
+    /* Environment / connectivity */
     NoNetwork: "no_network",
     AccountUnavailable: "account_unavailable",
     BridgeDisabled: "bridge_disabled",
     BridgeUnavailable: "bridge_unavailable",
 
-    /* Server-side outcomes (NAA-only today; PWB will emit via glue in PR 6) */
+    /* Server-side outcomes */
     TransientError: "transient_error",
     PersistentError: "persistent_error",
 
-    /* Broker-channel failures (PWB-only today; NAA may emit in the future) */
+    /* Broker-channel failures */
     BridgeTimeout: "bridge_timeout",
     BridgeHandshakeFailed: "bridge_handshake_failed",
     BridgeConnectionReset: "bridge_connection_reset",

--- a/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeErrorMap.ts
+++ b/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeErrorMap.ts
@@ -17,9 +17,9 @@ import {
 
 /**
  * Lift a normalized `WebBrokerBridgeError` to one of the four base
- * MSAL error classes. Per-bridge glue is responsible for lowering
- * transport-specific errors into this shape and, if needed, for
- * upgrading the result back to a bridge-specific subclass.
+ * MSAL error classes. Callers are responsible for lowering
+ * transport-specific errors into `WebBrokerBridgeError` before calling
+ * this function.
  */
 export function toAuthError(err: WebBrokerBridgeError): AuthError {
     const correlationId = err.correlationId ?? "";
@@ -80,8 +80,8 @@ export function toAuthError(err: WebBrokerBridgeError): AuthError {
 
         /*
          * PWB broker-channel failures. The common code doubles as the
-         * errorCode so PWB glue can rehydrate the original BrokerAuthError
-         * subclass by round-tripping the string.
+         * concrete errorCode on AuthError so the original error identity
+         * can be recovered by round-tripping the string.
          */
         case WebBrokerBridgeErrorCode.BridgeTimeout:
         case WebBrokerBridgeErrorCode.BridgeHandshakeFailed:

--- a/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeErrorMap.ts
+++ b/lib/msal-browser/src/webBrokerBridge/WebBrokerBridgeErrorMap.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    AuthError,
+    ClientAuthError,
+    ClientAuthErrorCodes,
+    InteractionRequiredAuthError,
+    ServerError,
+} from "@azure/msal-common/browser";
+import {
+    WebBrokerBridgeError,
+    WebBrokerBridgeErrorCode,
+} from "./WebBrokerBridgeError.js";
+
+/**
+ * Lift a normalized `WebBrokerBridgeError` to one of the four base
+ * MSAL error classes. Per-bridge glue is responsible for lowering
+ * transport-specific errors into this shape and, if needed, for
+ * upgrading the result back to a bridge-specific subclass.
+ */
+export function toAuthError(err: WebBrokerBridgeError): AuthError {
+    const correlationId = err.correlationId ?? "";
+
+    switch (err.code) {
+        case WebBrokerBridgeErrorCode.UserInteractionRequired:
+            return new InteractionRequiredAuthError(
+                err.innerErrorCode || "",
+                correlationId,
+                err.description,
+                err.subError
+            );
+
+        case WebBrokerBridgeErrorCode.TransientError:
+        case WebBrokerBridgeErrorCode.PersistentError:
+            return new ServerError(
+                err.innerErrorCode || "",
+                correlationId,
+                err.description,
+                err.subError
+            );
+
+        case WebBrokerBridgeErrorCode.UserCanceled:
+            return new ClientAuthError(
+                ClientAuthErrorCodes.userCanceled,
+                correlationId
+            );
+
+        case WebBrokerBridgeErrorCode.NoNetwork:
+            return new ClientAuthError(
+                ClientAuthErrorCodes.noNetworkConnectivity,
+                correlationId
+            );
+
+        case WebBrokerBridgeErrorCode.AccountUnavailable:
+            return new ClientAuthError(
+                ClientAuthErrorCodes.noAccountFound,
+                correlationId
+            );
+
+        case WebBrokerBridgeErrorCode.BridgeDisabled:
+            return new ClientAuthError(
+                ClientAuthErrorCodes.nestedAppAuthBridgeDisabled,
+                correlationId
+            );
+
+        case WebBrokerBridgeErrorCode.BridgeUnavailable:
+            /*
+             * NAA parity: pass through inner code when the broker supplied
+             * one, otherwise fall back to the disabled code.
+             */
+            return new ClientAuthError(
+                err.innerErrorCode ||
+                    ClientAuthErrorCodes.nestedAppAuthBridgeDisabled,
+                correlationId,
+                err.description
+            );
+
+        /*
+         * PWB broker-channel failures. The common code doubles as the
+         * errorCode so PWB glue can rehydrate the original BrokerAuthError
+         * subclass by round-tripping the string.
+         */
+        case WebBrokerBridgeErrorCode.BridgeTimeout:
+        case WebBrokerBridgeErrorCode.BridgeHandshakeFailed:
+        case WebBrokerBridgeErrorCode.BridgeConnectionReset:
+        case WebBrokerBridgeErrorCode.BridgeResponseInvalid:
+        case WebBrokerBridgeErrorCode.PopupWillRedirect:
+        case WebBrokerBridgeErrorCode.ShrGenerationError:
+            return new AuthError(
+                err.code,
+                correlationId,
+                err.description,
+                err.subError
+            );
+
+        case WebBrokerBridgeErrorCode.Unknown:
+        default:
+            return new AuthError(
+                err.innerErrorCode || "unknown_error",
+                correlationId,
+                err.description || "An unknown error occurred",
+                err.subError
+            );
+    }
+}

--- a/lib/msal-browser/src/webBrokerBridge/index.ts
+++ b/lib/msal-browser/src/webBrokerBridge/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @packageDocumentation
+ * @module @azure/msal-browser/web-broker-bridge
+ */
+
+/**
+ * Entrypoint for the web-broker-bridge subpath e.g.
+ * `import { PendingRequestRegistry } from "@azure/msal-browser/web-broker-bridge"`.
+ */
+
+export type {
+    IWebBrokerBridgeMessage,
+    IWebBrokerBridgeResponse,
+} from "./IWebBrokerBridgeMessage.js";
+export type { WebBrokerBridgeError } from "./WebBrokerBridgeError.js";
+export { WebBrokerBridgeErrorCode } from "./WebBrokerBridgeError.js";
+export { toAuthError } from "./WebBrokerBridgeErrorMap.js";
+export { PendingRequestRegistry } from "./PendingRequestRegistry.js";
+export type { WebBrokerBridgeSendFn } from "./PendingRequestRegistry.js";

--- a/lib/msal-browser/src/webBrokerBridge/index.ts
+++ b/lib/msal-browser/src/webBrokerBridge/index.ts
@@ -9,8 +9,9 @@
  */
 
 /**
- * Entrypoint for the web-broker-bridge subpath e.g.
- * `import { PendingRequestRegistry } from "@azure/msal-browser/web-broker-bridge"`.
+ * Internal scaffolding for a `@azure/msal-browser/web-broker-bridge`
+ * subpath export. The subpath is not yet wired in `package.json` / rollup,
+ * so this module has no external callers and is intra-package only.
  */
 
 export type {

--- a/lib/msal-browser/test/webBrokerBridge/PendingRequestRegistry.spec.ts
+++ b/lib/msal-browser/test/webBrokerBridge/PendingRequestRegistry.spec.ts
@@ -17,12 +17,12 @@ interface TestResponse extends IWebBrokerBridgeResponse {
     result?: string;
 }
 
-function req(id: string, method = "TestMethod"): TestRequest {
-    return { requestId: id, method };
+function req(id: string, type = "TestMethod"): TestRequest {
+    return { requestId: id, type };
 }
 
 function resp(id: string, result?: string): TestResponse {
-    return { requestId: id, method: "TestMethod", result };
+    return { requestId: id, type: "TestMethod", result };
 }
 
 describe("PendingRequestRegistry", () => {

--- a/lib/msal-browser/test/webBrokerBridge/PendingRequestRegistry.spec.ts
+++ b/lib/msal-browser/test/webBrokerBridge/PendingRequestRegistry.spec.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    IWebBrokerBridgeMessage,
+    IWebBrokerBridgeResponse,
+} from "../../src/webBrokerBridge/IWebBrokerBridgeMessage.js";
+import { PendingRequestRegistry } from "../../src/webBrokerBridge/PendingRequestRegistry.js";
+
+interface TestRequest extends IWebBrokerBridgeMessage {
+    payload?: string;
+}
+
+interface TestResponse extends IWebBrokerBridgeResponse {
+    result?: string;
+}
+
+function req(id: string, method = "TestMethod"): TestRequest {
+    return { requestId: id, method };
+}
+
+function resp(id: string, result?: string): TestResponse {
+    return { requestId: id, method: "TestMethod", result };
+}
+
+describe("PendingRequestRegistry", () => {
+    describe("register / resolve", () => {
+        it("resolves the awaiting promise with the response", async () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            const p = registry.register("r1");
+            registry.resolve("r1", resp("r1", "ok"));
+            await expect(p).resolves.toEqual(resp("r1", "ok"));
+        });
+
+        it("removes the entry once resolved", () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            void registry.register("r1");
+            registry.resolve("r1", resp("r1"));
+            expect(registry.has("r1")).toBe(false);
+        });
+
+        it("resolves in the order responses arrive, not the order requests registered", async () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            const p1 = registry.register("r1");
+            const p2 = registry.register("r2");
+            registry.resolve("r2", resp("r2", "second"));
+            registry.resolve("r1", resp("r1", "first"));
+            await expect(p2).resolves.toMatchObject({ result: "second" });
+            await expect(p1).resolves.toMatchObject({ result: "first" });
+        });
+    });
+
+    describe("reject", () => {
+        it("rejects the awaiting promise with the reason", async () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            const p = registry.register("r1");
+            const boom = new Error("boom");
+            registry.reject("r1", boom);
+            await expect(p).rejects.toBe(boom);
+        });
+
+        it("removes the entry once rejected", () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            void registry.register("r1").catch(() => undefined);
+            registry.reject("r1", new Error("x"));
+            expect(registry.has("r1")).toBe(false);
+        });
+    });
+
+    describe("unmatched ids", () => {
+        it("silently drops resolve() for an unknown requestId", () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            expect(() => registry.resolve("nope", resp("nope"))).not.toThrow();
+        });
+
+        it("silently drops reject() for an unknown requestId", () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            expect(() => registry.reject("nope", new Error("x"))).not.toThrow();
+        });
+    });
+
+    describe("sendAndAwait", () => {
+        it("invokes send synchronously with the message", async () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            const send = jest.fn<void, [TestRequest]>();
+            const message = req("r1");
+
+            const promise = registry.sendAndAwait(message, send);
+            expect(send).toHaveBeenCalledWith(message);
+
+            registry.resolve("r1", resp("r1", "ok"));
+            await expect(promise).resolves.toMatchObject({ result: "ok" });
+        });
+
+        it("rejects and unregisters when send throws", async () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            const boom = new Error("transport failure");
+            const send = jest.fn<void, [TestRequest]>(() => {
+                throw boom;
+            });
+
+            const promise = registry.sendAndAwait(req("r1"), send);
+            await expect(promise).rejects.toBe(boom);
+            expect(registry.has("r1")).toBe(false);
+        });
+
+        it("supports concurrent requests correlated by requestId", async () => {
+            const registry = new PendingRequestRegistry<TestResponse>();
+            const send = jest.fn<void, [TestRequest]>();
+
+            const p1 = registry.sendAndAwait(req("r1"), send);
+            const p2 = registry.sendAndAwait(req("r2"), send);
+            expect(send).toHaveBeenCalledTimes(2);
+
+            registry.resolve("r1", resp("r1", "one"));
+            registry.resolve("r2", resp("r2", "two"));
+
+            await expect(p1).resolves.toMatchObject({ result: "one" });
+            await expect(p2).resolves.toMatchObject({ result: "two" });
+        });
+    });
+});

--- a/lib/msal-browser/test/webBrokerBridge/WebBrokerBridgeErrorMap.spec.ts
+++ b/lib/msal-browser/test/webBrokerBridge/WebBrokerBridgeErrorMap.spec.ts
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    AuthError,
+    ClientAuthError,
+    ClientAuthErrorCodes,
+    InteractionRequiredAuthError,
+    ServerError,
+} from "@azure/msal-common/browser";
+import { WebBrokerBridgeErrorCode } from "../../src/webBrokerBridge/WebBrokerBridgeError.js";
+import { toAuthError } from "../../src/webBrokerBridge/WebBrokerBridgeErrorMap.js";
+
+describe("WebBrokerBridgeErrorMap", () => {
+    describe("toAuthError - base class selection", () => {
+        // Each row asserts (a) which base class the common code lifts to,
+        // and (b) the errorCode preserved on the resulting instance.
+        const cases: Array<{
+            code: WebBrokerBridgeErrorCode;
+            ctor: new (...args: never[]) => AuthError;
+            className: string;
+            expectedErrorCode: string;
+            innerErrorCode?: string;
+        }> = [
+            {
+                code: WebBrokerBridgeErrorCode.UserInteractionRequired,
+                ctor: InteractionRequiredAuthError,
+                className: "InteractionRequiredAuthError",
+                expectedErrorCode: "invalid_grant",
+                innerErrorCode: "invalid_grant",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.TransientError,
+                ctor: ServerError,
+                className: "ServerError",
+                expectedErrorCode: "server_temporarily_unavailable",
+                innerErrorCode: "server_temporarily_unavailable",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.PersistentError,
+                ctor: ServerError,
+                className: "ServerError",
+                expectedErrorCode: "invalid_request",
+                innerErrorCode: "invalid_request",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.UserCanceled,
+                ctor: ClientAuthError,
+                className: "ClientAuthError",
+                expectedErrorCode: ClientAuthErrorCodes.userCanceled,
+            },
+            {
+                code: WebBrokerBridgeErrorCode.NoNetwork,
+                ctor: ClientAuthError,
+                className: "ClientAuthError",
+                expectedErrorCode: ClientAuthErrorCodes.noNetworkConnectivity,
+            },
+            {
+                code: WebBrokerBridgeErrorCode.AccountUnavailable,
+                ctor: ClientAuthError,
+                className: "ClientAuthError",
+                expectedErrorCode: ClientAuthErrorCodes.noAccountFound,
+            },
+            {
+                code: WebBrokerBridgeErrorCode.BridgeDisabled,
+                ctor: ClientAuthError,
+                className: "ClientAuthError",
+                expectedErrorCode:
+                    ClientAuthErrorCodes.nestedAppAuthBridgeDisabled,
+            },
+            {
+                code: WebBrokerBridgeErrorCode.BridgeUnavailable,
+                ctor: ClientAuthError,
+                className: "ClientAuthError",
+                expectedErrorCode: "custom_unavailable_code",
+                innerErrorCode: "custom_unavailable_code",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.BridgeTimeout,
+                ctor: AuthError,
+                className: "AuthError",
+                expectedErrorCode: "bridge_timeout",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.BridgeHandshakeFailed,
+                ctor: AuthError,
+                className: "AuthError",
+                expectedErrorCode: "bridge_handshake_failed",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.BridgeConnectionReset,
+                ctor: AuthError,
+                className: "AuthError",
+                expectedErrorCode: "bridge_connection_reset",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.BridgeResponseInvalid,
+                ctor: AuthError,
+                className: "AuthError",
+                expectedErrorCode: "bridge_response_invalid",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.PopupWillRedirect,
+                ctor: AuthError,
+                className: "AuthError",
+                expectedErrorCode: "popup_will_redirect",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.ShrGenerationError,
+                ctor: AuthError,
+                className: "AuthError",
+                expectedErrorCode: "shr_generation_error",
+            },
+            {
+                code: WebBrokerBridgeErrorCode.Unknown,
+                ctor: AuthError,
+                className: "AuthError",
+                expectedErrorCode: "unknown_error",
+            },
+        ];
+
+        it.each(cases)(
+            "$code -> $className with errorCode=$expectedErrorCode",
+            ({ code, ctor, className, expectedErrorCode, innerErrorCode }) => {
+                const err = toAuthError({ code, innerErrorCode });
+                expect(err).toBeInstanceOf(ctor);
+                // Pin exact class (guard against silent subclass promotion).
+                expect(err.name).toBe(className);
+                expect(err.errorCode).toBe(expectedErrorCode);
+            }
+        );
+    });
+
+    describe("toAuthError - field propagation", () => {
+        it("propagates correlationId", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.UserCanceled,
+                correlationId: "corr-123",
+            });
+            expect(err.correlationId).toBe("corr-123");
+        });
+
+        it("defaults correlationId to empty string when omitted", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.UserCanceled,
+            });
+            expect(err.correlationId).toBe("");
+        });
+
+        it("propagates description and subError to ServerError", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.PersistentError,
+                innerErrorCode: "invalid_grant",
+                description: "AADSTS50076: MFA required",
+                subError: "consent_required",
+            });
+            expect(err).toBeInstanceOf(ServerError);
+            expect(err.errorMessage).toBe("AADSTS50076: MFA required");
+            expect(err.subError).toBe("consent_required");
+        });
+
+        it("propagates description and subError to InteractionRequiredAuthError", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.UserInteractionRequired,
+                innerErrorCode: "interaction_required",
+                description: "user must sign in",
+                subError: "consent_required",
+            });
+            expect(err).toBeInstanceOf(InteractionRequiredAuthError);
+            expect(err.errorMessage).toBe("user must sign in");
+            expect(err.subError).toBe("consent_required");
+        });
+
+        it("BridgeUnavailable falls back to nestedAppAuthBridgeDisabled when innerErrorCode is missing", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.BridgeUnavailable,
+            });
+            expect(err.errorCode).toBe(
+                ClientAuthErrorCodes.nestedAppAuthBridgeDisabled
+            );
+        });
+
+        it("Unknown supplies a default description when none is provided", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.Unknown,
+            });
+            expect(err.errorMessage).toBe("An unknown error occurred");
+        });
+    });
+
+    describe("toAuthError - NAA fromBridgeError parity", () => {
+        // Byte-for-byte parity with the current NAA fromBridgeError switch.
+        // Passing correlationId="" (as NAA does today) preserves the
+        // pre-migration wire behavior.
+        it("UserCancel matches NAA output", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.UserCanceled,
+                correlationId: "",
+            });
+            expect(err).toEqual(
+                new ClientAuthError(ClientAuthErrorCodes.userCanceled, "")
+            );
+        });
+
+        it("TransientError with no inner code matches NAA output", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.TransientError,
+                correlationId: "",
+                description: "temporary failure",
+            });
+            expect(err).toEqual(new ServerError("", "", "temporary failure"));
+        });
+
+        it("default (Unknown, no inner code) matches NAA's non-BridgeError branch", () => {
+            const err = toAuthError({
+                code: WebBrokerBridgeErrorCode.Unknown,
+                correlationId: "",
+            });
+            expect(err).toEqual(
+                new AuthError("unknown_error", "", "An unknown error occurred")
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary: 

Adds a new internal `msal-browser/src/webBrokerBridge/` module with three shared utilities (message interfaces, common error taxonomy + `toAuthError` mapper, transport-agnostic `PendingRequestRegistry`) that later PRs will migrate NAA and PWB onto. No callers touched, no public API surface change, no wire changes — pure scaffolding, part 1 of 6 in the [NAA/PWB One Bridge](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3668028) feature.

## Full description:

Part 1 of 6 in the [NAA/PWB One Bridge](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3668028) feature — unifies the internal plumbing that NAA (`msal-browser/src/naa`) and PWB (`msal-browser-1p/src/broker`) currently duplicate.

## What this PR does

Introduces a new internal `msal-browser/src/webBrokerBridge/` module. **No callers yet** — this is pure scaffolding. Nothing runs at runtime after this merges; nothing goes on the wire; nothing is exposed on the main public API.

The module contains three utilities that later PRs will migrate NAA and PWB onto:

- **`IWebBrokerBridgeMessage` / `IWebBrokerBridgeResponse`** — minimal interfaces (`requestId`, `method`, optional `error`) that both bridges' existing message types will structurally implement in later PRs.
- **`WebBrokerBridgeError` + `WebBrokerBridgeErrorCode` + `toAuthError`** — common error taxonomy lifting a bridge-neutral code to one of the four base MSAL error classes (`AuthError`, `ClientAuthError`, `ServerError`, `InteractionRequiredAuthError`). PWB-specific subclasses (`BrokerAuthError`, `BrowserAuthError`, etc.) will be re-upgraded by per-bridge "glue" adapters in PR 5/6, then dropped in v6.
- **`PendingRequestRegistry`** — transport-agnostic promise-correlation registry keyed by `requestId`. Replaces the ad-hoc arrays in `BridgeProxy` and the `Map` in `EmbeddedClientApplication.messageBroker()` (in later PRs). Timeouts intentionally not included (PWB keeps its own per-method timeout logic per FR-12).

Also adds `webBrokerBridge/index.ts` as a subpath barrel, following the pattern used by `custom_auth`, `popup_relay`, and `redirect_bridge`. `package.json` `exports` + rollup wiring will be added in PR 5 when `msal-browser-1p` becomes the first cross-package consumer.

## PR sequence

| # | Repo | Purpose |
|---|---|---|
| **1 (this PR)** | 3P | Foundation scaffold |
| 2 | 3P | NAA migration onto shared registry + error map |
| 3 | 3P | Cross-version adapter framework relocated to shared module |
| 4 | 1P | PWB message types implement `IWebBrokerBridgeMessage` |
| 5 | 1P | PWB client migration + perf-event name relocation |
| 6 | 1P | Cleanup |

Each PR is independently mergeable and revertible. If this PR merges and PR 2 never does, the repo has a dead but harmless `webBrokerBridge/` folder.

## Testing

- 34 new unit tests (`WebBrokerBridgeErrorMap.spec.ts` + `PendingRequestRegistry.spec.ts`). All passing.
- `webBrokerBridge/` absent from `msal-browser/src/index.ts` — no public API surface change; API Extractor diff should be empty.
- No modifications to existing source files.
