### PR TITLE
[NAA/PWB One Bridge] PR 3/6: Relocate cross-version request adapter to webBrokerBridge

### DIFF
--- a/change/@azure-msal-browser-unify-web-broker-bridge-adapter.json
+++ b/change/@azure-msal-browser-unify-web-broker-bridge-adapter.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Relocate the cross-version request adapter into the shared webBrokerBridge module without changing request transformation behavior [#8771](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8771)",
+    "packageName": "@azure/msal-browser",
+    "email": "shylasummers@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-browser/src/webBrokerBridge/adapter/CrossVersionRequestAdapter.ts
+++ b/lib/msal-browser/src/webBrokerBridge/adapter/CrossVersionRequestAdapter.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-type StringDict = Record<string, string>;
+import { StringDict } from "@azure/msal-common/browser";
 
 /**
  * Current request fields used by cross-version transformations.

--- a/lib/msal-browser/src/webBrokerBridge/adapter/CrossVersionRequestAdapter.ts
+++ b/lib/msal-browser/src/webBrokerBridge/adapter/CrossVersionRequestAdapter.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+type StringDict = Record<string, string>;
+
+/**
+ * Current request fields used by cross-version transformations.
+ */
+export interface CrossVersionRequestFields {
+    extraQueryParameters?: StringDict;
+    extraParameters?: StringDict;
+    resource?: string;
+}
+
+/**
+ * Deprecated request field names absent from the current request type.
+ */
+export interface LegacyRequestFields {
+    tokenQueryParameters?: StringDict;
+    tokenBodyParameters?: StringDict;
+    authorizePostBodyParameters?: StringDict;
+}
+
+/**
+ * Current request extended with all known legacy fields.
+ */
+export type CrossVersionRequest<
+    TRequest extends CrossVersionRequestFields = CrossVersionRequestFields
+> = TRequest & LegacyRequestFields;
+
+/**
+ * Promotes `extraParameters.resource` to the top-level `resource` field.
+ *
+ * Pre-5.5.0 embedded apps do not have a top-level `resource` field.
+ *
+ * @param request - The request to transform.
+ * @returns A new request with `resource` promoted if applicable.
+ */
+export function normalizeResourceField<
+    TRequest extends CrossVersionRequestFields
+>(request: TRequest): TRequest {
+    if (request.extraParameters?.resource) {
+        const { resource, ...remainingParams } = request.extraParameters;
+        const result = { ...request };
+        result.resource = resource;
+        result.extraParameters = remainingParams;
+        return result;
+    }
+    return request;
+}
+
+/**
+ * Demotes the top-level `resource` field into `extraParameters.resource`.
+ *
+ * Pre-5.5.0 embedded apps do not have a top-level `resource` field.
+ *
+ * @param request - The request to transform.
+ * @returns A new request with `resource` demoted if applicable.
+ */
+export function addResourceField<TRequest extends CrossVersionRequestFields>(
+    request: TRequest
+): TRequest {
+    if (request.resource) {
+        const resource = request.resource;
+        const result = { ...request };
+        result.extraParameters = {
+            ...result.extraParameters,
+            resource,
+        };
+        delete result.resource;
+        return result;
+    }
+    return request;
+}
+
+/**
+ * Normalize an incoming request from any embedded-app version so that
+ * the broker PCA methods can consume it correctly.
+ *
+ * - Folds legacy field values into their current equivalents.
+ * - Strips legacy field names from the returned object.
+ * - Is idempotent: safe to call on requests that already use current names.
+ *
+ * @param request - The request from a broker auth request.
+ * @returns A new request with current field names only.
+ */
+export function normalizeIncomingRequest<
+    TRequest extends CrossVersionRequestFields
+>(request: CrossVersionRequest<TRequest>): TRequest {
+    const normalized = normalizeResourceField(request);
+    const currentFields = { ...normalized };
+    const {
+        tokenQueryParameters,
+        tokenBodyParameters,
+        authorizePostBodyParameters,
+    } = currentFields;
+
+    delete currentFields.tokenQueryParameters;
+    delete currentFields.tokenBodyParameters;
+    delete currentFields.authorizePostBodyParameters;
+
+    /*
+     * tokenQueryParameters (removed in v5) → extraQueryParameters.
+     * Current values win on key conflicts.
+     */
+    if (tokenQueryParameters) {
+        currentFields.extraQueryParameters = {
+            ...tokenQueryParameters,
+            ...currentFields.extraQueryParameters,
+        };
+    }
+
+    /*
+     * tokenBodyParameters (removed in v5) → extraParameters.
+     * Current values win on key conflicts.
+     */
+    if (tokenBodyParameters) {
+        currentFields.extraParameters = {
+            ...tokenBodyParameters,
+            ...currentFields.extraParameters,
+        };
+    }
+
+    /*
+     * authorizePostBodyParameters (removed in v5) → extraParameters.
+     * Merged after tokenBodyParameters; current values still win.
+     */
+    if (authorizePostBodyParameters) {
+        currentFields.extraParameters = {
+            ...authorizePostBodyParameters,
+            ...currentFields.extraParameters,
+        };
+    }
+
+    return currentFields;
+}
+
+/**
+ * Add legacy field aliases to an outgoing request so that an older broker
+ * can still consume the parameters.
+ *
+ * - Copies current field values into all known legacy field names.
+ * - Merges extraParameters into extraQueryParameters (extraParameters wins)
+ *   so the v4 broker sees them on the /authorize query string.
+ * - Deliberately omits authorizePostBodyParameters.
+ * - Is idempotent: safe to call multiple times.
+ *
+ * @param request - The request about to be wrapped in a broker auth request.
+ * @returns A new request carrying both current and legacy field names.
+ */
+export function addLegacyRequestFields<
+    TRequest extends CrossVersionRequestFields
+>(request: TRequest): CrossVersionRequest<TRequest> {
+    const result: CrossVersionRequest<TRequest> = {
+        ...addResourceField(request),
+    };
+
+    // extraQueryParameters → also set legacy tokenQueryParameters (removed in v5)
+    if (result.extraQueryParameters) {
+        result.tokenQueryParameters = { ...result.extraQueryParameters };
+    }
+
+    // extraParameters → also set legacy field aliases (removed in v5)
+    if (result.extraParameters) {
+        // Token endpoint is always POST, so body params always apply.
+        result.tokenBodyParameters = { ...result.extraParameters };
+
+        /*
+         * In v5, extraParameters are sent on the /authorize query string (GET)
+         * or POST body depending on httpMethod. The v4 broker reads
+         * extraQueryParameters for both flows' query strings, so merging here
+         * covers both. We intentionally omit authorizePostBodyParameters
+         * because v4 throws if it is present without httpMethod === "POST",
+         * and the embedded app cannot expect control over how the request
+         * is made.
+         */
+        result.extraQueryParameters = {
+            ...result.extraQueryParameters,
+            ...result.extraParameters,
+        };
+    }
+
+    return result;
+}

--- a/lib/msal-browser/src/webBrokerBridge/index.ts
+++ b/lib/msal-browser/src/webBrokerBridge/index.ts
@@ -23,3 +23,14 @@ export { WebBrokerBridgeErrorCode } from "./WebBrokerBridgeError.js";
 export { toAuthError } from "./WebBrokerBridgeErrorMap.js";
 export { PendingRequestRegistry } from "./PendingRequestRegistry.js";
 export type { WebBrokerBridgeSendFn } from "./PendingRequestRegistry.js";
+export {
+    addLegacyRequestFields,
+    addResourceField,
+    normalizeIncomingRequest,
+    normalizeResourceField,
+} from "./adapter/CrossVersionRequestAdapter.js";
+export type {
+    CrossVersionRequest,
+    CrossVersionRequestFields,
+    LegacyRequestFields,
+} from "./adapter/CrossVersionRequestAdapter.js";

--- a/lib/msal-browser/test/webBrokerBridge/adapter/CrossVersionRequestAdapter.spec.ts
+++ b/lib/msal-browser/test/webBrokerBridge/adapter/CrossVersionRequestAdapter.spec.ts
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    addLegacyRequestFields,
+    addResourceField,
+    CrossVersionRequest,
+    CrossVersionRequestFields,
+    LegacyRequestFields,
+    normalizeIncomingRequest,
+    normalizeResourceField,
+} from "../../../src/webBrokerBridge/adapter/CrossVersionRequestAdapter.js";
+
+interface TestRequest extends CrossVersionRequestFields, LegacyRequestFields {
+    scopes?: string[];
+    correlationId?: string;
+    httpMethod?: string;
+}
+
+function adaptIncomingRequest(
+    request: CrossVersionRequest<TestRequest>
+): TestRequest {
+    return normalizeIncomingRequest(request);
+}
+
+function adaptOutgoingRequest(
+    request: TestRequest
+): CrossVersionRequest<TestRequest> {
+    return addLegacyRequestFields(request);
+}
+
+function promoteResource(request: TestRequest): TestRequest {
+    return normalizeResourceField(request);
+}
+
+function demoteResource(request: TestRequest): TestRequest {
+    return addResourceField(request);
+}
+
+describe("CrossVersionRequestAdapter", () => {
+    const baseRequest = {
+        scopes: ["openid"],
+        correlationId: "test-corr-id",
+    };
+
+    describe("normalizeIncomingRequest", () => {
+        it("folds tokenQueryParameters into extraQueryParameters", () => {
+            const result = adaptIncomingRequest({
+                ...baseRequest,
+                tokenQueryParameters: { foo: "bar" },
+            });
+            expect(result.extraQueryParameters).toEqual({ foo: "bar" });
+            expect(result).not.toHaveProperty("tokenQueryParameters");
+        });
+
+        it("folds tokenBodyParameters into extraParameters", () => {
+            const result = adaptIncomingRequest({
+                ...baseRequest,
+                tokenBodyParameters: { baz: "qux" },
+            });
+            expect(result.extraParameters).toEqual({ baz: "qux" });
+            expect(result).not.toHaveProperty("tokenBodyParameters");
+        });
+
+        it("folds authorizePostBodyParameters into extraParameters", () => {
+            const result = adaptIncomingRequest({
+                ...baseRequest,
+                authorizePostBodyParameters: { auth: "param" },
+            });
+            expect(result.extraParameters).toEqual({ auth: "param" });
+            expect(result).not.toHaveProperty("authorizePostBodyParameters");
+        });
+
+        it("merges authorizePostBodyParameters into existing extraParameters", () => {
+            const result = adaptIncomingRequest({
+                ...baseRequest,
+                tokenBodyParameters: { body: "1" },
+                authorizePostBodyParameters: { post: "2" },
+            });
+            expect(result.extraParameters).toEqual({
+                body: "1",
+                post: "2",
+            });
+            expect(result).not.toHaveProperty("tokenBodyParameters");
+            expect(result).not.toHaveProperty("authorizePostBodyParameters");
+        });
+
+        it("merges tokenQueryParameters into existing extraQueryParameters (v5 wins)", () => {
+            const result = adaptIncomingRequest({
+                ...baseRequest,
+                extraQueryParameters: {
+                    shared: "currentWins",
+                    currentOnly: "yes",
+                },
+                tokenQueryParameters: {
+                    shared: "legacyLoses",
+                    legacyOnly: "yes",
+                },
+            });
+            expect(result.extraQueryParameters).toEqual({
+                shared: "currentWins",
+                currentOnly: "yes",
+                legacyOnly: "yes",
+            });
+            expect(result).not.toHaveProperty("tokenQueryParameters");
+        });
+
+        it("merges tokenBodyParameters into existing extraParameters (v5 wins)", () => {
+            const result = adaptIncomingRequest({
+                ...baseRequest,
+                extraParameters: {
+                    shared: "currentWins",
+                    currentOnly: "yes",
+                },
+                tokenBodyParameters: {
+                    shared: "legacyLoses",
+                    legacyOnly: "yes",
+                },
+            });
+            expect(result.extraParameters).toEqual({
+                shared: "currentWins",
+                currentOnly: "yes",
+                legacyOnly: "yes",
+            });
+            expect(result).not.toHaveProperty("tokenBodyParameters");
+        });
+
+        it("merges authorizePostBodyParameters into existing extraParameters (v5 wins)", () => {
+            const result = adaptIncomingRequest({
+                ...baseRequest,
+                extraParameters: {
+                    shared: "currentWins",
+                    currentOnly: "yes",
+                },
+                authorizePostBodyParameters: {
+                    shared: "legacyLoses",
+                    legacyOnly: "yes",
+                },
+            });
+            expect(result.extraParameters).toEqual({
+                shared: "currentWins",
+                currentOnly: "yes",
+                legacyOnly: "yes",
+            });
+            expect(result).not.toHaveProperty("authorizePostBodyParameters");
+        });
+
+        it("does not mutate the input request", () => {
+            const request = {
+                ...baseRequest,
+                tokenQueryParameters: { foo: "bar" },
+                tokenBodyParameters: { baz: "qux" },
+                authorizePostBodyParameters: { auth: "param" },
+            };
+            adaptIncomingRequest(request);
+            expect(request.tokenQueryParameters).toEqual({ foo: "bar" });
+            expect(request.tokenBodyParameters).toEqual({ baz: "qux" });
+            expect(request.authorizePostBodyParameters).toEqual({
+                auth: "param",
+            });
+            expect(request).not.toHaveProperty("extraQueryParameters");
+            expect(request).not.toHaveProperty("extraParameters");
+        });
+
+        it("is idempotent on a v5 request", () => {
+            const result = adaptIncomingRequest({
+                ...baseRequest,
+                extraQueryParameters: { q: "1" },
+                extraParameters: { p: "2" },
+            });
+            expect(result.extraQueryParameters).toEqual({ q: "1" });
+            expect(result.extraParameters).toEqual({ p: "2" });
+        });
+
+        it("handles empty request with no extra parameters", () => {
+            const result = adaptIncomingRequest(baseRequest);
+            expect(result.extraQueryParameters).toBeUndefined();
+            expect(result.extraParameters).toBeUndefined();
+        });
+    });
+
+    describe("addLegacyRequestFields", () => {
+        it("copies extraQueryParameters to tokenQueryParameters", () => {
+            const result = adaptOutgoingRequest({
+                ...baseRequest,
+                extraQueryParameters: { foo: "bar" },
+            });
+            expect(result.tokenQueryParameters).toEqual({ foo: "bar" });
+            expect(result.extraQueryParameters).toEqual({ foo: "bar" });
+        });
+
+        it("sets tokenBodyParameters and merges extraParameters into extraQueryParameters", () => {
+            const result = adaptOutgoingRequest({
+                ...baseRequest,
+                extraParameters: { baz: "qux" },
+            });
+            expect(result.tokenBodyParameters).toEqual({ baz: "qux" });
+            expect(result.extraQueryParameters).toEqual({ baz: "qux" });
+            expect(result.tokenQueryParameters).toBeUndefined();
+            expect(result.authorizePostBodyParameters).toBeUndefined();
+            expect(result.extraParameters).toEqual({ baz: "qux" });
+        });
+
+        it("httpMethod POST does not change extraParameters handling", () => {
+            const result = adaptOutgoingRequest({
+                ...baseRequest,
+                httpMethod: "POST",
+                extraParameters: { baz: "qux" },
+            });
+            expect(result.tokenBodyParameters).toEqual({ baz: "qux" });
+            expect(result.extraQueryParameters).toEqual({ baz: "qux" });
+            expect(result.authorizePostBodyParameters).toBeUndefined();
+            expect(result.extraParameters).toEqual({ baz: "qux" });
+        });
+
+        it("merges extraParameters into extraQueryParameters (extraParameters wins)", () => {
+            const result = adaptOutgoingRequest({
+                ...baseRequest,
+                extraQueryParameters: {
+                    shared: "original",
+                    qsOnly: "yes",
+                },
+                extraParameters: {
+                    shared: "fromBody",
+                    bodyOnly: "yes",
+                },
+            });
+            expect(result.extraQueryParameters).toEqual({
+                shared: "fromBody",
+                qsOnly: "yes",
+                bodyOnly: "yes",
+            });
+            expect(result.tokenQueryParameters).toEqual({
+                shared: "original",
+                qsOnly: "yes",
+            });
+            expect(result.authorizePostBodyParameters).toBeUndefined();
+        });
+
+        it("httpMethod POST does not change merge precedence", () => {
+            const result = adaptOutgoingRequest({
+                ...baseRequest,
+                httpMethod: "POST",
+                extraQueryParameters: {
+                    shared: "original",
+                    qsOnly: "yes",
+                },
+                extraParameters: {
+                    shared: "fromBody",
+                    bodyOnly: "yes",
+                },
+            });
+            expect(result.extraQueryParameters).toEqual({
+                shared: "fromBody",
+                qsOnly: "yes",
+                bodyOnly: "yes",
+            });
+            expect(result.tokenQueryParameters).toEqual({
+                shared: "original",
+                qsOnly: "yes",
+            });
+            expect(result.tokenBodyParameters).toEqual({
+                shared: "fromBody",
+                bodyOnly: "yes",
+            });
+            expect(result.authorizePostBodyParameters).toBeUndefined();
+        });
+
+        it("does not mutate the input request", () => {
+            const request = {
+                ...baseRequest,
+                extraQueryParameters: { foo: "bar" },
+            };
+            adaptOutgoingRequest(request);
+            expect(request).not.toHaveProperty("tokenQueryParameters");
+        });
+
+        it("is idempotent when called multiple times", () => {
+            const request = {
+                ...baseRequest,
+                extraQueryParameters: { q: "1" },
+                extraParameters: { p: "2" },
+            };
+            const result1 = adaptOutgoingRequest(request);
+            const result2 = adaptOutgoingRequest(request);
+            expect(result1).toEqual(result2);
+            expect(result1.tokenQueryParameters).toEqual({ q: "1" });
+            expect(result1.tokenBodyParameters).toEqual({ p: "2" });
+            expect(result1.authorizePostBodyParameters).toBeUndefined();
+            expect(result1.extraQueryParameters).toEqual({
+                q: "1",
+                p: "2",
+            });
+        });
+
+        it("handles empty request with no extra parameters", () => {
+            const result = adaptOutgoingRequest(baseRequest);
+            expect(result.tokenQueryParameters).toBeUndefined();
+            expect(result.tokenBodyParameters).toBeUndefined();
+            expect(result.authorizePostBodyParameters).toBeUndefined();
+        });
+    });
+
+    describe("round-trip compatibility", () => {
+        it("v4 request with distinct per-endpoint params round-trips correctly", () => {
+            const normalized = adaptIncomingRequest({
+                ...baseRequest,
+                extraQueryParameters: { authorize_only: "1" },
+                tokenQueryParameters: { token_only: "2" },
+                tokenBodyParameters: { token_body: "3" },
+                authorizePostBodyParameters: { auth_body: "4" },
+            });
+            expect(normalized.extraQueryParameters).toEqual({
+                authorize_only: "1",
+                token_only: "2",
+            });
+            expect(normalized.extraParameters).toEqual({
+                token_body: "3",
+                auth_body: "4",
+            });
+            expect(normalized).not.toHaveProperty("tokenQueryParameters");
+            expect(normalized).not.toHaveProperty("tokenBodyParameters");
+            expect(normalized).not.toHaveProperty(
+                "authorizePostBodyParameters"
+            );
+        });
+
+        it("v4 → normalize → addLegacy preserves all params", () => {
+            const normalized = adaptIncomingRequest({
+                ...baseRequest,
+                tokenQueryParameters: { query: "val" },
+                tokenBodyParameters: { body: "val" },
+                authorizePostBodyParameters: { authBody: "val" },
+            });
+            expect(normalized.extraQueryParameters).toEqual({
+                query: "val",
+            });
+            expect(normalized.extraParameters).toEqual({
+                body: "val",
+                authBody: "val",
+            });
+
+            const withLegacy = adaptOutgoingRequest(normalized);
+            expect(withLegacy.tokenQueryParameters).toEqual({
+                query: "val",
+            });
+            expect(withLegacy.tokenBodyParameters).toEqual({
+                body: "val",
+                authBody: "val",
+            });
+            expect(withLegacy.authorizePostBodyParameters).toBeUndefined();
+            expect(withLegacy.extraQueryParameters).toEqual({
+                query: "val",
+                body: "val",
+                authBody: "val",
+            });
+        });
+
+        test.each(["GET", "POST"])(
+            "v5 %s → addLegacy → normalize preserves all params",
+            (httpMethod) => {
+                const withLegacy = adaptOutgoingRequest({
+                    ...baseRequest,
+                    ...(httpMethod === "POST" ? { httpMethod } : {}),
+                    extraQueryParameters: { query: "val" },
+                    extraParameters: { body: "val" },
+                });
+                expect(withLegacy.tokenQueryParameters).toEqual({
+                    query: "val",
+                });
+                expect(withLegacy.tokenBodyParameters).toEqual({
+                    body: "val",
+                });
+                expect(withLegacy.authorizePostBodyParameters).toBeUndefined();
+                expect(withLegacy.extraQueryParameters).toEqual({
+                    query: "val",
+                    body: "val",
+                });
+
+                const normalized = adaptIncomingRequest(withLegacy);
+                expect(normalized.extraQueryParameters).toEqual({
+                    query: "val",
+                    body: "val",
+                });
+                expect(normalized.extraParameters).toEqual({
+                    body: "val",
+                });
+                expect(normalized).not.toHaveProperty("tokenQueryParameters");
+                expect(normalized).not.toHaveProperty("tokenBodyParameters");
+                expect(normalized).not.toHaveProperty(
+                    "authorizePostBodyParameters"
+                );
+            }
+        );
+    });
+
+    describe("resource compatibility", () => {
+        it("preserves other extraParameters when promoting resource", () => {
+            const result = promoteResource({
+                ...baseRequest,
+                extraParameters: {
+                    resource: "https://resource.example.com",
+                    other: "value",
+                },
+            });
+            expect(result.resource).toBe("https://resource.example.com");
+            expect(result.extraParameters).toEqual({ other: "value" });
+        });
+
+        it("returns request unchanged when no extraParameters.resource", () => {
+            const result = promoteResource({
+                ...baseRequest,
+                extraParameters: { other: "value" },
+            });
+            expect(result.resource).toBeUndefined();
+            expect(result.extraParameters).toEqual({ other: "value" });
+        });
+
+        it("does not mutate extraParameters.resource", () => {
+            const request = {
+                ...baseRequest,
+                extraParameters: {
+                    resource: "https://resource.example.com",
+                },
+            };
+            promoteResource(request);
+            expect(request).not.toHaveProperty("resource");
+            expect(request.extraParameters.resource).toBe(
+                "https://resource.example.com"
+            );
+        });
+
+        it("merges into existing extraParameters when demoting resource", () => {
+            const result = demoteResource({
+                ...baseRequest,
+                resource: "https://resource.example.com",
+                extraParameters: { other: "value" },
+            });
+            expect(result.resource).toBeUndefined();
+            expect(result.extraParameters).toEqual({
+                other: "value",
+                resource: "https://resource.example.com",
+            });
+        });
+
+        it("returns request unchanged when no resource", () => {
+            const result = demoteResource({
+                ...baseRequest,
+                extraParameters: { other: "value" },
+            });
+            expect(result.resource).toBeUndefined();
+            expect(result.extraParameters).toEqual({ other: "value" });
+        });
+
+        it("does not mutate top-level resource", () => {
+            const request = {
+                ...baseRequest,
+                resource: "https://resource.example.com",
+            };
+            demoteResource(request);
+            expect(request.resource).toBe("https://resource.example.com");
+            expect(request).not.toHaveProperty("extraParameters");
+        });
+
+        it("normalizeResourceField → addResourceField round-trips", () => {
+            const promoted = promoteResource({
+                ...baseRequest,
+                extraParameters: {
+                    resource: "https://resource.example.com",
+                },
+            });
+            expect(promoted.resource).toBe("https://resource.example.com");
+            expect(promoted.extraParameters).toEqual({});
+
+            const demoted = demoteResource(promoted);
+            expect(demoted.resource).toBeUndefined();
+            expect(demoted.extraParameters).toEqual({
+                resource: "https://resource.example.com",
+            });
+        });
+
+        it("addResourceField → normalizeResourceField round-trips", () => {
+            const demoted = demoteResource({
+                ...baseRequest,
+                resource: "https://resource.example.com",
+            });
+            expect(demoted.resource).toBeUndefined();
+            expect(demoted.extraParameters?.resource).toBe(
+                "https://resource.example.com"
+            );
+
+            const promoted = promoteResource(demoted);
+            expect(promoted.resource).toBe("https://resource.example.com");
+            expect(promoted.extraParameters).toEqual({});
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Relocates the existing cross-version request adapter implementation into the shared `webBrokerBridge` module without changing its transformation behavior, and carries over the complete compatibility test suite.

## Implements

- AB#3668028 — Unify NAA and PWB embedded bridge

## How to validate

- Run `npm test --workspace=@azure/msal-browser -- --runInBand CrossVersionRequestAdapter.spec.ts`.
- Confirm all 30 cross-version compatibility cases pass.
- Confirm the adapter remains outside the main `msal-browser` public API.

## Notes

Created as a test PR for CI validation. No reviewers requested.

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: refactor
agent-tool: copilot-cli
agent-model: gpt-5.6-sol
work-item: AB#3668028
<!-- END pr-telemetry -->