### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,3 +61,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/beachball-check.yml
+++ b/.github/workflows/beachball-check.yml
@@ -24,7 +24,7 @@ jobs:
         env:
             BEACHBALL: 1
         steps:
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
               id: filter
               with:
                   # Will return true if any file is not markdown and any file is in /lib
@@ -33,14 +33,14 @@ jobs:
                         - 'lib/**/**.!(md)'
                         - 'extensions/msal-node-extensions/**/**.!(md)'
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
               if: ${{ steps.filter.outputs.lib == 'true' }}
               with:
                   fetch-depth: 0
 
             - name: Use Node.js
               if: ${{ steps.filter.outputs.lib == 'true' }}
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
             - name: Install beachball
               if: ${{ steps.filter.outputs.lib == 'true' }}

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -29,8 +29,8 @@ jobs:
         name: Run msal-node client-credential Regression Test
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+            - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node
@@ -43,13 +43,13 @@ jobs:
               working-directory: regression-tests/msal-node/client-credential
 
             - name: Download previous benchmark data
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: ./cache
                   key: ${{ runner.os }}-benchmark
 
             - name: Store benchmark result
-              uses: benchmark-action/github-action-benchmark@v1
+              uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
               with:
                   name: msal-node client-credential Regression Test
                   tool: "benchmarkjs"

--- a/.github/workflows/issue-template-bot.yml
+++ b/.github/workflows/issue-template-bot.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Run Bot
         uses: ./.github/actions/issue_template_bot

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -15,8 +15,8 @@ jobs:
         name: Performance regression check
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+            - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node
@@ -33,7 +33,7 @@ jobs:
             # /dev/bench is a path to put the benchmark dashboard page. They can be tweaked by
             # the gh-pages-branch, gh-repository and benchmark-data-dir-path inputs.
             - name: Store benchmark result
-              uses: benchmark-action/github-action-benchmark@v1
+              uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
               with:
                   name: msal-node client-credential Regression Test
                   tool: "benchmarkjs"

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -16,13 +16,13 @@ jobs:
       contents: write
       pages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
       - name: Install
         run: npm i --workspace=lib/** --workspace=@azure/msal-node-extensions --include-workspace-root
@@ -37,7 +37,7 @@ jobs:
         run: npm run doc:generate
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./ref


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning

<!-- BEGIN pr-telemetry -->
assistance: agentic-mixed
type: security
agent-tool: copilot-cli
agent-model: gpt-5.6-sol
work-item: AB#n/a
<!-- END pr-telemetry -->