### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,3 +61,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/beachball-check.yml
+++ b/.github/workflows/beachball-check.yml
@@ -24,7 +24,7 @@ jobs:
         env:
             BEACHBALL: 1
         steps:
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
               id: filter
               with:
                   # Will return true if any file is not markdown and any file is in /lib
@@ -33,14 +33,14 @@ jobs:
                         - 'lib/**/**.!(md)'
                         - 'extensions/msal-node-extensions/**/**.!(md)'
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
               if: ${{ steps.filter.outputs.lib == 'true' }}
               with:
                   fetch-depth: 0
 
             - name: Use Node.js
               if: ${{ steps.filter.outputs.lib == 'true' }}
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
             - name: Install beachball
               if: ${{ steps.filter.outputs.lib == 'true' }}

--- a/.github/workflows/client-credential-benchmark.yml
+++ b/.github/workflows/client-credential-benchmark.yml
@@ -29,8 +29,8 @@ jobs:
         name: Run msal-node client-credential Regression Test
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+            - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node
@@ -43,13 +43,13 @@ jobs:
               working-directory: regression-tests/msal-node/client-credential
 
             - name: Download previous benchmark data
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: ./cache
                   key: ${{ runner.os }}-benchmark
 
             - name: Store benchmark result
-              uses: benchmark-action/github-action-benchmark@v1
+              uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
               with:
                   name: msal-node client-credential Regression Test
                   tool: "benchmarkjs"

--- a/.github/workflows/issue-template-bot.yml
+++ b/.github/workflows/issue-template-bot.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Run Bot
         uses: ./.github/actions/issue_template_bot

--- a/.github/workflows/msal-node-confidential-client-benchmarks.yml
+++ b/.github/workflows/msal-node-confidential-client-benchmarks.yml
@@ -15,8 +15,8 @@ jobs:
         name: Performance regression check
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+            - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
             - name: Install dependencies
               run: npm install --workspace=lib/msal-common --workspace=lib/msal-node
@@ -33,7 +33,7 @@ jobs:
             # /dev/bench is a path to put the benchmark dashboard page. They can be tweaked by
             # the gh-pages-branch, gh-repository and benchmark-data-dir-path inputs.
             - name: Store benchmark result
-              uses: benchmark-action/github-action-benchmark@v1
+              uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
               with:
                   name: msal-node client-credential Regression Test
                   tool: "benchmarkjs"

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -16,13 +16,13 @@ jobs:
       contents: write
       pages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
 
       - name: Install
         run: npm i --workspace=lib/** --workspace=@azure/msal-node-extensions --include-workspace-root
@@ -37,7 +37,7 @@ jobs:
         run: npm run doc:generate
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./ref


### PR DESCRIPTION
## Summary

Bridges the approved fork contribution in #8812 into an upstream branch so the repository's full Azure Pipelines CI can validate it before merging to `dev`.

This change pins GitHub Actions to full-length commit SHAs and adds a seven-day Dependabot cooldown for GitHub Actions updates, reducing supply-chain risk from mutable or newly compromised action releases.

## Contribution

- Original PR: #8812 by @danfiedler-msft
- The squash commit records the original contributor in its commit metadata and message.

## How to validate

- Confirm all required GitHub Actions and Azure Pipelines checks complete successfully.
- Confirm each pinned SHA resolves to the intended action version documented by its adjacent version comment.
- Confirm Dependabot accepts the `github-actions` cooldown configuration.

<!-- BEGIN pr-telemetry -->
assistance: agentic-mixed
type: security
agent-tool: copilot-cli
agent-model: gpt-5.6-sol
work-item: AB#n/a
<!-- END pr-telemetry -->