### PR TITLE
[NAA/PWB One Bridge] PR 4/6: Export shared bridge message interface

### DIFF
--- a/change/@azure-msal-browser-export-web-broker-bridge-message.json
+++ b/change/@azure-msal-browser-export-web-broker-bridge-message.json
@@ -1,0 +1,7 @@
+{
+    "type": "minor",
+    "comment": "Export IWebBrokerBridgeMessage from the msal-browser package root [#8780](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8780)",
+    "packageName": "@azure/msal-browser",
+    "email": "shylasummers@microsoft.com",
+    "dependentChangeType": "minor"
+}

--- a/lib/msal-browser/apiReview/msal-browser.api.md
+++ b/lib/msal-browser/apiReview/msal-browser.api.md
@@ -721,6 +721,12 @@ function isInPopup(): boolean;
 // @public
 export function isPlatformBrokerAvailable(domConfig: boolean, loggerOptions?: LoggerOptions, perfClient?: IPerformanceClient, correlationId?: string): Promise<boolean>;
 
+// @public
+export interface IWebBrokerBridgeMessage {
+    readonly requestId: string;
+    readonly type: string;
+}
+
 // @public (undocumented)
 export interface IWindowStorage<T> {
     containsKey(key: string): boolean;

--- a/lib/msal-browser/src/index.ts
+++ b/lib/msal-browser/src/index.ts
@@ -66,6 +66,7 @@ export { AuthenticationResult } from "./response/AuthenticationResult.js";
 export { ClearCacheRequest } from "./request/ClearCacheRequest.js";
 export { InitializeApplicationRequest } from "./request/InitializeApplicationRequest.js";
 export { HandleRedirectPromiseOptions } from "./request/HandleRedirectPromiseOptions.js";
+export type { IWebBrokerBridgeMessage } from "./webBrokerBridge/IWebBrokerBridgeMessage.js";
 
 // Cache
 export { LoadTokenOptions } from "./cache/TokenCache.js";


### PR DESCRIPTION
## Summary

Exports `IWebBrokerBridgeMessage` from the `@azure/msal-browser` package root so `msal-browser-1p` can implement the shared interface without depending on a sibling checkout's generated declaration files.

## Implements

- AB#3668028 — Unify NAA and PWB embedded bridge

## How to validate

- Run `npm run build:all` from `lib/msal-browser`.
- Run `npm run apiExtractor` from `lib/msal-browser`.
- Confirm consumers can use `import type { IWebBrokerBridgeMessage } from "@azure/msal-browser"`.

## Notes

This is the 3P dependency for the corresponding 1P PR 4 changes. It changes only the public type export and generated API review; runtime behavior is unchanged.