### PR TITLE
Reject invalid Azure region names before URL construction

### DIFF
--- a/change/@azure-msal-common-region-validation.json
+++ b/change/@azure-msal-common-region-validation.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Validate Azure region names before constructing regional authority URLs [#8744](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8744)",
+    "packageName": "@azure/msal-common",
+    "email": "bogavril@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-common-region-validation.json
+++ b/change/@azure-msal-common-region-validation.json
@@ -1,6 +1,6 @@
 {
     "type": "patch",
-    "comment": "Validate Azure region names before constructing regional authority URLs [#8744](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8744)",
+    "comment": "Reject invalid Azure region names before constructing regional authority URLs [#8744](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8744)",
     "packageName": "@azure/msal-common",
     "email": "bogavril@microsoft.com",
     "dependentChangeType": "patch"

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -182,6 +182,10 @@ This error occurs when MSAL.js surpasses the allotted storage limit when attempt
 
 ## Client configuration errors
 
+### `invalid_azure_region`
+
+-   The configured or discovered Azure region is invalid. Region short names must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.
+
 ### `redirect_uri_empty`
 
 -   A redirect URI is required for all calls and none has been set.

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -43,7 +43,7 @@ import {
     isCloudInstanceDiscoveryErrorResponse,
 } from "./CloudInstanceDiscoveryErrorResponse.js";
 import { CloudDiscoveryMetadata } from "./CloudDiscoveryMetadata.js";
-import { isValidRegionName, RegionDiscovery } from "./RegionDiscovery.js";
+import { RegionDiscovery, validateRegionName } from "./RegionDiscovery.js";
 import { RegionDiscoveryMetadata } from "./RegionDiscoveryMetadata.js";
 import { ImdsOptions } from "./ImdsOptions.js";
 import type { AzureCloudOptions } from "../config/ClientConfiguration.js";
@@ -771,15 +771,10 @@ export class Authority {
                 userConfiguredAzureRegion !==
                 Constants.AZURE_REGION_AUTO_DISCOVER_FLAG
             ) {
-                if (!isValidRegionName(userConfiguredAzureRegion)) {
-                    this.regionDiscoveryMetadata.region_outcome =
-                        Constants.RegionDiscoveryOutcomes.CONFIGURED_NOT_DETECTED;
-                    this.logger.warning(
-                        "Regional authority ignored an invalid configured region.",
-                        this.correlationId
-                    );
-                    return metadata;
-                }
+                validateRegionName(
+                    userConfiguredAzureRegion,
+                    this.correlationId
+                );
 
                 this.regionDiscoveryMetadata.region_outcome =
                     Constants.RegionDiscoveryOutcomes.CONFIGURED_NO_AUTO_DETECTION;
@@ -1451,9 +1446,7 @@ export class Authority {
         correlationId: string,
         queryString?: string
     ): string {
-        if (!isValidRegionName(region)) {
-            return queryString ? `${host}?${queryString}` : host;
-        }
+        validateRegionName(region, correlationId);
 
         // Create and validate a Url string object with the initial authority string
         const authorityUrlInstance = new UrlString(host, correlationId);
@@ -1493,10 +1486,6 @@ export class Authority {
         azureRegion: string,
         correlationId: string
     ): OpenIdConfigResponse {
-        if (!isValidRegionName(azureRegion)) {
-            return metadata;
-        }
-
         const regionalMetadata = { ...metadata };
         regionalMetadata.authorization_endpoint =
             Authority.buildRegionalAuthorityString(

--- a/lib/msal-common/src/authority/Authority.ts
+++ b/lib/msal-common/src/authority/Authority.ts
@@ -43,7 +43,7 @@ import {
     isCloudInstanceDiscoveryErrorResponse,
 } from "./CloudInstanceDiscoveryErrorResponse.js";
 import { CloudDiscoveryMetadata } from "./CloudDiscoveryMetadata.js";
-import { RegionDiscovery } from "./RegionDiscovery.js";
+import { isValidRegionName, RegionDiscovery } from "./RegionDiscovery.js";
 import { RegionDiscoveryMetadata } from "./RegionDiscoveryMetadata.js";
 import { ImdsOptions } from "./ImdsOptions.js";
 import type { AzureCloudOptions } from "../config/ClientConfiguration.js";
@@ -771,6 +771,16 @@ export class Authority {
                 userConfiguredAzureRegion !==
                 Constants.AZURE_REGION_AUTO_DISCOVER_FLAG
             ) {
+                if (!isValidRegionName(userConfiguredAzureRegion)) {
+                    this.regionDiscoveryMetadata.region_outcome =
+                        Constants.RegionDiscoveryOutcomes.CONFIGURED_NOT_DETECTED;
+                    this.logger.warning(
+                        "Regional authority ignored an invalid configured region.",
+                        this.correlationId
+                    );
+                    return metadata;
+                }
+
                 this.regionDiscoveryMetadata.region_outcome =
                     Constants.RegionDiscoveryOutcomes.CONFIGURED_NO_AUTO_DETECTION;
                 this.regionDiscoveryMetadata.region_used =
@@ -1441,6 +1451,10 @@ export class Authority {
         correlationId: string,
         queryString?: string
     ): string {
+        if (!isValidRegionName(region)) {
+            return queryString ? `${host}?${queryString}` : host;
+        }
+
         // Create and validate a Url string object with the initial authority string
         const authorityUrlInstance = new UrlString(host, correlationId);
         authorityUrlInstance.validateAsUri();
@@ -1479,6 +1493,10 @@ export class Authority {
         azureRegion: string,
         correlationId: string
     ): OpenIdConfigResponse {
+        if (!isValidRegionName(azureRegion)) {
+            return metadata;
+        }
+
         const regionalMetadata = { ...metadata };
         regionalMetadata.authorization_endpoint =
             Authority.buildRegionalAuthorityString(

--- a/lib/msal-common/src/authority/AuthorityFactory.ts
+++ b/lib/msal-common/src/authority/AuthorityFactory.ts
@@ -15,6 +15,7 @@ import { Logger } from "../logger/Logger.js";
 import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.js";
 import * as PerformanceEvents from "../telemetry/performance/PerformanceEvents.js";
 import { invokeAsync } from "../utils/FunctionWrappers.js";
+import { ClientConfigurationError } from "../error/ClientConfigurationError.js";
 
 /**
  * Create an authority object of the correct type based on the url
@@ -68,6 +69,10 @@ export async function createDiscoveredInstance(
         )();
         return acquireTokenAuthority;
     } catch (e) {
+        if (e instanceof ClientConfigurationError) {
+            throw e;
+        }
+
         throw createClientAuthError(
             ClientAuthErrorCodes.endpointResolutionError,
             correlationId

--- a/lib/msal-common/src/authority/RegionDiscovery.ts
+++ b/lib/msal-common/src/authority/RegionDiscovery.ts
@@ -15,6 +15,32 @@ import * as PerformanceEvents from "../telemetry/performance/PerformanceEvents.j
 import { invokeAsync } from "../utils/FunctionWrappers.js";
 import { Logger } from "../logger/Logger.js";
 
+/**
+ * Returns whether the value follows the Azure region short-name format.
+ */
+export function isValidRegionName(region: unknown): region is string {
+    if (typeof region !== "string" || region.length === 0) {
+        return false;
+    }
+
+    const firstCharacter = region.charCodeAt(0);
+    if (firstCharacter < 97 || firstCharacter > 122) {
+        return false;
+    }
+
+    for (let i = 1; i < region.length; i++) {
+        const character = region.charCodeAt(i);
+        const isLowercaseLetter = character >= 97 && character <= 122;
+        const isDigit = character >= 48 && character <= 57;
+        const isHyphen = character === 45;
+        if (!isLowercaseLetter && !isDigit && !isHyphen) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 export class RegionDiscovery {
     // Network interface to make requests with.
     protected networkInterface: INetworkModule;
@@ -52,8 +78,20 @@ export class RegionDiscovery {
         environmentRegion: string | undefined,
         regionDiscoveryMetadata: RegionDiscoveryMetadata
     ): Promise<string | null> {
-        // Initialize auto detected region with the region from the envrionment
-        let autodetectedRegionName = environmentRegion;
+        let autodetectedRegionName: string | undefined;
+
+        if (environmentRegion) {
+            if (isValidRegionName(environmentRegion)) {
+                autodetectedRegionName = environmentRegion;
+                regionDiscoveryMetadata.region_source =
+                    Constants.RegionDiscoverySources.ENVIRONMENT_VARIABLE;
+            } else {
+                this.logger.warning(
+                    "Region discovery ignored an invalid environment region.",
+                    this.correlationId
+                );
+            }
+        }
 
         // Check if a region was detected from the environment, if not, attempt to get the region from IMDS
         if (!autodetectedRegionName) {
@@ -120,9 +158,17 @@ export class RegionDiscovery {
                     Constants.RegionDiscoverySources.FAILED_AUTO_DETECTION;
                 return null;
             }
-        } else {
-            regionDiscoveryMetadata.region_source =
-                Constants.RegionDiscoverySources.ENVIRONMENT_VARIABLE;
+        }
+
+        if (
+            autodetectedRegionName &&
+            !isValidRegionName(autodetectedRegionName)
+        ) {
+            this.logger.warning(
+                "Region discovery ignored an invalid IMDS region.",
+                this.correlationId
+            );
+            autodetectedRegionName = undefined;
         }
 
         // If no region was auto detected from the environment or from the IMDS endpoint, mark the attempt as a FAILED_AUTO_DETECTION

--- a/lib/msal-common/src/authority/RegionDiscovery.ts
+++ b/lib/msal-common/src/authority/RegionDiscovery.ts
@@ -14,6 +14,9 @@ import { IPerformanceClient } from "../telemetry/performance/IPerformanceClient.
 import * as PerformanceEvents from "../telemetry/performance/PerformanceEvents.js";
 import { invokeAsync } from "../utils/FunctionWrappers.js";
 import { Logger } from "../logger/Logger.js";
+import { createClientConfigurationError } from "../error/ClientConfigurationError.js";
+
+const INVALID_AZURE_REGION_ERROR_CODE = "invalid_azure_region";
 
 /**
  * Returns whether the value follows the Azure region short-name format.
@@ -39,6 +42,21 @@ export function isValidRegionName(region: unknown): region is string {
     }
 
     return true;
+}
+
+/**
+ * Throws when a value does not follow the Azure region short-name format.
+ */
+export function validateRegionName(
+    region: unknown,
+    correlationId: string
+): asserts region is string {
+    if (!isValidRegionName(region)) {
+        throw createClientConfigurationError(
+            INVALID_AZURE_REGION_ERROR_CODE,
+            correlationId
+        );
+    }
 }
 
 export class RegionDiscovery {
@@ -81,16 +99,10 @@ export class RegionDiscovery {
         let autodetectedRegionName: string | undefined;
 
         if (environmentRegion) {
-            if (isValidRegionName(environmentRegion)) {
-                autodetectedRegionName = environmentRegion;
-                regionDiscoveryMetadata.region_source =
-                    Constants.RegionDiscoverySources.ENVIRONMENT_VARIABLE;
-            } else {
-                this.logger.warning(
-                    "Region discovery ignored an invalid environment region.",
-                    this.correlationId
-                );
-            }
+            validateRegionName(environmentRegion, this.correlationId);
+            autodetectedRegionName = environmentRegion;
+            regionDiscoveryMetadata.region_source =
+                Constants.RegionDiscoverySources.ENVIRONMENT_VARIABLE;
         }
 
         // Check if a region was detected from the environment, if not, attempt to get the region from IMDS
@@ -160,15 +172,8 @@ export class RegionDiscovery {
             }
         }
 
-        if (
-            autodetectedRegionName &&
-            !isValidRegionName(autodetectedRegionName)
-        ) {
-            this.logger.warning(
-                "Region discovery ignored an invalid IMDS region.",
-                this.correlationId
-            );
-            autodetectedRegionName = undefined;
+        if (autodetectedRegionName) {
+            validateRegionName(autodetectedRegionName, this.correlationId);
         }
 
         // If no region was auto detected from the environment or from the IMDS endpoint, mark the attempt as a FAILED_AUTO_DETECTION

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -777,41 +777,29 @@ describe("Authority.ts Class Unit Tests", () => {
             "east.us",
             "EastUS",
             "east us",
-        ])(
-            "falls back to global endpoints for invalid configured region %s",
-            async (invalidRegion) => {
-                const deepCopyOpenIdResponse = JSON.parse(
-                    JSON.stringify(DEFAULT_OPENID_CONFIG_RESPONSE)
-                );
-                networkInterface.sendGetRequestAsync = (): any =>
-                    deepCopyOpenIdResponse;
-
-                const authority = new Authority(
-                    Constants.DEFAULT_AUTHORITY,
-                    networkInterface,
-                    mockStorage,
-                    {
-                        ...authorityOptions,
-                        azureRegionConfiguration: {
-                            azureRegion: invalidRegion,
-                            environmentRegion: undefined,
-                        },
+        ])("throws for invalid configured region %s", async (invalidRegion) => {
+            const authority = new Authority(
+                Constants.DEFAULT_AUTHORITY,
+                networkInterface,
+                mockStorage,
+                {
+                    ...authorityOptions,
+                    azureRegionConfiguration: {
+                        azureRegion: invalidRegion,
+                        environmentRegion: undefined,
                     },
-                    logger,
-                    TEST_CONFIG.CORRELATION_ID,
-                    new StubPerformanceClient()
-                );
+                },
+                logger,
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
+            );
 
-                await authority.resolveEndpointsAsync();
-
-                expect(authority.tokenEndpoint).toBe(
-                    deepCopyOpenIdResponse.body.token_endpoint.replace(
-                        "{tenant}",
-                        "common"
-                    )
-                );
-            }
-        );
+            await expect(
+                authority.resolveEndpointsAsync()
+            ).rejects.toMatchObject({
+                errorCode: "invalid_azure_region",
+            });
+        });
 
         it("region is not auto-discovered if a region is provided by the user", async () => {
             const deepCopyOpenIdResponse = JSON.parse(
@@ -1021,7 +1009,7 @@ describe("Authority.ts Class Unit Tests", () => {
             expect(isValidRegionName(region)).toBe(false);
         });
 
-        it("ignores an invalid environment region and uses a valid IMDS region", async () => {
+        it("throws for an invalid environment region", async () => {
             const networkInterface = buildNetworkInterface(() => ({
                 status: Constants.HTTP_SUCCESS,
                 body: { location: "centralus" },
@@ -1034,18 +1022,17 @@ describe("Authority.ts Class Unit Tests", () => {
             );
             const regionDiscoveryMetadata: RegionDiscoveryMetadata = {};
 
-            const region = await regionDiscovery.detectRegion(
-                "hostile.example/path",
-                regionDiscoveryMetadata
-            );
-
-            expect(region).toBe("centralus");
-            expect(regionDiscoveryMetadata.region_source).toBe(
-                Constants.RegionDiscoverySources.IMDS
-            );
+            await expect(
+                regionDiscovery.detectRegion(
+                    "hostile.example/path",
+                    regionDiscoveryMetadata
+                )
+            ).rejects.toMatchObject({
+                errorCode: "invalid_azure_region",
+            });
         });
 
-        it("rejects an invalid region returned by IMDS", async () => {
+        it("throws for an invalid region returned by IMDS", async () => {
             const networkInterface = buildNetworkInterface(() => ({
                 status: Constants.HTTP_SUCCESS,
                 body: { location: "hostile.example/path" },
@@ -1058,15 +1045,11 @@ describe("Authority.ts Class Unit Tests", () => {
             );
             const regionDiscoveryMetadata: RegionDiscoveryMetadata = {};
 
-            const region = await regionDiscovery.detectRegion(
-                undefined,
-                regionDiscoveryMetadata
-            );
-
-            expect(region).toBeNull();
-            expect(regionDiscoveryMetadata.region_source).toBe(
-                Constants.RegionDiscoverySources.FAILED_AUTO_DETECTION
-            );
+            await expect(
+                regionDiscovery.detectRegion(undefined, regionDiscoveryMetadata)
+            ).rejects.toMatchObject({
+                errorCode: "invalid_azure_region",
+            });
         });
 
         it("calls the IMDS /compute JSON endpoint and reads the location field", async () => {
@@ -3445,17 +3428,21 @@ describe("Authority.ts Class Unit Tests", () => {
     });
 
     describe("replaceWithRegionalInformation", () => {
-        it("does not regionalize an endpoint when the region is invalid", () => {
+        it("throws before regionalizing an endpoint when the region is invalid", () => {
             const tokenEndpoint =
                 "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token";
 
-            expect(
+            expect(() =>
                 Authority.buildRegionalAuthorityString(
                     tokenEndpoint,
                     "hostile.example/path",
                     ""
                 )
-            ).toBe(tokenEndpoint);
+            ).toThrow(
+                expect.objectContaining({
+                    errorCode: "invalid_azure_region",
+                })
+            );
         });
 
         it("replaces authorization_endpoint", () => {
@@ -3488,18 +3475,22 @@ describe("Authority.ts Class Unit Tests", () => {
             expect(regionalResponse.end_session_endpoint).toBeUndefined();
         });
 
-        it("does not modify metadata when the region is invalid", () => {
+        it("throws before modifying metadata when the region is invalid", () => {
             const originResponse: OpenIdConfigResponse = {
                 ...DEFAULT_OPENID_CONFIG_RESPONSE.body,
             };
 
-            const regionalResponse = Authority.replaceWithRegionalInformation(
-                originResponse,
-                "hostile.example/path",
-                ""
+            expect(() =>
+                Authority.replaceWithRegionalInformation(
+                    originResponse,
+                    "hostile.example/path",
+                    ""
+                )
+            ).toThrow(
+                expect.objectContaining({
+                    errorCode: "invalid_azure_region",
+                })
             );
-
-            expect(regionalResponse).toBe(originResponse);
         });
     });
 

--- a/lib/msal-common/test/authority/Authority.spec.ts
+++ b/lib/msal-common/test/authority/Authority.spec.ts
@@ -42,7 +42,10 @@ import {
     TimeUtils,
     UrlString,
 } from "../../src/index.js";
-import { RegionDiscovery } from "../../src/authority/RegionDiscovery.js";
+import {
+    isValidRegionName,
+    RegionDiscovery,
+} from "../../src/authority/RegionDiscovery.js";
 import { RegionDiscoveryMetadata } from "../../src/authority/RegionDiscoveryMetadata.js";
 import { InstanceDiscoveryMetadata } from "../../src/authority/AuthorityMetadata.js";
 import * as authorityMetadata from "../../src/authority/AuthorityMetadata.js";
@@ -767,6 +770,49 @@ describe("Authority.ts Class Unit Tests", () => {
             );
         });
 
+        it.each([
+            "hostile.example/path",
+            "hostile.example?query",
+            "hostile.example#fragment",
+            "east.us",
+            "EastUS",
+            "east us",
+        ])(
+            "falls back to global endpoints for invalid configured region %s",
+            async (invalidRegion) => {
+                const deepCopyOpenIdResponse = JSON.parse(
+                    JSON.stringify(DEFAULT_OPENID_CONFIG_RESPONSE)
+                );
+                networkInterface.sendGetRequestAsync = (): any =>
+                    deepCopyOpenIdResponse;
+
+                const authority = new Authority(
+                    Constants.DEFAULT_AUTHORITY,
+                    networkInterface,
+                    mockStorage,
+                    {
+                        ...authorityOptions,
+                        azureRegionConfiguration: {
+                            azureRegion: invalidRegion,
+                            environmentRegion: undefined,
+                        },
+                    },
+                    logger,
+                    TEST_CONFIG.CORRELATION_ID,
+                    new StubPerformanceClient()
+                );
+
+                await authority.resolveEndpointsAsync();
+
+                expect(authority.tokenEndpoint).toBe(
+                    deepCopyOpenIdResponse.body.token_endpoint.replace(
+                        "{tenant}",
+                        "common"
+                    )
+                );
+            }
+        );
+
         it("region is not auto-discovered if a region is provided by the user", async () => {
             const deepCopyOpenIdResponse = JSON.parse(
                 JSON.stringify(DEFAULT_OPENID_CONFIG_RESPONSE)
@@ -951,6 +997,76 @@ describe("Authority.ts Class Unit Tests", () => {
                 options?: NetworkRequestOptions
             ): Promise<T> => Promise.resolve(getImpl(url, options) as T),
             sendPostRequestAsync: <T>(): Promise<T> => Promise.resolve({} as T),
+        });
+
+        it.each(["eastus", "westus2", "east-us-2", "a", "a1", "a-1"])(
+            "accepts valid region name %s",
+            (region) => {
+                expect(isValidRegionName(region)).toBe(true);
+            }
+        );
+
+        it.each([
+            "",
+            "hostile.example/path",
+            "hostile.example?query",
+            "hostile.example#fragment",
+            "EastUS",
+            "1eastus",
+            "-eastus",
+            "east_us",
+            "east us",
+            "eastus\n",
+        ])("rejects invalid region name %s", (region) => {
+            expect(isValidRegionName(region)).toBe(false);
+        });
+
+        it("ignores an invalid environment region and uses a valid IMDS region", async () => {
+            const networkInterface = buildNetworkInterface(() => ({
+                status: Constants.HTTP_SUCCESS,
+                body: { location: "centralus" },
+            }));
+            const regionDiscovery = new RegionDiscovery(
+                networkInterface,
+                logger,
+                new StubPerformanceClient(),
+                correlationId
+            );
+            const regionDiscoveryMetadata: RegionDiscoveryMetadata = {};
+
+            const region = await regionDiscovery.detectRegion(
+                "hostile.example/path",
+                regionDiscoveryMetadata
+            );
+
+            expect(region).toBe("centralus");
+            expect(regionDiscoveryMetadata.region_source).toBe(
+                Constants.RegionDiscoverySources.IMDS
+            );
+        });
+
+        it("rejects an invalid region returned by IMDS", async () => {
+            const networkInterface = buildNetworkInterface(() => ({
+                status: Constants.HTTP_SUCCESS,
+                body: { location: "hostile.example/path" },
+            }));
+            const regionDiscovery = new RegionDiscovery(
+                networkInterface,
+                logger,
+                new StubPerformanceClient(),
+                correlationId
+            );
+            const regionDiscoveryMetadata: RegionDiscoveryMetadata = {};
+
+            const region = await regionDiscovery.detectRegion(
+                undefined,
+                regionDiscoveryMetadata
+            );
+
+            expect(region).toBeNull();
+            expect(regionDiscoveryMetadata.region_source).toBe(
+                Constants.RegionDiscoverySources.FAILED_AUTO_DETECTION
+            );
         });
 
         it("calls the IMDS /compute JSON endpoint and reads the location field", async () => {
@@ -3329,6 +3445,19 @@ describe("Authority.ts Class Unit Tests", () => {
     });
 
     describe("replaceWithRegionalInformation", () => {
+        it("does not regionalize an endpoint when the region is invalid", () => {
+            const tokenEndpoint =
+                "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token";
+
+            expect(
+                Authority.buildRegionalAuthorityString(
+                    tokenEndpoint,
+                    "hostile.example/path",
+                    ""
+                )
+            ).toBe(tokenEndpoint);
+        });
+
         it("replaces authorization_endpoint", () => {
             const originResponse: OpenIdConfigResponse = {
                 ...DEFAULT_OPENID_CONFIG_RESPONSE.body,
@@ -3357,6 +3486,20 @@ describe("Authority.ts Class Unit Tests", () => {
                 ""
             );
             expect(regionalResponse.end_session_endpoint).toBeUndefined();
+        });
+
+        it("does not modify metadata when the region is invalid", () => {
+            const originResponse: OpenIdConfigResponse = {
+                ...DEFAULT_OPENID_CONFIG_RESPONSE.body,
+            };
+
+            const regionalResponse = Authority.replaceWithRegionalInformation(
+                originResponse,
+                "hostile.example/path",
+                ""
+            );
+
+            expect(regionalResponse).toBe(originResponse);
         });
     });
 

--- a/lib/msal-common/test/authority/AuthorityFactory.spec.ts
+++ b/lib/msal-common/test/authority/AuthorityFactory.spec.ts
@@ -16,6 +16,7 @@ import {
     ClientAuthErrorCodes,
 } from "../../src/error/ClientAuthError";
 import { Logger, LogLevel, StubPerformanceClient } from "../../src";
+import { createClientConfigurationError } from "../../src/error/ClientConfigurationError";
 
 const loggerOptions = {
     loggerCallback: (): void => {},
@@ -99,6 +100,29 @@ describe("AuthorityFactory.ts Class Unit Tests", () => {
             expect(resolveEndpointsStub).toHaveBeenCalledTimes(1);
             done();
         });
+    });
+
+    it("createDiscoveredInstance preserves configuration errors", async () => {
+        const configurationError = createClientConfigurationError(
+            "invalid_azure_region",
+            TEST_CONFIG.CORRELATION_ID
+        );
+        jest.spyOn(
+            Authority.prototype,
+            "resolveEndpointsAsync"
+        ).mockRejectedValue(configurationError);
+
+        await expect(
+            AuthorityFactory.createDiscoveredInstance(
+                DEFAULT_AUTHORITY,
+                networkInterface,
+                mockStorage,
+                authorityOptions,
+                logger,
+                TEST_CONFIG.CORRELATION_ID,
+                new StubPerformanceClient()
+            )
+        ).rejects.toBe(configurationError);
     });
 
     it("createDiscoveredInstance transforms CIAM authority", async () => {

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -435,6 +435,37 @@ describe("ConfidentialClientApplication", () => {
                 checkRegion(sendPostRequestAsyncSpy.mock.lastCall[0], region);
             });
 
+            test("invalid MSAL_FORCE_REGION falls back to the global endpoint", async () => {
+                process.env[MSAL_FORCE_REGION] = "hostile.example/path";
+
+                const authResult = (await client.acquireTokenByClientCredential(
+                    request
+                )) as AuthenticationResult;
+
+                expect(authResult.accessToken).toEqual(
+                    CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT.body.access_token
+                );
+                expect(
+                    new URL(sendPostRequestAsyncSpy.mock.lastCall[0]).host
+                ).toBe("login.microsoftonline.com");
+            });
+
+            test("invalid request region falls back to the global endpoint", async () => {
+                const authResult = (await client.acquireTokenByClientCredential(
+                    {
+                        ...request,
+                        azureRegion: "hostile.example/path",
+                    }
+                )) as AuthenticationResult;
+
+                expect(authResult.accessToken).toEqual(
+                    CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT.body.access_token
+                );
+                expect(
+                    new URL(sendPostRequestAsyncSpy.mock.lastCall[0]).host
+                ).toBe("login.microsoftonline.com");
+            });
+
             test('region is not passed in through the request, the MSAL_FORCE_REGION environment variable is set to "DisableMsalForceRegion"', async () => {
                 const authResult = (await client.acquireTokenByClientCredential(
                     { ...request, azureRegion: "DisableMsalForceRegion" }

--- a/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
+++ b/lib/msal-node/test/client/ConfidentialClientApplication.spec.ts
@@ -435,35 +435,27 @@ describe("ConfidentialClientApplication", () => {
                 checkRegion(sendPostRequestAsyncSpy.mock.lastCall[0], region);
             });
 
-            test("invalid MSAL_FORCE_REGION falls back to the global endpoint", async () => {
+            test("invalid MSAL_FORCE_REGION throws", async () => {
                 process.env[MSAL_FORCE_REGION] = "hostile.example/path";
 
-                const authResult = (await client.acquireTokenByClientCredential(
-                    request
-                )) as AuthenticationResult;
-
-                expect(authResult.accessToken).toEqual(
-                    CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT.body.access_token
-                );
-                expect(
-                    new URL(sendPostRequestAsyncSpy.mock.lastCall[0]).host
-                ).toBe("login.microsoftonline.com");
+                await expect(
+                    client.acquireTokenByClientCredential(request)
+                ).rejects.toMatchObject({
+                    errorCode: "invalid_azure_region",
+                });
+                expect(sendPostRequestAsyncSpy).not.toHaveBeenCalled();
             });
 
-            test("invalid request region falls back to the global endpoint", async () => {
-                const authResult = (await client.acquireTokenByClientCredential(
-                    {
+            test("invalid request region throws", async () => {
+                await expect(
+                    client.acquireTokenByClientCredential({
                         ...request,
                         azureRegion: "hostile.example/path",
-                    }
-                )) as AuthenticationResult;
-
-                expect(authResult.accessToken).toEqual(
-                    CONFIDENTIAL_CLIENT_AUTHENTICATION_RESULT.body.access_token
-                );
-                expect(
-                    new URL(sendPostRequestAsyncSpy.mock.lastCall[0]).host
-                ).toBe("login.microsoftonline.com");
+                    })
+                ).rejects.toMatchObject({
+                    errorCode: "invalid_azure_region",
+                });
+                expect(sendPostRequestAsyncSpy).not.toHaveBeenCalled();
             });
 
             test('region is not passed in through the request, the MSAL_FORCE_REGION environment variable is set to "DisableMsalForceRegion"', async () => {


### PR DESCRIPTION
## Summary

Rejects invalid Azure region short names before they can be used to construct regional authority URLs. Invalid values from request configuration, `MSAL_FORCE_REGION`, `REGION_NAME`, or IMDS now fail closed with `ClientConfigurationError` code `invalid_azure_region`.

The validator uses an allocation-free ASCII character check and the final URL-construction boundary revalidates the input. This prevents URI metacharacters from pivoting confidential-client token requests to an unintended host.

Fixes #8605.

## Tests

- Invalid configured and `MSAL_FORCE_REGION` values throw before any token POST
- Invalid `REGION_NAME` and IMDS values throw `invalid_azure_region`
- URI path, query, and fragment separators are rejected at the final construction boundary
- Authority discovery preserves the configuration error instead of wrapping it as `endpoints_resolution_error`

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: security
agent-tool: copilot-cli
agent-model: gpt-5.6-sol
work-item: AB#3606898
<!-- END pr-telemetry -->