### PR TITLE
Fix @azure/msal-common DOM type dependency

### DIFF
--- a/change/@azure-msal-common-issue-8783-dom-types.json
+++ b/change/@azure-msal-common-issue-8783-dom-types.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Remove the DOM type dependency from public declarations [#8784](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8784)",
+    "packageName": "@azure/msal-common",
+    "email": "hectormmg@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/change/@azure-msal-node-issue-8783-no-dom-check.json
+++ b/change/@azure-msal-node-issue-8783-no-dom-check.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Validate Node consumers without DOM typings during type builds [#8784](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8784)",
+    "packageName": "@azure/msal-node",
+    "email": "hectormmg@microsoft.com",
+    "dependentChangeType": "patch"
+}

--- a/lib/msal-common/apiReview/msal-common.api.md
+++ b/lib/msal-common/apiReview/msal-common.api.md
@@ -2070,7 +2070,7 @@ function isTokenExpired(expiresOn: string, offset: number): boolean;
 
 // @internal
 export interface ITokenBindingKeyManager {
-    getTokenBindingPublicKeyJwk(kid: string, correlationId: string): Promise<JsonWebKey>;
+    getTokenBindingPublicKeyJwk(kid: string, correlationId: string): Promise<PublicJsonWebKey>;
     provisionTokenBindingKey(request: TokenBindingKeyProvisioningParameters): Promise<string>;
     removeTokenBindingKey(kid: string, correlationId: string): Promise<void>;
 }
@@ -2103,7 +2103,7 @@ export class JoseHeader {
     static getDpopHeader(dpopHeaderOptions: JoseHeaderOptions, correlationId: string): JoseHeader;
     static getShrHeader(shrHeaderOptions: JoseHeaderOptions, correlationId: string): JoseHeader;
     // (undocumented)
-    jwk?: JsonWebKey;
+    jwk?: PublicJsonWebKey;
     // (undocumented)
     kid?: string;
     // (undocumented)
@@ -2701,6 +2701,21 @@ declare namespace ProtocolUtils {
         parseRequestState
     }
 }
+
+// @internal
+export type PublicJsonWebKey = {
+    alg?: string;
+    crv?: string;
+    e?: string;
+    ext?: boolean;
+    key_ops?: string[];
+    kid?: string;
+    kty?: string;
+    n?: string;
+    use?: string;
+    x?: string;
+    y?: string;
+};
 
 // @public (undocumented)
 const REDIRECT_URI = "redirect_uri";

--- a/lib/msal-common/src/crypto/DpopProofGenerator.ts
+++ b/lib/msal-common/src/crypto/DpopProofGenerator.ts
@@ -11,6 +11,7 @@ import {
     ClientConfigurationErrorCodes,
 } from "../error/ClientConfigurationError.js";
 import { JoseHeader } from "./JoseHeader.js";
+import type { PublicJsonWebKey } from "./PublicJsonWebKey.js";
 
 /**
  * RFC 9449 DPoP proof JWT payload claims.
@@ -58,7 +59,7 @@ const DPOP_TOKEN_BINDING_KEY_TYPE = "dpop";
 const DPOP_JWT_HEADER_ALGORITHM = JsonWebTokenAlgorithms.ES256;
 
 function buildProofHeader(
-    publicJwk: JsonWebKey,
+    publicJwk: PublicJsonWebKey,
     correlationId: string
 ): JoseHeader {
     return JoseHeader.getDpopHeader(

--- a/lib/msal-common/src/crypto/ITokenBindingKeyManager.ts
+++ b/lib/msal-common/src/crypto/ITokenBindingKeyManager.ts
@@ -7,6 +7,7 @@ import {
     ClientAuthErrorCodes,
     createClientAuthError,
 } from "../error/ClientAuthError.js";
+import type { PublicJsonWebKey } from "./PublicJsonWebKey.js";
 
 /**
  * Parameters used by token-binding key managers to provision browser-managed
@@ -46,7 +47,7 @@ export interface ITokenBindingKeyManager {
     getTokenBindingPublicKeyJwk(
         kid: string,
         correlationId: string
-    ): Promise<JsonWebKey>;
+    ): Promise<PublicJsonWebKey>;
 }
 
 /**
@@ -75,7 +76,7 @@ export const DEFAULT_TOKEN_BINDING_KEY_MANAGER: ITokenBindingKeyManager = {
     async getTokenBindingPublicKeyJwk(
         _kid: string,
         correlationId: string
-    ): Promise<JsonWebKey> {
+    ): Promise<PublicJsonWebKey> {
         throw createClientAuthError(
             ClientAuthErrorCodes.methodNotImplemented,
             correlationId

--- a/lib/msal-common/src/crypto/JoseHeader.ts
+++ b/lib/msal-common/src/crypto/JoseHeader.ts
@@ -9,12 +9,13 @@ import {
 } from "../error/JoseHeaderError.js";
 import { isPlainObject } from "../utils/ObjectUtils.js";
 import { JsonWebTokenTypes } from "../utils/Constants.js";
+import type { PublicJsonWebKey } from "./PublicJsonWebKey.js";
 
 export type JoseHeaderOptions = {
     typ?: JsonWebTokenTypes;
     alg?: string;
     kid?: string;
-    jwk?: JsonWebKey;
+    jwk?: PublicJsonWebKey;
 };
 
 /** @internal */
@@ -22,7 +23,7 @@ export class JoseHeader {
     public typ?: JsonWebTokenTypes;
     public alg: string;
     public kid?: string;
-    public jwk?: JsonWebKey;
+    public jwk?: PublicJsonWebKey;
 
     constructor(
         options: JoseHeaderOptions & { alg: string },

--- a/lib/msal-common/src/crypto/PublicJsonWebKey.ts
+++ b/lib/msal-common/src/crypto/PublicJsonWebKey.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Environment-neutral representation of the public asymmetric JWK fields
+ * used by token-binding implementations.
+ *
+ * @internal
+ */
+export type PublicJsonWebKey = {
+    alg?: string;
+    crv?: string;
+    e?: string;
+    ext?: boolean;
+    key_ops?: string[];
+    kid?: string;
+    kty?: string;
+    n?: string;
+    use?: string;
+    x?: string;
+    y?: string;
+};

--- a/lib/msal-common/src/exports-common.ts
+++ b/lib/msal-common/src/exports-common.ts
@@ -111,6 +111,7 @@ export {
     DEFAULT_TOKEN_BINDING_KEY_MANAGER,
     TokenBindingKeyProvisioningParameters,
 } from "./crypto/ITokenBindingKeyManager.js";
+export { PublicJsonWebKey } from "./crypto/PublicJsonWebKey.js";
 
 export * as AuthorizeProtocol from "./protocol/Authorize.js";
 export * as TokenProtocol from "./protocol/Token.js";

--- a/lib/msal-node/package.json
+++ b/lib/msal-node/package.json
@@ -46,10 +46,11 @@
   ],
   "scripts": {
     "build": "npm run clean && rollup -c --strictDeprecations --bundleConfigAsCjs && npm run build:types",
-    "build:types": "tsc -p tsconfig.build.types.json",
+    "build:types": "tsc -p tsconfig.build.types.json && npm run test:types:no-dom",
     "build:watch": "rollup -c --watch --strictDeprecations --bundleConfigAsCjs",
     "clean": "shx rm -rf dist types lib",
     "test": "jest",
+    "test:types:no-dom": "tsc -p test/type-check/no-dom/tsconfig.json",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts",

--- a/lib/msal-node/test/type-check/no-dom/index.ts
+++ b/lib/msal-node/test/type-check/no-dom/index.ts
@@ -1,0 +1,3 @@
+import { PublicClientApplication } from "@azure/msal-node";
+
+void PublicClientApplication;

--- a/lib/msal-node/test/type-check/no-dom/tsconfig.json
+++ b/lib/msal-node/test/type-check/no-dom/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "lib": ["ES2020"],
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "noEmit": true,
+        "skipLibCheck": false,
+        "strict": true,
+        "target": "ES2020",
+        "types": ["node"]
+    },
+    "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary

Remove the unintended DOM type dependency from `@azure/msal-common` declarations by replacing the ambient `JsonWebKey` reference with an environment-neutral public JWK contract.

Add a strict `@azure/msal-node` consumer compilation fixture without `lib.dom` and run it as part of `build:types` so future declaration leaks fail CI.

Fixes #8783

## How to validate

- Build `@azure/msal-common` before `@azure/msal-node`.
- Run `npm run test:types:no-dom --workspace=@azure/msal-node`.
- Run API Extractor for `@azure/msal-common`.

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: bug
agent-tool: copilot-cli
agent-model: gpt-5.6-sol
work-item: AB#n/a
<!-- END pr-telemetry -->
