### PR TITLE
Bearer-over-mTLS (sendCertificateOverMtls) for confidential clients

### DIFF
--- a/change/@azure-msal-common-7d2e9b51-4a3c-4f80-8e16-bearerovermtls.json
+++ b/change/@azure-msal-common-7d2e9b51-4a3c-4f80-8e16-bearerovermtls.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Bearer-over-mTLS: add the getBearerOverMtlsCertificate helper and ClientCredentials.sendCertificateOverMtls so RefreshTokenClient and AuthorizationCodeClient can route to the mTLS token endpoint and present the client certificate on the TLS handshake while keeping a plain Bearer token. Per-request mTLS Proof-of-Possession still takes precedence [#8738](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8738)",
+  "packageName": "@azure/msal-common",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-3f8c1d24-6b0a-4e91-9c2d-bearerovermtls.json
+++ b/change/@azure-msal-node-3f8c1d24-6b0a-4e91-9c2d-bearerovermtls.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Bearer-over-mTLS for confidential clients: opt in at the app level with auth.clientCertificate.sendCertificateOverMtls to present the configured certificate on the TLS handshake to the mTLS token endpoint and receive a plain Bearer token (transport-authenticated, not certificate-bound). Honored across client-credentials, on-behalf-of, refresh-token and auth-code; a per-request mtlsProofOfPossession always takes precedence [#8738](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8738)",
+  "packageName": "@azure/msal-node",
+  "email": "rginsburg@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-3f8c1d24-6b0a-4e91-9c2d-bearerovermtls.json
+++ b/change/@azure-msal-node-3f8c1d24-6b0a-4e91-9c2d-bearerovermtls.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add Bearer-over-mTLS for confidential clients: opt in at the app level with auth.clientCertificate.sendCertificateOverMtls to present the configured certificate on the TLS handshake to the mTLS token endpoint and receive a plain Bearer token (transport-authenticated, not certificate-bound). Honored across client-credentials, on-behalf-of, refresh-token and auth-code; a per-request mtlsProofOfPossession always takes precedence [#8738](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8738)",
+  "comment": "Add Bearer-over-mTLS for confidential clients: opt in at the app level with auth.clientCertificate.sendCertificateOverMtls to present the configured certificate on the TLS handshake to the mTLS token endpoint and receive a plain Bearer token (transport-authenticated, not certificate-bound). Honored across client-credentials, on-behalf-of, refresh-token and auth-code; a per-request mtlsProofOfPossession always takes precedence. The flag is validated when the application is built: it requires a full certificate credential (x5c + privateKey) and is rejected when combined with a developer-supplied clientAssertion, which cannot carry the forced x5c chain [#8738](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8738)",
   "packageName": "@azure/msal-node",
   "email": "rginsburg@microsoft.com",
   "dependentChangeType": "patch"

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -1622,6 +1622,9 @@ function getAuthorizationCodePayload(serverParams: AuthorizeResponse, cachedStat
 // @internal
 function getAuthorizeUrl(authority: Authority, requestParameters: Map<string, string>): string;
 
+// @public
+export function getBearerOverMtlsCertificate(clientCredentials: ClientCredentials, authenticationScheme?: AuthenticationScheme): MtlsCertificate | undefined;
+
 // @public (undocumented)
 export function getClientAssertion(clientAssertion: string | ClientAssertionCallback, clientId: string, tokenEndpoint?: string, fmiPath?: string): Promise<string>;
 

--- a/lib/msal-common/src/account/ClientCredentials.ts
+++ b/lib/msal-common/src/account/ClientCredentials.ts
@@ -43,4 +43,12 @@ export type ClientCredentials = {
      * configured `clientCertificate`.
      */
     mtlsBindingCertificate?: MtlsBindingCertificate;
+    /**
+     * App-level opt-in to present the configured certificate as the client TLS certificate on the
+     * token request handshake (routing to the mTLS endpoint) while still receiving a plain Bearer
+     * token — i.e. Bearer-over-mTLS. Distinct from per-request mTLS Proof-of-Possession, which
+     * always takes precedence when both are set. Populated from the app's
+     * `clientCertificate.sendCertificateOverMtls`.
+     */
+    sendCertificateOverMtls?: boolean;
 };

--- a/lib/msal-common/src/client/AuthorizationCodeClient.ts
+++ b/lib/msal-common/src/client/AuthorizationCodeClient.ts
@@ -42,6 +42,7 @@ import * as PerformanceEvents from "../telemetry/performance/PerformanceEvents.j
 import { invokeAsync } from "../utils/FunctionWrappers.js";
 import { ClientAssertion } from "../account/ClientCredentials.js";
 import { getClientAssertion } from "../utils/ClientAssertionUtils.js";
+import { getBearerOverMtlsCertificate } from "../network/MtlsCertificateUtils.js";
 import { getRequestThumbprint } from "../network/RequestThumbprint.js";
 import {
     createTokenQueryParameters,
@@ -235,8 +236,14 @@ export class AuthorizationCodeClient {
             this.config.authOptions.redirectUri,
             this.performanceClient
         );
+        const bearerOverMtlsCertificate = getBearerOverMtlsCertificate(
+            this.config.clientCredentials,
+            request.authenticationScheme
+        );
         const endpoint = UrlString.appendQueryString(
-            authority.tokenEndpoint,
+            bearerOverMtlsCertificate
+                ? authority.getMtlsTokenEndpoint()
+                : authority.tokenEndpoint,
             queryParametersString
         );
 
@@ -293,7 +300,8 @@ export class AuthorizationCodeClient {
             this.networkClient,
             this.logger,
             this.performanceClient,
-            serverTelemetryManager
+            serverTelemetryManager,
+            bearerOverMtlsCertificate
         );
     }
 

--- a/lib/msal-common/src/client/RefreshTokenClient.ts
+++ b/lib/msal-common/src/client/RefreshTokenClient.ts
@@ -44,6 +44,7 @@ import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.
 import { invoke, invokeAsync } from "../utils/FunctionWrappers.js";
 import { ClientAssertion } from "../account/ClientCredentials.js";
 import { getClientAssertion } from "../utils/ClientAssertionUtils.js";
+import { getBearerOverMtlsCertificate } from "../network/MtlsCertificateUtils.js";
 import { getRequestThumbprint } from "../network/RequestThumbprint.js";
 import {
     createTokenQueryParameters,
@@ -342,8 +343,14 @@ export class RefreshTokenClient {
             this.config.authOptions.redirectUri,
             this.performanceClient
         );
+        const bearerOverMtlsCertificate = getBearerOverMtlsCertificate(
+            this.config.clientCredentials,
+            request.authenticationScheme
+        );
         const endpoint = UrlString.appendQueryString(
-            authority.tokenEndpoint,
+            bearerOverMtlsCertificate
+                ? authority.getMtlsTokenEndpoint()
+                : authority.tokenEndpoint,
             queryParametersString
         );
 
@@ -381,7 +388,8 @@ export class RefreshTokenClient {
             this.networkClient,
             this.logger,
             this.performanceClient,
-            this.serverTelemetryManager
+            this.serverTelemetryManager,
+            bearerOverMtlsCertificate
         );
     }
 

--- a/lib/msal-common/src/exports-node-only.ts
+++ b/lib/msal-common/src/exports-node-only.ts
@@ -24,6 +24,7 @@ export {
     ClientAssertionCallback,
     MtlsBindingCertificate,
 } from "./account/ClientCredentials.js";
+export { getBearerOverMtlsCertificate } from "./network/MtlsCertificateUtils.js";
 export {
     DeviceCodeResponse,
     ServerDeviceCodeResponse,

--- a/lib/msal-common/src/network/MtlsCertificateUtils.ts
+++ b/lib/msal-common/src/network/MtlsCertificateUtils.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ClientCredentials } from "../account/ClientCredentials.js";
+import { AuthenticationScheme } from "../utils/Constants.js";
+import { MtlsCertificate } from "./INetworkModule.js";
+
+const PEM_BEGIN = "-----BEGIN CERTIFICATE-----";
+const PEM_END = "-----END CERTIFICATE-----";
+
+/**
+ * Extracts the base64-encoded DER bodies of every certificate in an `x5c` value. Accepts either PEM
+ * (one or more `BEGIN/END CERTIFICATE` blocks) or a bare base64 DER string. Pure string logic so it
+ * is safe to run in every runtime (mirrors msal-node's `MtlsCertificateUtils`).
+ */
+function extractCertBodies(x5c: string): string[] {
+    if (x5c.includes(PEM_BEGIN)) {
+        const regex =
+            /-----BEGIN CERTIFICATE-----\r*\n?(.+?)\r*\n?-----END CERTIFICATE-----/gs;
+        const bodies: string[] = [];
+        let match;
+        while ((match = regex.exec(x5c)) !== null) {
+            bodies.push(match[1].replace(/\r*\n/g, ""));
+        }
+        return bodies;
+    }
+    // Bare base64 DER (single certificate) — strip any incidental whitespace.
+    return [x5c.replace(/\s+/g, "")];
+}
+
+/**
+ * Wraps a base64 DER certificate body into a PEM `BEGIN/END CERTIFICATE` block with 64-char lines.
+ */
+function wrapPem(base64Body: string): string {
+    const lines = base64Body.match(/.{1,64}/g) ?? [base64Body];
+    return `${PEM_BEGIN}\n${lines.join("\n")}\n${PEM_END}\n`;
+}
+
+/**
+ * Converts an `x5c` certificate value into a PEM string suitable for use as the client certificate
+ * on an mTLS handshake. PEM input is returned unchanged; a bare base64 DER string is wrapped.
+ */
+function x5cToPem(x5c: string): string {
+    if (x5c.includes(PEM_BEGIN)) {
+        return x5c;
+    }
+    return extractCertBodies(x5c).map(wrapPem).join("");
+}
+
+/**
+ * Decides whether a confidential-client request should present the app's configured certificate as
+ * the client TLS certificate on the token-endpoint handshake (routing to the mTLS endpoint) while
+ * still receiving a plain Bearer token — i.e. Bearer-over-mTLS.
+ *
+ * Returns the {@link MtlsCertificate} to present, or `undefined` when the request should proceed
+ * against the regular token endpoint. Per-request mTLS Proof-of-Possession always wins: when the
+ * request's `authenticationScheme` is `MTLS_POP` this returns `undefined` so the dedicated PoP path
+ * (which binds the token to the certificate) is used instead.
+ *
+ * @param clientCredentials - resolved app client credentials (holds the opt-in flag + certificate).
+ * @param authenticationScheme - the request's authentication scheme.
+ */
+export function getBearerOverMtlsCertificate(
+    clientCredentials: ClientCredentials,
+    authenticationScheme?: AuthenticationScheme
+): MtlsCertificate | undefined {
+    const bindingCertificate = clientCredentials.mtlsBindingCertificate;
+    if (
+        !clientCredentials.sendCertificateOverMtls ||
+        !bindingCertificate ||
+        authenticationScheme === AuthenticationScheme.MTLS_POP
+    ) {
+        return undefined;
+    }
+
+    return {
+        cert: x5cToPem(bindingCertificate.x5c),
+        key: bindingCertificate.privateKey,
+    };
+}

--- a/lib/msal-common/test/network/MtlsCertificateUtils.spec.ts
+++ b/lib/msal-common/test/network/MtlsCertificateUtils.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getBearerOverMtlsCertificate } from "../../src/network/MtlsCertificateUtils.js";
+import { ClientCredentials } from "../../src/account/ClientCredentials.js";
+import { AuthenticationScheme } from "../../src/utils/Constants.js";
+
+const PRIVATE_KEY =
+    "-----BEGIN PRIVATE KEY-----\nMIItest\n-----END PRIVATE KEY-----";
+const BARE_X5C =
+    "MIIBstubbase64derbodythatislongerthansixtyfourcharsforlinewrapAAAA";
+const PEM_X5C =
+    "-----BEGIN CERTIFICATE-----\nMIIBstub\n-----END CERTIFICATE-----\n";
+
+function credentials(
+    overrides: Partial<ClientCredentials> = {}
+): ClientCredentials {
+    return {
+        clientSecret: "",
+        clientAssertion: undefined,
+        mtlsBindingCertificate: {
+            privateKey: PRIVATE_KEY,
+            x5c: BARE_X5C,
+        },
+        sendCertificateOverMtls: true,
+        ...overrides,
+    };
+}
+
+describe("MtlsCertificateUtils.ts Unit Tests", () => {
+    describe("getBearerOverMtlsCertificate", () => {
+        it("returns the certificate when the flag is set and no auth scheme is provided", () => {
+            const result = getBearerOverMtlsCertificate(credentials());
+            expect(result).toBeDefined();
+            expect(result?.key).toEqual(PRIVATE_KEY);
+            expect(result?.cert).toContain("-----BEGIN CERTIFICATE-----");
+        });
+
+        it("returns the certificate for a Bearer scheme request", () => {
+            const result = getBearerOverMtlsCertificate(
+                credentials(),
+                AuthenticationScheme.BEARER
+            );
+            expect(result).toBeDefined();
+            expect(result?.cert).toContain("-----BEGIN CERTIFICATE-----");
+        });
+
+        it("returns undefined when the request is mTLS Proof-of-Possession (per-request opt-in wins)", () => {
+            const result = getBearerOverMtlsCertificate(
+                credentials(),
+                AuthenticationScheme.MTLS_POP
+            );
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when the flag is not set", () => {
+            const result = getBearerOverMtlsCertificate(
+                credentials({ sendCertificateOverMtls: false })
+            );
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when there is no binding certificate", () => {
+            const result = getBearerOverMtlsCertificate(
+                credentials({ mtlsBindingCertificate: undefined })
+            );
+            expect(result).toBeUndefined();
+        });
+
+        it("wraps a bare base64 DER x5c value into PEM", () => {
+            const result = getBearerOverMtlsCertificate(credentials());
+            expect(result?.cert).toContain("-----BEGIN CERTIFICATE-----");
+            expect(result?.cert).toContain("-----END CERTIFICATE-----");
+            // 64-char line wrapping of the DER body.
+            expect(result?.cert).toContain(BARE_X5C.substring(0, 64));
+        });
+
+        it("returns a PEM x5c value unchanged", () => {
+            const result = getBearerOverMtlsCertificate(
+                credentials({
+                    mtlsBindingCertificate: {
+                        privateKey: PRIVATE_KEY,
+                        x5c: PEM_X5C,
+                    },
+                })
+            );
+            expect(result?.cert).toEqual(PEM_X5C);
+        });
+    });
+});

--- a/lib/msal-node/apiReview/msal-node.api.md
+++ b/lib/msal-node/apiReview/msal-node.api.md
@@ -382,6 +382,7 @@ export type NodeAuthOptions = {
         thumbprintSha256?: string;
         privateKey: string;
         x5c?: string;
+        sendCertificateOverMtls?: boolean;
     };
     knownAuthorities?: Array<string>;
     cloudDiscoveryMetadata?: string;

--- a/lib/msal-node/src/client/ClientApplication.ts
+++ b/lib/msal-node/src/client/ClientApplication.ts
@@ -565,6 +565,8 @@ export abstract class ClientApplication {
                     discoveredAuthority
                 ),
                 mtlsBindingCertificate: mtlsBindingCertificate,
+                sendCertificateOverMtls:
+                    clientCertificate?.sendCertificateOverMtls,
             },
             libraryInfo: {
                 sku: NodeConstants.MSAL_SKU,

--- a/lib/msal-node/src/client/ClientCredentialClient.ts
+++ b/lib/msal-node/src/client/ClientCredentialClient.ts
@@ -30,6 +30,7 @@ import {
     createClientAuthError,
     ClientAssertion,
     getClientAssertion,
+    getBearerOverMtlsCertificate,
     UrlUtils,
 } from "@azure/msal-common/node";
 import { ApiId } from "../utils/Constants.js";
@@ -398,6 +399,21 @@ export class ClientCredentialClient extends BaseClient {
                     cert: x5cToPem(bindingCertificate.x5c),
                     key: bindingCertificate.privateKey,
                 };
+            } else {
+                /*
+                 * Bearer-over-mTLS: when the app opts in via clientCertificate.sendCertificateOverMtls,
+                 * present the same certificate as the client TLS certificate and route to the mTLS token
+                 * endpoint, but keep token_type Bearer — the certificate authenticates the transport, the
+                 * token is not bound to it. Per-request mtls_pop always takes precedence over the flag.
+                 */
+                const bearerOverMtlsCertificate = getBearerOverMtlsCertificate(
+                    this.config.clientCredentials,
+                    request.authenticationScheme
+                );
+                if (bearerOverMtlsCertificate) {
+                    tokenEndpoint = authority.getMtlsTokenEndpoint();
+                    mtlsCertificate = bearerOverMtlsCertificate;
+                }
             }
 
             const endpoint = UrlString.appendQueryString(

--- a/lib/msal-node/src/client/OnBehalfOfClient.ts
+++ b/lib/msal-node/src/client/OnBehalfOfClient.ts
@@ -27,6 +27,7 @@ import {
     UrlString,
     ClientAssertion,
     getClientAssertion,
+    getBearerOverMtlsCertificate,
     UrlUtils,
 } from "@azure/msal-common/node";
 import { ApiId } from "../utils/Constants.js";
@@ -301,8 +302,19 @@ export class OnBehalfOfClient extends BaseClient {
         additionalCacheKeyComponents?: Record<string, string>
     ): Promise<AuthenticationResult | null> {
         const queryParametersString = this.createTokenQueryParameters(request);
+        /*
+         * Bearer-over-mTLS: when the app opts in via clientCertificate.sendCertificateOverMtls, present
+         * the certificate as the client TLS certificate and route to the mTLS token endpoint while
+         * keeping token_type Bearer. Per-request mtls_pop always takes precedence over the flag.
+         */
+        const bearerOverMtlsCertificate = getBearerOverMtlsCertificate(
+            this.config.clientCredentials,
+            request.authenticationScheme
+        );
         const endpoint = UrlString.appendQueryString(
-            authority.tokenEndpoint,
+            bearerOverMtlsCertificate
+                ? authority.getMtlsTokenEndpoint()
+                : authority.tokenEndpoint,
             queryParametersString
         );
         const requestBody = await this.createTokenRequestBody(request);
@@ -326,7 +338,8 @@ export class OnBehalfOfClient extends BaseClient {
             requestBody,
             headers,
             thumbprint,
-            request.correlationId
+            request.correlationId,
+            bearerOverMtlsCertificate
         );
 
         const responseHandler = new ResponseHandler(

--- a/lib/msal-node/src/config/Configuration.ts
+++ b/lib/msal-node/src/config/Configuration.ts
@@ -224,6 +224,18 @@ export function buildAppConfiguration({
         throw NodeAuthError.createSendCertificateOverMtlsMissingCertificateError();
     }
 
+    // sendCertificateOverMtls must build the client_assertion FROM the certificate so it carries the
+    // forced x5c chain ESTS uses to SN/I-match over the mTLS channel. A developer-supplied opaque
+    // clientAssertion would instead win the request body without an x5c header, so reject the
+    // combination (fail-closed, mirroring MSAL.NET's InvalidCredentialMaterial) rather than silently
+    // emitting an x5c-less assertion on the mTLS handshake.
+    if (
+        auth.clientCertificate?.sendCertificateOverMtls &&
+        auth.clientAssertion
+    ) {
+        throw NodeAuthError.createSendCertificateOverMtlsWithClientAssertionError();
+    }
+
     // if client certificate was provided, ensure that at least one of the SHA-1 or SHA-256 thumbprints were provided
     if (
         !!auth.clientCertificate &&

--- a/lib/msal-node/src/config/Configuration.ts
+++ b/lib/msal-node/src/config/Configuration.ts
@@ -43,6 +43,14 @@ export type NodeAuthOptions = {
         thumbprintSha256?: string;
         privateKey: string;
         x5c?: string;
+        /**
+         * When true, the certificate is presented as the client TLS certificate on the handshake to
+         * the mTLS token endpoint (Bearer-over-mTLS): the transport is authenticated by the certificate
+         * and a plain Bearer token is returned (the token is NOT bound to the certificate). Requires a
+         * certificate credential (both x5c and privateKey). Defaults to false. A per-request mtls_pop
+         * opt-in always takes precedence over this app-level flag.
+         */
+        sendCertificateOverMtls?: boolean;
     };
     knownAuthorities?: Array<string>;
     cloudDiscoveryMetadata?: string;
@@ -138,6 +146,7 @@ const DEFAULT_AUTH_OPTIONS: Required<NodeAuthOptions> = {
         thumbprintSha256: "",
         privateKey: "",
         x5c: "",
+        sendCertificateOverMtls: false,
     },
     knownAuthorities: [],
     cloudDiscoveryMetadata: "",
@@ -205,6 +214,15 @@ export function buildAppConfiguration({
         loggerOptions: system?.loggerOptions || DEFAULT_LOGGER_OPTIONS,
         disableInternalRetries: system?.disableInternalRetries || false,
     };
+
+    // Bearer-over-mTLS requires a full certificate credential (public chain + private key) to present
+    // on the TLS handshake. Fail fast, naming the flag, if it is enabled without one.
+    if (
+        auth.clientCertificate?.sendCertificateOverMtls &&
+        !(auth.clientCertificate.x5c && auth.clientCertificate.privateKey)
+    ) {
+        throw NodeAuthError.createSendCertificateOverMtlsMissingCertificateError();
+    }
 
     // if client certificate was provided, ensure that at least one of the SHA-1 or SHA-256 thumbprints were provided
     if (

--- a/lib/msal-node/src/error/NodeAuthError.ts
+++ b/lib/msal-node/src/error/NodeAuthError.ts
@@ -57,6 +57,10 @@ export const NodeAuthErrorMessage = {
         code: "mtls_custom_network_client_unsupported",
         desc: "mTLS Proof-of-Possession requires MSAL's built-in HttpClient to attach the client certificate to the TLS connection. A custom networkClient cannot be used with mtlsProofOfPossession.",
     },
+    sendCertificateOverMtlsMissingCertificate: {
+        code: "send_certificate_over_mtls_missing_certificate",
+        desc: "sendCertificateOverMtls was enabled but no usable client certificate is configured. Provide a clientCertificate with both an x5c (public certificate or chain) and a privateKey; sendCertificateOverMtls presents that certificate on the TLS handshake to the mTLS token endpoint.",
+    },
 };
 
 export class NodeAuthError extends AuthError {
@@ -212,6 +216,20 @@ export class NodeAuthError extends AuthError {
             NodeAuthErrorMessage.mtlsCustomNetworkClientUnsupported.code,
             correlationId,
             NodeAuthErrorMessage.mtlsCustomNetworkClientUnsupported.desc
+        );
+    }
+
+    /**
+     * Creates an error thrown when sendCertificateOverMtls is enabled but no usable client
+     * certificate (x5c + privateKey) is configured.
+     */
+    static createSendCertificateOverMtlsMissingCertificateError(
+        correlationId: string = ""
+    ): NodeAuthError {
+        return new NodeAuthError(
+            NodeAuthErrorMessage.sendCertificateOverMtlsMissingCertificate.code,
+            correlationId,
+            NodeAuthErrorMessage.sendCertificateOverMtlsMissingCertificate.desc
         );
     }
 }

--- a/lib/msal-node/src/error/NodeAuthError.ts
+++ b/lib/msal-node/src/error/NodeAuthError.ts
@@ -61,6 +61,10 @@ export const NodeAuthErrorMessage = {
         code: "send_certificate_over_mtls_missing_certificate",
         desc: "sendCertificateOverMtls was enabled but no usable client certificate is configured. Provide a clientCertificate with both an x5c (public certificate or chain) and a privateKey; sendCertificateOverMtls presents that certificate on the TLS handshake to the mTLS token endpoint.",
     },
+    sendCertificateOverMtlsWithClientAssertion: {
+        code: "send_certificate_over_mtls_with_client_assertion",
+        desc: "sendCertificateOverMtls requires the configured clientCertificate to produce the client_assertion so it carries the forced x5c chain that authenticates the certificate over the mTLS channel. A developer-supplied clientAssertion (static string or callback) cannot be given an x5c header and is not supported with sendCertificateOverMtls. Remove clientAssertion, or disable sendCertificateOverMtls.",
+    },
 };
 
 export class NodeAuthError extends AuthError {
@@ -230,6 +234,23 @@ export class NodeAuthError extends AuthError {
             NodeAuthErrorMessage.sendCertificateOverMtlsMissingCertificate.code,
             correlationId,
             NodeAuthErrorMessage.sendCertificateOverMtlsMissingCertificate.desc
+        );
+    }
+
+    /**
+     * Creates an error thrown when sendCertificateOverMtls is enabled together with a
+     * developer-supplied clientAssertion. The opaque assertion would populate the request body
+     * without the forced x5c chain the mTLS SN/I match requires, so the combination is rejected
+     * (fail-closed, mirroring MSAL.NET's InvalidCredentialMaterial) rather than silently emitting
+     * an x5c-less assertion on the mTLS handshake.
+     */
+    static createSendCertificateOverMtlsWithClientAssertionError(
+        correlationId: string = ""
+    ): NodeAuthError {
+        return new NodeAuthError(
+            NodeAuthErrorMessage.sendCertificateOverMtlsWithClientAssertion.code,
+            correlationId,
+            NodeAuthErrorMessage.sendCertificateOverMtlsWithClientAssertion.desc
         );
     }
 }

--- a/lib/msal-node/test/client/ClientCredentialClientBearerOverMtls.spec.ts
+++ b/lib/msal-node/test/client/ClientCredentialClientBearerOverMtls.spec.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    Authority,
+    AuthorityOptions,
+    AuthenticationResult,
+    ClientConfiguration,
+    Constants,
+    Logger,
+    MtlsBindingCertificate,
+    NetworkResponse,
+    ProtocolMode,
+    ServerAuthorizationTokenResponse,
+    StubPerformanceClient,
+} from "@azure/msal-common";
+import {
+    CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT,
+    DEFAULT_OPENID_CONFIG_RESPONSE,
+    TEST_CONFIG,
+} from "../test_kit/StringConstants.js";
+import {
+    ClientTestUtils,
+    MockStorageClass,
+    mockCrypto,
+} from "./ClientTestUtils.js";
+import { mockNetworkClient } from "../utils/MockNetworkClient.js";
+import { CommonClientCredentialRequest } from "../../src/request/CommonClientCredentialRequest.js";
+import { ClientCredentialClient } from "../../src/client/ClientCredentialClient.js";
+import { HttpClient } from "../../src/network/HttpClient.js";
+import { x5cToPem } from "../../src/utils/MtlsCertificateUtils.js";
+
+const TENANT_ID = "3338040d-6c67-4c5b-b112-36a304b66dad";
+const TENANTED_AUTHORITY = `https://login.microsoftonline.com/${TENANT_ID}`;
+
+// Vanilla SNI cert (app clientCertificate) — authenticates the client at the TLS layer.
+const APP_CERT: MtlsBindingCertificate = {
+    x5c: Buffer.from("sni-leaf-cert-der-bytes").toString("base64"),
+    privateKey:
+        "-----BEGIN PRIVATE KEY-----\nsni-private-key\n-----END PRIVATE KEY-----\n",
+};
+
+// A private_key_jwt client assertion built by the app from the certificate (carries x5c on its header).
+const CLIENT_ASSERTION = {
+    assertion: "MOCK.CLIENT.ASSERTION",
+    assertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+};
+
+const BEARER_TOKEN_RESPONSE: ServerAuthorizationTokenResponse = {
+    token_type: Constants.AuthenticationScheme.BEARER,
+    scope: TEST_CONFIG.DEFAULT_GRAPH_SCOPE.join(" "),
+    expires_in: 3599,
+    ext_expires_in: 3599,
+    access_token: "thisIs.an.bearerOverMtls.accessT0ken",
+};
+
+const BEARER_NETWORK_RESPONSE: NetworkResponse<ServerAuthorizationTokenResponse> =
+    {
+        headers: {},
+        body: BEARER_TOKEN_RESPONSE,
+        status: 200,
+    };
+
+const MTLS_POP_NETWORK_RESPONSE: NetworkResponse<ServerAuthorizationTokenResponse> =
+    {
+        headers: {},
+        body: {
+            token_type: Constants.AuthenticationScheme.MTLS_POP,
+            expires_in: 3599,
+            ext_expires_in: 3599,
+            access_token: "thisIs.an.mtlsPop.accessT0ken",
+        },
+        status: 200,
+    };
+
+/**
+ * Builds a resolved, tenanted Authority so that `getMtlsTokenEndpoint()` does not reject the
+ * request as non-tenanted (the shared test authority is `/common`).
+ */
+async function resolveTenantedAuthority(): Promise<Authority> {
+    const mockStorage = new MockStorageClass(
+        TEST_CONFIG.MSAL_CLIENT_ID,
+        mockCrypto,
+        new Logger({}),
+        new StubPerformanceClient()
+    );
+    const authorityOptions: AuthorityOptions = {
+        protocolMode: ProtocolMode.AAD,
+        knownAuthorities: [TENANTED_AUTHORITY],
+        cloudDiscoveryMetadata: "",
+        authorityMetadata: "",
+    };
+    const authority = new Authority(
+        TENANTED_AUTHORITY,
+        mockNetworkClient(
+            DEFAULT_OPENID_CONFIG_RESPONSE.body,
+            CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT
+        ),
+        mockStorage,
+        authorityOptions,
+        new Logger({ loggerCallback: (): void => {} }),
+        TEST_CONFIG.CORRELATION_ID,
+        new StubPerformanceClient()
+    );
+    await authority.resolveEndpointsAsync();
+    return authority;
+}
+
+/**
+ * Builds a ClientConfiguration wired for Bearer-over-mTLS: a tenanted authority and a real HttpClient
+ * (so the mtls agent option is honored), with the HttpClient's POST spied to return the given token
+ * response without touching the network.
+ */
+async function buildConfig(
+    clientCredentials: ClientConfiguration["clientCredentials"],
+    tokenResponse: NetworkResponse<ServerAuthorizationTokenResponse> = BEARER_NETWORK_RESPONSE
+): Promise<{ config: ClientConfiguration; postSpy: jest.SpyInstance }> {
+    const config = await ClientTestUtils.createTestClientConfiguration(
+        undefined,
+        mockNetworkClient(
+            DEFAULT_OPENID_CONFIG_RESPONSE.body,
+            CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT
+        )
+    );
+
+    const httpClient = new HttpClient();
+    const postSpy = jest
+        .spyOn(httpClient, "sendPostRequestAsync")
+        .mockResolvedValue(tokenResponse);
+    jest.spyOn(httpClient, "sendGetRequestAsync").mockResolvedValue(
+        DEFAULT_OPENID_CONFIG_RESPONSE.body as never
+    );
+
+    config.authOptions.authority = await resolveTenantedAuthority();
+    config.networkInterface = httpClient;
+    config.clientCredentials = clientCredentials;
+
+    return { config, postSpy };
+}
+
+describe("ClientCredentialClient Bearer-over-mTLS (sendCertificateOverMtls)", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const baseRequest = (): CommonClientCredentialRequest => ({
+        authority: TENANTED_AUTHORITY,
+        correlationId: TEST_CONFIG.CORRELATION_ID,
+        scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+        skipCache: false,
+    });
+
+    describe("flag set with a certificate credential", () => {
+        const credentials = () => ({
+            mtlsBindingCertificate: APP_CERT,
+            clientAssertion: CLIENT_ASSERTION,
+            sendCertificateOverMtls: true,
+        });
+
+        it("targets the mTLS token endpoint", async () => {
+            const { config, postSpy } = await buildConfig(credentials());
+            const client = new ClientCredentialClient(config);
+
+            await client.acquireToken(baseRequest());
+
+            const endpoint = postSpy.mock.calls[0][0] as string;
+            expect(endpoint).toContain("mtlsauth.microsoft.com");
+            expect(endpoint).toContain(TENANT_ID);
+            expect(endpoint).not.toContain("//login.microsoftonline.com");
+        });
+
+        it("keeps a plain Bearer token: client_assertion in the body, no req_cnf and no token_type=mtls_pop", async () => {
+            const { config, postSpy } = await buildConfig(credentials());
+            const client = new ClientCredentialClient(config);
+
+            await client.acquireToken(baseRequest());
+
+            const body = postSpy.mock.calls[0][1]?.body as string;
+            expect(body).toContain("client_assertion=");
+            expect(body).toContain("client_assertion_type=");
+            expect(body).not.toContain("req_cnf");
+            expect(body).not.toContain(
+                `token_type=${encodeURIComponent("mtls_pop")}`
+            );
+        });
+
+        it("presents the configured certificate on the TLS connection", async () => {
+            const { config, postSpy } = await buildConfig(credentials());
+            const client = new ClientCredentialClient(config);
+
+            await client.acquireToken(baseRequest());
+
+            const mtlsCertificate = postSpy.mock.calls[0][1]?.mtlsCertificate;
+            expect(mtlsCertificate).toEqual({
+                cert: x5cToPem(APP_CERT.x5c),
+                key: APP_CERT.privateKey,
+            });
+        });
+
+        it("returns a Bearer token that is not certificate-bound", async () => {
+            const { config } = await buildConfig(credentials());
+            const client = new ClientCredentialClient(config);
+
+            const result = (await client.acquireToken(
+                baseRequest()
+            )) as AuthenticationResult;
+
+            expect(result.tokenType).toBe("Bearer");
+            expect(result.bindingCertificate).toBeUndefined();
+        });
+
+        it("serves the second acquisition from the plain Bearer cache without a second network call", async () => {
+            const { config, postSpy } = await buildConfig(credentials());
+            const client = new ClientCredentialClient(config);
+
+            const first = (await client.acquireToken(
+                baseRequest()
+            )) as AuthenticationResult;
+            const second = (await client.acquireToken(
+                baseRequest()
+            )) as AuthenticationResult;
+
+            expect(postSpy).toHaveBeenCalledTimes(1);
+            expect(second.fromCache).toBe(true);
+            expect(second.accessToken).toEqual(first.accessToken);
+        });
+    });
+
+    describe("precedence and negative cases", () => {
+        it("lets a per-request mtls_pop opt-in win over the app-level flag", async () => {
+            const { config, postSpy } = await buildConfig(
+                {
+                    mtlsBindingCertificate: APP_CERT,
+                    clientAssertion: CLIENT_ASSERTION,
+                    sendCertificateOverMtls: true,
+                },
+                MTLS_POP_NETWORK_RESPONSE
+            );
+            const client = new ClientCredentialClient(config);
+
+            const result = (await client.acquireToken({
+                ...baseRequest(),
+                authenticationScheme: Constants.AuthenticationScheme.MTLS_POP,
+            })) as AuthenticationResult;
+
+            const body = postSpy.mock.calls[0][1]?.body as string;
+            // mTLS PoP path ran: bound token_type in the body, and the token is bound.
+            expect(body).toContain(
+                `token_type=${encodeURIComponent("mtls_pop")}`
+            );
+            expect(result.tokenType).toBe("mtls_pop");
+        });
+
+        it("does not route to the mTLS endpoint when the flag is unset", async () => {
+            const { config, postSpy } = await buildConfig({
+                mtlsBindingCertificate: APP_CERT,
+                clientAssertion: CLIENT_ASSERTION,
+            });
+            const client = new ClientCredentialClient(config);
+
+            await client.acquireToken(baseRequest());
+
+            const endpoint = postSpy.mock.calls[0][0] as string;
+            expect(endpoint).toContain("login.microsoftonline.com");
+            expect(endpoint).not.toContain("mtlsauth.microsoft.com");
+            expect(postSpy.mock.calls[0][1]?.mtlsCertificate).toBeUndefined();
+        });
+    });
+});

--- a/lib/msal-node/test/client/ClientCredentialClientBearerOverMtls.spec.ts
+++ b/lib/msal-node/test/client/ClientCredentialClientBearerOverMtls.spec.ts
@@ -225,6 +225,32 @@ describe("ClientCredentialClient Bearer-over-mTLS (sendCertificateOverMtls)", ()
             expect(postSpy).toHaveBeenCalledTimes(1);
             expect(second.fromCache).toBe(true);
             expect(second.accessToken).toEqual(first.accessToken);
+            expect(second.tokenType).toBe(
+                Constants.AuthenticationScheme.BEARER
+            );
+
+            // Note #3: the Bearer-over-mTLS token must be cached under the PLAIN Bearer key (credentialType
+            // "AccessToken"), NOT the scheme-fenced "accesstoken_with_authscheme" key that mtls_pop uses -
+            // that is what lets an ordinary Bearer lookup (the 2nd call above) find it.
+            const accessTokenKey = config.storageInterface
+                ?.getKeys()
+                .find((key) => key.indexOf("accesstoken") >= 0);
+            expect(accessTokenKey).toBeDefined();
+            expect(accessTokenKey).not.toContain("accesstoken_with_authscheme");
+
+            // And it must be keyed under the CANONICAL authority environment (login.*/preferred_cache),
+            // never the physical mtlsauth.* POST host - so a 2nd lookup needs no region/instance metadata.
+            const cachedToken =
+                config.storageInterface?.getAccessTokenCredential(
+                    accessTokenKey!,
+                    TEST_CONFIG.CORRELATION_ID
+                );
+            expect(cachedToken?.credentialType).toBe("AccessToken");
+            expect(cachedToken?.tokenType).toBe(
+                Constants.AuthenticationScheme.BEARER
+            );
+            expect(cachedToken?.environment).not.toContain("mtlsauth");
+            expect(accessTokenKey).not.toContain("mtlsauth");
         });
     });
 

--- a/lib/msal-node/test/client/ClientCredentialClientBearerOverMtls.spec.ts
+++ b/lib/msal-node/test/client/ClientCredentialClientBearerOverMtls.spec.ts
@@ -249,6 +249,7 @@ describe("ClientCredentialClient Bearer-over-mTLS (sendCertificateOverMtls)", ()
             expect(cachedToken?.tokenType).toBe(
                 Constants.AuthenticationScheme.BEARER
             );
+            expect(cachedToken?.environment).toContain("login");
             expect(cachedToken?.environment).not.toContain("mtlsauth");
             expect(accessTokenKey).not.toContain("mtlsauth");
         });

--- a/lib/msal-node/test/client/ConfidentialClientApplicationBearerOverMtls.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplicationBearerOverMtls.spec.ts
@@ -30,8 +30,13 @@ jest.mock("jsonwebtoken");
  * Bearer. jsonwebtoken is mocked, so the certificate-derived assertion is a stub string.
  */
 describe("ConfidentialClientApplication Bearer-over-mTLS (sendCertificateOverMtls)", () => {
-    beforeAll(() => {
-        jest.spyOn(jwt, <any>"sign").mockReturnValue("fake_jwt_string");
+    let signSpy: jest.SpyInstance;
+    beforeEach(() => {
+        // Spy (not just stub) so the certificate-derived assertion header can be inspected: the x5c
+        // chain must be forced onto every Bearer-over-mTLS client_assertion for ESTS SN/I matching.
+        signSpy = jest
+            .spyOn(jwt, <any>"sign")
+            .mockReturnValue("fake_jwt_string");
     });
 
     afterEach(() => {
@@ -97,6 +102,18 @@ describe("ConfidentialClientApplication Bearer-over-mTLS (sendCertificateOverMtl
         expect(mtlsCertificate).toBeDefined();
         expect(mtlsCertificate.key).toEqual(TEST_CONSTANTS.PRIVATE_KEY);
         expect(mtlsCertificate.cert).toContain("BEGIN CERTIFICATE");
+
+        // The x5c chain must be FORCED onto the client_assertion JWT header (mirrors .NET
+        // CredentialMaterialResolver Mode=OAuth) - that public issuer chain is what lets ESTS do SN/I
+        // matching over the mTLS channel. Assert it is present on the signed assertion (msal-node
+        // parses the configured PEM into the base64 DER chain used for the x5c header).
+        const signedWithX5c = signSpy.mock.calls.find(
+            (call) => call[2]?.header?.x5c
+        );
+        expect(signedWithX5c).toBeDefined();
+        expect(signedWithX5c![2].header.x5c).toEqual(
+            TEST_CONSTANTS.X5C_FROM_PUBLIC_CERTIFICATE
+        );
     }
 
     test("client-credentials routes to the mTLS endpoint with a Bearer + client_assertion", async () => {

--- a/lib/msal-node/test/client/ConfidentialClientApplicationBearerOverMtls.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplicationBearerOverMtls.spec.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AuthenticationResult, INetworkModule } from "@azure/msal-common";
+import {
+    DEFAULT_OPENID_CONFIG_RESPONSE,
+    TEST_CONSTANTS,
+} from "../utils/TestConstants.js";
+import { CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT } from "../test_kit/StringConstants.js";
+import { ClientTestUtils } from "./ClientTestUtils.js";
+import {
+    ConfidentialClientApplication,
+    Configuration,
+    RefreshTokenRequest,
+    AuthorizationCodeRequest,
+    OnBehalfOfRequest,
+    ClientCredentialRequest,
+} from "../../src/index.js";
+import jwt from "jsonwebtoken";
+
+jest.mock("jsonwebtoken");
+
+/**
+ * End-to-end coverage that the app-level auth.clientCertificate.sendCertificateOverMtls flag threads
+ * through buildOauthClientConfiguration to EVERY confidential flow (client-credentials, OBO,
+ * refresh-token, auth-code): the request is routed to the mTLS token endpoint, the certificate is
+ * presented on the connection, and a private_key_jwt client_assertion is sent while token_type stays
+ * Bearer. jsonwebtoken is mocked, so the certificate-derived assertion is a stub string.
+ */
+describe("ConfidentialClientApplication Bearer-over-mTLS (sendCertificateOverMtls)", () => {
+    beforeAll(() => {
+        jest.spyOn(jwt, <any>"sign").mockReturnValue("fake_jwt_string");
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    async function buildApp(sendCertificateOverMtls: boolean): Promise<{
+        app: ConfidentialClientApplication;
+        postSpy: jest.Mock;
+    }> {
+        const postSpy = jest.fn(
+            async () => CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT
+        );
+        const networkClient: INetworkModule = {
+            sendGetRequestAsync: jest.fn(
+                async () => DEFAULT_OPENID_CONFIG_RESPONSE.body as any
+            ),
+            sendPostRequestAsync: postSpy as any,
+        };
+
+        const config: Configuration =
+            await ClientTestUtils.createTestConfidentialClientConfiguration(
+                undefined,
+                networkClient
+            );
+        config.auth.clientCertificate = {
+            thumbprintSha256: TEST_CONSTANTS.THUMBPRINT256,
+            privateKey: TEST_CONSTANTS.PRIVATE_KEY,
+            x5c: TEST_CONSTANTS.PUBLIC_CERTIFICATE,
+            sendCertificateOverMtls,
+        };
+
+        return {
+            app: new ConfidentialClientApplication(config),
+            postSpy,
+        };
+    }
+
+    /** Returns the endpoint + options of the token POST (the only POST; discovery uses GET). */
+    function tokenPost(postSpy: jest.Mock): {
+        endpoint: string;
+        body: string;
+        mtlsCertificate: any;
+    } {
+        const [endpoint, options] = postSpy.mock.calls[0];
+        return {
+            endpoint: endpoint as string,
+            body: options?.body as string,
+            mtlsCertificate: options?.mtlsCertificate,
+        };
+    }
+
+    function assertBearerOverMtls(
+        postSpy: jest.Mock,
+        grantMarker: string
+    ): void {
+        const { endpoint, body, mtlsCertificate } = tokenPost(postSpy);
+        expect(endpoint).toContain("mtlsauth.microsoft.com");
+        expect(endpoint).toContain("tenantid");
+        expect(body).toContain(grantMarker);
+        expect(body).toContain("client_assertion=");
+        expect(body).not.toContain("req_cnf");
+        expect(mtlsCertificate).toBeDefined();
+        expect(mtlsCertificate.key).toEqual(TEST_CONSTANTS.PRIVATE_KEY);
+        expect(mtlsCertificate.cert).toContain("BEGIN CERTIFICATE");
+    }
+
+    test("client-credentials routes to the mTLS endpoint with a Bearer + client_assertion", async () => {
+        const { app, postSpy } = await buildApp(true);
+        const request: ClientCredentialRequest = {
+            scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
+            skipCache: true,
+        };
+
+        (await app.acquireTokenByClientCredential(
+            request
+        )) as AuthenticationResult;
+
+        assertBearerOverMtls(postSpy, "grant_type=client_credentials");
+    });
+
+    test("on-behalf-of routes to the mTLS endpoint with the on_behalf_of grant", async () => {
+        const { app, postSpy } = await buildApp(true);
+        const request: OnBehalfOfRequest = {
+            scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
+            oboAssertion: "user_assertion_hash",
+            skipCache: true,
+        };
+
+        await app.acquireTokenOnBehalfOf(request);
+
+        assertBearerOverMtls(postSpy, "requested_token_use=on_behalf_of");
+    });
+
+    test("refresh-token routes to the mTLS endpoint with the refresh_token grant", async () => {
+        const { app, postSpy } = await buildApp(true);
+        const request: RefreshTokenRequest = {
+            scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
+            refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
+        };
+
+        await app.acquireTokenByRefreshToken(request);
+
+        assertBearerOverMtls(postSpy, "grant_type=refresh_token");
+    });
+
+    test("auth-code routes to the mTLS endpoint with the authorization_code grant", async () => {
+        const { app, postSpy } = await buildApp(true);
+        const request: AuthorizationCodeRequest = {
+            scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
+            redirectUri: TEST_CONSTANTS.REDIRECT_URI,
+            code: TEST_CONSTANTS.AUTHORIZATION_CODE,
+        };
+
+        await app.acquireTokenByCode(request);
+
+        assertBearerOverMtls(postSpy, "grant_type=authorization_code");
+    });
+
+    test("does not route to the mTLS endpoint when the flag is unset (negative)", async () => {
+        const { app, postSpy } = await buildApp(false);
+        const request: RefreshTokenRequest = {
+            scopes: TEST_CONSTANTS.DEFAULT_GRAPH_SCOPE,
+            refreshToken: TEST_CONSTANTS.REFRESH_TOKEN,
+        };
+
+        await app.acquireTokenByRefreshToken(request);
+
+        const { endpoint, mtlsCertificate } = tokenPost(postSpy);
+        expect(endpoint).toContain("login.microsoftonline.com");
+        expect(endpoint).not.toContain("mtlsauth.microsoft.com");
+        expect(mtlsCertificate).toBeUndefined();
+    });
+});

--- a/lib/msal-node/test/client/OnBehalfOfClientBearerOverMtls.spec.ts
+++ b/lib/msal-node/test/client/OnBehalfOfClientBearerOverMtls.spec.ts
@@ -6,7 +6,9 @@
 import {
     Authority,
     AuthorityOptions,
+    AuthenticationResult,
     ClientConfiguration,
+    Constants,
     Logger,
     MtlsBindingCertificate,
     NetworkResponse,
@@ -185,5 +187,65 @@ describe("OnBehalfOfClient Bearer-over-mTLS (sendCertificateOverMtls)", () => {
         expect(endpoint).toContain("login.microsoftonline.com");
         expect(endpoint).not.toContain("mtlsauth.microsoft.com");
         expect(postSpy.mock.calls[0][1]?.mtlsCertificate).toBeUndefined();
+    });
+
+    it("serves the second on-behalf-of acquisition from the plain Bearer cache under the canonical login environment", async () => {
+        const { config, postSpy } = await buildConfig({
+            mtlsBindingCertificate: APP_CERT,
+            clientAssertion: CLIENT_ASSERTION,
+            sendCertificateOverMtls: true,
+        });
+        const client = new OnBehalfOfClient(config);
+
+        // A cache-enabled OBO request (skipCache defaults on in oboRequest()); the tenant matches the
+        // id_token tid so the first response caches cleanly and a second identical call can hit it.
+        const cacheableRequest = (): CommonOnBehalfOfRequest => ({
+            authority: TENANTED_AUTHORITY,
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+            oboAssertion: "user_assertion_hash",
+            scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE],
+            skipCache: false,
+        });
+
+        const first = (await client.acquireToken(
+            cacheableRequest()
+        )) as AuthenticationResult;
+        expect(postSpy.mock.calls[0][0] as string).toContain(
+            "mtlsauth.microsoft.com"
+        );
+        expect(first.fromCache).toBe(false);
+
+        const second = (await client.acquireToken(
+            cacheableRequest()
+        )) as AuthenticationResult;
+
+        // Note #3 (OBO 2nd call): the metadata path is exercised (login host reachable/resolvable), and
+        // the Bearer-over-mTLS token is served from cache with NO second network POST.
+        expect(postSpy).toHaveBeenCalledTimes(1);
+        expect(second.fromCache).toBe(true);
+        expect(second.accessToken).toEqual(first.accessToken);
+        expect(second.tokenType).toBe(Constants.AuthenticationScheme.BEARER);
+
+        // It must be cached under the PLAIN Bearer key (credentialType AccessToken, not the scheme-fenced
+        // accesstoken_with_authscheme key mtls_pop uses) and under the CANONICAL authority environment
+        // (login.windows.net / preferred_cache), never the physical mtlsauth.* POST host - the cert is
+        // transport-only, so the entry is indistinguishable from a regular Bearer and reusable.
+        const accessTokenKey = config.storageInterface
+            ?.getKeys()
+            .find((key) => key.indexOf("accesstoken") >= 0);
+        expect(accessTokenKey).toBeDefined();
+        expect(accessTokenKey).not.toContain("accesstoken_with_authscheme");
+        expect(accessTokenKey).not.toContain("mtlsauth");
+
+        const cachedToken = config.storageInterface?.getAccessTokenCredential(
+            accessTokenKey!,
+            TEST_CONFIG.CORRELATION_ID
+        );
+        expect(cachedToken?.credentialType).toBe("AccessToken");
+        expect(cachedToken?.tokenType).toBe(
+            Constants.AuthenticationScheme.BEARER
+        );
+        expect(cachedToken?.environment).toContain("login");
+        expect(cachedToken?.environment).not.toContain("mtlsauth");
     });
 });

--- a/lib/msal-node/test/client/OnBehalfOfClientBearerOverMtls.spec.ts
+++ b/lib/msal-node/test/client/OnBehalfOfClientBearerOverMtls.spec.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    Authority,
+    AuthorityOptions,
+    ClientConfiguration,
+    Logger,
+    MtlsBindingCertificate,
+    NetworkResponse,
+    ProtocolMode,
+    ServerAuthorizationTokenResponse,
+    StubPerformanceClient,
+} from "@azure/msal-common";
+import {
+    AUTHENTICATION_RESULT,
+    CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT,
+    DEFAULT_OPENID_CONFIG_RESPONSE,
+    TEST_CONFIG,
+} from "../test_kit/StringConstants.js";
+import {
+    ClientTestUtils,
+    MockStorageClass,
+    mockCrypto,
+} from "./ClientTestUtils.js";
+import { mockNetworkClient } from "../utils/MockNetworkClient.js";
+import { CommonOnBehalfOfRequest } from "../../src/request/CommonOnBehalfOfRequest.js";
+import { OnBehalfOfClient } from "../../src/client/OnBehalfOfClient.js";
+import { HttpClient } from "../../src/network/HttpClient.js";
+import { x5cToPem } from "../../src/utils/MtlsCertificateUtils.js";
+
+const TENANT_ID = "3338040d-6c67-4c5b-b112-36a304b66dad";
+const TENANTED_AUTHORITY = `https://login.microsoftonline.com/${TENANT_ID}`;
+
+const APP_CERT: MtlsBindingCertificate = {
+    x5c: Buffer.from("sni-leaf-cert-der-bytes").toString("base64"),
+    privateKey:
+        "-----BEGIN PRIVATE KEY-----\nsni-private-key\n-----END PRIVATE KEY-----\n",
+};
+
+const CLIENT_ASSERTION = {
+    assertion: "MOCK.CLIENT.ASSERTION",
+    assertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+};
+
+const BEARER_NETWORK_RESPONSE: NetworkResponse<ServerAuthorizationTokenResponse> =
+    {
+        headers: {},
+        body: AUTHENTICATION_RESULT.body as ServerAuthorizationTokenResponse,
+        status: 200,
+    };
+
+async function resolveTenantedAuthority(): Promise<Authority> {
+    const mockStorage = new MockStorageClass(
+        TEST_CONFIG.MSAL_CLIENT_ID,
+        mockCrypto,
+        new Logger({}),
+        new StubPerformanceClient()
+    );
+    const authorityOptions: AuthorityOptions = {
+        protocolMode: ProtocolMode.AAD,
+        knownAuthorities: [TENANTED_AUTHORITY],
+        cloudDiscoveryMetadata: "",
+        authorityMetadata: "",
+    };
+    const authority = new Authority(
+        TENANTED_AUTHORITY,
+        mockNetworkClient(
+            DEFAULT_OPENID_CONFIG_RESPONSE.body,
+            CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT
+        ),
+        mockStorage,
+        authorityOptions,
+        new Logger({ loggerCallback: (): void => {} }),
+        TEST_CONFIG.CORRELATION_ID,
+        new StubPerformanceClient()
+    );
+    await authority.resolveEndpointsAsync();
+    return authority;
+}
+
+async function buildConfig(
+    clientCredentials: ClientConfiguration["clientCredentials"]
+): Promise<{ config: ClientConfiguration; postSpy: jest.SpyInstance }> {
+    const config = await ClientTestUtils.createTestClientConfiguration(
+        undefined,
+        mockNetworkClient(
+            DEFAULT_OPENID_CONFIG_RESPONSE.body,
+            CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT
+        )
+    );
+
+    const httpClient = new HttpClient();
+    const postSpy = jest
+        .spyOn(httpClient, "sendPostRequestAsync")
+        .mockResolvedValue(BEARER_NETWORK_RESPONSE);
+    jest.spyOn(httpClient, "sendGetRequestAsync").mockResolvedValue(
+        DEFAULT_OPENID_CONFIG_RESPONSE.body as never
+    );
+
+    config.authOptions.authority = await resolveTenantedAuthority();
+    config.networkInterface = httpClient;
+    config.clientCredentials = clientCredentials;
+
+    return { config, postSpy };
+}
+
+const oboRequest = (): CommonOnBehalfOfRequest => ({
+    authority: TENANTED_AUTHORITY,
+    correlationId: TEST_CONFIG.CORRELATION_ID,
+    oboAssertion: "user_assertion_hash",
+    scopes: [...TEST_CONFIG.DEFAULT_GRAPH_SCOPE],
+    skipCache: true,
+});
+
+/**
+ * Request-capture: the fake Bearer token cannot always be turned into a cached account, so response
+ * handling may reject. The outbound request is captured before that, and the wire contract is asserted
+ * on the captured request regardless (mirrors the .NET recording-HttpClient pattern for user flows).
+ */
+async function captureRequest(
+    client: OnBehalfOfClient,
+    request: CommonOnBehalfOfRequest
+): Promise<void> {
+    try {
+        await client.acquireToken(request);
+    } catch (e) {
+        // swallow — assertions run against the captured request
+    }
+}
+
+describe("OnBehalfOfClient Bearer-over-mTLS (sendCertificateOverMtls)", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("routes to the mTLS endpoint and sends the on_behalf_of grant with client_assertion when the flag is set", async () => {
+        const { config, postSpy } = await buildConfig({
+            mtlsBindingCertificate: APP_CERT,
+            clientAssertion: CLIENT_ASSERTION,
+            sendCertificateOverMtls: true,
+        });
+        const client = new OnBehalfOfClient(config);
+
+        await captureRequest(client, oboRequest());
+
+        const endpoint = postSpy.mock.calls[0][0] as string;
+        expect(endpoint).toContain("mtlsauth.microsoft.com");
+        expect(endpoint).toContain(TENANT_ID);
+
+        const body = postSpy.mock.calls[0][1]?.body as string;
+        expect(body).toContain("requested_token_use=on_behalf_of");
+        expect(body).toContain("client_assertion=");
+        expect(body).not.toContain("req_cnf");
+    });
+
+    it("presents the configured certificate on the TLS connection", async () => {
+        const { config, postSpy } = await buildConfig({
+            mtlsBindingCertificate: APP_CERT,
+            clientAssertion: CLIENT_ASSERTION,
+            sendCertificateOverMtls: true,
+        });
+        const client = new OnBehalfOfClient(config);
+
+        await captureRequest(client, oboRequest());
+
+        expect(postSpy.mock.calls[0][1]?.mtlsCertificate).toEqual({
+            cert: x5cToPem(APP_CERT.x5c),
+            key: APP_CERT.privateKey,
+        });
+    });
+
+    it("uses the regular login endpoint when the flag is unset (negative)", async () => {
+        const { config, postSpy } = await buildConfig({
+            mtlsBindingCertificate: APP_CERT,
+            clientAssertion: CLIENT_ASSERTION,
+        });
+        const client = new OnBehalfOfClient(config);
+
+        await captureRequest(client, oboRequest());
+
+        const endpoint = postSpy.mock.calls[0][0] as string;
+        expect(endpoint).toContain("login.microsoftonline.com");
+        expect(endpoint).not.toContain("mtlsauth.microsoft.com");
+        expect(postSpy.mock.calls[0][1]?.mtlsCertificate).toBeUndefined();
+    });
+});

--- a/lib/msal-node/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-node/test/config/ClientConfiguration.spec.ts
@@ -272,4 +272,72 @@ describe("ClientConfiguration tests", () => {
             })
         );
     });
+
+    describe("sendCertificateOverMtls (Bearer-over-mTLS)", () => {
+        test("is left falsy when not specified", () => {
+            const config: Configuration = buildAppConfiguration({
+                auth: {
+                    clientId: TEST_CONSTANTS.CLIENT_ID,
+                    clientCertificate: {
+                        thumbprintSha256: TEST_CONSTANTS.THUMBPRINT256,
+                        privateKey: TEST_CONSTANTS.PRIVATE_KEY,
+                        x5c: TEST_CONSTANTS.PUBLIC_CERTIFICATE,
+                    },
+                },
+            });
+
+            expect(
+                config.auth.clientCertificate?.sendCertificateOverMtls
+            ).toBeFalsy();
+        });
+
+        test("stores the flag when explicitly enabled with a certificate", () => {
+            const config: Configuration = buildAppConfiguration({
+                auth: {
+                    clientId: TEST_CONSTANTS.CLIENT_ID,
+                    clientCertificate: {
+                        thumbprintSha256: TEST_CONSTANTS.THUMBPRINT256,
+                        privateKey: TEST_CONSTANTS.PRIVATE_KEY,
+                        x5c: TEST_CONSTANTS.PUBLIC_CERTIFICATE,
+                        sendCertificateOverMtls: true,
+                    },
+                },
+            });
+
+            expect(config.auth.clientCertificate?.sendCertificateOverMtls).toBe(
+                true
+            );
+        });
+
+        test("throws an error naming the flag when enabled without a full certificate (missing x5c)", () => {
+            expect(() =>
+                buildAppConfiguration({
+                    auth: {
+                        clientId: TEST_CONSTANTS.CLIENT_ID,
+                        clientCertificate: {
+                            thumbprintSha256: TEST_CONSTANTS.THUMBPRINT256,
+                            privateKey: TEST_CONSTANTS.PRIVATE_KEY,
+                            sendCertificateOverMtls: true,
+                        },
+                    },
+                })
+            ).toThrow(/sendCertificateOverMtls/);
+        });
+
+        test("throws an error when enabled without a private key", () => {
+            expect(() =>
+                buildAppConfiguration({
+                    auth: {
+                        clientId: TEST_CONSTANTS.CLIENT_ID,
+                        clientCertificate: {
+                            thumbprintSha256: TEST_CONSTANTS.THUMBPRINT256,
+                            privateKey: "",
+                            x5c: TEST_CONSTANTS.PUBLIC_CERTIFICATE,
+                            sendCertificateOverMtls: true,
+                        },
+                    },
+                })
+            ).toThrow(/sendCertificateOverMtls/);
+        });
+    });
 });

--- a/lib/msal-node/test/config/ClientConfiguration.spec.ts
+++ b/lib/msal-node/test/config/ClientConfiguration.spec.ts
@@ -339,5 +339,61 @@ describe("ClientConfiguration tests", () => {
                 })
             ).toThrow(/sendCertificateOverMtls/);
         });
+
+        // Fail-closed parity with .NET (ConfidentialClientApplicationBuilder.Validate throws
+        // InvalidCredentialMaterial): sendCertificateOverMtls must build the client_assertion FROM the
+        // certificate so it carries the forced x5c chain that lets ESTS SN/I-match over the mTLS
+        // channel. A developer-supplied opaque clientAssertion would win the request body but cannot be
+        // given an x5c header, so the combination is rejected rather than silently emitting an
+        // x5c-less assertion on the mTLS handshake.
+        test("throws an error naming the flag when enabled alongside a static clientAssertion", () => {
+            expect(() =>
+                buildAppConfiguration({
+                    auth: {
+                        clientId: TEST_CONSTANTS.CLIENT_ID,
+                        clientAssertion: "developer.supplied.jwt",
+                        clientCertificate: {
+                            thumbprintSha256: TEST_CONSTANTS.THUMBPRINT256,
+                            privateKey: TEST_CONSTANTS.PRIVATE_KEY,
+                            x5c: TEST_CONSTANTS.PUBLIC_CERTIFICATE,
+                            sendCertificateOverMtls: true,
+                        },
+                    },
+                })
+            ).toThrow(/sendCertificateOverMtls/);
+        });
+
+        test("throws an error naming the flag when enabled alongside a clientAssertion callback", () => {
+            expect(() =>
+                buildAppConfiguration({
+                    auth: {
+                        clientId: TEST_CONSTANTS.CLIENT_ID,
+                        clientAssertion: async () => "developer.supplied.jwt",
+                        clientCertificate: {
+                            thumbprintSha256: TEST_CONSTANTS.THUMBPRINT256,
+                            privateKey: TEST_CONSTANTS.PRIVATE_KEY,
+                            x5c: TEST_CONSTANTS.PUBLIC_CERTIFICATE,
+                            sendCertificateOverMtls: true,
+                        },
+                    },
+                })
+            ).toThrow(/sendCertificateOverMtls/);
+        });
+
+        test("does not throw for a clientAssertion when the flag is not set", () => {
+            expect(() =>
+                buildAppConfiguration({
+                    auth: {
+                        clientId: TEST_CONSTANTS.CLIENT_ID,
+                        clientAssertion: "developer.supplied.jwt",
+                        clientCertificate: {
+                            thumbprintSha256: TEST_CONSTANTS.THUMBPRINT256,
+                            privateKey: TEST_CONSTANTS.PRIVATE_KEY,
+                            x5c: TEST_CONSTANTS.PUBLIC_CERTIFICATE,
+                        },
+                    },
+                })
+            ).not.toThrow();
+        });
     });
 });

--- a/samples/msal-node-samples/client-credentials-mtls-pop/app.ts
+++ b/samples/msal-node-samples/client-credentials-mtls-pop/app.ts
@@ -47,6 +47,33 @@ export const getMtlsPopToken = async (
 };
 
 /**
+ * SN/I certificate over mTLS -> plain Bearer.
+ *
+ * The confidential client is configured with an SN/I certificate AND the app-level
+ * `auth.clientCertificate.sendCertificateOverMtls` flag. MSAL presents that certificate as the
+ * client TLS certificate on the mutual-TLS handshake and routes to the mTLS token endpoint
+ * (mtlsauth.microsoft.com), but - because the request is NOT mtls_pop - Entra ID returns a plain
+ * Bearer access token authenticated by the transport (a `client_assertion` is sent; the token is
+ * NOT cryptographically bound to the certificate). Contrast with getMtlsPopToken (bound,
+ * token_type=mtls_pop) and with the ordinary client-assertion Bearer (certificate never on the TLS
+ * handshake, regular token endpoint).
+ */
+export const getBearerOverMtlsToken = async (
+    cca: ConfidentialClientApplication,
+    clientCredentialRequestScopes: Array<string>,
+    region?: string,
+    skipCache: boolean = true
+): Promise<AuthenticationResult | null> => {
+    const clientCredentialRequest = {
+        scopes: clientCredentialRequestScopes,
+        azureRegion: region, // recommended; falls back to the global mTLS endpoint if omitted
+        skipCache,
+    };
+
+    return cca.acquireTokenByClientCredential(clientCredentialRequest);
+};
+
+/**
  * The code below checks if the script is being executed manually or in automation.
  * If the script was executed manually, it will initialize a ConfidentialClientApplication object
  * and execute the sample mTLS Proof-of-Possession client credentials application.

--- a/samples/msal-node-samples/client-credentials-mtls-pop/test/client-credentials-mtls-pop-aad.spec.ts
+++ b/samples/msal-node-samples/client-credentials-mtls-pop/test/client-credentials-mtls-pop-aad.spec.ts
@@ -160,7 +160,10 @@ describe("Client Credentials mTLS Proof-of-Possession AAD Prod Tests", () => {
     // Credential_X509_Output_Bearer (cert signs a client_assertion to the REGULAR endpoint; cert
     // never on the handshake) and Credential_X509_Output_Pop (bound token, token_type=mtls_pop).
     // Runs GLOBAL (no azureRegion) for determinism, and the second acquire (skipCache=false)
-    // exercises the plain-Bearer cache hit against the mtlsauth.* environment.
+    // exercises the plain-Bearer cache hit from cache.
+    // The AT caches under the original login.* environment (only the token ENDPOINT is
+    // rewritten to mtlsauth.* via getMtlsTokenEndpoint(), never the authority), so the 2nd call
+    // resolves metadata against login.* and cannot hit the .NET-style mtlsauth.* discovery trap.
     describe("Credential_X509_SendCertificateOverMtls_Output_Bearer", () => {
         let bearerOverMtlsConfig: Configuration;
         beforeAll(async () => {
@@ -201,7 +204,9 @@ describe("Client Credentials mTLS Proof-of-Possession AAD Prod Tests", () => {
 
             // Second acquire without skipCache: the plain Bearer entry is cached under the standard
             // (non-thumbprint-fenced) access-token key, so an ordinary Bearer lookup must serve it
-            // from cache without crashing on the mtlsauth.* environment / regional metadata.
+            // from cache without crashing on region/instance metadata: the entry is
+            // keyed under the canonical login.* environment (only the token endpoint was mtlsauth.*),
+            // so the ordinary lookup resolves against login.* and never the rewritten host.
             const cachedResult: AuthenticationResult | null =
                 await getBearerOverMtlsToken(
                     confidentialClientApplication,
@@ -214,6 +219,18 @@ describe("Client Credentials mTLS Proof-of-Possession AAD Prod Tests", () => {
                 authenticationResult?.accessToken
             );
             expect(cachedResult?.fromCache).toBe(true);
+
+            // Env-lock tripwire (parity with Java/Go/Python): the certificate only rewrote the token
+            // ENDPOINT to mtlsauth.*; the AT must be cached under the canonical login.* environment,
+            // never the mtlsauth.* host - so a mis-cache under the rewritten host fails instantly.
+            const cachedTokens = await NodeCacheTestUtils.getTokens(
+                TEST_CACHE_LOCATION
+            );
+            expect(cachedTokens.accessTokens).toHaveLength(1);
+            const cachedAccessToken = cachedTokens.accessTokens[0];
+            expect(cachedAccessToken.credentialType).toBe("AccessToken");
+            expect(cachedAccessToken.environment).toContain("login");
+            expect(cachedAccessToken.environment).not.toContain("mtlsauth");
         });
     });
 });

--- a/samples/msal-node-samples/client-credentials-mtls-pop/test/client-credentials-mtls-pop-aad.spec.ts
+++ b/samples/msal-node-samples/client-credentials-mtls-pop/test/client-credentials-mtls-pop-aad.spec.ts
@@ -12,7 +12,7 @@ import {
     Configuration,
 } from "@azure/msal-node";
 import { DefaultAzureCredential } from "@azure/identity";
-import { getMtlsPopToken } from "../app";
+import { getMtlsPopToken, getBearerOverMtlsToken } from "../app";
 
 // Enable SNI (send certificate chain) for cert-based auth in CI
 process.env["AZURE_CLIENT_SEND_CERTIFICATE_CHAIN"] = "true";
@@ -149,6 +149,71 @@ describe("Client Credentials mTLS Proof-of-Possession AAD Prod Tests", () => {
             // token is a plain Bearer token — not certificate-bound.
             expect(authenticationResult?.tokenType).not.toBe("mtls_pop");
             expect(authenticationResult?.bindingCertificate).toBeFalsy();
+        });
+    });
+
+    // Credential_X509_SendCertificateOverMtls_Output_Bearer: the SN/I (X509) certificate is
+    // presented on the TLS handshake via the app-level auth.clientCertificate.sendCertificateOverMtls
+    // flag, so MSAL routes to the mTLS token endpoint (mtlsauth.microsoft.com) - but because the
+    // request is NOT mtls_pop, Entra returns a plain (non-bound) Bearer token. This is the distinct
+    // Bearer-over-mTLS path: cert ON the handshake -> Bearer from the mTLS endpoint. Contrast with
+    // Credential_X509_Output_Bearer (cert signs a client_assertion to the REGULAR endpoint; cert
+    // never on the handshake) and Credential_X509_Output_Pop (bound token, token_type=mtls_pop).
+    // Runs GLOBAL (no azureRegion) for determinism, and the second acquire (skipCache=false)
+    // exercises the plain-Bearer cache hit against the mtlsauth.* environment.
+    describe("Credential_X509_SendCertificateOverMtls_Output_Bearer", () => {
+        let bearerOverMtlsConfig: Configuration;
+        beforeAll(async () => {
+            await NodeCacheTestUtils.resetCache(TEST_CACHE_LOCATION);
+            bearerOverMtlsConfig = {
+                auth: {
+                    ...config.auth,
+                    clientCertificate: {
+                        ...config.auth.clientCertificate,
+                        // App-level opt-in: present the certificate on the mTLS handshake and route
+                        // to the mTLS endpoint, but keep a plain Bearer token (not mtls_pop-bound).
+                        sendCertificateOverMtls: true,
+                    },
+                },
+            };
+        });
+
+        afterEach(async () => {
+            await NodeCacheTestUtils.resetCache(TEST_CACHE_LOCATION);
+        });
+
+        it("presents the certificate on the mTLS handshake and receives a plain Bearer token, then serves the second call from cache", async () => {
+            const confidentialClientApplication: ConfidentialClientApplication =
+                new ConfidentialClientApplication(bearerOverMtlsConfig);
+
+            const authenticationResult: AuthenticationResult | null =
+                await getBearerOverMtlsToken(
+                    confidentialClientApplication,
+                    clientCredentialRequestScopes
+                );
+
+            expect(authenticationResult?.accessToken).toBeTruthy();
+            // The certificate authenticates the transport; the issued token is a plain Bearer, NOT
+            // certificate-bound - the whole point of Bearer-over-mTLS (contrast with the PoP cell).
+            expect(authenticationResult?.tokenType).not.toBe("mtls_pop");
+            expect(authenticationResult?.bindingCertificate).toBeFalsy();
+            expect(authenticationResult?.fromCache).toBe(false);
+
+            // Second acquire without skipCache: the plain Bearer entry is cached under the standard
+            // (non-thumbprint-fenced) access-token key, so an ordinary Bearer lookup must serve it
+            // from cache without crashing on the mtlsauth.* environment / regional metadata.
+            const cachedResult: AuthenticationResult | null =
+                await getBearerOverMtlsToken(
+                    confidentialClientApplication,
+                    clientCredentialRequestScopes,
+                    undefined,
+                    false
+                );
+
+            expect(cachedResult?.accessToken).toEqual(
+                authenticationResult?.accessToken
+            );
+            expect(cachedResult?.fromCache).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Bearer-over-mTLS (`sendCertificateOverMtls`)

Ports MSAL.NET `CertificateOptions.SendCertificateOverMtls` (.NET #5849 client-credentials + #6009 OBO/refresh/auth-code). A new app-level opt-in that presents the SN/I certificate as the **client TLS certificate on the handshake** to the mTLS token endpoint and receives a plain **Bearer** access token. The certificate authenticates the transport; the token is **not** bound to it.

This is **not** `mtls_pop` (which binds the token, `token_type=mtls_pop`, thumbprint-fenced cache) and **not** the existing X509 → `client_assertion` Bearer path (certificate never on the TLS handshake). Bearer-over-mTLS = cert **on** the TLS handshake → Bearer from the mTLS endpoint.

### API

```ts
auth: {
    clientCertificate: {
        thumbprintSha256, privateKey, x5c,
        sendCertificateOverMtls: true, // NEW — app-level, defaults false
    },
}
```

- Defaults `false` → zero behavior change when unset.
- Requires a certificate credential (`x5c` + `privateKey`); otherwise fails fast naming the flag.
- A per-request `mtlsProofOfPossession` (mtls_pop) **always** takes precedence over the flag.

### Wire contract (flag set AND request is not mtls_pop)

- Endpoint: global `https://mtlsauth.microsoft.com/{tenant}/oauth2/v2.0/token` (or regional `{region}.mtlsauth.microsoft.com`).
- TLS: certificate presented on the handshake — reuses the SNI mTLS transport (`INetworkModule.mtlsCertificate` + HttpClient mTLS agent).
- Body: normal grant params for the flow **plus** `client_assertion` (private_key_jwt, x5c). No `req_cnf`, no `token_type=mtls_pop`.
- `token_type`: Bearer; cached as a plain Bearer access-token entry (standard key, **not** thumbprint-fenced) so a normal Bearer lookup returns it.

### Coverage

Honored by **every** confidential flow — client-credentials, on-behalf-of, refresh-token, and auth-code.

- **msal-common**: `getBearerOverMtlsCertificate` decision helper; `sendCertificateOverMtls` on `ClientCredentials`; endpoint routing in `RefreshTokenClient` + `AuthorizationCodeClient`.
- **msal-node**: `auth.clientCertificate.sendCertificateOverMtls` config flag threaded through `buildOauthClientConfiguration`; endpoint routing in `ClientCredentialClient` + `OnBehalfOfClient`; fail-fast validation.

### Tests

- Unit (RED-first): helper decision matrix; CC + OBO client routing/body; config-flag validation.
- App-level integration: CC / OBO / refresh / auth-code all route to `mtlsauth` with the correct grant + `client_assertion` + presented certificate; negative case (no flag → regular login endpoint).
- E2E: Bearer-over-mTLS cell in `samples/msal-node-samples/client-credentials-mtls-pop` (live CC Bearer + `mtlsauth` endpoint + 2nd-call cache hit).
- Regenerated `apiReview/msal-common.api.md` + `apiReview/msal-node.api.md`; beachball change files added.

Targets `rginsburg/sni-mtls-pop` (a sibling to the FIC PR #8698, not stacked on it) so the diff is isolated to Bearer-over-mTLS. Will rebase/retarget to `dev` when the SNI PR #8693 merges.

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: feature
agent-tool: copilot-cli
agent-model: claude-opus-4.8
work-item: AB#n/a
<!-- END pr-telemetry -->
