### PR TITLE
fix(e2e): stop device-code sample tests timing out on optional ESTS pages

### DIFF
--- a/samples/e2eTestUtils/src/TestUtils.ts
+++ b/samples/e2eTestUtils/src/TestUtils.ts
@@ -350,7 +350,12 @@ export async function approveRemoteConnect(
     screenshot: Screenshot
 ): Promise<void> {
     try {
-        await page.waitForSelector(HtmlSelectors.REMOTE_LOCATION_DESCRPITION);
+        // This confirmation page is optional in the device-code flow. Use a
+        // short timeout so a run where it doesn't appear doesn't burn the full
+        // default timeout (which starves the rest of the login chain of time).
+        await page.waitForSelector(HtmlSelectors.REMOTE_LOCATION_DESCRPITION, {
+            timeout: 5000,
+        });
         await clickSubmitButton(page, screenshot);
     } catch (e) {
         return;

--- a/samples/msal-node-samples/device-code/test/device-code-aad-agc.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-aad-agc.spec.ts
@@ -42,7 +42,7 @@ config.resourceApi = {
 };
 
 describe("Device Code AAD AGC Tests", () => {
-    jest.setTimeout(90000);
+    jest.setTimeout(120000);
     jest.retryTimes(RETRY_TIMES);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;

--- a/samples/msal-node-samples/device-code/test/device-code-aad.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-aad.spec.ts
@@ -35,7 +35,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 const config = require("../config/AAD.json");
 
 describe("Device Code AAD Prod Tests", () => {
-    jest.setTimeout(90000);
+    jest.setTimeout(120000);
     jest.retryTimes(RETRY_TIMES);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;

--- a/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
+++ b/samples/msal-node-samples/device-code/test/device-code-adfs.spec.ts
@@ -36,7 +36,7 @@ const cachePlugin = require("../../cachePlugin.js")(TEST_CACHE_LOCATION);
 const config = require("../config/ADFS.json");
 
 describe("Device Code ADFS 2019 Tests", () => {
-    jest.setTimeout(90000);
+    jest.setTimeout(120000);
     jest.retryTimes(RETRY_TIMES);
     let browser: puppeteer.Browser;
     let context: puppeteer.BrowserContext;


### PR DESCRIPTION
## Problem  
The `device-code` sample e2e tests (`device-code-aad`, `device-code-adfs`, `device-code-aad-agc`) intermittently — and on slower agents, *consistently* — time out. The failure surfaces as `Waiting for selector #message failed` / `Target closed`, even though authentication actually succeeds.  

### Root cause  
The device-code login walks a long serial chain of real ESTS pages against a fixed `jest.setTimeout(90000)`. Several steps use the **30s default** `waitForSelector` timeout on *optional* pages. In the AAD device-code flow the `approveRemoteConnect` confirmation page ("Are you trying to sign in?") **does not appear**, so `waitForSelector` sits on its full default timeout before giving up — burning ~30s every run.  Screenshots captured locally showed a **43-second gap** between the device-code entry page and the username page, isolating that wasted wait. It pushes the baseline test time to ~85–90s, right on the 90s cap. `jest.retryTimes(5)` normally rescues it (one of six attempts lands under 90s), which is why most PRs stay green — but on a loaded/slow agent every attempt tips over and it looks like a hard, consistent failure.  

## Changes  
- **`approveRemoteConnect` (`e2eTestUtils/src/TestUtils.ts`)**: give the optional confirmation page a short **5s** explicit `waitForSelector` timeout instead of the 30s default, so a run where it doesn't appear doesn't starve the rest of the login chain. It's already wrapped in `try/catch/return`, so a missing page is a no-op — this is strictly an improvement for every caller.
- **device-code specs (aad, adfs, agc)**: raise `jest.setTimeout` **90s → 120s** for headroom against agent/network variance.  ## Validation  Ran locally on **Node v22.12** (the CI matrix version): `device-code-aad` now passes in **~43s** (test body 43.4s), where it previously timed out at 90s across all retries.  

Samples-only change — no changefile required.

<!-- BEGIN pr-telemetry --> assistance: agentic-cli type: test agent-tool: copilot-cli agent-model: claude-opus-4.8 work-item: AB#n/a <!-- END pr-telemetry -->  
