### PR TITLE
feat(msal-browser): support SMS MFA with distinct verification states

### DIFF
--- a/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
+++ b/lib/msal-browser/src/custom_auth/controller/CustomAuthStandardController.ts
@@ -48,7 +48,7 @@ import {
     FLOW_SIGN_UP_PASSWORD_REQUIRED_V2,
 } from "../core/interaction_client/v2/result/FlowActionResultV2.js";
 import { PasswordRequiredStateV2 } from "../sign_in/auth_flow/v2/state/PasswordRequiredStateV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "../core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import { MFARequiredStateV2 } from "../core/auth_flow/v2/state/MFARequiredStateV2.js";
 import { AttributesRequiredStateV2 } from "../sign_up/auth_flow/v2/state/AttributesRequiredStateV2.js";
 import { SignUpPasswordRequiredStateV2 } from "../sign_up/auth_flow/v2/state/SignUpPasswordRequiredStateV2.js";
@@ -671,7 +671,7 @@ export class CustomAuthStandardController
 
             if (result.type === FLOW_CODE_REQUIRED_V2) {
                 return new CustomAuthResultV2(
-                    new ChallengeVerificationRequiredStateV2({
+                    new CodeRequiredStateV2({
                         correlationId: result.correlationId,
                         logger: this.logger,
                         config: this.customAuthConfig,
@@ -782,7 +782,7 @@ export class CustomAuthStandardController
 
             if (result.type === FLOW_CODE_REQUIRED_V2) {
                 return new CustomAuthResultV2(
-                    new ChallengeVerificationRequiredStateV2({
+                    new CodeRequiredStateV2({
                         correlationId: result.correlationId,
                         logger: this.logger,
                         config: this.customAuthConfig,
@@ -887,7 +887,7 @@ export class CustomAuthStandardController
 
             if (result.type === FLOW_CODE_REQUIRED_V2) {
                 return new CustomAuthResultV2(
-                    new ChallengeVerificationRequiredStateV2({
+                    new CodeRequiredStateV2({
                         ...commonStateParameters,
                         sentTo: result.sentTo,
                         channel: result.channel,

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/MFARequestChallengeResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/MFARequestChallengeResultV2.ts
@@ -5,11 +5,11 @@
 
 import { CustomAuthResultV2 } from "../CustomAuthResultV2.js";
 import type { RequestChallengeErrorV2 } from "../error/RequestChallengeErrorV2.js";
-import type { ChallengeVerificationRequiredStateV2 } from "../state/ChallengeVerificationRequiredStateV2.js";
+import type { MFAVerificationRequiredStateV2 } from "../state/MFAVerificationRequiredStateV2.js";
 import type { FailedStateV2 } from "../state/FailedStateV2.js";
 
 export type MFARequestChallengeResultStateV2 =
-    | ChallengeVerificationRequiredStateV2
+    | MFAVerificationRequiredStateV2
     | FailedStateV2;
 
 export type MFARequestChallengeResultV2 = CustomAuthResultV2<

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/MFAResendChallengeResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/MFAResendChallengeResultV2.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { CustomAuthResultV2 } from "../CustomAuthResultV2.js";
+import type { RequestChallengeErrorV2 } from "../error/RequestChallengeErrorV2.js";
+import type { FailedStateV2 } from "../state/FailedStateV2.js";
+import type { MFAVerificationRequiredStateV2 } from "../state/MFAVerificationRequiredStateV2.js";
+
+/**
+ * States returned after an app requests a replacement MFA challenge. The
+ * operation either returns refreshed verification metadata or a failed state.
+ */
+export type MFAResendChallengeResultStateV2 =
+    | MFAVerificationRequiredStateV2
+    | FailedStateV2;
+
+/**
+ * Result returned after an app requests a replacement MFA challenge. Inspect
+ * the state before prompting the user for the new email or SMS challenge.
+ */
+export type MFAResendChallengeResultV2 = CustomAuthResultV2<
+    MFAResendChallengeResultStateV2,
+    RequestChallengeErrorV2
+>;

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/MFASubmitChallengeResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/MFASubmitChallengeResultV2.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { CustomAuthResultV2 } from "../CustomAuthResultV2.js";
+import type { VerifyChallengeErrorV2 } from "../error/VerifyChallengeErrorV2.js";
+import type { CompletedStateV2 } from "../state/CompletedStateV2.js";
+import type { FailedStateV2 } from "../state/FailedStateV2.js";
+import type { CustomAuthAccountData } from "../../../../get_account/auth_flow/CustomAuthAccountData.js";
+
+/**
+ * States returned after an app submits an MFA challenge. The operation either
+ * completes sign-in or returns a failed state with error details.
+ */
+export type MFASubmitChallengeResultStateV2 = CompletedStateV2 | FailedStateV2;
+
+/**
+ * Result returned after an app submits an MFA challenge. Inspect the state to
+ * determine whether sign-in completed or challenge verification failed.
+ */
+export type MFASubmitChallengeResultV2 = CustomAuthResultV2<
+    MFASubmitChallengeResultStateV2,
+    VerifyChallengeErrorV2,
+    CustomAuthAccountData | undefined
+>;

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/RequestChallengeResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/RequestChallengeResultV2.ts
@@ -5,7 +5,7 @@
 
 import { CustomAuthResultV2 } from "../CustomAuthResultV2.js";
 import type { RequestChallengeErrorV2 } from "../error/RequestChallengeErrorV2.js";
-import type { ChallengeVerificationRequiredStateV2 } from "../state/ChallengeVerificationRequiredStateV2.js";
+import type { CodeRequiredStateV2 } from "../state/CodeRequiredStateV2.js";
 import type { FailedStateV2 } from "../state/FailedStateV2.js";
 
 /**
@@ -13,7 +13,7 @@ import type { FailedStateV2 } from "../state/FailedStateV2.js";
  * Password reset supports email one-time-code verification only.
  */
 export type RequestChallengeResultStateV2 =
-    | ChallengeVerificationRequiredStateV2
+    | CodeRequiredStateV2
     | FailedStateV2;
 
 /**

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/ResetPasswordStartResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/ResetPasswordStartResultV2.ts
@@ -6,7 +6,7 @@
 import { CustomAuthResultV2 } from "../CustomAuthResultV2.js";
 import type { ResetPasswordStartErrorV2 } from "../error/ResetPasswordStartErrorV2.js";
 import type { AuthMethodSelectionRequiredStateV2 } from "../state/AuthMethodSelectionRequiredStateV2.js";
-import type { ChallengeVerificationRequiredStateV2 } from "../state/ChallengeVerificationRequiredStateV2.js";
+import type { CodeRequiredStateV2 } from "../state/CodeRequiredStateV2.js";
 import type { FailedStateV2 } from "../state/FailedStateV2.js";
 
 /**
@@ -16,7 +16,7 @@ import type { FailedStateV2 } from "../state/FailedStateV2.js";
  */
 export type ResetPasswordStartResultStateV2 =
     | AuthMethodSelectionRequiredStateV2
-    | ChallengeVerificationRequiredStateV2
+    | CodeRequiredStateV2
     | FailedStateV2;
 
 /**

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/VerifyChallengeResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/result/VerifyChallengeResultV2.ts
@@ -12,6 +12,7 @@ import type { CustomAuthAccountData } from "../../../../get_account/auth_flow/Cu
 import type { AttributesRequiredStateV2 } from "../../../../sign_up/auth_flow/v2/state/AttributesRequiredStateV2.js";
 import type { SignInContinuationStateV2 } from "../../../../sign_in/auth_flow/v2/state/SignInContinuationStateV2.js";
 import type { SignUpPasswordRequiredStateV2 } from "../../../../sign_up/auth_flow/v2/state/SignUpPasswordRequiredStateV2.js";
+import type { MFARequiredStateV2 } from "../state/MFARequiredStateV2.js";
 
 /**
  * The states a verify-challenge action can resolve to. Verifying the one-time
@@ -23,6 +24,7 @@ export type VerifyChallengeResultStateV2 =
     | SignUpPasswordRequiredStateV2
     | AttributesRequiredStateV2
     | SignInContinuationStateV2
+    | MFARequiredStateV2
     | CompletedStateV2
     | FailedStateV2;
 

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/AuthMethodSelectionRequiredStateV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/AuthMethodSelectionRequiredStateV2.ts
@@ -6,7 +6,7 @@
 import { AuthenticationMethodV2 } from "../AuthenticationMethodV2.js";
 import { CustomAuthResultV2 } from "../CustomAuthResultV2.js";
 import { RequestChallengeErrorV2 } from "../error/RequestChallengeErrorV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "./ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "./CodeRequiredStateV2.js";
 import type { AuthMethodSelectionRequiredStateParametersV2 } from "./CustomAuthStateParametersV2.js";
 import type { RequestChallengeResultV2 } from "../result/RequestChallengeResultV2.js";
 import { FLOW_CODE_REQUIRED_V2 } from "../../../interaction_client/v2/result/FlowActionResultV2.js";
@@ -63,7 +63,7 @@ export class AuthMethodSelectionRequiredStateV2 extends AuthenticationMethodSele
                         AuthenticationMethodTypeV2.SMS)
             ) {
                 return new CustomAuthResultV2(
-                    new ChallengeVerificationRequiredStateV2({
+                    new CodeRequiredStateV2({
                         ...commonStateParameters,
                         method: selectedMethod,
                         sentTo: result.sentTo,

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/AuthMethodSelectionRequiredStateV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/AuthMethodSelectionRequiredStateV2.ts
@@ -11,6 +11,7 @@ import type { AuthMethodSelectionRequiredStateParametersV2 } from "./CustomAuthS
 import type { RequestChallengeResultV2 } from "../result/RequestChallengeResultV2.js";
 import { FLOW_CODE_REQUIRED_V2 } from "../../../interaction_client/v2/result/FlowActionResultV2.js";
 import { AuthenticationMethodSelectionStateBaseV2 } from "./AuthenticationMethodSelectionStateBaseV2.js";
+import { AuthenticationMethodTypeV2 } from "../../../network_client/custom_auth_api/v2/ApiClientConstantsV2.js";
 import { CustomAuthError } from "../../../error/CustomAuthError.js";
 import { UNSUPPORTED_FLOW_TRANSITION } from "../../../network_client/custom_auth_api/v2/ErrorCodesV2.js";
 
@@ -56,7 +57,10 @@ export class AuthMethodSelectionRequiredStateV2 extends AuthenticationMethodSele
 
             if (
                 result.type === FLOW_CODE_REQUIRED_V2 &&
-                result.channel?.toLowerCase() === "email"
+                (result.channel?.toLowerCase() ===
+                    AuthenticationMethodTypeV2.EMAIL ||
+                    result.channel?.toLowerCase() ===
+                        AuthenticationMethodTypeV2.SMS)
             ) {
                 return new CustomAuthResultV2(
                     new ChallengeVerificationRequiredStateV2({
@@ -76,7 +80,7 @@ export class AuthMethodSelectionRequiredStateV2 extends AuthenticationMethodSele
                 `Challenge type '${resultType}' with channel '${
                     result.type === FLOW_CODE_REQUIRED_V2
                         ? result.channel
-                        : "password"
+                        : AuthenticationMethodTypeV2.PASSWORD
                 }' is not supported for password reset.`,
                 correlationId
             );

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationStateBaseV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationStateBaseV2.ts
@@ -11,7 +11,7 @@ import type {
     FlowSubmitCodeResultV2,
 } from "../../../interaction_client/v2/result/FlowActionResultV2.js";
 
-export abstract class CodeVerificationStateBaseV2<
+export abstract class ChallengeVerificationStateBaseV2<
     TParameters extends CodeVerificationStateParametersV2 = CodeVerificationStateParametersV2
 > extends AuthFlowActionRequiredStateBase<TParameters> {
     readonly method?: AuthenticationMethodV2;

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.ts
@@ -3,20 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { AuthFlowActionRequiredStateBase } from "../../AuthFlowState.js";
-import { AuthenticationMethodV2 } from "../AuthenticationMethodV2.js";
 import { CustomAuthResultV2 } from "../CustomAuthResultV2.js";
 import { VerifyChallengeErrorV2 } from "../error/VerifyChallengeErrorV2.js";
 import { RequestChallengeErrorV2 } from "../error/RequestChallengeErrorV2.js";
 import { NewPasswordRequiredStateV2 } from "../../../../reset_password/auth_flow/v2/state/NewPasswordRequiredStateV2.js";
-import type { ChallengeVerificationRequiredStateParametersV2 } from "./CustomAuthStateParametersV2.js";
+import type { CodeRequiredStateParametersV2 } from "./CustomAuthStateParametersV2.js";
 import type { VerifyChallengeResultV2 } from "../result/VerifyChallengeResultV2.js";
 import type { RequestChallengeResultV2 } from "../result/RequestChallengeResultV2.js";
 import { CompletedStateV2 } from "./CompletedStateV2.js";
+import { MFARequiredStateV2 } from "./MFARequiredStateV2.js";
 import { CustomAuthAccountData } from "../../../../get_account/auth_flow/CustomAuthAccountData.js";
 import {
     FLOW_ATTRIBUTES_REQUIRED_V2,
     FLOW_COMPLETED_V2,
+    FLOW_MFA_REQUIRED_V2,
     FLOW_NEW_PASSWORD_REQUIRED_V2,
     FLOW_SIGN_UP_PASSWORD_REQUIRED_V2,
     FLOW_SIGN_IN_CONTINUATION_REQUIRED_V2,
@@ -24,55 +24,28 @@ import {
 import { CustomAuthError } from "../../../error/CustomAuthError.js";
 import { UNSUPPORTED_FLOW_TRANSITION } from "../../../network_client/custom_auth_api/v2/ErrorCodesV2.js";
 import { SignInContinuationStateV2 } from "../../../../sign_in/auth_flow/v2/state/SignInContinuationStateV2.js";
+import { CodeVerificationStateBaseV2 } from "./CodeVerificationStateBaseV2.js";
 
 /**
- * State returned when the user must verify a challenge, for example by
- * submitting a one-time code sent to their email. It carries metadata about the
- * challenge and lets the app submit the code or request a fresh one.
+ * State returned when first-factor email authentication requires a one-time
+ * code. It allows the app to submit the code or request a replacement.
  */
-export class ChallengeVerificationRequiredStateV2 extends AuthFlowActionRequiredStateBase<ChallengeVerificationRequiredStateParametersV2> {
-    readonly stateType = "challengeVerificationRequired";
-
-    readonly method?: AuthenticationMethodV2;
-
-    readonly sentTo?: string;
-
-    readonly channel?: string;
-
-    readonly codeLength?: number;
-
-    constructor(
-        stateParameters: ChallengeVerificationRequiredStateParametersV2
-    ) {
-        super(stateParameters);
-        this.method = stateParameters.method;
-        this.sentTo = stateParameters.sentTo;
-        this.channel = stateParameters.channel;
-        this.codeLength = stateParameters.codeLength;
-    }
+export class CodeRequiredStateV2 extends CodeVerificationStateBaseV2<CodeRequiredStateParametersV2> {
+    readonly stateType = "codeRequired";
 
     /**
-     * Verifies the challenge with the code the user received. On success the
-     * result requests the next required action; failures identify invalid codes.
-     * @param code - The code to verify.
-     * @returns The result of verifying the challenge.
+     * Submits the first-factor email code and advances the active flow. The
+     * result may complete the operation or require another flow-specific step.
+     * @param code - The code to submit.
+     * @returns The result of submitting the first-factor code.
      */
-    async verifyChallenge(code: string): Promise<VerifyChallengeResultV2> {
-        const { correlationId, logger, continuationState, flowClient } =
+    async submitCode(code: string): Promise<VerifyChallengeResultV2> {
+        const { correlationId, logger, continuationState } =
             this.stateParameters;
 
         try {
-            if (this.stateParameters.codeLength) {
-                this.ensureCodeIsValid(code, this.stateParameters.codeLength);
-            }
-
-            logger.verbose("Verifying V2 challenge code.", correlationId);
-
-            const result = await flowClient.submitCode({
-                correlationId,
-                continuationState,
-                code,
-            });
+            logger.verbose("Submitting V2 first-factor code.", correlationId);
+            const result = await this.submitCodeCore(code);
             const resultType: string = result.type;
 
             if (result.type === FLOW_NEW_PASSWORD_REQUIRED_V2) {
@@ -81,7 +54,7 @@ export class ChallengeVerificationRequiredStateV2 extends AuthFlowActionRequired
                         correlationId: result.correlationId,
                         logger,
                         config: this.stateParameters.config,
-                        flowClient,
+                        flowClient: this.stateParameters.flowClient,
                         continuationState: result.continuationState,
                         cacheClient: this.stateParameters.cacheClient,
                     }),
@@ -116,9 +89,25 @@ export class ChallengeVerificationRequiredStateV2 extends AuthFlowActionRequired
                         correlationId: result.correlationId,
                         logger,
                         config: this.stateParameters.config,
-                        flowClient,
+                        flowClient: this.stateParameters.flowClient,
                         continuationState: result.continuationState,
                         cacheClient: this.stateParameters.cacheClient,
+                    }),
+                    undefined,
+                    result.continuationState.scenario
+                );
+            }
+
+            if (result.type === FLOW_MFA_REQUIRED_V2) {
+                return new CustomAuthResultV2(
+                    new MFARequiredStateV2({
+                        correlationId: result.correlationId,
+                        logger,
+                        config: this.stateParameters.config,
+                        flowClient: this.stateParameters.flowClient,
+                        continuationState: result.continuationState,
+                        cacheClient: this.stateParameters.cacheClient,
+                        methods: result.methods,
                     }),
                     undefined,
                     result.continuationState.scenario
@@ -143,12 +132,12 @@ export class ChallengeVerificationRequiredStateV2 extends AuthFlowActionRequired
 
             throw new CustomAuthError(
                 UNSUPPORTED_FLOW_TRANSITION,
-                `Challenge verification result type '${resultType}' is not supported.`,
+                `Code submission result type '${resultType}' is not supported.`,
                 correlationId
             );
         } catch (error) {
             logger.errorPii(
-                `Failed to verify V2 challenge. Error: '${error}'.`,
+                `Failed to submit V2 first-factor code. Error: '${error}'.`,
                 correlationId
             );
 
@@ -161,28 +150,24 @@ export class ChallengeVerificationRequiredStateV2 extends AuthFlowActionRequired
     }
 
     /**
-     * Requests a new challenge when the previous code was not received or expired.
-     * The returned result contains the newly issued challenge details.
-     * @returns The result of requesting a new challenge.
+     * Requests a replacement first-factor email code. The returned state
+     * contains the refreshed challenge metadata.
+     * @returns The result of requesting a replacement code.
      */
-    async requestNewChallenge(): Promise<RequestChallengeResultV2> {
-        const { correlationId, logger, continuationState, flowClient } =
+    async resendCode(): Promise<RequestChallengeResultV2> {
+        const { correlationId, logger, continuationState } =
             this.stateParameters;
 
         try {
-            logger.verbose("Resending V2 challenge code.", correlationId);
-
-            const result = await flowClient.resendCode({
-                correlationId,
-                continuationState,
-            });
+            logger.verbose("Resending V2 first-factor code.", correlationId);
+            const result = await this.resendCodeCore();
 
             return new CustomAuthResultV2(
-                new ChallengeVerificationRequiredStateV2({
+                new CodeRequiredStateV2({
                     correlationId: result.correlationId,
                     logger,
                     config: this.stateParameters.config,
-                    flowClient,
+                    flowClient: this.stateParameters.flowClient,
                     continuationState: result.continuationState,
                     cacheClient: this.stateParameters.cacheClient,
                     signUpStateTransitionHandler:
@@ -197,7 +182,7 @@ export class ChallengeVerificationRequiredStateV2 extends AuthFlowActionRequired
             );
         } catch (error) {
             logger.errorPii(
-                `Failed to resend V2 challenge. Error: '${error}'.`,
+                `Failed to resend V2 first-factor code. Error: '${error}'.`,
                 correlationId
             );
 

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.ts
@@ -24,13 +24,13 @@ import {
 import { CustomAuthError } from "../../../error/CustomAuthError.js";
 import { UNSUPPORTED_FLOW_TRANSITION } from "../../../network_client/custom_auth_api/v2/ErrorCodesV2.js";
 import { SignInContinuationStateV2 } from "../../../../sign_in/auth_flow/v2/state/SignInContinuationStateV2.js";
-import { CodeVerificationStateBaseV2 } from "./CodeVerificationStateBaseV2.js";
+import { ChallengeVerificationStateBaseV2 } from "./ChallengeVerificationStateBaseV2.js";
 
 /**
  * State returned when first-factor email authentication requires a one-time
  * code. It allows the app to submit the code or request a replacement.
  */
-export class CodeRequiredStateV2 extends CodeVerificationStateBaseV2<CodeRequiredStateParametersV2> {
+export class CodeRequiredStateV2 extends ChallengeVerificationStateBaseV2<CodeRequiredStateParametersV2> {
     readonly stateType = "codeRequired";
 
     /**

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/CodeVerificationStateBaseV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/CodeVerificationStateBaseV2.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AuthFlowActionRequiredStateBase } from "../../AuthFlowState.js";
+import type { AuthenticationMethodV2 } from "../AuthenticationMethodV2.js";
+import type { CodeVerificationStateParametersV2 } from "./CustomAuthStateParametersV2.js";
+import type {
+    FlowCodeRequiredResultV2,
+    FlowSubmitCodeResultV2,
+} from "../../../interaction_client/v2/result/FlowActionResultV2.js";
+
+export abstract class CodeVerificationStateBaseV2<
+    TParameters extends CodeVerificationStateParametersV2 = CodeVerificationStateParametersV2
+> extends AuthFlowActionRequiredStateBase<TParameters> {
+    readonly method?: AuthenticationMethodV2;
+
+    readonly sentTo?: string;
+
+    readonly channel?: string;
+
+    readonly codeLength?: number;
+
+    constructor(stateParameters: TParameters) {
+        super(stateParameters);
+        this.method = stateParameters.method;
+        this.sentTo = stateParameters.sentTo;
+        this.channel = stateParameters.channel;
+        this.codeLength = stateParameters.codeLength;
+    }
+
+    protected async submitCodeCore(
+        code: string
+    ): Promise<FlowSubmitCodeResultV2> {
+        if (this.codeLength) {
+            this.ensureCodeIsValid(code, this.codeLength);
+        }
+
+        return this.stateParameters.flowClient.submitCode({
+            correlationId: this.stateParameters.correlationId,
+            continuationState: this.stateParameters.continuationState,
+            code,
+        });
+    }
+
+    protected async resendCodeCore(): Promise<FlowCodeRequiredResultV2> {
+        return this.stateParameters.flowClient.resendCode({
+            correlationId: this.stateParameters.correlationId,
+            continuationState: this.stateParameters.continuationState,
+        });
+    }
+}

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/CustomAuthStateParametersV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/CustomAuthStateParametersV2.ts
@@ -27,11 +27,18 @@ export interface MFARequiredStateParametersV2
     methods: readonly AuthenticationMethodV2[];
 }
 
-export interface ChallengeVerificationRequiredStateParametersV2
+export interface CodeVerificationStateParametersV2
     extends CustomAuthActionRequiredStateParametersV2 {
-    signUpStateTransitionHandler?: SignUpStateTransitionHandlerV2;
     method?: AuthenticationMethodV2;
     sentTo?: string;
     channel?: string;
     codeLength?: number;
 }
+
+export interface CodeRequiredStateParametersV2
+    extends CodeVerificationStateParametersV2 {
+    signUpStateTransitionHandler?: SignUpStateTransitionHandlerV2;
+}
+
+export type MFAVerificationRequiredStateParametersV2 =
+    CodeVerificationStateParametersV2;

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/MFARequiredStateV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/MFARequiredStateV2.ts
@@ -9,7 +9,7 @@ import { RequestChallengeErrorV2 } from "../error/RequestChallengeErrorV2.js";
 import { CustomAuthError } from "../../../error/CustomAuthError.js";
 import { UNSUPPORTED_FLOW_TRANSITION } from "../../../network_client/custom_auth_api/v2/ErrorCodesV2.js";
 import { FLOW_CODE_REQUIRED_V2 } from "../../../interaction_client/v2/result/FlowActionResultV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "./ChallengeVerificationRequiredStateV2.js";
+import { MFAVerificationRequiredStateV2 } from "./MFAVerificationRequiredStateV2.js";
 import type { MFARequiredStateParametersV2 } from "./CustomAuthStateParametersV2.js";
 import type { MFARequestChallengeResultV2 } from "../result/MFARequestChallengeResultV2.js";
 import { AuthenticationMethodSelectionStateBaseV2 } from "./AuthenticationMethodSelectionStateBaseV2.js";
@@ -45,7 +45,7 @@ export class MFARequiredStateV2 extends AuthenticationMethodSelectionStateBaseV2
             }
 
             return new CustomAuthResultV2(
-                new ChallengeVerificationRequiredStateV2({
+                new MFAVerificationRequiredStateV2({
                     correlationId: result.correlationId,
                     logger,
                     config: this.stateParameters.config,

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.ts
@@ -14,13 +14,13 @@ import { CustomAuthAccountData } from "../../../../get_account/auth_flow/CustomA
 import { FLOW_COMPLETED_V2 } from "../../../interaction_client/v2/result/FlowActionResultV2.js";
 import { CustomAuthError } from "../../../error/CustomAuthError.js";
 import { UNSUPPORTED_FLOW_TRANSITION } from "../../../network_client/custom_auth_api/v2/ErrorCodesV2.js";
-import { CodeVerificationStateBaseV2 } from "./CodeVerificationStateBaseV2.js";
+import { ChallengeVerificationStateBaseV2 } from "./ChallengeVerificationStateBaseV2.js";
 
 /**
  * State returned when sign-in requires verification of an email or SMS MFA
  * challenge. It allows the app to submit the challenge or request a replacement.
  */
-export class MFAVerificationRequiredStateV2 extends CodeVerificationStateBaseV2<MFAVerificationRequiredStateParametersV2> {
+export class MFAVerificationRequiredStateV2 extends ChallengeVerificationStateBaseV2<MFAVerificationRequiredStateParametersV2> {
     readonly stateType = "mfaVerificationRequired";
 
     /**

--- a/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { CustomAuthResultV2 } from "../CustomAuthResultV2.js";
+import { VerifyChallengeErrorV2 } from "../error/VerifyChallengeErrorV2.js";
+import { RequestChallengeErrorV2 } from "../error/RequestChallengeErrorV2.js";
+import type { MFAVerificationRequiredStateParametersV2 } from "./CustomAuthStateParametersV2.js";
+import type { MFASubmitChallengeResultV2 } from "../result/MFASubmitChallengeResultV2.js";
+import type { MFAResendChallengeResultV2 } from "../result/MFAResendChallengeResultV2.js";
+import { CompletedStateV2 } from "./CompletedStateV2.js";
+import { CustomAuthAccountData } from "../../../../get_account/auth_flow/CustomAuthAccountData.js";
+import { FLOW_COMPLETED_V2 } from "../../../interaction_client/v2/result/FlowActionResultV2.js";
+import { CustomAuthError } from "../../../error/CustomAuthError.js";
+import { UNSUPPORTED_FLOW_TRANSITION } from "../../../network_client/custom_auth_api/v2/ErrorCodesV2.js";
+import { CodeVerificationStateBaseV2 } from "./CodeVerificationStateBaseV2.js";
+
+/**
+ * State returned when sign-in requires verification of an email or SMS MFA
+ * challenge. It allows the app to submit the challenge or request a replacement.
+ */
+export class MFAVerificationRequiredStateV2 extends CodeVerificationStateBaseV2<MFAVerificationRequiredStateParametersV2> {
+    readonly stateType = "mfaVerificationRequired";
+
+    /**
+     * Submits the email or SMS challenge as the second authentication factor.
+     * Successful verification completes sign-in.
+     * @param challenge - The challenge value to submit.
+     * @returns The result of submitting the MFA challenge.
+     */
+    async submitChallenge(
+        challenge: string
+    ): Promise<MFASubmitChallengeResultV2> {
+        const { correlationId, logger, continuationState } =
+            this.stateParameters;
+
+        try {
+            logger.verbose("Submitting V2 MFA challenge.", correlationId);
+            const result = await this.submitCodeCore(challenge);
+
+            if (result.type !== FLOW_COMPLETED_V2) {
+                throw new CustomAuthError(
+                    UNSUPPORTED_FLOW_TRANSITION,
+                    `MFA challenge submission result type '${result.type}' is not supported.`,
+                    correlationId
+                );
+            }
+
+            const account = new CustomAuthAccountData(
+                result.authenticationResult.account,
+                this.stateParameters.config,
+                this.stateParameters.cacheClient,
+                logger,
+                correlationId
+            );
+
+            return new CustomAuthResultV2(
+                new CompletedStateV2(),
+                account,
+                continuationState.scenario
+            );
+        } catch (error) {
+            logger.errorPii(
+                `Failed to submit V2 MFA challenge. Error: '${error}'.`,
+                correlationId
+            );
+
+            return CustomAuthResultV2.createWithError(error, {
+                errorType: VerifyChallengeErrorV2,
+                scenario: continuationState.scenario,
+                correlationId,
+            });
+        }
+    }
+
+    /**
+     * Requests a replacement challenge for the selected MFA method. The
+     * returned state contains the refreshed email or SMS challenge metadata.
+     * @returns The result of requesting a replacement MFA challenge.
+     */
+    async resendChallenge(): Promise<MFAResendChallengeResultV2> {
+        const { correlationId, logger, continuationState } =
+            this.stateParameters;
+
+        try {
+            logger.verbose("Resending V2 MFA challenge.", correlationId);
+            const result = await this.resendCodeCore();
+
+            return new CustomAuthResultV2(
+                new MFAVerificationRequiredStateV2({
+                    correlationId: result.correlationId,
+                    logger,
+                    config: this.stateParameters.config,
+                    flowClient: this.stateParameters.flowClient,
+                    continuationState: result.continuationState,
+                    cacheClient: this.stateParameters.cacheClient,
+                    method: this.method,
+                    sentTo: result.sentTo,
+                    channel: result.channel,
+                    codeLength: result.codeLength,
+                }),
+                undefined,
+                result.continuationState.scenario
+            );
+        } catch (error) {
+            logger.errorPii(
+                `Failed to resend V2 MFA challenge. Error: '${error}'.`,
+                correlationId
+            );
+
+            return CustomAuthResultV2.createWithError(error, {
+                errorType: RequestChallengeErrorV2,
+                scenario: continuationState.scenario,
+                correlationId,
+            });
+        }
+    }
+}

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.ts
@@ -71,10 +71,12 @@ import {
 } from "../../telemetry/FlowApiIdHelperV2.js";
 import {
     AuthenticationFactorV2,
-    type ChallengeResultV2,
+    ChallengeNextActionV2,
+    type ChallengeVerificationResultV2,
     VerifyNextActionV2,
     type VerifyResultV2,
 } from "../../network_client/custom_auth_api/v2/result/BaseResultsV2.js";
+import { AuthenticationMethodTypeV2 } from "../../network_client/custom_auth_api/v2/ApiClientConstantsV2.js";
 import type { FlowContinuationStateV2 } from "./FlowContinuationStateV2.js";
 import type { AuthenticationMethodV2 } from "../../auth_flow/v2/AuthenticationMethodV2.js";
 import {
@@ -374,7 +376,10 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
 
             if (
                 challengeResult.type === FLOW_CODE_REQUIRED_V2 &&
-                challengeResult.channel?.toLowerCase() === "email"
+                (challengeResult.channel?.toLowerCase() ===
+                    AuthenticationMethodTypeV2.EMAIL ||
+                    challengeResult.channel?.toLowerCase() ===
+                        AuthenticationMethodTypeV2.SMS)
             ) {
                 return {
                     ...challengeResult,
@@ -385,7 +390,7 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
             const channel =
                 challengeResult.type === FLOW_CODE_REQUIRED_V2
                     ? challengeResult.channel
-                    : "password";
+                    : AuthenticationMethodTypeV2.PASSWORD;
             const message = `Challenge type '${challengeResult.type}' with channel '${channel}' is not supported for password reset.`;
             this.logger.error(message, correlationId);
             throw new CustomAuthError(
@@ -418,13 +423,16 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
             parameters,
             "requestChallenge"
         );
-        const challengeType = challengeResult.type ?? "email";
+        const challengeType =
+            challengeResult.type ?? AuthenticationMethodTypeV2.EMAIL;
         const continuationState = this.createChallengeContinuationState(
             parameters.continuationState,
             challengeResult
         );
 
-        if (challengeType.toLowerCase() === "password") {
+        if (
+            challengeType.toLowerCase() === AuthenticationMethodTypeV2.PASSWORD
+        ) {
             return createFlowPasswordRequiredResultV2({
                 correlationId: parameters.correlationId,
                 continuationState,
@@ -838,10 +846,13 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
         correlationId: string
     ): AuthenticationMethodV2 {
         const passwordMethod = methods.find(
-            (method) => method.type.toLowerCase() === "password"
+            (method) =>
+                method.type.toLowerCase() ===
+                AuthenticationMethodTypeV2.PASSWORD
         );
         const emailMethod = methods.find(
-            (method) => method.type.toLowerCase() === "email"
+            (method) =>
+                method.type.toLowerCase() === AuthenticationMethodTypeV2.EMAIL
         );
 
         if (passwordProvided) {
@@ -1021,7 +1032,7 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
     private async sendMethodChallenge(
         parameters: FlowChallengeParamsV2,
         step: "requestChallenge" | "resendCode"
-    ): Promise<ChallengeResultV2> {
+    ): Promise<ChallengeVerificationResultV2> {
         const continuationState = parameters.continuationState;
         const correlationId = parameters.correlationId;
         const challengeHref =
@@ -1044,16 +1055,27 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
             correlationId
         );
 
-        return this.apiClient.requestChallenge(
+        const challengeResult = await this.apiClient.requestChallenge(
             this.requireLink(correlationId, challengeHref),
             { continuationToken: continuationState.continuationToken },
             context
         );
+
+        if (challengeResult.nextAction === ChallengeNextActionV2.VERIFY) {
+            return challengeResult;
+        }
+
+        const verificationResult = await this.apiClient.verifyRisk(
+            challengeResult.riskVerifyHref,
+            { continuationToken: challengeResult.continuationToken },
+            context
+        );
+        return verificationResult;
     }
 
     private createChallengeContinuationState(
         continuationState: FlowContinuationStateV2,
-        challengeResult: ChallengeResultV2
+        challengeResult: ChallengeVerificationResultV2
     ): FlowContinuationStateV2 {
         return {
             continuationToken: challengeResult.continuationToken,

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.ts
@@ -41,11 +41,11 @@ import type {
     FlowPasswordRequiredResultV2,
     FlowSignUpPasswordRequiredResultV2,
     FlowMFARequiredResultV2,
-    FlowNewPasswordRequiredResultV2,
     FlowAttributesRequiredResultV2,
     FlowSignInContinuationRequiredResultV2,
     FlowCompletedResultV2,
     FlowSignUpActionResultV2,
+    FlowSubmitCodeResultV2,
 } from "./result/FlowActionResultV2.js";
 import { BrowserConfiguration } from "../../../../config/Configuration.js";
 import { BrowserCacheManager } from "../../../../cache/BrowserCacheManager.js";
@@ -454,13 +454,7 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
      */
     async submitCode(
         parameters: FlowSubmitCodeParamsV2
-    ): Promise<
-        | FlowNewPasswordRequiredResultV2
-        | FlowSignUpPasswordRequiredResultV2
-        | FlowAttributesRequiredResultV2
-        | FlowSignInContinuationRequiredResultV2
-        | FlowCompletedResultV2
-    > {
+    ): Promise<FlowSubmitCodeResultV2> {
         const continuationState = parameters.continuationState;
         const correlationId = parameters.correlationId;
         const context = this.createRequestContext(
@@ -503,13 +497,10 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
             });
         }
 
-        if (
-            continuationState.scenario === CustomAuthFlowScenarioV2.SignIn &&
-            verifyResult.nextAction === VerifyNextActionV2.CONTINUE
-        ) {
-            return this.completeSignInAfterVerification(
+        if (continuationState.scenario === CustomAuthFlowScenarioV2.SignIn) {
+            return this.handleSignInVerification(
                 continuationState,
-                verifyResult.continuationToken,
+                verifyResult,
                 correlationId
             );
         }
@@ -737,7 +728,7 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
     ): Promise<FlowMFARequiredResultV2 | FlowCompletedResultV2> {
         const verifyResult = await this.verifySignInPassword(parameters);
 
-        return this.handleSignInPasswordVerification(
+        return this.handleSignInVerification(
             parameters.continuationState,
             verifyResult,
             parameters.correlationId
@@ -793,7 +784,7 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
         });
     }
 
-    private async handleSignInPasswordVerification(
+    private async handleSignInVerification(
         continuationState: FlowContinuationStateV2,
         verifyResult: VerifyResultV2,
         correlationId: string
@@ -802,7 +793,7 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
             this.ensureAuthenticationFactor(
                 verifyResult.authenticationFactor,
                 AuthenticationFactorV2.MULTI_FACTOR,
-                "after password verification",
+                "after sign-in verification",
                 correlationId
             );
 
@@ -831,7 +822,7 @@ export class FlowInteractionClientV2 extends InteractionClientBaseV2 {
             );
         }
 
-        const message = `Password verification next action '${verifyResult.nextAction}' is not supported for sign-in.`;
+        const message = `Verification next action '${verifyResult.nextAction}' is not supported for sign-in.`;
         this.logger.error(message, correlationId);
         throw new CustomAuthError(
             UNSUPPORTED_FLOW_TRANSITION,

--- a/lib/msal-browser/src/custom_auth/core/interaction_client/v2/result/FlowActionResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/interaction_client/v2/result/FlowActionResultV2.ts
@@ -102,6 +102,14 @@ export interface FlowCompletedResultV2 extends FlowActionResultBaseV2 {
     authenticationResult: AuthenticationResult;
 }
 
+export type FlowSubmitCodeResultV2 =
+    | FlowNewPasswordRequiredResultV2
+    | FlowSignUpPasswordRequiredResultV2
+    | FlowAttributesRequiredResultV2
+    | FlowSignInContinuationRequiredResultV2
+    | FlowMFARequiredResultV2
+    | FlowCompletedResultV2;
+
 export type FlowSignUpActionResultV2 =
     | FlowCodeRequiredResultV2
     | FlowSignUpPasswordRequiredResultV2

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/ApiClientConstantsV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/ApiClientConstantsV2.ts
@@ -10,7 +10,14 @@ export const JSON_CONTENT_TYPE = "application/json";
 export const UPDATE_RELATION = "update";
 export const CHALLENGE_RELATION = "challenge";
 export const VERIFY_RELATION = "verify";
+export const RISK_VERIFY_RELATION = "riskverify";
 export const COLLECT_ATTRIBUTES_RELATION = "collectAttributes";
+
+export const AuthenticationMethodTypeV2 = {
+    EMAIL: "email",
+    PASSWORD: "password",
+    SMS: "sms",
+} as const;
 
 /*
  * Known `state` values on a HAL response. Kept open (the body field is typed as string) because

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/CustomAuthApiClientV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/CustomAuthApiClientV2.ts
@@ -15,6 +15,8 @@ import {
     StartResultV2,
     StartMethodV2,
     ChallengeResultV2,
+    ChallengeNextActionV2,
+    ChallengeVerificationResultV2,
     VerifyResultV2,
     VerifyNextActionV2,
     AuthenticationFactorV2,
@@ -30,6 +32,9 @@ import {
     SignUpStartResponseV2,
     SignUpSubmitAttributesResponseV2,
     ChallengeResponseV2,
+    RiskVerificationRequiredResponseV2,
+    RiskVerificationResponseV2,
+    VerificationChallengeResponseV2,
     VerifyResponseV2,
     UpdatePasswordResponseV2,
     PollResponseV2,
@@ -52,6 +57,8 @@ import {
     COLLECT_ATTRIBUTES_RELATION,
     UPDATE_RELATION,
     VERIFY_RELATION,
+    RISK_VERIFY_RELATION,
+    AuthenticationMethodTypeV2,
     ResponseStateV2,
 } from "./ApiClientConstantsV2.js";
 import {
@@ -170,8 +177,7 @@ export class CustomAuthApiClientV2 extends BaseApiClientV2 {
 
         if (parsedResponse.body.action === VERIFY_RELATION) {
             return {
-                nextAction: SignUpSubmitAttributesNextActionV2.VERIFY,
-                ...this.toChallengeResult(parsedResponse),
+                ...this.toChallengeVerificationResult(parsedResponse),
                 attributes: parsedResponse.body.attributes,
             };
         }
@@ -204,6 +210,41 @@ export class CustomAuthApiClientV2 extends BaseApiClientV2 {
             );
 
         return this.toChallengeResult(parsedResponse);
+    }
+
+    async verifyRisk(
+        riskVerifyHref: string,
+        request: ChallengeRequestV2,
+        context: RequestContextV2
+    ): Promise<ChallengeVerificationResultV2> {
+        const parsedResponse =
+            await this.sendActionRequest<RiskVerificationResponseV2>(
+                riskVerifyHref,
+                HttpMethod.POST,
+                request,
+                context
+            );
+
+        if (parsedResponse.body.action !== VERIFY_RELATION) {
+            throw new CustomAuthApiError(
+                INVALID_HAL_RESPONSE,
+                "Invalid HAL response: SMS risk verification returned no known next action",
+                parsedResponse.correlationId
+            );
+        }
+
+        if (
+            parsedResponse.body.type?.toLowerCase() !==
+            AuthenticationMethodTypeV2.SMS
+        ) {
+            throw new CustomAuthApiError(
+                INVALID_HAL_RESPONSE,
+                "Invalid HAL response: SMS risk verification returned a non-SMS challenge",
+                parsedResponse.correlationId
+            );
+        }
+
+        return this.toChallengeVerificationResult(parsedResponse);
     }
 
     /*
@@ -404,6 +445,40 @@ export class CustomAuthApiClientV2 extends BaseApiClientV2 {
     private toChallengeResult(
         parsedResponse: ParsedResponseV2<ChallengeResponseV2>
     ): ChallengeResultV2 {
+        if (parsedResponse.body.action === RISK_VERIFY_RELATION) {
+            const riskResponse =
+                parsedResponse.body as RiskVerificationRequiredResponseV2;
+
+            return {
+                nextAction: ChallengeNextActionV2.RISK_VERIFY,
+                continuationToken: this.handler.requireContinuationToken(
+                    parsedResponse.continuationToken,
+                    parsedResponse.correlationId
+                ),
+                riskVerifyHref: this.handler.requireHref(
+                    riskResponse._links?.riskverify?.href,
+                    RISK_VERIFY_RELATION,
+                    parsedResponse.correlationId
+                ),
+            };
+        }
+
+        if (parsedResponse.body.action === VERIFY_RELATION) {
+            return this.toChallengeVerificationResult(
+                parsedResponse as ParsedResponseV2<VerificationChallengeResponseV2>
+            );
+        }
+
+        throw new CustomAuthApiError(
+            INVALID_HAL_RESPONSE,
+            "Invalid HAL response: challenge returned no known next action",
+            parsedResponse.correlationId
+        );
+    }
+
+    private toChallengeVerificationResult(
+        parsedResponse: ParsedResponseV2<VerificationChallengeResponseV2>
+    ): ChallengeVerificationResultV2 {
         const continuationToken = this.handler.requireContinuationToken(
             parsedResponse.continuationToken,
             parsedResponse.correlationId
@@ -417,6 +492,7 @@ export class CustomAuthApiClientV2 extends BaseApiClientV2 {
                 : undefined;
 
         return {
+            nextAction: ChallengeNextActionV2.VERIFY,
             continuationToken,
             verifyHref: this.handler.requireHref(
                 links?.verify?.href,

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/response/ResponsesV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/response/ResponsesV2.ts
@@ -105,9 +105,22 @@ export interface PasswordChallengeResponseV2 extends ChallengeResponseBaseV2 {
     };
 }
 
-export type ChallengeResponseV2 =
+export type VerificationChallengeResponseV2 =
     | CodeChallengeResponseV2
     | PasswordChallengeResponseV2;
+
+export interface RiskVerificationRequiredResponseV2
+    extends ChallengeResponseBaseV2 {
+    _links?: {
+        riskverify?: HalLink;
+    };
+}
+
+export type ChallengeResponseV2 =
+    | VerificationChallengeResponseV2
+    | RiskVerificationRequiredResponseV2;
+
+export type RiskVerificationResponseV2 = CodeChallengeResponseV2;
 
 export interface SignUpSubmitAttributesResponseV2
     extends Omit<CodeChallengeResponseV2, "_links"> {

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/result/BaseResultsV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/result/BaseResultsV2.ts
@@ -51,11 +51,13 @@ export interface StartResultV2 {
 export type ResetPasswordStartApiResultV2 = StartResultV2;
 export type SignInStartApiResultV2 = StartResultV2;
 
-/*
- * Result of requesting a challenge. It contains the verification link and
- * optional display metadata for the selected authentication method.
- */
-export interface ChallengeResultV2 {
+export const ChallengeNextActionV2 = {
+    VERIFY: "verify",
+    RISK_VERIFY: "riskVerify",
+} as const;
+
+export interface ChallengeVerificationResultV2 {
+    nextAction: typeof ChallengeNextActionV2.VERIFY;
     continuationToken: string;
     verifyHref: string;
     resendHref?: string;
@@ -63,6 +65,16 @@ export interface ChallengeResultV2 {
     hint?: string;
     type?: string;
 }
+
+export interface RiskVerificationRequiredResultV2 {
+    nextAction: typeof ChallengeNextActionV2.RISK_VERIFY;
+    continuationToken: string;
+    riskVerifyHref: string;
+}
+
+export type ChallengeResultV2 =
+    | ChallengeVerificationResultV2
+    | RiskVerificationRequiredResultV2;
 
 export const VerifyNextActionV2 = {
     UPDATE: "update",

--- a/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/result/SignUpResultsV2.ts
+++ b/lib/msal-browser/src/custom_auth/core/network_client/custom_auth_api/v2/result/SignUpResultsV2.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { ChallengeResultV2 } from "./BaseResultsV2.js";
+import type { ChallengeVerificationResultV2 } from "./BaseResultsV2.js";
 
 export interface SignUpAttributeV2 {
     attributeId: string;
@@ -28,7 +28,7 @@ export const SignUpSubmitAttributesNextActionV2 = {
 } as const;
 
 export type SignUpSubmitAttributesApiResultV2 =
-    | (ChallengeResultV2 & {
+    | (ChallengeVerificationResultV2 & {
           nextAction: typeof SignUpSubmitAttributesNextActionV2.VERIFY;
           attributes?: SignUpAttributeV2[];
       })

--- a/lib/msal-browser/src/custom_auth/index.ts
+++ b/lib/msal-browser/src/custom_auth/index.ts
@@ -275,7 +275,8 @@ export { SubmitAttributesErrorV2 } from "./sign_up/auth_flow/v2/error_type/Submi
 export { CompletedStateV2 } from "./core/auth_flow/v2/state/CompletedStateV2.js";
 export { FailedStateV2 } from "./core/auth_flow/v2/state/FailedStateV2.js";
 export { NewPasswordRequiredStateV2 } from "./reset_password/auth_flow/v2/state/NewPasswordRequiredStateV2.js";
-export { ChallengeVerificationRequiredStateV2 } from "./core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+export { CodeRequiredStateV2 } from "./core/auth_flow/v2/state/CodeRequiredStateV2.js";
+export { MFAVerificationRequiredStateV2 } from "./core/auth_flow/v2/state/MFAVerificationRequiredStateV2.js";
 export { AuthMethodSelectionRequiredStateV2 } from "./core/auth_flow/v2/state/AuthMethodSelectionRequiredStateV2.js";
 export { MFARequiredStateV2 } from "./core/auth_flow/v2/state/MFARequiredStateV2.js";
 export { PasswordRequiredStateV2 } from "./sign_in/auth_flow/v2/state/PasswordRequiredStateV2.js";
@@ -304,6 +305,14 @@ export {
     MFARequestChallengeResultV2,
     MFARequestChallengeResultStateV2,
 } from "./core/auth_flow/v2/result/MFARequestChallengeResultV2.js";
+export {
+    MFASubmitChallengeResultV2,
+    MFASubmitChallengeResultStateV2,
+} from "./core/auth_flow/v2/result/MFASubmitChallengeResultV2.js";
+export {
+    MFAResendChallengeResultV2,
+    MFAResendChallengeResultStateV2,
+} from "./core/auth_flow/v2/result/MFAResendChallengeResultV2.js";
 export {
     VerifyChallengeResultV2,
     VerifyChallengeResultStateV2,

--- a/lib/msal-browser/src/custom_auth/sign_in/auth_flow/v2/result/SignInStartResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/sign_in/auth_flow/v2/result/SignInStartResultV2.ts
@@ -10,14 +10,14 @@ import type { CustomAuthAccountData } from "../../../../get_account/auth_flow/Cu
 import type { SignInStartErrorV2 } from "../error_type/SignInStartErrorV2.js";
 import type { PasswordRequiredStateV2 } from "../state/PasswordRequiredStateV2.js";
 import type { MFARequiredStateV2 } from "../../../../core/auth_flow/v2/state/MFARequiredStateV2.js";
-import type { ChallengeVerificationRequiredStateV2 } from "../../../../core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import type { CodeRequiredStateV2 } from "../../../../core/auth_flow/v2/state/CodeRequiredStateV2.js";
 
 /**
  * States returned when native auth V2 sign-in starts.
  */
 export type SignInStartResultStateV2 =
     | PasswordRequiredStateV2
-    | ChallengeVerificationRequiredStateV2
+    | CodeRequiredStateV2
     | MFARequiredStateV2
     | CompletedStateV2
     | FailedStateV2;

--- a/lib/msal-browser/src/custom_auth/sign_up/auth_flow/v2/result/SignUpStartResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/sign_up/auth_flow/v2/result/SignUpStartResultV2.ts
@@ -4,7 +4,7 @@
  */
 
 import { CustomAuthResultV2 } from "../../../../core/auth_flow/v2/CustomAuthResultV2.js";
-import type { ChallengeVerificationRequiredStateV2 } from "../../../../core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import type { CodeRequiredStateV2 } from "../../../../core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import type { FailedStateV2 } from "../../../../core/auth_flow/v2/state/FailedStateV2.js";
 import type { SignUpStartErrorV2 } from "../error_type/SignUpStartErrorV2.js";
 import type { AttributesRequiredStateV2 } from "../state/AttributesRequiredStateV2.js";
@@ -14,7 +14,7 @@ import type { SignUpPasswordRequiredStateV2 } from "../state/SignUpPasswordRequi
  * States returned when native auth V2 sign-up starts.
  */
 export type SignUpStartResultStateV2 =
-    | ChallengeVerificationRequiredStateV2
+    | CodeRequiredStateV2
     | SignUpPasswordRequiredStateV2
     | AttributesRequiredStateV2
     | FailedStateV2;

--- a/lib/msal-browser/src/custom_auth/sign_up/auth_flow/v2/result/SubmitAttributesResultV2.ts
+++ b/lib/msal-browser/src/custom_auth/sign_up/auth_flow/v2/result/SubmitAttributesResultV2.ts
@@ -4,13 +4,13 @@
  */
 
 import { CustomAuthResultV2 } from "../../../../core/auth_flow/v2/CustomAuthResultV2.js";
-import type { ChallengeVerificationRequiredStateV2 } from "../../../../core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import type { CodeRequiredStateV2 } from "../../../../core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import type { FailedStateV2 } from "../../../../core/auth_flow/v2/state/FailedStateV2.js";
 import type { SignInContinuationStateV2 } from "../../../../sign_in/auth_flow/v2/state/SignInContinuationStateV2.js";
 import type { SubmitAttributesErrorV2 } from "../error_type/SubmitAttributesErrorV2.js";
 
 export type SubmitAttributesResultStateV2 =
-    | ChallengeVerificationRequiredStateV2
+    | CodeRequiredStateV2
     | SignInContinuationStateV2
     | FailedStateV2;
 

--- a/lib/msal-browser/src/custom_auth/sign_up/auth_flow/v2/state/SignUpStateTransitionHandlerV2.ts
+++ b/lib/msal-browser/src/custom_auth/sign_up/auth_flow/v2/state/SignUpStateTransitionHandlerV2.ts
@@ -4,7 +4,7 @@
  */
 
 import { CustomAuthResultV2 } from "../../../../core/auth_flow/v2/CustomAuthResultV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../../core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../../../../core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import { CustomAuthError } from "../../../../core/error/CustomAuthError.js";
 import {
     FLOW_ATTRIBUTES_REQUIRED_V2,
@@ -35,7 +35,7 @@ export class SignUpStateTransitionHandlerV2 {
 
         if (result.type === FLOW_CODE_REQUIRED_V2) {
             return new CustomAuthResultV2(
-                new ChallengeVerificationRequiredStateV2({
+                new CodeRequiredStateV2({
                     ...commonStateParameters,
                     sentTo: result.sentTo,
                     channel: result.channel,

--- a/lib/msal-browser/test/custom_auth/core/auth_flow/v2/CustomAuthResultV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/auth_flow/v2/CustomAuthResultV2.spec.ts
@@ -12,7 +12,7 @@ import { CustomAuthApiError } from "../../../../../src/custom_auth/core/error/Cu
 import { MsalCustomAuthError } from "../../../../../src/custom_auth/core/error/MsalCustomAuthError.js";
 import { UnexpectedError } from "../../../../../src/custom_auth/core/error/UnexpectedError.js";
 import { AuthMethodSelectionRequiredStateV2 } from "../../../../../src/custom_auth/core/auth_flow/v2/state/AuthMethodSelectionRequiredStateV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../../../src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../../../../../src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import { FailedStateV2 } from "../../../../../src/custom_auth/core/auth_flow/v2/state/FailedStateV2.js";
 import { AuthenticationMethodV2 } from "../../../../../src/custom_auth/core/auth_flow/v2/AuthenticationMethodV2.js";
 import { CustomAuthFlowScenarioV2 } from "../../../../../src/custom_auth/core/auth_flow/v2/CustomAuthFlowScenarioV2.js";
@@ -74,7 +74,7 @@ describe("CustomAuthResultV2", () => {
 
         it("narrows an auto-selected reset result to code verification", () => {
             const result: ResetPasswordStartResultV2 = new CustomAuthResultV2(
-                new ChallengeVerificationRequiredStateV2({
+                new CodeRequiredStateV2({
                     correlationId,
                     logger: getDefaultLogger(),
                     config: mockConfig,
@@ -92,8 +92,8 @@ describe("CustomAuthResultV2", () => {
                 })
             );
 
-            expect(result.isState("challengeVerificationRequired")).toBe(true);
-            if (result.isState("challengeVerificationRequired")) {
+            expect(result.isState("codeRequired")).toBe(true);
+            if (result.isState("codeRequired")) {
                 expect(result.state.method).toBe(method);
             }
         });

--- a/lib/msal-browser/test/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.spec.ts
@@ -6,16 +6,18 @@
 import { CustomAuthBrowserConfiguration } from "../../../../../../src/custom_auth/configuration/CustomAuthConfiguration.js";
 import { CustomAuthFlowScenarioV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/CustomAuthFlowScenarioV2.js";
 import { CustomAuthApiError } from "../../../../../../src/custom_auth/core/error/CustomAuthApiError.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import { CompletedStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/CompletedStateV2.js";
 import { AttributesRequiredStateV2 } from "../../../../../../src/custom_auth/sign_up/auth_flow/v2/state/AttributesRequiredStateV2.js";
 import { SignUpPasswordRequiredStateV2 } from "../../../../../../src/custom_auth/sign_up/auth_flow/v2/state/SignUpPasswordRequiredStateV2.js";
 import { SignUpStateTransitionHandlerV2 } from "../../../../../../src/custom_auth/sign_up/auth_flow/v2/state/SignUpStateTransitionHandlerV2.js";
 import { SignInContinuationStateV2 } from "../../../../../../src/custom_auth/sign_in/auth_flow/v2/state/SignInContinuationStateV2.js";
+import { MFARequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/MFARequiredStateV2.js";
 import { FlowInteractionClientV2 } from "../../../../../../src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.js";
 import {
     FLOW_ATTRIBUTES_REQUIRED_V2,
     FLOW_COMPLETED_V2,
+    FLOW_MFA_REQUIRED_V2,
     FLOW_SIGN_UP_PASSWORD_REQUIRED_V2,
     FLOW_SIGN_IN_CONTINUATION_REQUIRED_V2,
 } from "../../../../../../src/custom_auth/core/interaction_client/v2/result/FlowActionResultV2.js";
@@ -24,14 +26,14 @@ import { CustomAuthSilentCacheClient } from "../../../../../../src/custom_auth/g
 import type { AuthenticationResult } from "../../../../../../src/response/AuthenticationResult.js";
 import { getDefaultLogger } from "../../../../test_resources/TestModules.js";
 
-describe("ChallengeVerificationRequiredStateV2", () => {
+describe("CodeRequiredStateV2", () => {
     const correlationId = "test-correlation-id";
     const flowClient = {
         submitCode: jest.fn(),
     } as unknown as jest.Mocked<FlowInteractionClientV2>;
 
-    const buildState = (): ChallengeVerificationRequiredStateV2 =>
-        new ChallengeVerificationRequiredStateV2({
+    const buildState = (): CodeRequiredStateV2 =>
+        new CodeRequiredStateV2({
             correlationId,
             logger: getDefaultLogger(),
             config: {
@@ -61,8 +63,8 @@ describe("ChallengeVerificationRequiredStateV2", () => {
             codeLength: 6,
         });
 
-    const buildSignUpState = (): ChallengeVerificationRequiredStateV2 =>
-        new ChallengeVerificationRequiredStateV2({
+    const buildSignUpState = (): CodeRequiredStateV2 =>
+        new CodeRequiredStateV2({
             correlationId,
             logger: getDefaultLogger(),
             config: {
@@ -91,7 +93,7 @@ describe("ChallengeVerificationRequiredStateV2", () => {
         jest.clearAllMocks();
     });
 
-    it("returns completed sign-in after verifying an MFA code", async () => {
+    it("returns completed sign-in after submitting a first-factor code", async () => {
         flowClient.submitCode.mockResolvedValue({
             type: FLOW_COMPLETED_V2,
             correlationId,
@@ -102,7 +104,7 @@ describe("ChallengeVerificationRequiredStateV2", () => {
             } as unknown as AuthenticationResult,
         });
 
-        const result = await buildState().verifyChallenge("123456");
+        const result = await buildState().submitCode("123456");
 
         expect(flowClient.submitCode).toHaveBeenCalledWith({
             correlationId,
@@ -121,6 +123,33 @@ describe("ChallengeVerificationRequiredStateV2", () => {
         expect(result.isState("completed")).toBe(true);
         expect(result.state).toBeInstanceOf(CompletedStateV2);
         expect(result.data).toBeInstanceOf(CustomAuthAccountData);
+    });
+
+    it("returns MFA required after submitting a first-factor code", async () => {
+        flowClient.submitCode.mockResolvedValue({
+            type: FLOW_MFA_REQUIRED_V2,
+            correlationId,
+            continuationState: {
+                continuationToken: "ct-mfa",
+                scenario: CustomAuthFlowScenarioV2.SignIn,
+                links: {},
+                tokenRequest: {
+                    scopes: ["User.Read"],
+                },
+            },
+            methods: [
+                {
+                    id: "sms-mfa",
+                    type: "sms",
+                    challengeHref: "/mfa/sms/challenge",
+                },
+            ],
+        });
+
+        const result = await buildState().submitCode("123456");
+
+        expect(result.isState("mfaRequired")).toBe(true);
+        expect(result.state).toBeInstanceOf(MFARequiredStateV2);
     });
 
     it("returns attributes required after verifying a sign-up code", async () => {
@@ -147,7 +176,7 @@ describe("ChallengeVerificationRequiredStateV2", () => {
             ],
         });
 
-        const result = await buildSignUpState().verifyChallenge("12345678");
+        const result = await buildSignUpState().submitCode("12345678");
 
         expect(result.isState("attributesRequired")).toBe(true);
         expect(result.state).toBeInstanceOf(AttributesRequiredStateV2);
@@ -176,7 +205,7 @@ describe("ChallengeVerificationRequiredStateV2", () => {
             )
         );
 
-        const result = await buildSignUpState().verifyChallenge("12345678");
+        const result = await buildSignUpState().submitCode("12345678");
 
         expect(result.isFailed()).toBe(true);
         expect(result.error?.isUserAlreadyExists()).toBe(true);
@@ -206,7 +235,7 @@ describe("ChallengeVerificationRequiredStateV2", () => {
             requiredPasswordAttribute,
         });
 
-        const result = await buildSignUpState().verifyChallenge("12345678");
+        const result = await buildSignUpState().submitCode("12345678");
 
         expect(result.isState("passwordRequired")).toBe(true);
         expect(result.state).toBeInstanceOf(SignUpPasswordRequiredStateV2);
@@ -231,7 +260,7 @@ describe("ChallengeVerificationRequiredStateV2", () => {
             },
         });
 
-        const result = await buildSignUpState().verifyChallenge("12345678");
+        const result = await buildSignUpState().submitCode("12345678");
 
         expect(result.isState("signInContinuation")).toBe(true);
         expect(result.state).toBeInstanceOf(SignInContinuationStateV2);

--- a/lib/msal-browser/test/custom_auth/core/auth_flow/v2/state/MFARequiredStateV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/auth_flow/v2/state/MFARequiredStateV2.spec.ts
@@ -6,7 +6,7 @@
 import { CustomAuthBrowserConfiguration } from "../../../../../../src/custom_auth/configuration/CustomAuthConfiguration.js";
 import { AuthenticationMethodV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/AuthenticationMethodV2.js";
 import { CustomAuthFlowScenarioV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/CustomAuthFlowScenarioV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { MFAVerificationRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.js";
 import { MFARequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/MFARequiredStateV2.js";
 import { FlowInteractionClientV2 } from "../../../../../../src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.js";
 import { FLOW_CODE_REQUIRED_V2 } from "../../../../../../src/custom_auth/core/interaction_client/v2/result/FlowActionResultV2.js";
@@ -95,9 +95,9 @@ describe("MFARequiredStateV2", () => {
                 },
             },
         });
-        expect(result.isState("challengeVerificationRequired")).toBe(true);
+        expect(result.isState("mfaVerificationRequired")).toBe(true);
         expect(result.state).toBeInstanceOf(
-            ChallengeVerificationRequiredStateV2
+            MFAVerificationRequiredStateV2
         );
     });
 

--- a/lib/msal-browser/test/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.spec.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { CustomAuthBrowserConfiguration } from "../../../../../../src/custom_auth/configuration/CustomAuthConfiguration.js";
+import { CustomAuthFlowScenarioV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/CustomAuthFlowScenarioV2.js";
+import { CompletedStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/CompletedStateV2.js";
+import { MFAVerificationRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.js";
+import { FlowInteractionClientV2 } from "../../../../../../src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.js";
+import {
+    FLOW_CODE_REQUIRED_V2,
+    FLOW_COMPLETED_V2,
+} from "../../../../../../src/custom_auth/core/interaction_client/v2/result/FlowActionResultV2.js";
+import { CustomAuthAccountData } from "../../../../../../src/custom_auth/get_account/auth_flow/CustomAuthAccountData.js";
+import { CustomAuthSilentCacheClient } from "../../../../../../src/custom_auth/get_account/interaction_client/CustomAuthSilentCacheClient.js";
+import type { AuthenticationResult } from "../../../../../../src/response/AuthenticationResult.js";
+import { getDefaultLogger } from "../../../../test_resources/TestModules.js";
+
+describe("MFAVerificationRequiredStateV2", () => {
+    const correlationId = "test-correlation-id";
+    const flowClient = {
+        submitCode: jest.fn(),
+        resendCode: jest.fn(),
+    } as unknown as jest.Mocked<FlowInteractionClientV2>;
+
+    const buildState = (): MFAVerificationRequiredStateV2 =>
+        new MFAVerificationRequiredStateV2({
+            correlationId,
+            logger: getDefaultLogger(),
+            config: {
+                auth: { clientId: "test-client-id" },
+                customAuth: { challengeTypes: ["oob"] },
+            } as unknown as CustomAuthBrowserConfiguration,
+            flowClient,
+            cacheClient: {} as CustomAuthSilentCacheClient,
+            continuationState: {
+                continuationToken: "ct-mfa-challenge",
+                scenario: CustomAuthFlowScenarioV2.SignIn,
+                links: {
+                    verify: "/mfa/verify",
+                    resend: "/mfa/resend",
+                },
+                tokenRequest: {
+                    scopes: ["User.Read"],
+                },
+            },
+            method: {
+                id: "sms-mfa",
+                type: "sms",
+                hint: "+1******1234",
+                challengeHref: "/mfa/challenge",
+            },
+            sentTo: "+1******1234",
+            channel: "sms",
+            codeLength: 6,
+        });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("submits an MFA challenge and completes sign-in", async () => {
+        flowClient.submitCode.mockResolvedValue({
+            type: FLOW_COMPLETED_V2,
+            correlationId,
+            authenticationResult: {
+                account: {
+                    homeAccountId: "uid.utid",
+                },
+            } as unknown as AuthenticationResult,
+        });
+
+        const result = await buildState().submitChallenge("123456");
+
+        expect(flowClient.submitCode).toHaveBeenCalledWith({
+            correlationId,
+            continuationState: {
+                continuationToken: "ct-mfa-challenge",
+                scenario: CustomAuthFlowScenarioV2.SignIn,
+                links: {
+                    verify: "/mfa/verify",
+                    resend: "/mfa/resend",
+                },
+                tokenRequest: {
+                    scopes: ["User.Read"],
+                },
+            },
+            code: "123456",
+        });
+        expect(result.isState("completed")).toBe(true);
+        expect(result.state).toBeInstanceOf(CompletedStateV2);
+        expect(result.data).toBeInstanceOf(CustomAuthAccountData);
+    });
+
+    it("resends an MFA challenge and remains in MFA verification", async () => {
+        flowClient.resendCode.mockResolvedValue({
+            type: FLOW_CODE_REQUIRED_V2,
+            correlationId,
+            continuationState: {
+                continuationToken: "ct-mfa-resend",
+                scenario: CustomAuthFlowScenarioV2.SignIn,
+                links: {
+                    verify: "/mfa/verify",
+                    resend: "/mfa/resend",
+                },
+                tokenRequest: {
+                    scopes: ["User.Read"],
+                },
+            },
+            sentTo: "+1******5678",
+            channel: "sms",
+            codeLength: 6,
+        });
+
+        const result = await buildState().resendChallenge();
+
+        expect(result.isState("mfaVerificationRequired")).toBe(true);
+        expect(result.state).toBeInstanceOf(
+            MFAVerificationRequiredStateV2
+        );
+        if (result.isState("mfaVerificationRequired")) {
+            expect(result.state.method?.type).toBe("sms");
+            expect(result.state.sentTo).toBe("+1******5678");
+        }
+    });
+});

--- a/lib/msal-browser/test/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.spec.ts
@@ -381,6 +381,7 @@ describe("FlowInteractionClientV2", () => {
                 ],
             });
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-challenge",
                 verifyHref: "https://endpoint/password/verify",
                 type: "password",
@@ -448,6 +449,7 @@ describe("FlowInteractionClientV2", () => {
                 ],
             });
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-email",
                 verifyHref: "https://endpoint/email/verify",
                 resendHref: "https://endpoint/email/resend",
@@ -488,6 +490,7 @@ describe("FlowInteractionClientV2", () => {
                 ],
             });
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-email",
                 verifyHref: "https://endpoint/email/verify",
                 type: "email",
@@ -578,6 +581,7 @@ describe("FlowInteractionClientV2", () => {
                 ],
             });
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-password",
                 verifyHref: "https://endpoint/password/verify",
                 type: "password",
@@ -642,6 +646,7 @@ describe("FlowInteractionClientV2", () => {
                 ],
             });
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-password",
                 verifyHref: "https://endpoint/password/verify",
                 type: "password",
@@ -703,6 +708,7 @@ describe("FlowInteractionClientV2", () => {
                 ],
             });
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-challenge",
                 verifyHref: "https://endpoint/verify",
                 resendHref: "https://endpoint/resend",
@@ -833,6 +839,7 @@ describe("FlowInteractionClientV2", () => {
                 ],
             });
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-password",
                 verifyHref: "https://endpoint/password/verify",
                 type: "password",
@@ -902,6 +909,7 @@ describe("FlowInteractionClientV2", () => {
 
         it("posts the selected method's challenge href and returns a code-required result", async () => {
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-challenge",
                 verifyHref: "https://endpoint/verify",
                 resendHref: "https://endpoint/resend",
@@ -940,6 +948,7 @@ describe("FlowInteractionClientV2", () => {
 
         it("returns a password-required result for a selected password challenge", async () => {
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-challenge",
                 verifyHref: "https://endpoint/verify",
                 type: "password",
@@ -968,6 +977,7 @@ describe("FlowInteractionClientV2", () => {
 
         it("accepts a future non-password OTP channel", async () => {
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-challenge",
                 verifyHref: "https://endpoint/verify",
                 type: "sms",
@@ -984,6 +994,7 @@ describe("FlowInteractionClientV2", () => {
 
         it("defaults a challenge response without a type to email", async () => {
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-challenge",
                 verifyHref: "https://endpoint/verify",
             });
@@ -1128,7 +1139,7 @@ describe("FlowInteractionClientV2", () => {
             );
         });
 
-        it("rejects MFA-required after verifying a first-factor code", async () => {
+        it("returns MFA-required after verifying a first-factor code", async () => {
             const signInContinuationState: FlowContinuationStateV2 = {
                 continuationToken: "ct-email",
                 scenario: "signIn",
@@ -1152,15 +1163,20 @@ describe("FlowInteractionClientV2", () => {
                 ],
             });
 
-            await expect(
-                client.submitCode({
-                    correlationId,
-                    continuationState: signInContinuationState,
-                    code: "123456",
-                })
-            ).rejects.toMatchObject({
-                error: UNSUPPORTED_FLOW_TRANSITION,
+            const result = await client.submitCode({
+                correlationId,
+                continuationState: signInContinuationState,
+                code: "123456",
             });
+
+            expect(result.type).toBe(FLOW_MFA_REQUIRED_V2);
+            expect((result as FlowMFARequiredResultV2).methods).toEqual([
+                {
+                    id: "email-mfa",
+                    type: "email",
+                    challengeHref: "https://endpoint/mfa/challenge",
+                },
+            ]);
             expect(apiClient.completeWithTokens).not.toHaveBeenCalled();
         });
 
@@ -1582,6 +1598,7 @@ describe("FlowInteractionClientV2", () => {
 
         it("re-requests the challenge and returns a code-required result", async () => {
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-challenge-2",
                 verifyHref: "https://endpoint/verify-2",
                 resendHref: "https://endpoint/resend-2",
@@ -1630,6 +1647,7 @@ describe("FlowInteractionClientV2", () => {
                 "createRequestContext"
             );
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-sign-up-challenge-2",
                 verifyHref: "https://endpoint/verify-2",
                 resendHref: "https://endpoint/resend-2",
@@ -1667,6 +1685,7 @@ describe("FlowInteractionClientV2", () => {
 
         it("preserves a future OTP channel returned by resend", async () => {
             apiClient.requestChallenge.mockResolvedValue({
+                nextAction: "verify",
                 continuationToken: "ct-challenge-2",
                 verifyHref: "https://endpoint/verify-2",
                 type: "sms",

--- a/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/v2/CustomAuthApiClientV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/core/network_client/custom_auth_api/v2/CustomAuthApiClientV2.spec.ts
@@ -609,6 +609,7 @@ describe("CustomAuthApiClientV2", () => {
             mockHttpClient.sendAsync.mockResolvedValueOnce(
                 buildResponse({
                     continuationToken: "ct-challenge",
+                    action: "verify",
                     type: "email",
                     codeLength: 6,
                     hint: "u***@test.com",
@@ -626,6 +627,7 @@ describe("CustomAuthApiClientV2", () => {
             );
 
             expect(result).toEqual({
+                nextAction: "verify",
                 continuationToken: "ct-challenge",
                 type: "email",
                 verifyHref: "/tenant/api/v0.1/verify",
@@ -639,6 +641,7 @@ describe("CustomAuthApiClientV2", () => {
             mockHttpClient.sendAsync.mockResolvedValueOnce(
                 buildResponse({
                     continuationToken: "ct-challenge",
+                    action: "verify",
                     payload: { codeLength: 8 },
                     _links: { verify: { href: "/tenant/api/v0.1/verify" } },
                 })
@@ -649,14 +652,17 @@ describe("CustomAuthApiClientV2", () => {
                 { continuationToken: "ct-start" },
                 context
             );
-            expect(result.codeLength).toBe(8);
-            expect(result.codeLength).toBe(8);
+            expect(result).toMatchObject({
+                nextAction: "verify",
+                codeLength: 8,
+            });
         });
 
         it("maps a password challenge without OTP metadata", async () => {
             mockHttpClient.sendAsync.mockResolvedValueOnce(
                 buildResponse({
                     continuationToken: "ct-password",
+                    action: "verify",
                     id: "password-1",
                     type: "password",
                     _links: {
@@ -676,12 +682,206 @@ describe("CustomAuthApiClientV2", () => {
             );
 
             expect(result).toEqual({
+                nextAction: "verify",
                 continuationToken: "ct-password",
                 type: "password",
                 verifyHref: "/tenant/api/v0.1/password/verify",
                 resendHref: undefined,
                 codeLength: undefined,
                 hint: undefined,
+            });
+        });
+
+        it.each([undefined, "unsupported"])(
+            "rejects a challenge with action %s",
+            async (action) => {
+                mockHttpClient.sendAsync.mockResolvedValueOnce(
+                    buildResponse({
+                        continuationToken: "ct-challenge",
+                        action,
+                        type: "email",
+                        _links: {
+                            verify: { href: "/tenant/api/v0.1/verify" },
+                        },
+                    })
+                );
+
+                await expect(
+                    apiClient.requestChallenge(
+                        "/tenant/api/v0.1/challenge",
+                        { continuationToken: "ct-start" },
+                        context
+                    )
+                ).rejects.toMatchObject({
+                    error: INVALID_HAL_RESPONSE,
+                    errorDescription:
+                        "Invalid HAL response: challenge returned no known next action",
+                });
+            }
+        );
+
+        it("returns the risk-verification link for an SMS challenge", async () => {
+            mockHttpClient.sendAsync.mockResolvedValueOnce(
+                buildResponse({
+                    continuationToken: "ct-risk",
+                    state: "interactionRequired",
+                    action: "riskverify",
+                    _links: {
+                        riskverify: {
+                            href: "/tenant/api/v1.0-internal/risk/phone/verify",
+                        },
+                    },
+                })
+            );
+
+            await expect(
+                apiClient.requestChallenge(
+                    "/tenant/api/v0.1/sms/challenge",
+                    { continuationToken: "ct-start" },
+                    context
+                )
+            ).resolves.toEqual({
+                nextAction: "riskVerify",
+                continuationToken: "ct-risk",
+                riskVerifyHref: "/tenant/api/v1.0-internal/risk/phone/verify",
+            });
+        });
+
+        it("rejects risk verification without a riskverify link", async () => {
+            mockHttpClient.sendAsync.mockResolvedValueOnce(
+                buildResponse({
+                    continuationToken: "ct-risk",
+                    state: "interactionRequired",
+                    action: "riskverify",
+                    _links: {},
+                })
+            );
+
+            await expect(
+                apiClient.requestChallenge(
+                    "/tenant/api/v0.1/sms/challenge",
+                    { continuationToken: "ct-start" },
+                    context
+                )
+            ).rejects.toMatchObject({
+                error: INVALID_HAL_RESPONSE,
+                errorDescription:
+                    "Invalid HAL response: missing 'riskverify' link",
+            });
+        });
+    });
+
+    describe("verifyRisk", () => {
+        it("returns SMS verification metadata", async () => {
+            mockHttpClient.sendAsync.mockResolvedValueOnce(
+                buildResponse({
+                    continuationToken: "ct-sms-verify",
+                    state: "interactionRequired",
+                    action: "verify",
+                    scenario: "signin",
+                    type: "sms",
+                    hint: "+*** *******11",
+                    payload: { codeLength: 6 },
+                    _links: {
+                        verify: {
+                            href: "/tenant/api/v1.0-internal/sms/verify",
+                        },
+                        resend: {
+                            href: "/tenant/api/v1.0-internal/sms/challenge",
+                        },
+                    },
+                })
+            );
+
+            await expect(
+                apiClient.verifyRisk(
+                    "/tenant/api/v1.0-internal/risk/phone/verify",
+                    { continuationToken: "ct-risk" },
+                    context
+                )
+            ).resolves.toEqual({
+                nextAction: "verify",
+                continuationToken: "ct-sms-verify",
+                verifyHref: "/tenant/api/v1.0-internal/sms/verify",
+                resendHref: "/tenant/api/v1.0-internal/sms/challenge",
+                codeLength: 6,
+                hint: "+*** *******11",
+                type: "sms",
+            });
+        });
+
+        it("rejects a response without the verify action", async () => {
+            mockHttpClient.sendAsync.mockResolvedValueOnce(
+                buildResponse({
+                    continuationToken: "ct-risk",
+                    action: "unsupported",
+                })
+            );
+
+            await expect(
+                apiClient.verifyRisk(
+                    "/tenant/api/v1.0-internal/risk/phone/verify",
+                    { continuationToken: "ct-risk" },
+                    context
+                )
+            ).rejects.toMatchObject({
+                error: INVALID_HAL_RESPONSE,
+                errorDescription:
+                    "Invalid HAL response: SMS risk verification returned no known next action",
+            });
+        });
+
+        it.each([undefined, "email"])(
+            "rejects risk verification with challenge type %s",
+            async (type) => {
+                mockHttpClient.sendAsync.mockResolvedValueOnce(
+                    buildResponse({
+                        continuationToken: "ct-sms-verify",
+                        action: "verify",
+                        scenario: "signin",
+                        type,
+                        _links: {
+                            verify: {
+                                href: "/tenant/api/v1.0-internal/sms/verify",
+                            },
+                        },
+                    })
+                );
+
+                await expect(
+                    apiClient.verifyRisk(
+                        "/tenant/api/v1.0-internal/risk/phone/verify",
+                        { continuationToken: "ct-risk" },
+                        context
+                    )
+                ).rejects.toMatchObject({
+                    error: INVALID_HAL_RESPONSE,
+                    errorDescription:
+                        "Invalid HAL response: SMS risk verification returned a non-SMS challenge",
+                });
+            }
+        );
+
+        it("rejects risk verification without a verify link", async () => {
+            mockHttpClient.sendAsync.mockResolvedValueOnce(
+                buildResponse({
+                    continuationToken: "ct-sms-verify",
+                    action: "verify",
+                    scenario: "signin",
+                    type: "sms",
+                    _links: {},
+                })
+            );
+
+            await expect(
+                apiClient.verifyRisk(
+                    "/tenant/api/v1.0-internal/risk/phone/verify",
+                    { continuationToken: "ct-risk" },
+                    context
+                )
+            ).rejects.toMatchObject({
+                error: INVALID_HAL_RESPONSE,
+                errorDescription: "Invalid HAL response: missing 'verify' link",
             });
         });
     });

--- a/lib/msal-browser/test/custom_auth/integration_tests/ResetPasswordV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/ResetPasswordV2.spec.ts
@@ -81,11 +81,49 @@ const START_RESPONSE = {
 
 const CHALLENGE_RESPONSE = {
     continuationToken: "ct-challenge",
+    action: "verify",
     codeLength: 6,
     hint: "u***@contoso.com",
     type: "email",
     _links: {
         verify: { href: "/tenant/api/v0.1/verify" },
+    },
+};
+
+const SMS_METHOD = {
+    id: "sms",
+    type: "sms",
+    hint: "+*** *******11",
+    _links: {
+        challenge: {
+            href: "/tenant/api/v0.1/methods/sms/challenge",
+        },
+    },
+};
+
+const SMS_CHALLENGE_RESPONSE = {
+    continuationToken: "ct-risk",
+    state: "interactionRequired",
+    action: "riskverify",
+    _links: {
+        riskverify: {
+            href: "/tenant/api/v1.0-internal/risk/phone/verify",
+        },
+    },
+};
+
+const SMS_RISK_VERIFY_RESPONSE = {
+    continuationToken: "ct-sms-verify",
+    state: "interactionRequired",
+    action: "verify",
+    scenario: "recovery",
+    id: "sms",
+    type: "sms",
+    hint: "+*** *******11",
+    payload: { codeLength: 6 },
+    _links: {
+        verify: { href: "/tenant/api/v1.0-internal/sms/verify" },
+        resend: { href: "/tenant/api/v1.0-internal/sms/challenge" },
     },
 };
 
@@ -183,6 +221,61 @@ describe("Reset password V2 (SSPR)", () => {
         expect(codeState.method?.id).toBe("email");
         expect(codeState.channel).toBe("email");
         expect(fetch as jest.Mock).toHaveBeenCalledTimes(3);
+    });
+
+    it("resets the password with SMS as the first factor", async () => {
+        const smsStartResponse = {
+            ...START_RESPONSE,
+            _embedded: {
+                methods: [START_RESPONSE._embedded.methods[0], SMS_METHOD],
+            },
+        };
+        (fetch as jest.Mock)
+            .mockResolvedValueOnce(buildResponse(ENTRY_RESPONSE))
+            .mockResolvedValueOnce(buildResponse(smsStartResponse))
+            .mockResolvedValueOnce(buildResponse(SMS_CHALLENGE_RESPONSE))
+            .mockResolvedValueOnce(buildResponse(SMS_RISK_VERIFY_RESPONSE))
+            .mockResolvedValueOnce(buildResponse(VERIFY_RESPONSE))
+            .mockResolvedValueOnce(buildResponse(UPDATE_RESPONSE))
+            .mockResolvedValueOnce(buildResponse(POLL_COMPLETED_RESPONSE))
+            .mockResolvedValueOnce(buildResponse(CONTINUE_RESPONSE))
+            .mockResolvedValueOnce(buildResponse(TestServerTokenResponse));
+
+        const methodState = await startToMethodSelection();
+        const smsMethod = methodState.methods.find(
+            (method) => method.type === "sms"
+        );
+        if (!smsMethod) {
+            throw new Error("Expected an SMS password-reset method.");
+        }
+
+        const challengeResult = await methodState.requestChallenge(smsMethod);
+        expect(challengeResult.isState("challengeVerificationRequired")).toBe(
+            true
+        );
+
+        const codeState =
+            challengeResult.state as ChallengeVerificationRequiredStateV2;
+        expect(codeState.channel).toBe("sms");
+        expect(codeState.sentTo).toBe("+*** *******11");
+        expect(codeState.codeLength).toBe(6);
+
+        const verifyResult = await codeState.verifyChallenge("123456");
+        const passwordState = verifyResult.state as NewPasswordRequiredStateV2;
+        const submitResult = await passwordState.submitNewPassword(
+            "N3wP@ssw0rd!"
+        );
+        const signInState = submitResult.state as SignInContinuationStateV2;
+        const signInResult = await signInState.signIn();
+
+        expect(signInResult.isState("completed")).toBe(true);
+        expect(fetch as jest.Mock).toHaveBeenCalledTimes(9);
+        expect(String((fetch as jest.Mock).mock.calls[3][0])).toContain(
+            "/risk/phone/verify"
+        );
+        expect(String((fetch as jest.Mock).mock.calls[4][0])).toContain(
+            "/sms/verify"
+        );
     });
 
     it("appends OIDC scopes and caches the ID token when the app requests only an API scope", async () => {
@@ -334,28 +427,25 @@ describe("Reset password V2 (SSPR)", () => {
         expect(challengeResult.error?.isBrowserRequired()).toBe(true);
     });
 
-    it.each(["password", "sms"])(
-        "rejects a %s challenge for password reset",
-        async (type) => {
-            (fetch as jest.Mock)
-                .mockResolvedValueOnce(buildResponse(ENTRY_RESPONSE))
-                .mockResolvedValueOnce(buildResponse(START_RESPONSE))
-                .mockResolvedValueOnce(
-                    buildResponse({
-                        ...CHALLENGE_RESPONSE,
-                        type,
-                    })
-                );
-
-            const methodState = await startToMethodSelection();
-            const challengeResult = await methodState.requestChallenge(
-                methodState.methods[0]
+    it("rejects a password challenge for password reset", async () => {
+        (fetch as jest.Mock)
+            .mockResolvedValueOnce(buildResponse(ENTRY_RESPONSE))
+            .mockResolvedValueOnce(buildResponse(START_RESPONSE))
+            .mockResolvedValueOnce(
+                buildResponse({
+                    ...CHALLENGE_RESPONSE,
+                    type: "password",
+                })
             );
 
-            expect(challengeResult.isFailed()).toBe(true);
-            expect(challengeResult.error?.errorData.error).toBe(
-                UNSUPPORTED_FLOW_TRANSITION
-            );
-        }
-    );
+        const methodState = await startToMethodSelection();
+        const challengeResult = await methodState.requestChallenge(
+            methodState.methods[0]
+        );
+
+        expect(challengeResult.isFailed()).toBe(true);
+        expect(challengeResult.error?.errorData.error).toBe(
+            UNSUPPORTED_FLOW_TRANSITION
+        );
+    });
 });

--- a/lib/msal-browser/test/custom_auth/integration_tests/ResetPasswordV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/ResetPasswordV2.spec.ts
@@ -7,7 +7,7 @@ import { CustomAuthPublicClientApplication } from "../../../src/custom_auth/Cust
 import { CustomAuthStandardController } from "../../../src/custom_auth/controller/CustomAuthStandardController.js";
 import { CustomAuthAccountData } from "../../../src/custom_auth/get_account/auth_flow/CustomAuthAccountData.js";
 import { AuthMethodSelectionRequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/AuthMethodSelectionRequiredStateV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import { NewPasswordRequiredStateV2 } from "../../../src/custom_auth/reset_password/auth_flow/v2/state/NewPasswordRequiredStateV2.js";
 import { SignInContinuationStateV2 } from "../../../src/custom_auth/sign_in/auth_flow/v2/state/SignInContinuationStateV2.js";
 import { CompletedStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/CompletedStateV2.js";
@@ -212,12 +212,10 @@ describe("Reset password V2 (SSPR)", () => {
         });
 
         expect(result.isFailed()).toBe(false);
-        expect(result.isState("challengeVerificationRequired")).toBe(true);
-        expect(result.state).toBeInstanceOf(
-            ChallengeVerificationRequiredStateV2
-        );
+        expect(result.isState("codeRequired")).toBe(true);
+        expect(result.state).toBeInstanceOf(CodeRequiredStateV2);
 
-        const codeState = result.state as ChallengeVerificationRequiredStateV2;
+        const codeState = result.state as CodeRequiredStateV2;
         expect(codeState.method?.id).toBe("email");
         expect(codeState.channel).toBe("email");
         expect(fetch as jest.Mock).toHaveBeenCalledTimes(3);
@@ -250,17 +248,15 @@ describe("Reset password V2 (SSPR)", () => {
         }
 
         const challengeResult = await methodState.requestChallenge(smsMethod);
-        expect(challengeResult.isState("challengeVerificationRequired")).toBe(
-            true
-        );
+        expect(challengeResult.isState("codeRequired")).toBe(true);
 
         const codeState =
-            challengeResult.state as ChallengeVerificationRequiredStateV2;
+            challengeResult.state as CodeRequiredStateV2;
         expect(codeState.channel).toBe("sms");
         expect(codeState.sentTo).toBe("+*** *******11");
         expect(codeState.codeLength).toBe(6);
 
-        const verifyResult = await codeState.verifyChallenge("123456");
+        const verifyResult = await codeState.submitCode("123456");
         const passwordState = verifyResult.state as NewPasswordRequiredStateV2;
         const submitResult = await passwordState.submitNewPassword(
             "N3wP@ssw0rd!"
@@ -299,12 +295,12 @@ describe("Reset password V2 (SSPR)", () => {
         );
         expect(challengeResult.isFailed()).toBe(false);
         expect(challengeResult.state).toBeInstanceOf(
-            ChallengeVerificationRequiredStateV2
+            CodeRequiredStateV2
         );
 
         const codeState =
-            challengeResult.state as ChallengeVerificationRequiredStateV2;
-        const verifyResult = await codeState.verifyChallenge("123456");
+            challengeResult.state as CodeRequiredStateV2;
+        const verifyResult = await codeState.submitCode("123456");
         expect(verifyResult.isFailed()).toBe(false);
         expect(verifyResult.state).toBeInstanceOf(NewPasswordRequiredStateV2);
 
@@ -363,9 +359,9 @@ describe("Reset password V2 (SSPR)", () => {
             methodState.methods[0]
         );
         const codeState =
-            challengeResult.state as ChallengeVerificationRequiredStateV2;
+            challengeResult.state as CodeRequiredStateV2;
 
-        const verifyResult = await codeState.verifyChallenge("000000");
+        const verifyResult = await codeState.submitCode("000000");
 
         expect(verifyResult.isFailed()).toBe(true);
         expect(verifyResult.error).toBeInstanceOf(VerifyChallengeErrorV2);
@@ -397,8 +393,8 @@ describe("Reset password V2 (SSPR)", () => {
             methodState.methods[0]
         );
         const codeState =
-            challengeResult.state as ChallengeVerificationRequiredStateV2;
-        const verifyResult = await codeState.verifyChallenge("123456");
+            challengeResult.state as CodeRequiredStateV2;
+        const verifyResult = await codeState.submitCode("123456");
         const passwordState = verifyResult.state as NewPasswordRequiredStateV2;
 
         const submitResult = await passwordState.submitNewPassword("weak");

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignInV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignInV2.spec.ts
@@ -8,7 +8,8 @@ import { CustomAuthStandardController } from "../../../src/custom_auth/controlle
 import { PasswordRequiredStateV2 } from "../../../src/custom_auth/sign_in/auth_flow/v2/state/PasswordRequiredStateV2.js";
 import { CompletedStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/CompletedStateV2.js";
 import { MFARequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/MFARequiredStateV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.js";
+import { MFAVerificationRequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/MFAVerificationRequiredStateV2.js";
 import { CustomAuthAccountData } from "../../../src/custom_auth/get_account/auth_flow/CustomAuthAccountData.js";
 import {
     NO_AUTHENTICATION_METHODS,
@@ -102,6 +103,7 @@ const PASSWORD_AND_EMAIL_START_RESPONSE = {
 
 const PASSWORD_CHALLENGE_RESPONSE = {
     continuationToken: "ct-challenge",
+    action: "verify",
     id: "password-1",
     type: "password",
     _links: {
@@ -111,6 +113,7 @@ const PASSWORD_CHALLENGE_RESPONSE = {
 
 const EMAIL_CHALLENGE_RESPONSE = {
     continuationToken: "ct-email-challenge",
+    action: "verify",
     type: "email",
     codeLength: 6,
     hint: "u***@contoso.com",
@@ -153,6 +156,7 @@ const MFA_REQUIRED_RESPONSE = {
 
 const MFA_CHALLENGE_RESPONSE = {
     continuationToken: "ct-mfa-challenge",
+    action: "verify",
     codeLength: 6,
     hint: "u***@contoso.com",
     type: "email",
@@ -246,13 +250,11 @@ describe("Sign-in V2 entry", () => {
             scopes: ["User.Read"],
         });
 
-        expect(result.isState("challengeVerificationRequired")).toBe(true);
-        expect(result.state).toBeInstanceOf(
-            ChallengeVerificationRequiredStateV2
-        );
+        expect(result.isState("codeRequired")).toBe(true);
+        expect(result.state).toBeInstanceOf(CodeRequiredStateV2);
 
         const challengeState =
-            result.state as ChallengeVerificationRequiredStateV2;
+            result.state as CodeRequiredStateV2;
         expect(challengeState.method?.id).toBe("email-1");
         expect(challengeState.channel).toBe("email");
         expect(challengeState.sentTo).toBe("u***@contoso.com");
@@ -272,7 +274,7 @@ describe("Sign-in V2 entry", () => {
             password: "P@ssword1!",
         });
 
-        expect(result.isState("challengeVerificationRequired")).toBe(true);
+        expect(result.isState("codeRequired")).toBe(true);
         expect(fetch).toHaveBeenCalledTimes(3);
     });
 
@@ -290,15 +292,15 @@ describe("Sign-in V2 entry", () => {
             scopes: ["User.Read"],
         });
         const result = await (
-            startResult.state as ChallengeVerificationRequiredStateV2
-        ).verifyChallenge("123456");
+            startResult.state as CodeRequiredStateV2
+        ).submitCode("123456");
 
         expect(result.isState("completed")).toBe(true);
         expect(result.data).toBeInstanceOf(CustomAuthAccountData);
         expect(fetch).toHaveBeenCalledTimes(6);
     });
 
-    it("rejects MFA-required after first-factor email OTP", async () => {
+    it("returns MFA-required after first-factor email OTP", async () => {
         (fetch as jest.Mock)
             .mockResolvedValueOnce(buildResponse(ENTRY_RESPONSE))
             .mockResolvedValueOnce(buildResponse(EMAIL_START_RESPONSE))
@@ -310,11 +312,21 @@ describe("Sign-in V2 entry", () => {
             scopes: ["User.Read"],
         });
         const result = await (
-            startResult.state as ChallengeVerificationRequiredStateV2
-        ).verifyChallenge("123456");
+            startResult.state as CodeRequiredStateV2
+        ).submitCode("123456");
 
-        expect(result.isFailed()).toBe(true);
-        expect(result.error?.errorData.error).toBe(UNSUPPORTED_FLOW_TRANSITION);
+        expect(result.isState("mfaRequired")).toBe(true);
+        expect(result.state).toBeInstanceOf(MFARequiredStateV2);
+        if (result.isState("mfaRequired")) {
+            expect(result.state.methods).toEqual([
+                {
+                    id: "email-mfa",
+                    type: "email",
+                    hint: "u***@contoso.com",
+                    challengeHref: "/tenant/api/v0.1/mfa/challenge",
+                },
+            ]);
+        }
     });
 
     it("submits a password from PasswordRequiredStateV2 and completes sign-in", async () => {
@@ -405,24 +417,20 @@ describe("Sign-in V2 entry", () => {
             mfaState.methods[0]
         );
 
-        expect(challengeResult.isState("challengeVerificationRequired")).toBe(
-            true
-        );
+        expect(challengeResult.isState("mfaVerificationRequired")).toBe(true);
         expect(challengeResult.state).toBeInstanceOf(
-            ChallengeVerificationRequiredStateV2
+            MFAVerificationRequiredStateV2
         );
 
         const resendResult = await (
-            challengeResult.state as ChallengeVerificationRequiredStateV2
-        ).requestNewChallenge();
+            challengeResult.state as MFAVerificationRequiredStateV2
+        ).resendChallenge();
 
-        expect(resendResult.isState("challengeVerificationRequired")).toBe(
-            true
-        );
+        expect(resendResult.isState("mfaVerificationRequired")).toBe(true);
 
         const completedResult = await (
-            resendResult.state as ChallengeVerificationRequiredStateV2
-        ).verifyChallenge("123456");
+            resendResult.state as MFAVerificationRequiredStateV2
+        ).submitChallenge("123456");
 
         expect(completedResult.isState("completed")).toBe(true);
         expect(completedResult.state).toBeInstanceOf(CompletedStateV2);

--- a/lib/msal-browser/test/custom_auth/integration_tests/SignUpV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/integration_tests/SignUpV2.spec.ts
@@ -5,7 +5,7 @@
 
 import { CustomAuthPublicClientApplication } from "../../../src/custom_auth/CustomAuthPublicClientApplication.js";
 import { CustomAuthStandardController } from "../../../src/custom_auth/controller/CustomAuthStandardController.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import { CompletedStateV2 } from "../../../src/custom_auth/core/auth_flow/v2/state/CompletedStateV2.js";
 import { AttributesRequiredStateV2 } from "../../../src/custom_auth/sign_up/auth_flow/v2/state/AttributesRequiredStateV2.js";
 import { SignUpPasswordRequiredStateV2 } from "../../../src/custom_auth/sign_up/auth_flow/v2/state/SignUpPasswordRequiredStateV2.js";
@@ -131,13 +131,11 @@ describe("Sign-up V2 entry", () => {
         });
 
         expect(result.isFailed()).toBe(false);
-        expect(result.isState("challengeVerificationRequired")).toBe(true);
-        expect(result.state).toBeInstanceOf(
-            ChallengeVerificationRequiredStateV2
-        );
+        expect(result.isState("codeRequired")).toBe(true);
+        expect(result.state).toBeInstanceOf(CodeRequiredStateV2);
         expect(result.scenario).toBe("signUp");
 
-        if (result.isState("challengeVerificationRequired")) {
+        if (result.isState("codeRequired")) {
             expect(result.state.method).toBeUndefined();
             expect(result.state.sentTo).toBe("u***@contoso.com");
             expect(result.state.codeLength).toBe(8);
@@ -432,12 +430,12 @@ describe("Sign-up V2 entry", () => {
             username: "user@contoso.com",
         });
 
-        expect(startResult.isState("challengeVerificationRequired")).toBe(true);
-        if (!startResult.isState("challengeVerificationRequired")) {
+        expect(startResult.isState("codeRequired")).toBe(true);
+        if (!startResult.isState("codeRequired")) {
             throw new Error("Expected challenge verification state.");
         }
 
-        const verifyResult = await startResult.state.verifyChallenge(
+        const verifyResult = await startResult.state.submitCode(
             "12345678"
         );
 
@@ -553,11 +551,11 @@ describe("Sign-up V2 entry", () => {
             username: "user@contoso.com",
             password: "P@ssword1!",
         });
-        if (!startResult.isState("challengeVerificationRequired")) {
+        if (!startResult.isState("codeRequired")) {
             throw new Error("Expected challenge verification state.");
         }
 
-        const verifyResult = await startResult.state.verifyChallenge(
+        const verifyResult = await startResult.state.submitCode(
             "12345678"
         );
         expect(verifyResult.state).toBeInstanceOf(AttributesRequiredStateV2);
@@ -608,11 +606,11 @@ describe("Sign-up V2 entry", () => {
             password: "P@ssword1!",
         });
 
-        if (!startResult.isState("challengeVerificationRequired")) {
+        if (!startResult.isState("codeRequired")) {
             throw new Error("Expected challenge verification state.");
         }
 
-        const verifyResult = await startResult.state.verifyChallenge(
+        const verifyResult = await startResult.state.submitCode(
             "12345678"
         );
 
@@ -677,11 +675,11 @@ describe("Sign-up V2 entry", () => {
             password: "P@ssword1!",
             scopes: ["User.Read"],
         });
-        if (!startResult.isState("challengeVerificationRequired")) {
+        if (!startResult.isState("codeRequired")) {
             throw new Error("Expected challenge verification state.");
         }
 
-        const verifyResult = await startResult.state.verifyChallenge(
+        const verifyResult = await startResult.state.submitCode(
             "12345678"
         );
         if (!verifyResult.isState("attributesRequired")) {
@@ -760,11 +758,11 @@ describe("Sign-up V2 entry", () => {
             username: "user@contoso.com",
             scopes: ["User.Read"],
         });
-        if (!startResult.isState("challengeVerificationRequired")) {
+        if (!startResult.isState("codeRequired")) {
             throw new Error("Expected challenge verification state.");
         }
 
-        const verifyResult = await startResult.state.verifyChallenge(
+        const verifyResult = await startResult.state.submitCode(
             "12345678"
         );
         if (!verifyResult.isState("passwordRequired")) {
@@ -852,11 +850,11 @@ describe("Sign-up V2 entry", () => {
         const startResult = await app.signUpV2({
             username: "user@contoso.com",
         });
-        if (!startResult.isState("challengeVerificationRequired")) {
+        if (!startResult.isState("codeRequired")) {
             throw new Error("Expected challenge verification state.");
         }
 
-        const verifyResult = await startResult.state.verifyChallenge(
+        const verifyResult = await startResult.state.submitCode(
             "12345678"
         );
         if (!verifyResult.isState("passwordRequired")) {

--- a/lib/msal-browser/test/custom_auth/sign_up/auth_flow/v2/state/AttributesRequiredStateV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_up/auth_flow/v2/state/AttributesRequiredStateV2.spec.ts
@@ -6,7 +6,7 @@
 import { CustomAuthBrowserConfiguration } from "../../../../../../src/custom_auth/configuration/CustomAuthConfiguration.js";
 import { CustomAuthFlowScenarioV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/CustomAuthFlowScenarioV2.js";
 import { CustomAuthApiError } from "../../../../../../src/custom_auth/core/error/CustomAuthApiError.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import { FlowInteractionClientV2 } from "../../../../../../src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.js";
 import {
     FLOW_CODE_REQUIRED_V2,
@@ -105,9 +105,9 @@ describe("AttributesRequiredStateV2", () => {
             givenName: "Test",
         });
 
-        expect(result.isState("challengeVerificationRequired")).toBe(true);
+        expect(result.isState("codeRequired")).toBe(true);
         expect(result.state).toBeInstanceOf(
-            ChallengeVerificationRequiredStateV2
+            CodeRequiredStateV2
         );
     });
 

--- a/lib/msal-browser/test/custom_auth/sign_up/auth_flow/v2/state/SignUpPasswordRequiredStateV2.spec.ts
+++ b/lib/msal-browser/test/custom_auth/sign_up/auth_flow/v2/state/SignUpPasswordRequiredStateV2.spec.ts
@@ -5,7 +5,7 @@
 
 import { CustomAuthBrowserConfiguration } from "../../../../../../src/custom_auth/configuration/CustomAuthConfiguration.js";
 import { CustomAuthFlowScenarioV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/CustomAuthFlowScenarioV2.js";
-import { ChallengeVerificationRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/ChallengeVerificationRequiredStateV2.js";
+import { CodeRequiredStateV2 } from "../../../../../../src/custom_auth/core/auth_flow/v2/state/CodeRequiredStateV2.js";
 import { FlowInteractionClientV2 } from "../../../../../../src/custom_auth/core/interaction_client/v2/FlowInteractionClientV2.js";
 import {
     FLOW_CODE_REQUIRED_V2,
@@ -120,9 +120,9 @@ describe("SignUpPasswordRequiredStateV2", () => {
 
         const result = await buildState().submitPassword("P@ssword1!");
 
-        expect(result.isState("challengeVerificationRequired")).toBe(true);
+        expect(result.isState("codeRequired")).toBe(true);
         expect(result.state).toBeInstanceOf(
-            ChallengeVerificationRequiredStateV2
+            CodeRequiredStateV2
         );
     });
 


### PR DESCRIPTION
## Summary
- add Native Auth V2 SMS protocol and password-reset support
- replace the shared challenge verification state with `CodeRequiredStateV2` for first-factor email OTP
- add `MFAVerificationRequiredStateV2` with `submitChallenge` and `resendChallenge` for email or SMS MFA
- validate `singleFactor` at sign-in/reset start and `multiFactor` before surfacing MFA
- retain the sign-up transition handler for the repeating code/attribute flow

## Validation
- 797 Custom Auth tests
- msal-browser lint and type build
- msal-common and msal-browser package build
- Next.js V2 sign-in, sign-up, and password-reset production build

## Sample
The updated V2 sample pages are pushed in Azure-Samples/ms-identity-ciam-native-javascript-samples on branch `yongdi/native-auth-v2-sample-testing` at commit `4f50b3b`.

Supersedes #8818 with distinct first-factor and MFA verification states and no sign-in transition handler.