### PR TITLE
fix(security): bump js-yaml to patched versions (CVE-2026-59869)

### DIFF
--- a/.github/actions/issue_template_bot/package-lock.json
+++ b/.github/actions/issue_template_bot/package-lock.json
@@ -247,10 +247,21 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "version": "4.3.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/.github/actions/issue_template_bot/package-lock.json
+++ b/.github/actions/issue_template_bot/package-lock.json
@@ -248,20 +248,9 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10021,8 +10021,8 @@
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
             "version": "3.15.1",
-            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -22178,8 +22178,8 @@
         },
         "node_modules/eslint/node_modules/js-yaml": {
             "version": "3.15.1",
-            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -27098,8 +27098,8 @@
         },
         "node_modules/js-yaml": {
             "version": "4.3.1",
-            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "funding": [
                 {
                     "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10020,9 +10020,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -22177,9 +22177,9 @@
             }
         },
         "node_modules/eslint/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -27097,9 +27097,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
## Summary

Fixes the **js-yaml** quadratic merge-key Denial-of-Service vulnerability (**CVE-2026-59869** / **GHSA-52cp-r559-cp3m**). A small YAML payload using a chain of merge keys (`<<: *anchor`) can force O(N²) CPU for O(N) input and stall the Node.js event loop.

Affected ranges: `< 3.15.0` and `4.0.0 – < 4.3.0`.

## Changes

- `package-lock.json`
  - `js-yaml 3.14.2 → 3.15.1` (nested dev-dependency instances under `@istanbuljs/load-nyc-config` and `eslint`)
  - `js-yaml 4.2.0 → 4.3.1`
- `.github/actions/issue_template_bot/package-lock.json`
  - `js-yaml 4.0.0 → 4.3.1`

Lockfile-only change — no source or API changes (excluded from changefile requirements). js-yaml is a transitive dev/tooling dependency, not shipped in the MSAL runtime bundle.

## Testing

Verified via lockfile sweep that no vulnerable runtime `js-yaml` version remains (the sole `@types/js-yaml@4.0.0` is type definitions only). Dependency subtree unchanged (`argparse`/`esprima` ranges identical between 3.14.x and 3.15.x).

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: security
agent-tool: copilot-cli
agent-model: claude-opus-4.8
work-item: AB#n/a
<!-- END pr-telemetry -->
