### PR TITLE
test(msal-common): fix flaky lastUpdatedAt race in CacheManager PoP test

### DIFF
--- a/lib/msal-common/test/cache/CacheManager.spec.ts
+++ b/lib/msal-common/test/cache/CacheManager.spec.ts
@@ -2211,9 +2211,16 @@ describe("CacheManager.ts test cases", () => {
         );
 
         const atKey = generateCredentialKey(atWithAuthScheme);
-        expect(mockCache.cacheManager.getAccessTokenCredential(atKey)).toEqual(
-            atWithAuthScheme
-        );
+        const cachedAtWithAuthScheme =
+            mockCache.cacheManager.getAccessTokenCredential(atKey);
+        // `lastUpdatedAt` is stamped with `Date.now()` when the entity is
+        // seeded into the cache, which can differ by a millisecond from the
+        // value built above. Compare against the cached timestamp so the
+        // assertion doesn't race the clock.
+        expect(cachedAtWithAuthScheme).toEqual({
+            ...atWithAuthScheme,
+            lastUpdatedAt: cachedAtWithAuthScheme?.lastUpdatedAt,
+        });
         mockCache.cacheManager.removeAccessToken(atKey, RANDOM_TEST_GUID);
         expect(
             mockCache.cacheManager.getAccessTokenCredential(atKey)


### PR DESCRIPTION
## Problem

Intermittent CI failure in `msal-common`:

```
● CacheManager.ts test cases › removes token binding key when removeAccessToken is called for a PoP AccessToken_With_AuthScheme credential

    - "lastUpdatedAt": "1788378508238",
    + "lastUpdatedAt": "1788378508237",
```

### Root cause

`MockCache.initializeCache()` (run in `beforeEach`) seeds the PoP `AccessToken_With_AuthScheme` entity with `lastUpdatedAt: Date.now().toString()`. The test then **rebuilds an identical credential** with a **second** `Date.now()` call and deep-compares the cached copy against it via `toEqual`. `generateCredentialKey` doesn't include `lastUpdatedAt`, so the key still matches the seeded entity — but the two `Date.now()` calls occasionally straddle a millisecond boundary, so `lastUpdatedAt` differs by 1 and the assertion fails. It's a pure clock race, not a product bug.

## Fix

Compare the cached credential against the test object while taking `lastUpdatedAt` from the **cached value** itself, so the assertion no longer depends on two `Date.now()` calls landing in the same millisecond. Every other field is still asserted exactly.

Only the PoP test had this pattern — the DPoP and SSH siblings save/build their own credential and don't deep-compare, so they're unaffected.

## Validation

Ran on Node v22.12 (the failing matrix version): the previously-flaky test passes, and the full `CacheManager` suite is green (85/85).

Test-only change — no changefile required.

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: test
agent-tool: copilot-cli
agent-model: claude-opus-4.8
work-item: AB#n/a
<!-- END pr-telemetry -->
