### PR TITLE
chore(msal-node): remove disallowedChangeTypes guard to allow v6 major release

### DIFF
--- a/change/@azure-msal-node-allow-major-changetype.json
+++ b/change/@azure-msal-node-allow-major-changetype.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove the disallowedChangeTypes beachball guard on @azure/msal-node to allow the upcoming v6 major release",
+  "packageName": "@azure/msal-node",
+  "email": "joarroyo@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-msal-node-allow-major-changetype.json
+++ b/change/@azure-msal-node-allow-major-changetype.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Remove the disallowedChangeTypes beachball guard on @azure/msal-node to allow the upcoming v6 major release",
+  "comment": "Remove the disallowedChangeTypes beachball guard on @azure/msal-node to allow the upcoming v6 major release [#8782](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8782)",
   "packageName": "@azure/msal-node",
   "email": "joarroyo@microsoft.com",
   "dependentChangeType": "none"

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -60,11 +60,6 @@
     "format:fix": "prettier --ignore-path .gitignore --write src test",
     "apiExtractor": "api-extractor run"
   },
-  "beachball": {
-    "disallowedChangeTypes": [
-      "major"
-    ]
-  },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.7",
     "@rollup/plugin-node-resolve": "^15.0.1",


### PR DESCRIPTION
## Summary

`@azure/msal-node`'s `package.json` sets a beachball guard:

```json
"beachball": { "disallowedChangeTypes": ["major"] }
```

This blocks automatic `major` version bumps. The upcoming **v6 breaking release** (default `responseMode` → `form_post`, removal of `loopbackClient` / `ILoopbackClient`) requires a `major` changefile, which this guard rejects (`ERROR: Disallowed change type detected ... "major"`).

This PR removes the guard so the intentional major can proceed. There is precedent — the guard was removed for a prior major release and re-added afterward (commit `04055b06b` "disallow major changes").

Kept **separate from the v6 PR (#8779)** so each PR's `beachball-check` passes independently; once this merges to `dev`, the v6 PR rebases onto it and its `major` changefile validates cleanly.

## Validation
- `npx beachball check --branch origin/dev` → **passes** ("No change files are needed").
- Single-file change; no runtime/API impact.

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: chore
agent-tool: copilot-cli
agent-model: claude-opus-4.8
work-item: AB#n/a
<!-- END pr-telemetry -->
