### PR TITLE
Scope error-class throttling per-user for public-client flows

### DIFF
--- a/change/@azure-msal-common-throttling-user-scope.json
+++ b/change/@azure-msal-common-throttling-user-scope.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Scope error-class (HTTP 5xx) throttling per-user while keeping 429/Retry-After app-wide, so one user's failure no longer throttles other users (issue #1019)",
+    "packageName": "@azure/msal-common",
+    "email": "avdunn@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-throttling-user-scope.json
+++ b/change/@azure-msal-node-throttling-user-scope.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Include the username as the throttling user component for username/password (ROPC) so error-class (HTTP 5xx) throttling is scoped per-user (issue #1019)",
+    "packageName": "@azure/msal-node",
+    "email": "avdunn@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -3244,6 +3244,7 @@ export class ThrottlingUtils {
     static calculateThrottleTime(throttleTime: number): number;
     static checkResponseForRetryAfter(response: NetworkResponse<ServerAuthorizationTokenResponse>): boolean;
     static checkResponseStatus(response: NetworkResponse<ServerAuthorizationTokenResponse>): boolean;
+    static generateAppWideThrottlingStorageKey(thumbprint: RequestThumbprint): string;
     static generateThrottlingStorageKey(thumbprint: RequestThumbprint): string;
     static postProcess(cacheManager: CacheManager, thumbprint: RequestThumbprint, response: NetworkResponse<ServerAuthorizationTokenResponse>, correlationId: string): void;
     static preProcess(cacheManager: CacheManager, thumbprint: RequestThumbprint, correlationId: string): void;

--- a/lib/msal-common/src/network/ThrottlingUtils.ts
+++ b/lib/msal-common/src/network/ThrottlingUtils.ts
@@ -26,16 +26,31 @@ export class ThrottlingUtils {
     }
 
     /**
-     * Performs necessary throttling checks before a network request.
-     * @param cacheManager
+     * Prepares an app-wide throttling key that ignores any user component
+     * (homeAccountIdentifier). This is used for service-directed throttling
+     * (HTTP 429 / Retry-After) which applies to the whole application.
      * @param thumbprint
      */
-    static preProcess(
+    static generateAppWideThrottlingStorageKey(
+        thumbprint: RequestThumbprint
+    ): string {
+        const appWideThumbprint: RequestThumbprint = { ...thumbprint };
+        delete appWideThumbprint.homeAccountIdentifier;
+        return ThrottlingUtils.generateThrottlingStorageKey(appWideThumbprint);
+    }
+
+    /**
+     * Throws a ServerError if there is a live throttling entry for the given key,
+     * removing it first if it has expired.
+     * @param cacheManager
+     * @param key
+     * @param correlationId
+     */
+    private static throttleIfCached(
         cacheManager: CacheManager,
-        thumbprint: RequestThumbprint,
+        key: string,
         correlationId: string
     ): void {
-        const key = ThrottlingUtils.generateThrottlingStorageKey(thumbprint);
         const value = cacheManager.getThrottlingCache(key, correlationId);
 
         if (value) {
@@ -53,6 +68,41 @@ export class ThrottlingUtils {
     }
 
     /**
+     * Performs necessary throttling checks before a network request.
+     * @param cacheManager
+     * @param thumbprint
+     */
+    static preProcess(
+        cacheManager: CacheManager,
+        thumbprint: RequestThumbprint,
+        correlationId: string
+    ): void {
+        // Service-directed throttles (HTTP 429 / Retry-After) are stored app-wide.
+        const appWideKey =
+            ThrottlingUtils.generateAppWideThrottlingStorageKey(thumbprint);
+        ThrottlingUtils.throttleIfCached(
+            cacheManager,
+            appWideKey,
+            correlationId
+        );
+
+        /*
+         * Error-class throttles (HTTP 5xx) are stored per-user so one user's failure does
+         * not throttle a different user sharing the same clientId/authority/scopes.
+         * Only check the user-aware key when it actually differs (i.e. a user component exists).
+         */
+        const userAwareKey =
+            ThrottlingUtils.generateThrottlingStorageKey(thumbprint);
+        if (userAwareKey !== appWideKey) {
+            ThrottlingUtils.throttleIfCached(
+                cacheManager,
+                userAwareKey,
+                correlationId
+            );
+        }
+    }
+
+    /**
      * Performs necessary throttling checks after a network request.
      * @param cacheManager
      * @param thumbprint
@@ -64,10 +114,25 @@ export class ThrottlingUtils {
         response: NetworkResponse<ServerAuthorizationTokenResponse>,
         correlationId: string
     ): void {
-        if (
-            ThrottlingUtils.checkResponseStatus(response) ||
-            ThrottlingUtils.checkResponseForRetryAfter(response)
-        ) {
+        /*
+         * HTTP 429 and explicit Retry-After are service-directed rate limiting for the whole
+         * application, so they are throttled app-wide.
+         */
+        const isServiceThrottle =
+            response.status === 429 ||
+            ThrottlingUtils.checkResponseForRetryAfter(response);
+
+        /*
+         * HTTP 5xx (without a Retry-After) is a server/credential error that can be specific to a
+         * single user (e.g. a federated STS returning HTTP 500 for one user's bad password), so it
+         * is throttled per-user to avoid blocking other users.
+         */
+        const isServerError =
+            !isServiceThrottle &&
+            response.status >= 500 &&
+            response.status < 600;
+
+        if (isServiceThrottle || isServerError) {
             const thumbprintValue: ThrottlingEntity = {
                 throttleTime: ThrottlingUtils.calculateThrottleTime(
                     parseInt(
@@ -79,8 +144,15 @@ export class ThrottlingUtils {
                 errorMessage: response.body.error_description,
                 subError: response.body.suberror,
             };
+
+            const key = isServerError
+                ? ThrottlingUtils.generateThrottlingStorageKey(thumbprint)
+                : ThrottlingUtils.generateAppWideThrottlingStorageKey(
+                      thumbprint
+                  );
+
             cacheManager.setThrottlingCache(
-                ThrottlingUtils.generateThrottlingStorageKey(thumbprint),
+                key,
                 thumbprintValue,
                 correlationId
             );
@@ -146,7 +218,14 @@ export class ThrottlingUtils {
             request,
             homeAccountIdentifier
         );
-        const key = this.generateThrottlingStorageKey(thumbprint);
-        cacheManager.removeItem(key, request.correlationId);
+
+        // Remove both the app-wide (429 / Retry-After) and user-aware (5xx) throttling entries.
+        const userAwareKey = this.generateThrottlingStorageKey(thumbprint);
+        cacheManager.removeItem(userAwareKey, request.correlationId);
+
+        const appWideKey = this.generateAppWideThrottlingStorageKey(thumbprint);
+        if (appWideKey !== userAwareKey) {
+            cacheManager.removeItem(appWideKey, request.correlationId);
+        }
     }
 }

--- a/lib/msal-common/test/network/ThrottlingUtils.spec.ts
+++ b/lib/msal-common/test/network/ThrottlingUtils.spec.ts
@@ -4,7 +4,10 @@
  */
 
 import { ThrottlingUtils } from "../../src/network/ThrottlingUtils.js";
-import { RequestThumbprint } from "../../src/network/RequestThumbprint.js";
+import {
+    RequestThumbprint,
+    getRequestThumbprint,
+} from "../../src/network/RequestThumbprint.js";
 import { ThrottlingEntity } from "../../src/cache/entities/ThrottlingEntity.js";
 import { NetworkResponse } from "../../src/network/NetworkResponse.js";
 import { ServerAuthorizationTokenResponse } from "../../src/response/ServerAuthorizationTokenResponse.js";
@@ -302,6 +305,174 @@ describe("ThrottlingUtils", () => {
 
             ThrottlingUtils.removeThrottle(cache, clientId, request);
             expect(removeItemStub).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // Documents the app-wide fallback: when the thumbprint has NO user component
+    // (homeAccountIdentifier), error-class throttling remains app-wide. This confirms the
+    // per-user keying does not change behavior for flows that cannot supply a user identity.
+    describe("App-wide throttling when no user component is present", () => {
+        it("throttles a different user after another user's 5xx because the thumbprint has no user component", () => {
+            const cache = new MockStorageClass(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                mockCrypto,
+                new Logger({}),
+                performanceClient
+            );
+
+            // Two logically different users issuing the same public-client request
+            // (same clientId, authority and scopes). Because no user component is
+            // supplied, the requests are indistinguishable.
+            const userARequest: BaseAuthRequest = {
+                authority: TEST_CONFIG.validAuthority,
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+            };
+            const userBRequest: BaseAuthRequest = {
+                authority: TEST_CONFIG.validAuthority,
+                scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+                correlationId: TEST_CONFIG.CORRELATION_ID,
+            };
+
+            const thumbprintA = getRequestThumbprint(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                userARequest
+            );
+            const thumbprintB = getRequestThumbprint(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                userBRequest
+            );
+
+            // The two users collide on the same app-wide throttling key.
+            expect(
+                ThrottlingUtils.generateThrottlingStorageKey(thumbprintA)
+            ).toEqual(
+                ThrottlingUtils.generateThrottlingStorageKey(thumbprintB)
+            );
+
+            // User A's token request fails with a server-side 500.
+            const userAResponse: NetworkResponse<ServerAuthorizationTokenResponse> =
+                {
+                    headers: {},
+                    body: {
+                        error: "server_error",
+                        error_description: "user A's request failed",
+                    },
+                    status: 500,
+                };
+            ThrottlingUtils.postProcess(
+                cache,
+                thumbprintA,
+                userAResponse,
+                RANDOM_TEST_GUID
+            );
+
+            // With no user component the 5xx is stored app-wide, so User B is throttled.
+            expect(() =>
+                ThrottlingUtils.preProcess(cache, thumbprintB, RANDOM_TEST_GUID)
+            ).toThrowError(ServerError);
+        });
+    });
+
+    // Verifies response-type-aware throttling: when a user component (homeAccountIdentifier) is
+    // present, error-class (HTTP 5xx) throttling is scoped per-user, while service-directed
+    // throttling (HTTP 429 / Retry-After) stays app-wide.
+    describe("Response-type-aware throttling", () => {
+        const baseRequest: BaseAuthRequest = {
+            authority: TEST_CONFIG.validAuthority,
+            scopes: TEST_CONFIG.DEFAULT_GRAPH_SCOPE,
+            correlationId: TEST_CONFIG.CORRELATION_ID,
+        };
+
+        const server500Response: NetworkResponse<ServerAuthorizationTokenResponse> =
+            {
+                headers: {},
+                body: {
+                    error: "server_error",
+                    error_description: "user A's request failed",
+                },
+                status: 500,
+            };
+
+        const http429Response: NetworkResponse<ServerAuthorizationTokenResponse> =
+            {
+                headers: {},
+                body: {
+                    error: "temporarily_unavailable",
+                    error_description: "too many requests",
+                },
+                status: 429,
+            };
+
+        it("does NOT throttle a different user after another user's 5xx (per-user error-class throttling)", () => {
+            const cache = new MockStorageClass(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                mockCrypto,
+                new Logger({}),
+                performanceClient
+            );
+
+            const thumbprintA = getRequestThumbprint(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                baseRequest,
+                "userA-home-account-id"
+            );
+            const thumbprintB = getRequestThumbprint(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                baseRequest,
+                "userB-home-account-id"
+            );
+
+            // User A's request fails with HTTP 500.
+            ThrottlingUtils.postProcess(
+                cache,
+                thumbprintA,
+                server500Response,
+                RANDOM_TEST_GUID
+            );
+
+            // User B (a different user) is NOT throttled by user A's failure.
+            expect(() =>
+                ThrottlingUtils.preProcess(cache, thumbprintB, RANDOM_TEST_GUID)
+            ).not.toThrow();
+
+            // User A itself remains throttled.
+            expect(() =>
+                ThrottlingUtils.preProcess(cache, thumbprintA, RANDOM_TEST_GUID)
+            ).toThrowError(ServerError);
+        });
+
+        it("DOES throttle a different user after another user's 429 (service-directed throttling stays app-wide)", () => {
+            const cache = new MockStorageClass(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                mockCrypto,
+                new Logger({}),
+                performanceClient
+            );
+
+            const thumbprintA = getRequestThumbprint(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                baseRequest,
+                "userA-home-account-id"
+            );
+            const thumbprintB = getRequestThumbprint(
+                TEST_CONFIG.MSAL_CLIENT_ID,
+                baseRequest,
+                "userB-home-account-id"
+            );
+
+            // User A's request fails with HTTP 429 (service-directed rate limiting).
+            ThrottlingUtils.postProcess(
+                cache,
+                thumbprintA,
+                http429Response,
+                RANDOM_TEST_GUID
+            );
+
+            // User B is throttled because 429 back-off is app-wide.
+            expect(() =>
+                ThrottlingUtils.preProcess(cache, thumbprintB, RANDOM_TEST_GUID)
+            ).toThrowError(ServerError);
         });
     });
 });

--- a/lib/msal-node/src/client/UsernamePasswordClient.ts
+++ b/lib/msal-node/src/client/UsernamePasswordClient.ts
@@ -111,6 +111,11 @@ export class UsernamePasswordClient extends BaseClient {
             resourceRequestUri: request.resourceRequestUri,
             shrClaims: request.shrClaims,
             sshKid: request.sshKid,
+            /*
+             * Include the username as the user component so that error-class (HTTP 5xx) throttling
+             * is scoped per-user and one user's failure does not throttle others.
+             */
+            homeAccountIdentifier: request.username,
         };
 
         return this.executePostToTokenEndpoint(


### PR DESCRIPTION
Fixes an issue discovered in MSAL Java [#1019](https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/1019) which appears to also exist in MSAL Node.

See:
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6159
https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1055

## Problem

`ThrottlingUtils` throttles requests by a key derived from a `RequestThumbprint` (`throttling.` + `JSON.stringify(thumbprint)`). The thumbprint type has an optional `homeAccountIdentifier` field, but **no throttling caller populated it** — not the Node Username/Password (ROPC) flow, nor `RefreshTokenClient` / `AuthorizationCodeClient`. Because `JSON.stringify` omits `undefined` fields, every user of the same clientId/authority/scopes produced a **byte-identical** key, so all throttling was effectively app-wide.

As a result, when multiple users acquire tokens under the same app: a **HTTP 5xx** cached for user A throttles **every** other user of the app.

The `homeAccountIdentifier` field was effectively dead code: it implied per-user throttling was intended, but since nothing appeared to set it, per-user keying never took effect. (Populating that field is the fix, not the cause — an *absent* user component is exactly what makes the key collapse to an app-wide key.)

## Fix

Make throttling **response-type-aware** and actually populate the user component for ROPC.

`@azure/msal-common` — `src/network/ThrottlingUtils.ts`:

- `generateAppWideThrottlingStorageKey(thumbprint)` (new): a key with the `homeAccountIdentifier` user component stripped.
- `postProcess`: HTTP **5xx** (without `Retry-After`) → stored under the **user-aware** key; HTTP **429** / `Retry-After` → stored under the **app-wide** key.
- `preProcess`: checks the app-wide key first, then the user-aware key when it differs (throw logic refactored into a private `throttleIfCached` helper).
- `removeThrottle`: clears **both** keys on success.

`@azure/msal-node` — `src/client/UsernamePasswordClient.ts`:

- Populates `homeAccountIdentifier: request.username` on the request thumbprint so ROPC actually carries a per-user component. Without this, the keying change is a no-op for ROPC.

Because `JSON.stringify` omits `undefined`, the app-wide key (no `homeAccountIdentifier`) is byte-identical to the pre-fix key, so the 429/Retry-After path stays backward compatible.

### Files changed

- `lib/msal-common/src/network/ThrottlingUtils.ts`
- `lib/msal-node/src/client/UsernamePasswordClient.ts`
- Beachball changefiles: `change/@azure-msal-common-*.json`, `change/@azure-msal-node-*.json` (type `patch`).

## Behavior change

| Trigger | Before | After |
| --- | --- | --- |
| HTTP 5xx on ROPC | Throttles the whole client (all users) | Throttles **only that user** |
| HTTP 429 | App-wide | App-wide (unchanged) |
| Explicit `Retry-After` | App-wide | App-wide (unchanged) |
| Requests with no user component | App-wide | App-wide (unchanged) |

`ThrottlingUtils` is `@internal`, so there is no public API change. The `ThrottlingEntity` value shape is unchanged (only key derivation changed); entries are transient (default 60s, capped at 3600s), so this is not a persisted-schema break.

## Tests

`lib/msal-common/test/network/ThrottlingUtils.spec.ts`:

- `Issue #1019 fix - response-type-aware throttling`: 5xx for user A does **not** throttle user B (per-user), and user A stays throttled; 429 for user A **does** throttle user B (app-wide).
- The original no-user-component case is retained to document the app-wide fallback.