### PR TITLE
test(e2e): EAR ssoSilent + acquireTokenSilent coverage (follow-up to #8766)

### DIFF
--- a/samples/msal-browser-samples/ExpressSample/public/js/app.js
+++ b/samples/msal-browser-samples/ExpressSample/public/js/app.js
@@ -116,7 +116,8 @@ function setupEventListeners() {
     }
 
     // Profile page sign in buttons (may not exist on all pages)
-    const profileSignInPopupBtn = document.getElementById('profileSignInPopup');    const profileSignInRedirectBtn = document.getElementById('profileSignInRedirect');
+    const profileSignInPopupBtn = document.getElementById('profileSignInPopup');
+    const profileSignInRedirectBtn = document.getElementById('profileSignInRedirect');
 
     if (profileSignInPopupBtn) {
         profileSignInPopupBtn.addEventListener('click', function(e) {

--- a/samples/msal-browser-samples/ExpressSample/public/js/app.js
+++ b/samples/msal-browser-samples/ExpressSample/public/js/app.js
@@ -12,6 +12,8 @@ import {
     signOutRedirect,
     handleRetry,
     handleCancelRetry,
+    ssoSilent,
+    acquireTokenSilent,
     msalInstance
 } from './auth.js';
 import { toggleDropdown, closeAllDropdowns, updateUI } from './ui.js';
@@ -96,9 +98,25 @@ function setupEventListeners() {
         });
     }
 
+    // Silent API buttons (authenticated home view)
+    const ssoSilentBtn = document.getElementById('ssoSilentButton');
+    if (ssoSilentBtn) {
+        ssoSilentBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            ssoSilent();
+        });
+    }
+
+    const acquireTokenSilentBtn = document.getElementById('acquireTokenSilentButton');
+    if (acquireTokenSilentBtn) {
+        acquireTokenSilentBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            acquireTokenSilent();
+        });
+    }
+
     // Profile page sign in buttons (may not exist on all pages)
-    const profileSignInPopupBtn = document.getElementById('profileSignInPopup');
-    const profileSignInRedirectBtn = document.getElementById('profileSignInRedirect');
+    const profileSignInPopupBtn = document.getElementById('profileSignInPopup');    const profileSignInRedirectBtn = document.getElementById('profileSignInRedirect');
 
     if (profileSignInPopupBtn) {
         profileSignInPopupBtn.addEventListener('click', function(e) {

--- a/samples/msal-browser-samples/ExpressSample/public/js/auth.js
+++ b/samples/msal-browser-samples/ExpressSample/public/js/auth.js
@@ -152,6 +152,58 @@ export async function getAccessToken() {
     });
 }
 
+// Write the outcome of a silent call to #silentStatus. The e2e tests wait on the
+// data-status attribute to synchronize on completion.
+function setSilentStatus(status) {
+    const el = document.getElementById('silentStatus');
+    if (el) {
+        el.dataset.status = status;
+        el.textContent = status;
+    }
+}
+
+// ssoSilent on the main instance (hidden-iframe silent auth). With EAR config
+// this exercises the silent EAR authorize path.
+export async function ssoSilent() {
+    setSilentStatus('ssoSilent:pending');
+    try {
+        const account = msalInstance.getActiveAccount();
+        const response = await msalInstance.ssoSilent({
+            ...loginRequest,
+            account,
+            loginHint: account && account.username
+        });
+        msalInstance.setActiveAccount(response.account);
+        setSilentStatus('ssoSilent:success');
+        showSuccess('ssoSilent succeeded');
+    } catch (error) {
+        console.error('ssoSilent failed:', error);
+        setSilentStatus('ssoSilent:error');
+        showError('ssoSilent failed: ' + error.message);
+    }
+}
+
+// acquireTokenSilent on the main instance. forceRefresh guarantees a network
+// RT->AT exchange (/token) so the EAR-issued refresh token is actually used
+// rather than returning a cached access token.
+export async function acquireTokenSilent() {
+    setSilentStatus('acquireTokenSilent:pending');
+    try {
+        const response = await msalInstance.acquireTokenSilent({
+            ...loginRequest,
+            account: msalInstance.getActiveAccount(),
+            forceRefresh: true
+        });
+        msalInstance.setActiveAccount(response.account);
+        setSilentStatus('acquireTokenSilent:success');
+        showSuccess('acquireTokenSilent succeeded');
+    } catch (error) {
+        console.error('acquireTokenSilent failed:', error);
+        setSilentStatus('acquireTokenSilent:error');
+        showError('acquireTokenSilent failed: ' + error.message);
+    }
+}
+
 /**
  * Show warning message during popup authentication
  */

--- a/samples/msal-browser-samples/ExpressSample/server.js
+++ b/samples/msal-browser-samples/ExpressSample/server.js
@@ -407,13 +407,12 @@ app.use((err, req, res, next) => {
     });
 });
 
-// Serve over HTTPS when HTTPS=true (e2e harness). Secure origin needed for
-// platform-broker/WAM injection. Manual `npm start` stays http.
+// HTTPS when HTTPS=true (e2e); plain http otherwise.
 if (process.env.HTTPS === 'true') {
     const https = require('https');
-    // Throwaway in-memory self-signed cert; nothing written to disk.
+    // In-memory self-signed cert.
     const selfsigned = require('selfsigned');
-    // selfsigned v5 generate() returns a Promise (v2 was sync); handle both.
+    // generate() may be sync or async.
     Promise.resolve(
         selfsigned.generate(
             [{ name: 'commonName', value: 'localhost' }],

--- a/samples/msal-browser-samples/ExpressSample/test/browserEAR.spec.ts
+++ b/samples/msal-browser-samples/ExpressSample/test/browserEAR.spec.ts
@@ -93,15 +93,16 @@ describe("EAR (Encrypted Authorize Response) Tests", () => {
     let earServerProcess: ChildProcess;
 
     beforeAll(async () => {
-        // Start a dedicated HTTPS server for EAR and a cert-tolerant browser,
-        // leaving the shared http harness (port 3000) untouched. Spawn directly
-        // with stdio "ignore" instead of serverUtils.startServer: that helper's
-        // stdout/stderr/close handlers log after teardown ("Cannot log after
-        // tests are done") and make jest exit non-zero despite passing tests.
+        // Dedicated EAR HTTPS server + cert-tolerant browser; shared http
+        // harness (port 3000) untouched. Spawn directly (not
+        // serverUtils.startServer) to avoid its console-based stdout/close
+        // handlers that logged after teardown ("Cannot log after tests are
+        // done"). Inherit stdio so server logs surface; afterAll awaits child
+        // exit so no output races teardown.
         earServerProcess = spawn(EAR_START_CMD, {
             shell: true,
             cwd: EXPRESS_SAMPLE_ROOT,
-            stdio: "ignore",
+            stdio: ["ignore", "inherit", "inherit"],
         });
         const serverUp = await serverUtils.isServerUp(EAR_PORT, 60000);
         if (!serverUp) {

--- a/samples/msal-browser-samples/ExpressSample/test/browserEAR.spec.ts
+++ b/samples/msal-browser-samples/ExpressSample/test/browserEAR.spec.ts
@@ -44,6 +44,14 @@ function isAuthorizePost(request: puppeteer.HTTPRequest): boolean {
 }
 
 /**
+ * True when a POST hit the /token endpoint. acquireTokenSilent(forceRefresh)
+ * renews the access token from the cached refresh token via this call.
+ */
+function isTokenPost(request: puppeteer.HTTPRequest): boolean {
+    return request.url().includes("/token") && request.method() === "POST";
+}
+
+/**
  * AES-GCM WebCrypto decrypt count. In the EAR sessionStorage config the only such
  * call is decryptEarResponse, so a non-zero count proves the ear_jwe was decrypted.
  */
@@ -52,6 +60,27 @@ async function getEarDecryptCount(target: puppeteer.Page): Promise<number> {
         (key) => parseInt(window.sessionStorage.getItem(key) || "0", 10),
         EAR_DECRYPT_COUNT_KEY
     );
+}
+
+/**
+ * Interactive EAR redirect login. Silent tests need a prior interactive login in
+ * the same context to seed the ESTS session and cache the EAR-issued tokens.
+ */
+async function performRedirectLogin(
+    page: puppeteer.Page,
+    screenshot: Screenshot,
+    username: string,
+    accountPwd: string
+): Promise<void> {
+    await page.locator("button#signInButton").click();
+    await page.locator("a#signInRedirect").click();
+    await screenshot.takeScreenshot(page, "Sign in redirect clicked");
+    await enterCredentials(page, screenshot, username, accountPwd);
+    await page.waitForSelector("a#viewProfileButton", {
+        visible: true,
+        timeout: 30000,
+    });
+    await screenshot.takeScreenshot(page, "Logged In");
 }
 
 describe("EAR (Encrypted Authorize Response) Tests", () => {
@@ -262,6 +291,79 @@ describe("EAR (Encrypted Authorize Response) Tests", () => {
         // MSAL decrypted the EAR response (ear_jwe) in this window.
         expect(await getEarDecryptCount(page)).toBeGreaterThan(0);
         // Cache has Account, idToken, AccessToken, RefreshToken (RT inline via EAR).
+        await BrowserCache.verifyTokenStore({ scopes: EAR_SCOPES });
+    });
+
+    it("Performs EAR ssoSilent", async () => {
+        const screenshot = new Screenshot(
+            `${SCREENSHOT_BASE_FOLDER_NAME}/earSsoSilentBaseCase`
+        );
+        await screenshot.takeScreenshot(page, "Page loaded");
+
+        // Seed an interactive EAR login so ssoSilent has an ESTS session + account.
+        await performRedirectLogin(page, screenshot, username, accountPwd);
+
+        // ssoSilent runs a hidden-iframe authorize; with EAR that iframe POSTs
+        // /authorize and MSAL decrypts a fresh ear_jwe. Capture both signals.
+        let ssoAuthorizeWasPost = false;
+        page.on("request", (request) => {
+            if (isAuthorizePost(request)) {
+                ssoAuthorizeWasPost = true;
+            }
+        });
+        const decryptCountBefore = await getEarDecryptCount(page);
+
+        await page.locator("button#ssoSilentButton").click();
+        await page.waitForSelector('div#silentStatus[data-status="ssoSilent:success"]', {
+            timeout: 30000,
+        });
+        await screenshot.takeScreenshot(page, "ssoSilent completed");
+
+        // Silent EAR authorize used POST /authorize (not an auth-code GET).
+        expect(ssoAuthorizeWasPost).toBe(true);
+        // A new ear_jwe was decrypted during the silent authorize.
+        expect(await getEarDecryptCount(page)).toBeGreaterThan(decryptCountBefore);
+        // Token store still holds a full EAR token set after the silent renewal.
+        await BrowserCache.verifyTokenStore({ scopes: EAR_SCOPES });
+    });
+
+    it("Performs EAR acquireTokenSilent", async () => {
+        const screenshot = new Screenshot(
+            `${SCREENSHOT_BASE_FOLDER_NAME}/earAcquireTokenSilentBaseCase`
+        );
+        await screenshot.takeScreenshot(page, "Page loaded");
+
+        // Seed an interactive EAR login so the EAR-issued refresh token is cached.
+        await performRedirectLogin(page, screenshot, username, accountPwd);
+
+        // acquireTokenSilent(forceRefresh) renews the AT from the cached RT via a
+        // /token POST. It must NOT re-run the EAR /authorize flow or decrypt an
+        // ear_jwe, validating the EAR-issued RT works with the standard RT grant.
+        let tokenWasPost = false;
+        let authorizeWasPost = false;
+        page.on("request", (request) => {
+            if (isTokenPost(request)) {
+                tokenWasPost = true;
+            }
+            if (isAuthorizePost(request)) {
+                authorizeWasPost = true;
+            }
+        });
+        const decryptCountBefore = await getEarDecryptCount(page);
+
+        await page.locator("button#acquireTokenSilentButton").click();
+        await page.waitForSelector(
+            'div#silentStatus[data-status="acquireTokenSilent:success"]',
+            { timeout: 30000 }
+        );
+        await screenshot.takeScreenshot(page, "acquireTokenSilent completed");
+
+        // RT -> AT exchange happened over /token.
+        expect(tokenWasPost).toBe(true);
+        // No new EAR authorize and no new decrypt: the RT grant was used, not EAR.
+        expect(authorizeWasPost).toBe(false);
+        expect(await getEarDecryptCount(page)).toBe(decryptCountBefore);
+        // Token store still holds a full EAR token set after the silent renewal.
         await BrowserCache.verifyTokenStore({ scopes: EAR_SCOPES });
     });
 });

--- a/samples/msal-browser-samples/ExpressSample/test/browserEAR.spec.ts
+++ b/samples/msal-browser-samples/ExpressSample/test/browserEAR.spec.ts
@@ -12,49 +12,38 @@ import {
     BrowserCacheUtils,
 } from "e2e-test-utils";
 
-// CommonJS helper, not a package export -> require by relative path.
+// CommonJS helper; require by relative path.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const serverUtils = require("../../../e2eTestUtils/jest-puppeteer-utils/serverUtils");
 
 const SCREENSHOT_BASE_FOLDER_NAME = `${__dirname}/screenshots/browserEAR`;
 
-// Approach B: EAR runs on its own isolated HTTPS server + cert-tolerant browser.
-// https is required for future platform-broker/WAM injection. The shared jest
-// harness (http, port 3000) is left untouched.
+// EAR runs on its own HTTPS server + cert-tolerant browser; shared http
+// harness (port 3000) untouched.
 const EAR_PORT = 3443;
-// env-cmd loads .env.ear.e2e (HTTPS=true, PORT=3443, EAR config); server.js makes
-// an in-memory self-signed cert.
+// env-cmd loads .env.ear.e2e (HTTPS, port 3443, EAR config).
 const EAR_START_CMD = "env-cmd -f .env.ear.e2e npm start";
 const EXPRESS_SAMPLE_ROOT = path.join(__dirname, "..");
 
-// Mirrors public/js/earConfig.js; ?ear=true applies it and forces protocolMode "EAR".
+// ?ear=true forces EAR protocol (see earConfig.js).
 const EAR_QUERY_STRING = "?ear=true";
 const EAR_CACHE_LOCATION = "sessionStorage";
 const EAR_SCOPES = ["User.Read"];
 const EAR_ORIGIN = `https://localhost:${EAR_PORT}`;
-// sessionStorage key for the decrypt spy count; survives the redirect round-trip.
+// sessionStorage key for the decrypt spy count.
 const EAR_DECRYPT_COUNT_KEY = "__earDecryptCount";
 
-/**
- * True when the /authorize request used POST. EAR posts the encrypted JWK in the
- * body, so this distinguishes EAR from the default auth-code GET.
- */
+/** True when /authorize used POST (EAR posts the encrypted JWK). */
 function isAuthorizePost(request: puppeteer.HTTPRequest): boolean {
     return request.url().includes("/authorize") && request.method() === "POST";
 }
 
-/**
- * True when a POST hit the /token endpoint. acquireTokenSilent(forceRefresh)
- * renews the access token from the cached refresh token via this call.
- */
+/** True when a POST hit /token (token refresh). */
 function isTokenPost(request: puppeteer.HTTPRequest): boolean {
     return request.url().includes("/token") && request.method() === "POST";
 }
 
-/**
- * AES-GCM WebCrypto decrypt count. In the EAR sessionStorage config the only such
- * call is decryptEarResponse, so a non-zero count proves the ear_jwe was decrypted.
- */
+/** AES-GCM decrypt count; non-zero proves the EAR response was decrypted. */
 async function getEarDecryptCount(target: puppeteer.Page): Promise<number> {
     return target.evaluate(
         (key) => parseInt(window.sessionStorage.getItem(key) || "0", 10),
@@ -62,10 +51,7 @@ async function getEarDecryptCount(target: puppeteer.Page): Promise<number> {
     );
 }
 
-/**
- * Interactive EAR redirect login. Silent tests need a prior interactive login in
- * the same context to seed the ESTS session and cache the EAR-issued tokens.
- */
+/** Interactive EAR redirect login; seeds session + cache for the silent tests. */
 async function performRedirectLogin(
     page: puppeteer.Page,
     screenshot: Screenshot,
@@ -93,12 +79,8 @@ describe("EAR (Encrypted Authorize Response) Tests", () => {
     let earServerProcess: ChildProcess;
 
     beforeAll(async () => {
-        // Dedicated EAR HTTPS server + cert-tolerant browser; shared http
-        // harness (port 3000) untouched. Spawn directly (not
-        // serverUtils.startServer) to avoid its console-based stdout/close
-        // handlers that logged after teardown ("Cannot log after tests are
-        // done"). Inherit stdio so server logs surface; afterAll awaits child
-        // exit so no output races teardown.
+        // Dedicated EAR HTTPS server; spawn directly (not serverUtils) and
+        // inherit stdio so server logs surface. afterAll awaits child exit.
         earServerProcess = spawn(EAR_START_CMD, {
             shell: true,
             cwd: EXPRESS_SAMPLE_ROOT,
@@ -154,10 +136,8 @@ describe("EAR (Encrypted Authorize Response) Tests", () => {
         context = await browser.createBrowserContext();
         page = await context.newPage();
         BrowserCache = new BrowserCacheUtils(page, EAR_CACHE_LOCATION);
-        // Install a WebCrypto decrypt spy on every same-origin document before
-        // navigating. evaluateOnNewDocument re-applies across the redirect
-        // round-trip, the origin guard keeps it off ESTS, and the count is kept
-        // in sessionStorage to read after the flow.
+        // WebCrypto decrypt spy, re-applied on every same-origin document.
+        // Origin guard keeps it off ESTS; count kept in sessionStorage.
         await page.evaluateOnNewDocument(
             (config: { origin: string; key: string }) => {
                 try {
@@ -270,8 +250,7 @@ describe("EAR (Encrypted Authorize Response) Tests", () => {
             throw new Error("Popup window was not opened");
         }
 
-        // EAR posts /authorize from the popup window, so listen there. Attach
-        // before entering credentials so the navigation is captured.
+        // EAR posts /authorize from the popup window; attach before creds.
         let authorizeWasPost = false;
         popupPage.on("request", (request) => {
             if (isAuthorizePost(request)) {
@@ -304,8 +283,7 @@ describe("EAR (Encrypted Authorize Response) Tests", () => {
         // Seed an interactive EAR login so ssoSilent has an ESTS session + account.
         await performRedirectLogin(page, screenshot, username, accountPwd);
 
-        // ssoSilent runs a hidden-iframe authorize; with EAR that iframe POSTs
-        // /authorize and MSAL decrypts a fresh ear_jwe. Capture both signals.
+        // ssoSilent runs a hidden-iframe authorize; EAR POSTs /authorize + decrypts.
         let ssoAuthorizeWasPost = false;
         page.on("request", (request) => {
             if (isAuthorizePost(request)) {
@@ -337,9 +315,8 @@ describe("EAR (Encrypted Authorize Response) Tests", () => {
         // Seed an interactive EAR login so the EAR-issued refresh token is cached.
         await performRedirectLogin(page, screenshot, username, accountPwd);
 
-        // acquireTokenSilent(forceRefresh) renews the AT from the cached RT via a
-        // /token POST. It must NOT re-run the EAR /authorize flow or decrypt an
-        // ear_jwe, validating the EAR-issued RT works with the standard RT grant.
+        // acquireTokenSilent(forceRefresh) renews the AT from the cached RT via
+        // /token POST; no new /authorize or decrypt.
         let tokenWasPost = false;
         let authorizeWasPost = false;
         page.on("request", (request) => {

--- a/samples/msal-browser-samples/ExpressSample/test/browserEAR.spec.ts
+++ b/samples/msal-browser-samples/ExpressSample/test/browserEAR.spec.ts
@@ -293,7 +293,7 @@ describe("EAR (Encrypted Authorize Response) Tests", () => {
         const decryptCountBefore = await getEarDecryptCount(page);
 
         await page.locator("button#ssoSilentButton").click();
-        await page.waitForSelector('div#silentStatus[data-status="ssoSilent:success"]', {
+        await page.waitForSelector("div#silentStatus[data-status=\"ssoSilent:success\"]", {
             timeout: 30000,
         });
         await screenshot.takeScreenshot(page, "ssoSilent completed");

--- a/samples/msal-browser-samples/ExpressSample/views/partials/home-content.hbs
+++ b/samples/msal-browser-samples/ExpressSample/views/partials/home-content.hbs
@@ -15,7 +15,13 @@
 
         <div class="btn-group">
             <a href="/profile" id="viewProfileButton" class="btn spa-link">View Your Profile</a>
+            <button id="ssoSilentButton" class="btn">SSO Silent</button>
+            <button id="acquireTokenSilentButton" class="btn">Acquire Token Silently</button>
         </div>
+
+        <!-- Result of the last silent call. data-status is read by the e2e tests
+             (e.g. ssoSilent:success, acquireTokenSilent:error). -->
+        <div id="silentStatus" data-status="" style="display: none;"></div>
     </div>
 </div>
 

--- a/samples/msal-browser-samples/ExpressSample/views/partials/home-content.hbs
+++ b/samples/msal-browser-samples/ExpressSample/views/partials/home-content.hbs
@@ -15,8 +15,8 @@
 
         <div class="btn-group">
             <a href="/profile" id="viewProfileButton" class="btn spa-link">View Your Profile</a>
-            <button id="ssoSilentButton" class="btn">SSO Silent</button>
-            <button id="acquireTokenSilentButton" class="btn">Acquire Token Silently</button>
+            <button id="ssoSilentButton" class="btn">Silent Sign-In</button>
+            <button id="acquireTokenSilentButton" class="btn">Refresh Access Token</button>
         </div>
 
         <!-- Result of the last silent call. data-status is read by the e2e tests


### PR DESCRIPTION
## Summary
Follow-up to Foundation PR 3 (EAR sample config, #8766). Adds EAR e2e coverage for the two silent paths not exercised by `loginRedirect`/`loginPopup`, extending the ExpressSample `browserEAR` spec.

## Changes
- **`test/browserEAR.spec.ts`**
  - **ssoSilent** — drives the hidden-iframe EAR authorize path; asserts the silent `/authorize` used HTTP POST and that a fresh `ear_jwe` was decrypted (AES-GCM `subtle.decrypt` count increases).
  - **acquireTokenSilent** (`forceRefresh`) — asserts the EAR-issued refresh token works with the standard RT grant: a `/token` POST occurs, with **no** new `/authorize` and **no** re-decrypt.
- **Sample UI** (`home-content.hbs` / `auth.js` / `app.js`) — dedicated **SSO Silent** and **Acquire Token Silently** buttons in the authenticated home view, wired to the main `msalInstance` (which honors `?ear=true`), plus a `#silentStatus` element the tests synchronize on.

## Validation
- `browserEAR` e2e passes locally — all 4 tests (`loginRedirect`, `loginPopup`, `ssoSilent`, `acquireTokenSilent`) against the EAR-allow-listed app over the https EAR flow; clean jest exit.

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: test
agent-tool: copilot-cli
agent-model: claude-opus-4.8
work-item: AB#3688371
<!-- END pr-telemetry -->
